### PR TITLE
feat(guardrails): Phase 1 — accept kind=bedrock, chain skips with warn

### DIFF
--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -14,15 +14,15 @@
 //! lets operators narrow a rule to just one side (e.g. a PII regex
 //! that's expensive to run on long outputs).
 //!
-//! Rule kinds. v1 ships a single in-process kind plus a placeholder
-//! for the AWS Bedrock provider:
+//! Rule kinds:
 //!
 //!   * `keyword` — literal/regex blocklist; runs entirely in DP
 //!     process. Configured via `keyword.patterns` (list of
 //!     `{ kind: "literal" | "regex", value: "..." }`).
-//!   * `bedrock` — calls AWS Bedrock's ApplyGuardrail (TODO; the v1
-//!     loader rejects this kind so a half-wired DP doesn't silently
-//!     skip the policy).
+//!   * `bedrock` — calls AWS Bedrock's `ApplyGuardrail`. Phase 1
+//!     parses + accepts the kind but the chain builder logs
+//!     "bedrock not yet implemented" and skips the row; Phase 2
+//!     wires the actual dispatch (PRD-09c §6.7).
 //!
 //! See `aisix-guardrails/src/keyword.rs` for the runtime semantics
 //! the snapshot is parsed into.
@@ -65,6 +65,61 @@ pub struct KeywordConfig {
     pub patterns: Vec<KeywordPattern>,
 }
 
+/// AWS credentials for `kind: "bedrock"`. Phase 1 supports
+/// `static` (encrypted access-key pair); Phase 4 adds `role_arn`
+/// (sts:AssumeRole). The four ciphertext fields mirror cp-api's
+/// `provider_keys` envelope-encryption layout. They arrive as
+/// base64-encoded strings (Go's default JSON marshalling of
+/// `[]byte`); Phase 2 decodes them at chain build time using the
+/// master key shared via the dp-manager registration channel.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum BedrockAWSCredentials {
+    Static {
+        access_key_id: String,
+        /// Base64-encoded ciphertext. Phase 1 stores it; Phase 2
+        /// decodes + decrypts. Empty string on a corrupt cp-api
+        /// row — the chain builder will skip with a warn.
+        #[serde(default)]
+        secret_ciphertext: String,
+        #[serde(default)]
+        secret_nonce: String,
+        #[serde(default)]
+        encrypted_dek: String,
+        #[serde(default)]
+        master_key_id: String,
+    },
+}
+
+/// Per-guardrail latency policy for `kind: "bedrock"`. `serial`
+/// waits unconditionally; `timed` aborts at `timeout_ms` and
+/// applies the row-level `fail_open` flag. Range matches cp-api's
+/// validator (100..5000ms) — see PRD-09c §6.6.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum BedrockLatencyMode {
+    Serial,
+    Timed { timeout_ms: u32 },
+}
+
+/// Config block for `kind: "bedrock"`. Phase 1 stores the shape +
+/// passes it through `aisix-guardrails::build` which logs
+/// `bedrock not yet implemented` and skips the row.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BedrockConfig {
+    /// AWS-console-issued guardrail identifier (12 chars today).
+    pub guardrail_id: String,
+    /// Version label: `DRAFT`, `1`, `2`, ...
+    pub guardrail_version: String,
+    /// AWS region the Bedrock endpoint lives in (e.g. `us-east-1`).
+    pub region: String,
+    /// IAM credentials. v1 = static access keys (encrypted).
+    pub aws_credentials: BedrockAWSCredentials,
+    /// `serial` (default) or `timed { timeout_ms }`.
+    pub latency_mode: BedrockLatencyMode,
+}
+
 /// Provider discriminator. The kind drives which `*_config` block is
 /// expected; serde's `tag = "kind"` keeps us honest at parse time.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -72,10 +127,10 @@ pub struct KeywordConfig {
 pub enum GuardrailKind {
     /// In-process literal/regex blocklist. Always available.
     Keyword(KeywordConfig),
-    // Bedrock placeholder lives in the spec/PRD only for v1 — the DP
-    // refuses to load it. Adding the variant here lands with the
-    // ApplyGuardrail wiring; left out now to keep the snapshot
-    // schema strict.
+    /// AWS Bedrock managed guardrail. Phase 1 parses + persists;
+    /// the chain builder skips it with a warn log. Phase 2 wires
+    /// real `ApplyGuardrail` dispatch.
+    Bedrock(BedrockConfig),
 }
 
 /// Top-level `Guardrail` resource shape. Mirrors what cp-api writes
