### PR TITLE
feat(guardrails): GuardrailVerdict::Bypass + chat handler propagation (Phase 2 substrate)

### DIFF
--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -48,23 +48,45 @@ impl Guardrail for GuardrailChain {
     }
 
     async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
+        let mut bypass: Option<String> = None;
         for g in &self.guardrails {
             let verdict = g.check_input(req).await;
-            if verdict.is_block() {
-                return verdict;
+            match verdict {
+                GuardrailVerdict::Allow => continue,
+                GuardrailVerdict::Block { .. } => return verdict,
+                GuardrailVerdict::Bypass { reason } => {
+                    // First bypass sticks; downstream guardrails still
+                    // get to inspect the request (they may Block).
+                    if bypass.is_none() {
+                        bypass = Some(reason);
+                    }
+                }
             }
         }
-        GuardrailVerdict::Allow
+        match bypass {
+            Some(reason) => GuardrailVerdict::Bypass { reason },
+            None => GuardrailVerdict::Allow,
+        }
     }
 
     async fn check_output(&self, resp: &ChatResponse) -> GuardrailVerdict {
+        let mut bypass: Option<String> = None;
         for g in &self.guardrails {
             let verdict = g.check_output(resp).await;
-            if verdict.is_block() {
-                return verdict;
+            match verdict {
+                GuardrailVerdict::Allow => continue,
+                GuardrailVerdict::Block { .. } => return verdict,
+                GuardrailVerdict::Bypass { reason } => {
+                    if bypass.is_none() {
+                        bypass = Some(reason);
+                    }
+                }
             }
         }
-        GuardrailVerdict::Allow
+        match bypass {
+            Some(reason) => GuardrailVerdict::Bypass { reason },
+            None => GuardrailVerdict::Allow,
+        }
     }
 }
 
@@ -125,6 +147,57 @@ mod tests {
         ]);
         let v = chain.check_input(&req("this is way too long")).await;
         assert!(v.is_block());
