### PR TITLE
fix(managed): plumb cp_ca_cert_file into heartbeat / telemetry / BudgetClient too

### DIFF
--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -30,11 +30,21 @@ use tokio::sync::watch;
 /// to cp-api. Same three files written by `register::register_and_persist`
 /// (and re-used on every subsequent boot when the bundle is already on
 /// disk).
+///
+/// `extra_ca_pem` is an optional second CA bundle the operator points
+/// at via `managed.cp_ca_cert_file` — needed in e2e / on-prem
+/// deployments where dp-manager's *server* cert is signed by a CA
+/// distinct from the cert-manager-issued one (which only signs DP
+/// *client* certs). When set, every outbound mTLS client built from
+/// this bundle (heartbeat, telemetry, BudgetClient) appends it to
+/// the verify chain. Production with public-CA certs leaves this
+/// `None`.
 #[derive(Debug, Clone)]
 pub struct MtlsBundle {
     pub ca_cert_path: PathBuf,
     pub client_cert_path: PathBuf,
     pub client_key_path: PathBuf,
+    pub extra_ca_pem: Option<Vec<u8>>,
 }
 
 /// Configuration captured at register time. `url`, `dp_id`, `interval`
@@ -185,12 +195,21 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
 
     let ca = reqwest::Certificate::from_pem(&ca_pem).context("parse CA certificate")?;
 
-    reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")))
         .identity(identity)
         .add_root_certificate(ca)
-        .use_rustls_tls()
+        .use_rustls_tls();
+    // Operator-supplied extra root (e2e / on-prem). Covers the dp-
+    // manager server cert when it's signed by a CA distinct from the
+    // cert-manager-issued client-cert CA.
+    if let Some(extra) = mtls.extra_ca_pem.as_ref() {
+        let extra_ca = reqwest::Certificate::from_pem(extra)
+            .context("parse managed.cp_ca_cert_file as PEM certificate")?;
+        builder = builder.add_root_certificate(extra_ca);
+    }
+    builder
         .build()
         .context("build reqwest client with mTLS")
 }
@@ -239,6 +258,7 @@ mod tests {
             ca_cert_path: ca_path,
             client_cert_path: cert_path,
             client_key_path: key_path,
+            extra_ca_pem: None,
         }
     }
 
@@ -398,6 +418,7 @@ mod tests {
             ca_cert_path: "/definitely/missing/ca.crt".into(),
             client_cert_path: "/definitely/missing/client.crt".into(),
             client_key_path: "/definitely/missing/client.key".into(),
+            extra_ca_pem: None,
         };
         let err = build_client(&mtls).unwrap_err();
         // The error must mention which file was missing — operators

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -77,6 +77,13 @@ async fn main() -> anyhow::Result<()> {
 /// Factored out of `main` so the integration tests can drive the full
 /// startup with a real config struct and still use `#[tokio::test]`.
 async fn run(mut cfg: Config) -> anyhow::Result<()> {
+    // Operator-supplied extra trust root, threaded into every
+    // outbound mTLS client (register, etcd, heartbeat, telemetry,
+    // BudgetClient). Needed for e2e / on-prem deployments where the
+    // CP serves a cert distinct from the cert-manager-issued client-
+    // cert CA. Production with public-CA certs leaves this `None`.
+    let extra_ca_pem = register::read_optional_ca_pem(cfg.managed.cp_ca_cert_file.as_deref())?;
+
     // Managed-mode bootstrap. If we have to register (first boot),
     // we also capture the heartbeat config the CP sent back so the
     // worker can be spawned a few lines below. If the bundle is
@@ -163,6 +170,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                     ca_cert_path: r.ca_cert_path.clone(),
                     client_cert_path: r.client_cert_path.clone(),
                     client_key_path: r.client_key_path.clone(),
+                    extra_ca_pem: extra_ca_pem.clone(),
                 },
             ))
         } else if bundle_on_disk {
@@ -198,7 +206,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                     register::env_id_path(&cfg.managed.mtls_dir),
                 )
             })?;
