### PR TITLE
feat(guardrails): pluggable input/output content-policy hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ name = "aisix-guardrails"
 version = "0.1.0"
 dependencies = [
  "aisix-core",
+ "aisix-gateway",
  "async-trait",
  "regex",
  "serde",

--- a/crates/aisix-guardrails/Cargo.toml
+++ b/crates/aisix-guardrails/Cargo.toml
@@ -10,6 +10,7 @@ description = "aisix: pluggable guardrails (pre_call / during_call / post_call)"
 
 [dependencies]
 aisix-core = { path = "../aisix-core" }
+aisix-gateway = { path = "../aisix-gateway" }
 tokio.workspace = true
 async-trait.workspace = true
 serde.workspace = true
@@ -17,3 +18,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 regex.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -1,0 +1,146 @@
+//! Compose multiple guardrails into one. First [`GuardrailVerdict::Block`]
+//! short-circuits the chain; subsequent guardrails are not consulted.
+//! Useful for building a single `Arc<dyn Guardrail>` to hand to the
+//! proxy from a config-driven list.
+
+use aisix_gateway::{ChatFormat, ChatResponse};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::{Guardrail, GuardrailVerdict};
+
+#[derive(Clone)]
+pub struct GuardrailChain {
+    guardrails: Vec<Arc<dyn Guardrail>>,
+}
+
+impl std::fmt::Debug for GuardrailChain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let names: Vec<&'static str> = self.guardrails.iter().map(|g| g.name()).collect();
+        f.debug_struct("GuardrailChain")
+            .field("guardrails", &names)
+            .finish()
+    }
+}
+
+impl GuardrailChain {
+    pub fn new(guardrails: Vec<Arc<dyn Guardrail>>) -> Self {
+        Self { guardrails }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.guardrails.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.guardrails.is_empty()
+    }
+}
+
+#[async_trait]
+impl Guardrail for GuardrailChain {
+    fn name(&self) -> &'static str {
+        "chain"
+    }
+
+    async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
+        for g in &self.guardrails {
+            let verdict = g.check_input(req).await;
+            if verdict.is_block() {
+                return verdict;
+            }
+        }
+        GuardrailVerdict::Allow
+    }
+
+    async fn check_output(&self, resp: &ChatResponse) -> GuardrailVerdict {
+        for g in &self.guardrails {
+            let verdict = g.check_output(resp).await;
+            if verdict.is_block() {
+                return verdict;
+            }
+        }
+        GuardrailVerdict::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{KeywordBlocklist, KeywordRule, MaxContentLength};
+    use aisix_gateway::{ChatMessage, FinishReason, UsageStats};
+
+    fn req(msg: &str) -> ChatFormat {
+        ChatFormat::new("m", vec![ChatMessage::user(msg)])
+    }
+
+    fn resp(content: &str) -> ChatResponse {
+        ChatResponse {
+            id: "r".into(),
+            model: "m".into(),
+            message: ChatMessage::assistant(content),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(0, 0),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_chain_allows_everything() {
+        let chain = GuardrailChain::empty();
+        assert_eq!(chain.check_input(&req("hi")).await, GuardrailVerdict::Allow);
+        assert_eq!(
+            chain.check_output(&resp("hi")).await,
+            GuardrailVerdict::Allow,
+        );
+    }
+
+    #[tokio::test]
+    async fn first_block_short_circuits_subsequent_guardrails() {
+        // Both would block on the same input; the first wins so the
+        // reason is deterministic.
+        let chain = GuardrailChain::new(vec![
+            Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("alpha")])),
+            Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("beta")])),
+        ]);
+        let v = chain.check_input(&req("alpha and beta")).await;
+        if let GuardrailVerdict::Block { reason } = v {
+            assert!(reason.contains("alpha"));
+        } else {
+            panic!("expected Block");
+        }
+    }
+
+    #[tokio::test]
+    async fn allow_falls_through_to_next_guardrail() {
+        // First guardrail allows everything; second blocks on length.
+        let chain = GuardrailChain::new(vec![
+            Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal(
+                "nope-not-here",
+            )])),
+            Arc::new(MaxContentLength::input_only(5)),
+        ]);
+        let v = chain.check_input(&req("this is way too long")).await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn output_check_short_circuits_on_first_block() {
+        let chain = GuardrailChain::new(vec![
+            Arc::new(KeywordBlocklist::output_only(vec![KeywordRule::literal(
+                "secret",
+            )])),
+            Arc::new(MaxContentLength::output_only(2)),
+        ]);
+        // The keyword guardrail fires before length.
+        let v = chain.check_output(&resp("the secret answer")).await;
+        if let GuardrailVerdict::Block { reason } = v {
+            assert!(reason.contains("secret"));
+        } else {
+            panic!("expected Block");
+        }
+    }
+}

