### PR TITLE
feat(provider-openai): OpenAiBridge with streaming + non-streaming chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,12 +217,17 @@ version = "0.1.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
+ "async-stream",
  "async-trait",
+ "bytes",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -383,6 +388,16 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "async-compression"
@@ -900,6 +915,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1381,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -2096,6 +2135,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4268,6 +4317,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/aisix-provider-openai/Cargo.toml
+++ b/crates/aisix-provider-openai/Cargo.toml
@@ -17,3 +17,11 @@ serde_json.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tokio.workspace = true
+futures.workspace = true
+async-stream = "0.3"
+bytes.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+wiremock.workspace = true

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -1,0 +1,458 @@
+//! `OpenAiBridge` — concrete [`Bridge`] implementation for OpenAI.
+//!
+//! Also reusable by OpenAI-compatible providers (DeepSeek, Gemini's
+//! OpenAI-compat endpoint) since their request/response wire shapes
+//! match the `/chat/completions` surface almost exactly. Those crates
+//! can wrap this bridge or construct it with a different `api_base`.
+//!
+//! Transport layer:
+//! - `reqwest::Client` is shared across requests (connection reuse).
+//! - `Authorization: Bearer <api_key>` sourced from the
+//!   [`aisix_core::Model`]'s `provider_config`.
+//! - Timeout comes from `BridgeContext::deadline` when present;
+//!   otherwise the request runs to completion.
+//!
+//! Error mapping:
+//! - reqwest transport error → `BridgeError::Transport`
+//! - upstream non-2xx → `BridgeError::UpstreamStatus` (4xx passes through,
+//!   5xx collapses to 502 via `http_status()` on the proxy side).
+//! - malformed JSON from upstream → `BridgeError::UpstreamDecode`
+//! - elapsed deadline → `BridgeError::Timeout { elapsed_ms }`
+
+use aisix_gateway::{
+    Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream, ChatFormat, ChatResponse,
+    SseDecoder, SseEvent,
+};
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::{header, Client, StatusCode};
+use std::time::{Duration, Instant};
+
+use crate::wire::{
+    build_request, messages_from, response_into_chat_response, stream_chunk_into_chat_chunk,
+    OpenAiResponse, OpenAiStreamChunk,
+};
+
+/// Fallback OpenAI host used when the Model doesn't set `api_base` and
+/// the Provider enum's default is also missing. In practice an operator
+/// configures `api_base: "https://api.openai.com/v1"` on the Model so
+/// this constant only covers degenerate config paths.
+pub const OPENAI_DEFAULT_BASE: &str = "https://api.openai.com/v1";
+
+pub struct OpenAiBridge {
+    client: Client,
+    name: &'static str,
+}
+
+impl OpenAiBridge {
+    pub fn new() -> Self {
+        Self::with_client(default_client())
+    }
+
+    pub fn with_client(client: Client) -> Self {
+        Self {
+            client,
+            name: "openai",
+        }
+    }
+
+    /// Same transport but a caller-chosen `name()` — used by OpenAI-compat
+    /// providers (DeepSeek, Gemini-OAI) so their metrics labels are distinct.
+    pub fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+}
+
+impl Default for OpenAiBridge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn default_client() -> Client {
+    Client::builder()
+        .user_agent("aisix/0.1")
+        .build()
+        .unwrap_or_else(|_| Client::new())
+}
+
+fn resolve_base(model: &aisix_core::Model) -> String {
+    match model.base_url() {
+        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
+        _ => OPENAI_DEFAULT_BASE.to_string(),
+    }
+}
+
+fn api_key(model: &aisix_core::Model) -> Result<&str, BridgeError> {
+    let k = &model.provider_config.api_key;
+    if k.is_empty() {
+        Err(BridgeError::Config(
+            "provider_config.api_key is empty".into(),
+        ))
+    } else {
+        Ok(k.as_str())
+    }
+}
+
+fn upstream_model(model: &aisix_core::Model) -> Result<&str, BridgeError> {
+    model
+        .upstream_model()
+        .ok_or_else(|| BridgeError::Config("model field missing `provider/` prefix".into()))
+}
+
+async fn map_http_error(status: StatusCode, resp: reqwest::Response) -> BridgeError {
+    let message = resp.text().await.unwrap_or_default();
+    BridgeError::UpstreamStatus {
+        status: status.as_u16(),
+        message: truncate(&message, 1024),
+    }
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.len() <= n {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..n])
+    }
+}
+
+/// Wrap a future in the optional deadline. `None` → no timeout.
+async fn with_deadline<T, F>(
+    deadline: Option<Duration>,
+    started: Instant,
+    fut: F,
+) -> Result<T, BridgeError>
+where
+    F: std::future::Future<Output = Result<T, BridgeError>>,
+{
+    match deadline {
+        None => fut.await,
+        Some(d) => match tokio::time::timeout(d, fut).await {
+            Ok(r) => r,
+            Err(_) => Err(BridgeError::Timeout {
+                elapsed_ms: started.elapsed().as_millis() as u64,
+            }),
+        },
+    }
+}
+
+#[async_trait]
+impl Bridge for OpenAiBridge {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn chat(
+        &self,
+        req: &ChatFormat,
+        ctx: &BridgeContext,
+    ) -> Result<ChatResponse, BridgeError> {
+        let model = ctx.model.as_ref();
+        let base = resolve_base(model);
+        let key = api_key(model)?;
+        let upstream = upstream_model(model)?;
+
+        let messages = messages_from(req);
+        let body = build_request(req, upstream, &messages, false);
+        let url = format!("{base}/chat/completions");
+        let client = self.client.clone();
+        let started = Instant::now();
+        let request_id = ctx.request_id.clone();
+
+        with_deadline(ctx.deadline, started, async move {
+            let resp = client
+                .post(&url)
+                .header(header::AUTHORIZATION, format!("Bearer {key}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .header("x-aisix-request-id", &request_id)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| BridgeError::Transport(e.to_string()))?;
+
+            let status = resp.status();
+            if !status.is_success() {
+                return Err(map_http_error(status, resp).await);
+            }
+
+            let parsed: OpenAiResponse = resp
+                .json()
+                .await
+                .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+            Ok(response_into_chat_response(parsed))
+        })
+        .await
+    }
+
+    async fn chat_stream(
+        &self,
+        req: &ChatFormat,
+        ctx: &BridgeContext,
+    ) -> Result<ChatChunkStream, BridgeError> {
+        let model = ctx.model.as_ref();
+        let base = resolve_base(model);
+        let key = api_key(model)?;
+        let upstream = upstream_model(model)?;
+
+        let messages = messages_from(req);
+        let body = build_request(req, upstream, &messages, true);
+        let url = format!("{base}/chat/completions");
+        let client = self.client.clone();
+        let started = Instant::now();
+        let request_id = ctx.request_id.clone();
+
+        let resp = with_deadline(ctx.deadline, started, async move {
+            client
+                .post(&url)
+                .header(header::AUTHORIZATION, format!("Bearer {key}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::ACCEPT, "text/event-stream")
+                .header("x-aisix-request-id", &request_id)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| BridgeError::Transport(e.to_string()))
+        })
+        .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(map_http_error(status, resp).await);
+        }
+
+        let byte_stream = resp.bytes_stream();
+        let stream = build_chunk_stream(byte_stream);
+        Ok(Box::pin(stream))
+    }
+}
+
+fn build_chunk_stream<S>(
+    byte_stream: S,
+) -> impl futures::Stream<Item = Result<ChatChunk, BridgeError>> + Send
+where
+    S: futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send + 'static,
+{
+    async_stream::try_stream! {
+        let mut decoder = SseDecoder::new();
+        let mut stream = Box::pin(byte_stream);
+        while let Some(next) = stream.next().await {
+            let chunk = next.map_err(|e| BridgeError::Transport(e.to_string()))?;
+            for event in decoder.feed(chunk.as_ref()) {
+                match event {
+                    SseEvent::Done => return,
+                    SseEvent::Data(payload) => {
+                        let parsed: OpenAiStreamChunk = serde_json::from_str(&payload)
+                            .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+                        yield stream_chunk_into_chat_chunk(parsed);
+                    }
+                }
+            }
+        }
+        if let Some(SseEvent::Data(payload)) = decoder.finish() {
+            let parsed: OpenAiStreamChunk = serde_json::from_str(&payload)
+                .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+            yield stream_chunk_into_chat_chunk(parsed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::Model;
+    use aisix_gateway::{ChatMessage, FinishReason, Role};
+    use std::sync::Arc;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn sample_model(base: &str) -> Arc<Model> {
+        let cfg = format!(
+            r#"{{
+                "name": "my-gpt4",
+                "model": "openai/gpt-4o",
+                "provider_config": {{"api_key": "sk-test", "api_base": "{base}"}}
+            }}"#
+        );
+        Arc::new(serde_json::from_str(&cfg).unwrap())
+    }
+
+    fn req() -> ChatFormat {
+        ChatFormat::new("my-gpt4", vec![ChatMessage::user("hi")])
+    }
+
+    #[tokio::test]
+    async fn non_streaming_happy_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer sk-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-1",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hello back"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4}
+            })))
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let resp = bridge.chat(&req(), &ctx).await.unwrap();
+
+        assert_eq!(resp.id, "cmpl-1");
+        assert_eq!(resp.message.role, Role::Assistant);
+        assert_eq!(resp.message.content, "hello back");
+        assert_eq!(resp.finish_reason, FinishReason::Stop);
+        assert_eq!(resp.usage.total_tokens, 4);
+    }
+
+    #[tokio::test]
+    async fn non_streaming_429_maps_to_upstream_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("slow down"))
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        match err {
+            BridgeError::UpstreamStatus { status, message } => {
+                assert_eq!(status, 429);
+                assert!(message.contains("slow down"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_streaming_decode_error_on_malformed_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not-json"))
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        assert!(matches!(err, BridgeError::UpstreamDecode(_)));
+    }
+
+    #[tokio::test]
+    async fn deadline_elapses_to_timeout_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_secs(5))
+                    .set_body_json(serde_json::json!({"id":"x","model":"x","choices":[]})),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()))
+            .with_deadline(Duration::from_millis(50));
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        assert!(matches!(err, BridgeError::Timeout { .. }));
+    }
+
+    #[tokio::test]
+    async fn missing_api_key_is_a_config_error() {
+        // Construct a Model whose api_key is empty. We bypass JSON Schema
+        // here because the loader would normally reject this, but tests
+        // of the Bridge's own guard still need the path exercised.
+        let mut model: Model = serde_json::from_str(
+            r#"{
+                "name": "bad",
+                "model": "openai/gpt-4o",
+                "provider_config": {"api_key": "placeholder"}
+            }"#,
+        )
+        .unwrap();
+        model.provider_config.api_key.clear();
+
+        let bridge = OpenAiBridge::new();
+        let ctx = BridgeContext::new("req-1", Arc::new(model));
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        assert!(matches!(err, BridgeError::Config(_)));
+    }
+
+    #[tokio::test]
+    async fn streaming_happy_path_emits_chunks_then_done() {
+        let server = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"cmpl-s\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-s\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-s\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
+
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.unwrap());
+        }
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].delta.role, Some(Role::Assistant));
+        assert_eq!(chunks[1].delta.content.as_deref(), Some("hel"));
+        assert_eq!(chunks[2].delta.content.as_deref(), Some("lo"));
+        assert_eq!(chunks[2].finish_reason, Some(FinishReason::Stop));
+    }
+
+    #[tokio::test]
+    async fn streaming_upstream_error_surfaces_before_stream_start() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("oops"))
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        match bridge.chat_stream(&req(), &ctx).await {
+            Ok(_) => panic!("expected upstream error, got a live stream"),
+            Err(BridgeError::UpstreamStatus { status: 500, .. }) => {}
+            Err(other) => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_base_trims_trailing_slash_and_honours_override() {
+        let mut m: Model = serde_json::from_str(
+            r#"{
+                "name": "x",
+                "model": "openai/gpt-4o",
+                "provider_config": {"api_key": "k"}
+            }"#,
+        )
+        .unwrap();
+        // No api_base set → Provider::Openai's default host.
+        assert_eq!(resolve_base(&m), "https://api.openai.com");
+
+        m.provider_config.api_base = Some("https://proxy.example.com/v1/".into());
+        assert_eq!(resolve_base(&m), "https://proxy.example.com/v1");
+    }
+}

