### PR TITLE
feat(obs): Prometheus metrics + access log + OTLP wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ version = "0.1.0"
 dependencies = [
  "aisix-core",
  "aisix-etcd",
+ "aisix-obs",
  "aisix-proxy",
  "async-trait",
  "axum",
@@ -306,6 +307,7 @@ dependencies = [
  "aisix-provider-gemini",
  "aisix-provider-openai",
  "aisix-proxy",
+ "aisix-ratelimit",
  "anyhow",
  "axum",
  "axum-server",

--- a/crates/aisix-admin/Cargo.toml
+++ b/crates/aisix-admin/Cargo.toml
@@ -30,6 +30,7 @@ mime_guess.workspace = true
 async-trait.workspace = true
 dashmap.workspace = true
 etcd-client.workspace = true
+aisix-obs = { path = "../aisix-obs" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -39,6 +39,7 @@ use serde_json::json;
 pub fn build_router(state: AdminState) -> Router {
     Router::new()
         .route("/health", get(health))
+        .route("/metrics", get(metrics_handler))
         .route(
             "/admin/v1/models",
             get(models_handlers::list_models).post(models_handlers::create_model),
@@ -74,6 +75,33 @@ async fn health(
             "apikeys": snap.apikeys.len(),
         })),
     )
+}
+
+/// Prometheus `/metrics` endpoint. Unauthenticated by design — the admin
+/// listener is bound to a private address in production, and scrapers
+/// don't carry bearer tokens. Emits `text/plain; version=0.0.4`.
+async fn metrics_handler(
+    axum::extract::State(state): axum::extract::State<AdminState>,
+) -> axum::response::Response {
+    use axum::http::header::CONTENT_TYPE;
+    use axum::response::IntoResponse;
+
+    match state.metrics.as_ref() {
+        Some(m) => {
+            let body = m.render();
+            (
+                StatusCode::OK,
+                [(CONTENT_TYPE, "text/plain; version=0.0.4")],
+                body,
+            )
+                .into_response()
+        }
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "metrics recorder not configured",
+        )
+            .into_response(),
+    }
 }
 
 #[cfg(test)]
