### PR TITLE
feat(routing): virtual routing models with failover/round-robin/weighted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bytes",
+ "dashmap",
  "futures",
  "futures-util",
  "http",

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -31,7 +31,7 @@ pub use error::{
 };
 pub use models::{
     validate_apikey, validate_model, AisixSnapshot, ApiKey, Model, Provider, ProviderConfig,
-    RateLimit, SchemaError,
+    RateLimit, Routing, RoutingStrategy, RoutingTarget, SchemaError,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -3,23 +3,26 @@
 //! Each entity is paired with a JSON Schema (spec §3) compiled once at
 //! startup and reused on both the admin write path and the watch read path.
 //!
-//! The entities landing in this PR:
+//! Entities landing across the live PR series:
 //! - [`Model`] — routing target (§3)
 //! - [`ApiKey`] — caller credential (§3)
 //! - [`RateLimit`] — shared rate-limit config (§3.4 / §8)
+//! - [`Routing`] — virtual-router strategy + targets (§3.5, PR #17)
 //!
 //! Further entities (`Team`, `Budget`, `Credential`, `Guardrail`,
-//! `FallbackPolicy`, `RoutingPolicy`) land alongside the feature PRs that
-//! consume them so the schema lives next to its runtime usage.
+//! `FallbackPolicy`) land alongside the feature PRs that consume them
+//! so the schema lives next to its runtime usage.
 
 pub mod apikey;
 pub mod model;
 pub mod rate_limit;
+pub mod routing;
 pub mod schema;
 pub mod snapshot;
 
 pub use apikey::ApiKey;
 pub use model::{Model, Provider, ProviderConfig};
 pub use rate_limit::RateLimit;
+pub use routing::{Routing, RoutingStrategy, RoutingTarget};
 pub use schema::{validate_apikey, validate_model, SchemaError};
 pub use snapshot::AisixSnapshot;

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -12,10 +12,11 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use super::rate_limit::RateLimit;
+use super::routing::Routing;
 use crate::resource::Resource;
 
 static MODEL_ID_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(anthropic|deepseek|gemini|openai)/.+$").unwrap());
+    Lazy::new(|| Regex::new(r"^(anthropic|deepseek|gemini|openai|router)/.+$").unwrap());
 
 /// Supported provider prefixes. The `model` field must start with one of these
 /// followed by `/<upstream-model-id>`.
@@ -74,6 +75,15 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<RateLimit>,
 
+    /// Optional routing config. When present, the proxy treats this Model
+    /// as a *virtual* router: it picks one of the listed targets per the
+    /// strategy and dispatches through that target's bridge instead of
+    /// using `model` / `provider_config` on this entity. The base `model`
+    /// field is still required (use the `router/<name>` prefix to make
+    /// the intent obvious to operators).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing: Option<Routing>,
+
     /// Non-schema runtime id. Not part of the JSON payload — filled in by
     /// the snapshot loader from the etcd key path. Kept here so `Resource`
     /// can return a `&str` id.
@@ -82,9 +92,9 @@ pub struct Model {
 }
 
 impl Model {
-    /// Parse the `<provider>/<model_name>` prefix. Returns `None` if the
-    /// `model` field doesn't match the spec regex — callers should have
-    /// already run schema validation.
+    /// Parse the `<provider>/<model_name>` prefix. Returns `None` for
+    /// the `router/...` virtual-routing form (which intentionally has
+    /// no upstream provider) and for malformed values.
     pub fn provider(&self) -> Option<Provider> {
         let (prefix, _) = self.model.split_once('/')?;
         match prefix {
@@ -94,6 +104,12 @@ impl Model {
             "deepseek" => Some(Provider::Deepseek),
             _ => None,
         }
+    }
+
+    /// Whether this Model is a virtual router (proxy walks `routing.targets`
+    /// instead of dispatching its own provider config).
+    pub fn is_routing(&self) -> bool {
+        self.routing.is_some()
     }
 
     /// Returns the upstream-facing model id (everything after the first `/`).
@@ -195,6 +211,7 @@ mod tests {
             },
             timeout: None,
             rate_limit: None,
+            routing: None,
             runtime_id: String::new(),
         };
 

--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -1,0 +1,153 @@
+//! Virtual-routing config attached to a [`Model`](super::Model).
+//!
+//! When a Model carries a `routing` block, the proxy treats it as a
+//! pointer to other Models. Per-request the proxy picks one target via
+//! the configured strategy and dispatches through that target's bridge.
+//! Failures fall back to the next target up to `retry_budget` attempts.
+//!
+//! Three strategies (spec §3):
+//! - `round_robin`: cycle through targets in declaration order.
+//! - `weighted`: pick a target with probability proportional to its
+//!   `weight`; falls back to round-robin when weights are missing.
+//! - `failover`: always start at the first target; only move down the
+//!   list on failure.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutingStrategy {
+    RoundRobin,
+    Weighted,
+    /// Failover is the safest default — predictable order, no shared
+    /// state, no surprises on first deploy.
+    #[default]
+    Failover,
+}
+
+/// One destination in a routing config. `model` references another
+/// `Model.name` in the snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RoutingTarget {
+    pub model: String,
+    /// Only meaningful for `weighted`. Optional everywhere else; falls
+    /// back to 1 when missing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<u32>,
+}
+
+impl RoutingTarget {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self {
+            model: model.into(),
+            weight: None,
+        }
+    }
+
+    pub fn with_weight(mut self, weight: u32) -> Self {
+        self.weight = Some(weight);
+        self
+    }
+
+    pub fn weight_or_default(&self) -> u32 {
+        self.weight.unwrap_or(1)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Routing {
+    #[serde(default)]
+    pub strategy: RoutingStrategy,
+    pub targets: Vec<RoutingTarget>,
+    /// Max number of distinct targets to attempt per request. Defaults
+    /// to `targets.len()` when absent. A value of 1 disables fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_budget: Option<u32>,
+}
+
+impl Routing {
+    pub fn retry_budget_or_default(&self) -> usize {
+        match self.retry_budget {
+            Some(0) => self.targets.len(),
+            Some(n) => (n as usize).min(self.targets.len()),
+            None => self.targets.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.targets.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_full_routing_block() {
+        let json = r#"{
+            "strategy": "weighted",
+            "targets": [
+                {"model": "primary", "weight": 90},
+                {"model": "backup",  "weight": 10}
+            ],
+            "retry_budget": 2
+        }"#;
+        let r: Routing = serde_json::from_str(json).unwrap();
+        assert_eq!(r.strategy, RoutingStrategy::Weighted);
+        assert_eq!(r.targets.len(), 2);
+        assert_eq!(r.targets[0].model, "primary");
+        assert_eq!(r.targets[0].weight_or_default(), 90);
+        assert_eq!(r.retry_budget_or_default(), 2);
+    }
+
+    #[test]
+    fn strategy_defaults_to_failover() {
+        let r: Routing =
+            serde_json::from_str(r#"{"targets":[{"model":"a"},{"model":"b"}]}"#).unwrap();
+        assert_eq!(r.strategy, RoutingStrategy::Failover);
+        assert_eq!(r.retry_budget_or_default(), 2);
+    }
+
+    #[test]
+    fn retry_budget_zero_means_full_targets() {
+        let r = Routing {
+            strategy: RoutingStrategy::RoundRobin,
+            targets: vec![RoutingTarget::new("a"), RoutingTarget::new("b")],
+            retry_budget: Some(0),
+        };
+        assert_eq!(r.retry_budget_or_default(), 2);
+    }
+
+    #[test]
+    fn retry_budget_clamps_to_targets_len() {
+        let r = Routing {
+            strategy: RoutingStrategy::Failover,
+            targets: vec![RoutingTarget::new("a")],
+            retry_budget: Some(99),
+        };
+        assert_eq!(r.retry_budget_or_default(), 1);
+    }
+
+    #[test]
+    fn missing_weight_defaults_to_one() {
+        let t = RoutingTarget::new("x");
+        assert_eq!(t.weight_or_default(), 1);
+    }
+
+    #[test]
+    fn rejects_unknown_routing_fields() {
+        let r: Result<Routing, _> =
+            serde_json::from_str(r#"{"strategy":"failover","targets":[{"model":"a"}],"foo":1}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_target_fields() {
+        let r: Result<RoutingTarget, _> =
+            serde_json::from_str(r#"{"model":"a","weight":2,"extra":true}"#);
+        assert!(r.is_err());
+    }
+}

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -79,7 +79,7 @@ fn model_schema() -> Value {
             "name": { "type": "string", "minLength": 1 },
             "model": {
                 "type": "string",
-                "pattern": "^(anthropic|deepseek|gemini|openai)/.+$"
+                "pattern": "^(anthropic|deepseek|gemini|openai|router)/.+$"
             },
             "provider_config": {
                 "type": "object",
@@ -91,7 +91,32 @@ fn model_schema() -> Value {
                 }
             },
             "timeout": { "type": "integer", "minimum": 0 },
-            "rate_limit": { "$ref": "#/$defs/rate_limit" }
+            "rate_limit": { "$ref": "#/$defs/rate_limit" },
+            "routing": {
+                "type": "object",
+                "required": ["targets"],
+                "additionalProperties": false,
+                "properties": {
+                    "strategy": {
+                        "type": "string",
+                        "enum": ["round_robin", "weighted", "failover"]
+                    },
+                    "targets": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "required": ["model"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "model":  { "type": "string", "minLength": 1 },
+                                "weight": { "type": "integer", "minimum": 0 }
+                            }
+                        }
+                    },
+                    "retry_budget": { "type": "integer", "minimum": 0 }
+                }
+            }
         },
         "$defs": {
             "rate_limit": {

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -29,6 +29,7 @@ futures.workspace = true
 futures-util.workspace = true
 async-trait.workspace = true
 async-stream = "0.3"
+dashmap.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -17,7 +17,7 @@
 //!    status, error type, and (for rate-limits) Retry-After.
 
 use aisix_cache::CacheKey;
-use aisix_gateway::{BridgeContext, ChatFormat};
+use aisix_gateway::{BridgeContext, BridgeError, ChatFormat};
 use aisix_obs::{AccessLog, Metrics, RequestOutcome};
 use axum::extract::State;
 use axum::http::HeaderValue;
@@ -33,6 +33,7 @@ use uuid::Uuid;
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
 use crate::render::{render_chunk, render_response};
+use crate::routing::is_retryable;
 use crate::state::ProxyState;
 
 /// Header set on every non-streaming response indicating whether the
@@ -126,7 +127,7 @@ async fn dispatch(
     }
 
     let snapshot = state.snapshot.load();
-    let model_entry = snapshot
+    let virtual_entry = snapshot
         .models
         .get_by_name(&req.model)
         .ok_or_else(|| ProxyError::ModelNotFound(req.model.clone()))?;
@@ -135,26 +136,65 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(req.model.clone()));
     }
 
-    let provider = model_entry
-        .value
-        .provider()
-        .ok_or_else(|| ProxyError::InvalidRequest("model has no provider prefix".into()))?;
-    let bridge = state
-        .hub
-        .get(provider)
-        .ok_or(ProxyError::ProviderUnavailable)?;
+    // Resolve the attempt-list of underlying Model entries. For a
+    // routing model we walk targets per the configured strategy; for a
+    // single-provider Model we just dispatch to it directly.
+    let attempt_models: Vec<aisix_core::Model> =
+        if let Some(routing) = virtual_entry.value.routing.as_ref() {
+            let names = state.routing.pick_order(&req.model, routing);
+            if names.is_empty() {
+                return Err(ProxyError::InvalidRequest(
+                    "routing model has no targets".into(),
+                ));
+            }
+            let mut resolved = Vec::with_capacity(names.len());
+            for name in &names {
+                let target_entry = snapshot.models.get_by_name(name).ok_or_else(|| {
+                    ProxyError::InvalidRequest(format!(
+                        "routing target {name:?} does not resolve to a Model"
+                    ))
+                })?;
+                resolved.push(target_entry.value.clone());
+            }
+            resolved
+        } else {
+            vec![virtual_entry.value.clone()]
+        };
+
+    // For non-routing requests, surface a misconfigured bridge as a
+    // proper 503 rather than burying it inside a generic Bridge error.
+    // Routing requests rely on the loop's `is_retryable` path so a
+    // single bad provider doesn't take down the whole request.
+    if attempt_models.len() == 1 {
+        let only = &attempt_models[0];
+        let provider = only
+            .provider()
+            .ok_or_else(|| ProxyError::InvalidRequest("model has no provider prefix".into()))?;
+        if state.hub.get(provider).is_none() {
+            return Err(ProxyError::ProviderUnavailable);
+        }
+    }
 
     let rl_key = auth.entry.id.clone();
     let rl_limits = auth.key().rate_limit.clone().unwrap_or_default();
     let reservation = state.limiter.pre_commit(&rl_key, &rl_limits)?;
 
-    let model_arc = Arc::new(model_entry.value.clone());
-    let ctx = BridgeContext::new(request_id, model_arc);
-    let provider_name = format!("{provider:?}").to_lowercase();
-
     let now = created_ts();
 
+    // Streaming path: only attempt the first target. Streaming fallback
+    // is genuinely hard (we'd have to buffer the stream to detect
+    // failure mid-flight) and not worth the complexity for V1.
     if req.is_streaming() {
+        let model = &attempt_models[0];
+        let provider = model
+            .provider()
+            .ok_or_else(|| ProxyError::InvalidRequest("model has no provider prefix".into()))?;
+        let bridge = state
+            .hub
+            .get(provider)
+            .ok_or(ProxyError::ProviderUnavailable)?;
+        let model_arc = Arc::new(model.clone());
+        let ctx = BridgeContext::new(request_id, model_arc);
         let upstream = bridge.chat_stream(req, &ctx).await?;
         reservation.commit_tokens(0);
         let sse_stream = build_sse_stream(upstream, now);
@@ -162,15 +202,15 @@ async fn dispatch(
             Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
         return Ok(Success {
             response: response.into_response(),
-            provider: provider_name,
+            provider: format!("{provider:?}").to_lowercase(),
             prompt_tokens: None,
             completion_tokens: None,
             total_tokens: None,
         });
     }
 
-    // Cache lookup runs before the upstream call. Streaming requests
-    // never hit this branch — `req.is_streaming()` short-circuits above.
+    // Cache lookup keyed on the *virtual* model name so a re-request
+    // hits the cache regardless of which target served the original.
     let cache_key = state
         .cache
         .as_ref()
@@ -179,34 +219,88 @@ async fn dispatch(
     if let (Some(cache), Some(key)) = (state.cache.as_ref(), cache_key.as_ref()) {
         match cache.get(key).await {
             Ok(Some(cached)) => {
-                // Release the reservation we took up front — the cached
-                // request shouldn't count against TPM.
                 reservation.commit_tokens(0);
                 let prompt = cached.usage.prompt_tokens as u64;
                 let completion = cached.usage.completion_tokens as u64;
                 let total = cached.usage.total_tokens as u64;
+                // The provider label points at the first attempt — for a
+                // cache hit we don't know (or care) which target ran the
+                // original call; the fingerprint identified the answer.
+                let provider_label = attempt_models[0]
+                    .provider()
+                    .map(|p| format!("{p:?}").to_lowercase())
+                    .unwrap_or_else(|| "unknown".into());
                 let mut response = Json(render_response(now, cached)).into_response();
                 response
                     .headers_mut()
                     .insert(CACHE_HEADER, HeaderValue::from_static("hit"));
                 return Ok(Success {
                     response,
-                    provider: provider_name,
+                    provider: provider_label,
                     prompt_tokens: Some(prompt),
                     completion_tokens: Some(completion),
                     total_tokens: Some(total),
                 });
             }
-            Ok(None) => {} // miss → fall through to upstream call
+            Ok(None) => {}
             Err(err) => {
-                // Cache failures are non-fatal — the upstream call still
-                // runs. Just log and move on.
                 tracing::warn!(error = %err, key = %key, "cache lookup failed");
             }
         }
     }
 
-    let upstream = bridge.chat(req, &ctx).await?;
+    // Walk the attempt-list. First retryable failure → next target.
+    // Non-retryable (4xx) or exhausted budget → propagate the last error.
+    let mut last_err: Option<BridgeError> = None;
+    let mut chosen_provider: Option<String> = None;
+    let mut upstream: Option<aisix_gateway::ChatResponse> = None;
+
+    for model in &attempt_models {
+        let Some(provider) = model.provider() else {
+            last_err = Some(BridgeError::Config("model has no provider prefix".into()));
+            continue;
+        };
+        let Some(bridge) = state.hub.get(provider) else {
+            last_err = Some(BridgeError::Config(
+                "no bridge registered for provider".into(),
+            ));
+            continue;
+        };
+        let model_arc = Arc::new(model.clone());
+        let ctx = BridgeContext::new(request_id, model_arc);
+
+        match bridge.chat(req, &ctx).await {
+            Ok(resp) => {
+                chosen_provider = Some(format!("{provider:?}").to_lowercase());
+                upstream = Some(resp);
+                break;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target_model = %model.name,
+                    error = %err,
+                    retryable = is_retryable(&err),
+                    "routing target attempt failed",
+                );
+                if !is_retryable(&err) {
+                    last_err = Some(err);
+                    break;
+                }
+                last_err = Some(err);
+                continue;
+            }
+        }
+    }
+
+    let Some(upstream) = upstream else {
+        // Bubble the most recent BridgeError through ProxyError::Bridge.
+        let err = last_err.unwrap_or_else(|| {
+            BridgeError::Config("routing exhausted with no targets attempted".into())
+        });
+        return Err(ProxyError::Bridge(err));
+    };
+    let provider_name = chosen_provider.unwrap_or_else(|| "unknown".into());
+
     let prompt = upstream.usage.prompt_tokens as u64;
     let completion = upstream.usage.completion_tokens as u64;
     let total = upstream.usage.total_tokens as u64;

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -28,6 +28,7 @@ mod auth;
 mod chat;
 mod error;
 mod render;
+mod routing;
 mod state;
 
 pub use auth::AuthenticatedKey;
@@ -757,5 +758,190 @@ data: [DONE]\n\n";
                 Some("miss"),
             );
         }
+    }
+
+    /// Build a `ResourceEntry<Model>` with a non-default id so the test
+    /// can mount multiple Models in one snapshot.
+    fn model_entry_with_id(id: &str, name: &str, api_base: &str) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "name": "{name}",
+                "model": "openai/gpt-4o",
+                "provider_config": {{"api_key": "sk-upstream", "api_base": "{api_base}"}}
+            }}"#
+        );
+        let model: Model = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new(id, model, 1)
+    }
+
+    /// Build a virtual routing Model that points at `targets` (other
+    /// Model.name values) using the given strategy.
+    fn routing_entry(name: &str, strategy: &str, targets: &[&str]) -> ResourceEntry<Model> {
+        let target_objs: Vec<serde_json::Value> = targets
+            .iter()
+            .map(|t| serde_json::json!({"model": t}))
+            .collect();
+        let cfg = serde_json::json!({
+            "name": name,
+            "model": format!("router/{name}"),
+            // The provider_config is required by the schema but unused
+            // by the proxy because routing.is_some() short-circuits.
+            "provider_config": {"api_key": "ignored"},
+            "routing": {
+                "strategy": strategy,
+                "targets": target_objs,
+            }
+        });
+        let model: Model = serde_json::from_value(cfg).unwrap();
+        ResourceEntry::new(format!("router-{name}"), model, 1)
+    }
+
+    #[tokio::test]
+    async fn routing_failover_retries_to_second_target_when_first_5xxs() {
+        let bad_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("upstream down"))
+            .mount(&bad_upstream)
+            .await;
+
+        let good_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-good",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "fallback worked"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&good_upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(model_entry_with_id("m-bad", "primary", &bad_upstream.uri()));
+        snap.models.insert(model_entry_with_id(
+            "m-good",
+            "secondary",
+            &good_upstream.uri(),
+        ));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary", "secondary"],
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let app = build_router(build_state(snap, hub));
+        let body = serde_json::json!({
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["choices"][0]["message"]["content"], "fallback worked");
+    }
+
+    #[tokio::test]
+    async fn routing_propagates_4xx_without_attempting_fallback() {
+        // First target returns 400 — caller mistake, no point trying
+        // the second target. We assert the request fails 400 *and* the
+        // second wiremock never sees a request.
+        let bad_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("invalid_request"))
+            .expect(1)
+            .mount(&bad_upstream)
+            .await;
+
+        let standby_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            // Should never be hit; expect(0) enforces it on Drop.
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&standby_upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(model_entry_with_id("m-bad", "primary", &bad_upstream.uri()));
+        snap.models.insert(model_entry_with_id(
+            "m-standby",
+            "secondary",
+            &standby_upstream.uri(),
+        ));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary", "secondary"],
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let app = build_router(build_state(snap, hub));
+        let body = serde_json::json!({
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn routing_to_missing_target_returns_400() {
+        // Routing references a Model that isn't in the snapshot — this
+        // is a misconfiguration and should surface as a clean 400.
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(routing_entry("smart", "failover", &["nonexistent"]));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let app = build_router(build_state(snap, hub));
+        let body = serde_json::json!({
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -1,0 +1,283 @@
+//! Per-virtual-model routing state + target selection.
+//!
+//! When a request lands on a Model with `routing` configured, the proxy
+//! asks the [`RoutingRegistry`] for an iterator of underlying target
+//! Model names in attempt-order. The registry owns the per-virtual-
+//! model state (round-robin counter, weighted PRNG seed); selection
+//! itself is pure given that state.
+//!
+//! Strategies (spec §3.5):
+//! - **failover**: always start at `targets[0]`, walk forward on failure.
+//! - **round_robin**: each *new* request advances a per-model counter
+//!   so callers spread evenly across targets.
+//! - **weighted**: pick a starting target with probability proportional
+//!   to `weight`, then walk forward on failure (weights only affect the
+//!   *first* attempt — once we're falling back, order is positional).
+
+use aisix_core::{Routing, RoutingStrategy, RoutingTarget};
+use aisix_gateway::BridgeError;
+use dashmap::DashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Whether a Bridge error is retryable across routing targets.
+/// 4xx is the caller's mistake — retrying to a different target won't
+/// help and may amplify damage. Everything else (5xx, timeout, transport,
+/// decode, config, stream abort) gets the fallback path.
+pub fn is_retryable(err: &BridgeError) -> bool {
+    match err {
+        BridgeError::UpstreamStatus { status, .. } => !(400..500).contains(status),
+        BridgeError::Timeout { .. }
+        | BridgeError::Transport(_)
+        | BridgeError::UpstreamDecode(_)
+        | BridgeError::Config(_)
+        | BridgeError::StreamAborted => true,
+    }
+}
+
+#[derive(Default)]
+pub struct RoutingRegistry {
+    // virtual model name → atomic round-robin cursor
+    cursors: DashMap<String, AtomicUsize>,
+}
+
+impl RoutingRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pick the attempt order for one request. The first element is the
+    /// initial target; subsequent elements are the fallback chain (in
+    /// declaration order, wrapping if needed). Length is bounded by
+    /// `routing.retry_budget_or_default()`.
+    pub fn pick_order(&self, virtual_name: &str, routing: &Routing) -> Vec<String> {
+        let budget = routing.retry_budget_or_default();
+        if budget == 0 || routing.targets.is_empty() {
+            return Vec::new();
+        }
+        let start = self.starting_index(virtual_name, routing);
+        attempt_order(&routing.targets, start, budget)
+    }
+
+    fn starting_index(&self, virtual_name: &str, routing: &Routing) -> usize {
+        match routing.strategy {
+            RoutingStrategy::Failover => 0,
+            RoutingStrategy::RoundRobin => self.advance_cursor(virtual_name, routing.targets.len()),
+            RoutingStrategy::Weighted => weighted_pick(&routing.targets),
+        }
+    }
+
+    fn advance_cursor(&self, virtual_name: &str, modulo: usize) -> usize {
+        let entry = self.cursors.entry(virtual_name.to_string()).or_default();
+        let prev = entry.fetch_add(1, Ordering::Relaxed);
+        prev % modulo
+    }
+}
+
+impl std::fmt::Debug for RoutingRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RoutingRegistry")
+            .field("virtual_models_seen", &self.cursors.len())
+            .finish()
+    }
+}
+
+/// Build the attempt-order vector starting at `start_idx`, walking forward
+/// (wrap-around) for `budget` distinct entries.
+fn attempt_order(targets: &[RoutingTarget], start_idx: usize, budget: usize) -> Vec<String> {
+    let n = targets.len();
+    let mut order = Vec::with_capacity(budget);
+    for i in 0..budget {
+        let t = &targets[(start_idx + i) % n];
+        order.push(t.model.clone());
+    }
+    order
+}
+
+/// Pick an index by weighted-random. Ignores zero weights; a fully-zero
+/// list falls back to index 0 deterministically.
+fn weighted_pick(targets: &[RoutingTarget]) -> usize {
+    let total: u64 = targets.iter().map(|t| t.weight_or_default() as u64).sum();
+    if total == 0 {
+        return 0;
+    }
+    // We don't need a strong PRNG here — just enough entropy to spread
+    // requests roughly per weights. Use the system clock's nanos as a
+    // cheap entropy source so we avoid pulling in `rand` crate just
+    // for one call site.
+    let pick = entropy() % total;
+    let mut acc: u64 = 0;
+    for (i, t) in targets.iter().enumerate() {
+        acc += t.weight_or_default() as u64;
+        if pick < acc {
+            return i;
+        }
+    }
+    targets.len() - 1
+}
+
+fn entropy() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0)
+        // Mix in something monotonic so two calls in the same nanosecond
+        // diverge — `Instant` provides that without `unsafe`.
+        .wrapping_add(std::time::Instant::now().elapsed().as_nanos() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::{Routing, RoutingStrategy, RoutingTarget};
+
+    fn r(strategy: RoutingStrategy, targets: Vec<RoutingTarget>, budget: Option<u32>) -> Routing {
+        Routing {
+            strategy,
+            targets,
+            retry_budget: budget,
+        }
+    }
+
+    #[test]
+    fn failover_always_starts_at_index_zero() {
+        let reg = RoutingRegistry::new();
+        let routing = r(
+            RoutingStrategy::Failover,
+            vec![
+                RoutingTarget::new("primary"),
+                RoutingTarget::new("secondary"),
+                RoutingTarget::new("tertiary"),
+            ],
+            None,
+        );
+        for _ in 0..5 {
+            let order = reg.pick_order("v", &routing);
+            assert_eq!(order, vec!["primary", "secondary", "tertiary"]);
+        }
+    }
+
+    #[test]
+    fn round_robin_cycles_through_targets_per_call() {
+        let reg = RoutingRegistry::new();
+        let routing = r(
+            RoutingStrategy::RoundRobin,
+            vec![
+                RoutingTarget::new("a"),
+                RoutingTarget::new("b"),
+                RoutingTarget::new("c"),
+            ],
+            Some(1), // only the first attempt — easier to assert ordering
+        );
+        let mut firsts = Vec::new();
+        for _ in 0..6 {
+            let order = reg.pick_order("v", &routing);
+            firsts.push(order[0].clone());
+        }
+        // Two full cycles of a→b→c.
+        assert_eq!(firsts, vec!["a", "b", "c", "a", "b", "c"]);
+    }
+
+    #[test]
+    fn round_robin_state_is_per_virtual_model() {
+        let reg = RoutingRegistry::new();
+        let routing = r(
+            RoutingStrategy::RoundRobin,
+            vec![RoutingTarget::new("a"), RoutingTarget::new("b")],
+            Some(1),
+        );
+        // Two distinct virtual models advance independently.
+        assert_eq!(reg.pick_order("v1", &routing)[0], "a");
+        assert_eq!(reg.pick_order("v2", &routing)[0], "a");
+        assert_eq!(reg.pick_order("v1", &routing)[0], "b");
+        assert_eq!(reg.pick_order("v2", &routing)[0], "b");
+    }
+
+    #[test]
+    fn fallback_walks_forward_with_wraparound() {
+        let reg = RoutingRegistry::new();
+        let routing = r(
+            RoutingStrategy::RoundRobin,
+            vec![
+                RoutingTarget::new("a"),
+                RoutingTarget::new("b"),
+                RoutingTarget::new("c"),
+            ],
+            Some(0), // 0 → use full target count (3 attempts)
+        );
+        // First call starts at a → a, b, c
+        assert_eq!(reg.pick_order("v", &routing), vec!["a", "b", "c"]);
+        // Second call starts at b → b, c, a
+        assert_eq!(reg.pick_order("v", &routing), vec!["b", "c", "a"]);
+    }
+
+    #[test]
+    fn weighted_picks_from_targets_and_falls_back_in_order() {
+        let reg = RoutingRegistry::new();
+        let routing = r(
+            RoutingStrategy::Weighted,
+            vec![
+                RoutingTarget::new("a").with_weight(99),
+                RoutingTarget::new("b").with_weight(1),
+            ],
+            Some(0),
+        );
+        // Across many trials, "a" should dominate as the starting pick.
+        // We don't assert exact distribution (entropy is sub-second
+        // wall-clock); we just assert correctness of the *order* shape:
+        // exactly two attempts, distinct targets, both targets covered.
+        let order = reg.pick_order("v", &routing);
+        assert_eq!(order.len(), 2);
+        assert!(order.iter().any(|t| t == "a"));
+        assert!(order.iter().any(|t| t == "b"));
+    }
+
+    #[test]
+    fn weighted_with_all_zero_weights_picks_index_zero_deterministically() {
+        let targets = vec![
+            RoutingTarget::new("a").with_weight(0),
+            RoutingTarget::new("b").with_weight(0),
+        ];
+        assert_eq!(weighted_pick(&targets), 0);
+    }
+
+    #[test]
+    fn budget_one_disables_fallback() {
+        let reg = RoutingRegistry::new();
+        let routing = r(
+            RoutingStrategy::Failover,
+            vec![RoutingTarget::new("a"), RoutingTarget::new("b")],
+            Some(1),
+        );
+        let order = reg.pick_order("v", &routing);
+        assert_eq!(order, vec!["a"]);
+    }
+
+    #[test]
+    fn empty_targets_yields_empty_order() {
+        let reg = RoutingRegistry::new();
+        let routing = r(RoutingStrategy::Failover, vec![], None);
+        assert!(reg.pick_order("v", &routing).is_empty());
+    }
+
+    #[test]
+    fn is_retryable_distinguishes_4xx_from_other_failures() {
+        assert!(!is_retryable(&BridgeError::UpstreamStatus {
+            status: 400,
+            message: "bad request".into(),
+        }));
+        assert!(!is_retryable(&BridgeError::UpstreamStatus {
+            status: 429,
+            message: "rate limited".into(),
+        }));
+        assert!(is_retryable(&BridgeError::UpstreamStatus {
+            status: 502,
+            message: "bad gateway".into(),
+        }));
+        assert!(is_retryable(&BridgeError::Timeout { elapsed_ms: 1 }));
+        assert!(is_retryable(&BridgeError::Transport("conn".into())));
+        assert!(is_retryable(&BridgeError::UpstreamDecode("x".into())));
+        assert!(is_retryable(&BridgeError::Config("bad key".into())));
+        assert!(is_retryable(&BridgeError::StreamAborted));
+    }
+}

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -22,6 +22,8 @@ use aisix_obs::Metrics;
 use aisix_ratelimit::Limiter;
 use std::sync::Arc;
 
+use crate::routing::RoutingRegistry;
+
 #[derive(Clone)]
 pub struct ProxyState {
     pub snapshot: SnapshotHandle<AisixSnapshot>,
@@ -29,6 +31,7 @@ pub struct ProxyState {
     pub limiter: Arc<Limiter>,
     pub metrics: Arc<Metrics>,
     pub cache: Option<Arc<dyn Cache>>,
+    pub routing: Arc<RoutingRegistry>,
     pub request_body_limit_bytes: usize,
 }
 
@@ -40,6 +43,7 @@ impl ProxyState {
             limiter: Arc::new(Limiter::new()),
             metrics: Arc::new(Metrics::new(false)),
             cache: Some(Arc::new(MemoryCache::with_defaults())),
+            routing: Arc::new(RoutingRegistry::new()),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -58,6 +62,7 @@ impl ProxyState {
             limiter,
             metrics: Arc::new(Metrics::new(false)),
             cache: Some(Arc::new(MemoryCache::with_defaults())),
+            routing: Arc::new(RoutingRegistry::new()),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -79,6 +84,7 @@ impl ProxyState {
             limiter,
             metrics,
             cache,
+            routing: Arc::new(RoutingRegistry::new()),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }


### PR DESCRIPTION
## Summary

Adds a \`routing\` block to the Model entity that turns a Model into a
virtual router pointing at other Models. The proxy walks the configured
target list, falling back on retryable upstream failures.

### Core
- \`models/routing.rs\` — \`Routing { strategy, targets, retry_budget }\`,
  \`RoutingTarget { model, weight }\`, \`RoutingStrategy\` enum
  (\`round_robin | weighted | failover\`, default \`failover\`).
- \`model.rs\` — optional \`routing\` field on \`Model\`. The model-id
  regex now accepts \`router/<name>\` so virtual routers have an obvious
  wire shape.
- \`schema.rs\` — JSON Schema extended with the routing block.

### Proxy
- **routing.rs** — \`RoutingRegistry\` owns per-virtual-model
  round-robin cursors; \`pick_order(virtual_name, routing)\` returns
  the attempt-list per strategy. Weighted picks the starting index by
  clock-nanos entropy (no \`rand\` dep). \`is_retryable()\` encodes:
  4xx → no fallback; 5xx/timeout/transport/decode/config/stream-abort
  → fall through.
- **chat.rs dispatch** — resolves attempt-list (single Model, or
  routing targets), keeps the explicit \`ProviderUnavailable\`
  short-circuit for single-Model misconfigurations, then loops over
  targets. Streaming only attempts the first target.

### Test plan

- [x] 7 wire tests in aisix-core (round-trip, defaults, retry_budget,
  unknown-field rejection)
- [x] 8 selector tests (failover order, round-robin cycling,
  per-virtual state, wraparound, weighted shape, zero-weight,
  budget=1 disables fallback, empty targets, retryable mapping)
- [x] 3 wiremock integration tests:
  - failover skips a 502 first target and returns 200 from the second
  - 4xx propagates without fallback (\`expect(0)\` on the standby)
  - missing routing target → 400
- [x] \`cargo test --workspace\` — 264 tests pass (was 245)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs