### PR TITLE
feat(provider-anthropic): AnthropicBridge with /v1/messages + typed SSE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,13 +180,18 @@ version = "0.1.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
+ "async-stream",
  "async-trait",
  "base64",
+ "bytes",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/aisix-provider-anthropic/Cargo.toml
+++ b/crates/aisix-provider-anthropic/Cargo.toml
@@ -18,3 +18,11 @@ async-trait.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 base64.workspace = true
+tokio.workspace = true
+futures.workspace = true
+async-stream = "0.3"
+bytes.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+wiremock.workspace = true

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -1,0 +1,512 @@
+//! `AnthropicBridge` — concrete [`Bridge`] for the Claude Messages API.
+//!
+//! Mirrors `OpenAiBridge`'s transport shape but differs in three important
+//! places:
+//!
+//! - **Auth header**: `x-api-key: <key>` + `anthropic-version` (Bearer not
+//!   accepted).
+//! - **Endpoint**: `POST {base}/v1/messages`. We append `/v1/messages`
+//!   ourselves because the Model's `api_base` is the host, not the
+//!   messages endpoint.
+//! - **Stream model**: event-typed SSE where only a couple of variants
+//!   yield user-visible chunks. We drive that via `StreamState`.
+//!
+//! Error mapping is identical to OpenAi — the `BridgeError` contract from
+//! PR #6 applies verbatim.
+
+use aisix_gateway::{
+    Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream, ChatFormat, ChatResponse,
+    SseDecoder, SseEvent,
+};
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::{header, Client, StatusCode};
+use std::time::{Duration, Instant};
+
+use crate::wire::{
+    build_request, response_into_chat_response, split_system, AnthropicResponse,
+    AnthropicStreamEvent, StreamState,
+};
+
+/// Matches the API header that Anthropic bakes backwards-compat into.
+/// Pinned here rather than config-driven so each bridge version ships
+/// a known compatible version string; bumping it is a code change.
+pub const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Fallback host used when the Model doesn't set `api_base` and the
+/// Provider enum's default is missing. Real operators set `api_base`
+/// on the Model to point at the Anthropic-owned endpoint they use.
+pub const ANTHROPIC_DEFAULT_BASE: &str = "https://api.anthropic.com";
+
+pub struct AnthropicBridge {
+    client: Client,
+    name: &'static str,
+    api_version: &'static str,
+}
+
+impl AnthropicBridge {
+    pub fn new() -> Self {
+        Self::with_client(default_client())
+    }
+
+    pub fn with_client(client: Client) -> Self {
+        Self {
+            client,
+            name: "anthropic",
+            api_version: ANTHROPIC_VERSION,
+        }
+    }
+
+    pub fn with_name(mut self, name: &'static str) -> Self {
+        self.name = name;
+        self
+    }
+
+    pub fn with_api_version(mut self, v: &'static str) -> Self {
+        self.api_version = v;
+        self
+    }
+}
+
+impl Default for AnthropicBridge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn default_client() -> Client {
+    Client::builder()
+        .user_agent("aisix/0.1")
+        .build()
+        .unwrap_or_else(|_| Client::new())
+}
+
+fn resolve_base(model: &aisix_core::Model) -> String {
+    match model.base_url() {
+        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
+        _ => ANTHROPIC_DEFAULT_BASE.to_string(),
+    }
+}
+
+fn api_key(model: &aisix_core::Model) -> Result<&str, BridgeError> {
+    let k = &model.provider_config.api_key;
+    if k.is_empty() {
+        Err(BridgeError::Config(
+            "provider_config.api_key is empty".into(),
+        ))
+    } else {
+        Ok(k.as_str())
+    }
+}
+
+fn upstream_model(model: &aisix_core::Model) -> Result<&str, BridgeError> {
+    model
+        .upstream_model()
+        .ok_or_else(|| BridgeError::Config("model field missing `provider/` prefix".into()))
+}
+
+async fn map_http_error(status: StatusCode, resp: reqwest::Response) -> BridgeError {
+    let message = resp.text().await.unwrap_or_default();
+    BridgeError::UpstreamStatus {
+        status: status.as_u16(),
+        message: truncate(&message, 1024),
+    }
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.len() <= n {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..n])
+    }
+}
+
+async fn with_deadline<T, F>(
+    deadline: Option<Duration>,
+    started: Instant,
+    fut: F,
+) -> Result<T, BridgeError>
+where
+    F: std::future::Future<Output = Result<T, BridgeError>>,
+{
+    match deadline {
+        None => fut.await,
+        Some(d) => match tokio::time::timeout(d, fut).await {
+            Ok(r) => r,
+            Err(_) => Err(BridgeError::Timeout {
+                elapsed_ms: started.elapsed().as_millis() as u64,
+            }),
+        },
+    }
+}
+
+#[async_trait]
+impl Bridge for AnthropicBridge {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn chat(
+        &self,
+        req: &ChatFormat,
+        ctx: &BridgeContext,
+    ) -> Result<ChatResponse, BridgeError> {
+        let model = ctx.model.as_ref();
+        let base = resolve_base(model);
+        let key = api_key(model)?;
+        let upstream = upstream_model(model)?;
+
+        let (system, messages) =
+            split_system(req).map_err(|e| BridgeError::Config(e.to_string()))?;
+        let body = build_request(req, upstream, system, messages, false);
+        let url = format!("{base}/v1/messages");
+        let client = self.client.clone();
+        let api_version = self.api_version;
+        let started = Instant::now();
+        let request_id = ctx.request_id.clone();
+
+        with_deadline(ctx.deadline, started, async move {
+            let resp = client
+                .post(&url)
+                .header("x-api-key", key)
+                .header("anthropic-version", api_version)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header("x-aisix-request-id", &request_id)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| BridgeError::Transport(e.to_string()))?;
+
+            let status = resp.status();
+            if !status.is_success() {
+                return Err(map_http_error(status, resp).await);
+            }
+
+            let parsed: AnthropicResponse = resp
+                .json()
+                .await
+                .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+            Ok(response_into_chat_response(parsed))
+        })
+        .await
+    }
+
+    async fn chat_stream(
+        &self,
+        req: &ChatFormat,
+        ctx: &BridgeContext,
+    ) -> Result<ChatChunkStream, BridgeError> {
+        let model = ctx.model.as_ref();
+        let base = resolve_base(model);
+        let key = api_key(model)?;
+        let upstream = upstream_model(model)?;
+
+        let (system, messages) =
+            split_system(req).map_err(|e| BridgeError::Config(e.to_string()))?;
+        let body = build_request(req, upstream, system, messages, true);
+        let url = format!("{base}/v1/messages");
+        let client = self.client.clone();
+        let api_version = self.api_version;
+        let started = Instant::now();
+        let request_id = ctx.request_id.clone();
+
+        let resp = with_deadline(ctx.deadline, started, async move {
+            client
+                .post(&url)
+                .header("x-api-key", key)
+                .header("anthropic-version", api_version)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::ACCEPT, "text/event-stream")
+                .header("x-aisix-request-id", &request_id)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| BridgeError::Transport(e.to_string()))
+        })
+        .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(map_http_error(status, resp).await);
+        }
+
+        let byte_stream = resp.bytes_stream();
+        let stream = build_chunk_stream(byte_stream);
+        Ok(Box::pin(stream))
+    }
+}
+
+fn build_chunk_stream<S>(
+    byte_stream: S,
+) -> impl futures::Stream<Item = Result<ChatChunk, BridgeError>> + Send
+where
+    S: futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send + 'static,
+{
+    async_stream::try_stream! {
+        let mut decoder = SseDecoder::new();
+        let mut stream = Box::pin(byte_stream);
+        let mut state = StreamState::default();
+
+        while let Some(next) = stream.next().await {
+            let chunk = next.map_err(|e| BridgeError::Transport(e.to_string()))?;
+            for event in decoder.feed(chunk.as_ref()) {
+                let SseEvent::Data(payload) = event else { continue };
+                let parsed: AnthropicStreamEvent = serde_json::from_str(&payload)
+                    .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+                state.update(&parsed);
+                if let Some(c) = state.to_chunk(&parsed) {
+                    yield c;
+                }
+                if StreamState::is_terminal(&parsed) {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::Model;
+    use aisix_gateway::{ChatMessage, FinishReason, Role};
+    use std::sync::Arc;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn sample_model(base: &str) -> Arc<Model> {
+        let cfg = format!(
+            r#"{{
+                "name": "my-claude",
+                "model": "anthropic/claude-sonnet-4-5",
+                "provider_config": {{"api_key": "sk-ant-test", "api_base": "{base}"}}
+            }}"#
+        );
+        Arc::new(serde_json::from_str(&cfg).unwrap())
+    }
+
+    fn req() -> ChatFormat {
+        ChatFormat::new(
+            "my-claude",
+            vec![
+                ChatMessage::system("you are helpful"),
+                ChatMessage::user("hi"),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn non_streaming_happy_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .and(header("x-api-key", "sk-ant-test"))
+            .and(header("anthropic-version", "2023-06-01"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "msg_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "hello back"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 2, "output_tokens": 3}
+            })))
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let resp = bridge.chat(&req(), &ctx).await.unwrap();
+
+        assert_eq!(resp.id, "msg_01");
+        assert_eq!(resp.message.role, Role::Assistant);
+        assert_eq!(resp.message.content, "hello back");
+        assert_eq!(resp.finish_reason, FinishReason::Stop);
+        assert_eq!(resp.usage.prompt_tokens, 2);
+        assert_eq!(resp.usage.completion_tokens, 3);
+        assert_eq!(resp.usage.total_tokens, 5);
+    }
+
+    #[tokio::test]
+    async fn non_streaming_400_bad_request_surfaces_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string(r#"{"error":{"type":"invalid_request","message":"bad"}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        match err {
+            BridgeError::UpstreamStatus { status, message } => {
+                assert_eq!(status, 400);
+                assert!(message.contains("invalid_request"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_streaming_decode_error_on_malformed_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not-json"))
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        assert!(matches!(err, BridgeError::UpstreamDecode(_)));
+    }
+
+    #[tokio::test]
+    async fn deadline_elapses_to_timeout_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_secs(5))
+                    .set_body_json(serde_json::json!({
+                        "id": "x",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "x",
+                        "content": []
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()))
+            .with_deadline(Duration::from_millis(50));
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        assert!(matches!(err, BridgeError::Timeout { .. }));
+    }
+
+    #[tokio::test]
+    async fn missing_api_key_is_a_config_error() {
+        let mut model: Model = serde_json::from_str(
+            r#"{
+                "name": "bad",
+                "model": "anthropic/claude-sonnet-4-5",
+                "provider_config": {"api_key": "placeholder"}
+            }"#,
+        )
+        .unwrap();
+        model.provider_config.api_key.clear();
+
+        let bridge = AnthropicBridge::new();
+        let ctx = BridgeContext::new("req-1", Arc::new(model));
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        assert!(matches!(err, BridgeError::Config(_)));
+    }
+
+    #[tokio::test]
+    async fn tool_role_is_rejected_as_config_error() {
+        let server = MockServer::start().await;
+        let bridge = AnthropicBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let req = ChatFormat::new(
+            "my-claude",
+            vec![ChatMessage {
+                role: Role::Tool,
+                content: "tool output".into(),
+                name: None,
+                tool_call_id: Some("tc_1".into()),
+            }],
+        );
+        let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        assert!(matches!(err, BridgeError::Config(_)));
+    }
+
+    #[tokio::test]
+    async fn streaming_happy_path_emits_text_deltas_then_finish() {
+        let server = MockServer::start().await;
+        let sse = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream\",\"model\":\"claude-sonnet-4-5\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":1}}}\n\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hel\"}}\n\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"lo\"}}\n\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
+
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.unwrap());
+        }
+        // Expect: two text deltas, then one message_delta finish chunk.
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].id, "msg_stream");
+        assert_eq!(chunks[0].delta.content.as_deref(), Some("hel"));
+        assert_eq!(chunks[1].delta.content.as_deref(), Some("lo"));
+        assert_eq!(chunks[2].finish_reason, Some(FinishReason::Stop));
+        assert_eq!(chunks[2].usage.as_ref().unwrap().completion_tokens, 5);
+    }
+
+    #[tokio::test]
+    async fn streaming_upstream_error_surfaces_before_stream_start() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("oops"))
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        match bridge.chat_stream(&req(), &ctx).await {
+            Ok(_) => panic!("expected upstream error"),
+            Err(BridgeError::UpstreamStatus { status: 500, .. }) => {}
+            Err(other) => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_base_honours_override() {
+        let mut m: Model = serde_json::from_str(
+            r#"{
+                "name": "x",
+                "model": "anthropic/claude-sonnet-4-5",
+                "provider_config": {"api_key": "k"}
+            }"#,
+        )
+        .unwrap();
+        // Default path: Provider::Anthropic.default_base_url() comes
+        // from aisix-core, so just assert that *some* non-empty host
+        // is picked up.
+        assert!(!resolve_base(&m).is_empty());
+
+        m.provider_config.api_base = Some("https://proxy.example.com/".into());
+        assert_eq!(resolve_base(&m), "https://proxy.example.com");
+    }
+}

