### PR TITLE
ci: soft-fail coverage-gate while artifact quota persists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,9 +211,17 @@ jobs:
     name: coverage >= 90%
     needs: [rust-unit, e2e]
     runs-on: ubuntu-latest
+    # The threshold check itself is already a soft gate (the bash logic
+    # exits 0 even when below threshold; see comment on the merge step).
+    # Aligning the job-level setting with that intent: don't fail the
+    # workflow when coverage-gate fails — especially while the artifact
+    # storage quota outage prevents the upstream coverage-unit upload.
+    # Revert when the gate is flipped from advisory to gating (PR #5).
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+        continue-on-error: true
         with: { name: coverage-unit, path: cov/unit }
       - uses: actions/download-artifact@v4
         continue-on-error: true


### PR DESCRIPTION
## Summary

main CI is currently red on commit 6bf6227 because the \`coverage-gate\` job fails when its first \`download-artifact\` (coverage-unit) can't find an artifact. That artifact's upload was already soft-failed on the rust-unit job by PR #40 due to the GitHub Actions storage quota outage. The job-level \`continue-on-error\` was missed on coverage-gate so the workflow conclusion still rolls up to failure.

The coverage-gate threshold check is already a soft gate (the bash explicitly \`exit 0\`s even when below threshold; the comment says \"soft during scaffold milestones; flip to \`exit 1\` at PR #5\"). Aligning the job-level setting with that documented intent.

## Changes

- \`continue-on-error: true\` on the coverage-gate job
- \`continue-on-error: true\` on the first \`download-artifact\` step (coverage-unit) so the merge step still runs when only e2e coverage is present

## Test plan

- [x] main CI conclusion goes from failure → success after this PR lands
- [ ] Revert this and the other quota mitigations from PR #40 once GH org storage usage refreshes