@@ -103,6 +158,14 @@ pub struct Guardrail {
     #[serde(default)]
     pub hook_point: GuardrailHookPoint,
 
+    /// Behavior when a remote-API guardrail (today `kind=bedrock`)
+    /// can't reach its upstream. `true` lets the request through
+    /// (recorded in usage_events.guardrail_bypassed_reason);
+    /// `false` blocks with 422. No-op for `kind=keyword`. Defaults
+    /// `true` (matches the PG schema default + PRD-09c §6.4).
+    #[serde(default = "default_fail_open")]
+    pub fail_open: bool,
+
     /// The provider discriminator + its config. Use serde's flattening
     /// so the wire shape is `{ kind: "keyword", patterns: [...] }`
     /// rather than `{ kind: "keyword", keyword: { patterns: [...] }}`.
@@ -114,6 +177,10 @@ pub struct Guardrail {
 }
 
 fn default_enabled() -> bool {
+    true
+}
+
+fn default_fail_open() -> bool {
     true
 }
 
@@ -161,6 +228,7 @@ mod tests {
                     KeywordPattern::Regex(r"\bssn:\s*\d{3}-\d{2}-\d{4}".into())
                 );
             }
+            GuardrailKind::Bedrock(_) => panic!("expected Keyword variant"),
         }
     }
 
@@ -174,6 +242,19 @@ mod tests {
         let g: Guardrail = serde_json::from_value(v).unwrap();
         assert!(g.enabled);
         assert_eq!(g.hook_point, GuardrailHookPoint::Both);
+        assert!(g.fail_open);
+    }
+
+    #[test]
+    fn fail_open_round_trips() {
+        let v = json!({
+            "name": "strict-bedrock",
+            "kind": "keyword",
+            "patterns": [],
+            "fail_open": false
+        });
+        let g: Guardrail = serde_json::from_value(v).unwrap();
+        assert!(!g.fail_open);
     }
 
     #[test]
@@ -193,17 +274,70 @@ mod tests {
     }
 
     #[test]
-    fn bedrock_kind_does_not_deserialise_yet() {
-        // Adding the variant lands when ApplyGuardrail is implemented.
-        // Until then the loader errors on `kind: "bedrock"` rather
-        // than silently letting a half-wired policy through.
+    fn bedrock_kind_parses_with_serial_latency() {
         let v = json!({
-            "name": "g",
+            "name": "block-pii",
             "kind": "bedrock",
-            "guardrail_id": "abc"
+            "guardrail_id": "abcdefgh1234",
+            "guardrail_version": "DRAFT",
+            "region": "us-east-1",
+            "aws_credentials": {
+                "kind": "static",
+                "access_key_id": "AKIAEXAMPLE",
+                "secret_ciphertext": "Y2lwaGVy",
+                "secret_nonce": "bm9uY2U=",
+                "encrypted_dek": "ZGVr",
+                "master_key_id": "mk-1"
+            },
+            "latency_mode": { "kind": "serial" }
         });
-        let r: Result<Guardrail, _> = serde_json::from_value(v);
-        assert!(r.is_err());
+        let g: Guardrail = serde_json::from_value(v).unwrap();
+        match g.config {
+            GuardrailKind::Bedrock(b) => {
+                assert_eq!(b.guardrail_id, "abcdefgh1234");
+                assert_eq!(b.region, "us-east-1");
+                assert!(matches!(b.latency_mode, BedrockLatencyMode::Serial));
+                match b.aws_credentials {
+                    BedrockAWSCredentials::Static {
+                        access_key_id,
+                        secret_ciphertext,
+                        ..
+                    } => {
+                        assert_eq!(access_key_id, "AKIAEXAMPLE");
+                        assert_eq!(secret_ciphertext, "Y2lwaGVy");
+                    }
+                }
+            }
+            _ => panic!("expected Bedrock variant"),
+        }
+    }
+
+    #[test]
+    fn bedrock_kind_parses_with_timed_latency() {
+        let v = json!({
+            "name": "block-pii",
+            "kind": "bedrock",
+            "guardrail_id": "id",
+            "guardrail_version": "1",
+            "region": "us-east-1",
+            "aws_credentials": {
+                "kind": "static",
+                "access_key_id": "AKIA",
+                "secret_ciphertext": "x",
+                "secret_nonce": "y",
+                "encrypted_dek": "z",
+                "master_key_id": "m"
+            },
+            "latency_mode": { "kind": "timed", "timeout_ms": 500 }
+        });
+        let g: Guardrail = serde_json::from_value(v).unwrap();
+        match g.config {
+            GuardrailKind::Bedrock(b) => match b.latency_mode {
+                BedrockLatencyMode::Timed { timeout_ms } => assert_eq!(timeout_ms, 500),
+                _ => panic!("expected Timed"),
+            },
+            _ => panic!("expected Bedrock variant"),
+        }
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -238,15 +238,16 @@ fn guardrail_schema() -> Value {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "required": ["name", "kind"],
-        // The keyword variant adds `patterns`; we don't lock it down
-        // at the top level because future kinds will introduce their
-        // own keys. The kind-specific oneOf below pins per-kind.
+        // Each kind variant adds its own keys; the per-kind oneOf
+        // below pins them. Top-level stays open so future kinds
+        // (lakera, protect_ai) only edit the oneOf branch.
         "additionalProperties": true,
         "properties": {
             "name":       { "type": "string", "minLength": 1 },
             "enabled":    { "type": "boolean" },
             "hook_point": { "enum": ["input", "output", "both"] },
-            "kind":       { "enum": ["keyword"] }
+            "fail_open":  { "type": "boolean" },
+            "kind":       { "enum": ["keyword", "bedrock"] }
         },
         "oneOf": [
             {
@@ -259,6 +260,21 @@ fn guardrail_schema() -> Value {
                         "items": { "$ref": "#/$defs/keyword_pattern" }
                     }
                 }
+            },
+            {
+                "type": "object",
+                "required": [
+                    "kind", "guardrail_id", "guardrail_version",
+                    "region", "aws_credentials", "latency_mode"
+                ],
+                "properties": {
+                    "kind":               { "const": "bedrock" },
+                    "guardrail_id":       { "type": "string", "minLength": 1, "maxLength": 64 },
+                    "guardrail_version":  { "type": "string", "minLength": 1, "maxLength": 16 },
+                    "region":             { "type": "string", "minLength": 1 },
+                    "aws_credentials":    { "$ref": "#/$defs/bedrock_aws_credentials" },
+                    "latency_mode":       { "$ref": "#/$defs/bedrock_latency_mode" }
+                }
             }
         ],
         "$defs": {
@@ -270,6 +286,41 @@ fn guardrail_schema() -> Value {
                     "kind":  { "enum": ["literal", "regex"] },
                     "value": { "type": "string", "minLength": 1 }
                 }
+            },
+            "bedrock_aws_credentials": {
+                "type": "object",
+                // v1 ships kind=static (encrypted access keys);
+                // Phase 4 adds kind=role_arn (sts:AssumeRole) under
+                // the same `kind` discriminator.
+                "required": ["kind", "access_key_id"],
+                "properties": {
+                    "kind":              { "const": "static" },
+                    "access_key_id":     { "type": "string", "minLength": 1 },
+                    "secret_ciphertext": { "type": "string" },
+                    "secret_nonce":      { "type": "string" },
+                    "encrypted_dek":     { "type": "string" },
+                    "master_key_id":     { "type": "string" }
+                },
+                "additionalProperties": false
+            },
+            "bedrock_latency_mode": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["kind"],
+                        "properties": { "kind": { "const": "serial" } }
+                    },
+                    {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["kind", "timeout_ms"],
+                        "properties": {
+                            "kind":       { "const": "timed" },
+                            "timeout_ms": { "type": "integer", "minimum": 100, "maximum": 5000 }
+                        }
+                    }
+                ]
             }
         }
     })
