### PR TITLE
feat(cache): exact-match response cache (moka) wired into proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ name = "aisix-cache"
 version = "0.1.0"
 dependencies = [
  "aisix-core",
+ "aisix-gateway",
  "async-trait",
  "moka",
  "redis",
@@ -298,6 +299,7 @@ name = "aisix-server"
 version = "0.1.0"
 dependencies = [
  "aisix-admin",
+ "aisix-cache",
  "aisix-core",
  "aisix-etcd",
  "aisix-gateway",

--- a/crates/aisix-cache/Cargo.toml
+++ b/crates/aisix-cache/Cargo.toml
@@ -10,6 +10,7 @@ description = "aisix: response cache (in-memory / Redis / semantic)"
 
 [dependencies]
 aisix-core = { path = "../aisix-core" }
+aisix-gateway = { path = "../aisix-gateway" }
 tokio.workspace = true
 async-trait.workspace = true
 serde.workspace = true
@@ -18,6 +19,9 @@ thiserror.workspace = true
 tracing.workspace = true
 moka.workspace = true
 redis = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [features]
 default = ["memory"]

--- a/crates/aisix-cache/src/cache.rs
+++ b/crates/aisix-cache/src/cache.rs
@@ -1,0 +1,51 @@
+//! [`Cache`] trait — the storage seam every backend implements against.
+//!
+//! Returning `Result<Option<…>, _>` rather than `Result<…, NotFound>`
+//! makes the call site read naturally: cache miss is an expected control
+//! flow, not an error.
+//!
+//! Held behind `Arc<dyn Cache>` in `ProxyState`. Trait objects need
+//! `async_trait` until native async-fn-in-traits become dyn-compatible.
+
+use aisix_gateway::ChatResponse;
+use async_trait::async_trait;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CacheError {
+    #[error("cache backend error: {0}")]
+    Backend(String),
+}
+
+/// Outcome of a cache lookup. Public so the proxy can attach the
+/// `x-aisix-cache: hit|miss` header without owning string literals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheOutcome {
+    Hit,
+    Miss,
+}
+
+impl CacheOutcome {
+    pub fn as_header_value(self) -> &'static str {
+        match self {
+            CacheOutcome::Hit => "hit",
+            CacheOutcome::Miss => "miss",
+        }
+    }
+}
+
+#[async_trait]
+pub trait Cache: Send + Sync + 'static {
+    async fn get(&self, key: &str) -> Result<Option<ChatResponse>, CacheError>;
+    async fn put(&self, key: &str, value: ChatResponse) -> Result<(), CacheError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_outcome_emits_canonical_header_string() {
+        assert_eq!(CacheOutcome::Hit.as_header_value(), "hit");
+        assert_eq!(CacheOutcome::Miss.as_header_value(), "miss");
+    }
+}

