### PR TITLE
fix(ci): rename AISIX_REDIS_URL → CACHE_TEST_REDIS_URL to unblock CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,14 @@ jobs:
     env:
       # Picked up by crates/aisix-cache/tests/redis_integration.rs.
       # The tests no-op when this is unset (local dev), so absence is safe.
-      AISIX_REDIS_URL: redis://127.0.0.1:6379
+      #
+      # MUST NOT start with the `AISIX_` prefix — Config::load_from_path
+      # merges every AISIX_* env var into the root Config (via
+      # config-rs Environment::with_prefix("AISIX")), and Config has
+      # `#[serde(deny_unknown_fields)]`. An AISIX_REDIS_URL leaks into
+      # every Config::load_from_path test as `redis_url` and breaks
+      # the entire `aisix-core::config::tests` module.
+      CACHE_TEST_REDIS_URL: redis://127.0.0.1:6379
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/aisix-cache/src/redis.rs
+++ b/crates/aisix-cache/src/redis.rs
@@ -148,7 +148,7 @@ mod tests {
     }
 
     // The full integration path (real Redis round-trip) lives in
-    // `tests/redis_integration.rs` and is opt-in via the `AISIX_REDIS_URL`
+    // `tests/redis_integration.rs` and is opt-in via the `CACHE_TEST_REDIS_URL`
     // env var so the unit-test job stays hermetic. CI runs Redis as a
     // service so the integration test exercises the happy path.
 }

--- a/crates/aisix-cache/tests/redis_integration.rs
+++ b/crates/aisix-cache/tests/redis_integration.rs
@@ -1,6 +1,6 @@
 //! End-to-end Redis tests against a live Redis instance.
 //!
-//! Runs only when `AISIX_REDIS_URL` is set (e.g. on CI which spins
+//! Runs only when `CACHE_TEST_REDIS_URL` is set (e.g. on CI which spins
 //! `redis:7-alpine` as a service). The unit test module in
 //! `src/redis.rs` handles hermetic checks; this file proves the
 //! request → upstream → cache round-trip actually round-trips.
@@ -13,7 +13,7 @@ use aisix_cache::{Cache, RedisCache};
 use aisix_gateway::{ChatMessage, ChatResponse, FinishReason, UsageStats};
 
 fn redis_url() -> Option<String> {
-    std::env::var("AISIX_REDIS_URL").ok()
+    std::env::var("CACHE_TEST_REDIS_URL").ok()
 }
 
 fn sample(content: &str) -> ChatResponse {
@@ -29,7 +29,7 @@ fn sample(content: &str) -> ChatResponse {
 #[tokio::test]
 async fn put_then_get_round_trips_against_real_redis() {
     let Some(url) = redis_url() else {
-        eprintln!("skipping: AISIX_REDIS_URL not set");
+        eprintln!("skipping: CACHE_TEST_REDIS_URL not set");
         return;
     };
 
@@ -48,7 +48,7 @@ async fn put_then_get_round_trips_against_real_redis() {
 #[tokio::test]
 async fn ttl_eviction_drops_entry_after_window() {
     let Some(url) = redis_url() else {
-        eprintln!("skipping: AISIX_REDIS_URL not set");
+        eprintln!("skipping: CACHE_TEST_REDIS_URL not set");
         return;
     };
 
@@ -70,7 +70,7 @@ async fn ttl_eviction_drops_entry_after_window() {
 #[tokio::test]
 async fn missing_key_returns_none() {
     let Some(url) = redis_url() else {
-        eprintln!("skipping: AISIX_REDIS_URL not set");
+        eprintln!("skipping: CACHE_TEST_REDIS_URL not set");
         return;
     };
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,14 +71,14 @@ Used when a test needs a real external service.
 Current integration suites:
 
 - `crates/aisix-cache/tests/redis_integration.rs` — runs against a
-  real Redis. Requires `AISIX_REDIS_URL`; tests no-op silently if the
+  real Redis. Requires `CACHE_TEST_REDIS_URL`; tests no-op silently if the
   env var is unset, so local `cargo test` stays hermetic.
 
 CI exposes the env vars these tests need:
 
 | Test | Service | Env var |
 |---|---|---|
-| `redis_integration` | `redis:7-alpine` | `AISIX_REDIS_URL=redis://127.0.0.1:6379` |
+| `redis_integration` | `redis:7-alpine` | `CACHE_TEST_REDIS_URL=redis://127.0.0.1:6379` |
 
 Future suites that need etcd, an OTLP collector, or a Langfuse mock
 will follow the same pattern: a service container in CI, a no-op
@@ -226,7 +226,7 @@ Job descriptions:
 | Job | Purpose |
 |---|---|
 | `lint` | `cargo fmt --check`, `cargo clippy -D warnings`, `pnpm typecheck` |
-| `rust-unit` | `cargo llvm-cov --workspace --all-features` → uploads `lcov-unit.info`. Spins a `redis:7-alpine` service so `AISIX_REDIS_URL` integration tests can run |
+| `rust-unit` | `cargo llvm-cov --workspace --all-features` → uploads `lcov-unit.info`. Spins a `redis:7-alpine` service so `CACHE_TEST_REDIS_URL` integration tests can run |
 | `build-ui` | `pnpm build` in `ui/` → uploads `ui-dist` artifact for the next job |
 | `build-bin` | `cargo build` of `aisix-server` with `RUSTFLAGS=-C instrument-coverage` → uploads the binary artifact for the e2e job |
 | `e2e` | Spins etcd + redis services, downloads the binary artifact, runs Vitest. Currently `continue-on-error: true` while the harness stabilises across CI runners |


### PR DESCRIPTION
CI on `main` has been red since #34 because `aisix-core`'s `Config` loader merges every `AISIX_*` env var into the root `Config` struct (via config-rs `Environment::with_prefix("AISIX")`), and `Config` has `#[serde(deny_unknown_fields)]`.

The redis integration test sets `AISIX_REDIS_URL` on the `rust-unit` job, which leaks into every `Config::load_from_path` call as a stray `redis_url` field and panics:

```
Config("deserialize: unknown field \`redis_url\`, expected one of \`etcd\`, \`proxy\`, \`admin\`, \`observability\`, \`cache\`, \`managed\`")
```

8 / 9 `aisix-core::config::tests` fail (the one that passes is `rejects_unknown_fields` — it swallows the error intentionally).

## Fix

Rename the env var so it doesn't sit under the `AISIX_` prefix at all:

- `crates/aisix-cache/tests/redis_integration.rs` reads `CACHE_TEST_REDIS_URL`
- `.github/workflows/ci.yml` sets `CACHE_TEST_REDIS_URL`
- `crates/aisix-cache/src/redis.rs` doc comment + `docs/testing.md` updated to match

## Test plan

- [x] `cargo test -p aisix-core --lib config::tests` — all 9 pass with the rename
- [x] Repro the original failure: `AISIX_REDIS_URL=… cargo test … loads_minimal_config` still fails (so the loader behaviour for real `AISIX_*` overrides is unchanged)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)