### PR TITLE
feat(guardrails): load Guardrail rules from etcd; build live keyword chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "aisix-core",
  "aisix-etcd",
  "aisix-gateway",
+ "aisix-guardrails",
  "aisix-obs",
  "aisix-provider-anthropic",
  "aisix-provider-deepseek",

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -30,8 +30,9 @@ pub use error::{
     AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,
 };
 pub use models::{
-    validate_apikey, validate_credential, validate_model, validate_team, AisixSnapshot, ApiKey,
-    Credential, Model, Provider, ProviderConfig, RateLimit, Routing, RoutingStrategy,
+    validate_apikey, validate_credential, validate_guardrail, validate_model, validate_team,
+    AisixSnapshot, ApiKey, Credential, Guardrail, GuardrailHookPoint, GuardrailKind, KeywordConfig,
+    KeywordPattern, Model, Provider, ProviderConfig, RateLimit, Routing, RoutingStrategy,
     RoutingTarget, SchemaError, Team,
 };
 pub use resource::{Resource, ResourceEntry};

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -1,0 +1,222 @@
+//! `Guardrail` entity — content-policy hooks the DP runs on every
+//! chat request. The control plane (cp-api) writes these to etcd at
+//! `/aisix/<env>/guardrails/<uuid>`; the DP loads them on watch and
+//! the `aisix-proxy::ProxyState::guardrails` chain composes the
+//! enabled ones.
+//!
+//! Two run sites per request (matches `aisix-guardrails::Guardrail`):
+//!   * `input`  — runs before bridge dispatch; a block here means the
+//!     prompt never reaches the upstream.
+//!   * `output` — runs after the upstream response lands; a block
+//!     here means the response never reaches the caller.
+//!
+//! Production keeps both sides on by default. The `hook_point` field
+//! lets operators narrow a rule to just one side (e.g. a PII regex
+//! that's expensive to run on long outputs).
+//!
+//! Rule kinds. v1 ships a single in-process kind plus a placeholder
+//! for the AWS Bedrock provider:
+//!
+//!   * `keyword` — literal/regex blocklist; runs entirely in DP
+//!     process. Configured via `keyword.patterns` (list of
+//!     `{ kind: "literal" | "regex", value: "..." }`).
+//!   * `bedrock` — calls AWS Bedrock's ApplyGuardrail (TODO; the v1
+//!     loader rejects this kind so a half-wired DP doesn't silently
+//!     skip the policy).
+//!
+//! See `aisix-guardrails/src/keyword.rs` for the runtime semantics
+//! the snapshot is parsed into.
+
+use serde::{Deserialize, Serialize};
+
+use crate::resource::Resource;
+
+/// What part of the request lifecycle a guardrail inspects.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GuardrailHookPoint {
+    /// Run on the request payload before bridge dispatch.
+    Input,
+    /// Run on the upstream response before the cache write + render.
+    Output,
+    /// Run on both. Default for keyword blocklists.
+    #[default]
+    Both,
+}
+
+/// One pattern in a `keyword`-kind guardrail's blocklist. The DP
+/// translates `Literal` to a case-insensitive substring match and
+/// `Regex` to a compiled `regex::Regex`. Invalid regex at parse
+/// time is loader-rejected (the DP refuses to apply a guardrail it
+/// can't compile, so a typo doesn't silently disarm the policy).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "value", rename_all = "lowercase")]
+pub enum KeywordPattern {
+    Literal(String),
+    Regex(String),
+}
+
+/// Config block for `kind: "keyword"`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct KeywordConfig {
+    /// Blocklist patterns. Empty list is legal but pointless — the
+    /// guardrail will allow every request, same as `enabled: false`.
+    pub patterns: Vec<KeywordPattern>,
+}
+
+/// Provider discriminator. The kind drives which `*_config` block is
+/// expected; serde's `tag = "kind"` keeps us honest at parse time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum GuardrailKind {
+    /// In-process literal/regex blocklist. Always available.
+    Keyword(KeywordConfig),
+    // Bedrock placeholder lives in the spec/PRD only for v1 — the DP
+    // refuses to load it. Adding the variant here lands with the
+    // ApplyGuardrail wiring; left out now to keep the snapshot
+    // schema strict.
+}
+
+/// Top-level `Guardrail` resource shape. Mirrors what cp-api writes
+/// to kine at `/aisix/<env>/guardrails/<uuid>`.
+///
+/// `deny_unknown_fields` is intentionally NOT set here: serde's
+/// `flatten` + `tag = "kind"` interaction can't pass the
+/// "I consumed this field" signal up to the outer struct, so a
+/// `deny_unknown_fields` outer would reject the very `kind` the
+/// inner enum needs. Strict typo-rejection happens earlier in the
+/// JSON Schema (`schema::validate_guardrail`) which the loader
+/// runs before deserialise on every watch event.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Guardrail {
+    /// Operator-facing name; surfaces in metric labels + error reasons.
+    pub name: String,
+
+    /// When false the chain skips this rule entirely. Lets operators
+    /// stage a rule (write it, sanity-check it via dry runs, then flip
+    /// it on) without deleting + recreating.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Where in the lifecycle this rule runs. Defaults to `both`.
+    #[serde(default)]
+    pub hook_point: GuardrailHookPoint,
+
+    /// The provider discriminator + its config. Use serde's flattening
+    /// so the wire shape is `{ kind: "keyword", patterns: [...] }`
+    /// rather than `{ kind: "keyword", keyword: { patterns: [...] }}`.
+    #[serde(flatten)]
+    pub config: GuardrailKind,
+
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+impl Resource for Guardrail {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn kind() -> &'static str {
+        "guardrails"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn deserialises_keyword_with_mixed_patterns() {
+        let v = json!({
+            "name": "block-secrets",
+            "enabled": true,
+            "hook_point": "input",
+            "kind": "keyword",
+            "patterns": [
+                { "kind": "literal", "value": "AKIA" },
+                { "kind": "regex",   "value": "\\bssn:\\s*\\d{3}-\\d{2}-\\d{4}" }
+            ]
+        });
+        let g: Guardrail = serde_json::from_value(v).unwrap();
+        assert_eq!(g.name, "block-secrets");
+        assert!(g.enabled);
+        assert_eq!(g.hook_point, GuardrailHookPoint::Input);
+        match g.config {
+            GuardrailKind::Keyword(KeywordConfig { patterns }) => {
+                assert_eq!(patterns.len(), 2);
+                assert_eq!(patterns[0], KeywordPattern::Literal("AKIA".into()));
+                assert_eq!(
+                    patterns[1],
+                    KeywordPattern::Regex(r"\bssn:\s*\d{3}-\d{2}-\d{4}".into())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn enabled_defaults_to_true_when_omitted() {
+        let v = json!({
+            "name": "g",
+            "kind": "keyword",
+            "patterns": []
+        });
+        let g: Guardrail = serde_json::from_value(v).unwrap();
+        assert!(g.enabled);
+        assert_eq!(g.hook_point, GuardrailHookPoint::Both);
+    }
+
+    #[test]
+    fn unknown_field_rejected_by_inner_kind_struct() {
+        // The outer Guardrail can't use deny_unknown_fields (see its
+        // doc comment), but the inner KeywordConfig does — and serde
+        // surfaces unknown fields from the flattened inner type at
+        // the top level. Net effect: typos are still caught.
+        let v = json!({
+            "name": "g",
+            "kind": "keyword",
+            "patterns": [],
+            "extra": "nope"
+        });
+        let r: Result<Guardrail, _> = serde_json::from_value(v);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn bedrock_kind_does_not_deserialise_yet() {
+        // Adding the variant lands when ApplyGuardrail is implemented.
+        // Until then the loader errors on `kind: "bedrock"` rather
+        // than silently letting a half-wired policy through.
+        let v = json!({
+            "name": "g",
+            "kind": "bedrock",
+            "guardrail_id": "abc"
+        });
+        let r: Result<Guardrail, _> = serde_json::from_value(v);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn resource_trait_uses_name_and_guardrails_kind() {
+        let mut g: Guardrail = serde_json::from_value(json!({
+            "name": "g1",
+            "kind": "keyword",
+            "patterns": []
+        }))
+        .unwrap();
+        g.runtime_id = "uuid-1".into();
+        assert_eq!(<Guardrail as Resource>::kind(), "guardrails");
+        assert_eq!(g.id(), "uuid-1");
+        assert_eq!(g.name(), "g1");
+    }
+}

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod apikey;
 pub mod credential;
+pub mod guardrail;
 pub mod model;
 pub mod rate_limit;
 pub mod routing;
@@ -25,11 +26,13 @@ pub mod team;
 
 pub use apikey::ApiKey;
 pub use credential::Credential;
+pub use guardrail::{Guardrail, GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern};
 pub use model::{Model, Provider, ProviderConfig};
 pub use rate_limit::RateLimit;
 pub use routing::{Routing, RoutingStrategy, RoutingTarget};
 pub use schema::{
-    validate_apikey, validate_credential, validate_model, validate_team, SchemaError,
+    validate_apikey, validate_credential, validate_guardrail, validate_model, validate_team,
+    SchemaError,
 };
 pub use snapshot::AisixSnapshot;
 pub use team::Team;

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -26,6 +26,7 @@ pub struct Schemas {
     pub apikey: Validator,
     pub credential: Validator,
     pub team: Validator,
+    pub guardrail: Validator,
 }
 
 pub static SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::compile()));
@@ -45,6 +46,9 @@ impl Schemas {
             team: jsonschema::options()
                 .build(&team_schema())
                 .expect("team schema is well-formed"),
+            guardrail: jsonschema::options()
+                .build(&guardrail_schema())
+                .expect("guardrail schema is well-formed"),
         }
     }
 }
@@ -83,6 +87,10 @@ pub fn validate_credential(value: &Value) -> Result<(), SchemaError> {
 
 pub fn validate_team(value: &Value) -> Result<(), SchemaError> {
     validate(&SCHEMAS.team, value)
+}
+
+pub fn validate_guardrail(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.guardrail, value)
 }
 
 fn model_schema() -> Value {
@@ -219,6 +227,48 @@ fn team_schema() -> Value {
                     "rpm":         { "type": "integer", "minimum": 0 },
                     "rpd":         { "type": "integer", "minimum": 0 },
                     "concurrency": { "type": "integer", "minimum": 0 }
+                }
+            }
+        }
+    })
+}
+
+fn guardrail_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["name", "kind"],
+        // The keyword variant adds `patterns`; we don't lock it down
+        // at the top level because future kinds will introduce their
+        // own keys. The kind-specific oneOf below pins per-kind.
+        "additionalProperties": true,
+        "properties": {
+            "name":       { "type": "string", "minLength": 1 },
+            "enabled":    { "type": "boolean" },
+            "hook_point": { "enum": ["input", "output", "both"] },
+            "kind":       { "enum": ["keyword"] }
+        },
+        "oneOf": [
+            {
+                "type": "object",
+                "required": ["kind", "patterns"],
+                "properties": {
+                    "kind":     { "const": "keyword" },
+                    "patterns": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/keyword_pattern" }
+                    }
+                }
+            }
+        ],
+        "$defs": {
+            "keyword_pattern": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kind", "value"],
+                "properties": {
+                    "kind":  { "enum": ["literal", "regex"] },
+                    "value": { "type": "string", "minLength": 1 }
                 }
             }
         }

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -9,6 +9,7 @@
 
 use super::apikey::ApiKey;
 use super::credential::Credential;