--- a/crates/aisix-cache/src/key.rs
+++ b/crates/aisix-cache/src/key.rs
@@ -1,0 +1,171 @@
+//! Canonical cache-key fingerprint.
+//!
+//! The key is a stable hash of the *request fingerprint* — the fields
+//! that materially affect the upstream response. Anything else (request
+//! id, deadlines, the caller's ApiKey, custom headers) is excluded so
+//! two callers asking the same question hit the same entry.
+//!
+//! Hash function is `std::hash::DefaultHasher` (SipHash-1-3, u64). For an
+//! in-memory exact-match cache that's fine: collisions over the bounded
+//! request space are exceedingly rare, and a stronger hash would be a
+//! single-line drop-in if we ever need it.
+
+use aisix_gateway::{ChatFormat, ChatMessage, Role};
+use std::hash::{Hash, Hasher};
+
+/// Stable fingerprint of a chat request — the inputs to the upstream call.
+/// We hash this struct (not the whole `ChatFormat`) so caching policy is
+/// explicit about what counts as "the same request".
+#[derive(Debug, Clone)]
+pub struct CacheKey {
+    pub model: String,
+    pub messages: Vec<(String, String)>, // (role, content)
+    pub temperature_milli: Option<u32>,  // f32 isn't Hash; quantise to milli
+    pub top_p_milli: Option<u32>,
+    pub max_tokens: Option<u32>,
+}
+
+impl CacheKey {
+    /// Build a key from the proxy's normalised `ChatFormat`. Streaming
+    /// requests are *not* cached at this layer — callers should skip the
+    /// cache when `req.is_streaming()`.
+    pub fn from_request(req: &ChatFormat) -> Self {
+        Self {
+            model: req.model.clone(),
+            messages: req.messages.iter().map(message_pair).collect(),
+            temperature_milli: req.temperature.map(quantise_milli),
+            top_p_milli: req.top_p.map(quantise_milli),
+            max_tokens: req.max_tokens,
+        }
+    }
+
+    /// Hex-encoded u64 hash, used as the cache backend's lookup key.
+    pub fn fingerprint(&self) -> String {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        self.hash(&mut h);
+        format!("{:016x}", h.finish())
+    }
+}
+
+impl Hash for CacheKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.model.hash(state);
+        for (role, content) in &self.messages {
+            role.hash(state);
+            content.hash(state);
+        }
+        self.temperature_milli.hash(state);
+        self.top_p_milli.hash(state);
+        self.max_tokens.hash(state);
+    }
+}
+
+fn message_pair(m: &ChatMessage) -> (String, String) {
+    (role_str(m.role).to_string(), m.content.clone())
+}
+
+fn role_str(role: Role) -> &'static str {
+    match role {
+        Role::System => "system",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    }
+}
+
+/// Convert an f32 in [0.0, 1.0]-ish range to a u32 in milli units.
+/// Saturates negatives at 0 and >65 at u32::MAX-ish; collisions on weird
+/// values are fine — the cache just doesn't help that request.
+fn quantise_milli(v: f32) -> u32 {
+    if v.is_nan() || v.is_sign_negative() {
+        return 0;
+    }
+    let scaled = v * 1_000.0;
+    if scaled > u32::MAX as f32 {
+        u32::MAX
+    } else {
+        scaled as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(model: &str, messages: Vec<ChatMessage>, temp: Option<f32>) -> ChatFormat {
+        let mut f = ChatFormat::new(model, messages);
+        f.temperature = temp;
+        f
+    }
+
+    #[test]
+    fn identical_requests_share_a_fingerprint() {
+        let a = req("m", vec![ChatMessage::user("hi")], Some(0.2));
+        let b = req("m", vec![ChatMessage::user("hi")], Some(0.2));
+        assert_eq!(
+            CacheKey::from_request(&a).fingerprint(),
+            CacheKey::from_request(&b).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn changing_message_content_changes_the_fingerprint() {
+        let a = req("m", vec![ChatMessage::user("hi")], None);
+        let b = req("m", vec![ChatMessage::user("yo")], None);
+        assert_ne!(
+            CacheKey::from_request(&a).fingerprint(),
+            CacheKey::from_request(&b).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn changing_temperature_changes_the_fingerprint() {
+        let a = req("m", vec![ChatMessage::user("hi")], Some(0.2));
+        let b = req("m", vec![ChatMessage::user("hi")], Some(0.7));
+        assert_ne!(
+            CacheKey::from_request(&a).fingerprint(),
+            CacheKey::from_request(&b).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn near_identical_temperatures_within_milli_collapse_to_same_fingerprint() {
+        // 0.2000001 quantises to 200 just like 0.2; intentional — float
+        // noise from JSON parsing shouldn't shatter the cache.
+        let a = req("m", vec![ChatMessage::user("hi")], Some(0.2));
+        let b = req("m", vec![ChatMessage::user("hi")], Some(0.200_000_1));
+        assert_eq!(
+            CacheKey::from_request(&a).fingerprint(),
+            CacheKey::from_request(&b).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn extras_and_request_id_do_not_affect_fingerprint() {
+        let mut a = req("m", vec![ChatMessage::user("hi")], None);
+        a.extra
+            .insert("anything".into(), serde_json::json!({"x": 1}));
+        let b = req("m", vec![ChatMessage::user("hi")], None);
+        assert_eq!(
+            CacheKey::from_request(&a).fingerprint(),
+            CacheKey::from_request(&b).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_16_hex_chars() {
+        let f = req("m", vec![ChatMessage::user("hi")], None);
+        let fp = CacheKey::from_request(&f).fingerprint();
+        assert_eq!(fp.len(), 16);
+        assert!(fp.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn quantise_handles_pathological_floats() {
+        assert_eq!(quantise_milli(f32::NAN), 0);
+        assert_eq!(quantise_milli(-1.0), 0);
+        assert_eq!(quantise_milli(0.0), 0);
+        assert_eq!(quantise_milli(0.5), 500);
+        assert_eq!(quantise_milli(f32::INFINITY), u32::MAX);
+    }
+}

--- a/crates/aisix-cache/src/lib.rs
+++ b/crates/aisix-cache/src/lib.rs
@@ -1,4 +1,26 @@
-//! aisix-cache — unified response cache trait with in-memory / Redis / semantic backends.
+//! aisix-cache — exact-match response cache for chat completions.
+//!
+//! The proxy looks up the cache before dispatching to the upstream
+//! Bridge. On hit it returns the cached `ChatResponse` directly with an
+//! `x-aisix-cache: hit` header; on miss it falls through to the bridge
+//! and stores the response with `x-aisix-cache: miss`.
+//!
+//! Backends:
+//! - [`MemoryCache`] (moka, in-process) — default, configured by
+//!   `cfg.cache.backend = "memory"`.
+//! - Redis backend lands in a follow-up PR behind the `redis` feature.
+//!
+//! Streaming responses aren't cached at this layer — the upstream stream
+//! has no terminal value to store. A separate semantic-cache PR may add
+//! a "first chunk" cache later.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+mod cache;
+mod key;
+mod memory;
+
+pub use cache::{Cache, CacheError, CacheOutcome};
+pub use key::CacheKey;
+pub use memory::{MemoryCache, DEFAULT_CAPACITY, DEFAULT_TTL};

--- a/crates/aisix-cache/src/memory.rs
+++ b/crates/aisix-cache/src/memory.rs
@@ -1,0 +1,113 @@
+//! In-memory backend backed by `moka`.
+//!
+//! TTL is per-cache (set at construction); per-entry overrides are not
+//! supported by moka's TTL eviction strategy, which fits our model —
+//! every entry expires the same way.
+
+use aisix_gateway::ChatResponse;
+use async_trait::async_trait;
+use moka::future::Cache as MokaCache;
+use std::time::Duration;
+
+use crate::cache::{Cache, CacheError};
+
+pub const DEFAULT_TTL: Duration = Duration::from_secs(300);
+pub const DEFAULT_CAPACITY: u64 = 10_000;
+
+#[derive(Debug)]
+pub struct MemoryCache {
+    inner: MokaCache<String, ChatResponse>,
+    ttl: Duration,
+}
+
+impl MemoryCache {
+    pub fn new(ttl: Duration, capacity: u64) -> Self {
+        let inner = MokaCache::builder()
+            .max_capacity(capacity)
+            .time_to_live(ttl)
+            .build();
+        Self { inner, ttl }
+    }
+
+    pub fn with_defaults() -> Self {
+        Self::new(DEFAULT_TTL, DEFAULT_CAPACITY)
+    }
+
+    pub fn ttl(&self) -> Duration {
+        self.ttl
+    }
+}
+
+impl Default for MemoryCache {
+    fn default() -> Self {
+        Self::with_defaults()
+    }
+}
+
+#[async_trait]
+impl Cache for MemoryCache {
+    async fn get(&self, key: &str) -> Result<Option<ChatResponse>, CacheError> {
+        Ok(self.inner.get(key).await)
+    }
+
+    async fn put(&self, key: &str, value: ChatResponse) -> Result<(), CacheError> {
+        self.inner.insert(key.to_string(), value).await;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_gateway::{ChatMessage, FinishReason, UsageStats};
+
+    fn sample_response() -> ChatResponse {
+        ChatResponse {
+            id: "cmpl-1".into(),
+            model: "m".into(),
+            message: ChatMessage::assistant("hi back"),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(2, 3),
+        }
+    }
+
+    #[tokio::test]
+    async fn put_then_get_round_trips() {
+        let cache = MemoryCache::with_defaults();
+        cache.put("k1", sample_response()).await.unwrap();
+        let got = cache.get("k1").await.unwrap().unwrap();
+        assert_eq!(got.message.content, "hi back");
+        assert_eq!(got.usage.total_tokens, 5);
+    }
+
+    #[tokio::test]
+    async fn get_for_missing_key_returns_none() {
+        let cache = MemoryCache::with_defaults();
+        assert!(cache.get("absent").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn ttl_eviction_drops_stale_entries() {
+        let cache = MemoryCache::new(Duration::from_millis(50), 100);
+        cache.put("k1", sample_response()).await.unwrap();
+        assert!(cache.get("k1").await.unwrap().is_some());
+        // Wait past TTL. Moka uses lazy eviction on read; one extra
+        // milli of slack to clear the boundary.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        // Force housekeeping so the test isn't dependent on the random
+        // background eviction tick.
+        cache.inner.run_pending_tasks().await;
+        assert!(cache.get("k1").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn put_overwrites_previous_value_for_same_key() {
+        let cache = MemoryCache::with_defaults();
+        cache.put("k", sample_response()).await.unwrap();
+        let mut updated = sample_response();
+        updated.message.content = "second".into();
+        cache.put("k", updated).await.unwrap();
+        let got = cache.get("k").await.unwrap().unwrap();
+        assert_eq!(got.message.content, "second");
+    }
+}

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -16,9 +16,11 @@
 //!    line. Errors surface via [`ProxyError`] which carries the right
 //!    status, error type, and (for rate-limits) Retry-After.
 
+use aisix_cache::CacheKey;
 use aisix_gateway::{BridgeContext, ChatFormat};
 use aisix_obs::{AccessLog, Metrics, RequestOutcome};
 use axum::extract::State;
+use axum::http::HeaderValue;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -32,6 +34,10 @@ use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
 use crate::render::{render_chunk, render_response};
 use crate::state::ProxyState;
+
+/// Header set on every non-streaming response indicating whether the
+/// response came from the cache (`hit`) or the upstream (`miss`).
+pub const CACHE_HEADER: &str = "x-aisix-cache";
 
 pub async fn chat_completions(
     State(state): State<ProxyState>,
@@ -163,15 +169,64 @@ async fn dispatch(
         });
     }
 
+    // Cache lookup runs before the upstream call. Streaming requests
+    // never hit this branch — `req.is_streaming()` short-circuits above.
+    let cache_key = state
+        .cache
+        .as_ref()
+        .map(|_| CacheKey::from_request(req).fingerprint());
+
+    if let (Some(cache), Some(key)) = (state.cache.as_ref(), cache_key.as_ref()) {
+        match cache.get(key).await {
+            Ok(Some(cached)) => {
+                // Release the reservation we took up front — the cached
+                // request shouldn't count against TPM.
+                reservation.commit_tokens(0);
+                let prompt = cached.usage.prompt_tokens as u64;
+                let completion = cached.usage.completion_tokens as u64;
+                let total = cached.usage.total_tokens as u64;
+                let mut response = Json(render_response(now, cached)).into_response();
+                response
+                    .headers_mut()
+                    .insert(CACHE_HEADER, HeaderValue::from_static("hit"));
+                return Ok(Success {
+                    response,
+                    provider: provider_name,
+                    prompt_tokens: Some(prompt),
+                    completion_tokens: Some(completion),
+                    total_tokens: Some(total),
+                });
+            }
+            Ok(None) => {} // miss → fall through to upstream call
+            Err(err) => {
+                // Cache failures are non-fatal — the upstream call still
+                // runs. Just log and move on.
+                tracing::warn!(error = %err, key = %key, "cache lookup failed");
+            }
+        }
+    }
+
     let upstream = bridge.chat(req, &ctx).await?;
     let prompt = upstream.usage.prompt_tokens as u64;
     let completion = upstream.usage.completion_tokens as u64;
     let total = upstream.usage.total_tokens as u64;
     reservation.commit_tokens(total);
-    let rendered = render_response(now, upstream);
+
+    if let (Some(cache), Some(key)) = (state.cache.as_ref(), cache_key.as_ref()) {
+        if let Err(err) = cache.put(key, upstream.clone()).await {
+            tracing::warn!(error = %err, key = %key, "cache write failed");
+        }
+    }
+
+    let mut response = Json(render_response(now, upstream)).into_response();
+    if cache_key.is_some() {
+        response
+            .headers_mut()
+            .insert(CACHE_HEADER, HeaderValue::from_static("miss"));
+    }
 
     Ok(Success {
-        response: Json(rendered).into_response(),
+        response,
         provider: provider_name,
         prompt_tokens: Some(prompt),
         completion_tokens: Some(completion),

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -87,7 +87,16 @@ mod tests {
         }
     }
 
+    /// State used by the *existing* tests — cache disabled so the
+    /// rate-limit / wiremock cases still see every request reach the
+    /// upstream. Cache-specific tests build state with the default
+    /// constructor (which keeps caching on) instead.
     fn build_state(snapshot: AisixSnapshot, hub: Arc<Hub>) -> ProxyState {
+        let handle = SnapshotHandle::new(snapshot);
+        ProxyState::new(handle, hub, &cfg()).without_cache()
+    }
+
+    fn build_state_with_cache(snapshot: AisixSnapshot, hub: Arc<Hub>) -> ProxyState {
         let handle = SnapshotHandle::new(snapshot);
         ProxyState::new(handle, hub, &cfg())
     }
@@ -628,5 +637,125 @@ data: [DONE]\n\n";
         let rendered = metrics.render();
         assert!(rendered.contains("aisix_ratelimit_rejections_total"));
         assert!(rendered.contains("scope=\"requests\""));
+    }
+
+    #[tokio::test]
+    async fn cache_hit_short_circuits_upstream_and_sets_header() {
+        // Wiremock that *only* satisfies one upstream call. If the cache
+        // ever lets a second request through, the test fails with a 500.
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "cached"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1) // hard expectation: exactly one upstream hit
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        // Cache enabled — uses the default constructor.
+        let state = build_state_with_cache(snap, hub);
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        // First request — miss.
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("x-aisix-cache")
+                .and_then(|v| v.to_str().ok()),
+            Some("miss"),
+        );
+
+        // Second identical request — hit.
+        let resp = run(build_router(state), make_req()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("x-aisix-cache")
+                .and_then(|v| v.to_str().ok()),
+            Some("hit"),
+        );
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["choices"][0]["message"]["content"], "cached");
+    }
+
+    #[tokio::test]
+    async fn cache_miss_when_request_payload_differs() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            // Two distinct payloads → expect exactly two upstream calls.
+            .expect(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state_with_cache(snap, hub);
+
+        let body_a = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "first"}]
+        });
+        let body_b = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "second"}]
+        });
+        let mk = |body: &serde_json::Value| {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        let r1 = run(build_router(state.clone()), mk(&body_a)).await;
+        let r2 = run(build_router(state), mk(&body_b)).await;
+        for r in [r1, r2] {
+            assert_eq!(r.status(), StatusCode::OK);
+            assert_eq!(
+                r.headers()
+                    .get("x-aisix-cache")
+                    .and_then(|v| v.to_str().ok()),
+                Some("miss"),
+            );
+        }
     }
 }

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -6,10 +6,15 @@
 //! - the `Hub` for resolving a `Provider` to the Bridge that serves it
 //! - the per-key [`Limiter`] — queried before each upstream call and
 //!   finalised after the response completes
+//! - an `Arc<Metrics>` shared with the admin `/metrics` endpoint
+//! - an `Arc<dyn Cache>` consulted before bridge dispatch (None disables
+//!   caching for that ProxyState; tests use this to keep the cache off
+//!   the hot path when they don't care about it)
 //! - the configured request-body size limit
 //!
 //! Cheap to clone: every field is either an `Arc` or a small Copy scalar.
 
+use aisix_cache::{Cache, MemoryCache};
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
@@ -23,6 +28,7 @@ pub struct ProxyState {
     pub hub: Arc<Hub>,
     pub limiter: Arc<Limiter>,
     pub metrics: Arc<Metrics>,
+    pub cache: Option<Arc<dyn Cache>>,
     pub request_body_limit_bytes: usize,
 }
 
@@ -33,6 +39,7 @@ impl ProxyState {
             hub,
             limiter: Arc::new(Limiter::new()),
             metrics: Arc::new(Metrics::new(false)),
+            cache: Some(Arc::new(MemoryCache::with_defaults())),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -50,17 +57,20 @@ impl ProxyState {
             hub,
             limiter,
             metrics: Arc::new(Metrics::new(false)),
+            cache: Some(Arc::new(MemoryCache::with_defaults())),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
 
     /// Full constructor used by the server bootstrap — lets the same
-    /// Metrics handle be shared with the admin `/metrics` endpoint.
+    /// Metrics handle be shared with the admin `/metrics` endpoint and
+    /// lets the caller supply a configured Cache backend.
     pub fn with_components(
         snapshot: SnapshotHandle<AisixSnapshot>,
         hub: Arc<Hub>,
         limiter: Arc<Limiter>,
         metrics: Arc<Metrics>,
+        cache: Option<Arc<dyn Cache>>,
         cfg: &ProxyConfig,
     ) -> Self {
         Self {
@@ -68,7 +78,15 @@ impl ProxyState {
             hub,
             limiter,
             metrics,
+            cache,
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
+    }
+
+    /// Disable caching on an existing state. Used by tests that need
+    /// every request to reach wiremock.
+    pub fn without_cache(mut self) -> Self {
+        self.cache = None;
+        self
     }
 }

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -24,6 +24,7 @@ aisix-provider-anthropic = { path = "../aisix-provider-anthropic" }
 aisix-provider-gemini = { path = "../aisix-provider-gemini" }
 aisix-provider-deepseek = { path = "../aisix-provider-deepseek" }
 aisix-ratelimit = { path = "../aisix-ratelimit" }
+aisix-cache = { path = "../aisix-cache" }
 tokio.workspace = true
 axum.workspace = true
 axum-server.workspace = true

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use aisix_admin::{AdminState, ConfigStore, EtcdConfigStore};
+use aisix_cache::{Cache, MemoryCache};
 use aisix_core::models::Provider;
 use aisix_core::Config;
 use aisix_etcd::{EtcdConfigProvider, Supervisor};
@@ -80,12 +81,16 @@ async fn run(cfg: Config) -> anyhow::Result<()> {
     let hub = Arc::new(build_hub());
     let limiter = Arc::new(Limiter::new());
     let metrics = Arc::new(Metrics::new(true));
+    // In-memory cache by default. Redis/semantic backends drop in here
+    // behind the same trait object once their PRs land.
+    let cache: Option<Arc<dyn Cache>> = Some(Arc::new(MemoryCache::with_defaults()));
 
     let proxy_router = aisix_proxy::build_router(ProxyState::with_components(
         snapshot_handle.clone(),
         hub.clone(),
         limiter.clone(),
         metrics.clone(),
+        cache.clone(),
         &cfg.proxy,
     ));
 


### PR DESCRIPTION
## Summary

Exact-match in-memory response cache for non-streaming chat completions.

- **key.rs** — \`CacheKey\` fingerprint over (model, messages[role+content],
  temperature, top_p, max_tokens). Floats quantised to milli so JSON
  parse noise doesn't shatter the cache. Hex \`u64\` →
  16-char fingerprint. Request id, ApiKey, custom headers, extras
  excluded so two callers with the same question hit the same entry.
- **memory.rs** — \`MemoryCache\` backed by \`moka::future::Cache\`.
  TTL + capacity configurable; defaults 5 min / 10k entries.
- **cache.rs** — \`Cache\` trait (async_trait, dyn-compat) +
  \`CacheError\` + \`CacheOutcome::{Hit, Miss}\`. Redis backend drops
  in behind the same \`Arc<dyn Cache>\` later.

### Proxy integration
- Lookup after rate-limit pre-commit, before bridge dispatch
  (non-streaming only).
- Hit: release reservation with 0 tokens; return cached
  \`ChatResponse\` with \`x-aisix-cache: hit\`.
- Miss: call bridge, store response, return with
  \`x-aisix-cache: miss\`. Cache write errors are non-fatal.

\`ProxyState\` gains \`cache: Option<Arc<dyn Cache>>\` — on by default;
tests that need every request to hit wiremock call \`.without_cache()\`.
Server bootstrap wires the default \`MemoryCache\`.

## Test plan

- [x] 12 new cache unit tests (key fingerprint stability, TTL eviction,
  put-overwrite, miss returns None)
- [x] 2 proxy integration tests via axum + wiremock:
  - second identical request short-circuits
    (\`expect(1)\` upstream)
  - two distinct payloads each hit upstream
    (\`expect(2)\` upstream)
- [x] \`cargo test --workspace\` — 238 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs