### PR TITLE
feat(admin-ui): Models + ApiKeys CRUD UI, embedded into the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: install
         working-directory: ui
         run: pnpm install --no-frozen-lockfile
+      - name: ui unit tests
+        working-directory: ui
+        run: pnpm test
       - name: build
         working-directory: ui
         run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,11 @@ dist
 coverage/
 .nyc_output
 
-# Embedded UI build output (produced by Vite, consumed by rust-embed)
-/crates/aisix-admin/ui-dist
+# Embedded UI build output (produced by Vite, consumed by rust-embed).
+# The directory itself is checked in (with a .gitkeep) so rust-embed can
+# build cleanly on a fresh clone before `pnpm build` has run.
+/crates/aisix-admin/ui-dist/*
+!/crates/aisix-admin/ui-dist/.gitkeep
 
 # Editor / OS
 .DS_Store

--- a/crates/aisix-admin/src/embedded_ui.rs
+++ b/crates/aisix-admin/src/embedded_ui.rs
@@ -1,0 +1,89 @@
+//! Embed the Vite-built admin UI into the binary at compile time.
+//!
+//! Vite emits to `crates/aisix-admin/ui-dist/`. `rust-embed` walks
+//! that directory at compile time and pulls every file in. Missing
+//! dist (no UI build yet) is tolerated — `Asset::iter()` returns an
+//! empty iterator and the handler returns 404 for every UI request.
+//!
+//! The router mounts assets at `/ui/*` and a thin redirect at `/ui`
+//! that points at `/ui/index.html` so a bare visit lands on the
+//! single-page app.
+
+use axum::body::Body;
+use axum::extract::Path;
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Redirect, Response};
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "ui-dist/"]
+struct Asset;
+
+/// Handler for `GET /ui` — redirect to the index so SPA routing works
+/// against a clean URL bar.
+pub async fn ui_root() -> Redirect {
+    Redirect::permanent("/ui/index.html")
+}
+
+/// Handler for `GET /ui/*path` — serve the embedded asset, falling back
+/// to `index.html` for unknown paths so the SPA's client-side router
+/// can take over (typical `try_files` pattern).
+pub async fn ui_asset(Path(path): Path<String>) -> Response {
+    serve(&path).unwrap_or_else(|| serve("index.html").unwrap_or_else(not_found))
+}
+
+fn serve(path: &str) -> Option<Response> {
+    let asset = Asset::get(path)?;
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::from(asset.data.into_owned()))
+        .ok()?;
+    if let Ok(value) = HeaderValue::from_str(mime.as_ref()) {
+        response.headers_mut().insert(header::CONTENT_TYPE, value);
+    }
+    Some(response)
+}
+
+fn not_found() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        "admin UI is not bundled in this binary build",
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// rust-embed compiles the `ui-dist/` folder into the binary at
+    /// build time. CI runs the UI build before the Rust build, so the
+    /// embed is non-empty in CI artefacts; on a developer machine that
+    /// hasn't run `pnpm build` yet, it's empty — both are valid states
+    /// and the handler degrades gracefully.
+    #[tokio::test]
+    async fn ui_root_redirects_to_index() {
+        let resp = ui_root().await.into_response();
+        assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT);
+        let location = resp
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(location, "/ui/index.html");
+    }
+
+    #[tokio::test]
+    async fn ui_asset_returns_404_for_missing_when_no_index() {
+        // We can't assume index.html exists in a dev build with no
+        // ui-dist; only assert the handler doesn't panic on missing
+        // paths and returns *some* HTTP response.
+        let resp = ui_asset(Path("definitely-not-here.css".into())).await;
+        let status = resp.status();
+        assert!(
+            status == StatusCode::OK || status == StatusCode::NOT_FOUND,
+            "unexpected status: {status}",
+        );
+    }
+}

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -20,9 +20,11 @@
 
 mod apikeys_handlers;
 mod auth;
+mod embedded_ui;
 mod error;
 pub mod etcd_store;
 mod models_handlers;
+mod openapi;
 mod state;
 pub mod store;
 
@@ -40,6 +42,16 @@ pub fn build_router(state: AdminState) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/metrics", get(metrics_handler))
+        // OpenAPI scalar UI is unauthenticated like /metrics — admin
+        // listener is private in production.
+        .route("/admin/openapi.json", get(openapi::openapi_json))
+        .route("/admin/openapi-scalar", get(openapi::openapi_scalar))
+        // Embedded SPA. Bare `/ui` redirects to `/ui/index.html`; the
+        // wildcard handles every static asset and falls back to
+        // index.html for unknown paths so client-side routing works.
+        .route("/ui", get(embedded_ui::ui_root))
+        .route("/ui/", get(embedded_ui::ui_root))
+        .route("/ui/*path", get(embedded_ui::ui_asset))
         .route(
             "/admin/v1/models",
             get(models_handlers::list_models).post(models_handlers::create_model),
@@ -162,6 +174,48 @@ mod tests {
     async fn body_json(resp: axum::http::Response<Body>) -> Value {
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
         serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn openapi_json_endpoint_serves_the_spec() {
+        let app = build_router(build_state());
+        let req = Request::builder()
+            .uri("/admin/openapi.json")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["openapi"], "3.1.0");
+        assert!(v["paths"]["/admin/v1/models"].is_object());
+    }
+
+    #[tokio::test]
+    async fn openapi_scalar_endpoint_serves_html_loader() {
+        let app = build_router(build_state());
+        let req = Request::builder()
+            .uri("/admin/openapi-scalar")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(body.contains("/admin/openapi.json"));
+    }
+
+    #[tokio::test]
+    async fn ui_root_redirects_to_index() {
+        let app = build_router(build_state());
+        let req = Request::builder().uri("/ui").body(Body::empty()).unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT);
+        let location = resp
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(location, "/ui/index.html");
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1,0 +1,100 @@
+//! Minimal OpenAPI document + Scalar mount.
+//!
+//! Only the admin CRUD endpoints are described here today. The proxy
+//! `/v1/chat/completions` surface is OpenAI-compatible and operators
+//! refer to OpenAI's published spec for that — duplicating it here adds
+//! drift risk without adding signal. Future PRs that introduce
+//! aisix-specific request/response shapes can extend the spec inline.
+//!
+//! The Scalar UI is a single static HTML page that loads the JSON spec
+//! over HTTP — no JS bundling required.
+
+use axum::http::header;
+use axum::response::{Html, IntoResponse, Response};
+
+/// Hand-written JSON spec. Small enough that maintaining it by hand is
+/// less effort than wiring `utoipa` derive macros across every handler;
+/// the surface is stable enough that drift is easy to spot in review.
+const OPENAPI_JSON: &str = r#"{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "aisix admin API",
+    "version": "0.1.0",
+    "description": "CRUD for Models and ApiKeys. All endpoints require Bearer admin-key auth. Errors use {error_msg}."
+  },
+  "paths": {
+    "/admin/v1/models": {
+      "get":  { "summary": "list models",  "responses": {"200": {"description": "OK"}} },
+      "post": { "summary": "create model", "responses": {"200": {"description": "OK"}, "409": {"description": "duplicate name"}} }
+    },
+    "/admin/v1/models/{id}": {
+      "get":    { "summary": "get model",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
+      "put":    { "summary": "update model", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}, "409": {"description": "duplicate name"}} },
+      "delete": { "summary": "delete model", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
+    },
+    "/admin/v1/apikeys": {
+      "get":  { "summary": "list api keys",  "responses": {"200": {"description": "OK"}} },
+      "post": { "summary": "create api key", "responses": {"200": {"description": "OK"}, "409": {"description": "duplicate key"}} }
+    },
+    "/admin/v1/apikeys/{id}": {
+      "get":    { "summary": "get api key",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
+      "put":    { "summary": "update api key", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}, "409": {"description": "duplicate key"}} },
+      "delete": { "summary": "delete api key", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "AdminBearer": { "type": "http", "scheme": "bearer" }
+    }
+  },
+  "security": [{ "AdminBearer": [] }]
+}"#;
+
+const SCALAR_HTML: &str = r#"<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>aisix admin OpenAPI</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="/admin/openapi.json"
+      type="application/javascript"
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>"#;
+
+pub async fn openapi_json() -> Response {
+    ([(header::CONTENT_TYPE, "application/json")], OPENAPI_JSON).into_response()
+}
+
+pub async fn openapi_scalar() -> Html<&'static str> {
+    Html(SCALAR_HTML)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn openapi_json_is_well_formed_and_documents_admin_paths() {
+        let resp = openapi_json().await;
+        assert_eq!(resp.status(), 200);
+        // Validate by parsing — guards against typos in the literal block.
+        let parsed: serde_json::Value =
+            serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
+        assert!(parsed["paths"]["/admin/v1/models"].is_object());
+        assert!(parsed["paths"]["/admin/v1/apikeys/{id}"].is_object());
+    }
+
+    #[tokio::test]
+    async fn scalar_html_loads_the_spec_url() {
+        let html = openapi_scalar().await;
+        let body = html.0;
+        assert!(body.contains("/admin/openapi.json"));
+        assert!(body.contains("scalar"));
+    }
+}

--- a/crates/aisix-admin/ui-dist/.gitkeep
+++ b/crates/aisix-admin/ui-dist/.gitkeep
@@ -1,0 +1,1 @@
+Reserved for the Vite-built admin UI. Populated by `pnpm --filter aisix-ui build` (or the CI build-ui job) and embedded into the binary at compile time via rust-embed (see crates/aisix-admin/src/embedded_ui.rs).

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,29 +8,29 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "@monaco-editor/react": "^4.6.0",
-    "@tanstack/react-query": "^5.59.0",
-    "@tanstack/react-router": "^1.60.0",
     "clsx": "^2.1.1",
-    "i18next": "^23.15.0",
-    "next-themes": "^0.3.0",
-    "openai": "^4.67.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-i18next": "^15.0.0",
     "tailwind-merge": "^2.5.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.12.0",
+    "jsdom": "^25.0.1",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vitest": "^2.1.2"
   }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,21 +1,65 @@
-// aisix — Admin UI entrypoint. Scaffold for PR #1.
-// Real layout, routing, theme, i18n arrive in PR #11 (see plan §4.11).
+import { useState } from "react";
+import { ApiKeysView } from "./components/ApiKeysView";
+import { ConnectionForm } from "./components/ConnectionForm";
+import { ModelsView } from "./components/ModelsView";
+import { isConfigured, loadConnection } from "./storage";
+
+type Tab = "models" | "apikeys" | "connection";
 
 export default function App() {
+  const [connection, setConnection] = useState(loadConnection());
+  const [tab, setTab] = useState<Tab>(
+    isConfigured(loadConnection()) ? "models" : "connection",
+  );
+
   return (
-    <main className="min-h-dvh flex items-center justify-center bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
-      <section className="max-w-xl px-8 py-12">
-        <h1 className="text-5xl font-semibold tracking-tight">aisix</h1>
-        <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
-          AI Gateway scaffold. Admin console is arriving in PR #11 — models, API
-          keys, playground, observability, and the full bento dashboard.
-        </p>
-        <pre className="mt-8 rounded-md bg-zinc-900 text-zinc-100 px-4 py-3 text-xs overflow-x-auto">
-{`GET  /aisix/admin/health
-POST /aisix/admin/models
-POST /playground/chat/completions`}
-        </pre>
-      </section>
-    </main>
+    <div className="min-h-dvh bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
+      <header className="border-b border-zinc-200 bg-white px-6 py-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="mx-auto flex max-w-5xl items-center justify-between">
+          <h1 className="text-xl font-semibold tracking-tight">aisix admin</h1>
+          <nav className="flex gap-2">
+            <NavButton label="Models" active={tab === "models"} onClick={() => setTab("models")} />
+            <NavButton label="API keys" active={tab === "apikeys"} onClick={() => setTab("apikeys")} />
+            <NavButton label="Connection" active={tab === "connection"} onClick={() => setTab("connection")} />
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-5xl px-6 py-8">
+        {tab === "connection" && (
+          <ConnectionForm
+            initial={connection}
+            onSaved={(c) => {
+              setConnection(c);
+              setTab("models");
+            }}
+          />
+        )}
+        {tab === "models" && <ModelsView connection={connection} />}
+        {tab === "apikeys" && <ApiKeysView connection={connection} />}
+      </main>
+    </div>
+  );
+}
+
+interface NavButtonProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+function NavButton({ label, active, onClick }: NavButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? "rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-zinc-50 dark:bg-zinc-100 dark:text-zinc-900"
+          : "rounded-md px-3 py-1.5 text-sm font-medium hover:bg-zinc-100 dark:hover:bg-zinc-800"
+      }
+    >
+      {label}
+    </button>
   );
 }

--- a/ui/src/__tests__/storage.test.ts
+++ b/ui/src/__tests__/storage.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearConnection,
+  DEFAULT_CONNECTION,
+  isConfigured,
+  loadConnection,
+  saveConnection,
+} from "../storage";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("storage", () => {
+  it("returns the default connection when nothing is stored", () => {
+    expect(loadConnection()).toEqual(DEFAULT_CONNECTION);
+  });
+
+  it("round-trips a connection through save/load", () => {
+    saveConnection({ endpoint: "http://x", adminKey: "k" });
+    expect(loadConnection()).toEqual({ endpoint: "http://x", adminKey: "k" });
+  });
+
+  it("falls back to defaults when stored JSON is corrupt", () => {
+    window.localStorage.setItem("aisix.connection", "{not json");
+    expect(loadConnection()).toEqual(DEFAULT_CONNECTION);
+  });
+
+  it("clearConnection removes the entry", () => {
+    saveConnection({ endpoint: "http://x", adminKey: "k" });
+    clearConnection();
+    expect(window.localStorage.getItem("aisix.connection")).toBeNull();
+  });
+
+  it("isConfigured requires both endpoint and adminKey to be non-empty", () => {
+    expect(isConfigured({ endpoint: "", adminKey: "" })).toBe(false);
+    expect(isConfigured({ endpoint: "http://x", adminKey: "" })).toBe(false);
+    expect(isConfigured({ endpoint: "", adminKey: "k" })).toBe(false);
+    expect(isConfigured({ endpoint: "http://x", adminKey: "k" })).toBe(true);
+  });
+});

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,0 +1,88 @@
+// Tiny fetch wrapper around the admin API. Returns parsed JSON on
+// success, throws an `AdminApiError` carrying `error_msg` on failure
+// so handlers can render the canonical envelope.
+
+import type {
+  AdminError,
+  ApiKey,
+  Model,
+  ResourceEntry,
+} from "./types";
+import type { Connection } from "./storage";
+
+export class AdminApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "AdminApiError";
+    this.status = status;
+  }
+}
+
+async function request<T>(
+  conn: Connection,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const url = `${conn.endpoint.replace(/\/$/, "")}${path}`;
+  const init: RequestInit = {
+    method,
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${conn.adminKey}`,
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  const resp = await fetch(url, init);
+
+  if (!resp.ok) {
+    let msg = `${method} ${path} failed: ${resp.status} ${resp.statusText}`;
+    try {
+      const parsed = (await resp.json()) as AdminError;
+      if (parsed && typeof parsed.error_msg === "string") {
+        msg = parsed.error_msg;
+      }
+    } catch {
+      // body wasn't JSON — keep the default status-line message
+    }
+    throw new AdminApiError(msg, resp.status);
+  }
+
+  // 204 / empty body → return undefined cast to T (the caller knows
+  // its endpoint shape).
+  if (resp.status === 204 || resp.headers.get("content-length") === "0") {
+    return undefined as T;
+  }
+  return (await resp.json()) as T;
+}
+
+export const api = {
+  listModels: (c: Connection): Promise<ResourceEntry<Model>[]> =>
+    request(c, "GET", "/admin/v1/models"),
+  createModel: (c: Connection, m: Model): Promise<ResourceEntry<Model>> =>
+    request(c, "POST", "/admin/v1/models", m),
+  updateModel: (
+    c: Connection,
+    id: string,
+    m: Model,
+  ): Promise<ResourceEntry<Model>> =>
+    request(c, "PUT", `/admin/v1/models/${encodeURIComponent(id)}`, m),
+  deleteModel: (c: Connection, id: string): Promise<unknown> =>
+    request(c, "DELETE", `/admin/v1/models/${encodeURIComponent(id)}`),
+
+  listApiKeys: (c: Connection): Promise<ResourceEntry<ApiKey>[]> =>
+    request(c, "GET", "/admin/v1/apikeys"),
+  createApiKey: (c: Connection, k: ApiKey): Promise<ResourceEntry<ApiKey>> =>
+    request(c, "POST", "/admin/v1/apikeys", k),
+  updateApiKey: (
+    c: Connection,
+    id: string,
+    k: ApiKey,
+  ): Promise<ResourceEntry<ApiKey>> =>
+    request(c, "PUT", `/admin/v1/apikeys/${encodeURIComponent(id)}`, k),
+  deleteApiKey: (c: Connection, id: string): Promise<unknown> =>
+    request(c, "DELETE", `/admin/v1/apikeys/${encodeURIComponent(id)}`),
+};

--- a/ui/src/components/ApiKeysView.tsx
+++ b/ui/src/components/ApiKeysView.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState } from "react";
+import { api, AdminApiError } from "../api";
+import type { Connection } from "../storage";
+import type { ApiKey, ResourceEntry } from "../types";
+import { ErrorBanner } from "./ErrorBanner";
+
+interface ApiKeysViewProps {
+  connection: Connection;
+}
+
+interface FormState {
+  editingId: string | null;
+  key: string;
+  // Comma-separated for the form; split on save.
+  allowedModelsCsv: string;
+}
+
+const EMPTY_FORM: FormState = {
+  editingId: null,
+  key: "",
+  allowedModelsCsv: "",
+};
+
+export function ApiKeysView({ connection }: ApiKeysViewProps) {
+  const [entries, setEntries] = useState<ResourceEntry<ApiKey>[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await api.listApiKeys(connection);
+      setEntries(list);
+    } catch (e) {
+      setError(toMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connection.endpoint, connection.adminKey]);
+
+  function startCreate() {
+    setForm(EMPTY_FORM);
+  }
+
+  function startEdit(entry: ResourceEntry<ApiKey>) {
+    setForm({
+      editingId: entry.id,
+      key: entry.value.key,
+      allowedModelsCsv: entry.value.allowed_models.join(", "),
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const allowed = form.allowedModelsCsv
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const payload: ApiKey = {
+      key: form.key.trim(),
+      allowed_models: allowed,
+    };
+    try {
+      if (form.editingId) {
+        await api.updateApiKey(connection, form.editingId, payload);
+      } else {
+        await api.createApiKey(connection, payload);
+      }
+      setForm(EMPTY_FORM);
+      await refresh();
+    } catch (e) {
+      setError(toMessage(e));
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm(`Delete API key ${id}? This is permanent.`)) return;
+    setError(null);
+    try {
+      await api.deleteApiKey(connection, id);
+      if (form.editingId === id) setForm(EMPTY_FORM);
+      await refresh();
+    } catch (e) {
+      setError(toMessage(e));
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h2 className="text-2xl font-semibold tracking-tight">API keys</h2>
+        <button
+          type="button"
+          onClick={startCreate}
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          New
+        </button>
+      </header>
+
+      <ErrorBanner message={error} onDismiss={() => setError(null)} />
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-3 rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
+      >
+        <label className="block">
+          <span className="text-sm font-medium">Key</span>
+          <input
+            type="text"
+            value={form.key}
+            onChange={(e) => setForm((f) => ({ ...f, key: e.target.value }))}
+            required
+            placeholder="sk-..."
+            className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium">Allowed models (comma-separated)</span>
+          <input
+            type="text"
+            value={form.allowedModelsCsv}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, allowedModelsCsv: e.target.value }))
+            }
+            placeholder="my-gpt4, my-claude"
+            className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+          />
+          <span className="mt-1 block text-xs text-zinc-500">
+            Empty list denies all models (per spec §3).
+          </span>
+        </label>
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            {form.editingId ? "Update" : "Create"}
+          </button>
+          {form.editingId && (
+            <button
+              type="button"
+              onClick={() => setForm(EMPTY_FORM)}
+              className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
+
+      {loading ? (
+        <p className="text-sm text-zinc-500">Loading…</p>
+      ) : entries.length === 0 ? (
+        <p className="text-sm text-zinc-500">No API keys yet.</p>
+      ) : (
+        <ul className="divide-y divide-zinc-200 rounded-md border border-zinc-200 bg-white dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+          {entries.map((e) => (
+            <li
+              key={e.id}
+              className="flex items-center justify-between gap-4 px-4 py-3"
+            >
+              <div className="min-w-0">
+                <div className="font-mono text-sm">{e.value.key}</div>
+                <div className="truncate text-xs text-zinc-500">
+                  {e.value.allowed_models.length === 0
+                    ? "no models allowed"
+                    : `models: ${e.value.allowed_models.join(", ")}`}
+                  {" · rev "}
+                  {e.revision}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => startEdit(e)}
+                  className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(e.id)}
+                  className="rounded-md border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-300 dark:hover:bg-red-950"
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function toMessage(e: unknown): string {
+  if (e instanceof AdminApiError) return e.message;
+  if (e instanceof Error) return e.message;
+  return "Unknown error";
+}

--- a/ui/src/components/ConnectionForm.tsx
+++ b/ui/src/components/ConnectionForm.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import {
+  type Connection,
+  DEFAULT_CONNECTION,
+  saveConnection,
+} from "../storage";
+
+interface ConnectionFormProps {
+  initial: Connection;
+  onSaved: (c: Connection) => void;
+}
+
+// Connection settings form. Stores the admin endpoint + key in
+// localStorage via `saveConnection` so the user doesn't have to
+// re-enter on reload. Validation is intentionally light — the API
+// itself will reject bad endpoints and the {error_msg} envelope
+// surfaces through ErrorBanner.
+export function ConnectionForm({ initial, onSaved }: ConnectionFormProps) {
+  const [endpoint, setEndpoint] = useState(initial.endpoint);
+  const [adminKey, setAdminKey] = useState(initial.adminKey);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmedEndpoint = endpoint.trim();
+    const trimmedKey = adminKey.trim();
+    if (!trimmedEndpoint) {
+      setValidationError("Endpoint is required.");
+      return;
+    }
+    if (!trimmedKey) {
+      setValidationError("Admin key is required.");
+      return;
+    }
+    setValidationError(null);
+    const next: Connection = {
+      endpoint: trimmedEndpoint,
+      adminKey: trimmedKey,
+    };
+    saveConnection(next);
+    onSaved(next);
+  }
+
+  function handleReset() {
+    setEndpoint(DEFAULT_CONNECTION.endpoint);
+    setAdminKey("");
+    setValidationError(null);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-xl">
+      <h2 className="text-2xl font-semibold tracking-tight">Connection</h2>
+      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+        Where to reach the aisix admin listener and which admin key to use.
+        Stored in your browser only.
+      </p>
+
+      <label className="block">
+        <span className="text-sm font-medium">Admin endpoint</span>
+        <input
+          type="text"
+          value={endpoint}
+          onChange={(e) => setEndpoint(e.target.value)}
+          placeholder="http://127.0.0.1:3001"
+          className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        />
+      </label>
+
+      <label className="block">
+        <span className="text-sm font-medium">Admin key</span>
+        <input
+          type="password"
+          value={adminKey}
+          onChange={(e) => setAdminKey(e.target.value)}
+          placeholder="Bearer token from cfg.admin.admin_keys"
+          className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        />
+      </label>
+
+      {validationError && (
+        <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+          {validationError}
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          type="submit"
+          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          Reset
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/ui/src/components/ErrorBanner.tsx
+++ b/ui/src/components/ErrorBanner.tsx
@@ -1,0 +1,37 @@
+import clsx from "clsx";
+
+interface ErrorBannerProps {
+  message: string | null;
+  onDismiss?: () => void;
+}
+
+// Surfaces an admin API error envelope (`{error_msg}`) as a dismissible
+// banner. Returns null when there's nothing to show so callers can
+// always mount it unconditionally.
+export function ErrorBanner({ message, onDismiss }: ErrorBannerProps) {
+  if (!message) return null;
+  return (
+    <div
+      role="alert"
+      className={clsx(
+        "rounded-md border px-4 py-3 text-sm",
+        "border-red-300 bg-red-50 text-red-900",
+        "dark:border-red-700 dark:bg-red-950 dark:text-red-100",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <span className="break-words">{message}</span>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="text-red-700 hover:text-red-900 dark:text-red-300 dark:hover:text-red-100"
+            aria-label="Dismiss error"
+          >
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/ModelsView.tsx
+++ b/ui/src/components/ModelsView.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from "react";
+import { api, AdminApiError } from "../api";
+import type { Connection } from "../storage";
+import type { Model, ResourceEntry } from "../types";
+import { ErrorBanner } from "./ErrorBanner";
+
+interface ModelsViewProps {
+  connection: Connection;
+}
+
+interface FormState {
+  // Either creating (no id) or editing (id from the entry).
+  editingId: string | null;
+  name: string;
+  model: string;
+  apiKey: string;
+  apiBase: string;
+}
+
+const EMPTY_FORM: FormState = {
+  editingId: null,
+  name: "",
+  model: "openai/gpt-4o",
+  apiKey: "",
+  apiBase: "",
+};
+
+export function ModelsView({ connection }: ModelsViewProps) {
+  const [entries, setEntries] = useState<ResourceEntry<Model>[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await api.listModels(connection);
+      setEntries(list);
+    } catch (e) {
+      setError(toMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    // refresh whenever the connection changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connection.endpoint, connection.adminKey]);
+
+  function startCreate() {
+    setForm(EMPTY_FORM);
+  }
+
+  function startEdit(entry: ResourceEntry<Model>) {
+    setForm({
+      editingId: entry.id,
+      name: entry.value.name,
+      model: entry.value.model,
+      apiKey: entry.value.provider_config.api_key,
+      apiBase: entry.value.provider_config.api_base ?? "",
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const payload: Model = {
+      name: form.name.trim(),
+      model: form.model.trim(),
+      provider_config: {
+        api_key: form.apiKey,
+        api_base: form.apiBase.trim() === "" ? undefined : form.apiBase.trim(),
+      },
+    };
+    try {
+      if (form.editingId) {
+        await api.updateModel(connection, form.editingId, payload);
+      } else {
+        await api.createModel(connection, payload);
+      }
+      setForm(EMPTY_FORM);
+      await refresh();
+    } catch (e) {
+      setError(toMessage(e));
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm(`Delete model ${id}? This is permanent.`)) return;
+    setError(null);
+    try {
+      await api.deleteModel(connection, id);
+      if (form.editingId === id) setForm(EMPTY_FORM);
+      await refresh();
+    } catch (e) {
+      setError(toMessage(e));
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h2 className="text-2xl font-semibold tracking-tight">Models</h2>
+        <button
+          type="button"
+          onClick={startCreate}
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          New
+        </button>
+      </header>
+
+      <ErrorBanner message={error} onDismiss={() => setError(null)} />
+
+      <form onSubmit={handleSubmit} className="space-y-3 rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="grid grid-cols-2 gap-3">
+          <label className="block">
+            <span className="text-sm font-medium">Display name</span>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              required
+              className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">Provider/model</span>
+            <input
+              type="text"
+              value={form.model}
+              onChange={(e) => setForm((f) => ({ ...f, model: e.target.value }))}
+              required
+              placeholder="openai/gpt-4o"
+              className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">API key</span>
+            <input
+              type="password"
+              value={form.apiKey}
+              onChange={(e) => setForm((f) => ({ ...f, apiKey: e.target.value }))}
+              required
+              className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">API base (optional)</span>
+            <input
+              type="text"
+              value={form.apiBase}
+              onChange={(e) => setForm((f) => ({ ...f, apiBase: e.target.value }))}
+              className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+            />
+          </label>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            {form.editingId ? "Update" : "Create"}
+          </button>
+          {form.editingId && (
+            <button
+              type="button"
+              onClick={() => setForm(EMPTY_FORM)}
+              className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
+
+      {loading ? (
+        <p className="text-sm text-zinc-500">Loading…</p>
+      ) : entries.length === 0 ? (
+        <p className="text-sm text-zinc-500">No models yet.</p>
+      ) : (
+        <ul className="divide-y divide-zinc-200 rounded-md border border-zinc-200 bg-white dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+          {entries.map((e) => (
+            <li
+              key={e.id}
+              className="flex items-center justify-between gap-4 px-4 py-3"
+            >
+              <div className="min-w-0">
+                <div className="font-medium">{e.value.name}</div>
+                <div className="truncate text-xs text-zinc-500">
+                  {e.value.model} · rev {e.revision}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => startEdit(e)}
+                  className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(e.id)}
+                  className="rounded-md border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-300 dark:hover:bg-red-950"
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function toMessage(e: unknown): string {
+  if (e instanceof AdminApiError) return e.message;
+  if (e instanceof Error) return e.message;
+  return "Unknown error";
+}

--- a/ui/src/components/__tests__/ConnectionForm.test.tsx
+++ b/ui/src/components/__tests__/ConnectionForm.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectionForm } from "../ConnectionForm";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ConnectionForm", () => {
+  it("renders the supplied initial values", () => {
+    render(
+      <ConnectionForm
+        initial={{ endpoint: "http://example.test:9999", adminKey: "k1" }}
+        onSaved={() => {}}
+      />,
+    );
+    expect(screen.getByDisplayValue("http://example.test:9999")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("k1")).toBeInTheDocument();
+  });
+
+  it("blocks submit with empty admin key and shows a validation error", () => {
+    const onSaved = vi.fn();
+    render(
+      <ConnectionForm
+        initial={{ endpoint: "http://example.test", adminKey: "" }}
+        onSaved={onSaved}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/admin key/i);
+  });
+
+  it("persists trimmed values to localStorage and notifies parent on save", () => {
+    const onSaved = vi.fn();
+    render(
+      <ConnectionForm
+        initial={{ endpoint: "  http://example.test  ", adminKey: " k1 " }}
+        onSaved={onSaved}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    const stored = window.localStorage.getItem("aisix.connection");
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.endpoint).toBe("http://example.test");
+    expect(parsed.adminKey).toBe("k1");
+
+    expect(onSaved).toHaveBeenCalledWith({
+      endpoint: "http://example.test",
+      adminKey: "k1",
+    });
+  });
+
+  it("blocks submit when endpoint is whitespace-only", () => {
+    const onSaved = vi.fn();
+    render(
+      <ConnectionForm
+        initial={{ endpoint: "   ", adminKey: "k1" }}
+        onSaved={onSaved}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/endpoint/i);
+  });
+});

--- a/ui/src/storage.ts
+++ b/ui/src/storage.ts
@@ -1,0 +1,48 @@
+// Minimal localStorage wrapper for the connection settings the UI uses
+// to talk to the admin API. Kept tiny on purpose — there's no shared
+// state library because there's nothing else to share yet.
+
+const STORAGE_KEY = "aisix.connection";
+
+export interface Connection {
+  endpoint: string; // e.g. "http://127.0.0.1:3001"
+  adminKey: string;
+}
+
+export const DEFAULT_CONNECTION: Connection = {
+  endpoint: typeof window !== "undefined" ? window.location.origin : "",
+  adminKey: "",
+};
+
+export function loadConnection(): Connection {
+  if (typeof window === "undefined") {
+    return DEFAULT_CONNECTION;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return DEFAULT_CONNECTION;
+    }
+    const parsed = JSON.parse(raw) as Partial<Connection>;
+    return {
+      endpoint: parsed.endpoint ?? DEFAULT_CONNECTION.endpoint,
+      adminKey: parsed.adminKey ?? "",
+    };
+  } catch {
+    return DEFAULT_CONNECTION;
+  }
+}
+
+export function saveConnection(c: Connection): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(c));
+}
+
+export function clearConnection(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export function isConfigured(c: Connection): boolean {
+  return c.endpoint.trim().length > 0 && c.adminKey.trim().length > 0;
+}

--- a/ui/src/test-setup.ts
+++ b/ui/src/test-setup.ts
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom/vitest";
+
+// Vitest's jsdom environment doesn't provide a usable `confirm`; stub
+// it so component tests that exercise delete actions can run without
+// pulling in a separate dialog mock.
+if (typeof window !== "undefined") {
+  window.confirm = () => true;
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,0 +1,42 @@
+// Shared types mirroring `aisix-core` entities and the
+// `{prefix}/{kind}/{id}` resource-entry envelope returned by the admin
+// API. Kept narrow on purpose — the UI only needs the fields it
+// renders.
+
+export interface RateLimit {
+  rpm?: number | null;
+  rpd?: number | null;
+  tpm?: number | null;
+  tpd?: number | null;
+  concurrency?: number | null;
+}
+
+export interface ProviderConfig {
+  api_key: string;
+  api_base?: string | null;
+}
+
+export interface Model {
+  name: string;
+  model: string; // "<provider>/<upstream>"
+  provider_config: ProviderConfig;
+  rate_limit?: RateLimit | null;
+  timeout_ms?: number | null;
+}
+
+export interface ApiKey {
+  key: string;
+  allowed_models: string[];
+  rate_limit?: RateLimit | null;
+}
+
+export interface ResourceEntry<T> {
+  id: string;
+  value: T;
+  revision: number;
+}
+
+// Spec §3 admin envelope.
+export interface AdminError {
+  error_msg: string;
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
@@ -14,9 +15,15 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/aisix/admin": "http://127.0.0.1:3001",
-      "/playground": "http://127.0.0.1:3001",
-      "/openapi": "http://127.0.0.1:3001",
+      "/admin": "http://127.0.0.1:3001",
+      "/health": "http://127.0.0.1:3001",
+      "/metrics": "http://127.0.0.1:3001",
     },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
+    css: false,
   },
 });


### PR DESCRIPTION
## Summary

Replaces the placeholder \`ui/\` scaffold with a usable admin console
plus a connection form. The Vite output is embedded into the aisix
binary via rust-embed and served at \`/ui/*\` on the admin listener;
an OpenAPI scalar mount lives at \`/admin/openapi-scalar\`.

### UI (\`ui/\`)
- **types.ts** — TypeScript mirrors of aisix-core entities + admin
  error envelope.
- **storage.ts** — localStorage round-trip for the connection
  (endpoint + admin key). Falls back to defaults on corrupt JSON.
- **api.ts** — tiny fetch wrapper. Throws \`AdminApiError\` carrying
  the parsed \`error_msg\` so handlers render the canonical envelope.
- **ConnectionForm**, **ModelsView**, **ApiKeysView**,
  **ErrorBanner** components. Two-tab layout in \`App.tsx\`.
- Trimmed unused deps (monaco / openai / i18next / tanstack); single
  language, plain React state, fetch-based.
- Vitest + Testing Library wired; tests for the connection form and
  storage helpers.

### Rust (\`aisix-admin\`)
- **embedded_ui.rs** — rust-embed wraps \`ui-dist/\`. \`/ui\` →
  \`/ui/index.html\`; \`/ui/*path\` serves the asset with SPA fallback
  to \`index.html\` on miss.
- **openapi.rs** — hand-written OpenAPI 3.1 JSON + Scalar HTML
  loader. \`/admin/openapi.json\` + \`/admin/openapi-scalar\`.

### Build infra
- \`.gitignore\` keeps the \`ui-dist/\` directory (with \`.gitkeep\`)
  so rust-embed doesn't fail on a fresh clone.
- CI \`build-ui\` job runs \`pnpm test\` before \`pnpm build\`.

## Test plan

- [x] 7 new admin tests (openapi JSON shape, scalar HTML loader,
  \`/ui\` redirect, plus the \`embedded_ui\` + \`openapi\` unit tests)
- [x] UI vitest suite — \`ConnectionForm\` (4 cases) +
  \`storage\` (5 cases). Local node is too old to run; CI validates
  via \`pnpm test\` in the build-ui job.
- [x] \`cargo test --workspace\` — 245 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs (UI vitest + rust)