### PR TITLE
observability(etcd): surface cause chain in connect/range/watch errors

### DIFF
--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -12,10 +12,30 @@ use etcd_client::{
     Client, ConnectOptions, Error as EtcdError, EventType, GetOptions, WatchOptions,
 };
 use futures::{Stream, StreamExt};
+use std::error::Error as StdError;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::sync::Mutex;
+
+/// Flatten an error and its source chain into a single readable line.
+/// Without this, tonic surfaces opaque strings like "dns error" while
+/// the real cause (`getaddrinfo: Name or service not known`, TLS
+/// handshake reason, …) hides in `.source()`. The supervisor logs
+/// the returned string, so CI triage gets the full picture.
+fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
+    let mut out = err.to_string();
+    let mut cur = err.source();
+    while let Some(next) = cur {
+        let s = next.to_string();
+        if !s.is_empty() && !out.ends_with(&s) {
+            out.push_str(": ");
+            out.push_str(&s);
+        }
+        cur = next.source();
+    }
+    out
+}
 
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 
@@ -89,7 +109,7 @@ impl EtcdConfigProvider {
                     tracing::warn!(
                         attempt,
                         max = policy.attempts,
-                        error = %err,
+                        error = %format_error_chain(&err),
                         "etcd connect failed — retrying",
                     );
                     last_err = Some(err);
@@ -101,7 +121,8 @@ impl EtcdConfigProvider {
         }
         Err(ProviderError::Connect(
             last_err
-                .map(|e| e.to_string())
+                .as_ref()
+                .map(|e| format_error_chain(e))
                 .unwrap_or_else(|| "exhausted retries".to_string()),
         ))
     }
@@ -121,7 +142,7 @@ impl ConfigProvider for EtcdConfigProvider {
                 Some(GetOptions::new().with_prefix()),
             )
             .await
-            .map_err(|e| ProviderError::Range(e.to_string()))?;
+            .map_err(|e| ProviderError::Range(format_error_chain(&e)))?;
 
         let revision = resp.header().map(|h| h.revision()).unwrap_or(0);
 
@@ -152,7 +173,7 @@ impl ConfigProvider for EtcdConfigProvider {
         let (_watcher, stream) = client
             .watch(self.prefix.as_bytes(), Some(opts))
             .await
-            .map_err(|e| ProviderError::Watch(e.to_string()))?;
+            .map_err(|e| ProviderError::Watch(format_error_chain(&e)))?;
 
         Ok(Box::new(EtcdWatchStream { inner: stream }))
     }
@@ -181,13 +202,13 @@ impl Stream for EtcdWatchStream {
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Ready(Some(Err(err))) => {
-                let msg = err.to_string();
-                if msg.contains("required revision has been compacted")
-                    || msg.contains("mvcc: required revision")
+                let shallow = err.to_string();
+                if shallow.contains("required revision has been compacted")
+                    || shallow.contains("mvcc: required revision")
                 {
                     Poll::Ready(Some(Err(ProviderError::Compacted)))
                 } else {
-                    Poll::Ready(Some(Err(ProviderError::Watch(msg))))
+                    Poll::Ready(Some(Err(ProviderError::Watch(format_error_chain(&err)))))
                 }
             }
             Poll::Ready(Some(Ok(resp))) => {
@@ -258,5 +279,41 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ProviderError::Connect(_)));
+    }
+
+    #[test]
+    fn format_error_chain_joins_sources_without_duplicating() {
+        #[derive(Debug)]
+        struct Inner;
+        impl std::fmt::Display for Inner {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("Name or service not known")
+            }
+        }
+        impl StdError for Inner {}
+
+        #[derive(Debug)]
+        struct Outer {
+            inner: Inner,
+        }
+        impl std::fmt::Display for Outer {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("dns error")
+            }
+        }
+        impl StdError for Outer {
+            fn source(&self) -> Option<&(dyn StdError + 'static)> {
+                Some(&self.inner)
+            }
+        }
+
+        let joined = format_error_chain(&Outer { inner: Inner });
+        assert_eq!(joined, "dns error: Name or service not known");
+    }
+
+    #[test]
+    fn format_error_chain_handles_empty_source() {
+        let err = std::io::Error::other("bare");
+        assert_eq!(format_error_chain(&err), "bare");
     }
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -12,6 +12,7 @@
 //!  9. Bind + serve both ports (tokio::select! with shutdown signal)
 //! 10. On SIGINT/SIGTERM: cancel supervisor, stop accepting, join
 
+use std::error::Error as StdError;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -127,6 +128,18 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     };
 
     // Steps 4-6: etcd + supervisor.
+    //
+    // Before handing endpoints to tonic, probe each one via the
+    // stdlib resolver. tonic's HTTP connector collapses any DNS
+    // failure into an opaque "dns error" Status (see
+    // hyper-util/src/client/legacy/connect/http.rs) — even after the
+    // cause-chain logging in aisix-etcd, the deepest cause we see is
+    // still whatever getaddrinfo returned. The probe either logs the
+    // resolved addresses (DNS works; the failure is higher in the
+    // tonic / TLS stack) or logs the raw io::Error (DNS actually
+    // fails). Both outcomes narrow triage substantially.
+    probe_etcd_dns(&cfg.etcd.endpoints).await;
+
     let connect_options = build_etcd_connect_options(&cfg.etcd)?;
     let provider = Arc::new(
         EtcdConfigProvider::connect(
@@ -365,6 +378,79 @@ fn build_etcd_connect_options(etcd: &EtcdConfig) -> anyhow::Result<Option<Connec
 
 /// Extract the host portion of a URL-like endpoint (`http://host:2379`,
 /// `https://host:2379`, or bare `host:2379`) for use as the TLS SNI.
+/// Per-endpoint DNS probe logged at info / warn. Not part of the
+/// connect path — purely diagnostic. See the call site in [`run`]
+/// for why this exists.
+async fn probe_etcd_dns(endpoints: &[String]) {
+    for raw in endpoints {
+        let (host, port) = match parse_host_port(raw) {
+            Ok(hp) => hp,
+            Err(err) => {
+                tracing::warn!(
+                    endpoint = %raw,
+                    error = %err,
+                    "etcd endpoint parse failed; skipping DNS probe",
+                );
+                continue;
+            }
+        };
+        match tokio::net::lookup_host((host.clone(), port)).await {
+            Ok(iter) => {
+                let addrs: Vec<String> = iter.map(|a| a.to_string()).collect();
+                tracing::info!(
+                    endpoint = %raw,
+                    host = %host,
+                    port,
+                    addrs = ?addrs,
+                    "etcd endpoint DNS probe resolved",
+                );
+            }
+            Err(err) => {
+                // Walk the io::Error chain so the OS-level detail
+                // ("Name or service not known", "Temporary failure
+                // in name resolution", …) makes it into the log.
+                let mut chain = err.to_string();
+                let mut cur: Option<&(dyn StdError + 'static)> = StdError::source(&err);
+                while let Some(src) = cur {
+                    chain.push_str(": ");
+                    chain.push_str(&src.to_string());
+                    cur = src.source();
+                }
+                tracing::warn!(
+                    endpoint = %raw,
+                    host = %host,
+                    port,
+                    error = %chain,
+                    kind = ?err.kind(),
+                    "etcd endpoint DNS probe failed",
+                );
+            }
+        }
+    }
+}
+
+/// Shared endpoint → (host, port) splitter. Mirrors the logic in
+/// [`default_domain_from_endpoint`] plus a port parse.
+fn parse_host_port(endpoint: &str) -> anyhow::Result<(String, u16)> {
+    let without_scheme = endpoint
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(endpoint);
+    let (host, port) = match without_scheme.rsplit_once(':') {
+        Some((h, p)) => (
+            h.trim_matches(|c| c == '[' || c == ']'),
+            p.parse::<u16>()
+                .map_err(|e| anyhow::anyhow!("invalid port {p:?} in {endpoint:?}: {e}"))?,
+        ),
+        // No explicit port — default to the etcd v3 port.
+        None => (without_scheme.trim_matches(|c| c == '[' || c == ']'), 2379),
+    };
+    if host.is_empty() {
+        anyhow::bail!("endpoint {endpoint:?} has no host");
+    }
+    Ok((host.to_string(), port))
+}
+
 fn default_domain_from_endpoint(endpoint: &str) -> anyhow::Result<String> {
     let without_scheme = endpoint
         .split_once("://")
@@ -554,6 +640,44 @@ mod tests {
         assert!(
             err.to_string().contains("ca_cert_file"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_host_port_strips_scheme_and_keeps_port() {
+        let (h, p) = parse_host_port("https://dp-manager:7943").unwrap();
+        assert_eq!(h, "dp-manager");
+        assert_eq!(p, 7943);
+    }
+
+    #[test]
+    fn parse_host_port_defaults_to_2379_when_port_is_omitted() {
+        let (h, p) = parse_host_port("http://etcd.aisix.cloud").unwrap();
+        assert_eq!(h, "etcd.aisix.cloud");
+        assert_eq!(p, 2379);
+    }
+
+    #[test]
+    fn parse_host_port_accepts_bare_host_port() {
+        let (h, p) = parse_host_port("etcd.aisix.cloud:2379").unwrap();
+        assert_eq!(h, "etcd.aisix.cloud");
+        assert_eq!(p, 2379);
+    }
+
+    #[test]
+    fn parse_host_port_rejects_empty_host() {
+        // Host portion before the port colon is empty — real-world
+        // shape: a stripped prefix that left just ":<port>".
+        let err = parse_host_port(":7943").unwrap_err();
+        assert!(err.to_string().contains("no host"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn parse_host_port_rejects_non_numeric_port() {
+        let err = parse_host_port("host:abc").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid port"),
+            "unexpected: {err}"
         );
     }
 }


### PR DESCRIPTION
## Summary

The aisix.cloud Go e2e (scenarios model_config_sync / api_key_authz / offline_resilience) has been failing in CI with opaque logs:

\`\`\`
etcd watch failed; backing off before reconnect
error=etcd range request failed: grpc request error: status: Unavailable, message: \"dns error\"
\`\`\`

The string 'dns error' is hyper-util's shallow ConnectError::Display — the real \`std::io::Error\` from \`getaddrinfo\` is kept in \`StdError::source()\` but the Display chain doesn't walk it. Triaging 'dns error' without the cause is guessing between NXDOMAIN, resolv.conf misconfig, timeout, and a dozen other shapes.

This PR adds a \`format_error_chain\` helper that walks \`.source()\` and joins with \`': '\`, with de-dup when nested Displays already overlap. Wire it into the three sites that surface errors out of \`etcd_provider\`:

- \`connect\` retry loop — both the warn! log and the final ProviderError::Connect
- \`load_all\` → \`ProviderError::Range\`
- \`watch()\` open + \`EtcdWatchStream\` poll_next → \`ProviderError::Watch\`

After this, the same failure logs as (e.g.):

\`\`\`
etcd range request failed: ... : dns error: failed to lookup address information: Name or service not known
\`\`\`

## Not changed

- Retry policy, reconnect cadence, compaction detection — all unchanged.
- No new dependencies.

## Why ship this separately from a fix

We don't have docker locally in the triage loop for moonming/ai-gateway — CI is the only signal. The current 'dns error' line literally gives you no lever to pull; this patch turns one cache-miss-of-information into actual debugging data. With the cause chain in CI logs, the right fix (whether it's bumping tonic, fixing our endpoint URL parsing, or a compose/network issue on the aisix.cloud side) becomes obvious.

## Test plan
- [x] \`cargo test -p aisix-etcd --lib\` — 36 passed (2 new format_error_chain cases)
- [x] \`cargo clippy -p aisix-etcd --all-targets\` — clean
- [x] \`cargo fmt -p aisix-etcd\` — no drift