### PR TITLE
feat(docker): managed-mode env-var bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,16 @@
 # Build:
 #   docker build -t aisix:dev .
 #
-# Run:
+# Run, standalone (mount your own config):
 #   docker run --rm -v $(pwd)/config.example.yaml:/etc/aisix/config.yaml \
+#     aisix:dev
+#
+# Run, managed (aisix.cloud tenant — bake config + env-var overrides):
+#   docker run --rm \
+#     -e AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml \
+#     -e AISIX_MANAGED__REGISTRATION_TOKEN=$DEPLOYMENT_TOKEN \
+#     -e AISIX_MANAGED__CP_BASE_URL=https://api.us.aisix.cloud \
+#     -v aisix-mtls:/var/lib/aisix \
 #     aisix:dev
 
 # --- Stage 1: build ----------------------------------------------------------
@@ -55,11 +63,22 @@ RUN apt-get update \
 
 COPY --from=builder /usr/local/bin/aisix /usr/local/bin/aisix
 
+# Bake the managed-mode bootstrap config so aisix.cloud tenants can
+# `docker run` without mounting anything — env vars carry the per-DP
+# secret bits (registration token + CP base URL).
+COPY config.managed.yaml /etc/aisix/config.managed.yaml
+
+# Entrypoint script picks the config file via AISIX_CONFIG_PATH so the
+# same image serves both standalone (mount your config at the default
+# path) and managed (point AISIX_CONFIG_PATH at the baked file).
+COPY docker/entrypoint.sh /usr/local/bin/aisix-entrypoint
+RUN chmod 0755 /usr/local/bin/aisix-entrypoint
+
 # Proxy + admin listeners from config.example.yaml.
 EXPOSE 3000 3001
 
 USER aisix
 
-# tini forwards signals cleanly to the aisix process.
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/aisix"]
-CMD ["--config", "/etc/aisix/config.yaml"]
+# tini forwards signals cleanly to the aisix process; entrypoint script
+# resolves the config path from env, then execs the binary.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/aisix-entrypoint"]

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -1,0 +1,72 @@
+# aisix — managed-mode bootstrap config (aisix.cloud tenant).
+#
+# Used by the official Docker image as `/etc/aisix/config.yaml`.
+# Only the bare minimum is set here:
+#
+#   - `managed.enabled: true`           always on for this image
+#   - `etcd.endpoints: [placeholder]`   overridden at first boot by the
+#                                       `/dp/register` response
+#   - `admin.admin_keys: [placeholder]` validation requires the slot,
+#                                       but the admin listener is never
+#                                       bound in managed mode
+#
+# Operators inject these env vars at `docker run` time:
+#
+#   AISIX_MANAGED__REGISTRATION_TOKEN=aisix_dp_us_east_1_AbCd…
+#   AISIX_MANAGED__CP_BASE_URL=https://api.us.aisix.cloud
+#
+# Plus optionally `AISIX_PROXY__ADDR`, `AISIX_OBSERVABILITY__LOG_LEVEL`,
+# `AISIX_CACHE__BACKEND`, etc. — every config field is reachable via
+# `AISIX_<UPPER>__<UPPER>` (see crates/aisix-core/src/config.rs).
+#
+# Subsequent boots re-use the mTLS bundle written under
+# `managed.mtls_dir` and skip the register round-trip entirely.
+
+etcd:
+  # Placeholder — overwritten at first boot. The Rust bootstrap copies
+  # the etcd endpoint + mTLS paths from the /dp/register response into
+  # this field before opening the gRPC channel.
+  endpoints:
+    - "https://placeholder-overridden-at-register:2379"
+  prefix: "/aisix"
+  dial_timeout_ms: 5000
+  request_timeout_ms: 5000
+
+proxy:
+  addr: "0.0.0.0:3000"
+  request_body_limit_bytes: 10485760
+
+admin:
+  # Bind to an unbindable port so even if managed mode somehow
+  # toggled off, the admin surface wouldn't accidentally come up
+  # without an operator-supplied key.
+  addr: "127.0.0.1:0"
+  admin_keys:
+    - "managed-mode-admin-disabled"
+
+observability:
+  service_name: "aisix"
+  log_level: "info"
+  access_log: true
+  metrics:
+    prometheus:
+      enabled: true
+      path: "/metrics"
+    otlp:
+      enabled: false
+  tracing:
+    otlp:
+      enabled: false
+      sample_ratio: 1.0
+  langfuse:
+    enabled: false
+
+managed:
+  enabled: true
+  # registration_token + cp_base_url come from env vars — never bake
+  # secrets into the image.
+  mtls_dir: "/var/lib/aisix/mtls"
+  dp_id_file: "/var/lib/aisix/dp_id"
+
+cache:
+  backend: "memory"

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -602,6 +602,37 @@ managed:
     }
 
     #[test]