+    }
+
+    /// Bypass doesn't short-circuit: a downstream Block must still
+    /// fire. This is the failure mode that matters when an operator
+    /// stacks a Bedrock guardrail (which can bypass on AWS 5xx) on
+    /// top of a keyword guardrail (which is local + always available).
+    #[tokio::test]
+    async fn bypass_does_not_short_circuit_keyword_block() {
+        struct AlwaysBypass;
+        #[async_trait]
+        impl Guardrail for AlwaysBypass {
+            fn name(&self) -> &'static str {
+                "always-bypass"
+            }
+            async fn check_input(&self, _req: &ChatFormat) -> GuardrailVerdict {
+                GuardrailVerdict::Bypass { reason: "test".into() }
+            }
+        }
+        let chain = GuardrailChain::new(vec![
+            Arc::new(AlwaysBypass),
+            Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("AKIA")])),
+        ]);
+        // Bypass first, then a keyword Block — Block must win.
+        let v = chain.check_input(&req("here is AKIAEXAMPLE")).await;
+        assert!(v.is_block(), "expected Block, got {v:?}");
+    }
+
+    /// When no guardrail blocks but at least one bypassed, the chain's
+    /// verdict is the first bypass reason — chat handler attaches
+    /// it to the telemetry event.
+    #[tokio::test]
+    async fn bypass_propagates_when_no_block_fires() {
+        struct AlwaysBypass(&'static str);
+        #[async_trait]
+        impl Guardrail for AlwaysBypass {
+            fn name(&self) -> &'static str {
+                "always-bypass"
+            }
+            async fn check_input(&self, _req: &ChatFormat) -> GuardrailVerdict {
+                GuardrailVerdict::Bypass { reason: self.0.into() }
+            }
+        }
+        let chain = GuardrailChain::new(vec![
+            Arc::new(AlwaysBypass("first")),
+            Arc::new(AlwaysBypass("second")),
+        ]);
+        let v = chain.check_input(&req("hello")).await;
+        match v {
+            GuardrailVerdict::Bypass { reason } => assert_eq!(reason, "first"),
+            other => panic!("expected Bypass, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -32,15 +32,38 @@ pub use keyword::{KeywordBlocklist, KeywordRule};
 pub use length::MaxContentLength;
 
 /// What a guardrail decided about a request or response.
+///
+/// `Bypass` exists for remote-API guardrails (kind=bedrock) whose
+/// upstream is unreachable but the operator configured `fail_open=true`:
+/// the request goes through, but the bypass is recorded on the
+/// telemetry event so a compliance audit can see what slipped past.
+/// `Bypass` is **not** a block — the chain doesn't short-circuit on
+/// it, and other guardrails downstream still get to inspect the
+/// request. See PRD-09c §6.4.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GuardrailVerdict {
     Allow,
     Block { reason: String },
+    Bypass { reason: String },
 }
 
 impl GuardrailVerdict {
     pub fn is_block(&self) -> bool {
         matches!(self, GuardrailVerdict::Block { .. })
+    }
+
+    pub fn is_bypass(&self) -> bool {
+        matches!(self, GuardrailVerdict::Bypass { .. })
+    }
+
+    /// Extract the bypass reason if this is a `Bypass` verdict, else
+    /// `None`. Used by the chat handler to attach
+    /// `guardrail_bypassed_reason` to the telemetry event.
+    pub fn bypass_reason(&self) -> Option<&str> {
+        match self {
+            GuardrailVerdict::Bypass { reason } => Some(reason.as_str()),
+            _ => None,
+        }
     }
 }
 
@@ -70,5 +93,13 @@ mod tests {
     fn verdict_helpers() {
         assert!(!GuardrailVerdict::Allow.is_block());
         assert!(GuardrailVerdict::Block { reason: "x".into() }.is_block());
+        assert!(!GuardrailVerdict::Allow.is_bypass());
+        assert!(GuardrailVerdict::Bypass { reason: "y".into() }.is_bypass());
+        assert!(!GuardrailVerdict::Bypass { reason: "y".into() }.is_block());
+        assert_eq!(
+            GuardrailVerdict::Bypass { reason: "y".into() }.bypass_reason(),
+            Some("y"),
+        );
+        assert_eq!(GuardrailVerdict::Allow.bypass_reason(), None);
     }
 }

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -118,6 +118,18 @@ pub struct UsageEvent {
 
     /// True when a guardrail rejected the request (input or output).
     pub guardrail_blocked: bool,
+
+    /// Set when at least one remote-API guardrail (today: kind=bedrock)
+    /// failed open: its upstream was unreachable but the operator
+    /// configured `fail_open=true`, so the request went through. The
+    /// reason ("bedrock_5xx" / "bedrock_timeout" / "bedrock_throttled")
+    /// is what gets recorded so a compliance audit can identify
+    /// requests that slipped past the policy. Empty string = no
+    /// bypass (the normal Allow / Block paths). cp-api persists this
+    /// to `dpmgr_usage_events.guardrail_bypassed_reason`; on the
+    /// wire empty maps to NULL via `skip_serializing_if`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub guardrail_bypassed_reason: String,
 }
 
 #[inline]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -102,6 +102,7 @@ pub async fn chat_completions(
                     provider_request_id: success.provider_request_id.clone(),
                     provider_model_version: success.provider_model_version.clone(),
                     finish_reason: success.finish_reason.clone(),
+                    bypass_reason: success.bypass_reason.clone().unwrap_or_default(),
                 },
                 success.cost_usd,
                 /* guardrail_blocked */ false,
@@ -229,6 +230,12 @@ struct Success {
     /// Cost computed via the per-key Budget's pricing table, in USD.
     /// 0.0 when no budget is configured for the key.
     cost_usd: f64,
+    /// Set when at least one guardrail returned `Bypass` (remote-API
+    /// guardrail upstream unreachable + `fail_open=true`). The first
+    /// bypass reason wins. Goes onto `usage_events.guardrail_bypassed_reason`
+    /// so a compliance audit can see what slipped past during a Bedrock
+    /// outage. None for the normal Allow / Block paths.
+    bypass_reason: Option<String>,
 }
 
 /// Returns `Ok(Success)` on the happy path, or `Err((resolved_model_id, err))`
@@ -269,9 +276,18 @@ async fn dispatch(
 
     // Input guardrails. Run before reservation so a blocked prompt
     // doesn't burn an RPM slot — content-policy refusals shouldn't
-    // count against quota.
-    if let GuardrailVerdict::Block { reason } = state.guardrails.check_input(req).await {
-        return Err(with_model(ProxyError::ContentFiltered(reason)));
+    // count against quota. Bypass (remote-API guardrail unavailable
+    // + fail_open=true) doesn't short-circuit; the reason is stashed
+    // and attached to the telemetry event when the request finishes.
+    let mut bypass_reason: Option<String> = None;
+    match state.guardrails.check_input(req).await {
+        GuardrailVerdict::Allow => {}
+        GuardrailVerdict::Block { reason } => {
+            return Err(with_model(ProxyError::ContentFiltered(reason)));
+        }
+        GuardrailVerdict::Bypass { reason } => {
+            bypass_reason = Some(reason);
+        }
     }
 
     // Budget pre-check via cp-api. The DP no longer owns budget state;
@@ -373,6 +389,7 @@ async fn dispatch(
             provider_request_id: String::new(),
             provider_model_version: String::new(),
             finish_reason: String::new(),
+            bypass_reason: bypass_reason.clone(),
         });
     }
 
@@ -432,6 +449,7 @@ async fn dispatch(
                     // Cache hits don't burn cost on our side (we already
                     // paid the upstream price the first time around).
                     cost_usd: 0.0,
+                    bypass_reason: bypass_reason.clone(),
                 });
             }
             Ok(None) => {}
