### PR TITLE
feat(telemetry): emit cache + reasoning + provider-id detail per request

### DIFF
--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -126,12 +126,52 @@ pub enum FinishReason {
     Other(String),
 }
 
+/// Token usage stats from one upstream chat completion. The four
+/// fine-grained counters that follow `total_tokens` carry the
+/// provider-specific cache / reasoning detail used by cp-api's cost
+/// formula (see `aisix-cloud:internal/dpmgr/dpstore/pricing.go`).
+///
+/// Provider-protocol mapping (the canonical comment lives in cp-api's
+/// schema; mirrored here for grep-ability):
+///
+///   OpenAI Chat Completions response.usage:
+///     prompt_tokens                              → prompt_tokens (TOTAL,
+///                                                  includes cached_prompt)
+///     completion_tokens                          → completion_tokens (TOTAL,
+///                                                  includes reasoning)
+///     prompt_tokens_details.cached_tokens        → cached_prompt_tokens
+///     completion_tokens_details.reasoning_tokens → reasoning_tokens
+///
+///   Anthropic Messages API response.usage:
+///     input_tokens                  → prompt_tokens (NON-cached input)
+///     output_tokens                 → completion_tokens
+///     cache_creation_input_tokens   → cache_creation_tokens
+///     cache_read_input_tokens       → cache_read_tokens
+///
+/// Provider bridges that don't surface these (gemini, deepseek,
+/// mistral, …) leave the four new counters at 0; cp-api treats 0 as
+/// "no distinct rate" and falls back to the standard prompt /
+/// completion price for that token class.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UsageStats {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    /// OpenAI prompt-cache hit count. Subset of `prompt_tokens`.
+    #[serde(default)]
+    pub cached_prompt_tokens: u32,
+    /// OpenAI o1/o3 reasoning tokens. Subset of `completion_tokens`.
+    #[serde(default)]
+    pub reasoning_tokens: u32,
+    /// Anthropic cache_creation_input_tokens (cache write). Separate
+    /// counter on top of input_tokens.
+    #[serde(default)]
+    pub cache_creation_tokens: u32,
+    /// Anthropic cache_read_input_tokens (cache read). Separate
+    /// counter on top of input_tokens.
+    #[serde(default)]
+    pub cache_read_tokens: u32,
 }
 
 impl UsageStats {
@@ -140,6 +180,7 @@ impl UsageStats {
             prompt_tokens: prompt,
             completion_tokens: completion,
             total_tokens: prompt.saturating_add(completion),
+            ..Self::default()
         }
     }
 }

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -44,7 +44,7 @@ use serde::Serialize;
 /// cp-api stores empty strings as SQL NULL; the field is `Option`
 /// here so the JSON serialiser emits `""` (not `null`) — matches what
 /// the cp-api parser expects.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct UsageEvent {
     /// DP-supplied request id (idempotency key). Use the same id the
     /// `x-aisix-call-id` response header carries so logs join.
@@ -65,18 +65,64 @@ pub struct UsageEvent {
 
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
+
+    /// OpenAI prompt-cache hit count. Subset of `prompt_tokens`.
+    /// Defaults to 0 for providers that don't expose prompt caching.
+    /// Serialised with `omitempty`-equivalent behaviour: cp-api accepts
+    /// the absent-or-zero case identically.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub cached_prompt_tokens: u32,
+
+    /// OpenAI o1/o3 reasoning tokens. Subset of `completion_tokens`.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub reasoning_tokens: u32,
+
+    /// Anthropic cache_creation_input_tokens. Separate counter on top
+    /// of input_tokens; bills at ~1.25× prompt rate (per-model rate
+    /// resolved by cp-api from model_pricing).
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub cache_creation_tokens: u32,
+
+    /// Anthropic cache_read_input_tokens. Separate counter on top of
+    /// input_tokens; bills at ~0.10× prompt rate.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub cache_read_tokens: u32,
+
     pub latency_ms: u32,
 
     /// HTTP status code the proxy returned to the downstream caller.
     pub status_code: u16,
 
+    /// Provider response `id` — OpenAI's `chat.completion.id` or
+    /// Anthropic's message `id`. Empty when the request never reached
+    /// the upstream (guardrail block / pre-dispatch error).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub provider_request_id: String,
+
+    /// Resolved model the provider actually billed (e.g.
+    /// `gpt-4o-2024-08-06` when the request said `gpt-4o`). Differs
+    /// from cp-api's `model_id` which points at the dashboard alias.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub provider_model_version: String,
+
+    /// finish_reason / stop_reason from the upstream response. Empty
+    /// for upstream errors and guardrail blocks.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub finish_reason: String,
+
     /// Cost the DP computed for this request in US dollars. Zero when
     /// the request never reached cost calculation (e.g. blocked by a
-    /// guardrail before dispatch).
+    /// guardrail before dispatch). cp-api recomputes this server-side
+    /// from its pricing catalog; the DP-supplied value is dropped.
     pub cost_usd: f64,
 
     /// True when a guardrail rejected the request (input or output).
     pub guardrail_blocked: bool,
+}
+
+#[inline]
+fn is_zero_u32(n: &u32) -> bool {
+    *n == 0
 }
 
 /// Cheap clonable handle the proxy hands to request handlers. Backed