@@ -357,5 +408,72 @@ mod tests {
         let a = Arc::as_ptr(&*SCHEMAS);
         let b = Arc::as_ptr(&*SCHEMAS);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn guardrail_bedrock_serial_passes() {
+        let v = json!({
+            "name": "block-pii",
+            "kind": "bedrock",
+            "guardrail_id": "abcdefgh1234",
+            "guardrail_version": "DRAFT",
+            "region": "us-east-1",
+            "aws_credentials": {
+                "kind": "static",
+                "access_key_id": "AKIAEXAMPLE",
+                "secret_ciphertext": "Y2lwaGVy",
+                "secret_nonce": "bm9uY2U=",
+                "encrypted_dek": "ZGVr",
+                "master_key_id": "mk-1"
+            },
+            "latency_mode": { "kind": "serial" }
+        });
+        validate_guardrail(&v).unwrap();
+    }
+
+    #[test]
+    fn guardrail_bedrock_timed_with_valid_timeout_passes() {
+        let v = json!({
+            "name": "block-pii",
+            "kind": "bedrock",
+            "guardrail_id": "id",
+            "guardrail_version": "1",
+            "region": "us-east-1",
+            "aws_credentials": {
+                "kind": "static",
+                "access_key_id": "AKIA"
+            },
+            "latency_mode": { "kind": "timed", "timeout_ms": 500 }
+        });
+        validate_guardrail(&v).unwrap();
+    }
+
+    #[test]
+    fn guardrail_bedrock_timeout_below_min_rejected() {
+        let v = json!({
+            "name": "g",
+            "kind": "bedrock",
+            "guardrail_id": "id",
+            "guardrail_version": "1",
+            "region": "us-east-1",
+            "aws_credentials": { "kind": "static", "access_key_id": "AKIA" },
+            "latency_mode": { "kind": "timed", "timeout_ms": 50 }
+        });
+        assert!(validate_guardrail(&v).is_err());
+    }
+
+    #[test]
+    fn guardrail_bedrock_unknown_credential_kind_rejected() {
+        let v = json!({
+            "name": "g",
+            "kind": "bedrock",
+            "guardrail_id": "id",
+            "guardrail_version": "1",
+            "region": "us-east-1",
+            "aws_credentials": { "kind": "role_arn", "access_key_id": "AKIA" },
+            "latency_mode": { "kind": "serial" }
+        });
+        // Phase 4 will add role_arn; today it's rejected.
+        assert!(validate_guardrail(&v).is_err());
     }
 }

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -90,6 +90,17 @@ fn build_one(row: &DomainGuardrail) -> Result<Option<Arc<dyn Guardrail>>, BuildE
             };
             Ok(Some(Arc::new(blocklist)))
         }
+        GuardrailKind::Bedrock(_) => {
+            // Phase 1: cp-api accepts kind=bedrock and the snapshot
+            // carries the parsed BedrockConfig, but the runtime
+            // dispatcher (aws-sdk-bedrock-runtime client + KMS
+            // decrypt) doesn't ship until Phase 2 — see PRD-09c
+            // §6.7. Treat the row as disabled so it can't silently
+            // let traffic through, and warn loudly so a misconfig
+            // (Bedrock kind enabled before Phase 2 lands) is
+            // caught in DP logs.
+            Err(BuildError::NotYetImplemented("bedrock"))
+        }
     }
 }
 
@@ -100,6 +111,14 @@ enum BuildError {
         pattern: String,
         source: regex::Error,
     },
+    /// Reserved for guardrail kinds whose runtime dispatch isn't
+    /// wired yet (Phase 1 ships `bedrock` parsing but defers the
+    /// AWS SDK + KMS-decrypt path to Phase 2). The chain treats
+    /// these rows as disabled and the supervisor's warn log
+    /// surfaces the kind name so a misconfigured environment is
+    /// visible.
+    #[error("guardrail kind {0:?} not yet implemented; treating row as disabled")]
+    NotYetImplemented(&'static str),
 }
 
 /// Adapter that wraps a snapshot handle and rebuilds the runtime
