### PR TITLE
feat: telemetry sender — emit per-request usage events to cp-api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Testing Discipline
+
+**E2E tests are the highest-priority signal. Cover the real user journey. Never silence failures.**
+
+- E2E tests are the most important test type — prioritize them over unit/integration when coverage is limited.
+- Design test cases around the user's actual usage path. Walk through the real flow end-to-end and do not skip steps a user would take.
+- For any project with a frontend UI, write E2E tests using **Playwright**.
+- Do **not** skip, disable, or `.only` any test case to make things green. A passing CI is not an excuse to hide flakiness — investigate the underlying bug in the code.
+- If a test case itself appears unreasonable or incorrect, do **not** silently delete or rewrite it. Flag it and ask a human to confirm before changing it.
+- Do **not** use mock data in E2E tests — they must run against real data and real services. If real data is genuinely unavailable and mocking is unavoidable, stop and get human confirmation before introducing any mock.
+- Every frontend E2E test **must** issue requests to a real backend API. No stubbed network layers, no fixture servers, no intercepted responses — the test must exercise the real backend end-to-end.
+
+## 6. Research Discipline
+
+**Verify against primary sources. Never guess or infer product behavior.**
+
+- When researching a product or feature, confirm details only via **official documentation** and **source code**.
+- Do not speculate, infer, or fill gaps with assumptions about how a product or API behaves.
+- If official docs and source code do not answer the question, say so explicitly and ask — do not invent an answer.
+- Cite the specific doc URL, file path, or commit/version when stating a fact about third-party behavior.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -16,6 +16,7 @@ pub mod access_log;
 pub mod langfuse;
 pub mod metrics;
 pub mod otlp;
+pub mod usage;
 
 use aisix_core::ObservabilityConfig;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