@@ -173,6 +219,7 @@ mod tests {
             status_code: 200,
             cost_usd: 0.0012,
             guardrail_blocked: false,
+            ..Default::default()
         };
         let json = serde_json::to_string(&ev).unwrap();
         assert!(json.contains(r#""request_id":"req-1""#));
@@ -182,18 +229,58 @@ mod tests {
         assert!(json.contains(r#""guardrail_blocked":false"#));
     }
 
+    #[test]
+    fn cache_and_reasoning_fields_are_omitted_when_zero() {
+        // Older DP builds and providers without cache support emit
+        // events with these counters at 0. They must NOT appear in
+        // the JSON — cp-api treats absent and 0 identically, but a
+        // wire-compat regression here would inflate the request size
+        // for every event.
+        let ev = UsageEvent {
+            request_id: "req-1".into(),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert!(!json.contains("cached_prompt_tokens"));
+        assert!(!json.contains("reasoning_tokens"));
+        assert!(!json.contains("cache_creation_tokens"));
+        assert!(!json.contains("cache_read_tokens"));
+        assert!(!json.contains("provider_request_id"));
+        assert!(!json.contains("provider_model_version"));
+        assert!(!json.contains("finish_reason"));
+    }
+
+    #[test]
+    fn cache_and_reasoning_fields_serialise_when_set() {
+        let ev = UsageEvent {
+            request_id: "req-2".into(),
+            prompt_tokens: 1000,
+            completion_tokens: 200,
+            cached_prompt_tokens: 500,
+            reasoning_tokens: 50,
+            cache_creation_tokens: 100,
+            cache_read_tokens: 80,
+            provider_request_id: "chatcmpl-abc".into(),
+            provider_model_version: "gpt-4o-2024-08-06".into(),
+            finish_reason: "stop".into(),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert!(json.contains(r#""cached_prompt_tokens":500"#));
+        assert!(json.contains(r#""reasoning_tokens":50"#));
+        assert!(json.contains(r#""cache_creation_tokens":100"#));
+        assert!(json.contains(r#""cache_read_tokens":80"#));
+        assert!(json.contains(r#""provider_request_id":"chatcmpl-abc""#));
+        assert!(json.contains(r#""provider_model_version":"gpt-4o-2024-08-06""#));
+        assert!(json.contains(r#""finish_reason":"stop""#));
+    }
+
     fn sample_event(id: &str) -> UsageEvent {
         UsageEvent {
             request_id: id.into(),
             occurred_at: "2026-04-29T12:00:00Z".into(),
-            model_id: String::new(),
-            api_key_id: String::new(),
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            latency_ms: 0,
             status_code: 200,
-            cost_usd: 0.0,
-            guardrail_blocked: false,
+            ..Default::default()
         }
     }
 }

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -169,10 +169,17 @@ pub(crate) enum AnthropicResponseBlock {
     Other,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub(crate) struct AnthropicUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,
+    /// Tokens written to the prompt cache (1.25× input rate). Optional
+    /// — present only on requests with cache_control segments.
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
+    /// Tokens served from the prompt cache (0.10× input rate).
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
 }
 
 pub(crate) fn response_into_chat_response(raw: AnthropicResponse) -> ChatResponse {
@@ -188,7 +195,17 @@ pub(crate) fn response_into_chat_response(raw: AnthropicResponse) -> ChatRespons
 
     let usage = raw
         .usage
-        .map(|u| UsageStats::new(u.input_tokens, u.output_tokens))
+        .map(|u| UsageStats {
+            prompt_tokens: u.input_tokens,
+            completion_tokens: u.output_tokens,
+            total_tokens: u.input_tokens.saturating_add(u.output_tokens),
+            cache_creation_tokens: u.cache_creation_input_tokens,
+            cache_read_tokens: u.cache_read_input_tokens,
+            // Anthropic doesn't use OpenAI's cached-prompt-tokens or
+            // reasoning-tokens taxonomy; leave at 0.
+            cached_prompt_tokens: 0,
+            reasoning_tokens: 0,
+        })
         .unwrap_or_default();
 
     ChatResponse {
@@ -419,6 +436,37 @@ mod tests {
         assert_eq!(out.message.content, "hello");
         assert_eq!(out.finish_reason, FinishReason::Stop);
         assert_eq!(out.usage.total_tokens, 5);
+    }
+
+    #[test]
+    fn cache_creation_and_read_counters_populate_when_present() {
+        // Verified shape from
+        // https://docs.anthropic.com/en/api/messages (usage object
+        // with cache_creation_input_tokens + cache_read_input_tokens).
+        let body = r#"{
+            "id": "msg_cache_01",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "ok"}],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 4,
+                "cache_creation_input_tokens": 200,
+                "cache_read_input_tokens": 800
+            }
+        }"#;
+        let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.usage.prompt_tokens, 10);
+        assert_eq!(out.usage.completion_tokens, 4);
+        assert_eq!(out.usage.cache_creation_tokens, 200);
+        assert_eq!(out.usage.cache_read_tokens, 800);
+        // Anthropic doesn't use OpenAI's cached_prompt / reasoning
+        // taxonomy — these stay 0.
+        assert_eq!(out.usage.cached_prompt_tokens, 0);
+        assert_eq!(out.usage.reasoning_tokens, 0);
     }
 
     #[test]

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -115,11 +115,36 @@ pub(crate) struct OpenAiResponseMessage {
     pub content: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub(crate) struct OpenAiUsage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    /// Present on responses that touched the prompt cache. Subset of
+    /// `prompt_tokens`. Optional so older API versions / non-cached
+    /// responses parse without the field.
+    #[serde(default)]
+    pub prompt_tokens_details: Option<OpenAiPromptDetails>,
+    /// Present on responses from o1 / o3 reasoning models. Subset of
+    /// `completion_tokens`.
+    #[serde(default)]
+    pub completion_tokens_details: Option<OpenAiCompletionDetails>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct OpenAiPromptDetails {
+    /// Tokens served from the prompt cache (50% of prompt rate).
+    #[serde(default)]
+    pub cached_tokens: u32,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct OpenAiCompletionDetails {
+    /// o1/o3 reasoning tokens. Same rate as `completion_tokens`,
+    /// surfaced separately so admins can see "of which N were
+    /// reasoning" on the dashboard.
+    #[serde(default)]
+    pub reasoning_tokens: u32,
 }
 
 pub(crate) fn response_into_chat_response(mut raw: OpenAiResponse) -> ChatResponse {
@@ -153,6 +178,21 @@ fn into_usage(u: OpenAiUsage) -> UsageStats {
         prompt_tokens: u.prompt_tokens,
         completion_tokens: u.completion_tokens,
         total_tokens: u.total_tokens,
+        cached_prompt_tokens: u
+            .prompt_tokens_details
+            .as_ref()
+            .map(|d| d.cached_tokens)
+            .unwrap_or(0),
+        reasoning_tokens: u
+            .completion_tokens_details
+            .as_ref()
+            .map(|d| d.reasoning_tokens)
+            .unwrap_or(0),
+        // OpenAI doesn't currently expose Anthropic-style cache
+        // creation/read counters; leave at 0 (cp-api falls back to
+        // prompt rate for unset cache counters).
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
     }
 }
 
@@ -310,6 +350,40 @@ mod tests {
         assert_eq!(out.message.content, "hi there");
         assert_eq!(out.finish_reason, FinishReason::Stop);
         assert_eq!(out.usage.total_tokens, 6);
+        // No cache / reasoning details on this minimal response →
+        // counters stay at 0 (cp-api falls back to standard rates).
+        assert_eq!(out.usage.cached_prompt_tokens, 0);
+        assert_eq!(out.usage.reasoning_tokens, 0);
+    }
+
+    #[test]
+    fn cache_and_reasoning_details_populate_when_present() {
+        // Verified shape from
+        // https://platform.openai.com/docs/api-reference/chat/object#chat/object-usage
+        // (prompt_tokens_details + completion_tokens_details).
+        let body = r#"{
+            "id": "cmpl-2",
+            "object": "chat.completion",
+            "model": "o1-2024-12-17",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 500,
+                "total_tokens": 1500,
+                "prompt_tokens_details": {"cached_tokens": 800},
+                "completion_tokens_details": {"reasoning_tokens": 200}
+            }
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.usage.prompt_tokens, 1000);
+        assert_eq!(out.usage.cached_prompt_tokens, 800);
+        assert_eq!(out.usage.completion_tokens, 500);
+        assert_eq!(out.usage.reasoning_tokens, 200);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -89,6 +89,15 @@ pub async fn chat_completions(
                 elapsed,
                 success.prompt_tokens.unwrap_or(0) as u32,
                 success.completion_tokens.unwrap_or(0) as u32,
+                UsageExtras {
+                    cached_prompt_tokens: success.cached_prompt_tokens,
+                    reasoning_tokens: success.reasoning_tokens,
+                    cache_creation_tokens: success.cache_creation_tokens,
+                    cache_read_tokens: success.cache_read_tokens,
+                    provider_request_id: success.provider_request_id.clone(),
+                    provider_model_version: success.provider_model_version.clone(),
+                    finish_reason: success.finish_reason.clone(),
+                },
                 success.cost_usd,
                 /* guardrail_blocked */ false,
             );
@@ -153,6 +162,10 @@ pub async fn chat_completions(
                 elapsed,
                 /* prompt_tokens */ 0,
                 /* completion_tokens */ 0,
+                // Error path never reached the upstream — no provider
+                // id / model version / finish_reason to record, all
+                // zero / empty.
+                UsageExtras::default(),
                 /* cost_usd */ 0.0,
                 guardrail_blocked,
             );
@@ -189,6 +202,22 @@ struct Success {
     prompt_tokens: Option<u64>,
     completion_tokens: Option<u64>,
     total_tokens: Option<u64>,
+    /// Provider-specific cache + reasoning token counters. Default 0
+    /// for providers that don't expose them; cp-api falls back to the
+    /// standard prompt / completion rate when these are 0.
+    cached_prompt_tokens: u32,
+    reasoning_tokens: u32,
+    cache_creation_tokens: u32,
+    cache_read_tokens: u32,
+    /// Provider response `id` (OpenAI chat.completion.id or Anthropic
+    /// message id) — empty when the cached path served the request
+    /// (re-using a stored response's id would mislead reconciliation).
+    provider_request_id: String,
+    /// Resolved model the provider actually billed.
+    provider_model_version: String,
+    /// finish_reason / stop_reason as the upstream returned it. Empty
+    /// for streaming (no terminal event yet) and cache hits.
+    finish_reason: String,
     /// Cost computed via the per-key Budget's pricing table, in USD.
     /// 0.0 when no budget is configured for the key.
     cost_usd: f64,
@@ -308,6 +337,15 @@ async fn dispatch(
             // until the stream completes upstream). Phase 2 wires
             // mid-stream accumulation; for now telemetry records 0.
             cost_usd: 0.0,
+            // Cache / reasoning counters require parsing the terminal
+            // SSE chunk's usage block; not wired yet — Phase 2.
+            cached_prompt_tokens: 0,
+            reasoning_tokens: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            provider_request_id: String::new(),
+            provider_model_version: String::new(),
+            finish_reason: String::new(),
         });
     }
 
@@ -325,6 +363,16 @@ async fn dispatch(
                 let prompt = cached.usage.prompt_tokens as u64;
                 let completion = cached.usage.completion_tokens as u64;
                 let total = cached.usage.total_tokens as u64;
+                // Snapshot the cache / reasoning counters BEFORE the
+                // value moves into render_response below. Cache hits
+                // replay the original upstream's usage — we already
+                // paid the cost first time around — so the dashboard's
+                // "of which N were cache hits" stat reflects the
+                // original event accurately.
+                let cached_prompt_tokens = cached.usage.cached_prompt_tokens;
+                let reasoning_tokens = cached.usage.reasoning_tokens;
+                let cache_creation_tokens = cached.usage.cache_creation_tokens;
+                let cache_read_tokens = cached.usage.cache_read_tokens;
                 // The provider label points at the first attempt — for a
                 // cache hit we don't know (or care) which target ran the
                 // original call; the fingerprint identified the answer.
@@ -343,6 +391,17 @@ async fn dispatch(
                     prompt_tokens: Some(prompt),
                     completion_tokens: Some(completion),
                     total_tokens: Some(total),
+                    cached_prompt_tokens,
+                    reasoning_tokens,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    // The cache stored the original provider response;
+                    // a stable id here would mislead reconciliation
+                    // (the request didn't actually hit the upstream),
+                    // so we leave these blank deliberately.
+                    provider_request_id: String::new(),
+                    provider_model_version: String::new(),
+                    finish_reason: String::new(),
                     // Cache hits don't burn cost on our side (we already
                     // paid the upstream price the first time around).
                     cost_usd: 0.0,
@@ -419,6 +478,16 @@ async fn dispatch(
     let prompt = upstream.usage.prompt_tokens as u64;
     let completion = upstream.usage.completion_tokens as u64;
     let total = upstream.usage.total_tokens as u64;
+    // Snapshot the cache / reasoning counters + provider identity before
+    // the upstream gets moved into render_response below — we need them
+    // on the Success struct for telemetry.
+    let cached_prompt_tokens = upstream.usage.cached_prompt_tokens;
+    let reasoning_tokens = upstream.usage.reasoning_tokens;
+    let cache_creation_tokens = upstream.usage.cache_creation_tokens;
+    let cache_read_tokens = upstream.usage.cache_read_tokens;
+    let provider_request_id = upstream.id.clone();
+    let provider_model_version = upstream.model.clone();
+    let finish_reason = finish_reason_label(&upstream.finish_reason);
     reservation.commit_tokens(total);
 
     // cp-api recomputes cost server-side from its pricing catalog when
@@ -449,8 +518,29 @@ async fn dispatch(
         prompt_tokens: Some(prompt),
         completion_tokens: Some(completion),
         total_tokens: Some(total),
+        cached_prompt_tokens,
+        reasoning_tokens,
+        cache_creation_tokens,
+        cache_read_tokens,
+        provider_request_id,
+        provider_model_version,
+        finish_reason,
         cost_usd,
     })
+}
+
+/// Wire-shape label for `FinishReason`. cp-api stores this verbatim
+/// in `dpmgr_usage_events.finish_reason`; the dashboard reads it back
+/// to distinguish normal stops from truncation / content_filter.
+fn finish_reason_label(reason: &aisix_gateway::FinishReason) -> String {
+    use aisix_gateway::FinishReason;
+    match reason {
+        FinishReason::Stop => "stop".into(),
+        FinishReason::Length => "length".into(),
+        FinishReason::ContentFilter => "content_filter".into(),
+        FinishReason::ToolCalls => "tool_calls".into(),
+        FinishReason::Other(s) => s.clone(),
+    }
 }
 
 fn record_success(
@@ -470,9 +560,9 @@ fn record_success(
 
 /// Push one telemetry event onto the CP-side sink. Non-blocking;
 /// drops with a tracing::warn! if the worker queue is full.
-/// Centralised here so success / error / streaming all share the same
-/// event-construction logic and the wire shape stays consistent
-/// across paths.
+/// Centralised here so success / error / streaming / cache-hit paths
+/// all share the same event-construction logic and the wire shape
+/// stays consistent across them.
 #[allow(clippy::too_many_arguments)]
 fn emit_usage_event(
     sink: &UsageSink,
@@ -483,6 +573,7 @@ fn emit_usage_event(
     elapsed: Duration,
     prompt_tokens: u32,
     completion_tokens: u32,
+    extras: UsageExtras,
     cost_usd: f64,
     guardrail_blocked: bool,
 ) {
@@ -495,11 +586,35 @@ fn emit_usage_event(
         api_key_id: api_key_id.to_string(),
         prompt_tokens,
         completion_tokens,
+        cached_prompt_tokens: extras.cached_prompt_tokens,
+        reasoning_tokens: extras.reasoning_tokens,
+        cache_creation_tokens: extras.cache_creation_tokens,
+        cache_read_tokens: extras.cache_read_tokens,
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
+        provider_request_id: extras.provider_request_id,
+        provider_model_version: extras.provider_model_version,
+        finish_reason: extras.finish_reason,
         cost_usd,
         guardrail_blocked,
     });
+}
+
+/// Provider-detail bundle for `emit_usage_event`. Grouped here so the
+/// helper signature stays under the clippy-too-many-arguments bar
+/// without losing the structural relationship between the seven new
+/// fields. All seven default to "" / 0, which is exactly the
+/// "no provider info / no cache or reasoning detail" case (error path,
+/// streaming pre-Phase-2).
+#[derive(Default)]
+struct UsageExtras {
+    cached_prompt_tokens: u32,
+    reasoning_tokens: u32,
+    cache_creation_tokens: u32,
+    cache_read_tokens: u32,
+    provider_request_id: String,
+    provider_model_version: String,
+    finish_reason: String,
 }
 
 fn record_error(metrics: &Metrics, err: &ProxyError, model: &str, status: u16, elapsed: Duration) {

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -300,6 +300,7 @@ mod tests {
             status_code: 200,
             cost_usd: 0.001,
             guardrail_blocked: false,
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
## Why

The CP-side \`dpmgr_usage_events\` table grew seven new columns to make billing accurate (\`AISIX-Cloud\` PR #106 + #109):

- \`cached_prompt_tokens\` — OpenAI prompt-cache hit (subset of \`prompt_tokens\`)
- \`reasoning_tokens\` — OpenAI o1/o3 (subset of \`completion_tokens\`)
- \`cache_creation_tokens\` — Anthropic \`cache_creation_input_tokens\`
- \`cache_read_tokens\` — Anthropic \`cache_read_input_tokens\`
- \`provider_request_id\` — provider response \`id\` for reconciliation
- \`provider_model_version\` — actual billed model version
- \`finish_reason\` — stop_reason / finish_reason

Until the DP populates these on every request, the server-side cost formula falls back to standard prompt / completion rates — i.e. customers using cache hits keep getting **overcharged 2-10×**. This PR plugs the DP side.

## What

### \`aisix-gateway::UsageStats\`
Four new optional \`u32\` counters with \`#[serde(default)]\`. Inline doc comment mirrors the canonical mapping table from cp-api's schema.

### Provider bridges
- **OpenAI** (\`aisix-provider-openai/wire.rs\`): added \`OpenAiPromptDetails\` / \`OpenAiCompletionDetails\` with \`#[serde(default)]\` on both the parent \`Option\` and the field. \`into_usage\` maps the two detail blocks into \`UsageStats\`. Test pins the populated case against [the verified OpenAI shape](https://platform.openai.com/docs/api-reference/chat/object#chat/object-usage).
- **Anthropic** (\`aisix-provider-anthropic/wire.rs\`): \`AnthropicUsage\` gains \`cache_creation_input_tokens\` + \`cache_read_input_tokens\` with \`#[serde(default)]\`. Test pins against [the verified Anthropic shape](https://docs.anthropic.com/en/api/messages).

Other provider bridges (Gemini / DeepSeek / Mistral / xAI / …) leave the cache counters at 0 — same conservative "no distinct rate" default cp-api treats as fallback to standard rates.

### \`aisix-obs::UsageEvent\`
Seven new fields, all \`#[serde(skip_serializing_if)]\` so the wire stays minimal when nothing's set. \`Default\` derived so every test / fixture construction site is forward-compatible (\`..Default::default()\`).

### \`aisix-proxy/chat.rs\`
\`Success\` gains the seven fields. Plumbing per path:

| Path | Counters | Provider id / model / finish_reason |
|---|---|---|
| **Success** | snapshot from upstream before move into \`render_response\` | from \`upstream.{id, model, finish_reason}\` |
| **Cache hit** | replay from stored \`ChatResponse\` | **left blank** — the request didn't actually hit upstream; reusing the original id would mislead reconciliation |
| **Streaming** | 0 | empty (Phase 2 wires mid-stream usage parsing) |
| **Error** | 0 | empty |

\`emit_usage_event\` took 9 args; bundled the seven new ones into a \`UsageExtras\` helper struct so call sites stay readable and clippy's \`too-many-arguments\` stays happy.

\`finish_reason_label()\` maps the typed \`FinishReason\` → wire string verbatim (\`stop\` / \`length\` / \`content_filter\` / \`tool_calls\` / passthrough for \`Other\`).

## Wire compatibility

All seven new fields are optional. Older DP builds keep working unchanged (cache fields = 0 → no discount applied, conservative). cp-api already honours these in \`CostUSD\` (\`AISIX-Cloud\` PR #109), so the moment this PR ships, prompt-cache and Anthropic cache rebates start flowing through to customer bills.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` green (~400 unit tests)
- [x] New parser tests pin OpenAI cache+reasoning extraction and Anthropic cache_creation/read extraction
- [x] New \`aisix-obs\` tests pin: (a) zero values stay off the wire, (b) populated values serialise with right snake_case keys