### PR TITLE
feat(managed): cp_ca_cert_file — extra trust root for /dp/register + etcd

### DIFF
--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -147,6 +147,25 @@ pub struct ManagedConfig {
     #[serde(default)]
     pub cp_etcd_endpoint: Option<String>,
 
+    /// Optional path to a PEM-encoded CA bundle the DP adds as an
+    /// additional trust root for outbound calls to the CP — both the
+    /// `/dp/register` HTTPS handshake and the etcd v3 gRPC connection
+    /// after registration.
+    ///
+    /// In production the CP terminates TLS with a public-CA-issued
+    /// certificate that the system trust store already covers, so
+    /// this is `None`. In e2e / dev / on-prem deployments the CP
+    /// often serves a self-signed or private-CA-signed cert; pointing
+    /// this at the issuing CA's PEM bundle lets the DP trust it
+    /// without disabling verification entirely.
+    ///
+    /// The file is read at boot — rotation requires a DP restart.
+    /// When set but unreadable the boot fails fast with the path so
+    /// the operator can fix the mount; we never silently fall through
+    /// to `InsecureSkipVerify`.
+    #[serde(default)]
+    pub cp_ca_cert_file: Option<String>,
+
     /// Directory where the DP persists `ca.crt`, `client.crt`,
     /// `client.key` received from the register response. Files are
     /// written `0600`. Parent directory must already exist and be

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -229,7 +229,14 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // fails). Both outcomes narrow triage substantially.
     probe_etcd_dns(&cfg.etcd.endpoints).await;
 
-    let connect_options = build_etcd_connect_options(&cfg.etcd)?;
+    // managed.cp_ca_cert_file (when set) is a PEM-encoded trust root
+    // appended to the etcd TLS verify chain — needed for e2e / on-prem
+    // deployments where the dp-manager etcd listener serves a cert not
+    // covered by the cert-manager-issued CA. Production with public-CA
+    // certs leaves this `None`.
+    let extra_ca_pem = register::read_optional_ca_pem(cfg.managed.cp_ca_cert_file.as_deref())?;
+    let connect_options =
+        build_etcd_connect_options_with_extra_ca(&cfg.etcd, extra_ca_pem.as_deref())?;
     // effective_prefix() is `<prefix>/<env_id>` in v3 managed mode
     // (env_id populated from the register response above), bare
     // `<prefix>` in self-hosted dev where env_id is empty.
@@ -469,7 +476,15 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
 ///   endpoint. Callers only need to override when the CA issues certs
 ///   under a different name than the DNS they're dialing (rare but
 ///   possible when the endpoint is an IP or internal alias).
+#[cfg(test)]
 fn build_etcd_connect_options(etcd: &EtcdConfig) -> anyhow::Result<Option<ConnectOptions>> {
+    build_etcd_connect_options_with_extra_ca(etcd, None)
+}
+
+fn build_etcd_connect_options_with_extra_ca(
+    etcd: &EtcdConfig,
+    extra_ca_pem: Option<&[u8]>,
+) -> anyhow::Result<Option<ConnectOptions>> {
     let mut needs_options = false;
     let mut options = ConnectOptions::new();
 
@@ -482,8 +497,18 @@ fn build_etcd_connect_options(etcd: &EtcdConfig) -> anyhow::Result<Option<Connec
     }
 
     if let Some(tls) = etcd.tls.as_ref() {
-        let ca_pem = std::fs::read(&tls.ca_cert_file)
+        let mut ca_pem = std::fs::read(&tls.ca_cert_file)
             .map_err(|e| anyhow::anyhow!("etcd.tls.ca_cert_file = {:?}: {e}", tls.ca_cert_file))?;
+        // Append the operator-supplied extra trust root (typically a
+        // self-signed dev CA in e2e). rustls's PEM parser handles
+        // multi-cert blobs natively, so concatenation is enough — no
+        // need to construct a chain explicitly.
+        if let Some(extra) = extra_ca_pem {
+            if !ca_pem.ends_with(b"\n") {
+                ca_pem.push(b'\n');
+            }
+            ca_pem.extend_from_slice(extra);
+        }
         let cert_pem = std::fs::read(&tls.client_cert_file).map_err(|e| {
             anyhow::anyhow!(
                 "etcd.tls.client_cert_file = {:?}: {e}",

--- a/crates/aisix-server/src/register.rs
+++ b/crates/aisix-server/src/register.rs
@@ -83,7 +83,15 @@ pub async fn register_and_persist(cfg: &ManagedConfig) -> anyhow::Result<Registe
     let private_key_pem = keypair.serialize_pem();
     let public_key_pem = keypair.public_key_pem();
 
-    let resp = call_register(base, token, &gather_host_info()?, &public_key_pem).await?;
+    let extra_ca = read_optional_ca_pem(cfg.cp_ca_cert_file.as_deref())?;
+    let resp = call_register(
+        base,
+        token,
+        &gather_host_info()?,
+        &public_key_pem,
+        extra_ca.as_deref(),
+    )
+    .await?;
     let (ca_path, cert_path, key_path) = persist_mtls(
         &cfg.mtls_dir,
         &resp.ca_certificate,
@@ -118,6 +126,20 @@ pub fn bundle_exists(mtls_dir: impl AsRef<Path>) -> bool {
     ["ca.crt", "client.crt", "client.key"]
         .iter()
         .all(|name| dir.join(name).is_file())
+}
+
+/// Read a PEM-encoded CA bundle from disk if `path` is `Some`. Returns
+/// `Ok(None)` when the path is `None` or empty so the rest of the
+/// boot path doesn't have to special-case the unset case. Surfaces
+/// the path on read errors — a misconfigured or unmounted bundle in
+/// e2e is the most common reason this fires, and the path tells the
+/// operator exactly what to fix.
+pub fn read_optional_ca_pem(path: Option<&str>) -> anyhow::Result<Option<Vec<u8>>> {
+    let Some(p) = path.filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let bytes = std::fs::read(p).with_context(|| format!("read managed.cp_ca_cert_file = {p}"))?;
+    Ok(Some(bytes))
 }
 
 /// Well-known filename within `mtls_dir` for the issuer's CA cert.
@@ -186,12 +208,21 @@ async fn call_register(
     token: &str,
     host: &HostInfo,
     public_key_pem: &str,
+    extra_ca_pem: Option<&[u8]>,
 ) -> anyhow::Result<RegisterResponse> {
-    let client = reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(20))
-        .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")))
-        .build()
-        .context("build reqwest client")?;
+        .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")));
+    // Operator-supplied extra trust root, e.g. a self-signed dev CA in
+    // e2e or an on-prem private CA in air-gapped deployments. The
+    // public-CA chain remains in effect alongside this; we never swap
+    // it out, so production deployments don't lose any verification.
+    if let Some(pem) = extra_ca_pem {
+        let cert = reqwest::Certificate::from_pem(pem)
+            .context("parse managed.cp_ca_cert_file as PEM certificate")?;
+        builder = builder.add_root_certificate(cert);
+    }
+    let client = builder.build().context("build reqwest client")?;
 
     let url = format!("{}/dp/register", base_url.trim_end_matches('/'));
     let resp = client
@@ -368,6 +399,34 @@ mod tests {
     use wiremock::matchers::{body_partial_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    #[test]
+    fn read_optional_ca_pem_returns_none_for_unset_path() {
+        assert!(read_optional_ca_pem(None).unwrap().is_none());
+        assert!(read_optional_ca_pem(Some("")).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_optional_ca_pem_reads_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ca.pem");
+        std::fs::write(&path, b"-----BEGIN CERTIFICATE-----\nXX\n-----END CERTIFICATE-----\n")
+            .unwrap();
+        let bytes = read_optional_ca_pem(Some(path.to_str().unwrap()))
+            .unwrap()
+            .expect("Some when path is set");
+        assert!(bytes.starts_with(b"-----BEGIN CERTIFICATE-----"));
+    }
+
+    #[test]
+    fn read_optional_ca_pem_surfaces_path_on_read_error() {
+        let err = read_optional_ca_pem(Some("/no/such/path/ca.pem")).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("/no/such/path/ca.pem"),
+            "error must surface the configured path so operators can fix the mount: {msg}",
+        );
+    }
+
     fn fake_v3_response_body() -> serde_json::Value {
         json!({
             "dp_id":            "ed5e0f3e-2c32-4f3a-9b9e-d6c9d2c4d4e1",
@@ -405,6 +464,7 @@ mod tests {
             registration_token: Some("tok-xyz".into()),
             cp_base_url: Some(server.uri()),
             cp_etcd_endpoint: Some("etcd.local:7943".into()),
+            cp_ca_cert_file: None,
             mtls_dir: mtls_dir.to_string_lossy().into_owned(),
             dp_id_file: dp_id_file.to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
@@ -499,6 +559,7 @@ mod tests {
             registration_token: Some("t".into()),
             cp_base_url: Some(server.uri()),
             cp_etcd_endpoint: Some("etcd.local:7943".into()),
+            cp_ca_cert_file: None,
             mtls_dir: dir.path().join("mtls").to_string_lossy().into_owned(),
             dp_id_file: dir.path().join("dp_id").to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
@@ -527,6 +588,7 @@ mod tests {
             registration_token: Some("t".into()),
             cp_base_url: Some(server.uri()),
             cp_etcd_endpoint: Some("etcd.local:7943".into()),
+            cp_ca_cert_file: None,
             mtls_dir: dir.path().join("mtls").to_string_lossy().into_owned(),
             dp_id_file: dir.path().join("dp_id").to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
@@ -564,6 +626,7 @@ mod tests {
             registration_token: Some("t".into()),
             cp_base_url: Some(server.uri()),
             cp_etcd_endpoint: Some("etcd.local:7943".into()),
+            cp_ca_cert_file: None,
             mtls_dir: dir.path().join("mtls").to_string_lossy().into_owned(),
             dp_id_file: dir.path().join("dp_id").to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
@@ -595,6 +658,7 @@ mod tests {
             registration_token: Some("spent".into()),
             cp_base_url: Some(server.uri()),
             cp_etcd_endpoint: Some("etcd.local:7943".into()),
+            cp_ca_cert_file: None,
             mtls_dir: dir.path().join("mtls").to_string_lossy().into_owned(),
             dp_id_file: dir.path().join("dp_id").to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),


### PR DESCRIPTION
## Summary

Unblocks the AISIX-Cloud e2e harness's DP-dependent scenarios — including the chat→cap→429 round-trip on the budget feature ([AISIX-Cloud #100](https://github.com/api7/AISIX-Cloud/pull/100)) — by giving the DP a way to trust a self-signed or private-CA dev cert without disabling verification.

In production the CP terminates TLS with a public-CA-issued cert that the system trust store already covers, so this is `None`. In e2e (and on-prem) the CP serves a self-signed or private-CA cert, and the DP currently has no way to trust it.

New `managed.cp_ca_cert_file: Option<String>` (env: `AISIX_MANAGED__CP_CA_CERT_FILE`). When set, the PEM bundle at the path is appended to two outbound TLS verify chains:

1. **`POST /dp/register`** — `reqwest::Client::add_root_certificate`.
2. **etcd v3 gRPC** — concatenated with the cert-manager-issued CA before passing to `etcd_client::TlsOptions::ca_certificate`. Both need to be in the chain simultaneously: the cert-manager CA signs the DP's *client* cert, the extra CA covers the *server* cert. rustls's PEM parser handles multi-cert blobs natively, so concatenation suffices.

Behavior when unset is unchanged. When set but unreadable, boot fails fast with the path in the error — never silent fall-through to `InsecureSkipVerify`.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — all suites green, 3 new tests on `read_optional_ca_pem` (unset → None, present → read, unreadable → surfaces path)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Cloud e2e: paired PR ([api7/AISIX-Cloud#100](https://github.com/api7/AISIX-Cloud/pull/100)) mounts `dpmgr-certs` into DP and sets the env var; full chat→429 round-trip verifies the trust chain end-to-end