+    fn parses_managed_block_with_register_fields() {
+        // Mirrors the shape of the baked-in config.managed.yaml so the
+        // image's bootstrap template stays a valid Config; if anyone
+        // adds a required ManagedConfig field they have to update both
+        // the YAML and this test.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["https://placeholder:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:0"
+  admin_keys: ["disabled"]
+managed:
+  enabled: true
+  mtls_dir: "/var/lib/aisix/mtls"
+  dp_id_file: "/var/lib/aisix/dp_id"
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert!(cfg.managed.is_managed());
+        assert_eq!(cfg.managed.mtls_dir, "/var/lib/aisix/mtls");
+        assert_eq!(cfg.managed.dp_id_file, "/var/lib/aisix/dp_id");
+        // Token / CP URL come from env at runtime — empty here is fine.
+        assert!(cfg.managed.registration_token.is_none());
+        assert!(cfg.managed.cp_base_url.is_none());
+        assert!(!cfg.managed.registration_enabled());
+    }
+
+    #[test]
     fn parses_etcd_tls_block() {
         let f = write_yaml(
             r#"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Container entrypoint for aisix.
+#
+# Picks the config file based on AISIX_CONFIG_PATH (default
+# /etc/aisix/config.yaml). Two intended modes:
+#
+#   Standalone — operator mounts their own config:
+#       docker run -v ./config.yaml:/etc/aisix/config.yaml ghcr.io/moonming/ai-gateway:main
+#
+#   Managed (aisix.cloud tenant) — use the baked-in template + env vars:
+#       docker run \
+#         -e AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml \
+#         -e AISIX_MANAGED__REGISTRATION_TOKEN=$DEPLOYMENT_TOKEN \
+#         -e AISIX_MANAGED__CP_BASE_URL=https://api.us.aisix.cloud \
+#         ghcr.io/moonming/ai-gateway:main
+#
+# The Rust binary's `Config::load_from_path` already layers
+# `AISIX_<UPPER>__<UPPER>` env vars on top of the YAML, so any field
+# is reachable without re-templating the file.
+
+set -eu
+
+CONFIG_PATH="${AISIX_CONFIG_PATH:-/etc/aisix/config.yaml}"
+
+if [ ! -f "$CONFIG_PATH" ]; then
+    echo "aisix-entrypoint: config file not found at $CONFIG_PATH" >&2
+    echo "aisix-entrypoint: mount one at /etc/aisix/config.yaml or set" >&2
+    echo "aisix-entrypoint: AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml" >&2
+    exit 64
+fi
+
+exec /usr/local/bin/aisix --config "$CONFIG_PATH"

--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -1,0 +1,94 @@
+# Managed mode (aisix.cloud tenant)
+
+When `managed.enabled = true`, aisix runs as a tenant of an
+[aisix.cloud](https://github.com/api7/AISIX-Cloud) control plane:
+
+- The admin API listener is **not** bound.
+- The admin UI is **not** served.
+- The Playground endpoint is **not** exposed.
+- All entity configuration (models / API keys / routing / guardrails)
+  is read from etcd over an mTLS channel.
+
+This document covers running the official Docker image as a managed
+DP. Source-of-truth: `crates/aisix-server/src/{register,heartbeat}.rs`
+and `crates/aisix-core/src/config.rs`.
+
+## First boot — register against the control plane
+
+The DP performs a one-shot `POST /dp/register` with the deployment
+token and persists the returned mTLS bundle + `dp_id` to disk.
+Subsequent boots reuse the bundle and skip the round-trip.
+
+```bash
+docker run --rm \
+  -e AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml \
+  -e AISIX_MANAGED__REGISTRATION_TOKEN=aisix_dp_us_east_1_AbCd... \
+  -e AISIX_MANAGED__CP_BASE_URL=https://api.us.aisix.cloud \
+  -v aisix-mtls:/var/lib/aisix \
+  -p 3000:3000 \
+  ghcr.io/moonming/ai-gateway:main
+```
+
+What each flag does:
+
+- `AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml` — point the
+  binary at the bootstrap template baked into the image. The default
+  `/etc/aisix/config.yaml` doesn't exist in the image; standalone
+  users mount their own there.
+- `AISIX_MANAGED__REGISTRATION_TOKEN` — single-use deployment token
+  issued by the control plane (see prd-09 §9.3.1). Burned on first
+  successful register; subsequent boots ignore it.
+- `AISIX_MANAGED__CP_BASE_URL` — the CP HTTPS origin. Used for
+  `/dp/register` and `/dp/heartbeat`.
+- `-v aisix-mtls:/var/lib/aisix` — persist the cert bundle + `dp_id`
+  across container restarts. Without this every restart triggers a
+  fresh registration which the CP will reject (token already used).
+
+## Env-var overrides
+
+Every config field is reachable via `AISIX_<UPPER>__<UPPER>` (the
+`config` crate maps `__` to nested-path separators). Common knobs:
+
+| Env var | Maps to | Default |
+|:--------|:--------|:--------|
+| `AISIX_PROXY__ADDR` | `proxy.addr` | `0.0.0.0:3000` |
+| `AISIX_OBSERVABILITY__LOG_LEVEL` | `observability.log_level` | `info` |
+| `AISIX_CACHE__BACKEND` | `cache.backend` | `memory` |
+| `AISIX_MANAGED__MTLS_DIR` | `managed.mtls_dir` | `/var/lib/aisix/mtls` |
+| `AISIX_MANAGED__DP_ID_FILE` | `managed.dp_id_file` | `/var/lib/aisix/dp_id` |
+
+## Restart semantics
+
+1. **First boot, token + URL set, no bundle on disk** → register;
+   write `ca.crt`, `client.crt`, `client.key`, `dp_id`; connect etcd
+   via mTLS; spawn heartbeat worker.
+2. **Restart, bundle on disk** → skip register; reload bundle; load
+   `dp_id` for heartbeat payloads; connect etcd; spawn heartbeat.
+3. **Bundle missing AND token missing** → log a warning; the etcd
+   connect will fail since the placeholder endpoint is unreachable.
+   This is the user-error path.
+
+## Verifying
+
+After `docker run`, you should see:
+
+```
+INFO managed mode: registering with aisix.cloud CP
+INFO registered with control plane dp_id=dp_xxx gateway_id=aigg_xxx etcd=dp-manager:7943
+INFO heartbeat started url=https://api.us.aisix.cloud/dp/heartbeat dp_id=dp_xxx interval_secs=15
+```
+
+The CP dashboard's gateway view will show the new DP within one
+heartbeat interval.
+
+## Troubleshooting
+
+- **`DP registration failed`** — token may be already-consumed or
+  expired; revoke + re-issue from the CP dashboard.
+- **`build reqwest client failed`** — usually a TLS bundle path
+  mismatch. The default `/var/lib/aisix` must be writable by uid
+  `10001` (the `aisix` user); make sure your bind-mounted volume
+  has the right ownership.
+- **Heartbeat 404** — the CP doesn't recognize `dp_id`. Most often
+  the DP got the bundle from one CP and is now pointing at another;
+  delete the volume and re-register.


### PR DESCRIPTION
## Summary

Lets the same Docker image serve both standalone and managed (aisix.cloud tenant) deployments without re-templating config files.

- \`config.managed.yaml\` — baked into the image at \`/etc/aisix/config.managed.yaml\`. Placeholder etcd endpoint (overwritten by the \`/dp/register\` response), \`managed.enabled = true\`, unbindable admin port (defence-in-depth).
- \`docker/entrypoint.sh\` — picks the config via \`AISIX_CONFIG_PATH\`. Standalone: mount your config at the default \`/etc/aisix/config.yaml\`. Managed: point \`AISIX_CONFIG_PATH\` at the baked file and inject \`AISIX_MANAGED__REGISTRATION_TOKEN\` + \`AISIX_MANAGED__CP_BASE_URL\`.

The existing bootstrap from #30 + #31 already does the heavy lifting: register-and-persist on first boot, reload mTLS bundle on restart, spawn heartbeat worker.

## Why now

Unblocks AISIX-Cloud E2E scenarios 2 / 3 / 4. The test harness can now \`docker run ghcr.io/moonming/ai-gateway:aisix-e2e\` with a deployment_token from the SaaS layer and the DP registers itself without any pre-baked certs.

## Tests

- New \`parses_managed_block_with_register_fields\` locks the YAML shape — any new required \`ManagedConfig\` field will fail CI loudly instead of silently breaking the image template.
- \`cargo fmt --check\` + \`cargo clippy --all-targets --locked -- -D warnings\` clean.

## Out of scope

- DP-side local snapshot (offline_resilience prerequisite) — separate change.
- \`/dp/telemetry\` worker — separate change.

## Test plan

- [x] \`cargo test -p aisix-core\` (9 passing, +1 new)
- [x] \`cargo clippy --all-targets --locked -- -D warnings\`
- [ ] \`docker build -t aisix:dev .\` succeeds
- [ ] \`docker run -e AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml aisix:dev\` exits with the expected "missing token" error