### PR TITLE
ci: build + publish aisix container image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,11 @@
 .git
 .github
 target
-ui/node_modules
-ui/.next
-ui/dist
+
+# The Dockerfile only copies Cargo.* + crates/. Excluding the UI
+# tree entirely avoids shipping ~50 MB of node_modules (on dev
+# machines) and ~2 MB of checked-in sources into the build context.
+ui
 docs
 tests/fixtures/tmp
 **/.DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+target
+ui/node_modules
+ui/.next
+ui/dist
+docs
+tests/fixtures/tmp
+**/.DS_Store
+**/*.log

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,11 +2,13 @@ name: docker-image
 
 # Build and publish the aisix container image to GHCR.
 #
-# Tag strategy:
+# Tag strategy. Every push always carries a :sha-<shortsha> tag for
+# traceability; the other tags layer on top based on the trigger:
 #   - push to main              → :main + :sha-<shortsha>
 #   - push tag vX.Y.Z           → :X.Y.Z + :X.Y + :X + :latest
+#                                 + :sha-<shortsha>
 #   - pull request              → build-only (no push), sanity check
-#   - workflow_dispatch         → manual trigger, respects 'tag' input
+#   - workflow_dispatch         → :sha-<shortsha> + optional tag input
 
 on:
   push:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,90 @@
+name: docker-image
+
+# Build and publish the aisix container image to GHCR.
+#
+# Tag strategy:
+#   - push to main              → :main + :sha-<shortsha>
+#   - push tag vX.Y.Z           → :X.Y.Z + :X.Y + :X + :latest
+#   - pull request              → build-only (no push), sanity check
+#   - workflow_dispatch         → manual trigger, respects 'tag' input
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - .github/workflows/docker-image.yml
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - "crates/**"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Optional extra tag to publish (e.g. aisix-e2e)"
+        required: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}   # ghcr.io/moonming/ai-gateway
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
+          labels: |
+            org.opencontainers.image.title=aisix
+            org.opencontainers.image.description=AISIX — Rust AI Gateway
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false   # keep manifest format compatible with older clients

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
+# syntax=docker/dockerfile:1.7
+#
 # Multi-stage build for the aisix AI gateway.
 #
 # The workspace pins rustc via rust-toolchain.toml (currently 1.93.1).
 # We use the latest Debian-based official Rust image, then copy the
 # single `aisix` binary into a slim runtime image.
 #
+# BuildKit is required (the `--mount=type=cache` directives rely on
+# it). On recent Docker Desktop / Docker CE, BuildKit is the default;
+# on older clients run:  DOCKER_BUILDKIT=1 docker build -t aisix:dev .
+#
 # Build:
 #   docker build -t aisix:dev .
 #
 # Run:
 #   docker run --rm -v $(pwd)/config.example.yaml:/etc/aisix/config.yaml \
-#     -e AISIX_CONFIG=/etc/aisix/config.yaml aisix:dev
+#     aisix:dev
 
 # --- Stage 1: build ----------------------------------------------------------
 FROM rust:1.93-bookworm AS builder
@@ -21,15 +27,20 @@ RUN apt-get update \
 
 WORKDIR /src
 
-# Leverage Docker layer cache: copy manifests first so dependency
-# compilation only re-runs when Cargo.toml / Cargo.lock change.
+# BuildKit cache mounts carry `~/.cargo/registry` + `target/` across
+# builds, so changes to source files still reuse compiled dependencies.
+# We could split dep-build from source-build via a manifests-only warm
+# stage, but the cache mounts give us ~95% of the same win with half
+# the Dockerfile complexity. Source copy is a single layer.
 COPY Cargo.toml Cargo.lock rust-toolchain.toml rustfmt.toml ./
 COPY crates ./crates
 
-# The release build is what we ship.
+# `--locked` forces the build to use the exact versions in Cargo.lock —
+# fails fast if the lockfile is stale rather than silently resolving
+# fresh deps in CI.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
-    cargo build --release --bin aisix \
+    cargo build --locked --release --bin aisix \
     && cp target/release/aisix /usr/local/bin/aisix
 
 # --- Stage 2: runtime --------------------------------------------------------
@@ -38,7 +49,9 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates tini \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd --system --uid 10001 --no-create-home --shell /usr/sbin/nologin aisix
+    && useradd --system --uid 10001 --no-create-home --shell /usr/sbin/nologin aisix \
+    && mkdir -p /etc/aisix/tls /var/lib/aisix \
+    && chown -R aisix:aisix /etc/aisix /var/lib/aisix
 
 COPY --from=builder /usr/local/bin/aisix /usr/local/bin/aisix
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# Multi-stage build for the aisix AI gateway.
+#
+# The workspace pins rustc via rust-toolchain.toml (currently 1.93.1).
+# We use the latest Debian-based official Rust image, then copy the
+# single `aisix` binary into a slim runtime image.
+#
+# Build:
+#   docker build -t aisix:dev .
+#
+# Run:
+#   docker run --rm -v $(pwd)/config.example.yaml:/etc/aisix/config.yaml \
+#     -e AISIX_CONFIG=/etc/aisix/config.yaml aisix:dev
+
+# --- Stage 1: build ----------------------------------------------------------
+FROM rust:1.93-bookworm AS builder
+
+# protoc is required by dependencies that use prost/tonic-build.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Leverage Docker layer cache: copy manifests first so dependency
+# compilation only re-runs when Cargo.toml / Cargo.lock change.
+COPY Cargo.toml Cargo.lock rust-toolchain.toml rustfmt.toml ./
+COPY crates ./crates
+
+# The release build is what we ship.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/src/target \
+    cargo build --release --bin aisix \
+    && cp target/release/aisix /usr/local/bin/aisix
+
+# --- Stage 2: runtime --------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --no-create-home --shell /usr/sbin/nologin aisix
+
+COPY --from=builder /usr/local/bin/aisix /usr/local/bin/aisix
+
+# Proxy + admin listeners from config.example.yaml.
+EXPOSE 3000 3001
+
+USER aisix
+
+# tini forwards signals cleanly to the aisix process.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/aisix"]
+CMD ["--config", "/etc/aisix/config.yaml"]


### PR DESCRIPTION
## Summary

Adds a root `Dockerfile` and a `.github/workflows/docker-image.yml` workflow that publishes the aisix AI gateway image to **`ghcr.io/moonming/ai-gateway`**.

## Motivation

Downstream consumers need a pre-built container image to wire aisix into integrated test stacks without cloning this repo and running `cargo build` from scratch each time.

The immediate consumer is the aisix.cloud integrated E2E suite at [api7/AISIX-Cloud#3](https://github.com/api7/AISIX-Cloud/pull/3), whose `e2e/compose.yml` assumes `ghcr.io/api7/aisix-dp:aisix-e2e` is available. After this PR lands and publishes, api7.cloud will just pull from this namespace (or re-tag under `api7/` in a small downstream workflow). The AISIX.cloud PR #3 also documents the overall E2E strategy (5 happy-path scenarios verifying DP ↔ control plane cooperation).

## Dockerfile design

- **Stage 1 — builder**: `rust:1.93-bookworm`, installs `protobuf-compiler` for `prost`/`tonic-build`, uses BuildKit cache mounts on `$CARGO_HOME/registry` and `target/` so incremental pushes reuse deps.
- **Stage 2 — runtime**: `debian:bookworm-slim`, non-root uid `10001`, `tini` as PID 1 for clean signal forwarding, `ca-certificates` for outbound TLS. Exposes `:3000` (proxy) and `:3001` (admin) to match `config.example.yaml`. Config path is `/etc/aisix/config.yaml` by default; override with `--config` or `AISIX_CONFIG`.

## Workflow tag strategy

| Trigger | Tags pushed |
|:--------|:-----------|
| `push` to `main` | `:main`, `:sha-<shortsha>` |
| `push` tag `vX.Y.Z` | `:X.Y.Z`, `:X.Y`, `:X`, `:latest` |
| `pull_request` on Dockerfile / crates / workflow | **build-only** (no push) — serves as a sanity check that the image still builds |
| `workflow_dispatch` | manual; `tag` input publishes an additional custom tag (e.g. `aisix-e2e` for downstream integration testing) |

Uses `docker/metadata-action@v5` + `docker/build-push-action@v6` with GitHub Actions cache (`type=gha`).

## Image destination

`ghcr.io/moonming/ai-gateway` — same GHCR namespace as this repository. Downstream organisations can re-tag under their own namespace with a small follow-up workflow if desired (e.g. `docker pull` + `docker tag` + `docker push` to `ghcr.io/api7/aisix-dp:<tag>`).

## Test plan

- [x] `cargo fmt --check` / `cargo clippy` untouched (no code changes, existing `ci.yml` still runs)
- [ ] PR-trigger build-only job succeeds (validates the Dockerfile on this very PR without publishing)
- [ ] Post-merge, first `push` to `main` publishes `ghcr.io/moonming/ai-gateway:main` and `:sha-<shortsha>`
- [ ] Manual `workflow_dispatch` with `tag=aisix-e2e` publishes the tag used by aisix.cloud E2E

## No runtime code changes

This PR is strictly build + CI. The binary's behaviour, CLI flags, and config schema are unchanged.