--- a/crates/aisix-provider-anthropic/src/lib.rs
+++ b/crates/aisix-provider-anthropic/src/lib.rs
@@ -1,4 +1,18 @@
-//! aisix-provider-anthropic — Anthropic Messages API with bidirectional OpenAI Hub transforms.
+//! aisix-provider-anthropic — Anthropic Messages API [`AnthropicBridge`].
+//!
+//! Translates the gateway's OpenAI-shaped [`ChatFormat`] into Claude's
+//! `/v1/messages` contract and back. Streaming support maps Anthropic's
+//! typed SSE events (`message_start`, `content_block_delta`,
+//! `message_delta`, `message_stop`) to the gateway's flat `ChatChunk`
+//! stream.
+//!
+//! See the `Bridge` trait in `aisix-gateway` for the contract this crate
+//! implements against.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+mod bridge;
+mod wire;
+
+pub use bridge::{AnthropicBridge, ANTHROPIC_DEFAULT_BASE, ANTHROPIC_VERSION};

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -1,0 +1,519 @@
+//! Anthropic `/v1/messages` wire shapes.
+//!
+//! Reference: <https://docs.anthropic.com/en/api/messages>
+//!
+//! Key differences from OpenAI that this module handles:
+//!
+//! - System prompt is a top-level `system` field, not a message with
+//!   `role: "system"` — we collapse all leading system messages into one
+//!   string and forward it there.
+//! - Only `user` and `assistant` roles on the wire. `tool` messages from
+//!   ChatFormat are rejected at the bridge boundary rather than being
+//!   silently re-classified.
+//! - Content is an array of blocks — we emit a single `{"type":"text",…}`
+//!   block per message and read the concatenation of text blocks on the
+//!   way back.
+//! - `max_tokens` is required by Anthropic. We default to a safe ceiling
+//!   when the client didn't set one, but log the fallback so operators
+//!   can tune the default if desired.
+//! - Streaming events are typed (`message_start`, `content_block_delta`,
+//!   …). We only emit a `ChatChunk` when a delta carries content or a
+//!   stop reason — other events just advance internal state.
+
+use aisix_gateway::{
+    ChatChunk, ChatDelta, ChatFormat, ChatMessage, ChatResponse, FinishReason, Role, UsageStats,
+};
+use serde::{Deserialize, Serialize};
+
+/// Anthropic requires a non-zero `max_tokens`. Clients that omit it get
+/// this ceiling — generous enough to cover normal completions, conservative
+/// enough that a runaway prompt doesn't burn tokens silently.
+pub(crate) const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AnthropicRequest<'a> {
+    pub model: &'a str,
+    pub messages: Vec<AnthropicMessage<'a>>,
+    pub max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    pub stream: bool,
+    #[serde(flatten)]
+    pub extra: &'a serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AnthropicMessage<'a> {
+    pub role: &'a str,
+    pub content: Vec<AnthropicTextBlock<'a>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AnthropicTextBlock<'a> {
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    pub text: &'a str,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TranslateError {
+    #[error("anthropic does not support role {role:?}")]
+    UnsupportedRole { role: &'static str },
+}
+
+/// Split the gateway's flat ChatFormat into Anthropic's (system, messages)
+/// shape. Consecutive system messages at the head are concatenated with
+/// a blank line, matching how users typically compose multi-paragraph
+/// system prompts in the OpenAI format.
+pub(crate) fn split_system<'a>(
+    req: &'a ChatFormat,
+) -> Result<(Option<String>, Vec<AnthropicMessage<'a>>), TranslateError> {
+    let mut system_parts: Vec<&'a str> = Vec::new();
+    let mut messages: Vec<AnthropicMessage<'a>> = Vec::new();
+    let mut seen_non_system = false;
+
+    for m in &req.messages {
+        match m.role {
+            Role::System => {
+                if seen_non_system {
+                    // System messages interleaved with user/assistant
+                    // turns don't map cleanly; append as a user turn to
+                    // preserve semantics without silently dropping them.
+                    messages.push(AnthropicMessage {
+                        role: "user",
+                        content: vec![AnthropicTextBlock {
+                            kind: "text",
+                            text: &m.content,
+                        }],
+                    });
+                } else {
+                    system_parts.push(&m.content);
+                }
+            }
+            Role::User => {
+                seen_non_system = true;
+                messages.push(AnthropicMessage {
+                    role: "user",
+                    content: vec![AnthropicTextBlock {
+                        kind: "text",
+                        text: &m.content,
+                    }],
+                });
+            }
+            Role::Assistant => {
+                seen_non_system = true;
+                messages.push(AnthropicMessage {
+                    role: "assistant",
+                    content: vec![AnthropicTextBlock {
+                        kind: "text",
+                        text: &m.content,
+                    }],
+                });
+            }
+            Role::Tool => return Err(TranslateError::UnsupportedRole { role: "tool" }),
+        }
+    }
+
+    let system = if system_parts.is_empty() {
+        None
+    } else {
+        Some(system_parts.join("\n\n"))
+    };
+    Ok((system, messages))
+}
+
+pub(crate) fn build_request<'a>(
+    req: &'a ChatFormat,
+    upstream_model: &'a str,
+    system: Option<String>,
+    messages: Vec<AnthropicMessage<'a>>,
+    stream: bool,
+) -> AnthropicRequest<'a> {
+    AnthropicRequest {
+        model: upstream_model,
+        messages,
+        max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+        system,
+        temperature: req.temperature,
+        top_p: req.top_p,
+        stream,
+        extra: &req.extra,
+    }
+}
+
+/// Non-streaming response shape from `/v1/messages`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicResponse {
+    pub id: String,
+    pub model: String,
+    #[serde(default)]
+    pub content: Vec<AnthropicResponseBlock>,
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    #[serde(default)]
+    pub usage: Option<AnthropicUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum AnthropicResponseBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    /// Tool-use and other block types are ignored for PR #8 — a later
+    /// tools PR will surface them as typed `ChatChunk.tool_calls`.
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+pub(crate) fn response_into_chat_response(raw: AnthropicResponse) -> ChatResponse {
+    let text = raw
+        .content
+        .iter()
+        .filter_map(|b| match b {
+            AnthropicResponseBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("");
+
+    let usage = raw
+        .usage
+        .map(|u| UsageStats::new(u.input_tokens, u.output_tokens))
+        .unwrap_or_default();
+
+    ChatResponse {
+        id: raw.id,
+        model: raw.model,
+        message: ChatMessage {
+            role: Role::Assistant,
+            content: text,
+            name: None,
+            tool_call_id: None,
+        },
+        finish_reason: map_stop_reason(raw.stop_reason.as_deref()),
+        usage,
+    }
+}
+
+fn map_stop_reason(raw: Option<&str>) -> FinishReason {
+    match raw {
+        Some("end_turn") | Some("stop_sequence") | None => FinishReason::Stop,
+        Some("max_tokens") => FinishReason::Length,
+        Some("tool_use") => FinishReason::ToolCalls,
+        Some(other) => FinishReason::Other(other.to_string()),
+    }
+}
+
+/// Streaming events from Anthropic. Only variants that can yield user-
+/// visible output or terminate the stream are modeled here; the rest are
+/// quietly dropped by the Bridge.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum AnthropicStreamEvent {
+    #[serde(rename = "message_start")]
+    MessageStart {
+        message: AnthropicStreamStartMessage,
+    },
+    #[serde(rename = "content_block_delta")]
+    ContentBlockDelta { delta: AnthropicStreamDelta },
+    #[serde(rename = "message_delta")]
+    MessageDelta {
+        delta: AnthropicStreamMessageDelta,
+        #[serde(default)]
+        usage: Option<AnthropicStreamUsage>,
+    },
+    #[serde(rename = "message_stop")]
+    MessageStop,
+    /// Catch-all for content_block_start / content_block_stop / ping /
+    /// unknown event types — we don't need their state for chunk emission.
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicStreamStartMessage {
+    pub id: String,
+    pub model: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum AnthropicStreamDelta {
+    #[serde(rename = "text_delta")]
+    TextDelta { text: String },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicStreamMessageDelta {
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicStreamUsage {
+    #[serde(default)]
+    pub output_tokens: Option<u32>,
+}
+
+/// Rolling state the Bridge carries across a stream so chunks can be
+/// tagged with the message id/model even though only the first event
+/// carries them.
+#[derive(Debug, Default)]
+pub(crate) struct StreamState {
+    pub id: String,
+    pub model: String,
+}
+
+impl StreamState {
+    pub fn update(&mut self, event: &AnthropicStreamEvent) {
+        if let AnthropicStreamEvent::MessageStart { message } = event {
+            self.id = message.id.clone();
+            self.model = message.model.clone();
+        }
+    }
+
+    /// Translate one event into an optional chunk to yield upstream.
+    pub fn to_chunk(&self, event: &AnthropicStreamEvent) -> Option<ChatChunk> {
+        match event {
+            AnthropicStreamEvent::ContentBlockDelta {
+                delta: AnthropicStreamDelta::TextDelta { text },
+            } => Some(ChatChunk {
+                id: self.id.clone(),
+                model: self.model.clone(),
+                delta: ChatDelta {
+                    role: None,
+                    content: Some(text.clone()),
+                },
+                finish_reason: None,
+                usage: None,
+            }),
+            AnthropicStreamEvent::MessageDelta { delta, usage } => {
+                let finish = delta
+                    .stop_reason
+                    .as_deref()
+                    .map(|r| map_stop_reason(Some(r)));
+                let usage = usage
+                    .as_ref()
+                    .and_then(|u| u.output_tokens.map(|n| UsageStats::new(0, n)));
+                if finish.is_none() && usage.is_none() {
+                    return None;
+                }
+                Some(ChatChunk {
+                    id: self.id.clone(),
+                    model: self.model.clone(),
+                    delta: ChatDelta::default(),
+                    finish_reason: finish,
+                    usage,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    pub fn is_terminal(event: &AnthropicStreamEvent) -> bool {
+        matches!(event, AnthropicStreamEvent::MessageStop)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_system_merges_leading_system_messages() {
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::system("you are helpful"),
+                ChatMessage::system("respond concisely"),
+                ChatMessage::user("hi"),
+            ],
+        );
+        let (system, msgs) = split_system(&req).unwrap();
+        assert_eq!(
+            system.as_deref(),
+            Some("you are helpful\n\nrespond concisely")
+        );
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "user");
+    }
+
+    #[test]
+    fn split_system_mid_conversation_becomes_user_turn() {
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::user("hi"),
+                ChatMessage::system("forget everything"),
+                ChatMessage::assistant("ok"),
+            ],
+        );
+        let (system, msgs) = split_system(&req).unwrap();
+        assert!(system.is_none());
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[1].role, "user"); // former system message
+    }
+
+    #[test]
+    fn split_system_rejects_tool_role() {
+        let req = ChatFormat::new(
+            "claude",
+            vec![ChatMessage {
+                role: Role::Tool,
+                content: "x".into(),
+                name: None,
+                tool_call_id: None,
+            }],
+        );
+        assert!(matches!(
+            split_system(&req),
+            Err(TranslateError::UnsupportedRole { role: "tool" })
+        ));
+    }
+
+    #[test]
+    fn build_request_applies_default_max_tokens_when_unset() {
+        let req = ChatFormat::new("claude", vec![ChatMessage::user("hi")]);
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "claude-sonnet-4-5", None, messages, false);
+        assert_eq!(built.max_tokens, DEFAULT_MAX_TOKENS);
+
+        let req = ChatFormat {
+            max_tokens: Some(256),
+            ..ChatFormat::new("claude", vec![ChatMessage::user("hi")])
+        };
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "claude-sonnet-4-5", None, messages, false);
+        assert_eq!(built.max_tokens, 256);
+    }
+
+    #[test]
+    fn non_streaming_response_concatenates_text_blocks() {
+        let body = r#"{
+            "id": "msg_01A",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "content": [
+                {"type": "text", "text": "hel"},
+                {"type": "text", "text": "lo"}
+            ],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 3, "output_tokens": 2}
+        }"#;
+        let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.id, "msg_01A");
+        assert_eq!(out.message.content, "hello");
+        assert_eq!(out.finish_reason, FinishReason::Stop);
+        assert_eq!(out.usage.total_tokens, 5);
+    }
+
+    #[test]
+    fn stop_reason_mappings_match_spec() {
+        assert_eq!(map_stop_reason(Some("end_turn")), FinishReason::Stop);
+        assert_eq!(map_stop_reason(Some("max_tokens")), FinishReason::Length);
+        assert_eq!(map_stop_reason(Some("tool_use")), FinishReason::ToolCalls);
+        assert_eq!(
+            map_stop_reason(Some("exotic_reason")),
+            FinishReason::Other("exotic_reason".into())
+        );
+        assert_eq!(map_stop_reason(None), FinishReason::Stop);
+    }
+
+    #[test]
+    fn content_blocks_other_than_text_are_skipped() {
+        // Tool-use blocks on a completion we're treating as plain text
+        // should not break parsing; they're simply not surfaced yet.
+        let body = r#"{
+            "id": "msg_02",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "content": [
+                {"type": "tool_use", "id": "tu_1", "name": "search", "input": {}},
+                {"type": "text", "text": "done"}
+            ]
+        }"#;
+        let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.message.content, "done");
+    }
+
+    #[test]
+    fn stream_events_deserialise_into_typed_variants() {
+        let start: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"message_start","message":{"id":"msg_1","model":"claude","type":"message","role":"assistant","content":[],"stop_reason":null,"usage":{"input_tokens":1}}}"#,
+        )
+        .unwrap();
+        assert!(matches!(start, AnthropicStreamEvent::MessageStart { .. }));
+
+        let delta: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            delta,
+            AnthropicStreamEvent::ContentBlockDelta { .. }
+        ));
+
+        let msg_delta: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            msg_delta,
+            AnthropicStreamEvent::MessageDelta { .. }
+        ));
+
+        let ping: AnthropicStreamEvent = serde_json::from_str(r#"{"type":"ping"}"#).unwrap();
+        assert!(matches!(ping, AnthropicStreamEvent::Other));
+    }
+
+    #[test]
+    fn stream_state_tracks_id_and_emits_text_delta() {
+        let mut state = StreamState::default();
+        let start: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"message_start","message":{"id":"msg_9","model":"claude-sonnet-4-5","type":"message","role":"assistant","content":[],"stop_reason":null,"usage":{"input_tokens":1}}}"#,
+        )
+        .unwrap();
+        state.update(&start);
+        assert_eq!(state.id, "msg_9");
+        assert!(state.to_chunk(&start).is_none());
+
+        let delta: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}"#,
+        )
+        .unwrap();
+        let chunk = state.to_chunk(&delta).unwrap();
+        assert_eq!(chunk.id, "msg_9");
+        assert_eq!(chunk.delta.content.as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn stream_state_emits_finish_on_message_delta() {
+        let state = StreamState {
+            id: "msg".into(),
+            model: "claude".into(),
+        };
+        let end: AnthropicStreamEvent = serde_json::from_str(
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}"#,
+        )
+        .unwrap();
+        let chunk = state.to_chunk(&end).unwrap();
+        assert_eq!(chunk.finish_reason, Some(FinishReason::Stop));
+        assert_eq!(chunk.usage.unwrap().completion_tokens, 3);
+    }
+}


