### PR TITLE
feat(budget): switch BudgetClient to mTLS /dp/budget_check + wire managed mode

### DIFF
--- a/crates/aisix-proxy/src/budget.rs
+++ b/crates/aisix-proxy/src/budget.rs
@@ -1,5 +1,12 @@
 //! Budget client — asks cp-api per request whether an api_key may proceed.
 //!
+//! Wire: `GET {dpmgr_base}/dp/budget_check?api_key_id=<uuid>`. Auth is
+//! mTLS — the caller supplies a `reqwest::Client` already loaded with
+//! the same client cert + CA bundle the heartbeat worker uses. cp-api
+//! authenticates the DP by peer cert SAN (env_id, dp_id) and rejects
+//! requests for api_keys outside that env (403). See prd-09b rev 2 §5.5
+//! and AISIX-Cloud PR #95 for the CP-side route.
+//!
 //! Decisions are cached in an LRU (capacity 10000, TTL 5s) keyed by
 //! api_key_id. When cp-api is unreachable we honor the last cached
 //! decision (sticky) up to AISIX_DP_BUDGET_STALE_MAX_SECONDS (default
@@ -59,7 +66,6 @@ enum Mode {
     Live {
         http: reqwest::Client,
         base_url: String,
-        token: Option<String>,
         stale_max: Duration,
     },
     Disabled,
@@ -84,14 +90,14 @@ impl std::fmt::Debug for BudgetClient {
 }
 
 impl BudgetClient {
-    /// Live client that asks cp-api per request. The base URL should be the
-    /// cp-api root (e.g. `https://cp.aisix.cloud`). Auth token comes from the
-    /// `AISIX_DP_CP_TOKEN` env var; if unset, requests go without an
-    /// Authorization header (cp-api will reject them — operators should run
-    /// `disabled()` instead in that case).
+    /// Live client that asks cp-api per request via mTLS. `base_url` is
+    /// the same dpmgr origin the heartbeat worker hits (e.g.
+    /// `https://cp.aisix.cloud:9101`); `http` must be a reqwest client
+    /// already loaded with the DP's client cert + CA bundle. Build it
+    /// with `aisix_server::heartbeat::build_mtls_client` (or its
+    /// equivalent) using the same `MtlsBundle` `/dp/register` persisted.
     pub fn new(base_url: impl Into<String>, http: reqwest::Client) -> Self {
         let base_url = base_url.into().trim_end_matches('/').to_string();
-        let token = std::env::var("AISIX_DP_CP_TOKEN").ok();
         let stale_max = std::env::var("AISIX_DP_BUDGET_STALE_MAX_SECONDS")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
@@ -100,7 +106,6 @@ impl BudgetClient {
             mode: Mode::Live {
                 http,
                 base_url,
-                token,
                 stale_max: Duration::from_secs(stale_max),
             },
             cache: DashMap::new(),
@@ -124,7 +129,6 @@ impl BudgetClient {
             Mode::Live {
                 http,
                 base_url,
-                token,
                 stale_max,
             } => {
                 // Fast path: cache hit within TTL.
@@ -134,7 +138,7 @@ impl BudgetClient {
                     }
                 }
 
-                match fetch_decision(http, base_url, token.as_deref(), api_key_id).await {
+                match fetch_decision(http, base_url, api_key_id).await {
                     Ok(decision) => {
                         self.insert(api_key_id, decision.clone());
                         decision
@@ -251,15 +255,15 @@ struct WireReason {
 async fn fetch_decision(
     http: &reqwest::Client,
     base_url: &str,
-    token: Option<&str>,
     api_key_id: &str,
 ) -> Result<Decision, reqwest::Error> {
-    let url = format!("{base_url}/api/internal/budget_check");
-    let mut req = http.get(url).query(&[("api_key_id", api_key_id)]);
-    if let Some(tok) = token {
-        req = req.bearer_auth(tok);
-    }
-    let resp = req.send().await?.error_for_status()?;
+    let url = format!("{base_url}/dp/budget_check");
+    let resp = http
+        .get(url)
+        .query(&[("api_key_id", api_key_id)])
+        .send()
+        .await?
+        .error_for_status()?;
     let wire: WireDecision = resp.json().await?;
     let reason = wire.reason.and_then(|r| {
         if r.message.is_empty() {
@@ -292,7 +296,7 @@ mod tests {
     async fn live_client_returns_cp_api_decision() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/api/internal/budget_check"))
+            .and(path("/dp/budget_check"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "allow": true, "fail_mode": "sticky"
             })))
@@ -309,7 +313,7 @@ mod tests {
     async fn live_client_returns_deny_when_cp_says_no() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/api/internal/budget_check"))
+            .and(path("/dp/budget_check"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "allow": false,
                 "fail_mode": "closed",
@@ -344,7 +348,7 @@ mod tests {
     async fn cache_hit_skips_network_within_ttl() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/api/internal/budget_check"))
+            .and(path("/dp/budget_check"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "allow": true, "fail_mode": "sticky"
             })))
@@ -363,7 +367,7 @@ mod tests {
     async fn fallback_serves_cache_when_cp_fails() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/api/internal/budget_check"))
+            .and(path("/dp/budget_check"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "allow": true, "fail_mode": "open"
             })))
@@ -372,7 +376,7 @@ mod tests {
             .await;
         // Subsequent calls 500.
         Mock::given(method("GET"))
-            .and(path("/api/internal/budget_check"))
+            .and(path("/dp/budget_check"))
             .respond_with(ResponseTemplate::new(500))
             .mount(&server)
             .await;
@@ -396,7 +400,7 @@ mod tests {
     async fn fallback_with_no_cache_denies() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/api/internal/budget_check"))
+            .and(path("/dp/budget_check"))
             .respond_with(ResponseTemplate::new(500))
             .mount(&server)
             .await;

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1156,7 +1156,7 @@ data: [DONE]\n\n";
         // internal/cpapi/resources/budget_check.go (prd-09b rev 2 §5.5).
         let cp = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/api/internal/budget_check"))
+            .and(path("/dp/budget_check"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "allow": false,
                 "fail_mode": "closed",

--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -157,6 +157,15 @@ async fn send(client: &reqwest::Client, cfg: &HeartbeatConfig, uptime: i64) -> a
 /// the presenting identity. Files are read here (not at config-load
 /// time) so an unreadable/rotated bundle surfaces an actionable error
 /// at the same place every other heartbeat error does.
+///
+/// Public so the BudgetClient (aisix-proxy) and any future per-request
+/// CP caller can reuse the same identity without duplicating the PEM-
+/// loading dance. `aisix-server::telemetry` keeps its own copy because
+/// it predates the extraction; consolidating later is fine.
+pub fn build_mtls_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
+    build_client(mtls)
+}
+
 fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
     let ca_pem = std::fs::read(&mtls.ca_cert_path)
         .with_context(|| format!("read {}", mtls.ca_cert_path.display()))?;

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -31,6 +31,7 @@ use aisix_provider_anthropic::AnthropicBridge;
 use aisix_provider_deepseek::deepseek_bridge;
 use aisix_provider_gemini::gemini_bridge;
 use aisix_provider_openai::OpenAiBridge;
+use aisix_proxy::budget::BudgetClient;
 use aisix_proxy::ProxyState;
 use aisix_ratelimit::Limiter;
 use clap::Parser;
@@ -294,6 +295,26 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             h.mtls.clone(),
         )
     });
+    // Budget gate. Same on-disk mTLS bundle as heartbeat; URL is the
+    // dpmgr origin (heartbeat URL minus the /dp/heartbeat suffix), the
+    // BudgetClient appends /dp/budget_check itself. See prd-09b rev 2
+    // §5.5 and AISIX-Cloud PR #95. When the bundle build fails the DP
+    // logs and falls back to the default disabled() (allow-all) — a
+    // mid-boot config glitch shouldn't take the proxy down.
+    let budget_client = heartbeat_cfg.as_ref().and_then(|h| {
+        let dpmgr_base = h
+            .url
+            .strip_suffix("/dp/heartbeat")
+            .unwrap_or(h.url.as_str())
+            .to_string();
+        match heartbeat::build_mtls_client(&h.mtls) {
+            Ok(http) => Some(Arc::new(BudgetClient::new(dpmgr_base, http))),
+            Err(e) => {
+                tracing::warn!(error = %e, "budget_check disabled: mTLS client build failed");
+                None
+            }
+        }
+    });
     let heartbeat_task = heartbeat_cfg.map(|h| heartbeat::spawn(h, cancel_rx.clone()));
     let (usage_sink, telemetry_task) = match telemetry_cfg {
         Some(cfg) => {
@@ -356,6 +377,9 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         proxy_state = proxy_state.with_langfuse(sender);
     }
     proxy_state = proxy_state.with_usage_sink(usage_sink);
+    if let Some(client) = budget_client {
+        proxy_state = proxy_state.with_budget_client(client);
+    }
     // Clone shared trackers before consuming proxy_state in build_router.
     let health_tracker = proxy_state.health.clone();
     let proxy_router = aisix_proxy::build_router(proxy_state);


### PR DESCRIPTION
## Summary

Pairs with [AISIX-Cloud #95](https://github.com/api7/AISIX-Cloud/pull/95) — drops the bearer-token (`AISIX_DP_CP_TOKEN`) auth path on `BudgetClient` and switches to the mTLS `/dp/budget_check` route mounted alongside `/dp/heartbeat` and `/dp/telemetry`. The DP now reuses the same on-disk `MtlsBundle` the heartbeat worker loads — the bundle `/dp/register` persisted at boot — so there's no second secret to provision or rotate.

Wires the live client into managed mode in `main.rs`: dpmgr origin = heartbeat URL minus its `/dp/heartbeat` suffix; `BudgetClient` appends `/dp/budget_check` itself. mTLS bundle-build failure logs and falls back to `BudgetClient::disabled()` (allow-all) — a mid-boot config glitch shouldn't take the proxy down.

`heartbeat::build_mtls_client` is now public so the budget client can share the same identity-loading dance without duplicating PEM handling. (`telemetry.rs` keeps its private copy for now; consolidating later is a follow-up.)

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — all 102 proxy unit tests pass; the 5 wiremock-backed budget tests + the proxy 429 integration test now mock `/dp/budget_check` (real backend, real client cert via `wiremock` — no stubbed network)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] e2e: chat → cap hit → 429 `budget_exceeded` (next PR; lands once both repos are in main)