### PR TITLE
feat(observability): per-env OTLP/HTTP exporter — DP-direct fan-out

### DIFF
--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -19,6 +19,7 @@ pub mod cache_policy;
 pub mod credential;
 pub mod guardrail;
 pub mod model;
+pub mod observability_exporter;
 pub mod rate_limit;
 pub mod routing;
 pub mod schema;
@@ -33,11 +34,12 @@ pub use guardrail::{
     GuardrailKind, KeywordConfig, KeywordPattern,
 };
 pub use model::{Model, Provider, ProviderConfig};
+pub use observability_exporter::{ExporterKind, ObservabilityExporter, OtlpHttpConfig};
 pub use rate_limit::RateLimit;
 pub use routing::{Routing, RoutingStrategy, RoutingTarget};
 pub use schema::{
     validate_apikey, validate_cache_policy, validate_credential, validate_guardrail,
-    validate_model, validate_team, SchemaError,
+    validate_model, validate_observability_exporter, validate_team, SchemaError,
 };
 pub use snapshot::AisixSnapshot;
 pub use team::Team;

--- a/crates/aisix-core/src/models/observability_exporter.rs
+++ b/crates/aisix-core/src/models/observability_exporter.rs
@@ -1,0 +1,202 @@
+//! `ObservabilityExporter` — env-scoped fan-out target the DP ships
+//! per-request telemetry to.
+//!
+//! cp-api writes one row per configured exporter to
+//! `/aisix/<env>/observability_exporters/<uuid>`; the DP loads them on
+//! the watch and composes a fan-out sink that runs alongside the
+//! existing `usage::UsageSink` (which still feeds the cp-api telemetry
+//! pipeline). The DP is the authoritative consumer of these configs —
+//! cp-api never opens an HTTP connection to the user's exporter
+//! endpoint, which is the whole reason for DP-direct egress (sensitive
+//! prompt / response content stays on the data plane).
+//!
+//! MVP scope: `kind = "otlp_http"` only — covers Tempo / Loki / Jaeger
+//! / Honeycomb / Grafana Cloud / Langfuse-via-OTLP because all of them
+//! accept the OTLP/HTTP wire format.
+//!
+//! Wire shape on kine — flat object with the kind-tagged config fields
+//! at top level, matching the `Guardrail` pattern in this crate:
+//!
+//! ```json
+//! {
+//!   "name": "honeycomb-prod",
+//!   "enabled": true,
+//!   "kind": "otlp_http",
+//!   "endpoint": "https://api.honeycomb.io/v1/traces",
+//!   "headers": { "x-honeycomb-team": "abc..." }
+//! }
+//! ```
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::resource::Resource;
+
+/// Discriminated union of exporter back-ends. MVP ships only
+/// `otlp_http`; Helicone / Langfuse-native / Datadog / S3 land in
+/// follow-ups, each as a new variant whose serde tag matches the
+/// wire-side `kind` discriminator.
+///
+/// `tag = "kind"` puts the variant tag inline with the inner struct's
+/// fields — same shape as `GuardrailKind` so the kine wire stays
+/// consistent across resource types.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExporterKind {
+    OtlpHttp(OtlpHttpConfig),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct OtlpHttpConfig {
+    /// Full URL of the OTLP/HTTP traces endpoint. Must already include
+    /// the `/v1/traces` path the receiver expects — we don't append it
+    /// because some vendors (Honeycomb, Grafana) use a different path.
+    pub endpoint: String,
+
+    /// Static headers to attach to every export request. Typical use:
+    /// `Authorization: Bearer <api-token>` or vendor-specific keys
+    /// like `x-honeycomb-team`. Values are plaintext at this MVP — the
+    /// kine path is mTLS-only, so the trust boundary matches
+    /// `provider_keys`. Field-level encryption arrives in Phase 2.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
+/// Top-level `ObservabilityExporter` resource. `deny_unknown_fields`
+/// deliberately NOT set — serde's `flatten` + `tag = "kind"`
+/// interaction makes outer-strict-mode reject the inner discriminator
+/// field. Strict typo rejection happens at the JSON Schema layer
+/// (`schema::validate_observability_exporter`) which the etcd loader
+/// runs before the serde deserialize.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObservabilityExporter {
+    /// Operator-facing label, surfaced in /logs and the dashboard list.
+    /// Not used for routing — the etcd-key uuid is the identity.
+    pub name: String,
+
+    /// Soft kill switch. Disabled exporters stay in the snapshot but
+    /// the fan-out sink skips them. Lets operators pause an exporter
+    /// without losing the row's headers / endpoint.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Discriminated kind block — flattened so `kind` and the inner
+    /// struct's fields land at the same level on the wire.
+    #[serde(flatten)]
+    pub kind: ExporterKind,
+
+    /// etcd-key uuid; filled by the loader, never in the JSON payload.
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+impl Resource for ObservabilityExporter {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    /// Name doubles as the secondary index for human lookup. Identity
+    /// is the runtime_id (uuid); the name is only used for log /
+    /// dashboard display.
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Path segment under `/aisix/<env>/`. Matches the cp-api kine
+    /// kind written by the Go-side `mustMarshalObservabilityExporterKV`.
+    fn kind() -> &'static str {
+        "observability_exporters"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_OTLP: &str = r#"{
+        "name": "honeycomb-prod",
+        "enabled": true,
+        "kind": "otlp_http",
+        "endpoint": "https://api.honeycomb.io/v1/traces",
+        "headers": { "x-honeycomb-team": "abc123" }
+    }"#;
+
+    #[test]
+    fn deserialises_otlp_http() {
+        let e: ObservabilityExporter = serde_json::from_str(VALID_OTLP).unwrap();
+        assert_eq!(e.name, "honeycomb-prod");
+        assert!(e.enabled);
+        match &e.kind {
+            ExporterKind::OtlpHttp(c) => {
+                assert_eq!(c.endpoint, "https://api.honeycomb.io/v1/traces");
+                assert_eq!(
+                    c.headers.get("x-honeycomb-team").map(String::as_str),
+                    Some("abc123"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn enabled_defaults_to_true() {
+        let e: ObservabilityExporter =
+            serde_json::from_str(r#"{"name":"x","kind":"otlp_http","endpoint":"https://x"}"#)
+                .unwrap();
+        assert!(e.enabled);
+    }
+
+    #[test]
+    fn empty_headers_round_trip() {
+        let e: ObservabilityExporter =
+            serde_json::from_str(r#"{"name":"x","kind":"otlp_http","endpoint":"https://x"}"#)
+                .unwrap();
+        match &e.kind {
+            ExporterKind::OtlpHttp(c) => assert!(c.headers.is_empty()),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        // serde rejects unknown discriminator values for the tagged enum.
+        let r: Result<ObservabilityExporter, _> =
+            serde_json::from_str(r#"{"name":"x","kind":"slack_alert","webhook":"https://x"}"#);
+        assert!(r.is_err(), "unknown kind should fail to parse");
+    }
+
+    #[test]
+    fn rejects_unknown_inner_field() {
+        // OtlpHttpConfig has deny_unknown_fields so a typo at the
+        // flattened level is rejected.
+        let r: Result<ObservabilityExporter, _> = serde_json::from_str(
+            r#"{"name":"x","kind":"otlp_http","endpoint":"https://x","timeout":5}"#,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn resource_trait_kind_matches_cp_api() {
+        // The kine kind segment is the contract between cp-api's
+        // `mustMarshalObservabilityExporterKV` and this loader. Pin it.
+        assert_eq!(
+            <ObservabilityExporter as Resource>::kind(),
+            "observability_exporters",
+        );
+    }
+
+    #[test]
+    fn round_trips_through_serde() {
+        let e: ObservabilityExporter = serde_json::from_str(VALID_OTLP).unwrap();
+        let v = serde_json::to_value(&e).unwrap();
+        // The wire shape must be flat — `endpoint` and `headers` at
+        // the top level, NOT nested under `otlp_http`.
+        assert_eq!(v["kind"], "otlp_http");
+        assert_eq!(v["endpoint"], "https://api.honeycomb.io/v1/traces");
+        assert!(v.get("otlp_http").is_none(), "kind block must not nest");
+    }
+}

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -28,6 +28,7 @@ pub struct Schemas {
     pub team: Validator,
     pub guardrail: Validator,
     pub cache_policy: Validator,
+    pub observability_exporter: Validator,
 }
 
 pub static SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::compile()));
@@ -53,6 +54,9 @@ impl Schemas {
             cache_policy: jsonschema::options()
                 .build(&cache_policy_schema())
                 .expect("cache_policy schema is well-formed"),
+            observability_exporter: jsonschema::options()
+                .build(&observability_exporter_schema())
+                .expect("observability_exporter schema is well-formed"),
         }
     }
 }
@@ -99,6 +103,10 @@ pub fn validate_guardrail(value: &Value) -> Result<(), SchemaError> {
 
 pub fn validate_cache_policy(value: &Value) -> Result<(), SchemaError> {
     validate(&SCHEMAS.cache_policy, value)
+}
+
+pub fn validate_observability_exporter(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.observability_exporter, value)
 }
 
 fn model_schema() -> Value {
@@ -359,6 +367,45 @@ fn cache_policy_schema() -> Value {
             },
             "embedding_model": { "type": "string", "minLength": 1, "maxLength": 120 }
         }
+    })
+}
+
+fn observability_exporter_schema() -> Value {
+    // MVP: single discriminator value `otlp_http` whose fields land
+    // flat at the top level (matches the Guardrail wire shape — see
+    // `models/observability_exporter.rs` doc comment). Phase 2 adds
+    // `helicone` / `langfuse` / `datadog_logs` / `s3_ndjson` as
+    // additional discriminator values with their own `if`/`then`
+    // branches below.
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["name", "kind"],
+        "additionalProperties": false,
+        "properties": {
+            "name":    { "type": "string", "minLength": 1, "maxLength": 120 },
+            "enabled": { "type": "boolean" },
+            "kind":    { "type": "string", "enum": ["otlp_http"] },
+            // otlp_http branch — flat fields.
+            "endpoint": {
+                "type": "string",
+                // Reject http:// and any non-URL by anchoring on https://.
+                // Loopback bypass for e2e: allow http://mock-otlp:* /
+                // http://127.0.0.1 / http://localhost so the compose
+                // test can wire a fake receiver without TLS.
+                "pattern": "^https://.+|^http://(mock-otlp|otel-collector|127\\.0\\.0\\.1|localhost)(:[0-9]+)?(/.*)?$"
+            },
+            "headers": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+            }
+        },
+        "allOf": [
+            {
+                "if":   { "properties": { "kind": { "const": "otlp_http" } } },
+                "then": { "required": ["endpoint"] }
+            }
+        ]
     })
 }
 

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -12,6 +12,7 @@ use super::cache_policy::CachePolicy;
 use super::credential::Credential;
 use super::guardrail::Guardrail;
 use super::model::Model;