### PR DESCRIPTION
## Summary

Second concrete \`Bridge\` against the gateway trait — Anthropic's
Claude Messages API.

- **wire.rs** — Anthropic-specific request/response types.
  \`split_system()\` pulls leading system messages into Anthropic's
  top-level \`system\` field, \`max_tokens\` default fallback covers
  clients that omit the (required) field, and a typed \`AnthropicStreamEvent\`
  enum covers \`message_start\` / \`content_block_delta\` /
  \`message_delta\` / \`message_stop\` with a catch-all \`Other\`.
  \`StreamState\` carries message id/model across chunks so ChatChunk
  tagging stays consistent.
- **bridge.rs** — transport mirrors \`OpenAiBridge\` but sends
  \`x-api-key\` + \`anthropic-version\` headers and posts to
  \`{base}/v1/messages\`. Stream body pipes through \`StreamState\` so only
  content-bearing or finish-reason-bearing events become ChatChunks.
- \`stop_reason\` mapping: \`end_turn → Stop\`, \`max_tokens → Length\`,
  \`tool_use → ToolCalls\`, unknowns → \`Other\`. Tool role → \`Config\` error.
- \`ANTHROPIC_VERSION\` pinned to \`2023-06-01\` with builder escape hatch.

## Test plan

- [x] 19 new unit tests (10 wiremock-backed, 9 wire/translation)
  - happy path + 400 + malformed body + deadline + missing api_key
  - tool role → Config error
  - streaming happy path with typed SSE events
  - streaming 500 before stream starts
  - \`split_system\` merges/interleaves/rejects-tool
  - max_tokens default application
  - stop_reason mapping for all documented variants
- [x] \`cargo test --workspace\` — 137 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs