### PR TITLE
feat(server): startup sequence + health listeners

### DIFF
--- a/crates/aisix-admin/Cargo.toml
+++ b/crates/aisix-admin/Cargo.toml
@@ -27,3 +27,6 @@ utoipa-axum.workspace = true
 utoipa-scalar.workspace = true
 rust-embed.workspace = true
 mime_guess.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -1,4 +1,100 @@
-//! aisix-admin — Admin API (:3001).
+//! aisix-admin — Admin API + Playground + embedded UI (:3001).
+//!
+//! PR #5 provides only the startup-sequence building block: [`build_router`]
+//! mounts `/health` so the server binary can bind and serve its admin
+//! listener. The full CRUD surface for Models / ApiKeys, the OpenAPI
+//! scalar, and the embedded UI are implemented in follow-up PRs.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+use aisix_core::snapshot::SnapshotHandle;
+use aisix_core::{AdminConfig, AisixSnapshot};
+use axum::{http::StatusCode, routing::get, Json, Router};
+use serde_json::json;
+use std::sync::Arc;
+
+/// Runtime state shared across admin handlers.
+#[derive(Clone)]
+pub struct AdminState {
+    pub snapshot: SnapshotHandle<AisixSnapshot>,
+    /// Admin keys are held as an Arc<[String]> so cloning the state is cheap.
+    pub admin_keys: Arc<[String]>,
+}
+
+impl AdminState {
+    pub fn new(snapshot: SnapshotHandle<AisixSnapshot>, cfg: &AdminConfig) -> Self {
+        Self {
+            snapshot,
+            admin_keys: Arc::from(cfg.admin_keys.clone()),
+        }
+    }
+}
+
+/// Build the admin router. For PR #5 this is just `/health`.
+pub fn build_router(state: AdminState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .with_state(state)
+}
+
+async fn health(
+    axum::extract::State(state): axum::extract::State<AdminState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let snap = state.snapshot.load();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": "ok",
+            "models": snap.models.len(),
+            "apikeys": snap.apikeys.len(),
+        })),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn cfg() -> AdminConfig {
+        AdminConfig {
+            addr: "127.0.0.1:0".into(),
+            admin_keys: vec!["k1".into()],
+            tls: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn health_returns_ok_and_counts() {
+        let handle = SnapshotHandle::new(AisixSnapshot::new());
+        let state = AdminState::new(handle, &cfg());
+        let app = build_router(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["status"], "ok");
+    }
+
+    #[test]
+    fn admin_state_clones_admin_keys_into_arc() {
+        let handle = SnapshotHandle::new(AisixSnapshot::new());
+        let state = AdminState::new(handle, &cfg());
+        let b = state.clone();
+        assert_eq!(b.admin_keys.len(), 1);
+        assert_eq!(&*b.admin_keys[0], "k1");
+    }
+}

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -1,4 +1,85 @@
-//! aisix-obs — observability facade (tracing + metrics + access log).
+//! aisix-obs — observability bootstrap.
+//!
+//! This crate will hold the OpenTelemetry + Prometheus wiring and the
+//! access-log middleware. For PR #5 we expose just [`init_tracing`], the
+//! startup-sequence call that turns the config's `log_level` into an
+//! `EnvFilter` and installs a formatted subscriber.
+//!
+//! OTLP export, Langfuse, and Prometheus registration arrive in their own
+//! PRs so this crate stays focused.
 
-#![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+use aisix_core::ObservabilityConfig;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ObsError {
+    #[error("invalid log filter directive {directive:?}: {source}")]
+    Filter {
+        directive: String,
+        #[source]
+        source: tracing_subscriber::filter::ParseError,
+    },
+    #[error("tracing subscriber already initialised")]
+    AlreadyInitialised,
+}
+
+/// Install a process-wide tracing subscriber.
+///
+/// - Log level comes from `cfg.log_level` (a `tracing_subscriber::EnvFilter`
+///   directive string, e.g. `"info"`, `"aisix=debug,tower=warn"`).
+/// - The `RUST_LOG` env var, if set, overrides the config's directive —
+///   standard Rust convention so operators can debug without a restart
+///   of the rollout pipeline.
+/// - Output format is plain text to stderr for now; structured JSON will
+///   be a config knob in a later PR.
+pub fn init_tracing(cfg: &ObservabilityConfig) -> Result<(), ObsError> {
+    let filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(&cfg.log_level))
+        .map_err(|source| ObsError::Filter {
+            directive: cfg.log_level.clone(),
+            source,
+        })?;
+
+    let fmt_layer = fmt::layer().with_target(true).with_writer(std::io::stderr);
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt_layer)
+        .try_init()
+        .map_err(|_| ObsError::AlreadyInitialised)?;
+
+    tracing::info!(
+        service = %cfg.service_name,
+        level = %cfg.log_level,
+        "tracing initialised",
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn already_initialised_variant_is_displayable() {
+        let err = ObsError::AlreadyInitialised;
+        assert_eq!(err.to_string(), "tracing subscriber already initialised");
+    }
+
+    #[test]
+    fn filter_error_carries_the_bad_directive() {
+        // Directly exercise the EnvFilter parse error path — fabricating
+        // the error avoids touching the global tracing subscriber, which
+        // is a process-wide singleton that can't be re-initialised safely
+        // across tests.
+        let bad = "BAD=@notalevel";
+        let err = tracing_subscriber::EnvFilter::try_new(bad).unwrap_err();
+        let wrapped = ObsError::Filter {
+            directive: bad.into(),
+            source: err,
+        };
+        assert!(wrapped.to_string().contains(bad));
+    }
+}

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -31,3 +31,6 @@ async-trait.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1,4 +1,97 @@
-//! aisix-proxy — client-facing Proxy router (:3000).
+//! aisix-proxy — client-facing proxy router (:3000).
+//!
+//! This crate will host the full `/v1/*` OpenAI-compatible surface. For
+//! PR #5 only the startup-sequence building block is here: [`build_router`]
+//! returns a minimal router with `/health` so the server binary can bind,
+//! serve, and be exercised by the startup-sequence e2e test.
+//!
+//! The full routes, middleware stack, and streaming bridges land in their
+//! own follow-up PRs.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+use aisix_core::snapshot::SnapshotHandle;
+use aisix_core::{AisixSnapshot, ProxyConfig};
+use axum::{http::StatusCode, routing::get, Json, Router};
+use serde_json::json;
+
+/// Runtime state the proxy router hands to handlers. Cheap to clone
+/// (contains only an `Arc`-backed `SnapshotHandle`).
+#[derive(Clone)]
+pub struct ProxyState {
+    pub snapshot: SnapshotHandle<AisixSnapshot>,
+    pub request_body_limit_bytes: usize,
+}
+
+impl ProxyState {
+    pub fn new(snapshot: SnapshotHandle<AisixSnapshot>, cfg: &ProxyConfig) -> Self {
+        Self {
+            snapshot,
+            request_body_limit_bytes: cfg.request_body_limit_bytes,
+        }
+    }
+}
+
+/// Build the proxy router. For PR #5 this is just `/health`; subsequent
+/// PRs will mount `/v1/chat/completions`, `/v1/models`, etc.
+pub fn build_router(state: ProxyState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .with_state(state)
+}
+
+async fn health(
+    axum::extract::State(state): axum::extract::State<ProxyState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let snap = state.snapshot.load();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": "ok",
+            "models": snap.models.len(),
+            "apikeys": snap.apikeys.len(),
+        })),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::snapshot::SnapshotHandle;
+    use axum::body::to_bytes;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn cfg() -> ProxyConfig {
+        ProxyConfig {
+            addr: "127.0.0.1:0".into(),
+            request_body_limit_bytes: 1024,
+            tls: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn health_returns_snapshot_counts() {
+        let handle = SnapshotHandle::new(AisixSnapshot::new());
+        let state = ProxyState::new(handle, &cfg());
+        let app = build_router(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["status"], "ok");
+        assert_eq!(v["models"], 0);
+        assert_eq!(v["apikeys"], 0);
+    }
+}

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1,9 +1,157 @@
 //! aisix — single-binary AI gateway entrypoint.
 //!
-//! This is a scaffold. The full 10-step startup sequence from spec §1 will be
-//! implemented in PR #5.
+//! Startup sequence (spec §1):
+//!  1. Parse CLI args (`--config <path>`)
+//!  2. Load + validate config (YAML/TOML/JSON, `AISIX__*` env overrides)
+//!  3. Initialise tracing
+//!  4. Connect to etcd with 5s × 5 retry
+//!  5. Bootstrap initial snapshot
+//!  6. Spawn watch supervisor
+//!  7. Build proxy router
+//!  8. Build admin router
+//!  9. Bind + serve both ports (tokio::select! with shutdown signal)
+//! 10. On SIGINT/SIGTERM: cancel supervisor, stop accepting, join
 
-fn main() -> anyhow::Result<()> {
-    println!("aisix: scaffold — full startup sequence arriving in PR #5");
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use aisix_admin::AdminState;
+use aisix_core::Config;
+use aisix_etcd::{EtcdConfigProvider, Supervisor};
+use aisix_obs::init_tracing;
+use aisix_proxy::ProxyState;
+use clap::Parser;
+use tokio::sync::watch;
+
+#[derive(Debug, Parser)]
+#[command(name = "aisix", version, about = "aisix AI Gateway")]
+struct Cli {
+    /// Path to the bootstrap config file (YAML / TOML / JSON).
+    #[arg(short, long, env = "AISIX_CONFIG")]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    // Steps 1-2: config.
+    let cfg = Config::load_from_path(Some(&cli.config))
+        .map_err(|e| anyhow::anyhow!("config load failed: {e}"))?;
+
+    // Step 3: tracing.
+    init_tracing(&cfg.observability).map_err(|e| anyhow::anyhow!("tracing init failed: {e}"))?;
+
+    run(cfg).await
+}
+
+/// Factored out of `main` so the integration tests can drive the full
+/// startup with a real config struct and still use `#[tokio::test]`.
+async fn run(cfg: Config) -> anyhow::Result<()> {
+    // Steps 4-6: etcd + supervisor.
+    let provider = Arc::new(
+        EtcdConfigProvider::connect(&cfg.etcd.endpoints, cfg.etcd.prefix.clone(), None)
+            .await
+            .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
+    );
+    let supervisor = Arc::new(Supervisor::new(provider, cfg.etcd.prefix.clone()));
+    let snapshot_handle = supervisor.handle();
+
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    let watch_task = tokio::spawn(supervisor.clone().run(cancel_rx.clone()));
+
+    // Steps 7-8: routers.
+    let proxy_router =
+        aisix_proxy::build_router(ProxyState::new(snapshot_handle.clone(), &cfg.proxy));
+    let admin_router =
+        aisix_admin::build_router(AdminState::new(snapshot_handle.clone(), &cfg.admin));
+
+    // Step 9: bind + serve.
+    let proxy_addr: std::net::SocketAddr = cfg.proxy.addr.parse()?;
+    let admin_addr: std::net::SocketAddr = cfg.admin.addr.parse()?;
+    let proxy_listener = tokio::net::TcpListener::bind(proxy_addr).await?;
+    let admin_listener = tokio::net::TcpListener::bind(admin_addr).await?;
+    tracing::info!(proxy = %proxy_addr, admin = %admin_addr, "aisix listening");
+
+    let proxy_serve = axum::serve(proxy_listener, proxy_router)
+        .with_graceful_shutdown(shutdown_signal(cancel_rx.clone(), "proxy"));
+    let admin_serve = axum::serve(admin_listener, admin_router)
+        .with_graceful_shutdown(shutdown_signal(cancel_rx.clone(), "admin"));
+
+    // Step 10: shutdown coordinator. Whichever of (signal, proxy, admin)
+    // completes first triggers the rest.
+    let signal_task = tokio::spawn(wait_for_signal(cancel_tx.clone()));
+
+    let (proxy_res, admin_res) = tokio::join!(proxy_serve, admin_serve);
+    proxy_res.map_err(|e| anyhow::anyhow!("proxy serve error: {e}"))?;
+    admin_res.map_err(|e| anyhow::anyhow!("admin serve error: {e}"))?;
+
+    // Ask the supervisor to stop (no-op if the signal task already did).
+    let _ = cancel_tx.send(true);
+    let _ = signal_task.await;
+    let _ = watch_task.await;
+    tracing::info!("aisix shut down cleanly");
     Ok(())
+}
+
+/// Completes when the process receives SIGINT or SIGTERM (best-effort on
+/// Windows — Ctrl+C only) OR when another part of the system has already
+/// flipped the cancel channel.
+async fn shutdown_signal(mut cancel: watch::Receiver<bool>, label: &'static str) {
+    loop {
+        if *cancel.borrow() {
+            tracing::info!(label, "shutdown signal observed — stopping listener");
+            return;
+        }
+        if cancel.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn wait_for_signal(cancel_tx: watch::Sender<bool>) {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let term = async {
+        use tokio::signal::unix::{signal, SignalKind};
+        if let Ok(mut s) = signal(SignalKind::terminate()) {
+            s.recv().await;
+        } else {
+            std::future::pending::<()>().await;
+        }
+    };
+
+    #[cfg(not(unix))]
+    let term = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => tracing::info!("received SIGINT"),
+        _ = term => tracing::info!("received SIGTERM"),
+    }
+
+    let _ = cancel_tx.send(true);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn cli_requires_config_path() {
+        // Missing --config must error (either from env var or arg).
+        let result = Cli::try_parse_from(["aisix"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cli_accepts_short_and_long_flags() {
+        let a = Cli::try_parse_from(["aisix", "-c", "/tmp/x.yaml"]).unwrap();
+        let b = Cli::try_parse_from(["aisix", "--config", "/tmp/x.yaml"]).unwrap();
+        assert_eq!(a.config, b.config);
+        assert_eq!(a.config, PathBuf::from("/tmp/x.yaml"));
+    }
 }


### PR DESCRIPTION
## Summary

Wires the 10-step startup sequence from spec §1 into the \`aisix\`
binary:

1. Parse CLI args (\`--config\`, with \`AISIX_CONFIG\` env fallback)
2. Load + validate bootstrap config
3. \`init_tracing\` — \`aisix-obs\` now installs an \`EnvFilter\` subscriber
4. \`EtcdConfigProvider::connect\` (5s × 5 retry, reused from PR #3)
5. Initial snapshot load via \`Supervisor::load_once\`
6. Spawn \`Supervisor::run\` on a dedicated task (cancel via \`watch\`)
7. Build proxy router (\`aisix-proxy\` now exposes \`build_router\`)
8. Build admin router (\`aisix-admin\` now exposes \`build_router\`)
9. Bind + serve both listeners with \`axum::serve\` + graceful shutdown
10. SIGINT/SIGTERM → flip cancel → drain serves → join supervisor

Both routers only mount \`/health\` for now so the bootstrap is
observable without dragging in feature code that hasn't landed yet.
The health handler reports current snapshot table sizes so the full
path is end-to-end verifiable.

## Test plan

- [x] \`cargo test --workspace\` — 75 tests pass (new + existing)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo build --bin aisix\` succeeds
- [ ] CI green on all 6 jobs