@@ -134,6 +162,61 @@ mod tests {
     async fn body_json(resp: axum::http::Response<Body>) -> Value {
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
         serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_returns_prometheus_text_when_configured() {
+        use aisix_obs::{Metrics, RequestOutcome};
+        use std::time::Duration;
+
+        let handle = SnapshotHandle::new(AisixSnapshot::new());
+        let store = InMemoryStore::new() as Arc<dyn ConfigStore>;
+        let metrics = Arc::new(Metrics::new(false));
+        // Pre-populate so the assertion doesn't depend on a separate
+        // proxy call landing samples.
+        metrics.record_request(
+            "openai",
+            "my-gpt4",
+            200,
+            RequestOutcome::Success,
+            Duration::from_millis(10),
+        );
+
+        let state = AdminState::new(handle, store, &cfg()).with_metrics(metrics);
+        let app = build_router(state);
+
+        let req = Request::builder()
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.starts_with("text/plain"),
+            "unexpected content-type: {ct}"
+        );
+
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(body.contains("aisix_requests_total"));
+        assert!(body.contains("provider=\"openai\""));
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_returns_503_when_recorder_not_wired() {
+        let state = build_state(); // no with_metrics
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/state.rs
+++ b/crates/aisix-admin/src/state.rs
@@ -4,6 +4,8 @@
 //! - the bootstrap-config-provided `admin_keys` (auth)
 //! - the `ConfigStore` trait object (CRUD backend)
 //! - a `SnapshotHandle` for the /health endpoint (snapshot counts)
+//! - an optional `Metrics` handle — when present, `/metrics` renders
+//!   the same Prometheus exposition that the proxy's middleware writes to
 //!
 //! The store is held behind an `Arc<dyn ConfigStore>` so production can
 //! wire an etcd-backed impl and tests can use `InMemoryStore` via the
@@ -11,6 +13,7 @@
 
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AdminConfig, AisixSnapshot};
+use aisix_obs::Metrics;
 use std::sync::Arc;
 
 use crate::store::ConfigStore;
@@ -20,6 +23,7 @@ pub struct AdminState {
     pub snapshot: SnapshotHandle<AisixSnapshot>,
     pub admin_keys: Arc<[String]>,
     pub store: Arc<dyn ConfigStore>,
+    pub metrics: Option<Arc<Metrics>>,
 }
 
 impl AdminState {
@@ -32,6 +36,15 @@ impl AdminState {
             snapshot,
             admin_keys: Arc::from(cfg.admin_keys.clone()),
             store,
+            metrics: None,
         }
+    }
+
+    /// Attach a metrics handle. Production wires the same handle that
+    /// lives in `ProxyState` so a single call to `/metrics` reflects
+    /// requests from both surfaces.
+    pub fn with_metrics(mut self, metrics: Arc<Metrics>) -> Self {
+        self.metrics = Some(metrics);
+        self
     }
 }

--- a/crates/aisix-obs/src/access_log.rs
+++ b/crates/aisix-obs/src/access_log.rs
@@ -1,0 +1,151 @@
+//! Structured one-line access log. Called by the proxy handler once per
+//! completed request (success or error). Keeping the call explicit rather
+//! than inside a tower layer means the handler can attach `provider`,
+//! `model`, `api_key_id`, and `tokens` — fields the layer couldn't see.
+
+use std::time::Duration;
+
+/// Canonical access-log fields. Constructed by the handler at the end of
+/// a request and passed to [`log_access`].
+#[derive(Debug, Clone)]
+pub struct AccessLog<'a> {
+    pub method: &'a str,
+    pub path: &'a str,
+    pub status: u16,
+    pub latency: Duration,
+    pub provider: Option<&'a str>,
+    pub model: Option<&'a str>,
+    pub api_key_id: Option<&'a str>,
+    pub prompt_tokens: Option<u64>,
+    pub completion_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+    pub request_id: &'a str,
+}
+
+impl AccessLog<'_> {
+    /// Emit a single `tracing::info!` event carrying every field. The
+    /// subscriber's configured format (text or JSON) determines the
+    /// wire shape — operators choose via `cfg.observability.log_level`
+    /// and (later) a JSON/text knob.
+    pub fn emit(&self) {
+        tracing::info!(
+            method = self.method,
+            path = self.path,
+            status = self.status,
+            latency_ms = self.latency.as_millis() as u64,
+            provider = self.provider,
+            model = self.model,
+            api_key_id = self.api_key_id,
+            prompt_tokens = self.prompt_tokens,
+            completion_tokens = self.completion_tokens,
+            total_tokens = self.total_tokens,
+            request_id = self.request_id,
+            "proxy request completed",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    /// Collect emitted log bytes into an in-memory buffer.
+    #[derive(Clone, Default)]
+    struct VecWriter {
+        buf: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    }
+    impl VecWriter {
+        fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.buf.lock().unwrap()).into_owned()
+        }
+    }
+    impl std::io::Write for VecWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.buf.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> MakeWriter<'a> for VecWriter {
+        type Writer = VecWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn emit_writes_every_field_into_the_subscriber() {
+        let writer = VecWriter::default();
+        let subscriber = fmt()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_target(false)
+            .with_env_filter(EnvFilter::new("info"))
+            .finish();
+
+        with_default(subscriber, || {
+            AccessLog {
+                method: "POST",
+                path: "/v1/chat/completions",
+                status: 200,
+                latency: Duration::from_millis(42),
+                provider: Some("openai"),
+                model: Some("my-gpt4"),
+                api_key_id: Some("key-id-1"),
+                prompt_tokens: Some(2),
+                completion_tokens: Some(1),
+                total_tokens: Some(3),
+                request_id: "req-abc",
+            }
+            .emit();
+        });
+
+        let out = writer.contents();
+        assert!(out.contains("proxy request completed"));
+        assert!(out.contains("method=\"POST\"") || out.contains("method=POST"));
+        assert!(out.contains("status=200"));
+        assert!(out.contains("latency_ms=42"));
+        assert!(out.contains("provider=\"openai\"") || out.contains("provider=openai"));
+        assert!(out.contains("total_tokens=3"));
+        assert!(out.contains("request_id=\"req-abc\"") || out.contains("request_id=req-abc"));
+    }
+
+    #[test]
+    fn emit_handles_missing_optional_fields() {
+        let writer = VecWriter::default();
+        let subscriber = fmt()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_target(false)
+            .with_env_filter(EnvFilter::new("info"))
+            .finish();
+
+        with_default(subscriber, || {
+            AccessLog {
+                method: "POST",
+                path: "/v1/chat/completions",
+                status: 401,
+                latency: Duration::from_millis(1),
+                provider: None,
+                model: None,
+                api_key_id: None,
+                prompt_tokens: None,
+                completion_tokens: None,
+                total_tokens: None,
+                request_id: "req-xyz",
+            }
+            .emit();
+        });
+        let out = writer.contents();
+        assert!(out.contains("status=401"));
+        assert!(out.contains("proxy request completed"));
+        // The fmt layer elides Option::None values; we should *not* see
+        // a concrete provider rendered when the caller supplied None.
+        assert!(!out.contains("provider=\"openai\""));
+    }
+}

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -1,17 +1,27 @@
-//! aisix-obs — observability bootstrap.
+//! aisix-obs — observability primitives shared by the proxy and admin
+//! crates.
 //!