-            match load_heartbeat_config_from_disk(&cfg.managed) {
+            match load_heartbeat_config_from_disk(&cfg.managed, extra_ca_pem.clone()) {
                 Ok(h) => Some(h),
                 Err(e) => {
                     tracing::warn!(error = %e,
@@ -229,12 +237,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // fails). Both outcomes narrow triage substantially.
     probe_etcd_dns(&cfg.etcd.endpoints).await;
 
-    // managed.cp_ca_cert_file (when set) is a PEM-encoded trust root
-    // appended to the etcd TLS verify chain — needed for e2e / on-prem
-    // deployments where the dp-manager etcd listener serves a cert not
-    // covered by the cert-manager-issued CA. Production with public-CA
-    // certs leaves this `None`.
-    let extra_ca_pem = register::read_optional_ca_pem(cfg.managed.cp_ca_cert_file.as_deref())?;
+    // Same extra trust root reused by the etcd connect options.
     let connect_options =
         build_etcd_connect_options_with_extra_ca(&cfg.etcd, extra_ca_pem.as_deref())?;
     // effective_prefix() is `<prefix>/<env_id>` in v3 managed mode
@@ -636,6 +639,7 @@ fn default_domain_from_endpoint(endpoint: &str) -> anyhow::Result<String> {
 /// an inconsistent on-disk state an operator should know about.
 fn load_heartbeat_config_from_disk(
     managed: &aisix_core::ManagedConfig,
+    extra_ca_pem: Option<Vec<u8>>,
 ) -> anyhow::Result<heartbeat::HeartbeatConfig> {
     let base = managed
         .cp_base_url
@@ -660,6 +664,7 @@ fn load_heartbeat_config_from_disk(
             ca_cert_path: register::ca_cert_path(&managed.mtls_dir),
             client_cert_path: register::client_cert_path(&managed.mtls_dir),
             client_key_path: register::client_key_path(&managed.mtls_dir),
+            extra_ca_pem,
         },
     ))
 }

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -236,12 +236,20 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
 
     let ca = reqwest::Certificate::from_pem(&ca_pem).context("parse CA certificate")?;
 
-    reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")))
         .identity(identity)
         .add_root_certificate(ca)
-        .use_rustls_tls()
+        .use_rustls_tls();
+    // Mirror heartbeat::build_client — pick up the operator-supplied
+    // extra trust root (managed.cp_ca_cert_file) when set.
+    if let Some(extra) = mtls.extra_ca_pem.as_ref() {
+        let extra_ca = reqwest::Certificate::from_pem(extra)
+            .context("parse managed.cp_ca_cert_file as PEM certificate")?;
+        builder = builder.add_root_certificate(extra_ca);
+    }
+    builder
         .build()
         .context("build reqwest client with mTLS")
 }
@@ -285,6 +293,7 @@ mod tests {
             ca_cert_path: ca_path,
             client_cert_path: cert_path,
             client_key_path: key_path,
+            extra_ca_pem: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #70. That PR threaded \`managed.cp_ca_cert_file\` through the register reqwest client + etcd TlsOptions but missed three other outbound mTLS clients (heartbeat, telemetry, BudgetClient). They still only trusted the cert-manager-issued CA — which signs DP *client* certs, not dp-manager's *server* cert.

In the AISIX-Cloud e2e (PR #100) the DP now boots and registers cleanly but every subsequent \`/dp/heartbeat\`, \`/dp/telemetry\`, and \`/dp/budget_check\` fails with \`tls: unknown certificate authority\`. The chat handler returns 429 \`budget_exceeded\` not because the cap was hit but because BudgetClient's HTTP call to cp-api times out and the sticky-default fallback kicks in.

## Fix

Carry \`extra_ca_pem\` on \`MtlsBundle\` itself so all three call sites append it identically:
- \`heartbeat::build_client\`
- \`telemetry::build_client\`
- \`BudgetClient\` via \`heartbeat::build_mtls_client\`

\`main.rs\` reads \`cp_ca_cert_file\` once at boot and stamps it onto every MtlsBundle constructor (register-branch literal, bundle-on-disk via \`load_heartbeat_config_from_disk\`).

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — all suites green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] AISIX-Cloud #100 e2e: testBudgetEnforcement gets past the TLS handshake gate