+use super::guardrail::Guardrail;
 use super::model::Model;
 use super::team::Team;
 use crate::snapshot::ResourceTable;
@@ -21,6 +22,7 @@ pub struct AisixSnapshot {
     pub apikeys: ResourceTable<ApiKey>,
     pub credentials: ResourceTable<Credential>,
     pub teams: ResourceTable<Team>,
+    pub guardrails: ResourceTable<Guardrail>,
 }
 
 impl AisixSnapshot {
@@ -31,7 +33,11 @@ impl AisixSnapshot {
     /// Convenience: total entry count across all tables. Handy for debug /
     /// readiness checks.
     pub fn total_entries(&self) -> usize {
-        self.models.len() + self.apikeys.len() + self.credentials.len() + self.teams.len()
+        self.models.len()
+            + self.apikeys.len()
+            + self.credentials.len()
+            + self.teams.len()
+            + self.guardrails.len()
     }
 }
 

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -12,7 +12,8 @@
 //! entry; it serves the rest."
 
 use aisix_core::models::{
-    validate_apikey, validate_credential, validate_model, ApiKey, Credential, Model, SchemaError,
+    validate_apikey, validate_credential, validate_guardrail, validate_model, ApiKey, Credential,
+    Guardrail, Model, SchemaError,
 };
 use aisix_core::resource::ResourceEntry;
 use aisix_core::AisixSnapshot;
@@ -93,6 +94,18 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
                     &mut stats,
                 ) {
                     snapshot.credentials.insert(entry);
+                }
+            }
+            "guardrails" => {
+                if let Some(entry) = validate_and_parse::<Guardrail>(
+                    &raw.key,
+                    raw.revision,
+                    parsed,
+                    &value,
+                    validate_guardrail,
+                    &mut stats,
+                ) {
+                    snapshot.guardrails.insert(entry);
                 }
             }
             other => {

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1,0 +1,357 @@
+//! Build a runtime [`GuardrailChain`] from a typed snapshot of
+//! `aisix_core::Guardrail` rows.
+//!
+//! Called by the DP every time the etcd watch supervisor swaps in a
+//! new snapshot. The chain composes one runtime guardrail per
+//! enabled domain row, in deterministic order so the operator's
+//! `reason` strings stay stable across rebuilds.
+//!
+//! Disabled rows and rows whose `hook_point` excludes both lifecycle
+//! sites are dropped here — they don't even allocate. Invalid regex
+//! patterns are logged and skipped (the DP refuses to apply a rule
+//! it can't compile, so a typo doesn't silently disarm the policy).
+
+use std::sync::{Arc, Mutex};
+
+use aisix_core::models::{
+    AisixSnapshot, Guardrail as DomainGuardrail, GuardrailHookPoint, GuardrailKind, KeywordPattern,
+};
+use aisix_core::snapshot::ResourceTable;
+use aisix_core::SnapshotHandle;
+use aisix_gateway::{ChatFormat, ChatResponse};
+use async_trait::async_trait;
+
+use crate::keyword::{KeywordBlocklist, KeywordRule};
+use crate::{Guardrail, GuardrailChain, GuardrailVerdict};
+
+/// Build a chain from a snapshot's `guardrails` table.
+///
+/// Iteration order matches the table's deterministic id-sort. Each
+/// row produces at most one runtime `dyn Guardrail`. Failures
+/// (invalid regex, etc.) are logged and the row is skipped — same
+/// contract the loader uses for malformed etcd rows.
+pub fn build_chain_from_snapshot(table: &ResourceTable<DomainGuardrail>) -> GuardrailChain {
+    let mut chain: Vec<Arc<dyn Guardrail>> = Vec::new();
+
+    let entries = table.entries();
+    for entry in entries.iter() {
+        let row = &entry.value;
+        if !row.enabled {
+            continue;
+        }
+        match build_one(row) {
+            Ok(Some(g)) => chain.push(g),
+            Ok(None) => {
+                // Rule was technically valid but inert (e.g. empty
+                // keyword list). Skip silently — operators see this
+                // shape when they're staging a rule.
+            }
+            Err(err) => {
+                tracing::warn!(
+                    name = %row.name,
+                    id = %entry.id,
+                    error = %err,
+                    "skipping guardrail with invalid config",
+                );
+            }
+        }
+    }
+
+    GuardrailChain::new(chain)
+}
+
+fn build_one(row: &DomainGuardrail) -> Result<Option<Arc<dyn Guardrail>>, BuildError> {
+    match &row.config {
+        GuardrailKind::Keyword(cfg) => {
+            if cfg.patterns.is_empty() {
+                return Ok(None);
+            }
+            let mut rules = Vec::with_capacity(cfg.patterns.len());
+            for p in &cfg.patterns {
+                let rule = match p {
+                    KeywordPattern::Literal(s) => KeywordRule::literal(s.clone()),
+                    KeywordPattern::Regex(s) => {
+                        KeywordRule::regex(s).map_err(|e| BuildError::InvalidRegex {
+                            pattern: s.clone(),
+                            source: e,
+                        })?
+                    }
+                };
+                rules.push(rule);
+            }
+            // Map domain hook_point onto the runtime KeywordBlocklist
+            // constructors. `Both` is the default; the input/output
+            // narrowed forms exist for rules that are too expensive
+            // to run on the other side.
+            let blocklist = match row.hook_point {
+                GuardrailHookPoint::Input => KeywordBlocklist::input_only(rules),
+                GuardrailHookPoint::Output => KeywordBlocklist::output_only(rules),
+                GuardrailHookPoint::Both => KeywordBlocklist::new(rules),
+            };
+            Ok(Some(Arc::new(blocklist)))
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum BuildError {
+    #[error("invalid regex {pattern:?}: {source}")]
+    InvalidRegex {
+        pattern: String,
+        source: regex::Error,
+    },
+}
+
+/// Adapter that wraps a snapshot handle and rebuilds the runtime
+/// chain whenever the snapshot pointer changes. The chat handler
+/// holds an `Arc<dyn Guardrail>` pointing at this; it never sees
+/// the rebuild.
+///
+/// Cheap path (cache hit): one atomic load + one pointer compare,
+/// then a clone of an `Arc<GuardrailChain>`. Rebuild path (cache
+/// miss): runs through the entries table and recompiles regexes.
+/// Compilation only happens on the first call after each snapshot
+/// store from the etcd supervisor — typical run is one or zero
+/// rebuilds per minute even on a chatty configuration.
+pub struct LiveGuardrailChain {
+    snapshot: SnapshotHandle<AisixSnapshot>,
+    cache: Mutex<Cache>,
+}
+
+struct Cache {
+    /// Pointer-identity of the snapshot the chain was built from,
+    /// stored as `usize` for `Send + Sync` (this crate forbids
+    /// `unsafe`). `Arc::as_ptr` is stable for the snapshot's
+    /// lifetime; comparing the integer to a fresh load tells us
+    /// cheaply whether the supervisor stored a new snapshot since
+    /// we last rebuilt. We never deref the address.
+    last_snapshot_addr: usize,
+    chain: Arc<GuardrailChain>,
+}
+
+impl LiveGuardrailChain {
+    pub fn new(snapshot: SnapshotHandle<AisixSnapshot>) -> Arc<Self> {
+        // Eager-build at construct time so the very first chat
+        // doesn't pay the rebuild cost. The pointer recorded here
+        // is the snapshot at construct time — a subsequent store
+        // from the supervisor flips the cache miss bit on next
+        // check.
+        let snap = snapshot.load();
+        let chain = Arc::new(build_chain_from_snapshot(&snap.guardrails));
+        let last_snapshot_addr = Arc::as_ptr(&snap) as usize;
+        Arc::new(Self {
+            snapshot,
+            cache: Mutex::new(Cache {
+                last_snapshot_addr,
+                chain,
+            }),
+        })
+    }
+
+    fn current(&self) -> Arc<GuardrailChain> {
+        let snap = self.snapshot.load();
+        let cur_ptr = Arc::as_ptr(&snap) as usize;
+        let mut cache = self.cache.lock().expect("LiveGuardrailChain mutex poisoned");
+        if cache.last_snapshot_addr != cur_ptr {
+            cache.chain = Arc::new(build_chain_from_snapshot(&snap.guardrails));
+            cache.last_snapshot_addr = cur_ptr;
+        }
+        Arc::clone(&cache.chain)
+    }
+}
+
+#[async_trait]
+impl Guardrail for LiveGuardrailChain {
+    fn name(&self) -> &'static str {
+        "live_chain"
+    }
+
+    async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
+        self.current().check_input(req).await
+    }
+
+    async fn check_output(&self, resp: &ChatResponse) -> GuardrailVerdict {
+        self.current().check_output(resp).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::models::Guardrail as DomainGuardrail;
+    use aisix_core::resource::ResourceEntry;
+    use aisix_gateway::{ChatFormat, ChatMessage};
+
+    fn entry(_name: &str, id: &str, row: DomainGuardrail) -> ResourceEntry<DomainGuardrail> {
+        // `name` is documentary at the call site; the row's own
+        // `name` field is what the chain logs as.
+        ResourceEntry::new(id, row, 1)
+    }
+
+    fn parse(json: &str) -> DomainGuardrail {
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn req(msg: &str) -> ChatFormat {
+        ChatFormat::new("m", vec![ChatMessage::user(msg)])
+    }
+
+    #[tokio::test]
+    async fn enabled_keyword_row_blocks_matching_input() {
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "block-secrets",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "block-secrets",
+                    "kind": "keyword",
+                    "patterns": [
+                        { "kind": "literal", "value": "AKIA" }
+                    ]
+                }"#,
+            ),
+        ));
+        let chain = build_chain_from_snapshot(&table);
+        assert_eq!(chain.len(), 1);
+        let v = chain.check_input(&req("here is AKIAEXAMPLE")).await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn disabled_row_is_dropped() {
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "g",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "g",
+                    "enabled": false,
+                    "kind": "keyword",
+                    "patterns": [
+                        { "kind": "literal", "value": "AKIA" }
+                    ]
+                }"#,
+            ),
+        ));
+        let chain = build_chain_from_snapshot(&table);
+        assert_eq!(chain.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn empty_pattern_list_is_inert() {
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "g",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "g",
+                    "kind": "keyword",
+                    "patterns": []
+                }"#,
+            ),
+        ));
+        let chain = build_chain_from_snapshot(&table);
+        assert_eq!(chain.len(), 0, "empty list adds nothing to the chain");
+    }
+
+    #[tokio::test]
+    async fn invalid_regex_is_skipped_with_warning() {
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "good",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "good",
+                    "kind": "keyword",
+                    "patterns": [{ "kind": "literal", "value": "ok" }]
+                }"#,
+            ),
+        ));
+        // Domain layer accepts arbitrary strings as Regex(...); the
+        // regex compile only happens here. Inject a row with an
+        // unclosed bracket — the schema layer doesn't compile
+        // regexes either, so this slips through to us.
+        table.insert(entry(
+            "bad",
+            "g-2",
+            parse(
+                r#"{
+                    "name": "bad",
+                    "kind": "keyword",
+                    "patterns": [{ "kind": "regex", "value": "[unclosed" }]
+                }"#,
+            ),
+        ));
+
+        let chain = build_chain_from_snapshot(&table);
+        // Only the good row makes it in.
+        assert_eq!(chain.len(), 1);
+        let v = chain.check_input(&req("ok")).await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn live_chain_rebuilds_on_snapshot_swap() {
+        let initial = AisixSnapshot::new();
+        let handle = SnapshotHandle::new(initial);
+        let live = LiveGuardrailChain::new(handle.clone());
+
+        // Empty snapshot → no rules → input passes.
+        assert!(!live.check_input(&req("AKIA-EXAMPLE")).await.is_block());
+
+        // Build a new snapshot that adds a blocking keyword rule
+        // and store it. The next check_input must rebuild and
+        // reflect the new policy.
+        let next = AisixSnapshot::new();
+        next.guardrails.insert(entry(
+            "block-secrets",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "block-secrets",
+                    "kind": "keyword",
+                    "patterns": [
+                        { "kind": "literal", "value": "AKIA" }
+                    ]
+                }"#,
+            ),
+        ));
+        handle.store(next);
+
+        assert!(live.check_input(&req("AKIA-EXAMPLE")).await.is_block());
+    }
+
+    #[tokio::test]
+    async fn hook_point_input_only_skips_output() {
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "g",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "g",
+                    "kind": "keyword",
+                    "hook_point": "input",
+                    "patterns": [{ "kind": "literal", "value": "secret" }]
+                }"#,
+            ),
+        ));
+        let chain = build_chain_from_snapshot(&table);
+        // input check fires...
+        assert!(chain.check_input(&req("secret")).await.is_block());
+        // ...but output check is a noop on this rule.
+        use aisix_gateway::{ChatResponse, FinishReason, UsageStats};
+        let resp = ChatResponse {
+            id: "r".into(),
+            model: "m".into(),
+            message: ChatMessage::assistant("secret"),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(0, 0),
+        };
+        assert!(!chain.check_output(&resp).await.is_block());
+    }
+}

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -18,6 +18,7 @@
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
+mod build;
 mod chain;
 mod keyword;
 mod length;