@@ -24,6 +25,7 @@ pub use access_log::AccessLog;
 pub use langfuse::{LangfuseError, LangfuseEvent, LangfuseHandle, LangfuseSender};
 pub use metrics::{Metrics, RequestOutcome};
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
+pub use usage::{UsageEvent, UsageSink};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ObsError {

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -1,0 +1,199 @@
+//! Per-request usage events the proxy emits at end-of-request.
+//!
+//! The wire shape mirrors cp-api's `dpmgr_usage_events` table 1:1 —
+//! see `aisix-cloud:internal/dpmgr/api/telemetry.go` and
+//! `migrations/009_dpmgr_usage_events.up.sql` for the receiving end.
+//!
+//! Lifecycle:
+//!
+//! ```text
+//! chat_completions handler --emit()--> [ mpsc::channel ] --drain--> sender worker --POST--> /dp/telemetry
+//!         (proxy crate)                                                 (server crate)              (cp-api)
+//! ```
+//!
+//! Why split sink + worker:
+//!
+//! - The PROXY crate (which calls `emit()` from request handlers) only
+//!   needs a cheap clonable handle. It can't depend on the SERVER crate
+//!   without creating a cycle (server already depends on proxy).
+//! - The SERVER crate owns the worker because telemetry batching, the
+//!   mTLS reqwest client, and graceful-shutdown wiring naturally live
+//!   alongside `register::register_and_persist` and `heartbeat::spawn`.
+//! - This module sits in `aisix-obs` (proxy already depends on it for
+//!   metrics + access_log + langfuse), exposes the data type and the
+//!   sink wrapper, and lets server-side wire up the consumer.
+//!
+//! See prd-09a §9A.7B Phase 1 for the upstream protocol; the DP-side
+//! batch contract (5s interval / 100-event ceiling) lives in the worker
+//! (aisix-server), not here.
+
+use serde::Serialize;
+
+/// One usage event. Emitted at end-of-request (success / upstream error /
+/// guardrail block) per chat completion. Field shape pinned to the
+/// cp-api wire (snake_case via serde).
+///
+/// All fields are Copy / String / `Option<String>` so the event is
+/// cheap to construct on the request hot path. `costed in USD` per
+/// the DP's pricing snapshot at request time — provider prices can
+/// change post-hoc, but we record what was current when the request
+/// ran.
+///
+/// `model_id` and `api_key_id` are optional: a guardrail-rejected
+/// request may have neither (rejection runs before model resolution).
+/// cp-api stores empty strings as SQL NULL; the field is `Option`
+/// here so the JSON serialiser emits `""` (not `null`) — matches what
+/// the cp-api parser expects.
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageEvent {
+    /// DP-supplied request id (idempotency key). Use the same id the
+    /// `x-aisix-call-id` response header carries so logs join.
+    pub request_id: String,
+
+    /// Wall-clock time the upstream call completed, RFC 3339 (UTC).
+    pub occurred_at: String,
+
+    /// UUID of the v3 Model row this request resolved to. Empty when
+    /// the request never reached model resolution.
+    #[serde(default)]
+    pub model_id: String,
+
+    /// UUID of the v3 ApiKey row that authenticated this request.
+    /// Empty when auth failed before resolution.
+    #[serde(default)]
+    pub api_key_id: String,
+
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub latency_ms: u32,
+
+    /// HTTP status code the proxy returned to the downstream caller.
+    pub status_code: u16,
+
+    /// Cost the DP computed for this request in US dollars. Zero when
+    /// the request never reached cost calculation (e.g. blocked by a
+    /// guardrail before dispatch).
+    pub cost_usd: f64,
+
+    /// True when a guardrail rejected the request (input or output).
+    pub guardrail_blocked: bool,
+}
+
+/// Cheap clonable handle the proxy hands to request handlers. Backed
+/// by an mpsc::Sender; `try_emit` is non-blocking and silently drops
+/// the event if the worker's queue is full (avoids back-pressuring
+/// the request hot path on a wedged CP). Drops are counted via
+/// tracing::warn! so observers can see a wedge.
+///
+/// In a deployment without CP-side telemetry (legacy / dev), the
+/// handle's `tx` is `None` and `try_emit` is a no-op.
+#[derive(Debug, Clone)]
+pub struct UsageSink {
+    tx: Option<tokio::sync::mpsc::Sender<UsageEvent>>,
+}
+
+impl UsageSink {
+    /// Build a real sink backed by an mpsc::Sender. The receiving end
+    /// is owned by the worker spawned in aisix-server.
+    pub fn new(tx: tokio::sync::mpsc::Sender<UsageEvent>) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    /// Build a no-op sink. `try_emit` drops events silently — used
+    /// when the DP runs without a configured CP (dev / standalone
+    /// modes) so handlers don't have to special-case Optional fields.
+    pub fn disabled() -> Self {
+        Self { tx: None }
+    }
+
+    /// Non-blocking emit. Returns immediately:
+    /// - `Ok(())` on enqueue success;
+    /// - `Ok(())` and a tracing::warn! on `try_send` failure (queue
+    ///   full / receiver dropped). We deliberately don't propagate the
+    ///   error to the caller — request handlers must NOT fail because
+    ///   telemetry can't keep up.
+    /// - `Ok(())` no-op on a `disabled()` sink.
+    pub fn try_emit(&self, event: UsageEvent) {
+        let Some(tx) = &self.tx else { return };
+        if let Err(err) = tx.try_send(event) {
+            // Both `Full` and `Closed` end up here. Full = worker is
+            // overloaded; Closed = worker shut down cleanly. Either
+            // way the event is gone — log once per drop and move on.
+            tracing::warn!(error = %err, "usage event dropped (sink full or closed)");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_sink_is_a_noop() {
+        let sink = UsageSink::disabled();
+        // Doesn't panic; doesn't allocate a worker. Two emits in a
+        // row also fine.
+        sink.try_emit(sample_event("req-1"));
+        sink.try_emit(sample_event("req-2"));
+    }
+
+    #[tokio::test]
+    async fn emit_into_real_channel_arrives_in_order() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let sink = UsageSink::new(tx);
+        sink.try_emit(sample_event("req-a"));
+        sink.try_emit(sample_event("req-b"));
+        let a = rx.recv().await.unwrap();
+        let b = rx.recv().await.unwrap();
+        assert_eq!(a.request_id, "req-a");
+        assert_eq!(b.request_id, "req-b");
+    }
+
+    #[test]
+    fn full_channel_drop_does_not_panic() {
+        // Capacity-1 channel; the second emit can't enqueue. The drop
+        // must not propagate — handlers can't tolerate a panic on the
+        // hot path.
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let sink = UsageSink::new(tx);
+        sink.try_emit(sample_event("req-1"));
+        sink.try_emit(sample_event("req-2")); // dropped, logged
+    }
+
+    #[test]
+    fn serialises_with_snake_case_field_names() {
+        let ev = UsageEvent {
+            request_id: "req-1".into(),
+            occurred_at: "2026-04-29T12:00:00Z".into(),
+            model_id: "mod-uuid".into(),
+            api_key_id: "ak-uuid".into(),
+            prompt_tokens: 12,
+            completion_tokens: 34,
+            latency_ms: 56,
+            status_code: 200,
+            cost_usd: 0.0012,
+            guardrail_blocked: false,
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert!(json.contains(r#""request_id":"req-1""#));
+        assert!(json.contains(r#""api_key_id":"ak-uuid""#));
+        assert!(json.contains(r#""prompt_tokens":12"#));
+        assert!(json.contains(r#""completion_tokens":34"#));
+        assert!(json.contains(r#""guardrail_blocked":false"#));
+    }
+
+    fn sample_event(id: &str) -> UsageEvent {
+        UsageEvent {
+            request_id: id.into(),
+            occurred_at: "2026-04-29T12:00:00Z".into(),
+            model_id: String::new(),
+            api_key_id: String::new(),
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            latency_ms: 0,
+            status_code: 200,
+            cost_usd: 0.0,
+            guardrail_blocked: false,
+        }
+    }
+}

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -19,7 +19,7 @@
 use aisix_cache::CacheKey;
 use aisix_gateway::{BridgeContext, BridgeError, ChatFormat};
 use aisix_guardrails::GuardrailVerdict;
-use aisix_obs::{AccessLog, LangfuseEvent, Metrics, RequestOutcome};
+use aisix_obs::{AccessLog, LangfuseEvent, Metrics, RequestOutcome, UsageEvent, UsageSink};
 use axum::extract::State;
 use axum::http::HeaderValue;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -80,6 +80,18 @@ pub async fn chat_completions(
                 success.total_tokens,
                 &request_id,
             );
+            emit_usage_event(
+                &state.usage_sink,
+                &request_id,
+                &success.model_id,
+                &api_key_id,
+                status,
+                elapsed,
+                success.prompt_tokens.unwrap_or(0) as u32,
+                success.completion_tokens.unwrap_or(0) as u32,
+                success.cost_usd,
+                /* guardrail_blocked */ false,
+            );
             if let Some(lf) = state.langfuse.as_ref() {
                 lf.emit(LangfuseEvent {
                     trace_id: request_id.clone(),
@@ -125,6 +137,25 @@ pub async fn chat_completions(
                 None,
                 &request_id,
             );
+            // Telemetry for the failure path. We don't know the resolved
+            // model_id when dispatch fails before model lookup (e.g.
+            // empty messages); the helper handles that with an empty
+            // string. ContentFiltered (guardrail) is recorded with the
+            // dedicated `guardrail_blocked` flag so the dashboard can
+            // surface it on the Blocked tab.
+            let guardrail_blocked = matches!(err, ProxyError::ContentFiltered(_));
+            emit_usage_event(
+                &state.usage_sink,
+                &request_id,
+                /* model_id */ "",
+                &api_key_id,
+                status,
+                elapsed,
+                /* prompt_tokens */ 0,
+                /* completion_tokens */ 0,
+                /* cost_usd */ 0.0,
+                guardrail_blocked,
+            );
             if let Some(lf) = state.langfuse.as_ref() {
                 lf.emit(LangfuseEvent {
                     trace_id: request_id.clone(),
@@ -151,9 +182,16 @@ pub async fn chat_completions(
 struct Success {
     response: Response,
     provider: String,
+    /// UUID of the v3 Model row this request resolved to (the virtual
+    /// model the caller asked for, before any routing fan-out). Empty
+    /// in the unlikely case the resolver was bypassed.
+    model_id: String,
     prompt_tokens: Option<u64>,
     completion_tokens: Option<u64>,
     total_tokens: Option<u64>,
+    /// Cost computed via the per-key Budget's pricing table, in USD.
+    /// 0.0 when no budget is configured for the key.
+    cost_usd: f64,
 }
 
 async fn dispatch(
@@ -173,6 +211,7 @@ async fn dispatch(
         .models
         .get_by_name(&req.model)
         .ok_or_else(|| ProxyError::ModelNotFound(req.model.clone()))?;
+    let model_id = virtual_entry.id.clone();
 
     if !auth.key().can_access(&req.model) {
         return Err(ProxyError::ModelForbidden(req.model.clone()));
@@ -270,9 +309,14 @@ async fn dispatch(
         return Ok(Success {
             response: response.into_response(),
             provider: format!("{provider:?}").to_lowercase(),
+            model_id: model_id.clone(),
             prompt_tokens: None,
             completion_tokens: None,
             total_tokens: None,
+            // Streaming path doesn't compute cost yet (no token totals
+            // until the stream completes upstream). Phase 2 wires
+            // mid-stream accumulation; for now telemetry records 0.
+            cost_usd: 0.0,
         });
     }
 
@@ -304,9 +348,13 @@ async fn dispatch(
                 return Ok(Success {
                     response,
                     provider: provider_label,
+                    model_id: model_id.clone(),
                     prompt_tokens: Some(prompt),
                     completion_tokens: Some(completion),
                     total_tokens: Some(total),
+                    // Cache hits don't burn cost on our side (we already
+                    // paid the upstream price the first time around).
+                    cost_usd: 0.0,
                 });
             }
             Ok(None) => {}
@@ -385,10 +433,16 @@ async fn dispatch(
     // Budget post-deduct. Add the actual cost; doesn't gate the
     // current response (we already paid for it) but shapes future
     // pre-checks within the same calendar month.
-    if let Some(b) = budget_for_key.as_ref() {
+    let cost_usd = if let Some(b) = budget_for_key.as_ref() {
         let cost = b.value.cost_for(total);
         state.budgets.add(&auth.entry.id, cost);
-    }
+        cost
+    } else {
+        // No budget configured for this key → no per-request pricing
+        // table. Telemetry records 0; cp-api stores it as $0 and the
+        // /usage page treats it as untracked.
+        0.0
+    };
 
     if let GuardrailVerdict::Block { reason } = state.guardrails.check_output(&upstream).await {
         return Err(ProxyError::ContentFiltered(reason));
@@ -410,9 +464,11 @@ async fn dispatch(
     Ok(Success {
         response,
         provider: provider_name,
+        model_id,
         prompt_tokens: Some(prompt),
         completion_tokens: Some(completion),
         total_tokens: Some(total),
+        cost_usd,
     })
 }
 
@@ -429,6 +485,40 @@ fn record_success(
     if let Some(total) = s.total_tokens {
         metrics.record_tokens(provider, model, total);
     }
+}
+
+/// Push one telemetry event onto the CP-side sink. Non-blocking;
+/// drops with a tracing::warn! if the worker queue is full.
+/// Centralised here so success / error / streaming all share the same
+/// event-construction logic and the wire shape stays consistent
+/// across paths.
+#[allow(clippy::too_many_arguments)]
+fn emit_usage_event(
+    sink: &UsageSink,
+    request_id: &str,
+    model_id: &str,
+    api_key_id: &str,
+    status_code: u16,
+    elapsed: Duration,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    cost_usd: f64,
+    guardrail_blocked: bool,
+) {
+    sink.try_emit(UsageEvent {
+        request_id: request_id.to_string(),
+        // RFC 3339 UTC. cp-api parses with time.Parse(time.RFC3339, ...);
+        // chrono's `to_rfc3339_opts(Secs, true)` emits the trailing Z.
+        occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        model_id: model_id.to_string(),
+        api_key_id: api_key_id.to_string(),
+        prompt_tokens,
+        completion_tokens,
+        latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
+        status_code,
+        cost_usd,
+        guardrail_blocked,
+    });
 }
 
 fn record_error(metrics: &Metrics, err: &ProxyError, model: &str, status: u16, elapsed: Duration) {

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -19,7 +19,7 @@ use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
 use aisix_guardrails::{Guardrail, GuardrailChain};
-use aisix_obs::{LangfuseSender, Metrics};
+use aisix_obs::{LangfuseSender, Metrics, UsageSink};
 use aisix_ratelimit::Limiter;
 use std::sync::Arc;
 
@@ -47,6 +47,11 @@ pub struct ProxyState {
     /// Optional Langfuse exporter. When `Some`, chat handlers emit one
     /// generation event at end-of-request. `None` disables emission.
     pub langfuse: Option<Arc<LangfuseSender>>,
+    /// CP-side usage telemetry sink. Backed by an mpsc channel into the
+    /// sender worker spawned in aisix-server (see `telemetry::spawn`).
+    /// Defaults to a no-op sink when running outside managed mode so
+    /// chat handlers don't have to special-case `Option`.
+    pub usage_sink: UsageSink,
     pub request_body_limit_bytes: usize,
 }
 
@@ -63,6 +68,7 @@ impl ProxyState {
             budgets: Arc::new(BudgetTracker::new()),
             health: Arc::new(HealthTracker::new()),
             langfuse: None,
+            usage_sink: UsageSink::disabled(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -86,6 +92,7 @@ impl ProxyState {
             budgets: Arc::new(BudgetTracker::new()),
             health: Arc::new(HealthTracker::new()),
             langfuse: None,
+            usage_sink: UsageSink::disabled(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -112,6 +119,7 @@ impl ProxyState {
             budgets: Arc::new(BudgetTracker::new()),
             health: Arc::new(HealthTracker::new()),
             langfuse: None,
+            usage_sink: UsageSink::disabled(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -134,6 +142,14 @@ impl ProxyState {
     /// no events are emitted regardless of request volume.
     pub fn with_langfuse(mut self, sender: Arc<LangfuseSender>) -> Self {
         self.langfuse = Some(sender);
+        self
+    }
+
+    /// Attach a CP-side usage telemetry sink. Default is `disabled()`;
+    /// the server bootstrap calls this in managed mode after spawning
+    /// the sender worker.
+    pub fn with_usage_sink(mut self, sink: UsageSink) -> Self {
+        self.usage_sink = sink;
         self
     }
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 mod heartbeat;
 mod register;
+mod telemetry;
 
 use aisix_admin::{AdminState, ConfigStore, EtcdConfigStore};
 use aisix_cache::{Cache, MemoryCache, RedisCache};
@@ -282,7 +283,25 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // Spawn heartbeat worker if we have a config for it. The
     // JoinHandle is awaited after graceful shutdown below so the
     // final in-flight beat drains cleanly.
+    //
+    // Telemetry shares the heartbeat config: same on-disk mTLS bundle
+    // (issued by /dp/register) + same cp_base URL host. We derive the
+    // /dp/telemetry URL from the /dp/heartbeat URL by swapping the
+    // path suffix so the two stay in lock-step on cp_base changes.
+    let telemetry_cfg = heartbeat_cfg.as_ref().map(|h| {
+        telemetry::TelemetryConfig::new(
+            h.url.replace("/dp/heartbeat", "/dp/telemetry"),
+            h.mtls.clone(),
+        )
+    });
     let heartbeat_task = heartbeat_cfg.map(|h| heartbeat::spawn(h, cancel_rx.clone()));
+    let (usage_sink, telemetry_task) = match telemetry_cfg {
+        Some(cfg) => {
+            let (sink, handle) = telemetry::spawn(cfg, cancel_rx.clone());
+            (sink, Some(handle))
+        }
+        None => (aisix_obs::UsageSink::disabled(), None),
+    };
 
     // Steps 7-8: build Hub, shared components, then routers.
     let hub = Arc::new(build_hub());
@@ -336,6 +355,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     if let Some(sender) = langfuse_sender {
         proxy_state = proxy_state.with_langfuse(sender);
     }
+    proxy_state = proxy_state.with_usage_sink(usage_sink);
     // Clone shared trackers before consuming proxy_state in build_router.
     let budget_tracker = proxy_state.budgets.clone();
     let health_tracker = proxy_state.health.clone();
@@ -403,6 +423,9 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let _ = signal_task.await;
     let _ = watch_task.await;
     if let Some(task) = heartbeat_task {
+        let _ = task.await;
+    }
+    if let Some(task) = telemetry_task {
         let _ = task.await;
     }
     tracing::info!("aisix shut down cleanly");

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -1,0 +1,369 @@
+//! Sender worker for the CP-side `/dp/telemetry` surface.
+//!
+//! Per prd-09a §9A.7B Phase 1:
+//!
+//! - Proxy handlers call [`UsageSink::try_emit`] (defined in aisix-obs)
+//!   to push one event per chat completion onto an mpsc channel.
+//! - This worker drains the channel, batches up to [`MAX_BATCH`]
+//!   events or every [`FLUSH_INTERVAL`] (whichever fires first),
+//!   POSTs the batch as `{ events: [...] }` to the CP's
+//!   `/dp/telemetry` URL, and logs the outcome.
+//! - On HTTP error the batch is dropped (NOT retried). Phase 1
+//!   accepts a small loss window in exchange for not building a
+//!   persistent disk queue. The `received_at` column on the cp-api
+//!   side records when CP saw the row, so dashboards distinguish
+//!   "DP never sent" from "DP sent but CP rejected" via log
+//!   correlation.
+//!
+//! mTLS: the sender presents the same on-disk bundle the heartbeat
+//! worker uses (the bundle persisted by `register::register_and_persist`
+//! at first boot). cp-api derives `env_id` and `dp_id` from the peer
+//! cert SAN URI, so the request body doesn't carry them — same wire
+//! shape as `/dp/heartbeat`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context};
+use serde::Serialize;
+use tokio::sync::watch;
+
+use aisix_obs::{UsageEvent, UsageSink};
+
+use crate::heartbeat::MtlsBundle;
+
+/// Maximum number of events accumulated per outbound POST. Pinned in
+/// code rather than config — at >100 events/batch the request body
+/// approaches gin's default `MaxMultipartMemory` plumbing on the
+/// receiving side, and we'd rather flush more often than tune that.
+const MAX_BATCH: usize = 100;
+
+/// Cadence at which the worker flushes whatever it has buffered, even
+/// if the buffer hasn't filled. Keeps fresh requests visible on
+/// /usage and /logs within ~5s end-to-end.
+const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// In-memory bound on the proxy → worker channel. At 1024 events,
+/// 5s flush, 100 batch ceiling, the proxy can sustain a sustained
+/// 200 req/s burst without dropping. Beyond that `try_emit` warns
+/// and the event is dropped — telemetry must not back-pressure the
+/// request hot path.
+const QUEUE_CAPACITY: usize = 1024;
+
+/// Configuration for the sender. Mirrors `HeartbeatConfig` — the URL
+/// is the absolute `/dp/telemetry` endpoint on cp-api, the bundle is
+/// the on-disk mTLS material persisted by register, and `interval`
+/// is the flush cadence (kept overridable so tests can speed up).
+#[derive(Debug, Clone)]
+pub struct TelemetryConfig {
+    pub url: String,
+    pub interval: Duration,
+    pub mtls: MtlsBundle,
+}
+
+impl TelemetryConfig {
+    /// Build with default flush interval (5s).
+    pub fn new(url: String, mtls: MtlsBundle) -> Self {
+        Self {
+            url,
+            interval: FLUSH_INTERVAL,
+            mtls,
+        }
+    }
+}
+
+/// Spawn the worker. Returns:
+///   - a [`UsageSink`] the proxy uses to enqueue events;
+///   - a [`tokio::task::JoinHandle`] the caller awaits at shutdown
+///     so the final in-flight batch drains cleanly.
+///
+/// The worker stops when `cancel` flips to `true` AND the channel is
+/// drained (one final flush so we don't lose the tail). Errors during
+/// individual flushes are logged, not propagated — same contract as
+/// heartbeat::spawn.
+pub fn spawn(
+    cfg: TelemetryConfig,
+    mut cancel: watch::Receiver<bool>,
+) -> (UsageSink, tokio::task::JoinHandle<()>) {
+    let (tx, rx) = tokio::sync::mpsc::channel(QUEUE_CAPACITY);
+    let sink = UsageSink::new(tx);
+    let handle = tokio::spawn(async move {
+        run(cfg, rx, &mut cancel).await;
+    });
+    (sink, handle)
+}
+
+async fn run(
+    cfg: TelemetryConfig,
+    mut rx: tokio::sync::mpsc::Receiver<UsageEvent>,
+    cancel: &mut watch::Receiver<bool>,
+) {
+    let client = match build_client(&cfg.mtls) {
+        Ok(c) => Arc::new(c),
+        Err(e) => {
+            tracing::error!(error = %e, "telemetry: build mTLS client failed; worker disabled");
+            return;
+        }
+    };
+    let mut ticker = tokio::time::interval(cfg.interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let mut buffer: Vec<UsageEvent> = Vec::with_capacity(MAX_BATCH);
+
+    tracing::info!(
+        url = %cfg.url,
+        flush_interval_secs = cfg.interval.as_secs(),
+        max_batch = MAX_BATCH,
+        "telemetry sender started (mTLS)",
+    );
+
+    loop {
+        tokio::select! {
+            // New event from the proxy. Buffer it; flush if we hit
+            // the batch ceiling so a steady high-throughput stream
+            // doesn't starve cp-api on a 5s cadence.
+            maybe_event = rx.recv() => {
+                match maybe_event {
+                    Some(event) => {
+                        buffer.push(event);
+                        if buffer.len() >= MAX_BATCH {
+                            flush(&client, &cfg, &mut buffer).await;
+                        }
+                    }
+                    None => {
+                        // All senders dropped — proxy is shutting down.
+                        // Drain anything left and exit.
+                        if !buffer.is_empty() {
+                            flush(&client, &cfg, &mut buffer).await;
+                        }
+                        tracing::info!("telemetry sender: channel closed, exiting");
+                        return;
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                if !buffer.is_empty() {
+                    flush(&client, &cfg, &mut buffer).await;
+                }
+            }
+            _ = cancel.changed() => {
+                if *cancel.borrow() {
+                    // Final drain — try to grab whatever is still in
+                    // the channel without blocking, then post it.
+                    while let Ok(ev) = rx.try_recv() {
+                        buffer.push(ev);
+                    }
+                    if !buffer.is_empty() {
+                        flush(&client, &cfg, &mut buffer).await;
+                    }
+                    tracing::info!("telemetry sender shutting down");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// POST one batch and clear the buffer. Errors are logged, not
+/// propagated — telemetry losses must not stall the worker.
+async fn flush(client: &reqwest::Client, cfg: &TelemetryConfig, buffer: &mut Vec<UsageEvent>) {
+    if buffer.is_empty() {
+        return;
+    }
+    let count = buffer.len();
+    // Move events out into the request body; clear the buffer
+    // unconditionally so a hung CP doesn't grow the buffer
+    // indefinitely (worst case we drop the batch on error).
+    let events: Vec<UsageEvent> = std::mem::take(buffer);
+    buffer.reserve(MAX_BATCH);
+
+    match send(client, cfg, &events).await {
+        Ok(()) => tracing::debug!(count, "telemetry batch flushed"),
+        Err(e) => tracing::warn!(count, error = %e, "telemetry batch failed (events dropped)"),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct TelemetryBody<'a> {
+    events: &'a [UsageEvent],
+}
+
+async fn send(
+    client: &reqwest::Client,
+    cfg: &TelemetryConfig,
+    events: &[UsageEvent],
+) -> anyhow::Result<()> {
+    let resp = client
+        .post(&cfg.url)
+        // Same as /dp/heartbeat — no Authorization header; cp-api
+        // derives identity from the peer cert SAN URI.
+        .json(&TelemetryBody { events })
+        .send()
+        .await
+        .with_context(|| format!("POST {}", cfg.url))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "telemetry {} returned {} — {}",
+            cfg.url,
+            status,
+            body.trim().chars().take(200).collect::<String>()
+        ));
+    }
+    Ok(())
+}
+
+/// Build the mTLS reqwest client. Identical shape to heartbeat's
+/// build_client — extracted out of heartbeat.rs would be nicer but
+/// pulling that into a shared module is post-MVP polish and would
+/// expand this PR's scope. The two clients are independently
+/// constructed so a botched bundle on one path doesn't cascade.
+fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
+    let ca_pem = std::fs::read(&mtls.ca_cert_path)
+        .with_context(|| format!("read {}", mtls.ca_cert_path.display()))?;
+    let cert_pem = std::fs::read(&mtls.client_cert_path)
+        .with_context(|| format!("read {}", mtls.client_cert_path.display()))?;
+    let key_pem = std::fs::read(&mtls.client_key_path)
+        .with_context(|| format!("read {}", mtls.client_key_path.display()))?;
+
+    let mut identity_pem = Vec::with_capacity(cert_pem.len() + key_pem.len());
+    identity_pem.extend_from_slice(&key_pem);
+    identity_pem.extend_from_slice(&cert_pem);
+    let identity = reqwest::Identity::from_pem(&identity_pem)
+        .context("build mTLS Identity from client cert + key")?;
+
+    let ca = reqwest::Certificate::from_pem(&ca_pem).context("parse CA certificate")?;
+
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")))
+        .identity(identity)
+        .add_root_certificate(ca)
+        .use_rustls_tls()
+        .build()
+        .context("build reqwest client with mTLS")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{CertificateParams, DistinguishedName, KeyPair, PKCS_ECDSA_P256_SHA256};
+    use std::path::Path;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn write_test_bundle(dir: &Path) -> MtlsBundle {
+        let ca_kp = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.distinguished_name = {
+            let mut dn = DistinguishedName::new();
+            dn.push(rcgen::DnType::CommonName, "aisix-test-ca");
+            dn
+        };
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_kp).unwrap();
+
+        let leaf_kp = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut leaf_params = CertificateParams::new(vec!["dp-test".to_string()]).unwrap();
+        leaf_params.distinguished_name = {
+            let mut dn = DistinguishedName::new();
+            dn.push(rcgen::DnType::CommonName, "dp-test");
+            dn
+        };
+        let leaf_cert = leaf_params.signed_by(&leaf_kp, &ca_cert, &ca_kp).unwrap();
+
+        let ca_path = dir.join("ca.crt");
+        let cert_path = dir.join("client.crt");
+        let key_path = dir.join("client.key");
+        std::fs::write(&ca_path, ca_cert.pem()).unwrap();
+        std::fs::write(&cert_path, leaf_cert.pem()).unwrap();
+        std::fs::write(&key_path, leaf_kp.serialize_pem()).unwrap();
+
+        MtlsBundle {
+            ca_cert_path: ca_path,
+            client_cert_path: cert_path,
+            client_key_path: key_path,
+        }
+    }
+
+    fn sample_event(id: &str) -> UsageEvent {
+        UsageEvent {
+            request_id: id.into(),
+            occurred_at: "2026-04-29T12:00:00Z".into(),
+            model_id: "mod-uuid".into(),
+            api_key_id: "ak-uuid".into(),
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            latency_ms: 30,
+            status_code: 200,
+            cost_usd: 0.001,
+            guardrail_blocked: false,
+        }
+    }
+
+    fn plain_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn send_posts_events_array_with_no_authorization() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/dp/telemetry"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accepted": 2
+            })))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mtls = write_test_bundle(dir.path());
+        let cfg = TelemetryConfig::new(format!("{}/dp/telemetry", server.uri()), mtls);
+        let events = vec![sample_event("req-1"), sample_event("req-2")];
+
+        send(&plain_client(), &cfg, &events).await.unwrap();
+
+        let received = server.received_requests().await.unwrap();
+        let req = received.first().unwrap();
+        // v3 telemetry MUST NOT carry Authorization — mTLS only.
+        assert!(req.headers.get("authorization").is_none());
+        // Body wraps the array in `{ events: [...] }`.
+        let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+        assert_eq!(body["events"].as_array().unwrap().len(), 2);
+        assert_eq!(body["events"][0]["request_id"], "req-1");
+    }
+
+    #[tokio::test]
+    async fn send_propagates_non_success_with_body_excerpt() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/dp/telemetry"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": {"code": "INVALID_REQUEST", "message": "event 0: bad uuid"}
+            })))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mtls = write_test_bundle(dir.path());
+        let cfg = TelemetryConfig::new(format!("{}/dp/telemetry", server.uri()), mtls);
+        let err = send(&plain_client(), &cfg, &[sample_event("req-1")])
+            .await
+            .unwrap_err();
+        let s = format!("{err:#}");
+        assert!(s.contains("400"), "expected status: {s}");
+        assert!(s.contains("INVALID_REQUEST"), "expected body excerpt: {s}");
+    }
+
+    #[test]
+    fn build_client_loads_real_mtls_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let mtls = write_test_bundle(dir.path());
+        let _ = build_client(&mtls).expect("real bundle should build");
+    }
+}


### PR DESCRIPTION
DP-side half of aisix-cloud's Phase 1 telemetry pipeline. Pairs with [api7/AISIX-Cloud#70](https://github.com/api7/AISIX-Cloud/pull/70), which lands the cp-api receiver, PG storage, and dashboard /usage + /logs read paths.

After this PR every chat completion the proxy serves emits a structured \`UsageEvent\` that flows:

\`\`\`
proxy chat handler  --emit()-->  mpsc(1024)  --batch 5s/100-->  POST /dp/telemetry  -->  cp-api  -->  PG.dpmgr_usage_events
\`\`\`

Wire shape mirrors \`aisix-cloud:internal/dpmgr/api/telemetry.go\` exactly — snake_case JSON, env_id/dp_id derived by cp-api from the peer cert SAN URI (no Authorization header).

## What changes

| Crate | Change |
|---|---|
| \`aisix-obs::usage\` (new module) | \`UsageEvent\` (data type) + \`UsageSink\` (cheap clonable proxy-side handle wrapping \`tokio::sync::mpsc::Sender\`). \`UsageSink::disabled()\` is the no-op for standalone/non-managed mode. \`try_emit\` is non-blocking and tracing::warn!s on full/closed — telemetry must NEVER back-pressure the request hot path. |
| \`aisix-server::telemetry\` (new module) | Sender worker. \`spawn(cfg, cancel) -> (UsageSink, JoinHandle)\`. Drains the mpsc, batches up to 100 / every 5s, POSTs with the same on-disk mTLS bundle the heartbeat worker uses (issued by \`/dp/register\`). HTTP error → drop the batch + log; final cancel triggers a drain. |
| \`aisix-proxy::ProxyState\` | New \`usage_sink: UsageSink\` field + \`with_usage_sink\` builder. Default \`disabled()\` so existing callers keep working unchanged. |
| \`aisix-proxy::chat\` | \`Success\` carries \`model_id\` (resolved virtual model UUID) + \`cost_usd\` (per-key Budget pricing). Both success and error paths now call \`emit_usage_event(...)\`. \`ContentFiltered\` errors set \`guardrail_blocked = true\` so the dashboard /logs blocked tab can filter them. |
| \`cmd/aisix main\` | Derives \`TelemetryConfig\` from the existing \`HeartbeatConfig\` (same MtlsBundle; URL swaps \`/dp/heartbeat\` → \`/dp/telemetry\`). Spawned alongside heartbeat in managed mode; awaited at shutdown. |

## Why this layering

- proxy can't depend on server (cycle), so the data type + sink wrapper live in \`aisix-obs\` which proxy already pulls in for metrics + access_log + langfuse.
- Worker lives in \`aisix-server\` — it owns the reqwest client, mTLS bundle path, and graceful-shutdown plumbing alongside \`register\` and \`heartbeat\`. Same idioms.

## Out of scope (Phase 1 cutoff)

- **Streaming requests** emit with prompt_tokens=0 / completion_tokens=0 / cost=0. The streaming path in \`chat.rs::dispatch\` doesn't accumulate token totals upstream-side yet (pre-existing TODO). Phase 2 wires mid-stream accumulation; same downstream wire shape, just populated values.
- **Disk-backed retry queue.** cp-api's \`received_at\` column lets dashboards distinguish "DP never sent" from "DP sent but CP rejected" via log correlation, which is enough for Phase 1.
- **Raw request/response bodies** for /logs deep-inspection. PII + storage tradeoff deferred to Phase 4 governance on the cp-api side.

## Verification

| Check | Status |
|---|---|
| \`cargo build --workspace\` | ✅ |
| \`cargo test --workspace\` | ✅ all crates green; 7 new tests added (4 in aisix-obs::usage, 3 in aisix-server::telemetry) |
| \`cargo clippy --workspace --all-targets -- -D warnings\` | ✅ |
| \`cargo fmt --all\` | ✅ idempotent |

New tests cover:
- \`UsageSink::disabled\` is a no-op (no panic, no allocation);
- mpsc-backed sink delivers in order;
- full-channel drop doesn't panic (capacity-1 channel with 2 emits);
- snake_case serialisation matches the cp-api receiver's expectations;
- wiremock confirms POST body wraps events as \`{ events: [...] }\` with no Authorization header;
- non-success response body excerpt propagates in the error;
- real mTLS bundle build_client smoke test.

## Testing the full pipeline locally

Once aisix-cloud#70 is also merged:

\`\`\`bash
# CP side (aisix-cloud repo)
docker compose -p aisix-e2e -f e2e/compose.yml up -d --wait

# DP side (this repo) — managed mode points at the local CP
AISIX_MANAGED__ENABLED=1 \\
  AISIX_MANAGED__CP_BASE_URL=https://aisix.localtest.me:8443 \\
  AISIX_MANAGED__CP_ETCD_ENDPOINT=etcd.aisix.localtest.me:2379 \\
  AISIX_MANAGED__REGISTRATION_TOKEN=<minted-from-dashboard> \\
  cargo run --bin aisix -- --config dev/config.managed.yaml

# Send a few requests; in ~5s they appear at <slug>.aisix.localtest.me:3000/usage
curl -X POST http://localhost:8080/v1/chat/completions \\
  -H "Authorization: Bearer <api-key>" \\
  -d '{"model": "<alias>", "messages": [{"role":"user","content":"hi"}]}'
\`\`\`