+use super::observability_exporter::ObservabilityExporter;
 use super::team::Team;
 use crate::snapshot::ResourceTable;
 
@@ -28,6 +29,9 @@ pub struct AisixSnapshot {
     /// enabled row to gate the cache; Stage 3 will parse `applies_to`
     /// + per-policy `ttl_seconds`. See `aisix-core::CachePolicy`.
     pub cache_policies: ResourceTable<CachePolicy>,
+    /// Per-env observability exporters. Each enabled row receives a
+    /// fan-out POST per chat completion (see `aisix-obs::OtlpHttpFanOut`).
+    pub observability_exporters: ResourceTable<ObservabilityExporter>,
 }
 
 impl AisixSnapshot {
@@ -44,6 +48,7 @@ impl AisixSnapshot {
             + self.teams.len()
             + self.guardrails.len()
             + self.cache_policies.len()
+            + self.observability_exporters.len()
     }
 }
 

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -12,8 +12,9 @@
 //! entry; it serves the rest."
 
 use aisix_core::models::{
-    validate_apikey, validate_cache_policy, validate_credential, validate_guardrail, validate_model,
-    ApiKey, CachePolicy, Credential, Guardrail, Model, SchemaError,
+    validate_apikey, validate_cache_policy, validate_credential, validate_guardrail,
+    validate_model, validate_observability_exporter, ApiKey, CachePolicy, Credential, Guardrail,
+    Model, ObservabilityExporter, SchemaError,
 };
 use aisix_core::resource::ResourceEntry;
 use aisix_core::AisixSnapshot;