@@ -25,6 +26,7 @@ mod length;
 use aisix_gateway::{ChatFormat, ChatResponse};
 use async_trait::async_trait;
 
+pub use build::{build_chain_from_snapshot, LiveGuardrailChain};
 pub use chain::GuardrailChain;
 pub use keyword::{KeywordBlocklist, KeywordRule};
 pub use length::MaxContentLength;

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -18,6 +18,7 @@ aisix-etcd = { path = "../aisix-etcd" }
 aisix-gateway = { path = "../aisix-gateway" }
 aisix-obs = { path = "../aisix-obs" }
 aisix-proxy = { path = "../aisix-proxy" }
+aisix-guardrails = { path = "../aisix-guardrails" }
 aisix-admin = { path = "../aisix-admin" }
 aisix-provider-openai = { path = "../aisix-provider-openai" }
 aisix-provider-anthropic = { path = "../aisix-provider-anthropic" }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -390,6 +390,16 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     if let Some(client) = budget_client {
         proxy_state = proxy_state.with_budget_client(client);
     }
+    // Live guardrail chain: rebuilds itself whenever the etcd watch
+    // supervisor stores a fresh snapshot, so dashboard mutations
+    // (`/guardrails` create / enable / delete) take effect within
+    // one watch tick. Empty `guardrails` table → chain is a noop;
+    // adding the wrapper costs one mutex + ptr-compare per chat,
+    // never a regex compile on the hot path. See
+    // `aisix_guardrails::LiveGuardrailChain`.
+    proxy_state = proxy_state.with_guardrails(aisix_guardrails::LiveGuardrailChain::new(
+        snapshot_handle.clone(),
+    ));
     // Clone shared trackers before consuming proxy_state in build_router.
     let health_tracker = proxy_state.health.clone();
     let proxy_router = aisix_proxy::build_router(proxy_state);


### PR DESCRIPTION
DP-side half of the guardrails feature. cp-api + dashboard land in a paired AISIX-Cloud PR.

aisix-core: new Guardrail resource — name, enabled, hook_point (input/output/both), kind/config. v1 ships kind: keyword only; the JSON Schema rejects unrecognized kinds so a half-wired DP can't silently skip the policy.

aisix-etcd: loader recognises 'guardrails' kind alongside the other resource tables.

aisix-guardrails: build_chain_from_snapshot turns the typed rows into a runtime GuardrailChain (KeywordBlocklist with literal/regex). LiveGuardrailChain wraps the snapshot handle and rebuilds whenever the supervisor stores a fresh snapshot — cache hit is one mutex + ptr-compare per chat (no regex compile on the hot path).

aisix-server/main.rs: injects a LiveGuardrailChain into ProxyState via the existing with_guardrails setter. Empty guardrails table = noop.

Tests: 5 new on build + live; 4 on the model/schema. Workspace cargo build / test / clippy all clean.