@@ -291,6 +310,55 @@ mod tests {
         // Only the good row makes it in.
         assert_eq!(chain.len(), 1);
         let v = chain.check_input(&req("ok")).await;
+        assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn bedrock_kind_is_skipped_until_phase_2_lands() {
+        // Phase 1 contract: cp-api accepts kind=bedrock and the
+        // snapshot carries the parsed config, but the chain builder
+        // skips with a warn-log and the row contributes nothing to
+        // request-time enforcement. A keyword row in the same
+        // snapshot must still build + fire so a half-rolled
+        // environment doesn't get worse than no-op.
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "bedrock-row",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "bedrock-row",
+                    "kind": "bedrock",
+                    "guardrail_id": "abcdefgh1234",
+                    "guardrail_version": "DRAFT",
+                    "region": "us-east-1",
+                    "aws_credentials": {
+                        "kind": "static",
+                        "access_key_id": "AKIA",
+                        "secret_ciphertext": "Y2lwaGVy",
+                        "secret_nonce": "bm9uY2U=",
+                        "encrypted_dek": "ZGVr",
+                        "master_key_id": "mk-1"
+                    },
+                    "latency_mode": { "kind": "serial" }
+                }"#,
+            ),
+        ));
+        table.insert(entry(
+            "keyword-row",
+            "g-2",
+            parse(
+                r#"{
+                    "name": "keyword-row",
+                    "kind": "keyword",
+                    "patterns": [{ "kind": "literal", "value": "AKIA" }]
+                }"#,
+            ),
+        ));
+        let chain = build_chain_from_snapshot(&table);
+        // Only the keyword row materialises in the runtime chain.
+        assert_eq!(chain.len(), 1);
+        let v = chain.check_input(&req("here is AKIAEXAMPLE")).await;
         assert!(v.is_block());
     }
 


### PR DESCRIPTION
## Summary

Phase 1 of PRD-09c §6 Bedrock Guardrails. The DP now **parses + persists** kind=bedrock rows but **does not enforce** them — the chain builder logs "guardrail kind \"bedrock\" not yet implemented; treating row as disabled" so a misconfigured environment is visible in DP logs without silently letting traffic through.

Pairs with the cp-api PR (api7/AISIX-Cloud-budgets#TBD) which adds the matching CRUD validation + KMS envelope-encryption of the AWS secret.

## What lands

- \`aisix-core\`: \`BedrockConfig\` (+ \`BedrockAWSCredentials\` static-key variant + \`BedrockLatencyMode\` serial|timed). \`fail_open: bool\` on top-level \`Guardrail\` (defaults true).
- JSON Schema \`guardrail_schema()\` grows a per-kind oneOf branch for bedrock with \`$defs\` for credentials + latency_mode. Timeout range 100..5000ms.
- \`aisix-guardrails::build\`: \`BuildError::NotYetImplemented(&'static str)\` for kinds whose runtime path isn't wired. Bedrock arm returns it; existing warn path surfaces the row + kind.

## Phase 2 (separate PR)

- AWS-SDK \`bedrock-runtime\` client behind an LRU keyed by \`(region, access_key_id)\`.
- KMS decrypt of the ciphertext fields at chain build time.
- \`ApplyGuardrail\` dispatch on input + (non-streaming) output.
- \`latency_mode\` enforcement (\`timed\` aborts at \`timeout_ms\`, applies row's \`fail_open\`).
- \`guardrail_bypassed_reason\` telemetry tag on Bedrock 5xx / timeout / throttle bypass.

## Test plan

- [x] \`cargo test --workspace\` — all crates green
- [x] \`cargo clippy -p aisix-core -p aisix-guardrails --all-targets -- -D warnings\` clean
- [x] New regression: \`bedrock_kind_is_skipped_until_phase_2_lands\` (snapshot with bedrock + keyword row → chain of length 1, keyword still fires)
- [x] New schema tests: bedrock+serial, bedrock+timed, timeout-out-of-range rejected, unknown credentials kind rejected