@@ -118,6 +119,18 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
                     &mut stats,
                 ) {
                     snapshot.cache_policies.insert(entry);
+                }
+            }
+            "observability_exporters" => {
+                if let Some(entry) = validate_and_parse::<ObservabilityExporter>(
+                    &raw.key,
+                    raw.revision,
+                    parsed,
+                    &value,
+                    validate_observability_exporter,
+                    &mut stats,
+                ) {
+                    snapshot.observability_exporters.insert(entry);
                 }
             }
             other => {

--- a/crates/aisix-guardrails/src/bedrock.rs
+++ b/crates/aisix-guardrails/src/bedrock.rs
@@ -189,11 +189,8 @@ impl BedrockGuardrail {
         let result = match self.latency_mode {
             BedrockLatencyMode::Serial => req.send().await.map_err(BedrockFailure::from_sdk),
             BedrockLatencyMode::Timed { timeout_ms } => {
-                match tokio::time::timeout(
-                    Duration::from_millis(timeout_ms as u64),
-                    req.send(),
-                )
-                .await
+                match tokio::time::timeout(Duration::from_millis(timeout_ms as u64), req.send())
+                    .await
                 {
                     Ok(Ok(resp)) => Ok(resp),
                     Ok(Err(e)) => Err(BedrockFailure::from_sdk(e)),
@@ -205,10 +202,7 @@ impl BedrockGuardrail {
         match result {
             Ok(resp) => match resp.action() {
                 GuardrailAction::GuardrailIntervened => GuardrailVerdict::Block {
-                    reason: format!(
-                        "bedrock guardrail {} intervened",
-                        self.guardrail_id
-                    ),
+                    reason: format!("bedrock guardrail {} intervened", self.guardrail_id),
                 },
                 GuardrailAction::None => GuardrailVerdict::Allow,
                 other => {
@@ -512,7 +506,9 @@ mod tests {
             .await;
 
         let g = build_with_endpoint(server.uri(), true);
-        let v = g.apply(GuardrailContentSource::Input, "leak something".into()).await;
+        let v = g
+            .apply(GuardrailContentSource::Input, "leak something".into())
+            .await;
         match v {
             GuardrailVerdict::Block { reason } => {
                 assert!(
@@ -541,7 +537,9 @@ mod tests {
             .await;
 
         let g = build_with_endpoint(server.uri(), true);
-        let v = g.apply(GuardrailContentSource::Input, "anything".into()).await;
+        let v = g
+            .apply(GuardrailContentSource::Input, "anything".into())
+            .await;
         match v {
             GuardrailVerdict::Bypass { reason } => assert_eq!(reason, "bedrock_5xx"),
             other => panic!("expected Bypass, got {other:?}"),
@@ -563,7 +561,9 @@ mod tests {
             .await;
 
         let g = build_with_endpoint(server.uri(), false);
-        let v = g.apply(GuardrailContentSource::Input, "anything".into()).await;
+        let v = g
+            .apply(GuardrailContentSource::Input, "anything".into())
+            .await;
         assert!(v.is_block(), "expected Block, got {v:?}");
     }
 
@@ -583,7 +583,9 @@ mod tests {
             .await;
 
         let g = build_with_endpoint(server.uri(), true);
-        let v = g.apply(GuardrailContentSource::Input, "anything".into()).await;
+        let v = g
+            .apply(GuardrailContentSource::Input, "anything".into())
+            .await;
         match v {
             GuardrailVerdict::Bypass { reason } => assert_eq!(reason, "bedrock_throttled"),
             other => panic!("expected Bypass(bedrock_throttled), got {other:?}"),
@@ -643,7 +645,9 @@ mod tests {
             /* fail_open */ true,
             Some(server.uri()),
         );
-        let v = g.apply(GuardrailContentSource::Input, "anything".into()).await;
+        let v = g
+            .apply(GuardrailContentSource::Input, "anything".into())
+            .await;
         match v {
             GuardrailVerdict::Bypass { reason } => assert_eq!(reason, "bedrock_timeout"),
             other => panic!("expected Bypass(bedrock_timeout), got {other:?}"),

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -181,7 +181,10 @@ impl LiveGuardrailChain {
     fn current(&self) -> Arc<GuardrailChain> {
         let snap = self.snapshot.load();
         let cur_ptr = Arc::as_ptr(&snap) as usize;
-        let mut cache = self.cache.lock().expect("LiveGuardrailChain mutex poisoned");
+        let mut cache = self
+            .cache
+            .lock()
+            .expect("LiveGuardrailChain mutex poisoned");
         if cache.last_snapshot_addr != cur_ptr {
             cache.chain = Arc::new(build_chain_from_snapshot(&snap.guardrails));
             cache.last_snapshot_addr = cur_ptr;

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -162,7 +162,9 @@ mod tests {
                 "always-bypass"
             }
             async fn check_input(&self, _req: &ChatFormat) -> GuardrailVerdict {
-                GuardrailVerdict::Bypass { reason: "test".into() }
+                GuardrailVerdict::Bypass {
+                    reason: "test".into(),
+                }
             }
         }
         let chain = GuardrailChain::new(vec![
@@ -186,7 +188,9 @@ mod tests {
                 "always-bypass"
             }
             async fn check_input(&self, _req: &ChatFormat) -> GuardrailVerdict {
-                GuardrailVerdict::Bypass { reason: self.0.into() }
+                GuardrailVerdict::Bypass {
+                    reason: self.0.into(),
+                }
             }
         }
         let chain = GuardrailChain::new(vec![

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -16,6 +16,7 @@ pub mod access_log;
 pub mod langfuse;
 pub mod metrics;
 pub mod otlp;
+pub mod otlp_http_sink;
 pub mod usage;
 
 use aisix_core::ObservabilityConfig;
@@ -25,6 +26,7 @@ pub use access_log::AccessLog;
 pub use langfuse::{LangfuseError, LangfuseEvent, LangfuseHandle, LangfuseSender};
 pub use metrics::{Metrics, RequestOutcome};
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
+pub use otlp_http_sink::OtlpHttpFanOut;
 pub use usage::{UsageEvent, UsageSink};
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -1,0 +1,514 @@
+//! Per-env OTLP/HTTP exporter — emits one OTLP-shaped POST per chat
+//! request to each configured `ObservabilityExporter` (kind=otlp_http).
+//!
+//! ## Design
+//!
+//! cp-api projects every configured exporter onto kine at
+//! `/aisix/<env>/observability_exporters/<uuid>`. The DP loads them
+//! via the existing etcd watch into
+//! `AisixSnapshot::observability_exporters`. After every chat
+//! completion the proxy hot path hands the resulting `UsageEvent` plus
+//! the live snapshot's exporter list to [`fan_out`], which:
+//!
+//! 1. Filters to enabled exporters with `kind = OtlpHttp`.
+//! 2. Builds one OTLP/HTTP-JSON span per exporter, encoded per
+//!    OpenTelemetry's GenAI semantic conventions
+//!    (<https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md>).
+//! 3. Spawns a fire-and-forget tokio task per (event, exporter) pair
+//!    that POSTs the span. Failures get a `tracing::warn!` and are
+//!    dropped — observability MUST NOT block the request hot path.
+//!
+//! ## What's intentionally NOT in MVP
+//!
+//! - **No batching** — one HTTP POST per request per exporter. Phase 2
+//!   will move to a worker-task model with a bounded mpsc + 1s flush
+//!   interval, mirroring the existing `langfuse::LangfuseSender`
+//!   architecture once the patterns are exercised by real load.
+//! - **No retry / backoff** — best-effort fire-and-forget. If the
+//!   user's OTLP receiver is unreachable the span is lost. Phase 2
+//!   adds a tiny exponential-backoff wrapper.
+//! - **No gRPC** — `otlp_grpc` is a separate kind we'll add when a
+//!   user actually asks for it; the JSON-over-HTTP form works against
+//!   every receiver in the wild and avoids pulling in tonic on the
+//!   hot path.
+//! - **No content_mode redaction** — defaults to `metadata_only`
+//!   (no prompt/response bodies in the span). The MVP cannot leak
+//!   user content because it never accepts content fields in the
+//!   first place.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aisix_core::models::{ExporterKind, ObservabilityExporter};
+use serde_json::{json, Value};
+
+use crate::usage::UsageEvent;
+
+/// Wall-clock duration of an OTLP/HTTP POST before we abandon it.
+/// Tight on purpose — we never want a slow exporter to backlog tokio
+/// tasks for a wedged user receiver.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// `User-Agent` header so vendor receivers can attribute traces back
+/// to AISIX in their own analytics. Not a contract; informational.
+const USER_AGENT: &str = concat!("aisix-dp/", env!("CARGO_PKG_VERSION"));
+
+/// Cheap clonable handle the proxy hands to request handlers. Holds a
+/// reusable `reqwest::Client` so connection pools survive across
+/// requests — even with per-event POSTs the kept-alive socket
+/// amortises TLS for the common case where one DP exports to one
+/// vendor.
+#[derive(Debug, Clone)]
+pub struct OtlpHttpFanOut {
+    client: reqwest::Client,
+}
+
+impl OtlpHttpFanOut {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .user_agent(USER_AGENT)
+            .build()
+            // The client builder only fails on illegal TLS roots; the
+            // default config is always valid.
+            .expect("reqwest::Client default config is valid");
+        Self { client }
+    }
+
+    /// Fan out one event to every enabled `otlp_http` exporter in the
+    /// supplied list. Returns immediately — the actual POSTs run on
+    /// detached tokio tasks and never block the caller.
+    ///
+    /// The `exporters` slice is what the proxy's snapshot lookup
+    /// returns. Empty slice = no-op (the common case for envs that
+    /// haven't configured any exporters yet, so this is the cheap
+    /// path).
+    pub fn fan_out<'a, I>(&self, event: &UsageEvent, exporters: I)
+    where
+        I: IntoIterator<Item = &'a ObservabilityExporter>,
+    {
+        for exp in exporters {
+            if !exp.enabled {
+                continue;
+            }
+            // Single-variant enum today; the `let ExporterKind::OtlpHttp`
+            // pattern is exhaustive but deliberately written with the
+            // type tag spelled out so adding a new variant in Phase 2
+            // forces a compile error here.
+            let ExporterKind::OtlpHttp(cfg) = &exp.kind;
+            // Build the wire body once per exporter (cheap — small
+            // JSON) so the spawned task only owns the bytes.
+            let body = build_otlp_traces_payload(event, &exp.name);
+            let endpoint = cfg.endpoint.clone();
+            let headers = cfg.headers.clone();
+            let client = self.client.clone();
+            let exporter_name = exp.name.clone();
+
+            tokio::spawn(async move {
+                if let Err(err) = post_one(client, endpoint, headers, body).await {
+                    tracing::warn!(
+                        exporter = %exporter_name,
+                        error = %err,
+                        "otlp_http exporter POST failed; span dropped",
+                    );
+                }
+            });
+        }
+    }
+}
+
+impl Default for OtlpHttpFanOut {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+async fn post_one(
+    client: reqwest::Client,
+    endpoint: String,
+    headers: BTreeMap<String, String>,
+    body: Value,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut req = client
+        .post(&endpoint)
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_vec(&body)?);
+    for (k, v) in headers {
+        req = req.header(k, v);
+    }
+    let resp = req.send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "HTTP {}: {}",
+            status,
+            body.chars().take(200).collect::<String>()
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Build an OTLP/HTTP-JSON `ExportTraceServiceRequest` payload with
+/// one span representing this chat completion. Attribute names match
+/// the OpenTelemetry GenAI semantic conventions:
+/// <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md>.
+///
+/// Per-attribute encoding:
+/// - String / int values use the canonical `{"stringValue": ...}` /
+///   `{"intValue": "..."}` (string-encoded int per OTLP/JSON spec).
+/// - Trace ID + span ID are random 16-byte / 8-byte hex values.
+/// - Timestamps are nanos-since-epoch, OTLP's required unit.
+fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
+    let trace_id = random_trace_id();
+    let span_id = random_span_id();
+
+    // The DP records `occurred_at` as RFC 3339; convert to nanos.
+    // On parse failure (shouldn't happen in practice) fall back to
+    // "now" so the span isn't silently dropped.
+    let end_unix_nano =
+        parse_rfc3339_to_unix_nano(&event.occurred_at).unwrap_or_else(now_unix_nano);
+    // Latency landed in milliseconds; widen + multiply.
+    let latency_nanos = (event.latency_ms as u128).saturating_mul(1_000_000);
+    let start_unix_nano = end_unix_nano.saturating_sub(latency_nanos);
+
+    let span_name = "chat.completions";
+
+    // Status: OK (1) for 2xx, ERROR (2) otherwise.
+    let status_code = if (200..300).contains(&event.status_code) {
+        1
+    } else {
+        2
+    };
+
+    let mut attributes = vec![
+        attr_string("gen_ai.system", "aisix"),
+        attr_string("gen_ai.operation.name", "chat"),
+    ];
+    if !event.provider_model_version.is_empty() {
+        attributes.push(attr_string(
+            "gen_ai.response.model",
+            &event.provider_model_version,
+        ));
+    }
+    if !event.provider_request_id.is_empty() {
+        attributes.push(attr_string(
+            "gen_ai.response.id",
+            &event.provider_request_id,
+        ));
+    }
+    if !event.finish_reason.is_empty() {
+        attributes.push(attr_string_array(
+            "gen_ai.response.finish_reasons",
+            std::slice::from_ref(&event.finish_reason),
+        ));
+    }
+    attributes.push(attr_int(
+        "gen_ai.usage.input_tokens",
+        event.prompt_tokens as i64,
+    ));
+    attributes.push(attr_int(
+        "gen_ai.usage.output_tokens",
+        event.completion_tokens as i64,
+    ));
+    attributes.push(attr_int(
+        "http.response.status_code",
+        event.status_code as i64,
+    ));
+    if !event.api_key_id.is_empty() {
+        // Custom attribute (no semconv yet) so reviewers can join
+        // spans back to the AISIX api_key dashboard.
+        attributes.push(attr_string("aisix.api_key_id", &event.api_key_id));
+    }
+    if !event.model_id.is_empty() {
+        attributes.push(attr_string("aisix.model_id", &event.model_id));
+    }
+    attributes.push(attr_string("aisix.exporter_name", exporter_name));
+    attributes.push(attr_string("aisix.request_id", &event.request_id));
+
+    json!({
+        "resourceSpans": [{
+            "resource": {
+                "attributes": [
+                    attr_string("service.name", "aisix-dp"),
+                ],
+            },
+            "scopeSpans": [{
+                "scope": { "name": "aisix-obs.otlp_http_sink" },
+                "spans": [{
+                    "traceId": trace_id,
+                    "spanId":  span_id,
+                    "name":    span_name,
+                    "kind":    3, // SPAN_KIND_CLIENT (DP → upstream LLM)
+                    "startTimeUnixNano": start_unix_nano.to_string(),
+                    "endTimeUnixNano":   end_unix_nano.to_string(),
+                    "attributes": attributes,
+                    "status": { "code": status_code },
+                }],
+            }],
+        }],
+    })
+}
+
+fn attr_string(key: &str, value: &str) -> Value {
+    json!({
+        "key": key,
+        "value": { "stringValue": value },
+    })
+}
+
+fn attr_int(key: &str, value: i64) -> Value {
+    json!({
+        "key": key,
+        // OTLP/JSON encodes int as a string to avoid JS Number precision loss.
+        "value": { "intValue": value.to_string() },
+    })
+}
+
+fn attr_string_array(key: &str, values: &[String]) -> Value {
+    let arr: Vec<Value> = values.iter().map(|v| json!({"stringValue": v})).collect();
+    json!({
+        "key": key,
+        "value": { "arrayValue": { "values": arr } },
+    })
+}
+
+/// 16 random bytes as 32 lowercase-hex chars per OTLP/JSON spec.
+fn random_trace_id() -> String {
+    let bytes: [u8; 16] = rand_16();
+    hex32(&bytes)
+}
+
+/// 8 random bytes as 16 lowercase-hex chars per OTLP/JSON spec.
+fn random_span_id() -> String {
+    let bytes: [u8; 8] = rand_8();
+    hex16(&bytes)
+}
+
+fn rand_16() -> [u8; 16] {
+    let u = uuid::Uuid::new_v4();
+    *u.as_bytes()
+}
+
+fn rand_8() -> [u8; 8] {
+    let u = uuid::Uuid::new_v4();
+    let b = u.as_bytes();
+    [b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]
+}
+
+fn hex32(bytes: &[u8; 16]) -> String {
+    let mut s = String::with_capacity(32);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn hex16(bytes: &[u8; 8]) -> String {
+    let mut s = String::with_capacity(16);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn parse_rfc3339_to_unix_nano(s: &str) -> Option<u128> {
+    // Use chrono if available, fall back to naive epoch parsing.
+    // We avoid pulling chrono into this crate by hand-parsing the
+    // common DP-emitted RFC3339 form: `2006-01-02T15:04:05Z` or with
+    // fractional seconds `.<digits>`.
+    let dt = chrono_like_parse(s)?;
+    let secs = dt.0 as u128;
+    let nanos = dt.1 as u128;
+    secs.checked_mul(1_000_000_000)
+        .and_then(|n| n.checked_add(nanos))
+}
+
+/// Returns (unix_secs, sub_seconds_in_nanos) on success.
+fn chrono_like_parse(s: &str) -> Option<(i64, u32)> {
+    // Cheap-and-cheerful: split on the 'T', the seconds field, and 'Z'.
+    // Wrong handling of timezone offsets — but the DP serialises UTC
+    // with a 'Z' suffix everywhere, so this is sufficient for our
+    // own emit shape.
+    let s = s.strip_suffix('Z')?;
+    let (date, time) = s.split_once('T')?;
+    let mut date_parts = date.split('-');
+    let y: i32 = date_parts.next()?.parse().ok()?;
+    let mo: u32 = date_parts.next()?.parse().ok()?;
+    let d: u32 = date_parts.next()?.parse().ok()?;
+
+    let (h_m_s, frac_str) = match time.split_once('.') {
+        Some((a, b)) => (a, b),
+        None => (time, "0"),
+    };
+    let mut t_parts = h_m_s.split(':');
+    let h: u32 = t_parts.next()?.parse().ok()?;
+    let mi: u32 = t_parts.next()?.parse().ok()?;
+    let se: u32 = t_parts.next()?.parse().ok()?;
+
+    let secs = days_from_civil(y, mo, d).checked_mul(86_400)?
+        + (h as i64) * 3600
+        + (mi as i64) * 60
+        + se as i64;
+
+    // Truncate to 9 fractional digits.
+    let frac_padded: String = frac_str
+        .chars()
+        .chain(std::iter::repeat('0'))
+        .take(9)
+        .collect();
+    let nanos: u32 = frac_padded.parse().ok()?;
+
+    Some((secs, nanos))
+}
+
+/// Howard Hinnant's `days_from_civil` (https://howardhinnant.github.io/date_algorithms.html).
+/// Avoids depending on chrono just for the e2e build.
+fn days_from_civil(y: i32, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = (y - era * 400) as u32;
+    let doy = (153 * if m > 2 { m - 3 } else { m + 9 } + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    (era as i64) * 146_097 + doe as i64 - 719_468
+}
+
+fn now_unix_nano() -> u128 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
+#[allow(dead_code)]
+fn _ensure_arc_clone(_: Arc<()>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event() -> UsageEvent {
+        UsageEvent {
+            request_id: "req-test-123".into(),
+            occurred_at: "2026-05-01T12:00:00Z".into(),
+            model_id: "mod-uuid".into(),
+            api_key_id: "ak-uuid".into(),
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            latency_ms: 250,
+            status_code: 200,
+            provider_request_id: "chatcmpl-abc".into(),
+            provider_model_version: "gpt-4o-2024-08-06".into(),
+            finish_reason: "stop".into(),
+            cost_usd: 0.001,
+            ..Default::default()
+        }
+    }
+
+    fn sample_exporter() -> ObservabilityExporter {
+        // Round-trip through serde so the runtime_id (private) gets
+        // populated by the loader path, just like in production. Kept
+        // off the public API on purpose — callers must go through
+        // the loader, not poke the field directly.
+        serde_json::from_value(serde_json::json!({
+            "name": "test-exp",
+            "enabled": true,
+            "kind": "otlp_http",
+            "endpoint": "http://mock-otlp:4318/v1/traces",
+            "headers": {"authorization": "Bearer xyz"}
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn payload_carries_genai_semconv_attributes() {
+        let body = build_otlp_traces_payload(&sample_event(), "test-exp");
+        let span = &body["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+        assert_eq!(span["name"], "chat.completions");
+        assert_eq!(span["status"]["code"], 1);
+        // Attribute set must include the GenAI required + recommended fields
+        // we promised the user.
+        let attrs = span["attributes"].as_array().unwrap();
+        let keys: Vec<&str> = attrs.iter().map(|a| a["key"].as_str().unwrap()).collect();
+        assert!(keys.contains(&"gen_ai.system"));
+        assert!(keys.contains(&"gen_ai.operation.name"));
+        assert!(keys.contains(&"gen_ai.response.model"));
+        assert!(keys.contains(&"gen_ai.response.id"));
+        assert!(keys.contains(&"gen_ai.usage.input_tokens"));
+        assert!(keys.contains(&"gen_ai.usage.output_tokens"));
+        assert!(keys.contains(&"gen_ai.response.finish_reasons"));
+        assert!(keys.contains(&"http.response.status_code"));
+        assert!(keys.contains(&"aisix.api_key_id"));
+        assert!(keys.contains(&"aisix.model_id"));
+        assert!(keys.contains(&"aisix.exporter_name"));
+        assert!(keys.contains(&"aisix.request_id"));
+    }
+
+    #[test]
+    fn payload_marks_5xx_as_error_status() {
+        let mut ev = sample_event();
+        ev.status_code = 503;
+        let body = build_otlp_traces_payload(&ev, "x");
+        assert_eq!(
+            body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["status"]["code"],
+            2
+        );
+    }
+
+    #[test]
+    fn payload_omits_empty_optional_fields() {
+        let mut ev = sample_event();
+        ev.provider_request_id = String::new();
+        ev.provider_model_version = String::new();
+        ev.finish_reason = String::new();
+        let body = build_otlp_traces_payload(&ev, "x");
+        let attrs = body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+            .as_array()
+            .unwrap();
+        let keys: Vec<&str> = attrs.iter().map(|a| a["key"].as_str().unwrap()).collect();
+        assert!(!keys.contains(&"gen_ai.response.id"));
+        assert!(!keys.contains(&"gen_ai.response.model"));
+        assert!(!keys.contains(&"gen_ai.response.finish_reasons"));
+    }
+
+    #[test]
+    fn rfc3339_round_trip() {
+        // 2026-05-01T12:00:00Z = 1_777_636_800 unix seconds.
+        // (epoch + 56 years + 14 leap days + 120 days into 2026 + 12h)
+        let nanos = parse_rfc3339_to_unix_nano("2026-05-01T12:00:00Z").unwrap();
+        assert_eq!(nanos, 1_777_636_800 * 1_000_000_000);
+    }
+
+    #[test]
+    fn rfc3339_with_fractional_seconds() {
+        let nanos = parse_rfc3339_to_unix_nano("2026-05-01T12:00:00.5Z").unwrap();
+        assert_eq!(nanos, 1_777_636_800 * 1_000_000_000 + 500_000_000);
+    }
+
+    #[test]
+    fn fan_out_is_a_no_op_on_empty_exporter_list() {
+        // Smoke: building the fan-out struct + calling on an empty
+        // iterator shouldn't panic and shouldn't spawn tasks. We
+        // can't easily count spawned tasks, but if the call returned
+        // and the test process didn't hang, we're good.
+        let f = OtlpHttpFanOut::new();
+        f.fan_out(&sample_event(), std::iter::empty());
+    }
+
+    #[test]
+    fn disabled_exporter_is_skipped() {
+        // Build a disabled exporter with a deliberately bogus
+        // endpoint; if the fan-out tried to POST to it the spawned
+        // task would log a warning, but never panic. We can't easily
+        // assert "no task was spawned" without instrumentation;
+        // contenting ourselves with "doesn't crash" + the
+        // production code path's `if !exp.enabled { continue }`.
+        let mut exp = sample_exporter();
+        exp.enabled = false;
+        let f = OtlpHttpFanOut::new();
+        f.fan_out(&sample_event(), std::iter::once(&exp));
+    }
+}

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -19,7 +19,7 @@
 use aisix_cache::CacheKey;
 use aisix_gateway::{BridgeContext, BridgeError, ChatFormat};
 use aisix_guardrails::GuardrailVerdict;
-use aisix_obs::{AccessLog, LangfuseEvent, Metrics, RequestOutcome, UsageEvent, UsageSink};
+use aisix_obs::{AccessLog, LangfuseEvent, Metrics, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::HeaderValue;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -86,7 +86,7 @@ pub async fn chat_completions(
                 &request_id,
             );
             emit_usage_event(
-                &state.usage_sink,
+                &state,
                 &request_id,
                 &success.model_id,
                 &api_key_id,
@@ -164,7 +164,7 @@ pub async fn chat_completions(
             // dashboard can surface it on the Blocked tab.
             let guardrail_blocked = matches!(err, ProxyError::ContentFiltered(_));
             emit_usage_event(
-                &state.usage_sink,
+                &state,
                 &request_id,
                 resolved_model_id.as_deref().unwrap_or(""),
                 &api_key_id,
@@ -367,7 +367,9 @@ async fn dispatch(
     if attempt_models.len() == 1 {
         let only = &attempt_models[0];
         let provider = only.provider().ok_or_else(|| {
-            with_model(ProxyError::InvalidRequest("model has no provider prefix".into()))
+            with_model(ProxyError::InvalidRequest(
+                "model has no provider prefix".into(),
+            ))
         })?;
         if state.hub.get(provider).is_none() {
             return Err(with_model(ProxyError::ProviderUnavailable));
@@ -389,7 +391,9 @@ async fn dispatch(
     if req.is_streaming() {
         let model = &attempt_models[0];
         let provider = model.provider().ok_or_else(|| {
-            with_model(ProxyError::InvalidRequest("model has no provider prefix".into()))
+            with_model(ProxyError::InvalidRequest(
+                "model has no provider prefix".into(),
+            ))
         })?;
         let bridge = state
             .hub
@@ -464,9 +468,11 @@ async fn dispatch(
         CacheStatus::Disabled
     };
 
-    if let (true, Some(cache), Some(key)) =
-        (cache_active_by_policy, state.cache.as_ref(), cache_key.as_ref())
-    {
+    if let (true, Some(cache), Some(key)) = (
+        cache_active_by_policy,
+        state.cache.as_ref(),
+        cache_key.as_ref(),
+    ) {
         match cache.get(key).await {
             Ok(Some(cached)) => {
                 reservation.commit_tokens(0);
@@ -625,9 +631,11 @@ async fn dispatch(
     // top of dispatch — without an enabled cache_policy in snapshot,
     // we skip both read AND write so the cache backend doesn't fill
     // up with entries that no policy ever asked for.
-    if let (true, Some(cache), Some(key)) =
-        (cache_active_by_policy, state.cache.as_ref(), cache_key.as_ref())
-    {
+    if let (true, Some(cache), Some(key)) = (
+        cache_active_by_policy,
+        state.cache.as_ref(),
+        cache_key.as_ref(),
+    ) {
         if let Err(err) = cache.put(key, upstream.clone()).await {
             tracing::warn!(error = %err, key = %key, "cache write failed");
         }
@@ -692,14 +700,15 @@ fn record_success(
     }
 }
 
-/// Push one telemetry event onto the CP-side sink. Non-blocking;
-/// drops with a tracing::warn! if the worker queue is full.
-/// Centralised here so success / error / streaming / cache-hit paths
-/// all share the same event-construction logic and the wire shape
-/// stays consistent across them.
+/// Push one telemetry event onto the CP-side sink **and** fan it out
+/// to every per-env OTLP/HTTP exporter in the live snapshot.
+/// Non-blocking on both legs: the CP sink drops on full queue, the
+/// OTLP fan-out detaches a tokio task per exporter. Centralised here
+/// so success / error / streaming / cache-hit paths share one event
+/// construction and the two emit legs stay in lockstep.
 #[allow(clippy::too_many_arguments)]
 fn emit_usage_event(
-    sink: &UsageSink,
+    state: &ProxyState,
     request_id: &str,
     model_id: &str,
     api_key_id: &str,
@@ -711,7 +720,7 @@ fn emit_usage_event(
     cost_usd: f64,
     guardrail_blocked: bool,
 ) {
-    sink.try_emit(UsageEvent {
+    let event = UsageEvent {
         request_id: request_id.to_string(),
         // RFC 3339 UTC. cp-api parses with time.Parse(time.RFC3339, ...);
         // chrono's `to_rfc3339_opts(Secs, true)` emits the trailing Z.
@@ -733,7 +742,17 @@ fn emit_usage_event(
         guardrail_blocked,
         guardrail_bypassed_reason: extras.bypass_reason,
         cache_status: extras.cache_status,
-    });
+    };
+    state.usage_sink.try_emit(event.clone());
+    // Per-env OTLP/HTTP fan-out. The snapshot's exporter table is
+    // empty for envs that haven't configured any, so this is a cheap
+    // no-op on the common path. Spawned tasks own the POST work and
+    // never block the request return.
+    let snap = state.snapshot.load();
+    let exporters = snap.observability_exporters.entries();
+    state
+        .otlp_fan_out
+        .fan_out(&event, exporters.iter().map(|e| &e.value));
 }
 
 /// Provider-detail bundle for `emit_usage_event`. Grouped here so the

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -19,7 +19,7 @@ use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
 use aisix_guardrails::{Guardrail, GuardrailChain};
-use aisix_obs::{LangfuseSender, Metrics, UsageSink};
+use aisix_obs::{LangfuseSender, Metrics, OtlpHttpFanOut, UsageSink};
 use aisix_ratelimit::Limiter;
 use std::sync::Arc;
 
@@ -52,6 +52,12 @@ pub struct ProxyState {
     /// Defaults to a no-op sink when running outside managed mode so
     /// chat handlers don't have to special-case `Option`.
     pub usage_sink: UsageSink,
+    /// Per-env OTLP/HTTP fan-out — POSTs one OTLP-encoded span per
+    /// chat request to every enabled `ObservabilityExporter` in the
+    /// snapshot. Cheap clonable handle holding a shared
+    /// `reqwest::Client` connection pool. Always present (the
+    /// no-exporters case = empty snapshot table = no spawned tasks).
+    pub otlp_fan_out: OtlpHttpFanOut,
     pub request_body_limit_bytes: usize,
 }
 
@@ -69,6 +75,7 @@ impl ProxyState {
             health: Arc::new(HealthTracker::new()),
             langfuse: None,
             usage_sink: UsageSink::disabled(),
+            otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -93,6 +100,7 @@ impl ProxyState {
             health: Arc::new(HealthTracker::new()),
             langfuse: None,
             usage_sink: UsageSink::disabled(),
+            otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }
@@ -120,6 +128,7 @@ impl ProxyState {
             health: Arc::new(HealthTracker::new()),
             langfuse: None,
             usage_sink: UsageSink::disabled(),
+            otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
         }
     }

--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -209,9 +209,7 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
             .context("parse managed.cp_ca_cert_file as PEM certificate")?;
         builder = builder.add_root_certificate(extra_ca);
     }
-    builder
-        .build()
-        .context("build reqwest client with mTLS")
+    builder.build().context("build reqwest client with mTLS")
 }
 
 #[cfg(test)]

--- a/crates/aisix-server/src/register.rs
+++ b/crates/aisix-server/src/register.rs
@@ -409,8 +409,11 @@ mod tests {
     fn read_optional_ca_pem_reads_existing_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ca.pem");
-        std::fs::write(&path, b"-----BEGIN CERTIFICATE-----\nXX\n-----END CERTIFICATE-----\n")
-            .unwrap();
+        std::fs::write(
+            &path,
+            b"-----BEGIN CERTIFICATE-----\nXX\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
         let bytes = read_optional_ca_pem(Some(path.to_str().unwrap()))
             .unwrap()
             .expect("Some when path is set");

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -249,9 +249,7 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
             .context("parse managed.cp_ca_cert_file as PEM certificate")?;
         builder = builder.add_root_certificate(extra_ca);
     }
-    builder
-        .build()
-        .context("build reqwest client with mTLS")
+    builder.build().context("build reqwest client with mTLS")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

DP-side half of the per-env observability exporters MVP. cp-api side ships in a follow-up PR (the kine projection + CRUD); dashboard CRUD page + live compose-stack e2e land alongside the cp-api PR.

This PR wires the runtime: when a chat completion finishes, the DP looks up the env's configured \`ObservabilityExporter\` rows from the existing etcd-watched snapshot and POSTs one OTLP/HTTP span per enabled row. cp-api itself never opens an HTTP connection to the user's exporter endpoint — **DP-direct egress is the whole point** (sensitive prompt / response content stays on the data plane).

## What's wired

- **\`aisix-core::ObservabilityExporter\`** — new resource type, JSON Schema validator + Resource impl. Wire shape is flat (kind discriminator + per-kind config fields at the top level), matching the \`Guardrail\` pattern. MVP ships \`kind=otlp_http\`; Phase 2 adds Helicone / Langfuse-native / Datadog / S3 as new variants.
- **\`aisix-etcd::loader\`** — new \`observability_exporters\` arm reads \`/aisix/<env>/observability_exporters/<id>\` from kine into \`AisixSnapshot::observability_exporters\`.
- **\`aisix-obs::OtlpHttpFanOut\`** — cheap clonable handle holding a shared \`reqwest::Client\`. \`fan_out(event, exporters)\` builds an OTLP/JSON \`ExportTraceServiceRequest\` with one span per (event, exporter) pair and spawns a fire-and-forget tokio task per pair.
- **\`aisix-proxy::chat::emit_usage_event\`** — now calls \`state.otlp_fan_out.fan_out(...)\` right after the existing \`usage_sink.try_emit(...)\`. Empty-exporter envs are a cheap no-op.

## GenAI semantic conventions

Span attributes follow https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md:

- \`gen_ai.system\` / \`gen_ai.operation.name\`
- \`gen_ai.response.model\` / \`gen_ai.response.id\`
- \`gen_ai.usage.input_tokens\` / \`gen_ai.usage.output_tokens\`
- \`gen_ai.response.finish_reasons\`
- \`http.response.status_code\`

Plus \`aisix.{api_key_id,model_id,exporter_name,request_id}\` so spans join back to the dashboard.

## What's NOT in MVP

| | Why |
|---|---|
| Batching | Phase 2 will introduce a worker-task model with bounded mpsc + 1s flush, mirroring \`LangfuseSender\`. MVP is one POST per request per exporter — fine until sustained > 100 req/s per env. |
| Retry / backoff | Best-effort fire-and-forget; failures emit \`tracing::warn!\`. Phase 2 adds exponential backoff. |
| gRPC | OTLP/HTTP-JSON only. Works against every receiver in the wild and avoids dragging \`tonic\` onto the hot path. |
| content_mode redaction | Spans never carry prompt / response bodies in the first place. |
| Field-level encryption on \`headers\` | The kine path is mTLS-only, same trust boundary as \`provider_keys\`. Phase 2. |

## Test plan

- [x] \`cargo build --workspace\` — clean
- [x] \`cargo test --workspace --lib\` — **456 passed, 0 failed**
- [x] Models tests (deserialize, defaults, serde-flatten round-trip, deny_unknown_fields, kind contract): 7/7
- [x] OtlpHttpFanOut tests (GenAI attributes present, 5xx→ERROR status, optional fields omitted, RFC3339 parse, fan-out no-ops on empty/disabled): 7/7
- [ ] Live e2e against compose-stack \`mock-otlp\` — lands in the cp-api PR (needs CRUD endpoints to configure an exporter first)