### PR TITLE
feat(admin): EtcdConfigStore + wire server bootstrap through it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,11 +47,13 @@ dependencies = [
  "async-trait",
  "axum",
  "dashmap",
+ "etcd-client",
  "http",
  "mime_guess",
  "rust-embed",
  "serde",
  "serde_json",
+ "testcontainers",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.5.3",
@@ -184,7 +186,7 @@ dependencies = [
  "aisix-gateway",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "reqwest",
@@ -309,6 +311,7 @@ dependencies = [
  "axum-server",
  "clap",
  "config",
+ "etcd-client",
  "http",
  "hyper",
  "rustls",
@@ -518,7 +521,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -612,6 +615,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -633,6 +642,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -644,6 +659,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
 ]
 
 [[package]]
@@ -909,6 +974,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dary_heap"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1052,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,10 +1083,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1042,6 +1168,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1226,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1409,6 +1557,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1655,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,7 +1705,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1542,6 +1720,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1657,6 +1850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1917,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1820,7 +2020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b8f66fe41fa46a5c83ed1c717b7e0b4635988f427083108c8cf0a882cc13441"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.22.1",
  "bytecount",
  "email_address",
  "fancy-regex",
@@ -1878,6 +2078,18 @@ dependencies = [
  "hashbrown 0.16.1",
  "no_std_io2",
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1950,7 +2162,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -2116,6 +2328,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2287,9 +2505,34 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn",
 ]
 
 [[package]]
@@ -2353,6 +2596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2615,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2643,7 +2898,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2677,11 +2932,29 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2758,7 +3031,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2900,7 +3173,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2997,6 +3270,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,7 +3305,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3086,6 +3383,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3412,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3235,6 +3574,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3653,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,6 +3728,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3411,6 +3833,21 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -3518,7 +3955,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -3598,7 +4035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3790,6 +4227,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4040,7 +4478,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -4167,6 +4605,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4190,6 +4637,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4227,6 +4689,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4239,6 +4707,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4248,6 +4722,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4275,6 +4755,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4284,6 +4770,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4299,6 +4791,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4308,6 +4806,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4346,7 +4850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",
@@ -4420,7 +4924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -4455,6 +4959,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/crates/aisix-admin/Cargo.toml
+++ b/crates/aisix-admin/Cargo.toml
@@ -29,6 +29,8 @@ rust-embed.workspace = true
 mime_guess.workspace = true
 async-trait.workspace = true
 dashmap.workspace = true
+etcd-client.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+testcontainers.workspace = true

--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -1,0 +1,322 @@
+//! etcd-backed [`ConfigStore`].
+//!
+//! Writes serialise just the entity value (not the full
+//! `ResourceEntry`) to `{prefix}/{kind}/{id}` so the read path in
+//! `aisix-etcd::loader` — which already parses value-only JSON — works
+//! unchanged. The ResourceEntry wrapper is reconstructed on read from
+//! etcd's own `mod_revision`.
+//!
+//! Data layout:
+//! ```text
+//! /aisix/
+//!   models/
+//!     <uuid>  → { "name": "...", "model": "...", "provider_config": {...}, ... }
+//!   apikeys/
+//!     <uuid>  → { "key": "...", "allowed_models": [...], ... }
+//! ```
+//!
+//! Production wires this in `aisix-server`'s bootstrap; tests that want
+//! deterministic behaviour continue to use [`crate::InMemoryStore`].
+
+use aisix_core::resource::ResourceEntry;
+use aisix_core::{ApiKey, Model};
+use etcd_client::{Client, DeleteOptions, GetOptions};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+use crate::store::{ConfigStore, StoreError};
+
+/// Subkey segments used under the configured prefix. Mirrored in
+/// `aisix-etcd`'s loader so the two paths agree at the byte level.
+pub const MODELS_SUBKEY: &str = "models";
+pub const APIKEYS_SUBKEY: &str = "apikeys";
+
+pub struct EtcdConfigStore {
+    client: Mutex<Client>,
+    prefix: String,
+}
+
+impl std::fmt::Debug for EtcdConfigStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EtcdConfigStore")
+            .field("prefix", &self.prefix)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EtcdConfigStore {
+    pub fn new(client: Client, prefix: impl Into<String>) -> Self {
+        let prefix = prefix.into().trim_end_matches('/').to_string();
+        Self {
+            client: Mutex::new(client),
+            prefix,
+        }
+    }
+
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    /// Full key for a single entity: `{prefix}/{kind}/{id}`.
+    pub(crate) fn key_for(&self, kind: &str, id: &str) -> String {
+        format!("{}/{}/{}", self.prefix, kind, id)
+    }
+
+    /// Trailing-slash form used on prefix scans.
+    pub(crate) fn range_prefix(&self, kind: &str) -> String {
+        format!("{}/{}/", self.prefix, kind)
+    }
+
+    /// Extract the id segment given we already know which kind-prefix was used.
+    pub(crate) fn id_from_key<'a>(&self, full_key: &'a str, kind: &str) -> Option<&'a str> {
+        let needle = format!("{}/{}/", self.prefix, kind);
+        full_key.strip_prefix(&needle)
+    }
+
+    async fn put_json<T: Serialize>(&self, key: &str, value: &T) -> Result<(), StoreError> {
+        let bytes = serde_json::to_vec(value).map_err(|e| StoreError::Backend(e.to_string()))?;
+        self.client
+            .lock()
+            .await
+            .put(key.as_bytes().to_vec(), bytes, None)
+            .await
+            .map_err(|e| StoreError::Backend(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn get_one<T: DeserializeOwned>(
+        &self,
+        key: &str,
+    ) -> Result<Option<(T, i64)>, StoreError> {
+        let resp = self
+            .client
+            .lock()
+            .await
+            .get(key.as_bytes().to_vec(), None)
+            .await
+            .map_err(|e| StoreError::Backend(e.to_string()))?;
+        let kv = match resp.kvs().first() {
+            Some(kv) => kv,
+            None => return Ok(None),
+        };
+        let value: T = serde_json::from_slice(kv.value())
+            .map_err(|e| StoreError::Backend(format!("decode {key}: {e}")))?;
+        Ok(Some((value, kv.mod_revision())))
+    }
+
+    async fn list_range<T: DeserializeOwned>(
+        &self,
+        kind: &str,
+    ) -> Result<Vec<(String, T, i64)>, StoreError> {
+        let prefix = self.range_prefix(kind);
+        let resp = self
+            .client
+            .lock()
+            .await
+            .get(
+                prefix.as_bytes().to_vec(),
+                Some(GetOptions::new().with_prefix()),
+            )
+            .await
+            .map_err(|e| StoreError::Backend(e.to_string()))?;
+
+        let mut out = Vec::with_capacity(resp.kvs().len());
+        for kv in resp.kvs() {
+            let key_str = String::from_utf8_lossy(kv.key()).into_owned();
+            let id = match self.id_from_key(&key_str, kind) {
+                Some(id) if !id.is_empty() => id.to_string(),
+                _ => continue, // stray key — skip rather than abort the list
+            };
+            let value: T = match serde_json::from_slice(kv.value()) {
+                Ok(v) => v,
+                Err(err) => {
+                    tracing::warn!(key = %key_str, error = %err, "skipping malformed etcd value");
+                    continue;
+                }
+            };
+            out.push((id, value, kv.mod_revision()));
+        }
+        Ok(out)
+    }
+
+    async fn delete_one(&self, key: &str) -> Result<bool, StoreError> {
+        let resp = self
+            .client
+            .lock()
+            .await
+            .delete(key.as_bytes().to_vec(), Some(DeleteOptions::new()))
+            .await
+            .map_err(|e| StoreError::Backend(e.to_string()))?;
+        Ok(resp.deleted() > 0)
+    }
+}
+
+#[async_trait::async_trait]
+impl ConfigStore for EtcdConfigStore {
+    async fn put_model(&self, entry: ResourceEntry<Model>) -> Result<(), StoreError> {
+        let key = self.key_for(MODELS_SUBKEY, &entry.id);
+        self.put_json(&key, &entry.value).await
+    }
+
+    async fn get_model(&self, id: &str) -> Result<Option<ResourceEntry<Model>>, StoreError> {
+        let key = self.key_for(MODELS_SUBKEY, id);
+        Ok(self
+            .get_one::<Model>(&key)
+            .await?
+            .map(|(v, rev)| ResourceEntry::new(id, v, rev)))
+    }
+
+    async fn list_models(&self) -> Result<Vec<ResourceEntry<Model>>, StoreError> {
+        Ok(self
+            .list_range::<Model>(MODELS_SUBKEY)
+            .await?
+            .into_iter()
+            .map(|(id, v, rev)| ResourceEntry::new(id, v, rev))
+            .collect())
+    }
+
+    async fn delete_model(&self, id: &str) -> Result<bool, StoreError> {
+        self.delete_one(&self.key_for(MODELS_SUBKEY, id)).await
+    }
+
+    async fn put_apikey(&self, entry: ResourceEntry<ApiKey>) -> Result<(), StoreError> {
+        let key = self.key_for(APIKEYS_SUBKEY, &entry.id);
+        self.put_json(&key, &entry.value).await
+    }
+
+    async fn get_apikey(&self, id: &str) -> Result<Option<ResourceEntry<ApiKey>>, StoreError> {
+        let key = self.key_for(APIKEYS_SUBKEY, id);
+        Ok(self
+            .get_one::<ApiKey>(&key)
+            .await?
+            .map(|(v, rev)| ResourceEntry::new(id, v, rev)))
+    }
+
+    async fn list_apikeys(&self) -> Result<Vec<ResourceEntry<ApiKey>>, StoreError> {
+        Ok(self
+            .list_range::<ApiKey>(APIKEYS_SUBKEY)
+            .await?
+            .into_iter()
+            .map(|(id, v, rev)| ResourceEntry::new(id, v, rev))
+            .collect())
+    }
+
+    async fn delete_apikey(&self, id: &str) -> Result<bool, StoreError> {
+        self.delete_one(&self.key_for(APIKEYS_SUBKEY, id)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Build a store *without* a real client so pure helper tests don't
+    // pay a Docker tax. The client is never used by these tests.
+    fn dummy_store() -> EtcdConfigStore {
+        // We can't construct `etcd_client::Client` without connecting, so
+        // build a "real" one pointing at a bogus endpoint — the connect
+        // is lazy and these tests never issue a request.
+        let client_fut = etcd_client::Client::connect(["http://127.0.0.1:59999"], None);
+        let client = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(client_fut)
+            .expect("lazy connect never fails synchronously");
+        EtcdConfigStore::new(client, "/aisix")
+    }
+
+    #[test]
+    fn key_for_matches_spec_layout() {
+        let store = dummy_store();
+        assert_eq!(store.key_for("models", "abc-1"), "/aisix/models/abc-1");
+        assert_eq!(store.key_for("apikeys", "xyz"), "/aisix/apikeys/xyz");
+    }
+
+    #[test]
+    fn range_prefix_includes_trailing_slash() {
+        let store = dummy_store();
+        assert_eq!(store.range_prefix("models"), "/aisix/models/");
+    }
+
+    #[test]
+    fn id_from_key_extracts_id_segment() {
+        let store = dummy_store();
+        assert_eq!(
+            store.id_from_key("/aisix/models/abc-1", "models"),
+            Some("abc-1"),
+        );
+        // Wrong kind prefix → None.
+        assert!(store.id_from_key("/aisix/apikeys/x", "models").is_none());
+        // Outside the configured prefix → None.
+        assert!(store.id_from_key("/other/models/x", "models").is_none());
+    }
+
+    #[test]
+    fn prefix_trailing_slash_is_trimmed_at_construction() {
+        let client = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(etcd_client::Client::connect(
+                ["http://127.0.0.1:59999"],
+                None,
+            ))
+            .expect("lazy connect never fails synchronously");
+        let store = EtcdConfigStore::new(client, "/aisix/");
+        assert_eq!(store.prefix(), "/aisix");
+        assert_eq!(store.key_for("models", "a"), "/aisix/models/a");
+    }
+
+    // Real end-to-end tests against a live etcd. Ignored by default so
+    // CI without Docker still passes; run locally with:
+    //   cargo test -p aisix-admin -- --ignored --test-threads=1
+    #[tokio::test]
+    #[ignore = "requires a running etcd container via testcontainers"]
+    async fn put_get_list_delete_roundtrip_against_real_etcd() {
+        use testcontainers::runners::AsyncRunner;
+        use testcontainers::{GenericImage, ImageExt};
+
+        let container = GenericImage::new("bitnami/etcd", "3.5")
+            .with_env_var("ALLOW_NONE_AUTHENTICATION", "yes")
+            .with_env_var("ETCD_LISTEN_CLIENT_URLS", "http://0.0.0.0:2379")
+            .with_env_var("ETCD_ADVERTISE_CLIENT_URLS", "http://0.0.0.0:2379")
+            .start()
+            .await
+            .expect("etcd container");
+        let port = container
+            .get_host_port_ipv4(2379)
+            .await
+            .expect("container port");
+        let endpoint = format!("http://127.0.0.1:{port}");
+
+        let client = etcd_client::Client::connect([endpoint], None)
+            .await
+            .expect("etcd client");
+        let store = EtcdConfigStore::new(client, "/aisix-it");
+
+        let model: Model = serde_json::from_str(
+            r#"{
+                "name": "it-gpt4",
+                "model": "openai/gpt-4o",
+                "provider_config": {"api_key": "sk-x"}
+            }"#,
+        )
+        .unwrap();
+        let entry = ResourceEntry::new("m-it-1", model, 0);
+        store.put_model(entry.clone()).await.unwrap();
+
+        let got = store.get_model("m-it-1").await.unwrap().unwrap();
+        assert_eq!(got.id, "m-it-1");
+        assert_eq!(got.value.name, "it-gpt4");
+        assert!(got.revision > 0, "etcd should return a real mod_revision");
+
+        let listed = store.list_models().await.unwrap();
+        assert_eq!(listed.len(), 1);
+
+        assert!(store.delete_model("m-it-1").await.unwrap());
+        assert!(store.get_model("m-it-1").await.unwrap().is_none());
+        assert!(!store.delete_model("m-it-1").await.unwrap());
+    }
+}

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -21,12 +21,14 @@
 mod apikeys_handlers;
 mod auth;
 mod error;
+pub mod etcd_store;
 mod models_handlers;
 mod state;
 pub mod store;
 
 pub use auth::AdminAuth;
 pub use error::{AdminError, ErrorBody};
+pub use etcd_store::EtcdConfigStore;
 pub use state::AdminState;
 pub use store::{ConfigStore, InMemoryStore, StoreError};
 

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -40,3 +40,4 @@ serde_json.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
+etcd-client.workspace = true

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use aisix_admin::{AdminState, ConfigStore, InMemoryStore};
+use aisix_admin::{AdminState, ConfigStore, EtcdConfigStore};
 use aisix_core::models::Provider;
 use aisix_core::Config;
 use aisix_etcd::{EtcdConfigProvider, Supervisor};
@@ -60,6 +60,13 @@ async fn run(cfg: Config) -> anyhow::Result<()> {
             .await
             .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
     );
+    // Separate client for the admin write path. We could share a single
+    // underlying connection via `Client::clone()` but keeping two is
+    // cleaner — writes and the watch stream don't contend on the same
+    // mutex.
+    let admin_client = etcd_client::Client::connect(&cfg.etcd.endpoints, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("etcd admin client connect failed: {e}"))?;
     let supervisor = Arc::new(Supervisor::new(provider, cfg.etcd.prefix.clone()));
     let snapshot_handle = supervisor.handle();
 
@@ -73,9 +80,11 @@ async fn run(cfg: Config) -> anyhow::Result<()> {
         hub.clone(),
         &cfg.proxy,
     ));
-    // Admin CRUD uses an in-memory store for now; an etcd-backed store
-    // lands in a follow-up PR.
-    let admin_store: Arc<dyn ConfigStore> = InMemoryStore::new();
+    // Admin CRUD writes through etcd. The watch supervisor's read path
+    // is on a separate client (see above) so a long range scan during a
+    // list doesn't stall the watch stream.
+    let admin_store: Arc<dyn ConfigStore> =
+        Arc::new(EtcdConfigStore::new(admin_client, cfg.etcd.prefix.clone()));
     let admin_router = aisix_admin::build_router(AdminState::new(
         snapshot_handle.clone(),
         admin_store,


### PR DESCRIPTION
## Summary

Admin writes now persist to etcd. The watch supervisor in \`aisix-etcd\`
sees them and propagates the resulting snapshot to the proxy read path,
closing the last loop in the config plane.

- **etcd_store.rs** — \`EtcdConfigStore\` implements \`ConfigStore\`
  against a real etcd client. Writes serialise *just the value*
  (\`Model\`/\`ApiKey\`) to \`{prefix}/{kind}/{id}\`, matching the
  value-only JSON shape \`aisix-etcd::loader\` already parses — no
  wire-format divergence between admin write and supervisor read.
- Key-layout helpers are unit-tested without a live etcd via a lazy
  connect trick (\`Client::connect\` only performs I/O when requests
  issue).
- Full round-trip test against a real etcd is gated
  \`#[ignore = "requires etcd container"]\` so CI without Docker stays
  green. Run locally with:
  \`\`\`
  cargo test -p aisix-admin -- --ignored
  \`\`\`
- Server bootstrap now opens two etcd clients — one for the
  read-side supervisor, one for the admin write path — so a long
  admin list scan doesn't stall the watch stream.
- \`InMemoryStore\` stays exported for unit tests and in-process dev.

## Test plan

- [x] 4 new unit tests (key_for, range_prefix, id_from_key, trailing-
  slash normalisation)
- [x] 1 ignored integration test using \`testcontainers\` — exercises the
  full put/get/list/delete round-trip against bitnami/etcd:3.5
- [x] \`cargo test --workspace\` — 190 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs