### PR TITLE
PR #2: aisix-core — Config, ResourceEntry, Snapshot, error taxonomies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,11 +81,15 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "chrono",
+ "config",
  "dashmap",
+ "humantime-serde",
  "insta",
  "rstest",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "thiserror 1.0.69",
  "tracing",
  "uuid",
@@ -1315,6 +1319,22 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -2828,6 +2848,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,6 +3508,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,11 +113,16 @@ redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "clu
 # Tokenization / counting (optional hard-mode TPM)
 tiktoken-rs = "0.5"
 
+# Duration / humanised types
+humantime = "2.1"
+humantime-serde = "1.1"
+
 # Test-only
 wiremock = "0.6"
 rstest = "0.23"
 insta = { version = "1", features = ["json", "yaml"] }
 testcontainers = "0.23"
+tempfile = "3.13"
 
 [profile.release]
 lto = "thin"

--- a/crates/aisix-core/Cargo.toml
+++ b/crates/aisix-core/Cargo.toml
@@ -18,7 +18,11 @@ anyhow.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 tracing.workspace = true
+config.workspace = true
+humantime-serde.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
 rstest.workspace = true
+serde_yaml.workspace = true
+tempfile.workspace = true

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -1,0 +1,415 @@
+//! Bootstrap configuration loaded from a YAML/TOML/JSON file at startup.
+//!
+//! Everything in here is the *static* config (addresses, TLS, etcd endpoints,
+//! observability sinks). Dynamic resources — Models, API keys, budgets — live
+//! in etcd and are loaded via the `aisix-etcd` crate.
+//!
+//! Loading order (spec §2):
+//! 1. Defaults
+//! 2. File contents (path from CLI `--config` or discovery list)
+//! 3. Environment-variable overrides (prefix `AISIX_`, separator `__`)
+//!
+//! Example (see `config.example.yaml`):
+//!
+//! ```yaml
+//! etcd:
+//!   endpoints: ["http://127.0.0.1:2379"]
+//!   prefix: "/aisix"
+//! proxy:
+//!   addr: "0.0.0.0:3000"
+//! admin:
+//!   addr: "127.0.0.1:3001"
+//!   admin_keys: ["admin-local-only-change-me"]
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::time::Duration;
+
+use crate::error::BootstrapError;
+
+/// Root config struct. Construct via [`Config::load_from_path`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    pub etcd: EtcdConfig,
+    pub proxy: ProxyConfig,
+    pub admin: AdminConfig,
+    #[serde(default)]
+    pub observability: ObservabilityConfig,
+    #[serde(default)]
+    pub cache: CacheConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EtcdConfig {
+    pub endpoints: Vec<String>,
+    #[serde(default = "EtcdConfig::default_prefix")]
+    pub prefix: String,
+    #[serde(default)]
+    pub user: Option<String>,
+    /// Name of the env var that contains the password. The actual secret is
+    /// read at connect time — never stored in the config struct.
+    #[serde(default)]
+    pub password_env: Option<String>,
+    #[serde(default = "EtcdConfig::default_dial_timeout")]
+    pub dial_timeout_ms: u64,
+    #[serde(default = "EtcdConfig::default_request_timeout")]
+    pub request_timeout_ms: u64,
+}
+
+impl EtcdConfig {
+    fn default_prefix() -> String {
+        "/aisix".into()
+    }
+    const fn default_dial_timeout() -> u64 {
+        5_000
+    }
+    const fn default_request_timeout() -> u64 {
+        5_000
+    }
+
+    pub const fn dial_timeout(&self) -> Duration {
+        Duration::from_millis(self.dial_timeout_ms)
+    }
+
+    pub const fn request_timeout(&self) -> Duration {
+        Duration::from_millis(self.request_timeout_ms)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProxyConfig {
+    pub addr: String,
+    #[serde(default = "ProxyConfig::default_body_limit")]
+    pub request_body_limit_bytes: usize,
+    #[serde(default)]
+    pub tls: Option<TlsConfig>,
+}
+
+impl ProxyConfig {
+    const fn default_body_limit() -> usize {
+        10 * 1024 * 1024
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdminConfig {
+    pub addr: String,
+    /// Statically-provisioned admin keys. A request is authorised if it
+    /// presents any of these via `Authorization: Bearer <k>` or `x-api-key`.
+    pub admin_keys: Vec<String>,
+    #[serde(default)]
+    pub tls: Option<TlsConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TlsConfig {
+    pub cert_file: String,
+    pub key_file: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct ObservabilityConfig {
+    #[serde(default = "ObservabilityConfig::default_service_name")]
+    pub service_name: String,
+    #[serde(default = "ObservabilityConfig::default_log_level")]
+    pub log_level: String,
+    #[serde(default = "ObservabilityConfig::default_access_log")]
+    pub access_log: bool,
+    pub metrics: MetricsConfig,
+    pub tracing: TracingConfig,
+    pub langfuse: LangfuseConfig,
+}
+
+impl ObservabilityConfig {
+    fn default_service_name() -> String {
+        "aisix".into()
+    }
+    fn default_log_level() -> String {
+        "info".into()
+    }
+    const fn default_access_log() -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct MetricsConfig {
+    pub prometheus: PrometheusConfig,
+    pub otlp: OtlpConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct PrometheusConfig {
+    pub enabled: bool,
+    pub path: String,
+}
+
+impl Default for PrometheusConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            path: "/metrics".into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct OtlpConfig {
+    pub enabled: bool,
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct TracingConfig {
+    pub otlp: OtlpTracingConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct OtlpTracingConfig {
+    pub enabled: bool,
+    pub endpoint: Option<String>,
+    pub sample_ratio: f64,
+}
+
+impl Default for OtlpTracingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: None,
+            sample_ratio: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct LangfuseConfig {
+    pub enabled: bool,
+    pub host: Option<String>,
+    pub public_key_env: Option<String>,
+    pub secret_key_env: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct CacheConfig {
+    pub backend: CacheBackend,
+    pub redis: Option<RedisCacheConfig>,
+    pub qdrant: Option<QdrantCacheConfig>,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            backend: CacheBackend::Memory,
+            redis: None,
+            qdrant: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CacheBackend {
+    Memory,
+    Redis,
+    Qdrant,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RedisCacheConfig {
+    pub url: String,
+    #[serde(default = "RedisCacheConfig::default_mode")]
+    pub mode: String,
+}
+
+impl RedisCacheConfig {
+    fn default_mode() -> String {
+        "single".into()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QdrantCacheConfig {
+    pub url: String,
+    pub collection: String,
+}
+
+impl Config {
+    /// Load + merge + validate.
+    ///
+    /// - If `path` is Some, the file is loaded (format inferred from extension).
+    /// - Env vars prefixed `AISIX_` override anything in the file.
+    /// - Basic invariants are checked (non-empty etcd endpoints, at least one
+    ///   admin key, bind addresses parse).
+    pub fn load_from_path(path: Option<&Path>) -> Result<Self, BootstrapError> {
+        use ::config::{Config as CConfig, Environment, File};
+
+        let mut builder = CConfig::builder();
+
+        if let Some(p) = path {
+            let source = File::from(p).required(true);
+            builder = builder.add_source(source);
+        }
+
+        builder = builder.add_source(
+            Environment::with_prefix("AISIX")
+                .separator("__")
+                .list_separator(",")
+                .try_parsing(true),
+        );
+
+        let raw = builder
+            .build()
+            .map_err(|e| BootstrapError::Config(format!("build: {e}")))?;
+
+        let cfg: Self = raw
+            .try_deserialize()
+            .map_err(|e| BootstrapError::Config(format!("deserialize: {e}")))?;
+
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    fn validate(&self) -> Result<(), BootstrapError> {
+        if self.etcd.endpoints.is_empty() {
+            return Err(BootstrapError::Config(
+                "etcd.endpoints must contain at least one endpoint".into(),
+            ));
+        }
+        if self.admin.admin_keys.is_empty() {
+            return Err(BootstrapError::Config(
+                "admin.admin_keys must contain at least one key".into(),
+            ));
+        }
+        if self.proxy.addr.parse::<std::net::SocketAddr>().is_err() {
+            return Err(BootstrapError::Config(format!(
+                "proxy.addr invalid socket address: {}",
+                self.proxy.addr
+            )));
+        }
+        if self.admin.addr.parse::<std::net::SocketAddr>().is_err() {
+            return Err(BootstrapError::Config(format!(
+                "admin.addr invalid socket address: {}",
+                self.admin.addr
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_yaml(body: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".yaml").tempfile().unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn loads_minimal_config() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.etcd.endpoints, vec!["http://127.0.0.1:2379"]);
+        assert_eq!(cfg.proxy.request_body_limit_bytes, 10 * 1024 * 1024);
+        assert!(cfg.observability.metrics.prometheus.enabled);
+        assert_eq!(cfg.cache.backend, CacheBackend::Memory);
+    }
+
+    #[test]
+    fn rejects_empty_etcd_endpoints() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: []
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("etcd.endpoints"));
+    }
+
+    #[test]
+    fn rejects_empty_admin_keys() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://localhost:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: []
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("admin.admin_keys"));
+    }
+
+    #[test]
+    fn rejects_invalid_bind_addr() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://localhost:2379"]
+proxy:
+  addr: "not-a-socket-addr"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("proxy.addr"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://localhost:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+bogus_field: 1
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("bogus_field"));
+    }
+}

--- a/crates/aisix-core/src/error.rs
+++ b/crates/aisix-core/src/error.rs
@@ -1,0 +1,295 @@
+//! Error taxonomies used across the gateway.
+//!
+//! Two public envelopes:
+//! - [`ProxyError`] — OpenAI-compatible `{error: {message,type,param,code}}` envelope
+//!   returned from the proxy surface (spec §4.1.1).
+//! - [`AdminError`] — simple `{error_msg}` envelope returned from the admin surface
+//!   (spec §10).
+//!
+//! Framework-specific `IntoResponse` impls live in the `aisix-proxy` / `aisix-admin`
+//! crates so this crate stays dependency-light.
+
+use serde::Serialize;
+use thiserror::Error;
+
+/// Errors surfaced on the `:3000` proxy API.
+///
+/// Each variant carries the information needed to build the OpenAI-compatible
+/// response envelope, plus an HTTP status code.
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    #[error("missing or invalid API key")]
+    Unauthorized,
+
+    #[error("model `{0}` not found")]
+    ModelNotFound(String),
+
+    #[error("API key does not have access to model `{0}`")]
+    ModelAccessForbidden(String),
+
+    #[error("request body exceeds limit")]
+    PayloadTooLarge,
+
+    #[error("validation failed: {0}")]
+    InvalidRequest(String),
+
+    #[error("rate limit exceeded ({scope})")]
+    RateLimitExceeded {
+        scope: RateLimitScope,
+        retry_after_secs: Option<u64>,
+    },
+
+    #[error("concurrency limit exceeded")]
+    ConcurrencyLimitExceeded,
+
+    #[error("budget exceeded")]
+    BudgetExceeded,
+
+    #[error("request timed out after {0} ms")]
+    RequestTimeout(u64),
+
+    #[error("upstream provider error: {0}")]
+    ProviderError(String),
+
+    #[error("content policy violation")]
+    ContentPolicyViolation,
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+/// Which quota was exhausted. Used for the OpenAI error envelope `code` field
+/// and to decide which `x-ratelimit-*` headers to emit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateLimitScope {
+    Requests,
+    Tokens,
+    Concurrency,
+}
+
+impl std::fmt::Display for RateLimitScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Requests => "requests",
+            Self::Tokens => "tokens",
+            Self::Concurrency => "concurrency",
+        })
+    }
+}
+
+impl ProxyError {
+    /// HTTP status code per spec §4.
+    pub const fn status(&self) -> u16 {
+        match self {
+            Self::Unauthorized => 401,
+            Self::ModelNotFound(_) | Self::InvalidRequest(_) => 400,
+            Self::ModelAccessForbidden(_) | Self::ContentPolicyViolation => 403,
+            Self::PayloadTooLarge => 413,
+            Self::RateLimitExceeded { .. }
+            | Self::ConcurrencyLimitExceeded
+            | Self::BudgetExceeded => 429,
+            Self::RequestTimeout(_) => 504,
+            Self::ProviderError(_) => 502,
+            Self::Internal(_) => 500,
+        }
+    }
+
+    /// OpenAI `error.type` field.
+    pub const fn error_type(&self) -> &'static str {
+        match self {
+            Self::Unauthorized => "invalid_request_error",
+            Self::ModelNotFound(_) => "invalid_request_error",
+            Self::ModelAccessForbidden(_) => "permission_error",
+            Self::PayloadTooLarge => "invalid_request_error",
+            Self::InvalidRequest(_) => "invalid_request_error",
+            Self::RateLimitExceeded { .. } => "rate_limit_error",
+            Self::ConcurrencyLimitExceeded => "rate_limit_error",
+            Self::BudgetExceeded => "rate_limit_error",
+            Self::RequestTimeout(_) => "api_error",
+            Self::ProviderError(_) => "api_error",
+            Self::ContentPolicyViolation => "invalid_request_error",
+            Self::Internal(_) => "api_error",
+        }
+    }
+
+    /// OpenAI `error.code` field.
+    pub const fn error_code(&self) -> &'static str {
+        match self {
+            Self::Unauthorized => "invalid_api_key",
+            Self::ModelNotFound(_) => "model_not_found",
+            Self::ModelAccessForbidden(_) => "model_access_forbidden",
+            Self::PayloadTooLarge => "request_too_large",
+            Self::InvalidRequest(_) => "invalid_request",
+            Self::RateLimitExceeded { scope, .. } => match scope {
+                RateLimitScope::Requests => "rate_limit_exceeded",
+                RateLimitScope::Tokens => "token_limit_exceeded",
+                RateLimitScope::Concurrency => "concurrency_limit_exceeded",
+            },
+            Self::ConcurrencyLimitExceeded => "concurrency_limit_exceeded",
+            Self::BudgetExceeded => "budget_exceeded",
+            Self::RequestTimeout(_) => "request_timeout",
+            Self::ProviderError(_) => "provider_error",
+            Self::ContentPolicyViolation => "content_policy_violation",
+            Self::Internal(_) => "internal_error",
+        }
+    }
+
+    /// Build the OpenAI-compatible response body.
+    pub fn to_envelope(&self) -> ProxyErrorEnvelope {
+        ProxyErrorEnvelope {
+            error: ProxyErrorBody {
+                message: self.to_string(),
+                r#type: self.error_type(),
+                param: None,
+                code: self.error_code(),
+            },
+        }
+    }
+
+    /// If the error corresponds to a quota reset, returns seconds to wait.
+    pub const fn retry_after_secs(&self) -> Option<u64> {
+        match self {
+            Self::RateLimitExceeded {
+                retry_after_secs, ..
+            } => *retry_after_secs,
+            _ => None,
+        }
+    }
+}
+
+/// Serialisable OpenAI error envelope.
+#[derive(Debug, Serialize)]
+pub struct ProxyErrorEnvelope {
+    pub error: ProxyErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProxyErrorBody {
+    pub message: String,
+    pub r#type: &'static str,
+    pub param: Option<String>,
+    pub code: &'static str,
+}
+
+/// Errors surfaced on the `:3001` admin API.
+///
+/// Admin errors use a dead-simple `{ "error_msg": ... }` envelope (spec §10).
+#[derive(Debug, Error)]
+pub enum AdminError {
+    #[error("missing or invalid admin key")]
+    Unauthorized,
+
+    #[error("resource not found: {0}")]
+    NotFound(String),
+
+    #[error("duplicate name: {0}")]
+    DuplicateName(String),
+
+    #[error("validation failed: {0}")]
+    Validation(String),
+
+    #[error("storage error: {0}")]
+    Storage(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl AdminError {
+    pub const fn status(&self) -> u16 {
+        match self {
+            Self::Unauthorized => 401,
+            Self::NotFound(_) => 404,
+            Self::DuplicateName(_) | Self::Validation(_) => 400,
+            Self::Storage(_) | Self::Internal(_) => 500,
+        }
+    }
+
+    pub fn to_envelope(&self) -> AdminErrorEnvelope {
+        AdminErrorEnvelope {
+            error_msg: self.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminErrorEnvelope {
+    pub error_msg: String,
+}
+
+/// Bootstrap-time failures (config load, TLS, bind). Returned by `aisix-server`.
+#[derive(Debug, Error)]
+pub enum BootstrapError {
+    #[error("failed to load configuration: {0}")]
+    Config(String),
+
+    #[error("etcd connection failed after {attempts} attempts: {source}")]
+    Etcd {
+        attempts: u32,
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("failed to bind {addr}: {source}")]
+    Bind {
+        addr: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("invalid TLS material (field={field}): {reason}")]
+    Tls { field: &'static str, reason: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_error_statuses_match_spec() {
+        assert_eq!(ProxyError::Unauthorized.status(), 401);
+        assert_eq!(ProxyError::ModelNotFound("x".into()).status(), 400);
+        assert_eq!(ProxyError::ModelAccessForbidden("x".into()).status(), 403);
+        assert_eq!(ProxyError::PayloadTooLarge.status(), 413);
+        assert_eq!(
+            ProxyError::RateLimitExceeded {
+                scope: RateLimitScope::Requests,
+                retry_after_secs: Some(5),
+            }
+            .status(),
+            429
+        );
+        assert_eq!(ProxyError::RequestTimeout(1000).status(), 504);
+        assert_eq!(ProxyError::ProviderError("x".into()).status(), 502);
+    }
+
+    #[test]
+    fn proxy_error_envelope_is_openai_shape() {
+        let err = ProxyError::ModelNotFound("gpt-9".into());
+        let env = err.to_envelope();
+        let body = serde_json::to_value(env).unwrap();
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["code"], "model_not_found");
+        assert!(body["error"]["message"].as_str().unwrap().contains("gpt-9"));
+    }
+
+    #[test]
+    fn admin_error_envelope_is_simple_shape() {
+        let env = AdminError::DuplicateName("openai/gpt-4".into()).to_envelope();
+        let body = serde_json::to_value(env).unwrap();
+        assert!(body.get("error_msg").is_some());
+        assert!(body.get("error").is_none());
+    }
+
+    #[test]
+    fn retry_after_only_set_for_rpm_tpm_not_concurrency() {
+        let rpm = ProxyError::RateLimitExceeded {
+            scope: RateLimitScope::Requests,
+            retry_after_secs: Some(12),
+        };
+        assert_eq!(rpm.retry_after_secs(), Some(12));
+
+        let conc = ProxyError::ConcurrencyLimitExceeded;
+        assert_eq!(conc.retry_after_secs(), None);
+    }
+}

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -1,8 +1,32 @@
-//! aisix-core — shared primitives used across the gateway.
+//! aisix-core — primitives shared across every other aisix crate.
 //!
-//! This crate only contains types and errors. It must not depend on any
-//! I/O framework (no tokio, no axum, no reqwest) so that it can be reused
-//! by every other crate in the workspace.
+//! Four responsibilities:
+//! 1. **Config** ([`config::Config`]) — bootstrap YAML/TOML/JSON loader.
+//! 2. **Resources** ([`resource::Resource`], [`resource::ResourceEntry`]) — trait
+//!    and wrapper for every entity stored in etcd.
+//! 3. **Snapshot** ([`snapshot::ResourceTable`], [`snapshot::SnapshotHandle`]) —
+//!    lock-free read path via `ArcSwap`, O(1) lookup by id or name.
+//! 4. **Errors** ([`error::ProxyError`], [`error::AdminError`],
+//!    [`error::BootstrapError`]) — the three error envelopes that show up at
+//!    the two HTTP surfaces plus startup.
+//!
+//! This crate is intentionally framework-agnostic — no axum, no reqwest.
+//! `IntoResponse` impls live in `aisix-proxy` / `aisix-admin`.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+pub mod config;
+pub mod error;
+pub mod resource;
+pub mod snapshot;
+
+pub use config::{
+    AdminConfig, CacheBackend, CacheConfig, Config, EtcdConfig, ObservabilityConfig, ProxyConfig,
+    TlsConfig,
+};
+pub use error::{
+    AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,
+};
+pub use resource::{Resource, ResourceEntry};
+pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/resource.rs
+++ b/crates/aisix-core/src/resource.rs
@@ -1,0 +1,118 @@
+//! [`Resource`] trait and [`ResourceEntry`] wrapper.
+//!
+//! Every entity stored in etcd (Model, ApiKey, Team, Budget, …) is wrapped in a
+//! [`ResourceEntry<T>`] carrying its UUID and the etcd revision it came from.
+//!
+//! Downstream code (proxy handlers, admin handlers, routing) holds
+//! `Arc<ResourceEntry<T>>` and usually wants to reach the `T` directly —
+//! hence the `Deref` impl.
+//!
+//! Spec references: §3 (ResourceEntry<T> Deref to T), §2 (secondary indices
+//! keyed by name / api-key value).
+
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+
+/// Trait every gateway entity implements so the [`crate::snapshot::Snapshot`]
+/// can build a secondary name-index without knowing the concrete type.
+pub trait Resource: Send + Sync + 'static {
+    /// Stable UUID v4 identifying this resource (etcd key suffix).
+    fn id(&self) -> &str;
+
+    /// Human-readable unique name within the resource kind. Used for
+    /// `name → id` lookups and for duplicate-detection on create/update.
+    fn name(&self) -> &str;
+
+    /// Prefix segment used for the etcd key (e.g. `"models"`, `"apikeys"`).
+    /// Constant per type.
+    fn kind() -> &'static str
+    where
+        Self: Sized;
+}
+
+/// Generic wrapper over a typed resource with its etcd coordinates.
+///
+/// Cheap to clone (fields are small / already Arc'd for nested payloads).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceEntry<T> {
+    pub id: String,
+    pub value: T,
+    pub revision: i64,
+}
+
+impl<T> ResourceEntry<T> {
+    pub fn new(id: impl Into<String>, value: T, revision: i64) -> Self {
+        Self {
+            id: id.into(),
+            value,
+            revision,
+        }
+    }
+}
+
+/// Deref-through so callers can write `entry.name()` instead of `entry.value.name()`.
+///
+/// Example:
+/// ```ignore
+/// let entry: ResourceEntry<Model> = …;
+/// let name: &str = entry.name();   // routes through Deref → Model::name()
+/// ```
+impl<T> Deref for ResourceEntry<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct Widget {
+        id: String,
+        name: String,
+    }
+
+    impl Resource for Widget {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn kind() -> &'static str {
+            "widgets"
+        }
+    }
+
+    #[test]
+    fn deref_forwards_to_inner_resource_methods() {
+        let w = Widget {
+            id: "w-1".into(),
+            name: "alpha".into(),
+        };
+        let entry = ResourceEntry::new("w-1", w, 42);
+        // The whole point: .name() resolves through Deref without `entry.value.`.
+        assert_eq!(entry.name(), "alpha");
+        assert_eq!(entry.id(), "w-1");
+        assert_eq!(entry.revision, 42);
+    }
+
+    #[test]
+    fn serialises_as_flat_id_value_revision() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct Tiny {
+            x: u32,
+        }
+
+        let e = ResourceEntry::new("t-1", Tiny { x: 7 }, 3);
+        let json = serde_json::to_value(&e).unwrap();
+        assert_eq!(json["id"], "t-1");
+        assert_eq!(json["revision"], 3);
+        assert_eq!(json["value"]["x"], 7);
+    }
+}

--- a/crates/aisix-core/src/snapshot.rs
+++ b/crates/aisix-core/src/snapshot.rs
@@ -1,0 +1,233 @@
+//! Lock-free configuration snapshot.
+//!
+//! The data plane holds an `ArcSwap<Arc<Snapshot>>`. Reads are a single atomic
+//! load — no mutex, no RCU dance in user code. Writes build a fresh snapshot
+//! off the etcd watch thread and atomically replace the pointer (spec §2:
+//! "no mutex on the read path, atomic replace on write").
+//!
+//! A [`Snapshot`] holds a [`ResourceTable<T>`] per entity kind. Each table
+//! provides:
+//! - O(1) `get_by_id` via a primary `DashMap<id, Arc<ResourceEntry<T>>>`
+//! - O(1) `get_by_name` via a secondary `DashMap<name, id>` index
+//! - `len()` / `iter()` for listing
+//!
+//! Concrete Snapshot shape (which tables it holds) lives closer to the
+//! business types and will be filled in by PR #4 once `Model`, `ApiKey`,
+//! `Team`, etc. exist. This crate provides the primitive only.
+
+use crate::resource::{Resource, ResourceEntry};
+use arc_swap::ArcSwap;
+use dashmap::DashMap;
+use std::sync::Arc;
+
+/// Per-kind table with primary id-index and secondary name-index.
+///
+/// Both indices point at the same `Arc<ResourceEntry<T>>` so there is no
+/// duplicate storage — the name map just holds ids.
+#[derive(Debug)]
+pub struct ResourceTable<T: Resource> {
+    by_id: DashMap<String, Arc<ResourceEntry<T>>>,
+    by_name: DashMap<String, String>,
+}
+
+impl<T: Resource> Default for ResourceTable<T> {
+    fn default() -> Self {
+        Self {
+            by_id: DashMap::new(),
+            by_name: DashMap::new(),
+        }
+    }
+}
+
+impl<T: Resource> ResourceTable<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Insert or replace an entry, updating both indices.
+    ///
+    /// If an entry with the same id already exists, the old name index entry
+    /// is removed first (handles rename on update).
+    pub fn insert(&self, entry: ResourceEntry<T>) {
+        let id = entry.id.clone();
+        let name = entry.value.name().to_string();
+
+        if let Some(old) = self.by_id.get(&id) {
+            let old_name = old.value.name().to_string();
+            if old_name != name {
+                // Only clear the old mapping if it still points at us.
+                self.by_name.remove_if(&old_name, |_, v| v == &id);
+            }
+        }
+
+        self.by_name.insert(name, id.clone());
+        self.by_id.insert(id, Arc::new(entry));
+    }
+
+    /// Remove by id; also removes the matching name index entry.
+    pub fn remove(&self, id: &str) -> Option<Arc<ResourceEntry<T>>> {
+        let (_, entry) = self.by_id.remove(id)?;
+        let name = entry.value.name().to_string();
+        self.by_name.remove_if(&name, |_, v| v == id);
+        Some(entry)
+    }
+
+    pub fn get_by_id(&self, id: &str) -> Option<Arc<ResourceEntry<T>>> {
+        self.by_id.get(id).map(|r| r.clone())
+    }
+
+    pub fn get_by_name(&self, name: &str) -> Option<Arc<ResourceEntry<T>>> {
+        let id = self.by_name.get(name)?.clone();
+        self.get_by_id(&id)
+    }
+
+    /// True if a different id already owns `name`. Used for duplicate-name
+    /// detection on admin create/update (`self_id` = the id being updated,
+    /// None for create).
+    pub fn name_conflicts(&self, name: &str, self_id: Option<&str>) -> bool {
+        match self.by_name.get(name) {
+            Some(existing_id) => match self_id {
+                Some(me) => existing_id.as_str() != me,
+                None => true,
+            },
+            None => false,
+        }
+    }
+
+    /// Snapshot of all entries. Callers get owned `Arc` clones, so iteration
+    /// does not hold DashMap shards.
+    pub fn entries(&self) -> Vec<Arc<ResourceEntry<T>>> {
+        self.by_id.iter().map(|kv| kv.value().clone()).collect()
+    }
+}
+
+/// Handle consumers clone to reach the current snapshot.
+///
+/// `SnapshotHandle<S>` is the type actually stored in axum state — consumers
+/// call [`SnapshotHandle::load`] on every request to get the current `Arc<S>`
+/// without any locking.
+#[derive(Debug, Clone)]
+pub struct SnapshotHandle<S> {
+    inner: Arc<ArcSwap<S>>,
+}
+
+impl<S> SnapshotHandle<S> {
+    pub fn new(initial: S) -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(initial)),
+        }
+    }
+
+    /// Atomic load. Cheap (one Acquire load).
+    pub fn load(&self) -> Arc<S> {
+        self.inner.load_full()
+    }
+
+    /// Atomic store. Called by the etcd watch supervisor after building a
+    /// fresh snapshot.
+    pub fn store(&self, new: S) {
+        self.inner.store(Arc::new(new));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct Item {
+        id: String,
+        name: String,
+    }
+
+    impl Resource for Item {
+        fn id(&self) -> &str {
+            &self.id
+        }
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn kind() -> &'static str {
+            "items"
+        }
+    }
+
+    fn entry(id: &str, name: &str) -> ResourceEntry<Item> {
+        ResourceEntry::new(
+            id,
+            Item {
+                id: id.into(),
+                name: name.into(),
+            },
+            1,
+        )
+    }
+
+    #[test]
+    fn insert_lookup_by_id_and_name() {
+        let t = ResourceTable::<Item>::new();
+        t.insert(entry("a-1", "alpha"));
+        t.insert(entry("b-2", "beta"));
+
+        assert_eq!(t.len(), 2);
+        assert_eq!(t.get_by_id("a-1").unwrap().name(), "alpha");
+        assert_eq!(t.get_by_name("beta").unwrap().id(), "b-2");
+        assert!(t.get_by_name("missing").is_none());
+    }
+
+    #[test]
+    fn rename_on_update_cleans_old_name_index() {
+        let t = ResourceTable::<Item>::new();
+        t.insert(entry("a-1", "alpha"));
+
+        // Rename a-1 from alpha → aleph.
+        t.insert(entry("a-1", "aleph"));
+
+        assert_eq!(t.len(), 1);
+        assert!(t.get_by_name("alpha").is_none());
+        assert_eq!(t.get_by_name("aleph").unwrap().id(), "a-1");
+    }
+
+    #[test]
+    fn duplicate_name_creates_conflict() {
+        let t = ResourceTable::<Item>::new();
+        t.insert(entry("a-1", "alpha"));
+        assert!(t.name_conflicts("alpha", None));
+        assert!(!t.name_conflicts("alpha", Some("a-1"))); // updating self is fine
+        assert!(t.name_conflicts("alpha", Some("other")));
+    }
+
+    #[test]
+    fn remove_clears_both_indices() {
+        let t = ResourceTable::<Item>::new();
+        t.insert(entry("a-1", "alpha"));
+        assert!(t.remove("a-1").is_some());
+        assert!(t.get_by_id("a-1").is_none());
+        assert!(t.get_by_name("alpha").is_none());
+    }
+
+    #[test]
+    fn snapshot_handle_atomic_swap() {
+        let handle: SnapshotHandle<u64> = SnapshotHandle::new(0);
+        assert_eq!(*handle.load(), 0);
+        handle.store(42);
+        assert_eq!(*handle.load(), 42);
+    }
+
+    #[test]
+    fn handle_is_clone_and_share_the_same_cell() {
+        let a: SnapshotHandle<u64> = SnapshotHandle::new(1);
+        let b = a.clone();
+        a.store(99);
+        // b sees a's write — same underlying ArcSwap.
+        assert_eq!(*b.load(), 99);
+    }
+}


### PR DESCRIPTION
## Summary

Lands the four primitives every other crate in the workspace depends on. No framework pulls — the crate stays free of axum/tokio/reqwest so it can be reused everywhere.

## What's in

### `config::Config`
YAML/TOML/JSON bootstrap loader (extension-inferred) with:
- env overrides (\`AISIX__<section>__<key>\`)
- \`deny_unknown_fields\` everywhere so typos fail loud
- validation: non-empty etcd endpoints, at least one admin key, proxy/admin \`addr\` must parse as \`SocketAddr\`
- sections: \`etcd\`, \`proxy\`, \`admin\`, \`observability\`, \`cache\` — matches \`config.example.yaml\`

### \`resource::Resource\` + \`ResourceEntry<T>\`
- \`Resource\` trait: \`id()\` / \`name()\` / \`kind()\` — every etcd entity will implement this in PR #4
- \`ResourceEntry<T> { id, value, revision }\` with \`Deref<Target = T>\` so handlers write \`entry.name()\` instead of \`entry.value.name()\` (spec §3)

### \`snapshot::ResourceTable<T>\` + \`SnapshotHandle<S>\`
- \`ResourceTable\`: DashMap primary id-index + secondary name-index, both point at the same \`Arc<ResourceEntry<T>>\`. Rename-on-update cleans the stale name entry atomically.
- \`name_conflicts(name, self_id)\` — duplicate-detection primitive the admin layer needs for 400s on POST/PUT
- \`SnapshotHandle<S>\`: single-method wrapper over \`ArcSwap<S>\` so consumers call \`.load()\` (one Acquire load) on every request — no mutex on the read path (spec §2)

### \`error::{ProxyError, AdminError, BootstrapError}\`
- \`ProxyError\`: OpenAI-compatible \`{error: {message, type, param, code}}\` envelope with per-variant HTTP status (401 / 403 / 413 / 429 / 502 / 504). \`retry_after_secs\` is \`Some\` for RPM/TPM and \`None\` for concurrency (spec §8 \`Retry-After\` rule).
- \`AdminError\`: simple \`{error_msg}\` envelope (spec §10).
- \`BootstrapError\`: typed startup failures carrying the exact field/addr that went wrong (spec §1 TLS / port-conflict error requirements).

## Test plan

- [x] \`cargo test -p aisix-core\` — 17 tests green
  - error: 4 (statuses, OpenAI envelope shape, simple admin envelope, retry-after semantics)
  - resource: 2 (Deref through, serde shape)
  - snapshot: 5 (insert/lookup, rename, duplicate detection, remove, atomic swap, clone-shares-cell)
  - config: 5 (minimal load, empty endpoints, empty admin keys, bad addr, unknown fields)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] Full workspace compiles

## Intentionally NOT here

| Lands in | Scope |
|----------|-------|
| PR #3 | \`ConfigProvider\` trait + etcd watch supervisor (connects the static \`Config\` to the dynamic resource stream) |
| PR #4 | Concrete \`Model\`, \`ApiKey\`, \`Team\`, \`Budget\`, \`Credential\`, \`Guardrail\`, \`FallbackPolicy\` — all implementing \`Resource\`, with Draft 2020-12 JSON Schema validators |
| PR #5 | The real bootstrap in \`aisix-server\` (10-step startup, \`SnapshotHandle\` plumbed into axum state) |