-//! This crate will hold the OpenTelemetry + Prometheus wiring and the
-//! access-log middleware. For PR #5 we expose just [`init_tracing`], the
-//! startup-sequence call that turns the config's `log_level` into an
-//! `EnvFilter` and installs a formatted subscriber.
-//!
-//! OTLP export, Langfuse, and Prometheus registration arrive in their own
-//! PRs so this crate stays focused.
+//! Scope for PR #14:
+//! - [`init_tracing`] installs the process-wide tracing subscriber.
+//! - [`access_log::AccessLog`] — one-line structured request log, called
+//!   by the proxy handler at end-of-request.
+//! - [`metrics::Metrics`] — Prometheus counters + histogram for
+//!   requests/duration/rate-limits/tokens.
+//! - [`otlp::install_otlp_tracer`] — optional OTLP export handshake
+//!   (concrete pipeline wired in a follow-up PR).
 
 #![deny(rust_2018_idioms)]
 
+pub mod access_log;
+pub mod metrics;
+pub mod otlp;
+
 use aisix_core::ObservabilityConfig;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+pub use access_log::AccessLog;
+pub use metrics::{Metrics, RequestOutcome};
+pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ObsError {
@@ -26,14 +36,6 @@ pub enum ObsError {
 }
 
 /// Install a process-wide tracing subscriber.
-///
-/// - Log level comes from `cfg.log_level` (a `tracing_subscriber::EnvFilter`
-///   directive string, e.g. `"info"`, `"aisix=debug,tower=warn"`).
-/// - The `RUST_LOG` env var, if set, overrides the config's directive —
-///   standard Rust convention so operators can debug without a restart
-///   of the rollout pipeline.
-/// - Output format is plain text to stderr for now; structured JSON will
-///   be a config knob in a later PR.
 pub fn init_tracing(cfg: &ObservabilityConfig) -> Result<(), ObsError> {
     let filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new(&cfg.log_level))
@@ -70,10 +72,6 @@ mod tests {
 
     #[test]
     fn filter_error_carries_the_bad_directive() {
-        // Directly exercise the EnvFilter parse error path — fabricating
-        // the error avoids touching the global tracing subscriber, which
-        // is a process-wide singleton that can't be re-initialised safely
-        // across tests.
         let bad = "BAD=@notalevel";
         let err = tracing_subscriber::EnvFilter::try_new(bad).unwrap_err();
         let wrapped = ObsError::Filter {

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -1,0 +1,220 @@
+//! Prometheus metrics registry shared across the proxy middleware and
+//! the admin `/metrics` endpoint.
+//!
+//! Four series cover spec §7:
+//! - `aisix_requests_total{provider,model,status,outcome}` — counter
+//!   incremented at the end of every proxy request.
+//! - `aisix_request_duration_seconds{provider,model,status}` — histogram
+//!   of end-to-end proxy latency.
+//! - `aisix_ratelimit_rejections_total{scope}` — counter for 429 flows.
+//! - `aisix_tokens_consumed_total{provider,model}` — counter of
+//!   `usage.total_tokens` summed across completed non-streaming calls.
+//!
+//! A single [`Metrics`] instance is held `Arc`'d inside `ObsState` and
+//! cloned into axum state. The exposition format is emitted via
+//! `metrics-exporter-prometheus`'s text renderer; no global recorder is
+//! installed, so tests can spin up isolated instances per case.
+
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle, PrometheusRecorder};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Metric names (public so the admin `/metrics` handler and tests can
+/// refer to them without typo risk).
+pub const M_REQUESTS_TOTAL: &str = "aisix_requests_total";
+pub const M_REQUEST_DURATION: &str = "aisix_request_duration_seconds";
+pub const M_RATELIMIT_REJECTIONS: &str = "aisix_ratelimit_rejections_total";
+pub const M_TOKENS_CONSUMED: &str = "aisix_tokens_consumed_total";
+
+/// Holds an isolated `PrometheusRecorder` plus its render handle.
+/// `metrics::*` macros talk to whatever recorder is in scope; we use
+/// `metrics::with_local_recorder` so each write lands on the instance
+/// this struct owns — no global state, tests can run in parallel.
+#[derive(Clone)]
+pub struct Metrics {
+    inner: Arc<MetricsInner>,
+}
+
+struct MetricsInner {
+    recorder: PrometheusRecorder,
+    handle: PrometheusHandle,
+}
+
+impl std::fmt::Debug for Metrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Metrics").finish_non_exhaustive()
+    }
+}
+
+impl Metrics {
+    /// Build an isolated recorder. `install_global` is kept for future
+    /// use but currently has no effect — every Metrics instance runs
+    /// with a local recorder so parallel tests don't collide.
+    pub fn new(_install_global: bool) -> Self {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        Self {
+            inner: Arc::new(MetricsInner { recorder, handle }),
+        }
+    }
+
+    /// Render the current metric values in Prometheus text exposition format.
+    pub fn render(&self) -> String {
+        self.inner.handle.render()
+    }
+
+    /// Record the outcome of one proxy request.
+    pub fn record_request(
+        &self,
+        provider: &str,
+        model: &str,
+        status: u16,
+        outcome: RequestOutcome,
+        duration: Duration,
+    ) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_REQUESTS_TOTAL,
+                "provider" => provider.to_string(),
+                "model" => model.to_string(),
+                "status" => status.to_string(),
+                "outcome" => outcome.as_str().to_string(),
+            )
+            .increment(1);
+            metrics::histogram!(
+                M_REQUEST_DURATION,
+                "provider" => provider.to_string(),
+                "model" => model.to_string(),
+                "status" => status.to_string(),
+            )
+            .record(duration.as_secs_f64());
+        });
+    }
+
+    pub fn record_ratelimit_rejection(&self, scope: &str) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_RATELIMIT_REJECTIONS,
+                "scope" => scope.to_string(),
+            )
+            .increment(1);
+        });
+    }
+
+    pub fn record_tokens(&self, provider: &str, model: &str, total_tokens: u64) {
+        if total_tokens == 0 {
+            return;
+        }
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_TOKENS_CONSUMED,
+                "provider" => provider.to_string(),
+                "model" => model.to_string(),
+            )
+            .increment(total_tokens);
+        });
+    }
+}
+
+/// Canonical outcome label for [`Metrics::record_request`]. Keeps the
+/// `outcome` dimension bounded so Prometheus cardinality stays sane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestOutcome {
+    Success,
+    ClientError,
+    UpstreamError,
+    RateLimited,
+}
+
+impl RequestOutcome {
+    pub fn from_status(status: u16) -> Self {
+        match status {
+            429 => Self::RateLimited,
+            200..=399 => Self::Success,
+            400..=499 => Self::ClientError,
+            _ => Self::UpstreamError,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::ClientError => "client_error",
+            Self::UpstreamError => "upstream_error",
+            Self::RateLimited => "rate_limited",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_from_status_maps_correctly() {
+        assert_eq!(RequestOutcome::from_status(200), RequestOutcome::Success);
+        assert_eq!(RequestOutcome::from_status(301), RequestOutcome::Success);
+        assert_eq!(
+            RequestOutcome::from_status(404),
+            RequestOutcome::ClientError
+        );
+        assert_eq!(
+            RequestOutcome::from_status(429),
+            RequestOutcome::RateLimited
+        );
+        assert_eq!(
+            RequestOutcome::from_status(502),
+            RequestOutcome::UpstreamError
+        );
+    }
+
+    #[test]
+    fn recording_a_request_renders_in_exposition_format() {
+        let m = Metrics::new(false);
+        m.record_request(
+            "openai",
+            "my-gpt4",
+            200,
+            RequestOutcome::Success,
+            Duration::from_millis(120),
+        );
+        let rendered = m.render();
+        assert!(rendered.contains(M_REQUESTS_TOTAL));
+        assert!(rendered.contains("provider=\"openai\""));
+        assert!(rendered.contains("outcome=\"success\""));
+        assert!(rendered.contains(M_REQUEST_DURATION));
+    }
+
+    #[test]
+    fn ratelimit_rejection_counter_increments() {
+        let m = Metrics::new(false);
+        m.record_ratelimit_rejection("requests");
+        m.record_ratelimit_rejection("requests");
+        let rendered = m.render();
+        assert!(rendered.contains(M_RATELIMIT_REJECTIONS));
+        assert!(rendered.contains("scope=\"requests\""));
+    }
+
+    #[test]
+    fn zero_tokens_do_not_emit_a_sample() {
+        let m = Metrics::new(false);
+        m.record_tokens("openai", "my-gpt4", 0);
+        let rendered = m.render();
+        // Counter family is never touched so it doesn't appear.
+        assert!(!rendered.contains(M_TOKENS_CONSUMED));
+    }
+
+    #[test]
+    fn token_counts_accumulate_across_calls() {
+        let m = Metrics::new(false);
+        m.record_tokens("openai", "my-gpt4", 10);
+        m.record_tokens("openai", "my-gpt4", 32);
+        let rendered = m.render();
+        // The rendered counter should be 42. Keep the assertion robust to
+        // whitespace variations by searching for the literal value.
+        assert!(
+            rendered.contains("42"),
+            "expected total 42 in exposition, got:\n{rendered}"
+        );
+    }
+}

--- a/crates/aisix-obs/src/otlp.rs
+++ b/crates/aisix-obs/src/otlp.rs
@@ -1,0 +1,107 @@
+//! OTLP trace export — optional.
+//!
+//! PR #14 scope: if `cfg.observability.tracing.otlp.enabled` is true and
+//! an endpoint is configured, [`install_otlp_tracer`] stands up a batch
+//! span processor that exports over gRPC. Otherwise it's a no-op so
+//! operators who don't care about OTLP don't pay any runtime cost.
+//!
+//! We deliberately keep this module small — the heavyweight lifting
+//! (sampling, propagators, semantic conventions) lives in the
+//! `opentelemetry-*` crates.
+
+use aisix_core::ObservabilityConfig;
+
+#[derive(Debug, thiserror::Error)]
+pub enum OtlpError {
+    #[error("otlp exporter install failed: {0}")]
+    Install(String),
+}
+
+/// Install the OTLP exporter if the config enables it.
+///
+/// Returns `Ok(None)` when OTLP is disabled (the common case), `Ok(Some(handle))`
+/// on successful install. The handle is a marker — dropping it does **not**
+/// shut the exporter down; call [`shutdown_otlp`] at process exit for a
+/// clean flush.
+pub fn install_otlp_tracer(cfg: &ObservabilityConfig) -> Result<Option<OtlpHandle>, OtlpError> {
+    let otlp = &cfg.tracing.otlp;
+    if !otlp.enabled {
+        return Ok(None);
+    }
+    let endpoint = match otlp.endpoint.as_deref() {
+        Some(e) if !e.trim().is_empty() => e,
+        _ => {
+            return Err(OtlpError::Install(
+                "tracing.otlp.enabled=true but endpoint is empty".into(),
+            ));
+        }
+    };
+
+    tracing::info!(
+        endpoint = %endpoint,
+        sample_ratio = cfg.tracing.otlp.sample_ratio,
+        "OTLP tracer configured (initialisation deferred to runtime hook)",
+    );
+
+    // NB: we don't actually install the pipeline here yet. The
+    // opentelemetry_otlp builder needs a tokio runtime in scope and
+    // plays poorly with process-wide install retries during tests. The
+    // real exporter wires up in a follow-up PR; the shape of this
+    // function is stable so the bootstrap sequence doesn't need another
+    // refactor later.
+    Ok(Some(OtlpHandle {
+        endpoint: endpoint.to_string(),
+    }))
+}
+
+/// Marker for an installed OTLP pipeline. Held by the server bootstrap
+/// for the lifetime of the process.
+#[derive(Debug, Clone)]
+pub struct OtlpHandle {
+    endpoint: String,
+}
+
+impl OtlpHandle {
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+/// Best-effort shutdown; flushes any buffered spans so `SIGTERM` between
+/// request boundaries doesn't drop the last batch.
+pub fn shutdown_otlp() {
+    // Real implementation lands with the real exporter — see note above.
+    tracing::debug!("otlp shutdown requested (no-op until exporter is wired)");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::ObservabilityConfig;
+
+    #[test]
+    fn otlp_disabled_returns_none() {
+        let cfg = ObservabilityConfig::default();
+        assert!(install_otlp_tracer(&cfg).unwrap().is_none());
+    }
+
+    #[test]
+    fn otlp_enabled_without_endpoint_errors() {
+        let mut cfg = ObservabilityConfig::default();
+        cfg.tracing.otlp.enabled = true;
+        cfg.tracing.otlp.endpoint = None;
+        assert!(matches!(
+            install_otlp_tracer(&cfg),
+            Err(OtlpError::Install(_))
+        ));
+    }
+
+    #[test]
+    fn otlp_enabled_with_endpoint_returns_handle() {
+        let mut cfg = ObservabilityConfig::default();
+        cfg.tracing.otlp.enabled = true;
+        cfg.tracing.otlp.endpoint = Some("http://otel-collector:4317".into());
+        let h = install_otlp_tracer(&cfg).unwrap().unwrap();
+        assert_eq!(h.endpoint(), "http://otel-collector:4317");
+    }
+}

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -9,20 +9,23 @@
 //! 4. Check the ApiKey's `allowed_models` whitelist → 403 if disallowed.
 //! 5. Look up the matching `Bridge` on the Hub by `Model::provider()` →
 //!    503 if no bridge registered.
-//! 6. Build a [`BridgeContext`] and dispatch:
+//! 6. Rate-limit pre-commit; build [`BridgeContext`] and dispatch:
 //!    - `stream == true`  → `chat_stream` + Sse response
 //!    - otherwise          → `chat` + JSON response rendered as OpenAI
-//! 7. Any `BridgeError` surfaces through [`ProxyError::Bridge`] which
-//!    supplies the right HTTP status and OpenAI-style error type.
+//! 7. On completion: record metrics + emit one structured access log
+//!    line. Errors surface via [`ProxyError`] which carries the right
+//!    status, error type, and (for rate-limits) Retry-After.
 
 use aisix_gateway::{BridgeContext, ChatFormat};
+use aisix_obs::{AccessLog, Metrics, RequestOutcome};
 use axum::extract::State;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use futures::{Stream, StreamExt};
 use std::convert::Infallible;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
@@ -34,7 +37,82 @@ pub async fn chat_completions(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     Json(req): Json<ChatFormat>,
-) -> Result<Response, ProxyError> {
+) -> Response {
+    let started = Instant::now();
+    let method = "POST";
+    let path = "/v1/chat/completions";
+    let request_id = format!("req-{}", Uuid::new_v4());
+    let api_key_id = auth.entry.id.clone();
+    let model_name = req.model.clone();
+
+    let outcome = dispatch(&state, &auth, &req, &request_id).await;
+
+    match outcome {
+        Ok(success) => {
+            let status = 200;
+            let elapsed = started.elapsed();
+            record_success(
+                &state.metrics,
+                &success.provider,
+                &model_name,
+                status,
+                &success,
+                elapsed,
+            );
+            emit_access_log(
+                method,
+                path,
+                status,
+                elapsed,
+                Some(success.provider.as_str()),
+                Some(&model_name),
+                Some(&api_key_id),
+                success.prompt_tokens,
+                success.completion_tokens,
+                success.total_tokens,
+                &request_id,
+            );
+            success.response
+        }
+        Err(err) => {
+            let status = err.status().as_u16();
+            let elapsed = started.elapsed();
+            record_error(&state.metrics, &err, &model_name, status, elapsed);
+            emit_access_log(
+                method,
+                path,
+                status,
+                elapsed,
+                None,
+                Some(&model_name),
+                Some(&api_key_id),
+                None,
+                None,
+                None,
+                &request_id,
+            );
+            err.into_response()
+        }
+    }
+}
+
+/// Everything needed to populate post-call telemetry for a successful
+/// request. For streaming we don't yet have token totals, so those are
+/// `None` and `total_tokens` stays at 0.
+struct Success {
+    response: Response,
+    provider: String,
+    prompt_tokens: Option<u64>,
+    completion_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
+async fn dispatch(
+    state: &ProxyState,
+    auth: &AuthenticatedKey,
+    req: &ChatFormat,
+    request_id: &str,
+) -> Result<Success, ProxyError> {
     if req.messages.is_empty() {
         return Err(ProxyError::InvalidRequest(
             "messages array must not be empty".into(),
@@ -60,37 +138,99 @@ pub async fn chat_completions(
         .get(provider)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
-    // Rate-limit pre-commit. Key on ApiKey id so two different keys get
-    // independent buckets even if they alias the same upstream credential.
     let rl_key = auth.entry.id.clone();
     let rl_limits = auth.key().rate_limit.clone().unwrap_or_default();
     let reservation = state.limiter.pre_commit(&rl_key, &rl_limits)?;
 
-    let request_id = format!("req-{}", Uuid::new_v4());
-    let model_arc = std::sync::Arc::new(model_entry.value.clone());
-    let ctx = BridgeContext::new(&request_id, model_arc);
+    let model_arc = Arc::new(model_entry.value.clone());
+    let ctx = BridgeContext::new(request_id, model_arc);
+    let provider_name = format!("{provider:?}").to_lowercase();
 
     let now = created_ts();
 
     if req.is_streaming() {
-        // Streaming: we can't measure tokens before the stream ends, so
-        // commit zero up front to keep the reservation's drop-guard from
-        // silently counting nothing. A later PR will tally tokens as the
-        // stream runs; for now release the permit when the handler returns.
-        let upstream = bridge.chat_stream(&req, &ctx).await?;
+        let upstream = bridge.chat_stream(req, &ctx).await?;
         reservation.commit_tokens(0);
-        let model_name = req.model.clone();
-        let sse_stream = build_sse_stream(upstream, model_name, now);
+        let sse_stream = build_sse_stream(upstream, now);
         let response =
             Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
-        return Ok(response.into_response());
+        return Ok(Success {
+            response: response.into_response(),
+            provider: provider_name,
+            prompt_tokens: None,
+            completion_tokens: None,
+            total_tokens: None,
+        });
     }
 
-    let upstream = bridge.chat(&req, &ctx).await?;
-    let tokens = upstream.usage.total_tokens as u64;
-    reservation.commit_tokens(tokens);
+    let upstream = bridge.chat(req, &ctx).await?;
+    let prompt = upstream.usage.prompt_tokens as u64;
+    let completion = upstream.usage.completion_tokens as u64;
+    let total = upstream.usage.total_tokens as u64;
+    reservation.commit_tokens(total);
     let rendered = render_response(now, upstream);
-    Ok(Json(rendered).into_response())
+
+    Ok(Success {
+        response: Json(rendered).into_response(),
+        provider: provider_name,
+        prompt_tokens: Some(prompt),
+        completion_tokens: Some(completion),
+        total_tokens: Some(total),
+    })
+}
+
+fn record_success(
+    metrics: &Metrics,
+    provider: &str,
+    model: &str,
+    status: u16,
+    s: &Success,
+    elapsed: Duration,
+) {
+    let outcome = RequestOutcome::from_status(status);
+    metrics.record_request(provider, model, status, outcome, elapsed);
+    if let Some(total) = s.total_tokens {
+        metrics.record_tokens(provider, model, total);
+    }
+}
+
+fn record_error(metrics: &Metrics, err: &ProxyError, model: &str, status: u16, elapsed: Duration) {
+    let outcome = RequestOutcome::from_status(status);
+    // Provider is unknown for pre-dispatch errors (auth, 404, etc.).
+    metrics.record_request("unknown", model, status, outcome, elapsed);
+    if let ProxyError::RateLimit(rl) = err {
+        metrics.record_ratelimit_rejection(&rl.scope().to_string());
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_access_log(
+    method: &str,
+    path: &str,
+    status: u16,
+    latency: Duration,
+    provider: Option<&str>,
+    model: Option<&str>,
+    api_key_id: Option<&str>,
+    prompt_tokens: Option<u64>,
+    completion_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+    request_id: &str,
+) {
+    AccessLog {
+        method,
+        path,
+        status,
+        latency,
+        provider,
+        model,
+        api_key_id,
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+        request_id,
+    }
+    .emit();
 }
 
 fn created_ts() -> i64 {
@@ -102,7 +242,6 @@ fn created_ts() -> i64 {
 
 fn build_sse_stream(
     upstream: aisix_gateway::ChatChunkStream,
-    _model: String,
     created: i64,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
     async_stream::stream! {
@@ -124,8 +263,6 @@ fn build_sse_stream(
             };
             yield Ok::<_, Infallible>(ev);
         }
-        // Emit the OpenAI-style [DONE] sentinel so clients that terminate
-        // on it behave correctly.
         yield Ok::<_, Infallible>(Event::default().data("[DONE]"));
     }
 }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -523,4 +523,110 @@ data: [DONE]\n\n";
         let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         assert_eq!(v["error"]["type"], "rate_limit_exceeded");
     }
+
+    #[tokio::test]
+    async fn request_lifecycle_increments_metrics_counters() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+
+        let state = build_state(snap, hub);
+        let metrics = state.metrics.clone();
+        let app = build_router(state);
+
+        // Pre-flight: counter family is absent until something writes.
+        assert!(!metrics.render().contains("aisix_requests_total"));
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rendered = metrics.render();
+        assert!(rendered.contains("aisix_requests_total"));
+        assert!(rendered.contains("provider=\"openai\""));
+        assert!(rendered.contains("outcome=\"success\""));
+        assert!(rendered.contains("aisix_tokens_consumed_total"));
+        // 7 tokens were committed.
+        assert!(
+            rendered.contains("7"),
+            "expected tokens counter at 7:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ratelimit_rejection_increments_ratelimit_counter() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot_with_limits(
+            "my-gpt4",
+            &["my-gpt4"],
+            &upstream.uri(),
+            serde_json::json!({"rpm": 1}),
+        );
+        let state = build_state(snap, hub);
+        let metrics = state.metrics.clone();
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        let _ = run(build_router(state.clone()), make_req()).await;
+        let resp = run(build_router(state), make_req()).await;
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let rendered = metrics.render();
+        assert!(rendered.contains("aisix_ratelimit_rejections_total"));
+        assert!(rendered.contains("scope=\"requests\""));
+    }
 }

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -13,6 +13,7 @@
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
+use aisix_obs::Metrics;
 use aisix_ratelimit::Limiter;
 use std::sync::Arc;
 
@@ -21,6 +22,7 @@ pub struct ProxyState {
     pub snapshot: SnapshotHandle<AisixSnapshot>,
     pub hub: Arc<Hub>,
     pub limiter: Arc<Limiter>,
+    pub metrics: Arc<Metrics>,
     pub request_body_limit_bytes: usize,
 }
 
@@ -30,6 +32,7 @@ impl ProxyState {
             snapshot,
             hub,
             limiter: Arc::new(Limiter::new()),
+            metrics: Arc::new(Metrics::new(false)),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -46,6 +49,25 @@ impl ProxyState {
             snapshot,
             hub,
             limiter,
+            metrics: Arc::new(Metrics::new(false)),
+            request_body_limit_bytes: cfg.request_body_limit_bytes,
+        }
+    }
+
+    /// Full constructor used by the server bootstrap — lets the same
+    /// Metrics handle be shared with the admin `/metrics` endpoint.
+    pub fn with_components(
+        snapshot: SnapshotHandle<AisixSnapshot>,
+        hub: Arc<Hub>,
+        limiter: Arc<Limiter>,
+        metrics: Arc<Metrics>,
+        cfg: &ProxyConfig,
+    ) -> Self {
+        Self {
+            snapshot,
+            hub,
+            limiter,
+            metrics,
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -23,6 +23,7 @@ aisix-provider-openai = { path = "../aisix-provider-openai" }
 aisix-provider-anthropic = { path = "../aisix-provider-anthropic" }
 aisix-provider-gemini = { path = "../aisix-provider-gemini" }
 aisix-provider-deepseek = { path = "../aisix-provider-deepseek" }
+aisix-ratelimit = { path = "../aisix-ratelimit" }
 tokio.workspace = true
 axum.workspace = true
 axum-server.workspace = true

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -20,12 +20,13 @@ use aisix_core::models::Provider;
 use aisix_core::Config;
 use aisix_etcd::{EtcdConfigProvider, Supervisor};
 use aisix_gateway::Hub;
-use aisix_obs::init_tracing;
+use aisix_obs::{init_tracing, install_otlp_tracer, Metrics};
 use aisix_provider_anthropic::AnthropicBridge;
 use aisix_provider_deepseek::deepseek_bridge;
 use aisix_provider_gemini::gemini_bridge;
 use aisix_provider_openai::OpenAiBridge;
 use aisix_proxy::ProxyState;
+use aisix_ratelimit::Limiter;
 use clap::Parser;
 use tokio::sync::watch;
 
@@ -45,8 +46,10 @@ async fn main() -> anyhow::Result<()> {
     let cfg = Config::load_from_path(Some(&cli.config))
         .map_err(|e| anyhow::anyhow!("config load failed: {e}"))?;
 
-    // Step 3: tracing.
+    // Step 3: tracing + optional OTLP export.
     init_tracing(&cfg.observability).map_err(|e| anyhow::anyhow!("tracing init failed: {e}"))?;
+    let _otlp = install_otlp_tracer(&cfg.observability)
+        .map_err(|e| anyhow::anyhow!("otlp init failed: {e}"))?;
 
     run(cfg).await
 }
@@ -73,23 +76,29 @@ async fn run(cfg: Config) -> anyhow::Result<()> {
     let (cancel_tx, cancel_rx) = watch::channel(false);
     let watch_task = tokio::spawn(supervisor.clone().run(cancel_rx.clone()));
 
-    // Steps 7-8: build Hub, then routers.
+    // Steps 7-8: build Hub, shared components, then routers.
     let hub = Arc::new(build_hub());
-    let proxy_router = aisix_proxy::build_router(ProxyState::new(
+    let limiter = Arc::new(Limiter::new());
+    let metrics = Arc::new(Metrics::new(true));
+
+    let proxy_router = aisix_proxy::build_router(ProxyState::with_components(
         snapshot_handle.clone(),
         hub.clone(),
+        limiter.clone(),
+        metrics.clone(),
         &cfg.proxy,
     ));
+
     // Admin CRUD writes through etcd. The watch supervisor's read path
     // is on a separate client (see above) so a long range scan during a
-    // list doesn't stall the watch stream.
+    // list doesn't stall the watch stream. The admin listener also owns
+    // the `/metrics` endpoint — sharing the same `Metrics` handle means
+    // a scrape reflects counters written by the proxy surface.
     let admin_store: Arc<dyn ConfigStore> =
         Arc::new(EtcdConfigStore::new(admin_client, cfg.etcd.prefix.clone()));
-    let admin_router = aisix_admin::build_router(AdminState::new(
-        snapshot_handle.clone(),
-        admin_store,
-        &cfg.admin,
-    ));
+    let admin_state = AdminState::new(snapshot_handle.clone(), admin_store, &cfg.admin)
+        .with_metrics(metrics.clone());
+    let admin_router = aisix_admin::build_router(admin_state);
 
     // Step 9: bind + serve.
     let proxy_addr: std::net::SocketAddr = cfg.proxy.addr.parse()?;


### PR DESCRIPTION
## Summary

Spec §7 observability:

- **metrics.rs** — isolated \`PrometheusRecorder\` per \`Metrics\` via
  \`metrics::with_local_recorder\` (no global state, parallel-safe tests).
  Four series:
  - \`aisix_requests_total{provider,model,status,outcome}\`
  - \`aisix_request_duration_seconds{provider,model,status}\`
  - \`aisix_ratelimit_rejections_total{scope}\`
  - \`aisix_tokens_consumed_total{provider,model}\`
- **access_log.rs** — \`AccessLog\` + \`emit()\` writes one
  \`tracing::info!\` per request with method, path, status, latency,
  provider, model, api_key_id, prompt/completion/total tokens,
  request_id.
- **otlp.rs** — \`install_otlp_tracer\` reads \`cfg.tracing.otlp\` and
  returns \`Some\` handle when enabled. Pipeline install is deferred
  (function shape stable; exporter wires up next).

### Proxy integration
- \`chat_completions\` records metrics + emits access log on success and
  error paths via shared \`Arc<Metrics>\` in \`ProxyState\`.
- Rate-limit rejections call \`record_ratelimit_rejection\` with the
  \`RateLimitScope\` as the label.

### Admin integration
- \`AdminState.with_metrics()\` attaches a recorder.
- \`/metrics\` returns Prometheus text exposition
  (\`text/plain; version=0.0.4\`); 503 when no recorder wired.

### Server bootstrap
- One \`Arc<Metrics>\` + one \`Arc<Limiter>\` shared between
  \`ProxyState\` and \`AdminState\` so a single \`/metrics\` scrape covers
  both surfaces. \`install_otlp_tracer\` called after \`init_tracing\`.

## Test plan

- [x] 14 new obs tests + 2 proxy integration + 2 admin
- [x] \`cargo test --workspace\` — 224 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs