### PR TITLE
fix(config): pin env prefix_separator so AISIX_ vars actually apply

### DIFF
--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -408,8 +408,18 @@ impl Config {
             builder = builder.add_source(source);
         }
 
+        // config-rs default: when `separator` is set, the prefix
+        // separator inherits from it — so `separator("__")` alone
+        // would demand `AISIX__FOO__BAR` env vars. That's at odds
+        // with every other aisix.cloud service (and the existing
+        // docs / Dockerfile / e2e harness), which all use
+        // `AISIX_FOO__BAR` (single underscore between prefix and
+        // first key segment, double underscore for nested keys).
+        // Pin prefix_separator explicitly so the two shapes are
+        // distinct: `AISIX_` strips the prefix, `__` splits keys.
         builder = builder.add_source(
             Environment::with_prefix("AISIX")
+                .prefix_separator("_")
                 .separator("__")
                 .list_separator(",")
                 .try_parsing(true),
@@ -652,6 +662,17 @@ managed:
         assert!(cfg.managed.cp_base_url.is_none());
         assert!(!cfg.managed.registration_enabled());
     }
+
+    // NOTE: the env-prefix regression (config-rs default
+    // prefix_separator inheriting from separator, silently dropping
+    // `AISIX_FOO__BAR` shaped vars) is covered end-to-end by
+    // aisix.cloud's Go e2e suite, which runs the DP docker image
+    // with `AISIX_MANAGED__REGISTRATION_TOKEN` + `AISIX_MANAGED__CP_BASE_URL`
+    // and asserts on registration_enabled=true via the structured
+    // boot log added in the same release. A unit test here would
+    // need std::env::set_var (forbidden by the crate-level
+    // #![forbid(unsafe_code)]) or an extra dev-dep for a guarded
+    // env helper; the downstream integration coverage is enough.
 
     #[test]
     fn parses_etcd_tls_block() {


### PR DESCRIPTION
## The bug

Every \`AISIX_<SECTION>__<FIELD>\` env var advertised in the managed-mode Dockerfile — \`AISIX_MANAGED__REGISTRATION_TOKEN\`, \`AISIX_MANAGED__CP_BASE_URL\`, \`AISIX_PROXY__ADDR\`, … — has been **silently dropped** since the config loader was written.

## Why

config-rs 0.14 [env.rs lines 239-243](https://github.com/rust-cli/config-rs/blob/v0.14.1/src/env.rs#L239-L243):

\`\`\`rust
let prefix_separator = match (self.prefix_separator.as_deref(), self.separator.as_deref()) {
    (Some(pre), _) => pre,
    (None, Some(sep)) => sep,     // ← inherits from separator
    (None, None) => "_",
};
\`\`\`

We set \`separator(\"__\")\` (so \`FOO__BAR\` → \`foo.bar\`). Without an explicit \`prefix_separator\`, the crate defaulted the **prefix** separator to \"__\" as well — so it expected \`AISIX__FOO__BAR\` (double underscore after the prefix), not \`AISIX_FOO__BAR\`.

## Surfaced by

The managed-mode bootstrap diagnostic log added in #36:
\`\`\`
managed-mode bootstrap branch inputs
  bundle_exists=false
  registration_enabled=false  ← env vars were set; crate didn't see them
  mtls_dir=/var/lib/aisix/mtls
\`\`\`

## Fix

One line: pin \`prefix_separator(\"_\")\` explicitly. Now \`_\` strips the prefix, \`__\` splits nested keys — two distinct roles.

## Test plan
- [x] \`cargo test -p aisix-core --lib\` — 70/70 passed
- [x] \`cargo clippy\` — clean
- [x] \`cargo fmt\` — no drift
- [ ] aisix.cloud Go e2e logs show \`registration_enabled=true\` next run → scenarios 2/3 unblock at last