--- a/crates/aisix-guardrails/src/keyword.rs
+++ b/crates/aisix-guardrails/src/keyword.rs
@@ -1,0 +1,232 @@
+//! Keyword + regex blocklist guardrail.
+//!
+//! Two pattern flavours mix freely in the same blocklist:
+//! - `Literal(s)`: case-insensitive substring match.
+//! - `Regex(re)`: compiled once at construction; case-sensitivity is
+//!   the caller's responsibility (use `(?i)` in the regex if needed).
+//!
+//! Applies to both input messages (concatenated content of every
+//! message) and output content. Whichever side a request triggers, the
+//! verdict carries the matching pattern text in `reason` so operators
+//! can debug from the access log.
+
+use aisix_gateway::{ChatFormat, ChatResponse};
+use async_trait::async_trait;
+use regex::Regex;
+
+use crate::{Guardrail, GuardrailVerdict};
+
+#[derive(Debug, Clone)]
+pub enum KeywordRule {
+    Literal(String),
+    Regex(Regex),
+}
+
+impl KeywordRule {
+    pub fn literal(s: impl Into<String>) -> Self {
+        Self::Literal(s.into())
+    }
+
+    pub fn regex(pattern: &str) -> Result<Self, regex::Error> {
+        Regex::new(pattern).map(Self::Regex)
+    }
+
+    fn matches(&self, haystack: &str) -> bool {
+        match self {
+            KeywordRule::Literal(needle) => {
+                let h = haystack.to_lowercase();
+                let n = needle.to_lowercase();
+                !needle.is_empty() && h.contains(&n)
+            }
+            KeywordRule::Regex(re) => re.is_match(haystack),
+        }
+    }
+
+    fn description(&self) -> String {
+        match self {
+            KeywordRule::Literal(s) => format!("literal {s:?}"),
+            KeywordRule::Regex(r) => format!("regex /{}/", r.as_str()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct KeywordBlocklist {
+    rules: Vec<KeywordRule>,
+    /// Apply on input messages.
+    pub check_input_enabled: bool,
+    /// Apply on output content.
+    pub check_output_enabled: bool,
+}
+
+impl KeywordBlocklist {
+    pub fn new(rules: Vec<KeywordRule>) -> Self {
+        Self {
+            rules,
+            check_input_enabled: true,
+            check_output_enabled: true,
+        }
+    }
+
+    pub fn input_only(rules: Vec<KeywordRule>) -> Self {
+        Self {
+            rules,
+            check_input_enabled: true,
+            check_output_enabled: false,
+        }
+    }
+
+    pub fn output_only(rules: Vec<KeywordRule>) -> Self {
+        Self {
+            rules,
+            check_input_enabled: false,
+            check_output_enabled: true,
+        }
+    }
+
+    fn first_match<'a>(&'a self, text: &str) -> Option<&'a KeywordRule> {
+        self.rules.iter().find(|r| r.matches(text))
+    }
+}
+
+#[async_trait]
+impl Guardrail for KeywordBlocklist {
+    fn name(&self) -> &'static str {
+        "keyword_blocklist"
+    }
+
+    async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
+        if !self.check_input_enabled {
+            return GuardrailVerdict::Allow;
+        }
+        // Concatenate the message contents — checking each message
+        // separately would cost the same and never catch any extra
+        // hits since rules don't span messages.
+        let combined: String = req
+            .messages
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        match self.first_match(&combined) {
+            Some(rule) => GuardrailVerdict::Block {
+                reason: format!("input blocked by {}", rule.description()),
+            },
+            None => GuardrailVerdict::Allow,
+        }
+    }
+
+    async fn check_output(&self, resp: &ChatResponse) -> GuardrailVerdict {
+        if !self.check_output_enabled {
+            return GuardrailVerdict::Allow;
+        }
+        match self.first_match(&resp.message.content) {
+            Some(rule) => GuardrailVerdict::Block {
+                reason: format!("output blocked by {}", rule.description()),
+            },
+            None => GuardrailVerdict::Allow,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_gateway::{ChatMessage, FinishReason, UsageStats};
+
+    fn req(messages: &[(&str, &str)]) -> ChatFormat {
+        let msgs = messages
+            .iter()
+            .map(|(role, content)| match *role {
+                "system" => ChatMessage::system(*content),
+                "user" => ChatMessage::user(*content),
+                _ => ChatMessage::assistant(*content),
+            })
+            .collect();
+        ChatFormat::new("m", msgs)
+    }
+
+    fn resp(content: &str) -> ChatResponse {
+        ChatResponse {
+            id: "r".into(),
+            model: "m".into(),
+            message: ChatMessage::assistant(content),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(0, 0),
+        }
+    }
+
+    #[tokio::test]
+    async fn literal_match_is_case_insensitive() {
+        let g = KeywordBlocklist::new(vec![KeywordRule::literal("Forbidden")]);
+        let v = g
+            .check_input(&req(&[("user", "say the FORBIDDEN word")]))
+            .await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn empty_literal_pattern_never_matches() {
+        let g = KeywordBlocklist::new(vec![KeywordRule::literal("")]);
+        let v = g.check_input(&req(&[("user", "anything")])).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+    }
+
+    #[tokio::test]
+    async fn regex_pattern_matches_when_provided() {
+        let g = KeywordBlocklist::new(vec![
+            KeywordRule::regex(r"\bssn:\s*\d{3}-\d{2}-\d{4}").unwrap()
+        ]);
+        let v = g
+            .check_input(&req(&[("user", "the user's ssn: 123-45-6789 is")]))
+            .await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn no_match_returns_allow() {
+        let g = KeywordBlocklist::new(vec![KeywordRule::literal("nothing here")]);
+        let v = g.check_input(&req(&[("user", "hello world")])).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+    }
+
+    #[tokio::test]
+    async fn output_check_runs_against_response_content() {
+        let g = KeywordBlocklist::new(vec![KeywordRule::literal("dangerous")]);
+        let v = g.check_output(&resp("here is a dangerous answer")).await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn input_only_skips_output_checks() {
+        let g = KeywordBlocklist::input_only(vec![KeywordRule::literal("zeta")]);
+        let v = g.check_output(&resp("zeta zeta zeta")).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+    }
+
+    #[tokio::test]
+    async fn output_only_skips_input_checks() {
+        let g = KeywordBlocklist::output_only(vec![KeywordRule::literal("zeta")]);
+        let v = g.check_input(&req(&[("user", "zeta zeta")])).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+    }
+
+    #[tokio::test]
+    async fn first_matching_rule_wins_so_reason_is_deterministic() {
+        let g = KeywordBlocklist::new(vec![
+            KeywordRule::literal("alpha"),
+            KeywordRule::literal("beta"),
+        ]);
+        let v = g.check_input(&req(&[("user", "alpha and beta")])).await;
+        if let GuardrailVerdict::Block { reason } = v {
+            assert!(reason.contains("alpha"));
+        } else {
+            panic!("expected Block");
+        }
+    }
+
+    #[test]
+    fn invalid_regex_is_a_clean_error_not_a_panic() {
+        assert!(KeywordRule::regex("[unclosed").is_err());
+    }
+}

--- a/crates/aisix-guardrails/src/length.rs
+++ b/crates/aisix-guardrails/src/length.rs
@@ -1,0 +1,162 @@
+//! Cap on total content length.
+//!
+//! Two thresholds:
+//! - `max_input_chars`: total characters across all input messages.
+//!   Catches "send me 1MB of text" abuse before it hits the upstream
+//!   timeout / per-request token cap.
+//! - `max_output_chars`: total characters of the assistant message.
+//!   Catches misbehaving models or guardrail-jailbreak completions.
+//!
+//! Either bound can be `None` to disable that side. Counts are
+//! `chars()`-based (Unicode scalar values) — same metric a user would
+//! see counting graphemes by hand, and stable across re-encodings.
+
+use aisix_gateway::{ChatFormat, ChatResponse};
+use async_trait::async_trait;
+
+use crate::{Guardrail, GuardrailVerdict};
+
+#[derive(Debug, Clone, Copy)]
+pub struct MaxContentLength {
+    pub max_input_chars: Option<usize>,
+    pub max_output_chars: Option<usize>,
+}
+
+impl MaxContentLength {
+    pub fn new(max_input_chars: Option<usize>, max_output_chars: Option<usize>) -> Self {
+        Self {
+            max_input_chars,
+            max_output_chars,
+        }
+    }
+
+    pub fn input_only(max: usize) -> Self {
+        Self {
+            max_input_chars: Some(max),
+            max_output_chars: None,
+        }
+    }
+
+    pub fn output_only(max: usize) -> Self {
+        Self {
+            max_input_chars: None,
+            max_output_chars: Some(max),
+        }
+    }
+}
+
+#[async_trait]
+impl Guardrail for MaxContentLength {
+    fn name(&self) -> &'static str {
+        "max_content_length"
+    }
+
+    async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
+        let Some(cap) = self.max_input_chars else {
+            return GuardrailVerdict::Allow;
+        };
+        let total: usize = req.messages.iter().map(|m| m.content.chars().count()).sum();
+        if total > cap {
+            return GuardrailVerdict::Block {
+                reason: format!("input exceeds {cap} chars (was {total})"),
+            };
+        }
+        GuardrailVerdict::Allow
+    }
+
+    async fn check_output(&self, resp: &ChatResponse) -> GuardrailVerdict {
+        let Some(cap) = self.max_output_chars else {
+            return GuardrailVerdict::Allow;
+        };
+        let len = resp.message.content.chars().count();
+        if len > cap {
+            return GuardrailVerdict::Block {
+                reason: format!("output exceeds {cap} chars (was {len})"),
+            };
+        }
+        GuardrailVerdict::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_gateway::{ChatMessage, FinishReason, UsageStats};
+
+    fn req(parts: &[&str]) -> ChatFormat {
+        ChatFormat::new("m", parts.iter().map(|p| ChatMessage::user(*p)).collect())
+    }
+
+    fn resp(content: &str) -> ChatResponse {
+        ChatResponse {
+            id: "r".into(),
+            model: "m".into(),
+            message: ChatMessage::assistant(content),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(0, 0),
+        }
+    }
+
+    #[tokio::test]
+    async fn input_within_cap_passes() {
+        let g = MaxContentLength::input_only(100);
+        assert_eq!(
+            g.check_input(&req(&["short prompt"])).await,
+            GuardrailVerdict::Allow,
+        );
+    }
+
+    #[tokio::test]
+    async fn input_exceeds_cap_blocks_with_useful_reason() {
+        let g = MaxContentLength::input_only(10);
+        let v = g
+            .check_input(&req(&["this is way too long for a tiny cap"]))
+            .await;
+        if let GuardrailVerdict::Block { reason } = v {
+            assert!(reason.contains("exceeds 10"));
+        } else {
+            panic!("expected Block");
+        }
+    }
+
+    #[tokio::test]
+    async fn input_total_sums_across_messages() {
+        let g = MaxContentLength::input_only(15);
+        // Two 10-char messages → 20 total > 15 cap.
+        let v = g.check_input(&req(&["1234567890", "1234567890"])).await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn unbounded_input_never_blocks_input_check() {
+        let g = MaxContentLength::output_only(5);
+        let v = g.check_input(&req(&["any length is fine here"])).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+    }
+
+    #[tokio::test]
+    async fn output_exceeds_cap_blocks() {
+        let g = MaxContentLength::output_only(5);
+        let v = g.check_output(&resp("123456")).await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn output_within_cap_passes() {
+        let g = MaxContentLength::output_only(100);
+        let v = g.check_output(&resp("ok")).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+    }
+
+    #[tokio::test]
+    async fn unicode_counted_by_chars_not_bytes() {
+        // Each emoji is 4 bytes UTF-8 but 1 char (BMP scalar). 3 emojis
+        // == 3 chars.
+        let g = MaxContentLength::input_only(3);
+        let v = g.check_input(&req(&["🚀🚀🚀"])).await; // 3 chars, fits
+        assert_eq!(v, GuardrailVerdict::Allow);
+
+        let v = g.check_input(&req(&["🚀🚀🚀🚀"])).await; // 4 chars, blocks
+        assert!(v.is_block());
+    }
+}

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -1,4 +1,72 @@
-//! aisix-guardrails — content safety / PII / policy enforcement hooks.
+//! aisix-guardrails — pluggable content-policy hooks.
+//!
+//! Two phases per request (spec §6):
+//! - **input**: runs after auth + rate-limit but before bridge dispatch
+//!   so a blocked prompt never reaches the upstream. A block here also
+//!   short-circuits the cache write — no point storing a refusal.
+//! - **output**: runs after the upstream response lands, before the
+//!   cache write and the JSON render. Lets policies inspect the
+//!   model's text and refuse if it crosses a line.
+//!
+//! Implementations:
+//! - [`KeywordBlocklist`] — case-insensitive literal or regex patterns.
+//! - [`MaxContentLength`] — caps total characters across input messages
+//!   or output content.
+//! - [`GuardrailChain`] — composes multiple guardrails; first
+//!   [`GuardrailVerdict::Block`] short-circuits.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
+
+mod chain;
+mod keyword;
+mod length;
+
+use aisix_gateway::{ChatFormat, ChatResponse};
+use async_trait::async_trait;
+
+pub use chain::GuardrailChain;
+pub use keyword::{KeywordBlocklist, KeywordRule};
+pub use length::MaxContentLength;
+
+/// What a guardrail decided about a request or response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardrailVerdict {
+    Allow,
+    Block { reason: String },
+}
+
+impl GuardrailVerdict {
+    pub fn is_block(&self) -> bool {
+        matches!(self, GuardrailVerdict::Block { .. })
+    }
+}
+
+/// Pluggable content-policy hook. Production wires `Arc<dyn Guardrail>`
+/// in `ProxyState`; tests construct in-memory chains directly.
+#[async_trait]
+pub trait Guardrail: Send + Sync + 'static {
+    /// Stable name for log/metric labels.
+    fn name(&self) -> &'static str;
+
+    /// Inspect the incoming request. Default: allow everything.
+    async fn check_input(&self, _req: &ChatFormat) -> GuardrailVerdict {
+        GuardrailVerdict::Allow
+    }
+
+    /// Inspect the upstream response. Default: allow everything.
+    async fn check_output(&self, _resp: &ChatResponse) -> GuardrailVerdict {
+        GuardrailVerdict::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verdict_helpers() {
+        assert!(!GuardrailVerdict::Allow.is_block());
+        assert!(GuardrailVerdict::Block { reason: "x".into() }.is_block());
+    }
+}

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -18,6 +18,7 @@
 
 use aisix_cache::CacheKey;
 use aisix_gateway::{BridgeContext, BridgeError, ChatFormat};
+use aisix_guardrails::GuardrailVerdict;
 use aisix_obs::{AccessLog, Metrics, RequestOutcome};
 use axum::extract::State;
 use axum::http::HeaderValue;
@@ -134,6 +135,13 @@ async fn dispatch(
 
     if !auth.key().can_access(&req.model) {
         return Err(ProxyError::ModelForbidden(req.model.clone()));
+    }
+
+    // Input guardrails. Run before reservation so a blocked prompt
+    // doesn't burn an RPM slot — content-policy refusals shouldn't
+    // count against quota.
+    if let GuardrailVerdict::Block { reason } = state.guardrails.check_input(req).await {
+        return Err(ProxyError::ContentFiltered(reason));
     }
 
     // Resolve the attempt-list of underlying Model entries. For a
@@ -301,10 +309,17 @@ async fn dispatch(
     };
     let provider_name = chosen_provider.unwrap_or_else(|| "unknown".into());
 
+    // Output guardrail. Tokens still count against quota — the upstream
+    // already burned them — so commit before the check, and refuse the
+    // refusal-write to the cache so a re-request gets a fresh chance.
     let prompt = upstream.usage.prompt_tokens as u64;
     let completion = upstream.usage.completion_tokens as u64;
     let total = upstream.usage.total_tokens as u64;
     reservation.commit_tokens(total);
+
+    if let GuardrailVerdict::Block { reason } = state.guardrails.check_output(&upstream).await {
+        return Err(ProxyError::ContentFiltered(reason));
+    }
 
     if let (Some(cache), Some(key)) = (state.cache.as_ref(), cache_key.as_ref()) {
         if let Err(err) = cache.put(key, upstream.clone()).await {

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -72,6 +72,8 @@ pub enum ProxyError {
     InvalidRequest(String),
     #[error("no bridge registered for provider")]
     ProviderUnavailable,
+    #[error("content blocked by policy: {0}")]
+    ContentFiltered(String),
     #[error(transparent)]
     RateLimit(#[from] RateLimitError),
     #[error(transparent)]
@@ -86,6 +88,7 @@ impl ProxyError {
             ProxyError::ModelNotFound(_) => StatusCode::NOT_FOUND,
             ProxyError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
             ProxyError::ProviderUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+            ProxyError::ContentFiltered(_) => StatusCode::UNPROCESSABLE_ENTITY,
             ProxyError::RateLimit(_) => StatusCode::TOO_MANY_REQUESTS,
             ProxyError::Bridge(b) => {
                 StatusCode::from_u16(b.http_status()).unwrap_or(StatusCode::BAD_GATEWAY)
@@ -100,6 +103,7 @@ impl ProxyError {
             ProxyError::ModelNotFound(_) => "model_not_found",
             ProxyError::InvalidRequest(_) => "invalid_request_error",
             ProxyError::ProviderUnavailable => "provider_unavailable",
+            ProxyError::ContentFiltered(_) => "content_filter",
             ProxyError::RateLimit(_) => "rate_limit_exceeded",
             ProxyError::Bridge(b) => b.error_type(),
         }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -944,4 +944,100 @@ data: [DONE]\n\n";
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
+
+    #[tokio::test]
+    async fn input_guardrail_block_returns_422_and_skips_upstream() {
+        use aisix_guardrails::{GuardrailChain, KeywordBlocklist, KeywordRule};
+
+        // wiremock that fails the test if it's hit at all.
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0) // hard expectation — guardrail must short-circuit
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+
+        let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(KeywordBlocklist::new(
+            vec![KeywordRule::literal("forbidden-token")],
+        ))]));
+        let state = build_state(snap, hub).with_guardrails(guardrails);
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "say the forbidden-token please"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("forbidden-token"));
+    }
+
+    #[tokio::test]
+    async fn output_guardrail_block_returns_422_after_upstream_runs() {
+        use aisix_guardrails::{GuardrailChain, KeywordBlocklist, KeywordRule};
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "here is your secret-string"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1) // upstream IS called; guardrail blocks the response
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+
+        let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(
+            KeywordBlocklist::output_only(vec![KeywordRule::literal("secret-string")]),
+        )]));
+        let state = build_state(snap, hub).with_guardrails(guardrails);
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "anything"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
 }

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -18,6 +18,7 @@ use aisix_cache::{Cache, MemoryCache};
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
+use aisix_guardrails::{Guardrail, GuardrailChain};
 use aisix_obs::Metrics;
 use aisix_ratelimit::Limiter;
 use std::sync::Arc;
@@ -32,6 +33,9 @@ pub struct ProxyState {
     pub metrics: Arc<Metrics>,
     pub cache: Option<Arc<dyn Cache>>,
     pub routing: Arc<RoutingRegistry>,
+    /// Content-policy hooks. Default is an empty chain (no-op); the
+    /// server bootstrap loads a real chain from config.
+    pub guardrails: Arc<dyn Guardrail>,
     pub request_body_limit_bytes: usize,
 }
 
@@ -44,6 +48,7 @@ impl ProxyState {
             metrics: Arc::new(Metrics::new(false)),
             cache: Some(Arc::new(MemoryCache::with_defaults())),
             routing: Arc::new(RoutingRegistry::new()),
+            guardrails: Arc::new(GuardrailChain::empty()),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -63,6 +68,7 @@ impl ProxyState {
             metrics: Arc::new(Metrics::new(false)),
             cache: Some(Arc::new(MemoryCache::with_defaults())),
             routing: Arc::new(RoutingRegistry::new()),
+            guardrails: Arc::new(GuardrailChain::empty()),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -85,6 +91,7 @@ impl ProxyState {
             metrics,
             cache,
             routing: Arc::new(RoutingRegistry::new()),
+            guardrails: Arc::new(GuardrailChain::empty()),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -93,6 +100,13 @@ impl ProxyState {
     /// every request to reach wiremock.
     pub fn without_cache(mut self) -> Self {
         self.cache = None;
+        self
+    }
+
+    /// Replace the guardrail chain. Used by both the server bootstrap
+    /// and tests that want a deterministic policy.
+    pub fn with_guardrails(mut self, guardrails: Arc<dyn Guardrail>) -> Self {
+        self.guardrails = guardrails;
         self
     }
 }


### PR DESCRIPTION
## Summary

\`aisix-guardrails\` ships the \`Guardrail\` trait + two reference
implementations + a short-circuiting chain, wired through the proxy
as \`ProxyError::ContentFiltered\` → 422 with OpenAI-style
\`"content_filter"\` error type.

### Guardrails crate
- \`Guardrail\` trait (\`async_trait\`) with \`check_input(req)\` and
  \`check_output(resp)\`. \`GuardrailVerdict::{Allow, Block { reason }}\`.
- **KeywordBlocklist** — literal (case-insensitive) or regex rules.
  Applies to input and/or output independently. First match wins so
  reason is deterministic.
- **MaxContentLength** — per-side char caps. Counts Unicode chars,
  not bytes.
- **GuardrailChain** — composes \`Vec<Arc<dyn Guardrail>>\`; first
  \`Block\` short-circuits.

### Proxy integration
- \`ProxyState\` gains \`guardrails: Arc<dyn Guardrail>\` (default
  empty chain). New \`with_guardrails()\` builder.
- \`check_input\` runs after auth/model resolve but **before**
  reservation — blocked prompts don't burn an RPM slot.
- \`check_output\` runs after the bridge response but **before** cache
  write — refusals don't poison the cache.
- \`ProxyError::ContentFiltered(reason)\` → 422 + \`"content_filter"\`.

## Test plan

- [x] 21 guardrail tests (literal/regex, case-insensitive, unicode
  char counting, chain short-circuit, input/output-only configs,
  invalid regex returns clean error)
- [x] 2 wiremock integration tests:
  - input block → 422, \`expect(0)\` proves upstream skipped
  - output block → 422 after \`expect(1)\` proves upstream ran
- [x] \`cargo test --workspace\` — 287 tests pass (264 + 23)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green across all 6 jobs