### PR TITLE
ci: revert artifact-quota mitigations now that storage budget is set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,6 @@ jobs:
       - name: unit tests with coverage
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov-unit.info
       - uses: actions/upload-artifact@v4
-        # Soft until the org-level Actions storage quota refreshes (every
-        # 6-12h per GH). Tests passing is the gating signal here; the
-        # coverage artifact only feeds the advisory coverage-gate job.
-        # Remove this `continue-on-error` when storage usage has been
-        # raised or has fallen below quota.
-        continue-on-error: true
         with:
           name: coverage-unit
           path: lcov-unit.info
@@ -105,12 +99,6 @@ jobs:
         working-directory: ui
         run: pnpm build
       - uses: actions/upload-artifact@v4
-        # Soft until the org-level Actions storage quota refreshes. The
-        # downstream build-bin / e2e jobs depend on this artifact; if
-        # the upload fails their download-artifact will fail and they
-        # will be skipped (e2e is already continue-on-error at the job
-        # level; coverage-gate is advisory). Remove when quota is OK.
-        continue-on-error: true
         with:
           name: ui-dist
           path: crates/aisix-admin/ui-dist
@@ -120,11 +108,6 @@ jobs:
     name: build aisix (instrumented)
     needs: build-ui
     runs-on: ubuntu-latest
-    # Soft while the artifact storage quota issue persists. This job
-    # only feeds the advisory e2e job; if its download-artifact for
-    # ui-dist fails because build-ui couldn't upload, don't fail the
-    # whole PR. Revert once quota is OK.
-    continue-on-error: true
     env:
       RUSTFLAGS: "-C instrument-coverage"
       LLVM_PROFILE_FILE: "coverage/aisix-%p-%m.profraw"
@@ -211,17 +194,9 @@ jobs:
     name: coverage >= 90%
     needs: [rust-unit, e2e]
     runs-on: ubuntu-latest
-    # The threshold check itself is already a soft gate (the bash logic
-    # exits 0 even when below threshold; see comment on the merge step).
-    # Aligning the job-level setting with that intent: don't fail the
-    # workflow when coverage-gate fails — especially while the artifact
-    # storage quota outage prevents the upstream coverage-unit upload.
-    # Revert when the gate is flipped from advisory to gating (PR #5).
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
-        continue-on-error: true
         with: { name: coverage-unit, path: cov/unit }
       - uses: actions/download-artifact@v4
         continue-on-error: true


### PR DESCRIPTION
## Summary

The Packages spending limit on the moonming account was raised from \$0 → \$5/mo (artifact storage is billed under the Packages SKU, not Actions). Verified empirically: re-running [run 24948385951](https://github.com/moonming/ai-gateway/actions/runs/24948385951), build-ui's upload-artifact step no longer hits \"Artifact storage quota has been hit\" and downstream build-aisix successfully downloads ui-dist.

Time to remove the soft-fail mitigations.

## What's reverted

Four \`continue-on-error\` markers from #40 + #41:
- rust-unit's \`coverage-unit\` upload-artifact (#40)
- build-ui's \`ui-dist\` upload-artifact (#40)
- build-bin (build aisix) job-level (#40)
- coverage-gate job-level + first download-artifact (#41)

## What's preserved

Two pre-existing markers that predate the quota issue:
- \`e2e\` job-level (etcd service startup / undici flake — separate problem)
- \`coverage-gate\`'s \`coverage-e2e\` download (e2e legitimately produces no coverage when its tests don't run)

## Test plan

- [x] Latest main run verified post-budget-fix: build-ui upload SUCCESS, build-aisix download + build SUCCESS
- [ ] After this PR lands, main CI is fully green at job level (the 3 X marks gone)