### PR TITLE
ci: cap artifact retention to prevent storage-quota blackout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           name: coverage-unit
           path: lcov-unit.info
+          retention-days: 7
 
   build-ui:
     name: build ui
@@ -94,6 +95,7 @@ jobs:
         with:
           name: ui-dist
           path: crates/aisix-admin/ui-dist
+          retention-days: 7
 
   build-bin:
     name: build aisix (instrumented)
@@ -121,6 +123,9 @@ jobs:
         with:
           name: aisix-bin
           path: target/debug/aisix
+          # 72 MB binary × many runs will refill the quota quickly;
+          # keep only as long as the downstream e2e job needs it.
+          retention-days: 1
 
   e2e:
     name: e2e (vitest) + coverage
@@ -176,6 +181,7 @@ jobs:
           name: coverage-e2e
           path: tests/e2e/coverage/lcov.info
           if-no-files-found: ignore
+          retention-days: 7
 
   coverage-gate:
     name: coverage >= 90%
@@ -207,3 +213,4 @@ jobs:
         with:
           name: coverage-combined
           path: cov/combined.info
+          retention-days: 7


### PR DESCRIPTION
## Summary

Stop the CI quota fire twice-in-one-day. [#28](https://github.com/moonming/ai-gateway/pull/28) (and [#27](https://github.com/moonming/ai-gateway/pull/27) before it) failed at ` actions/upload-artifact ` with:

```
##[error]Failed to CreateArtifact: Artifact storage quota has been hit.
```

Tests themselves pass; only the upload step blows up. Root cause: free-tier Actions storage is ~500 MB shared across the repo, and each `aisix-bin` artifact is 72 MB. After ~7 main-branch runs we're already over, and subsequent PRs silently fail their CI.

## Fix

Add per-artifact `retention-days` to every `actions/upload-artifact@v4` call in `ci.yml`, tuned to the expected re-read horizon:

| Artifact | Retention | Rationale |
|:---------|:----------|:----------|
| `aisix-bin` | **1 day** | Only consumed by same-day `e2e` job; trivially re-runnable from source |
| `ui-dist` | 7 days | Same-day `e2e`, kept a week for manual inspection |
| `coverage-unit` | 7 days | Manual debugging of flaky coverage gates |
| `coverage-e2e` | 7 days | Same |
| `coverage-combined` | 7 days | Same |

Nothing downstream relies on week+ old binaries — the `needs:` chain `build-bin → e2e` will regenerate `aisix-bin` when earlier runs have expired.

## Companion cleanup

Already done out-of-band: 223 pre-existing artifacts (mostly 72 MB `aisix-bin` duplicates) were purged via the API to reclaim immediate quota. The retention caps here prevent re-accumulation.

## Test plan

- [x] YAML still valid (`yaml_parse` implicit via GitHub)
- [ ] PR-trigger CI succeeds (validates the change doesn't regress any existing job)
- [ ] Post-merge on main: next run of main publishes artifacts with 1d / 7d retention