### PR TITLE
feat(core): Model, ApiKey, RateLimit entities + JSON Schema validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -85,6 +87,9 @@ dependencies = [
  "dashmap",
  "humantime-serde",
  "insta",
+ "jsonschema",
+ "once_cell",
+ "regex",
  "rstest",
  "serde",
  "serde_json",
@@ -576,6 +581,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,10 +611,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -900,6 +932,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1020,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1059,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1094,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1681,6 +1754,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f66fe41fa46a5c83ed1c717b7e0b4635988f427083108c8cf0a882cc13441"
+dependencies = [
+ "ahash",
+ "base64",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +2019,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,11 +2043,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2037,6 +2186,12 @@ dependencies = [
  "tokio-stream",
  "tracing",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -2460,6 +2615,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dcb5ab28989ad7c91eb1b9531a37a1a137cc69a0499aee4117cae4a107c464"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2690,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -3614,6 +3803,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3824,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"

--- a/crates/aisix-core/Cargo.toml
+++ b/crates/aisix-core/Cargo.toml
@@ -20,6 +20,9 @@ chrono.workspace = true
 tracing.workspace = true
 config.workspace = true
 humantime-serde.workspace = true
+jsonschema.workspace = true
+once_cell.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod config;
 pub mod error;
+pub mod models;
 pub mod resource;
 pub mod snapshot;
 
@@ -27,6 +28,10 @@ pub use config::{
 };
 pub use error::{
     AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,
+};
+pub use models::{
+    validate_apikey, validate_model, AisixSnapshot, ApiKey, Model, Provider, ProviderConfig,
+    RateLimit, SchemaError,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -1,0 +1,108 @@
+//! `ApiKey` entity — the caller-facing credential presented in
+//! `Authorization: Bearer <key>` (spec §3, §7).
+
+use serde::{Deserialize, Serialize};
+
+use super::rate_limit::RateLimit;
+use crate::resource::Resource;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApiKey {
+    /// The actual secret bearer value. Secondary-indexed for O(1) auth.
+    pub key: String,
+
+    /// Whitelisted Model names. An **empty array** denies every model —
+    /// it is not a shortcut for "all" (spec §3 authz rule).
+    pub allowed_models: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<RateLimit>,
+
+    /// etcd-key uuid; filled by the loader, never in the JSON payload.
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+impl ApiKey {
+    /// True if this key is allowed to call the given Model.
+    pub fn can_access(&self, model_name: &str) -> bool {
+        self.allowed_models.iter().any(|n| n == model_name)
+    }
+}
+
+impl Resource for ApiKey {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    /// For ApiKey the "secondary-indexed" field is `key`, not a human name.
+    /// The name-index in the snapshot therefore points from key → id.
+    fn name(&self) -> &str {
+        &self.key
+    }
+
+    fn kind() -> &'static str {
+        "apikeys"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ApiKey {
+        serde_json::from_str(
+            r#"{
+              "key": "sk-my-api-key-123",
+              "allowed_models": ["my-gpt4", "my-claude"],
+              "rate_limit": {"rpm": 60, "concurrency": 5}
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn deserialises_spec_sample() {
+        let k = sample();
+        assert_eq!(k.key, "sk-my-api-key-123");
+        assert_eq!(k.allowed_models.len(), 2);
+        assert_eq!(k.rate_limit.as_ref().unwrap().concurrency, Some(5));
+    }
+
+    #[test]
+    fn empty_allowed_models_denies_everything() {
+        let k = ApiKey {
+            key: "sk-x".into(),
+            allowed_models: vec![],
+            rate_limit: None,
+            runtime_id: String::new(),
+        };
+        assert!(!k.can_access("my-gpt4"));
+        assert!(!k.can_access("anything"));
+    }
+
+    #[test]
+    fn can_access_checks_whitelist() {
+        let k = sample();
+        assert!(k.can_access("my-gpt4"));
+        assert!(k.can_access("my-claude"));
+        assert!(!k.can_access("other"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let r: Result<ApiKey, _> =
+            serde_json::from_str(r#"{"key":"x","allowed_models":[],"extra":1}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn resource_trait_points_at_key_and_kind() {
+        let mut k = sample();
+        k.runtime_id = "uuid-ak".into();
+        assert_eq!(<ApiKey as Resource>::kind(), "apikeys");
+        assert_eq!(k.id(), "uuid-ak");
+        assert_eq!(k.name(), "sk-my-api-key-123");
+    }
+}

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -1,0 +1,25 @@
+//! Typed entities persisted in etcd and loaded into the gateway snapshot.
+//!
+//! Each entity is paired with a JSON Schema (spec §3) compiled once at
+//! startup and reused on both the admin write path and the watch read path.
+//!
+//! The entities landing in this PR:
+//! - [`Model`] — routing target (§3)
+//! - [`ApiKey`] — caller credential (§3)
+//! - [`RateLimit`] — shared rate-limit config (§3.4 / §8)
+//!
+//! Further entities (`Team`, `Budget`, `Credential`, `Guardrail`,
+//! `FallbackPolicy`, `RoutingPolicy`) land alongside the feature PRs that
+//! consume them so the schema lives next to its runtime usage.
+
+pub mod apikey;
+pub mod model;
+pub mod rate_limit;
+pub mod schema;
+pub mod snapshot;
+
+pub use apikey::ApiKey;
+pub use model::{Model, Provider, ProviderConfig};
+pub use rate_limit::RateLimit;
+pub use schema::{validate_apikey, validate_model, SchemaError};
+pub use snapshot::AisixSnapshot;

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -1,0 +1,238 @@
+//! `Model` entity — the routing target users reference from API requests
+//! (spec §3).
+//!
+//! A Model has a user-chosen unique `name`, a canonical `model` id of the
+//! form `<provider>/<model_name>`, a `provider_config` block with the
+//! upstream API key, an optional `timeout`, and an optional `rate_limit`.
+//!
+//! etcd path: `{prefix}/models/{uuid}`. Secondary index on `name`.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use super::rate_limit::RateLimit;
+use crate::resource::Resource;
+
+static MODEL_ID_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(anthropic|deepseek|gemini|openai)/.+$").unwrap());
+
+/// Supported provider prefixes. The `model` field must start with one of these
+/// followed by `/<upstream-model-id>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Provider {
+    Openai,
+    Anthropic,
+    Gemini,
+    Deepseek,
+}
+
+impl Provider {
+    pub const fn default_base_url(self) -> &'static str {
+        match self {
+            Self::Openai => "https://api.openai.com",
+            Self::Anthropic => "https://api.anthropic.com",
+            Self::Gemini => "https://generativelanguage.googleapis.com/v1beta/openai",
+            Self::Deepseek => "https://api.deepseek.com",
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Openai => "openai",
+            Self::Anthropic => "anthropic",
+            Self::Gemini => "gemini",
+            Self::Deepseek => "deepseek",
+        }
+    }
+}
+
+/// Upstream provider credentials and endpoint override.
+///
+/// Per spec §3, ProviderConfig is *untagged* — the provider type is derived
+/// from the `model` field's prefix, not from a discriminator in this struct.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderConfig {
+    pub api_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_base: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Model {
+    pub name: String,
+    pub model: String,
+    pub provider_config: ProviderConfig,
+
+    /// Request timeout in ms. 0 or absent = no timeout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<RateLimit>,
+
+    /// Non-schema runtime id. Not part of the JSON payload — filled in by
+    /// the snapshot loader from the etcd key path. Kept here so `Resource`
+    /// can return a `&str` id.
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+impl Model {
+    /// Parse the `<provider>/<model_name>` prefix. Returns `None` if the
+    /// `model` field doesn't match the spec regex — callers should have
+    /// already run schema validation.
+    pub fn provider(&self) -> Option<Provider> {
+        let (prefix, _) = self.model.split_once('/')?;
+        match prefix {
+            "openai" => Some(Provider::Openai),
+            "anthropic" => Some(Provider::Anthropic),
+            "gemini" => Some(Provider::Gemini),
+            "deepseek" => Some(Provider::Deepseek),
+            _ => None,
+        }
+    }
+
+    /// Returns the upstream-facing model id (everything after the first `/`).
+    pub fn upstream_model(&self) -> Option<&str> {
+        self.model.split_once('/').map(|(_, m)| m)
+    }
+
+    /// The base URL reqwest should use — provider default or the explicit
+    /// `api_base` override.
+    pub fn base_url(&self) -> Option<String> {
+        let base = self
+            .provider_config
+            .api_base
+            .clone()
+            .or_else(|| self.provider().map(|p| p.default_base_url().to_string()))?;
+        Some(base)
+    }
+
+    /// True if the model id matches the spec regex.
+    pub fn has_valid_model_id(&self) -> bool {
+        MODEL_ID_RE.is_match(&self.model)
+    }
+}
+
+impl Resource for Model {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn kind() -> &'static str {
+        "models"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_json() -> &'static str {
+        r#"{
+          "name": "my-gpt4",
+          "model": "openai/gpt-4o",
+          "provider_config": {
+            "api_key": "sk-redacted",
+            "api_base": "https://api.openai.com/v1"
+          },
+          "timeout": 30000,
+          "rate_limit": {"rpm": 100, "tpm": 100000}
+        }"#
+    }
+
+    #[test]
+    fn deserialises_spec_sample() {
+        let m: Model = serde_json::from_str(sample_json()).unwrap();
+        assert_eq!(m.name, "my-gpt4");
+        assert_eq!(m.provider(), Some(Provider::Openai));
+        assert_eq!(m.upstream_model(), Some("gpt-4o"));
+        assert_eq!(m.base_url().as_deref(), Some("https://api.openai.com/v1"));
+        assert_eq!(m.timeout, Some(30_000));
+        assert_eq!(m.rate_limit.as_ref().unwrap().rpm, Some(100));
+    }
+
+    #[test]
+    fn base_url_falls_back_to_provider_default() {
+        let m: Model = serde_json::from_str(
+            r#"{
+              "name": "x",
+              "model": "anthropic/claude-3",
+              "provider_config": {"api_key": "k"}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(m.base_url().as_deref(), Some("https://api.anthropic.com"));
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_fields() {
+        let r: Result<Model, _> = serde_json::from_str(
+            r#"{
+              "name":"x","model":"openai/gpt-4","provider_config":{"api_key":"k"},
+              "foo": 1
+            }"#,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn has_valid_model_id_matches_spec_regex() {
+        let mk = |s: &str| Model {
+            name: "x".into(),
+            model: s.into(),
+            provider_config: ProviderConfig {
+                api_key: "k".into(),
+                api_base: None,
+            },
+            timeout: None,
+            rate_limit: None,
+            runtime_id: String::new(),
+        };
+
+        assert!(mk("openai/gpt-4").has_valid_model_id());
+        assert!(mk("anthropic/claude-3.5").has_valid_model_id());
+        assert!(mk("deepseek/dsv3").has_valid_model_id());
+        assert!(mk("gemini/gemini-1.5-pro").has_valid_model_id());
+        assert!(!mk("mistral/large").has_valid_model_id());
+        assert!(!mk("openai").has_valid_model_id());
+        assert!(!mk("openai/").has_valid_model_id());
+    }
+
+    #[test]
+    fn resource_trait_routes_through_name() {
+        let mut m: Model = serde_json::from_str(sample_json()).unwrap();
+        m.runtime_id = "uuid-1".into();
+        assert_eq!(<Model as Resource>::kind(), "models");
+        assert_eq!(m.id(), "uuid-1");
+        assert_eq!(m.name(), "my-gpt4");
+    }
+
+    #[test]
+    fn provider_default_urls_are_stable() {
+        assert_eq!(
+            Provider::Openai.default_base_url(),
+            "https://api.openai.com"
+        );
+        assert_eq!(
+            Provider::Anthropic.default_base_url(),
+            "https://api.anthropic.com"
+        );
+        assert_eq!(
+            Provider::Gemini.default_base_url(),
+            "https://generativelanguage.googleapis.com/v1beta/openai"
+        );
+        assert_eq!(
+            Provider::Deepseek.default_base_url(),
+            "https://api.deepseek.com"
+        );
+    }
+}

--- a/crates/aisix-core/src/models/rate_limit.rs
+++ b/crates/aisix-core/src/models/rate_limit.rs
@@ -1,0 +1,71 @@
+//! Rate-limit configuration attached to Models and ApiKeys.
+//!
+//! All fields are optional; absence means "no limit on that dimension".
+//! Windows per spec §3:
+//! - `tpm`/`rpm` — 60s fixed window
+//! - `tpd`/`rpd` — 86400s fixed window
+//! - `concurrency` — semaphore capacity (not windowed)
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RateLimit {
+    /// Tokens per minute (60s window).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tpm: Option<u64>,
+
+    /// Tokens per day (86400s window).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tpd: Option<u64>,
+
+    /// Requests per minute (60s window).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpm: Option<u64>,
+
+    /// Requests per day (86400s window).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpd: Option<u64>,
+
+    /// Max concurrent in-flight requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<u32>,
+}
+
+impl RateLimit {
+    pub const fn is_unrestricted(&self) -> bool {
+        self.tpm.is_none()
+            && self.tpd.is_none()
+            && self.rpm.is_none()
+            && self.rpd.is_none()
+            && self.concurrency.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_unrestricted() {
+        assert!(RateLimit::default().is_unrestricted());
+    }
+
+    #[test]
+    fn omits_none_fields_on_serialise() {
+        let rl = RateLimit {
+            rpm: Some(60),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&rl).unwrap();
+        assert_eq!(json["rpm"], 60);
+        assert!(json.get("tpm").is_none());
+        assert!(json.get("concurrency").is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let r: Result<RateLimit, _> = serde_json::from_str(r#"{"rpm": 10, "extra": 1}"#);
+        assert!(r.is_err());
+    }
+}

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1,0 +1,224 @@
+//! JSON Schema Draft 2020-12 validators for every entity written via the
+//! Admin API (spec §2, §3).
+//!
+//! The flow on write is:
+//! ```text
+//! 1. parse bytes as serde_json::Value
+//! 2. validator.validate(&value)       → emits detailed field path on failure
+//! 3. serde deserialise into the typed struct (cheap after schema passes)
+//! 4. duplicate-name check vs snapshot
+//! 5. etcd txn commit
+//! ```
+//!
+//! The watch path reuses step 2 on incoming events — malformed payloads are
+//! skipped with a warning and do not take down the gateway.
+
+use jsonschema::Validator;
+use once_cell::sync::Lazy;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use thiserror::Error;
+
+/// Cached compiled schemas. Compiling on every write would be wasteful; the
+/// schemas are static, so we build them once.
+pub struct Schemas {
+    pub model: Validator,
+    pub apikey: Validator,
+}
+
+pub static SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::compile()));
+
+impl Schemas {
+    fn compile() -> Self {
+        Self {
+            model: jsonschema::options()
+                .build(&model_schema())
+                .expect("model schema is well-formed"),
+            apikey: jsonschema::options()
+                .build(&apikey_schema())
+                .expect("apikey schema is well-formed"),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("schema validation failed at `{path}`: {message}")]
+pub struct SchemaError {
+    pub path: String,
+    pub message: String,
+}
+
+/// Run a compiled validator and collapse all errors into a single
+/// human-readable message containing the first failing JSON pointer.
+pub fn validate(validator: &Validator, value: &Value) -> Result<(), SchemaError> {
+    let mut errors = validator.iter_errors(value);
+    if let Some(err) = errors.next() {
+        return Err(SchemaError {
+            path: err.instance_path.to_string(),
+            message: err.to_string(),
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_model(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.model, value)
+}
+
+pub fn validate_apikey(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.apikey, value)
+}
+
+fn model_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["name", "model", "provider_config"],
+        "additionalProperties": false,
+        "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "model": {
+                "type": "string",
+                "pattern": "^(anthropic|deepseek|gemini|openai)/.+$"
+            },
+            "provider_config": {
+                "type": "object",
+                "required": ["api_key"],
+                "additionalProperties": false,
+                "properties": {
+                    "api_key": { "type": "string", "minLength": 1 },
+                    "api_base": { "type": "string" }
+                }
+            },
+            "timeout": { "type": "integer", "minimum": 0 },
+            "rate_limit": { "$ref": "#/$defs/rate_limit" }
+        },
+        "$defs": {
+            "rate_limit": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "tpm":         { "type": "integer", "minimum": 0 },
+                    "tpd":         { "type": "integer", "minimum": 0 },
+                    "rpm":         { "type": "integer", "minimum": 0 },
+                    "rpd":         { "type": "integer", "minimum": 0 },
+                    "concurrency": { "type": "integer", "minimum": 0 }
+                }
+            }
+        }
+    })
+}
+
+fn apikey_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["key", "allowed_models"],
+        "additionalProperties": false,
+        "properties": {
+            "key": { "type": "string", "minLength": 1 },
+            "allowed_models": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "rate_limit": { "$ref": "#/$defs/rate_limit" }
+        },
+        "$defs": {
+            "rate_limit": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "tpm":         { "type": "integer", "minimum": 0 },
+                    "tpd":         { "type": "integer", "minimum": 0 },
+                    "rpm":         { "type": "integer", "minimum": 0 },
+                    "rpd":         { "type": "integer", "minimum": 0 },
+                    "concurrency": { "type": "integer", "minimum": 0 }
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn model_happy_path_passes() {
+        let v = json!({
+            "name": "my-gpt4",
+            "model": "openai/gpt-4o",
+            "provider_config": {"api_key": "sk-x"},
+            "timeout": 30000,
+            "rate_limit": {"rpm": 100}
+        });
+        validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_missing_name_fails_with_useful_path() {
+        let v = json!({
+            "model": "openai/gpt-4o",
+            "provider_config": {"api_key": "sk-x"}
+        });
+        let err = validate_model(&v).unwrap_err();
+        assert!(err.message.contains("name"));
+    }
+
+    #[test]
+    fn model_bad_provider_prefix_fails() {
+        let v = json!({
+            "name": "x",
+            "model": "mistral/large",
+            "provider_config": {"api_key": "k"}
+        });
+        let err = validate_model(&v).unwrap_err();
+        assert!(err.path.contains("/model") || err.message.to_lowercase().contains("pattern"));
+    }
+
+    #[test]
+    fn model_rejects_additional_top_level() {
+        let v = json!({
+            "name":"x","model":"openai/g","provider_config":{"api_key":"k"},
+            "rogue": 1
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn apikey_happy_path_passes() {
+        let v = json!({"key":"sk-x","allowed_models":["a","b"]});
+        validate_apikey(&v).unwrap();
+    }
+
+    #[test]
+    fn apikey_missing_allowed_models_fails() {
+        let v = json!({"key":"sk-x"});
+        let err = validate_apikey(&v).unwrap_err();
+        assert!(err.message.to_lowercase().contains("allowed_models"));
+    }
+
+    #[test]
+    fn apikey_empty_allowed_models_is_valid_but_denies_all() {
+        // Schema permits []; runtime ApiKey::can_access enforces deny-all.
+        let v = json!({"key":"sk-x","allowed_models":[]});
+        validate_apikey(&v).unwrap();
+    }
+
+    #[test]
+    fn rate_limit_negative_value_rejected() {
+        let v = json!({
+            "name":"x","model":"openai/g","provider_config":{"api_key":"k"},
+            "rate_limit": {"rpm": -1}
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn schemas_initialise_once() {
+        let a = Arc::as_ptr(&*SCHEMAS);
+        let b = Arc::as_ptr(&*SCHEMAS);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -1,0 +1,81 @@
+//! The concrete snapshot shape for aisix — one table per entity kind.
+//!
+//! The etcd watch supervisor builds a fresh [`AisixSnapshot`] on every
+//! coherent rebuild (compaction, initial load) and atomically swaps it into
+//! a [`SnapshotHandle<AisixSnapshot>`]. The data plane only sees the handle.
+//!
+//! Later entities (`Team`, `Budget`, `Guardrail`, …) will be added here as
+//! their feature PRs land.
+
+use super::apikey::ApiKey;
+use super::model::Model;
+use crate::snapshot::ResourceTable;
+
+/// Composite of every typed [`ResourceTable`] the gateway reads on the hot
+/// path. Cheap to construct empty; populated by the loader.
+#[derive(Debug, Default)]
+pub struct AisixSnapshot {
+    pub models: ResourceTable<Model>,
+    pub apikeys: ResourceTable<ApiKey>,
+}
+
+impl AisixSnapshot {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Convenience: total entry count across all tables. Handy for debug /
+    /// readiness checks.
+    pub fn total_entries(&self) -> usize {
+        self.models.len() + self.apikeys.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::ResourceEntry;
+
+    fn sample_model() -> Model {
+        serde_json::from_str(
+            r#"{
+              "name": "my-gpt4",
+              "model": "openai/gpt-4o",
+              "provider_config": {"api_key": "sk-x"}
+            }"#,
+        )
+        .unwrap()
+    }
+
+    fn sample_apikey() -> ApiKey {
+        serde_json::from_str(r#"{"key": "sk-my-api-key-123", "allowed_models": ["my-gpt4"]}"#)
+            .unwrap()
+    }
+
+    #[test]
+    fn empty_snapshot_has_no_entries() {
+        let s = AisixSnapshot::new();
+        assert_eq!(s.total_entries(), 0);
+        assert!(s.models.is_empty());
+        assert!(s.apikeys.is_empty());
+    }
+
+    #[test]
+    fn tables_are_independent() {
+        let s = AisixSnapshot::new();
+        s.models
+            .insert(ResourceEntry::new("m-1", sample_model(), 1));
+        s.apikeys
+            .insert(ResourceEntry::new("k-1", sample_apikey(), 1));
+
+        assert_eq!(s.total_entries(), 2);
+        // Note: `.id` is the wrapper field (etcd key uuid); the inner
+        // `Resource::id()` would read the private `runtime_id` which the
+        // loader fills in separately.
+        assert_eq!(s.models.get_by_name("my-gpt4").unwrap().id, "m-1");
+        assert_eq!(
+            s.apikeys.get_by_name("sk-my-api-key-123").unwrap().id,
+            "k-1"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the three entities from spec §3 that the admin plane writes and
the data plane reads on every request, alongside their Draft 2020-12
JSON Schemas and the composite \`AisixSnapshot\`.

- **Model** — \`<provider>/<upstream>\` routing target. \`Provider\` enum
  (openai/anthropic/gemini/deepseek) with default base URLs;
  \`ProviderConfig\` supports an \`api_base\` override.
- **ApiKey** — bearer credential with \`allowed_models\` whitelist.
  Empty array denies all per spec §3 authz rule.
- **RateLimit** — tpm / tpd / rpm / rpd / concurrency, all optional.
- **schema.rs** — validators compiled once via \`Lazy<Arc<Schemas>>\`,
  reused on admin write *and* etcd watch read paths. \`SchemaError\`
  collapses to the first failing JSON pointer.
- **AisixSnapshot** — \`ResourceTable<Model>\` + \`ResourceTable<ApiKey>\`;
  the atomic-swap target for the future watch supervisor.

Reuses the generic \`ResourceTable\` / \`SnapshotHandle\` primitives that
landed in #2.

## Test plan

- [x] \`cargo test -p aisix-core\` — 42 tests pass
- [x] \`cargo clippy -p aisix-core --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs