### PR TITLE
fix(env): per-key list parsing + unset AISIX_CONFIG_PATH before exec

### DIFF
--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -421,7 +421,17 @@ impl Config {
             Environment::with_prefix("AISIX")
                 .prefix_separator("_")
                 .separator("__")
+                // Per-key list parsing. Setting `list_separator`
+                // without explicit `with_list_parse_key` would force
+                // EVERY string env override through comma-splitting —
+                // which blows up secrets that happen to contain a
+                // comma (AISIX_MANAGED__REGISTRATION_TOKEN has been
+                // the visible victim) with a serde "invalid type:
+                // sequence, expected a string" error. Opt in only for
+                // fields that are actually Vec<String>.
                 .list_separator(",")
+                .with_list_parse_key("etcd.endpoints")
+                .with_list_parse_key("admin.admin_keys")
                 .try_parsing(true),
         );
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -29,4 +29,12 @@ if [ ! -f "$CONFIG_PATH" ]; then
     exit 64
 fi
 
+# AISIX_CONFIG_PATH is ours, not the binary's. The Rust Config
+# loader scrapes every AISIX_* env var as a deserialisation override,
+# so leaving CONFIG_PATH in the environment makes it try to
+# deserialise a field called "config_path" (which doesn't exist on
+# the root Config struct) and fail with "unknown field `config_path`".
+# Unset before exec so the binary never sees it.
+unset AISIX_CONFIG_PATH
+
 exec /usr/local/bin/aisix --config "$CONFIG_PATH"


### PR DESCRIPTION
Two follow-ups revealed by #37's env-prefix fix (which stopped silently dropping every AISIX_ override and finally let real values reach the deserialiser):

1. **Global `list_separator` was coercing every string env override through comma-splitting.** The DP's registration token happened to contain a comma, which surfaced as `invalid type: sequence, expected a string` for `managed.registration_token`. Fix: switch to `with_list_parse_key` and scope comma-splitting to the fields that are genuinely `Vec<String>` (`etcd.endpoints`, `admin.admin_keys`). Other string secrets pass through verbatim.

2. **`AISIX_CONFIG_PATH` was leaking from entrypoint state into the binary's deserialiser.** The env loader scrapes every `AISIX_*` var, so it tried to deserialise a top-level `config_path` field that doesn't exist, failing with `unknown field \`config_path\``. Fix: `unset AISIX_CONFIG_PATH` in `docker/entrypoint.sh` right before `exec`, so the binary never sees it.

## Test plan
- [x] `cargo test -p aisix-core --lib` — 70/70 passed
- [x] `cargo clippy` + `cargo fmt` — clean
- [ ] aisix.cloud Go e2e scenarios 2-4 stop error-ing during config load → DP actually boots and register fires