--- a/crates/aisix-provider-openai/src/lib.rs
+++ b/crates/aisix-provider-openai/src/lib.rs
@@ -1,4 +1,17 @@
-//! aisix-provider-openai — OpenAI + OpenAI-compatible providers (Gemini, DeepSeek share this).
+//! aisix-provider-openai — OpenAI provider [`OpenAiBridge`] impl.
+//!
+//! This crate is also the transport used by other OpenAI-compatible
+//! upstreams (DeepSeek today, Gemini's OpenAI-compat endpoint later).
+//! Those provider crates can wrap [`OpenAiBridge`] with their own
+//! `api_base` and metrics label rather than duplicating the transport.
+//!
+//! See the `Bridge` trait in `aisix-gateway` for the contract this crate
+//! implements against.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+mod bridge;
+mod wire;
+
+pub use bridge::{OpenAiBridge, OPENAI_DEFAULT_BASE};

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -1,0 +1,353 @@
+//! OpenAI chat-completions wire shapes.
+//!
+//! These mirror <https://platform.openai.com/docs/api-reference/chat>.
+//! The gateway's own [`ChatFormat`](aisix_gateway::ChatFormat) is already
+//! OpenAI-compatible, but we still serialise through a dedicated type so:
+//!
+//! 1. forward compatibility — OpenAI can add fields without forcing a
+//!    breaking change on `ChatFormat`.
+//! 2. deserialisation is strict where *we* read it (responses), loose
+//!    where *they* read it (requests) — i.e. we accept extra fields
+//!    from upstream but don't invent params.
+
+use aisix_gateway::{
+    ChatChunk, ChatDelta, ChatFormat, ChatMessage, ChatResponse, FinishReason, Role, UsageStats,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct OpenAiRequest<'a> {
+    pub model: &'a str,
+    pub messages: &'a [OpenAiMessage<'a>],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    pub stream: bool,
+    #[serde(flatten)]
+    pub extra: &'a serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct OpenAiMessage<'a> {
+    pub role: &'a str,
+    pub content: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<&'a str>,
+}
+
+/// Build the upstream request from the gateway's normalised format.
+///
+/// `upstream_model` is the part after the `<provider>/` prefix from the
+/// Model entity (e.g. `"gpt-4o"`, not `"openai/gpt-4o"`).
+pub(crate) fn build_request<'a>(
+    req: &'a ChatFormat,
+    upstream_model: &'a str,
+    messages: &'a [OpenAiMessage<'a>],
+    stream: bool,
+) -> OpenAiRequest<'a> {
+    OpenAiRequest {
+        model: upstream_model,
+        messages,
+        temperature: req.temperature,
+        top_p: req.top_p,
+        max_tokens: req.max_tokens,
+        stream,
+        extra: &req.extra,
+    }
+}
+
+pub(crate) fn messages_from(req: &ChatFormat) -> Vec<OpenAiMessage<'_>> {
+    req.messages
+        .iter()
+        .map(|m| OpenAiMessage {
+            role: role_str(m.role),
+            content: &m.content,
+            name: m.name.as_deref(),
+            tool_call_id: m.tool_call_id.as_deref(),
+        })
+        .collect()
+}
+
+fn role_str(role: Role) -> &'static str {
+    match role {
+        Role::System => "system",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    }
+}
+
+fn role_from_str(s: &str) -> Role {
+    match s {
+        "system" => Role::System,
+        "user" => Role::User,
+        "tool" => Role::Tool,
+        _ => Role::Assistant,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiResponse {
+    pub id: String,
+    pub model: String,
+    pub choices: Vec<OpenAiChoice>,
+    #[serde(default)]
+    pub usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiChoice {
+    pub message: OpenAiResponseMessage,
+    #[serde(default)]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiResponseMessage {
+    pub role: String,
+    #[serde(default)]
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+pub(crate) fn response_into_chat_response(mut raw: OpenAiResponse) -> ChatResponse {
+    let first = raw.choices.drain(..).next();
+    let (message, finish) = match first {
+        Some(c) => (
+            ChatMessage {
+                role: role_from_str(&c.message.role),
+                content: c.message.content.unwrap_or_default(),
+                name: None,
+                tool_call_id: None,
+            },
+            finish_reason(c.finish_reason.as_deref()),
+        ),
+        None => (ChatMessage::assistant(""), FinishReason::Stop),
+    };
+
+    let usage = raw.usage.map(into_usage).unwrap_or_default();
+
+    ChatResponse {
+        id: raw.id,
+        model: raw.model,
+        message,
+        finish_reason: finish,
+        usage,
+    }
+}
+
+fn into_usage(u: OpenAiUsage) -> UsageStats {
+    UsageStats {
+        prompt_tokens: u.prompt_tokens,
+        completion_tokens: u.completion_tokens,
+        total_tokens: u.total_tokens,
+    }
+}
+
+fn finish_reason(raw: Option<&str>) -> FinishReason {
+    match raw {
+        Some("stop") | None => FinishReason::Stop,
+        Some("length") => FinishReason::Length,
+        Some("content_filter") => FinishReason::ContentFilter,
+        Some("tool_calls") => FinishReason::ToolCalls,
+        Some(other) => FinishReason::Other(other.to_string()),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiStreamChunk {
+    pub id: String,
+    pub model: String,
+    pub choices: Vec<OpenAiStreamChoice>,
+    #[serde(default)]
+    pub usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiStreamChoice {
+    pub delta: OpenAiStreamDelta,
+    #[serde(default)]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiStreamDelta {
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub content: Option<String>,
+}
+
+pub(crate) fn stream_chunk_into_chat_chunk(mut raw: OpenAiStreamChunk) -> ChatChunk {
+    let first = raw.choices.drain(..).next();
+    let (delta, finish) = match first {
+        Some(c) => (
+            ChatDelta {
+                role: c.delta.role.as_deref().map(role_from_str),
+                content: c.delta.content,
+            },
+            c.finish_reason
+                .as_deref()
+                .map(|r| finish_reason(Some(r)))
+                .filter(|_| c.finish_reason.is_some()),
+        ),
+        None => (ChatDelta::default(), None),
+    };
+    ChatChunk {
+        id: raw.id,
+        model: raw.model,
+        delta,
+        finish_reason: finish,
+        usage: raw.usage.map(into_usage),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_streaming_response_parses_into_chat_response() {
+        let body = r#"{
+            "id": "cmpl-1",
+            "object": "chat.completion",
+            "model": "gpt-4o",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi there"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6}
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.id, "cmpl-1");
+        assert_eq!(out.model, "gpt-4o");
+        assert_eq!(out.message.role, Role::Assistant);
+        assert_eq!(out.message.content, "hi there");
+        assert_eq!(out.finish_reason, FinishReason::Stop);
+        assert_eq!(out.usage.total_tokens, 6);
+    }
+
+    #[test]
+    fn missing_finish_reason_defaults_to_stop() {
+        let body = r#"{
+            "id": "cmpl-x",
+            "model": "gpt-4o",
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.finish_reason, FinishReason::Stop);
+        assert_eq!(out.usage, UsageStats::default());
+    }
+
+    #[test]
+    fn unknown_finish_reason_lands_in_other() {
+        let body = r#"{
+            "id": "cmpl-y",
+            "model": "gpt-4o",
+            "choices": [{
+                "message": {"role": "assistant", "content": ""},
+                "finish_reason": "weird_reason"
+            }]
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(
+            out.finish_reason,
+            FinishReason::Other("weird_reason".into())
+        );
+    }
+
+    #[test]
+    fn stream_chunk_maps_content_delta() {
+        let body = r#"{
+            "id": "cmpl-s",
+            "model": "gpt-4o",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "hel"},
+                "finish_reason": null
+            }]
+        }"#;
+        let raw: OpenAiStreamChunk = serde_json::from_str(body).unwrap();
+        let chunk = stream_chunk_into_chat_chunk(raw);
+        assert_eq!(chunk.delta.content.as_deref(), Some("hel"));
+        assert!(chunk.finish_reason.is_none());
+    }
+
+    #[test]
+    fn stream_chunk_terminal_emits_finish_reason() {
+        let body = r#"{
+            "id": "cmpl-s",
+            "model": "gpt-4o",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop"
+            }]
+        }"#;
+        let raw: OpenAiStreamChunk = serde_json::from_str(body).unwrap();
+        let chunk = stream_chunk_into_chat_chunk(raw);
+        assert_eq!(chunk.finish_reason, Some(FinishReason::Stop));
+    }
+
+    #[test]
+    fn build_request_sets_stream_flag_and_propagates_params() {
+        let req = ChatFormat {
+            model: "my-model".into(),
+            messages: vec![ChatMessage::user("hi")],
+            temperature: Some(0.4),
+            top_p: Some(0.9),
+            max_tokens: Some(64),
+            stream: None,
+            extra: serde_json::Map::new(),
+        };
+        let msgs = messages_from(&req);
+        let built = build_request(&req, "gpt-4o", &msgs, true);
+        let json = serde_json::to_value(&built).unwrap();
+        assert_eq!(json["model"], "gpt-4o");
+        // Temperature is f32 → serialises with f64-ish precision.
+        let t = json["temperature"].as_f64().unwrap();
+        assert!((t - 0.4).abs() < 1e-6, "temperature was {t}");
+        let p = json["top_p"].as_f64().unwrap();
+        assert!((p - 0.9).abs() < 1e-6, "top_p was {p}");
+        assert_eq!(json["max_tokens"], 64);
+        assert_eq!(json["stream"], true);
+        assert_eq!(json["messages"][0]["role"], "user");
+        assert_eq!(json["messages"][0]["content"], "hi");
+    }
+
+    #[test]
+    fn extra_fields_flatten_into_request() {
+        let mut extra = serde_json::Map::new();
+        extra.insert("seed".into(), serde_json::json!(42));
+        extra.insert("presence_penalty".into(), serde_json::json!(0.1));
+        let req = ChatFormat {
+            model: "m".into(),
+            messages: vec![],
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            stream: None,
+            extra,
+        };
+        let msgs = messages_from(&req);
+        let built = build_request(&req, "gpt-4o", &msgs, false);
+        let json = serde_json::to_value(&built).unwrap();
+        assert_eq!(json["seed"], 42);
+        assert_eq!(json["presence_penalty"], 0.1);
+    }
+}