@@ -521,8 +539,19 @@ async fn dispatch(
     // ingesting telemetry; the DP just records 0.0 on the wire.
     let cost_usd = 0.0;
 
-    if let GuardrailVerdict::Block { reason } = state.guardrails.check_output(&upstream).await {
-        return Err(with_model(ProxyError::ContentFiltered(reason)));
+    match state.guardrails.check_output(&upstream).await {
+        GuardrailVerdict::Allow => {}
+        GuardrailVerdict::Block { reason } => {
+            return Err(with_model(ProxyError::ContentFiltered(reason)));
+        }
+        GuardrailVerdict::Bypass { reason } => {
+            // First bypass wins — input bypass already populated
+            // bypass_reason if it fired, in which case we keep the
+            // earlier signal (it's the policy that failed first).
+            if bypass_reason.is_none() {
+                bypass_reason = Some(reason);
+            }
+        }
     }
 
     if let (Some(cache), Some(key)) = (state.cache.as_ref(), cache_key.as_ref()) {
@@ -553,6 +582,7 @@ async fn dispatch(
         provider_model_version,
         finish_reason,
         cost_usd,
+        bypass_reason,
     })
 }
 
@@ -624,6 +654,7 @@ fn emit_usage_event(
         finish_reason: extras.finish_reason,
         cost_usd,
         guardrail_blocked,
+        guardrail_bypassed_reason: extras.bypass_reason,
     });
 }
 
@@ -642,6 +673,12 @@ struct UsageExtras {
     provider_request_id: String,
     provider_model_version: String,
     finish_reason: String,
+    /// Set when at least one guardrail returned `Bypass` for this
+    /// request (remote-API guardrail upstream unreachable +
+    /// `fail_open=true`). Goes onto
+    /// `dpmgr_usage_events.guardrail_bypassed_reason`. Default empty
+    /// string = no bypass; cp-api stores NULL in that case.
+    bypass_reason: String,
 }
 
 fn record_error(metrics: &Metrics, err: &ProxyError, model: &str, status: u16, elapsed: Duration) {


### PR DESCRIPTION
## Summary

Phase 2 substrate for PRD-09c §6.4. Adds the third verdict variant that remote-API guardrails (kind=bedrock and future kinds like lakera / protect_ai) need when their upstream is unreachable but the operator configured \`fail_open=true\`: the request goes through, but the bypass reason flows onto the telemetry event so a compliance audit can identify what slipped past during a Bedrock outage.

**This PR is substrate only.** No AWS SDK, no BedrockGuardrail impl, no cp-api projection-time decrypt — those are deliberately split into the next two PRs:
- **PR-B** (next): \`aws-sdk-bedrockruntime\` dep + \`BedrockGuardrail\` impl + build.rs wires the chain. Adds ~30s to cold builds.
- **PR-C** (after): cp-api decrypt-at-projection + dpmgr telemetry column + dashboard /logs bypass badge.

## Verdict + chain semantics

- \`GuardrailVerdict::Bypass { reason }\` + \`is_bypass()\` / \`bypass_reason()\` helpers.
- Bypass does NOT short-circuit. A Bedrock guardrail bypassing on 5xx must not silently disarm a downstream keyword guardrail. If no Block fires, the chain returns the first bypass reason; if any Block fires, Block wins.
- 2 new chain tests pin the no-short-circuit + first-reason-sticky behavior.

## Wire shape

\`UsageEvent.guardrail_bypassed_reason: String\` — serde \`skip_serializing_if\` empty, maps to NULL on the cp-api side.

## Chat handler

Input + output checks now match three arms. \`bypass_reason\` flows from \`Success\` through \`UsageExtras\` into the emitted telemetry. First bypass wins when both input + output bypass on the same request.

## Test plan

- [x] \`cargo test --workspace\` — 30 aisix-guardrails + 103 aisix-proxy tests green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] New regression tests: \`bypass_does_not_short_circuit_keyword_block\`, \`bypass_propagates_when_no_block_fires\`
- [ ] PR-B will add: BedrockGuardrail with mocked aws-sdk + bypass test (5xx + fail_open=true → Bypass verdict)