### PR TITLE
fix(managed): trailing-slash etcd prefix + request_id pure UUID

### DIFF
--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -238,15 +238,24 @@ impl EtcdConfig {
     }
 
     /// The full env-scoped key prefix the DP watches and parses.
-    /// v3: `<prefix>/<env_id>` (e.g. `/aisix/<uuid>`); v2 fallback
+    /// v3: `<prefix>/<env_id>/` (e.g. `/aisix/<uuid>/`); v2 fallback
     /// (env_id empty): bare `<prefix>` for backwards compat with
     /// self-managed deployments that haven't migrated yet.
+    ///
+    /// The trailing slash matters for the kine etcd-auth interceptor
+    /// (internal/dpmgr/etcdauth on the dp-manager side): it requires
+    /// the DP's Range key to start with `<prefix>/<env_id>/`, NOT
+    /// `<prefix>/<env_id>`. Without the slash a bare `<prefix>/<env_id>`
+    /// Range request gets `PermissionDenied: outside env <env_id> prefix`
+    /// because the auth check sees the bare-prefix Range as escaping
+    /// into a sibling env's space (the env-id substring could be any
+    /// prefix-of-prefix until the slash terminates it).
     pub fn effective_prefix(&self) -> String {
         if self.env_id.is_empty() {
             self.prefix.clone()
         } else {
             let trimmed = self.prefix.trim_end_matches('/');
-            format!("{trimmed}/{}", self.env_id)
+            format!("{trimmed}/{}/", self.env_id)
         }
     }
 }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -49,7 +49,12 @@ pub async fn chat_completions(
     let started = Instant::now();
     let method = "POST";
     let path = "/v1/chat/completions";
-    let request_id = format!("req-{}", Uuid::new_v4());
+    // Pure UUID — cp-api's telemetry handler stores this in the
+    // `request_id UUID` column of dpmgr_usage_events, so a "req-…"
+    // prefix on the wire would be rejected (event 0: request_id must
+    // be a uuid). The downstream `x-aisix-call-id` header carries the
+    // same value for human correlation.
+    let request_id = Uuid::new_v4().to_string();
     let api_key_id = auth.entry.id.clone();
     let model_name = req.model.clone();
 


### PR DESCRIPTION
Two silent-failure wire-shape bugs found while wiring an end-to-end cache-billing test on the aisix.cloud side (api7/AISIX-Cloud#119).

## 1. effective_prefix() missing trailing slash

Returned `/aisix/<env_id>`, but dp-manager's etcdauth interceptor expects `/aisix/<env_id>/` (its EnvKeyPrefix has the trailing slash). Result: every Range query gets `PermissionDenied: outside env <env_id> prefix`. DP's etcd watch loops forever in backoff; snapshot stays empty; every chat returns 401 invalid_api_key.

Doc comment already said `/aisix/<env_id>/`; implementation just disagreed.

## 2. request_id had `req-` prefix

chat.rs emitted `format!("req-{}", Uuid::new_v4())`. cp-api stores request_id in a UUID column and parses with uuid.Parse → rejects with 'request_id must be a uuid'. The entire telemetry batch gets dropped, no usage_events ever land, dashboard /usage stays empty for ALL traffic.

Fix: emit bare UUID. The x-aisix-call-id response header carries the same value; the prefix wasn't load-bearing.

## Verified

Against api7/AISIX-Cloud cache_billing_e2e (which exercises the full DP→CP→PG→cost-formula round-trip):

--- PASS: TestHappyPath/cache_billing_e2e (36.07s)

cargo test --workspace stays green.