### PR DESCRIPTION
## Summary

First concrete \`Bridge\` implementation against the \`aisix-gateway\`
trait. Also serves as the reusable transport for OpenAI-compatible
providers (DeepSeek today, Gemini-OAI later).

- **wire.rs** — OpenAI \`/chat/completions\` request/response types plus
  the mappers that round-trip \`ChatFormat\`/\`ChatResponse\`/\`ChatChunk\`
  against the upstream shape. Request extras flow through
  \`#[serde(flatten)]\` so \`seed\`, \`presence_penalty\`, etc. forward.
- **bridge.rs** — \`OpenAiBridge\` owns a shared \`reqwest::Client\`.
  \`chat()\` does \`POST /chat/completions\` with a typed body +
  tokio::time::timeout for deadlines. \`chat_stream()\` pipes
  \`bytes_stream()\` through the gateway's \`SseDecoder\` and yields
  \`ChatChunk\`s via \`async_stream\`, terminating on \`[DONE]\`.
- Error mapping follows the \`BridgeError\` contract: transport → Transport,
  non-2xx → UpstreamStatus, malformed JSON → UpstreamDecode, elapsed
  deadline → Timeout { elapsed_ms }.
- \`with_name()\` lets OpenAI-compat providers reuse this transport with a
  distinct metrics label.

## Test plan

- [x] 15 new unit tests (10 wiremock-backed)
  - non-streaming happy path
  - 429 pass-through
  - 500 before stream starts
  - malformed body → decode error
  - deadline → timeout
  - missing api_key → config error
  - SSE roundtrip (role/content/finish_reason/[DONE])
  - resolve_base trailing-slash handling
- [x] \`cargo test --workspace\` — 118 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs