### PR TITLE
feat(providers): Gemini + DeepSeek bridges via OpenAI-compat transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,10 @@ dependencies = [
  "aisix-gateway",
  "aisix-provider-openai",
  "async-trait",
+ "serde_json",
+ "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -213,7 +216,10 @@ dependencies = [
  "aisix-gateway",
  "aisix-provider-openai",
  "async-trait",
+ "serde_json",
+ "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/aisix-provider-deepseek/Cargo.toml
+++ b/crates/aisix-provider-deepseek/Cargo.toml
@@ -14,3 +14,8 @@ aisix-gateway = { path = "../aisix-gateway" }
 aisix-provider-openai = { path = "../aisix-provider-openai" }
 async-trait.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+wiremock.workspace = true
+serde_json.workspace = true

--- a/crates/aisix-provider-deepseek/src/lib.rs
+++ b/crates/aisix-provider-deepseek/src/lib.rs
@@ -1,4 +1,86 @@
-//! aisix-provider-deepseek — DeepSeek via OpenAI-compatible endpoint.
+//! aisix-provider-deepseek — DeepSeek via its OpenAI-compatible endpoint.
+//!
+//! DeepSeek's chat API is a straight `/chat/completions` clone, so this
+//! crate is a one-function factory around `aisix_provider_openai::OpenAiBridge`
+//! with `name()` overridden to `"deepseek"` for metrics and log labels.
+//!
+//! The Model entity drives the actual base URL and API key — DeepSeek
+//! users typically configure `api_base: "https://api.deepseek.com"` on
+//! the Model.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+use aisix_provider_openai::OpenAiBridge;
+
+/// Default DeepSeek host. Only used if a Model is missing an `api_base`
+/// override; operators should set one explicitly.
+pub const DEEPSEEK_DEFAULT_BASE: &str = "https://api.deepseek.com";
+
+/// Build a Bridge that speaks DeepSeek's OpenAI-compatible chat API.
+///
+/// Returns the underlying [`OpenAiBridge`] value so callers can still
+/// reach `Bridge` methods — `Arc::new(deepseek_bridge()) as Arc<dyn Bridge>`
+/// is how the Hub registers it at startup.
+pub fn deepseek_bridge() -> OpenAiBridge {
+    OpenAiBridge::new().with_name("deepseek")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_gateway::{Bridge, BridgeContext, ChatFormat, ChatMessage};
+    use std::sync::Arc;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn bridge_reports_deepseek_name() {
+        let b = deepseek_bridge();
+        assert_eq!(b.name(), "deepseek");
+    }
+
+    #[test]
+    fn default_base_points_at_deepseek_host() {
+        assert_eq!(DEEPSEEK_DEFAULT_BASE, "https://api.deepseek.com");
+    }
+
+    #[tokio::test]
+    async fn forwards_chat_through_openai_transport() {
+        // DeepSeek is OpenAI-compatible, so the wiremock expectation is
+        // exactly an OpenAI /chat/completions call — proving this crate
+        // is a thin relabel rather than a parallel transport.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer ds-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-ds",
+                "model": "deepseek-chat",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "pong"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&server)
+            .await;
+
+        let cfg = format!(
+            r#"{{
+                "name": "my-deepseek",
+                "model": "deepseek/deepseek-chat",
+                "provider_config": {{"api_key": "ds-test", "api_base": "{uri}"}}
+            }}"#,
+            uri = server.uri()
+        );
+        let model: aisix_core::Model = serde_json::from_str(&cfg).unwrap();
+        let ctx = BridgeContext::new("req-1", Arc::new(model));
+        let req = ChatFormat::new("my-deepseek", vec![ChatMessage::user("ping")]);
+
+        let resp = deepseek_bridge().chat(&req, &ctx).await.unwrap();
+        assert_eq!(resp.message.content, "pong");
+        assert_eq!(resp.usage.total_tokens, 2);
+    }
+}

--- a/crates/aisix-provider-gemini/Cargo.toml
+++ b/crates/aisix-provider-gemini/Cargo.toml
@@ -14,3 +14,8 @@ aisix-gateway = { path = "../aisix-gateway" }
 aisix-provider-openai = { path = "../aisix-provider-openai" }
 async-trait.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+wiremock.workspace = true
+serde_json.workspace = true

--- a/crates/aisix-provider-gemini/src/lib.rs
+++ b/crates/aisix-provider-gemini/src/lib.rs
@@ -1,4 +1,89 @@
-//! aisix-provider-gemini — Google Gemini via /v1beta/openai endpoint.
+//! aisix-provider-gemini — Google Gemini via its OpenAI-compatible endpoint.
+//!
+//! Google exposes an OpenAI-shaped `/chat/completions` surface at
+//! `generativelanguage.googleapis.com/v1beta/openai`. The wire format is
+//! close enough to plain OpenAI that the upstream `OpenAiBridge` covers
+//! every field we care about — this crate only relabels the bridge
+//! (`name() == "gemini"`) so metrics and logs can distinguish traffic.
+//!
+//! Operators configure Gemini access by setting on the Model:
+//!
+//! ```yaml
+//! provider_config:
+//!   api_key: "AIza…"
+//!   api_base: "https://generativelanguage.googleapis.com/v1beta/openai"
+//! ```
+//!
+//! The Gemini native `:generateContent` format (different request/response
+//! shape, split role model) is intentionally out of scope here; routing
+//! to it would belong in its own crate with its own wire module.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+use aisix_provider_openai::OpenAiBridge;
+
+/// Default base for Gemini's OpenAI-compat endpoint. Only used when the
+/// Model doesn't carry an explicit `api_base` — production configs should
+/// set one.
+pub const GEMINI_DEFAULT_BASE: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
+
+/// Build a Bridge that speaks Gemini's OpenAI-compatible chat API.
+pub fn gemini_bridge() -> OpenAiBridge {
+    OpenAiBridge::new().with_name("gemini")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_gateway::{Bridge, BridgeContext, ChatFormat, ChatMessage};
+    use std::sync::Arc;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn bridge_reports_gemini_name() {
+        assert_eq!(gemini_bridge().name(), "gemini");
+    }
+
+    #[test]
+    fn default_base_targets_v1beta_openai_shim() {
+        assert!(GEMINI_DEFAULT_BASE.contains("/v1beta/openai"));
+    }
+
+    #[tokio::test]
+    async fn forwards_chat_through_openai_transport() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer AIzaTEST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-gem",
+                "model": "gemini-2.5-flash",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ciao"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4}
+            })))
+            .mount(&server)
+            .await;
+
+        let cfg = format!(
+            r#"{{
+                "name": "my-gemini",
+                "model": "gemini/gemini-2.5-flash",
+                "provider_config": {{"api_key": "AIzaTEST", "api_base": "{uri}"}}
+            }}"#,
+            uri = server.uri()
+        );
+        let model: aisix_core::Model = serde_json::from_str(&cfg).unwrap();
+        let ctx = BridgeContext::new("req-1", Arc::new(model));
+        let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hola")]);
+
+        let resp = gemini_bridge().chat(&req, &ctx).await.unwrap();
+        assert_eq!(resp.message.content, "ciao");
+        assert_eq!(resp.usage.total_tokens, 4);
+    }
+}


### PR DESCRIPTION
## Summary

Both providers land together because both expose OpenAI-shaped
\`/chat/completions\` endpoints — the existing \`OpenAiBridge\` covers the
transport, these crates just relabel.

- **aisix-provider-deepseek** — \`deepseek_bridge()\` returns
  \`OpenAiBridge.with_name("deepseek")\`. Default base
  \`https://api.deepseek.com\`.
- **aisix-provider-gemini** — \`gemini_bridge()\` returns
  \`OpenAiBridge.with_name("gemini")\`. Default base targets Google's
  \`/v1beta/openai\` OpenAI-compat shim. The native \`:generateContent\`
  format is deliberately out of scope — belongs in its own crate.

Relabeling rather than duplicating transport keeps the provider surface
honest: every OpenAI-compat upstream uses the exact same Rust code, and
divergence (like Anthropic's \`/v1/messages\`) earns its own crate.

## Test plan

- [x] 6 new unit tests, 3 per crate:
  - name() reports the provider label
  - default-base constant asserts the right host family
  - wiremock-backed chat round-trip proves the wrapper actually forwards
- [x] \`cargo test --workspace\` — 143 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs