### PR TITLE
feat(managed): etcd mTLS + managed-mode switch (skip admin/UI/Playground)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,17 @@ etcd:
   # password_env: "AISIX_ETCD_PASSWORD"
   dial_timeout_ms: 5000
   request_timeout_ms: 5000
+  # Optional TLS / mTLS bundle. Required when connecting to an
+  # aisix.cloud DP Manager (endpoint is https:// and the CP issues
+  # a client cert via IssueAIDataplaneCertificate). Uncomment and
+  # point to your mTLS bundle.
+  # tls:
+  #   ca_cert_file:     "/etc/aisix/mtls/ca.crt"
+  #   client_cert_file: "/etc/aisix/mtls/client.crt"
+  #   client_key_file:  "/etc/aisix/mtls/client.key"
+  #   # Optional: override the TLS SNI / cert-subject-alt-name.
+  #   # Defaults to the hostname portion of endpoints[0].
+  #   # domain_name: "etcd.aisix.cloud"
 
 proxy:
   addr: "0.0.0.0:3000"
@@ -48,6 +59,13 @@ observability:
     # public_key_env: "LANGFUSE_PUBLIC_KEY"
     # secret_key_env: "LANGFUSE_SECRET_KEY"
     # host: "https://cloud.langfuse.com"
+
+# Managed-mode switch. Uncomment when running as an aisix.cloud
+# tenant: the admin API, admin UI, and Playground will NOT be
+# bound — all configuration flows from etcd via the mTLS channel
+# above, driven by the aisix.cloud control plane.
+# managed:
+#   enabled: true
 
 cache:
   backend: "memory"   # memory | redis | qdrant

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -34,11 +34,21 @@ use crate::error::BootstrapError;
 pub struct Config {
     pub etcd: EtcdConfig,
     pub proxy: ProxyConfig,
+    /// Admin surface. Defaulted so managed-mode configs can omit this
+    /// block entirely; the default values are NOT bound at runtime —
+    /// [`ManagedConfig::is_managed`] gates the listener.
+    #[serde(default)]
     pub admin: AdminConfig,
     #[serde(default)]
     pub observability: ObservabilityConfig,
     #[serde(default)]
     pub cache: CacheConfig,
+    /// Optional managed-mode configuration. When `managed.enabled = true`
+    /// the admin API, admin UI, and Playground endpoints are **not**
+    /// bound — the DP is a pure etcd reader driven by the aisix.cloud
+    /// control plane. Missing or `enabled = false` runs standalone.
+    #[serde(default)]
+    pub managed: ManagedConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,6 +67,58 @@ pub struct EtcdConfig {
     pub dial_timeout_ms: u64,
     #[serde(default = "EtcdConfig::default_request_timeout")]
     pub request_timeout_ms: u64,
+    /// Optional TLS / mTLS bundle used to authenticate to the etcd
+    /// endpoint. Required when talking to an aisix.cloud DP Manager
+    /// (see prd-09 §9.3.3 — the CP issues a 10-year client cert via
+    /// `IssueAIDataplaneCertificate`). Leave unset for plain-HTTP
+    /// etcd (local dev, integration tests).
+    #[serde(default)]
+    pub tls: Option<EtcdTlsConfig>,
+}
+
+/// Paths to the mTLS bundle used for etcd client auth. Files are read
+/// lazily at connect time — absent files surface as a BootstrapError.
+///
+/// When `domain_name` is unset, callers typically derive it from the
+/// first endpoint's hostname so the tonic TLS layer knows what SNI /
+/// cert-subject-alt-name to match against.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EtcdTlsConfig {
+    /// PEM-encoded CA bundle used to verify the etcd server cert.
+    pub ca_cert_file: String,
+    /// PEM-encoded client certificate (from `IssueAIDataplaneCertificate`).
+    pub client_cert_file: String,
+    /// PEM-encoded client private key. Paired with `client_cert_file`.
+    pub client_key_file: String,
+    /// Expected server name for TLS verification. Usually the hostname
+    /// portion of `etcd.endpoints[0]`. Only required when the CA issues
+    /// certs under a different SNI than the endpoint DNS name.
+    #[serde(default)]
+    pub domain_name: Option<String>,
+}
+
+/// Optional managed-mode configuration (prd-09 §9.2.2).
+///
+/// When `enabled = true`, aisix runs as a tenant of aisix.cloud:
+///
+/// - The admin API listener is **not** bound.
+/// - The admin UI is **not** served.
+/// - The Playground endpoint is **not** exposed.
+///
+/// All configuration is read from etcd via the TLS channel (see
+/// [`EtcdTlsConfig`]).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct ManagedConfig {
+    pub enabled: bool,
+}
+
+impl ManagedConfig {
+    /// True if the DP should behave as an aisix.cloud tenant.
+    pub const fn is_managed(&self) -> bool {
+        self.enabled
+    }
 }
 
 impl EtcdConfig {
@@ -98,12 +160,33 @@ impl ProxyConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AdminConfig {
+    #[serde(default = "AdminConfig::default_addr")]
     pub addr: String,
     /// Statically-provisioned admin keys. A request is authorised if it
     /// presents any of these via `Authorization: Bearer <k>` or `x-api-key`.
+    #[serde(default)]
     pub admin_keys: Vec<String>,
     #[serde(default)]
     pub tls: Option<TlsConfig>,
+}
+
+impl AdminConfig {
+    fn default_addr() -> String {
+        // Intentionally non-routable. Managed-mode configs never bind
+        // this; standalone configs are rejected by `Config::validate`
+        // if they leave it at the default without overriding.
+        "127.0.0.1:0".into()
+    }
+}
+
+impl Default for AdminConfig {
+    fn default() -> Self {
+        Self {
+            addr: Self::default_addr(),
+            admin_keys: Vec::new(),
+            tls: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -291,21 +374,29 @@ impl Config {
                 "etcd.endpoints must contain at least one endpoint".into(),
             ));
         }
-        if self.admin.admin_keys.is_empty() {
-            return Err(BootstrapError::Config(
-                "admin.admin_keys must contain at least one key".into(),
-            ));
+        // In managed mode the admin listener is not bound, so requiring
+        // admin_keys or a valid admin.addr would be punishing the user
+        // for fields that aren't going to be used. In standalone mode
+        // we keep the original invariants.
+        if !self.managed.is_managed() {
+            if self.admin.admin_keys.is_empty() {
+                return Err(BootstrapError::Config(
+                    "admin.admin_keys must contain at least one key \
+                     (required when managed.enabled is false)"
+                        .into(),
+                ));
+            }
+            if self.admin.addr.parse::<std::net::SocketAddr>().is_err() {
+                return Err(BootstrapError::Config(format!(
+                    "admin.addr invalid socket address: {}",
+                    self.admin.addr
+                )));
+            }
         }
         if self.proxy.addr.parse::<std::net::SocketAddr>().is_err() {
             return Err(BootstrapError::Config(format!(
                 "proxy.addr invalid socket address: {}",
                 self.proxy.addr
-            )));
-        }
-        if self.admin.addr.parse::<std::net::SocketAddr>().is_err() {
-            return Err(BootstrapError::Config(format!(
-                "admin.addr invalid socket address: {}",
-                self.admin.addr
             )));
         }
         Ok(())
@@ -411,5 +502,84 @@ bogus_field: 1
         );
         let err = Config::load_from_path(Some(f.path())).unwrap_err();
         assert!(err.to_string().contains("bogus_field"));
+    }
+
+    #[test]
+    fn managed_mode_lets_admin_fields_be_omitted() {
+        // A managed-mode config is the minimum aisix.cloud tenant
+        // shape: etcd + tls + proxy + managed.enabled = true. Admin
+        // keys / addr are fine to leave out entirely because the
+        // admin surface is never bound.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["https://etcd.aisix.cloud:2379"]
+  prefix: "/aisix"
+  tls:
+    ca_cert_file: "/etc/aisix/mtls/ca.crt"
+    client_cert_file: "/etc/aisix/mtls/client.crt"
+    client_key_file: "/etc/aisix/mtls/client.key"
+proxy:
+  addr: "0.0.0.0:3000"
+managed:
+  enabled: true
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert!(cfg.managed.is_managed());
+        assert_eq!(
+            cfg.etcd.tls.as_ref().unwrap().client_cert_file,
+            "/etc/aisix/mtls/client.crt"
+        );
+        assert!(cfg.admin.admin_keys.is_empty());
+    }
+
+    #[test]
+    fn standalone_still_requires_admin_keys_even_with_managed_false() {
+        // managed.enabled = false (or missing) must keep the original
+        // "admin_keys must be non-empty" invariant. Otherwise a user
+        // accidentally dropping admin_keys would silently lose auth
+        // on their admin listener.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: []
+managed:
+  enabled: false
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("admin.admin_keys"));
+    }
+
+    #[test]
+    fn parses_etcd_tls_block() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["https://etcd.aisix.cloud:2379"]
+  tls:
+    ca_cert_file: "/a.crt"
+    client_cert_file: "/c.crt"
+    client_key_file: "/c.key"
+    domain_name: "etcd.aisix.cloud"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        let tls = cfg.etcd.tls.expect("tls parsed");
+        assert_eq!(tls.ca_cert_file, "/a.crt");
+        assert_eq!(tls.client_cert_file, "/c.crt");
+        assert_eq!(tls.client_key_file, "/c.key");
+        assert_eq!(tls.domain_name.as_deref(), Some("etcd.aisix.cloud"));
     }
 }

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -23,8 +23,8 @@ pub mod resource;
 pub mod snapshot;
 
 pub use config::{
-    AdminConfig, CacheBackend, CacheConfig, Config, EtcdConfig, LangfuseConfig,
-    ObservabilityConfig, ProxyConfig, TlsConfig,
+    AdminConfig, CacheBackend, CacheConfig, Config, EtcdConfig, EtcdTlsConfig, LangfuseConfig,
+    ManagedConfig, ObservabilityConfig, ProxyConfig, TlsConfig,
 };
 pub use error::{
     AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use aisix_admin::{AdminState, ConfigStore, EtcdConfigStore};
 use aisix_cache::{Cache, MemoryCache, RedisCache};
 use aisix_core::models::Provider;
-use aisix_core::{CacheBackend, Config};
+use aisix_core::{CacheBackend, Config, EtcdConfig};
 use aisix_etcd::{EtcdConfigProvider, Supervisor};
 use aisix_gateway::Hub;
 use aisix_obs::{init_tracing, install_otlp_tracer, langfuse, Metrics};
@@ -29,6 +29,7 @@ use aisix_provider_openai::OpenAiBridge;
 use aisix_proxy::ProxyState;
 use aisix_ratelimit::Limiter;
 use clap::Parser;
+use etcd_client::{Certificate, ConnectOptions, Identity, TlsOptions};
 use tokio::sync::watch;
 
 #[derive(Debug, Parser)]
@@ -59,18 +60,30 @@ async fn main() -> anyhow::Result<()> {
 /// startup with a real config struct and still use `#[tokio::test]`.
 async fn run(cfg: Config) -> anyhow::Result<()> {
     // Steps 4-6: etcd + supervisor.
+    let connect_options = build_etcd_connect_options(&cfg.etcd)?;
     let provider = Arc::new(
-        EtcdConfigProvider::connect(&cfg.etcd.endpoints, cfg.etcd.prefix.clone(), None)
-            .await
-            .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
-    );
-    // Separate client for the admin write path. We could share a single
-    // underlying connection via `Client::clone()` but keeping two is
-    // cleaner — writes and the watch stream don't contend on the same
-    // mutex.
-    let admin_client = etcd_client::Client::connect(&cfg.etcd.endpoints, None)
+        EtcdConfigProvider::connect(
+            &cfg.etcd.endpoints,
+            cfg.etcd.prefix.clone(),
+            connect_options.clone(),
+        )
         .await
-        .map_err(|e| anyhow::anyhow!("etcd admin client connect failed: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
+    );
+    // Separate client for the admin write path — only needed when the
+    // admin surface is bound. We could share a single underlying
+    // connection via `Client::clone()` but keeping two is cleaner:
+    // writes and the watch stream don't contend on the same mutex.
+    // In managed mode this client is simply skipped.
+    let admin_client = if cfg.managed.is_managed() {
+        None
+    } else {
+        Some(
+            etcd_client::Client::connect(&cfg.etcd.endpoints, connect_options.clone())
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd admin client connect failed: {e}"))?,
+        )
+    };
     let supervisor = Arc::new(Supervisor::new(provider, cfg.etcd.prefix.clone()));
     let snapshot_handle = supervisor.handle();
 
@@ -134,45 +147,62 @@ async fn run(cfg: Config) -> anyhow::Result<()> {
     let health_tracker = proxy_state.health.clone();
     let proxy_router = aisix_proxy::build_router(proxy_state);
 
-    // Admin CRUD writes through etcd. The watch supervisor's read path
-    // is on a separate client (see above) so a long range scan during a
-    // list doesn't stall the watch stream. The admin listener also owns
-    // the `/metrics` endpoint — sharing the same `Metrics` handle means
-    // a scrape reflects counters written by the proxy surface.
-    let admin_store: Arc<dyn ConfigStore> =
-        Arc::new(EtcdConfigStore::new(admin_client, cfg.etcd.prefix.clone()));
-    let admin_state = AdminState::new(snapshot_handle.clone(), admin_store, &cfg.admin)
-        .with_metrics(metrics.clone())
-        // Share the in-process budget tracker so /admin/v1/spend reports
-        // live current-month spend without a database round-trip.
-        .with_budget_tracker(budget_tracker)
-        // Share the health tracker so /admin/v1/health reflects live
-        // per-model upstream failure counts.
-        .with_health_tracker(health_tracker)
-        // Share the proxy router so the playground endpoint can forward
-        // requests in-process without an extra network hop.
-        .with_proxy_router(proxy_router.clone());
-    let admin_router = aisix_admin::build_router(admin_state);
+    // Admin router + listener are only built in standalone mode.
+    // In managed mode (`cfg.managed.enabled = true`) the DP reads
+    // configuration exclusively from etcd; exposing admin writes or
+    // the Playground would bypass the aisix.cloud control plane.
+    let admin_serve_handle = if let Some(admin_client) = admin_client {
+        let admin_store: Arc<dyn ConfigStore> =
+            Arc::new(EtcdConfigStore::new(admin_client, cfg.etcd.prefix.clone()));
+        let admin_state = AdminState::new(snapshot_handle.clone(), admin_store, &cfg.admin)
+            .with_metrics(metrics.clone())
+            // Share the in-process budget tracker so /admin/v1/spend reports
+            // live current-month spend without a database round-trip.
+            .with_budget_tracker(budget_tracker)
+            // Share the health tracker so /admin/v1/health reflects live
+            // per-model upstream failure counts.
+            .with_health_tracker(health_tracker)
+            // Share the proxy router so the playground endpoint can forward
+            // requests in-process without an extra network hop.
+            .with_proxy_router(proxy_router.clone());
+        let admin_router = aisix_admin::build_router(admin_state);
 
-    // Step 9: bind + serve.
+        let admin_addr: std::net::SocketAddr = cfg.admin.addr.parse()?;
+        let admin_listener = tokio::net::TcpListener::bind(admin_addr).await?;
+        tracing::info!(admin = %admin_addr, "aisix admin listening");
+        let admin_serve = axum::serve(admin_listener, admin_router)
+            .with_graceful_shutdown(shutdown_signal(cancel_rx.clone(), "admin"));
+        Some(tokio::spawn(async move { admin_serve.await }))
+    } else {
+        // Drop unused shared components so the compiler can see they
+        // don't escape managed mode. The budget/health trackers exist
+        // on proxy_state and keep working regardless.
+        let _ = (&budget_tracker, &health_tracker);
+        tracing::info!("managed mode enabled — admin surface not bound");
+        None
+    };
+
+    // Step 9: bind + serve the proxy (always). Admin is handled above.
     let proxy_addr: std::net::SocketAddr = cfg.proxy.addr.parse()?;
-    let admin_addr: std::net::SocketAddr = cfg.admin.addr.parse()?;
     let proxy_listener = tokio::net::TcpListener::bind(proxy_addr).await?;
-    let admin_listener = tokio::net::TcpListener::bind(admin_addr).await?;
-    tracing::info!(proxy = %proxy_addr, admin = %admin_addr, "aisix listening");
+    tracing::info!(proxy = %proxy_addr, "aisix proxy listening");
 
     let proxy_serve = axum::serve(proxy_listener, proxy_router)
         .with_graceful_shutdown(shutdown_signal(cancel_rx.clone(), "proxy"));
-    let admin_serve = axum::serve(admin_listener, admin_router)
-        .with_graceful_shutdown(shutdown_signal(cancel_rx.clone(), "admin"));
 
     // Step 10: shutdown coordinator. Whichever of (signal, proxy, admin)
     // completes first triggers the rest.
     let signal_task = tokio::spawn(wait_for_signal(cancel_tx.clone()));
 
-    let (proxy_res, admin_res) = tokio::join!(proxy_serve, admin_serve);
+    let proxy_res = proxy_serve.await;
     proxy_res.map_err(|e| anyhow::anyhow!("proxy serve error: {e}"))?;
-    admin_res.map_err(|e| anyhow::anyhow!("admin serve error: {e}"))?;
+    if let Some(handle) = admin_serve_handle {
+        match handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(anyhow::anyhow!("admin serve error: {e}")),
+            Err(e) => return Err(anyhow::anyhow!("admin task join error: {e}")),
+        }
+    }
 
     // Ask the supervisor to stop (no-op if the signal task already did).
     let _ = cancel_tx.send(true);
@@ -180,6 +210,82 @@ async fn run(cfg: Config) -> anyhow::Result<()> {
     let _ = watch_task.await;
     tracing::info!("aisix shut down cleanly");
     Ok(())
+}
+
+/// Build the etcd-client `ConnectOptions` from `cfg.etcd`, wiring in
+/// the mTLS bundle when `cfg.etcd.tls` is present.
+///
+/// Returns `Ok(None)` for plain HTTP etcd (no TLS, no user/password) so
+/// callers can pass the value straight into `Client::connect`.
+///
+/// Design notes:
+///
+/// - We deliberately read the cert / key files inside this helper
+///   rather than in a `load_from_path` prologue. It keeps the config
+///   struct a pure POD — serialisable round-trippable — and the I/O
+///   failure bubbles up as a nicely-contextualised BootstrapError at
+///   the same point as other etcd connection errors.
+/// - `domain_name` defaults to the hostname portion of the first
+///   endpoint. Callers only need to override when the CA issues certs
+///   under a different name than the DNS they're dialing (rare but
+///   possible when the endpoint is an IP or internal alias).
+fn build_etcd_connect_options(etcd: &EtcdConfig) -> anyhow::Result<Option<ConnectOptions>> {
+    let mut needs_options = false;
+    let mut options = ConnectOptions::new();
+
+    if let (Some(user), Some(env_key)) = (etcd.user.as_ref(), etcd.password_env.as_ref()) {
+        let pw = std::env::var(env_key).map_err(|_| {
+            anyhow::anyhow!("etcd.password_env = {env_key:?} is set but the env var is missing")
+        })?;
+        options = options.with_user(user.clone(), pw);
+        needs_options = true;
+    }
+
+    if let Some(tls) = etcd.tls.as_ref() {
+        let ca_pem = std::fs::read(&tls.ca_cert_file)
+            .map_err(|e| anyhow::anyhow!("etcd.tls.ca_cert_file = {:?}: {e}", tls.ca_cert_file))?;
+        let cert_pem = std::fs::read(&tls.client_cert_file).map_err(|e| {
+            anyhow::anyhow!(
+                "etcd.tls.client_cert_file = {:?}: {e}",
+                tls.client_cert_file
+            )
+        })?;
+        let key_pem = std::fs::read(&tls.client_key_file).map_err(|e| {
+            anyhow::anyhow!("etcd.tls.client_key_file = {:?}: {e}", tls.client_key_file)
+        })?;
+
+        let domain = match tls.domain_name.clone() {
+            Some(d) => d,
+            None => default_domain_from_endpoint(&etcd.endpoints[0])?,
+        };
+
+        let tls_opts = TlsOptions::new()
+            .domain_name(domain)
+            .ca_certificate(Certificate::from_pem(ca_pem))
+            .identity(Identity::from_pem(cert_pem, key_pem));
+        options = options.with_tls(tls_opts);
+        needs_options = true;
+    }
+
+    Ok(needs_options.then_some(options))
+}
+
+/// Extract the host portion of a URL-like endpoint (`http://host:2379`,
+/// `https://host:2379`, or bare `host:2379`) for use as the TLS SNI.
+fn default_domain_from_endpoint(endpoint: &str) -> anyhow::Result<String> {
+    let without_scheme = endpoint
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(endpoint);
+    let host = without_scheme
+        .rsplit_once(':')
+        .map(|(h, _)| h)
+        .unwrap_or(without_scheme)
+        .trim_matches(|c| c == '[' || c == ']'); // strip IPv6 brackets
+    if host.is_empty() {
+        anyhow::bail!("cannot derive TLS domain_name from endpoint {endpoint:?}");
+    }
+    Ok(host.to_string())
 }
 
 /// Register all four provider bridges on a fresh Hub. The Hub is
@@ -253,5 +359,75 @@ mod tests {
         let b = Cli::try_parse_from(["aisix", "--config", "/tmp/x.yaml"]).unwrap();
         assert_eq!(a.config, b.config);
         assert_eq!(a.config, PathBuf::from("/tmp/x.yaml"));
+    }
+
+    #[test]
+    fn default_domain_strips_scheme_port_and_brackets() {
+        // Plain hostnames.
+        assert_eq!(
+            default_domain_from_endpoint("http://etcd.aisix.cloud:2379").unwrap(),
+            "etcd.aisix.cloud"
+        );
+        assert_eq!(
+            default_domain_from_endpoint("https://etcd.aisix.cloud:2379").unwrap(),
+            "etcd.aisix.cloud"
+        );
+        assert_eq!(
+            default_domain_from_endpoint("etcd.aisix.cloud:2379").unwrap(),
+            "etcd.aisix.cloud"
+        );
+        assert_eq!(
+            default_domain_from_endpoint("etcd.aisix.cloud").unwrap(),
+            "etcd.aisix.cloud"
+        );
+        // IPv6 addresses show up with brackets; the SNI value should be
+        // the bare numeric literal (TLS libraries reject brackets).
+        assert_eq!(
+            default_domain_from_endpoint("https://[::1]:2379").unwrap(),
+            "::1"
+        );
+    }
+
+    #[test]
+    fn build_connect_options_none_when_plain_http() {
+        let etcd = aisix_core::EtcdConfig {
+            endpoints: vec!["http://127.0.0.1:2379".into()],
+            prefix: "/aisix".into(),
+            user: None,
+            password_env: None,
+            dial_timeout_ms: 5000,
+            request_timeout_ms: 5000,
+            tls: None,
+        };
+        let opts = build_etcd_connect_options(&etcd).unwrap();
+        assert!(
+            opts.is_none(),
+            "plain HTTP etcd must not synthesise options"
+        );
+    }
+
+    #[test]
+    fn build_connect_options_surfaces_missing_cert_files() {
+        let etcd = aisix_core::EtcdConfig {
+            endpoints: vec!["https://etcd.aisix.cloud:2379".into()],
+            prefix: "/aisix".into(),
+            user: None,
+            password_env: None,
+            dial_timeout_ms: 5000,
+            request_timeout_ms: 5000,
+            tls: Some(aisix_core::EtcdTlsConfig {
+                ca_cert_file: "/definitely/does/not/exist/ca.crt".into(),
+                client_cert_file: "/tmp/c.crt".into(),
+                client_key_file: "/tmp/c.key".into(),
+                domain_name: None,
+            }),
+        };
+        let err = build_etcd_connect_options(&etcd).unwrap_err();
+        // The error must mention which file was missing — operators
+        // should not have to diff config against filesystem state.
+        assert!(
+            err.to_string().contains("ca_cert_file"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds two closely-related DP-side capabilities required for AISIX to act as an aisix.cloud tenant:

1. **etcd mTLS client** — the aisix.cloud DP Manager serves etcd v3 over mTLS, so the DP needs to read a CA + client cert + client key from disk and wire them into the existing `etcd-client` `ConnectOptions`.
2. **Managed-mode switch** — when enabled, the admin API listener, admin UI, and Playground endpoint are **not** bound. All configuration flows from etcd; resource mutations happen through the cloud control plane.

This is the first of ~three DP-side PRs. Registration (fetching the mTLS bundle from cp-api at boot), heartbeat, and local snapshot fallback land in follow-ups.

## Config shape

```yaml
etcd:
  endpoints: ["https://etcd.aisix.cloud:2379"]
  tls:
    ca_cert_file:     "/etc/aisix/mtls/ca.crt"
    client_cert_file: "/etc/aisix/mtls/client.crt"
    client_key_file:  "/etc/aisix/mtls/client.key"
    # domain_name: "etcd.aisix.cloud"  # optional; defaults to endpoints[0] host
proxy:
  addr: "0.0.0.0:3000"
managed:
  enabled: true
```

Standalone users are unaffected: new fields are all optional and defaulted, `validate()` keeps the existing invariants when `managed.enabled = false`.

## What the managed switch actually flips

| Component | Standalone | Managed |
|:----------|:-----------|:--------|
| Proxy listener | ✅ bound | ✅ bound |
| etcd provider + watch supervisor | ✅ | ✅ |
| Admin etcd client (write path) | ✅ | ❌ skipped |
| Admin router (`/admin/v1/*`, UI, Playground) | ✅ bound | ❌ never constructed |
| Admin TCP listener | ✅ bound | ❌ never bound |
| `/metrics` (currently mounted on admin) | ✅ served | ❌ not served |

The last row is worth calling out: Phase 1 mounts Prometheus on the admin listener, so managed mode loses it. Adding a dedicated observability listener is a follow-up; for aisix.cloud tenants, Prometheus scraping is expected to happen on the cloud control plane side anyway.

## New helper

`build_etcd_connect_options(&EtcdConfig) -> anyhow::Result<Option<ConnectOptions>>`:

- Returns `None` for plain HTTP etcd (keeps the hot path cheap — no pointless `ConnectOptions::new()` allocation when nothing needs wiring).
- Reads the three PEM files and constructs `TlsOptions::new().domain_name(...).ca_certificate(...).identity(...)`.
- Missing files surface with the config key name (`etcd.tls.ca_cert_file = "/..."`) in the error so operators don't have to diff config against filesystem state.

`default_domain_from_endpoint()` extracts the SNI from URL-ish strings: `http://`, `https://`, bare `host:port`, and IPv6 literals `[::1]:2379` — table-tested.

## Tests

`cargo test --workspace --all-features` green (407 tests). New cases:

- `aisix-core::config::tests::managed_mode_lets_admin_fields_be_omitted` — minimum aisix.cloud tenant YAML loads cleanly.
- `aisix-core::config::tests::standalone_still_requires_admin_keys_even_with_managed_false` — original invariant preserved.
- `aisix-core::config::tests::parses_etcd_tls_block` — round-trip for all four TLS fields.
- `aisix-server::tests::default_domain_strips_scheme_port_and_brackets` — SNI extractor table.
- `aisix-server::tests::build_connect_options_none_when_plain_http` — hot path stays zero-cost.
- `aisix-server::tests::build_connect_options_surfaces_missing_cert_files` — operator-friendly error.

`cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Explicitly out of scope (follow-up PRs on this branch's successor stack)

- **Registration flow**: the DP currently expects the mTLS bundle already on disk. The next PR adds `POST /dp/register` client that exchanges a one-time Deployment Token for the bundle at boot and persists it atomically.
- **Heartbeat**: periodic `POST /api/ai_dataplane/heartbeat` so cp-api knows the DP is alive (and so the Gateway page in aisix.cloud shows green dots).
- **Local config snapshot**: continue serving proxy traffic when the etcd watch disconnects mid-flight (see aisix.cloud PRD prd-09 §9.7.2).
- **Structured request logs + hashes**: the observability schema aisix.cloud telemetry consumes.

## Relationship

Paired with the aisix.cloud side in [`api7/AISIX-Cloud#8`](https://github.com/api7/AISIX-Cloud/pull/8): that PR's `GatewayHandlers.create` calls `IssueDataplaneCertificate` on api7ee CP and returns the bundle to the user, who then drops it on their DP machine. The DP then boots with this PR's new config block pointing at those files.