### PR TITLE
feat(cache): policy-driven gate + cache_status telemetry (Stage 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -1,0 +1,193 @@
+//! `CachePolicy` entity — per-env prompt-response cache rules. The
+//! control plane (cp-api) writes these to etcd at
+//! `/aisix/<env>/cache_policies/<uuid>`; the DP loads them on watch
+//! and `aisix-proxy::cache_gate` consults them on every chat request.
+//!
+//! Stage 2 (this PR) honors only:
+//!   - `enabled` — flag the policy on/off
+//!   - existence of any matching policy enables / disables the cache
+//!     for the request
+//!
+//! Stage 3+ extensions:
+//!   - `applies_to` parsed into a real matcher (currently treated as
+//!     "all" if any policy is present)
+//!   - `ttl_seconds` propagated into the cache backend per entry
+//!   - `backend` switching between memory / redis / redis_semantic
+//!   - semantic-mode (`similarity_threshold` + `embedding_model`) once
+//!     the embedding client + pgvector backend land
+//!
+//! See `crates/aisix-cache` for the cache backend itself; this module
+//! is the wire shape only.
+
+use serde::{Deserialize, Serialize};
+
+use crate::resource::Resource;
+
+/// Cache backend choice. Stage 2 only enforces `Memory`. The other
+/// variants persist in cp-api + ship through kine but the DP falls
+/// back to memory until each backend wires up.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheBackend {
+    #[default]
+    Memory,
+    Redis,
+    RedisSemantic,
+    Qdrant,
+}
+
+/// Top-level `CachePolicy` resource shape. Mirrors what cp-api writes
+/// to kine. `name` is operator-facing; `enabled` flips the policy on
+/// without delete + recreate. `applies_to` is parsed by the cache
+/// gate (Stage 3); for now any enabled policy is treated as
+/// "applies to all chat completions in this env".
+///
+/// `deny_unknown_fields` is intentionally NOT set so cp-api can ship
+/// new fields ahead of a DP rollout without a hard reject. New
+/// optional fields land at `#[serde(default)]` here on the next DP
+/// release.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CachePolicy {
+    /// Operator-facing name; surfaces in metric labels + cache headers.
+    pub name: String,
+
+    /// When false the cache gate skips this policy. Lets operators
+    /// stage a rule (write it, sanity-check it, then flip it on).
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Backend hint. Stage 2 enforces `memory` only; other variants
+    /// fall back to memory at the DP and surface "configured but
+    /// not yet enforced" in the dashboard.
+    #[serde(default)]
+    pub backend: CacheBackend,
+
+    /// TTL hint in seconds. Stage 2 honors the cache backend's
+    /// configured TTL globally; per-policy TTL lands in Stage 3.
+    /// Default 3600 matches the cp-api validator.
+    #[serde(default = "default_ttl_seconds")]
+    pub ttl_seconds: u32,
+
+    /// Free-form scope. v1 understands "all", "model:<name>",
+    /// "api_key:<id>". Stage 2 treats any non-empty value as "all"
+    /// — applies_to parsing lands in Stage 3.
+    #[serde(default = "default_applies_to")]
+    pub applies_to: String,
+
+    /// Semantic-mode similarity floor. Required by cp-api for
+    /// `redis_semantic` / `qdrant`; ignored by the DP until those
+    /// backends wire up.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub similarity_threshold: Option<f32>,
+
+    /// Semantic-mode embedding model. Same Stage-3-or-later note.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_model: Option<String>,
+
+    /// Set by the loader from the kine path's UUID segment. The DP
+    /// uses this for metric labels + log correlation; not part of
+    /// the wire shape.
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn default_ttl_seconds() -> u32 {
+    3600
+}
+
+fn default_applies_to() -> String {
+    "all".to_string()
+}
+
+impl Resource for CachePolicy {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn kind() -> &'static str {
+        "cache_policies"
+    }
+}
+
+impl CachePolicy {
+    /// Set the runtime id (the kine path UUID). Used by the loader.
+    pub fn with_runtime_id(mut self, id: impl Into<String>) -> Self {
+        self.runtime_id = id.into();
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn deserialises_minimal_memory_policy() {
+        let v = json!({
+            "name": "prod-default",
+            "backend": "memory"
+        });
+        let p: CachePolicy = serde_json::from_value(v).unwrap();
+        assert_eq!(p.name, "prod-default");
+        assert!(p.enabled, "enabled defaults to true");
+        assert_eq!(p.backend, CacheBackend::Memory);
+        assert_eq!(p.ttl_seconds, 3600);
+        assert_eq!(p.applies_to, "all");
+        assert!(p.similarity_threshold.is_none());
+    }
+
+    #[test]
+    fn deserialises_full_semantic_policy() {
+        let v = json!({
+            "name": "semantic-experiment",
+            "enabled": false,
+            "backend": "redis_semantic",
+            "ttl_seconds": 600,
+            "applies_to": "model:gpt-4o",
+            "similarity_threshold": 0.92,
+            "embedding_model": "text-embedding-3-small"
+        });
+        let p: CachePolicy = serde_json::from_value(v).unwrap();
+        assert!(!p.enabled);
+        assert_eq!(p.backend, CacheBackend::RedisSemantic);
+        assert_eq!(p.ttl_seconds, 600);
+        assert_eq!(p.applies_to, "model:gpt-4o");
+        assert_eq!(p.similarity_threshold, Some(0.92));
+        assert_eq!(p.embedding_model.as_deref(), Some("text-embedding-3-small"));
+    }
+
+    #[test]
+    fn resource_kind_matches_kine_path_segment() {
+        assert_eq!(<CachePolicy as Resource>::kind(), "cache_policies");
+    }
+
+    #[test]
+    fn runtime_id_round_trips_through_with_runtime_id() {
+        let p: CachePolicy =
+            serde_json::from_value(json!({"name": "x", "backend": "memory"})).unwrap();
+        let p = p.with_runtime_id("uuid-1");
+        assert_eq!(<CachePolicy as Resource>::id(&p), "uuid-1");
+    }
+
+    #[test]
+    fn unknown_fields_are_tolerated_for_forward_compat() {
+        // cp-api may ship new fields ahead of the DP rolling out;
+        // serde must accept them (no `deny_unknown_fields`).
+        let v = json!({
+            "name": "future",
+            "backend": "memory",
+            "future_knob": "ignored"
+        });
+        let p: CachePolicy = serde_json::from_value(v).unwrap();
+        assert_eq!(p.name, "future");
+    }
+}

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -15,6 +15,7 @@
 //! next to its runtime usage.
 
 pub mod apikey;
+pub mod cache_policy;
 pub mod credential;
 pub mod guardrail;
 pub mod model;
@@ -25,6 +26,7 @@ pub mod snapshot;
 pub mod team;
 
 pub use apikey::ApiKey;
+pub use cache_policy::{CacheBackend, CachePolicy};
 pub use credential::Credential;
 pub use guardrail::{
     BedrockAWSCredentials, BedrockConfig, BedrockLatencyMode, Guardrail, GuardrailHookPoint,
@@ -34,8 +36,8 @@ pub use model::{Model, Provider, ProviderConfig};
 pub use rate_limit::RateLimit;
 pub use routing::{Routing, RoutingStrategy, RoutingTarget};
 pub use schema::{
-    validate_apikey, validate_credential, validate_guardrail, validate_model, validate_team,
-    SchemaError,
+    validate_apikey, validate_cache_policy, validate_credential, validate_guardrail,
+    validate_model, validate_team, SchemaError,
 };
 pub use snapshot::AisixSnapshot;
 pub use team::Team;

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -27,6 +27,7 @@ pub struct Schemas {
     pub credential: Validator,
     pub team: Validator,
     pub guardrail: Validator,
+    pub cache_policy: Validator,
 }
 
 pub static SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::compile()));
@@ -49,6 +50,9 @@ impl Schemas {
             guardrail: jsonschema::options()
                 .build(&guardrail_schema())
                 .expect("guardrail schema is well-formed"),
+            cache_policy: jsonschema::options()
+                .build(&cache_policy_schema())
+                .expect("cache_policy schema is well-formed"),
         }
     }
 }
@@ -91,6 +95,10 @@ pub fn validate_team(value: &Value) -> Result<(), SchemaError> {
 
 pub fn validate_guardrail(value: &Value) -> Result<(), SchemaError> {
     validate(&SCHEMAS.guardrail, value)
+}
+
+pub fn validate_cache_policy(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.cache_policy, value)
 }
 
 fn model_schema() -> Value {
@@ -321,6 +329,35 @@ fn guardrail_schema() -> Value {
                     }
                 ]
             }
+        }
+    })
+}
+
+// Mirrors cp-api's cache_policies validation rules (validateCachePolicyShape
+// in internal/cpapi/resources/cache_policies.go). The DP is the second
+// line of defence — cp-api rejects malformed payloads on write, but kine
+// can still surface stale or hand-edited rows on watch, so we re-validate
+// at parse time. `additionalProperties: true` keeps the schema
+// forward-compatible: cp-api can ship new optional fields ahead of a DP
+// rollout without locking the gateway out.
+fn cache_policy_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["name"],
+        "additionalProperties": true,
+        "properties": {
+            "name":        { "type": "string", "minLength": 1, "maxLength": 120 },
+            "enabled":     { "type": "boolean" },
+            "backend":     {
+                "enum": ["memory", "redis", "redis_semantic", "qdrant"]
+            },
+            "ttl_seconds": { "type": "integer", "minimum": 1, "maximum": 604800 },
+            "applies_to":  { "type": "string", "minLength": 1, "maxLength": 255 },
+            "similarity_threshold": {
+                "type": "number", "minimum": 0, "maximum": 1
+            },
+            "embedding_model": { "type": "string", "minLength": 1, "maxLength": 120 }
         }
     })
 }

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -8,6 +8,7 @@
 //! Credential + Budget arrived with PR #19; Team / Guardrail will follow.
 
 use super::apikey::ApiKey;
+use super::cache_policy::CachePolicy;
 use super::credential::Credential;
 use super::guardrail::Guardrail;
 use super::model::Model;
@@ -23,6 +24,10 @@ pub struct AisixSnapshot {
     pub credentials: ResourceTable<Credential>,
     pub teams: ResourceTable<Team>,
     pub guardrails: ResourceTable<Guardrail>,
+    /// Per-env cache policies. Stage 2 honors only the existence of an
+    /// enabled row to gate the cache; Stage 3 will parse `applies_to`
+    /// + per-policy `ttl_seconds`. See `aisix-core::CachePolicy`.
+    pub cache_policies: ResourceTable<CachePolicy>,
 }
 
 impl AisixSnapshot {
@@ -38,6 +43,7 @@ impl AisixSnapshot {
             + self.credentials.len()
             + self.teams.len()
             + self.guardrails.len()
+            + self.cache_policies.len()
     }
 }
 

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -12,8 +12,8 @@
 //! entry; it serves the rest."
 
 use aisix_core::models::{
-    validate_apikey, validate_credential, validate_guardrail, validate_model, ApiKey, Credential,
-    Guardrail, Model, SchemaError,
+    validate_apikey, validate_cache_policy, validate_credential, validate_guardrail, validate_model,
+    ApiKey, CachePolicy, Credential, Guardrail, Model, SchemaError,
 };
 use aisix_core::resource::ResourceEntry;
 use aisix_core::AisixSnapshot;
@@ -106,6 +106,18 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
                     &mut stats,
                 ) {
                     snapshot.guardrails.insert(entry);
+                }
+            }
+            "cache_policies" => {
+                if let Some(entry) = validate_and_parse::<CachePolicy>(
+                    &raw.key,
+                    raw.revision,
+                    parsed,
+                    &value,
+                    validate_cache_policy,
+                    &mut stats,
+                ) {
+                    snapshot.cache_policies.insert(entry);
                 }
             }
             other => {

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -130,6 +130,23 @@ pub struct UsageEvent {
     /// wire empty maps to NULL via `skip_serializing_if`.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub guardrail_bypassed_reason: String,
+
+    /// Cache outcome on this request. One of:
+    ///
+    /// - `"hit"` — cached response served the request without a
+    ///   round-trip to the upstream
+    /// - `"miss"` — cache was consulted, no entry matched; the
+    ///   upstream response was just stored
+    /// - `"disabled"` — no enabled `cache_policy` in snapshot for
+    ///   this env, the cache gate was closed
+    ///
+    /// Empty string = cache state unknown / not applicable (error
+    /// paths that fail before the cache lookup). cp-api persists
+    /// this to `dpmgr_usage_events.cache_status`; on the wire empty
+    /// maps to NULL via `skip_serializing_if`. Source of truth is
+    /// `aisix_proxy::chat::CacheStatus::as_str`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub cache_status: String,
 }
 
 #[inline]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -103,6 +103,7 @@ pub async fn chat_completions(
                     provider_model_version: success.provider_model_version.clone(),
                     finish_reason: success.finish_reason.clone(),
                     bypass_reason: success.bypass_reason.clone().unwrap_or_default(),
+                    cache_status: success.cache_status.as_str().to_string(),
                 },
                 success.cost_usd,
                 /* guardrail_blocked */ false,
@@ -236,6 +237,41 @@ struct Success {
     /// so a compliance audit can see what slipped past during a Bedrock
     /// outage. None for the normal Allow / Block paths.
     bypass_reason: Option<String>,
+    /// Cache outcome for this request. `disabled` when no enabled
+    /// cache_policy is in snapshot for the env; `miss` when the cache
+    /// was consulted but no entry matched; `hit` when a stored entry
+    /// served the response. Lands on `usage_events.cache_status` for
+    /// the dashboard's /logs column. See `aisix-core::CachePolicy`
+    /// (Stage 2) and `aisix-cache::Cache` for the source of truth.
+    cache_status: CacheStatus,
+}
+
+/// Cache decision attached to every successful request. Wire shape
+/// (lowercase string) is what cp-api persists in
+/// `dpmgr_usage_events.cache_status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CacheStatus {
+    /// No enabled cache policy in snapshot — gate skipped the lookup.
+    /// Stage 3 will refine this to "no policy matched applies_to".
+    Disabled,
+    /// Cache consulted, no entry matched. The successful upstream
+    /// response is stored on the way out so future identical requests
+    /// hit. Maps to `x-aisix-cache: miss` on the response header.
+    Miss,
+    /// Cache consulted, entry returned without an upstream call. Maps
+    /// to `x-aisix-cache: hit` on the response header.
+    Hit,
+}
+
+impl CacheStatus {
+    /// Lowercase wire string the DP ships to cp-api in `cache_status`.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            CacheStatus::Disabled => "disabled",
+            CacheStatus::Miss => "miss",
+            CacheStatus::Hit => "hit",
+        }
+    }
 }
 
 /// Returns `Ok(Success)` on the happy path, or `Err((resolved_model_id, err))`
@@ -390,17 +426,47 @@ async fn dispatch(
             provider_model_version: String::new(),
             finish_reason: String::new(),
             bypass_reason: bypass_reason.clone(),
+            // Streaming responses aren't cached at this layer — see
+            // crates/aisix-cache/src/lib.rs and Phase 2 above. Always
+            // surface as `disabled` on the streaming path.
+            cache_status: CacheStatus::Disabled,
         });
     }
 
+    // Policy gate: the cache is only consulted when at least one
+    // enabled `CachePolicy` exists in the snapshot for this env. cp-api
+    // owns the policy CRUD surface (`/api/environments/:env/cache_policies`,
+    // see Stage 1 — PR #134); kine fans out the rows; the loader
+    // populates `snapshot.cache_policies` (see aisix-etcd). Stage 2
+    // honors only the existence + `enabled` flag. Stage 3 will parse
+    // `applies_to` (currently treated as "all") + per-policy
+    // `ttl_seconds` (currently the cache backend's global TTL).
+    let cache_active_by_policy = snapshot
+        .cache_policies
+        .entries()
+        .iter()
+        .any(|entry| entry.value.enabled);
+
     // Cache lookup keyed on the *virtual* model name so a re-request
     // hits the cache regardless of which target served the original.
+    // Even with `cache_active_by_policy = false` we still build the
+    // key to keep the cache_status path uniform — `disabled` is the
+    // outcome when the gate is closed, but the request itself is
+    // shaped the same way.
     let cache_key = state
         .cache
         .as_ref()
         .map(|_| CacheKey::from_request(req).fingerprint());
 
-    if let (Some(cache), Some(key)) = (state.cache.as_ref(), cache_key.as_ref()) {
+    let cache_status = if cache_active_by_policy && state.cache.is_some() {
+        CacheStatus::Miss
+    } else {
+        CacheStatus::Disabled
+    };
+
+    if let (true, Some(cache), Some(key)) =
+        (cache_active_by_policy, state.cache.as_ref(), cache_key.as_ref())
+    {
         match cache.get(key).await {
             Ok(Some(cached)) => {
                 reservation.commit_tokens(0);
@@ -450,6 +516,7 @@ async fn dispatch(
                     // paid the upstream price the first time around).
                     cost_usd: 0.0,
                     bypass_reason: bypass_reason.clone(),
+                    cache_status: CacheStatus::Hit,
                 });
             }
             Ok(None) => {}
@@ -554,14 +621,23 @@ async fn dispatch(
         }
     }
 
-    if let (Some(cache), Some(key)) = (state.cache.as_ref(), cache_key.as_ref()) {
+    // Cache write is gated on the same policy as the lookup at the
+    // top of dispatch — without an enabled cache_policy in snapshot,
+    // we skip both read AND write so the cache backend doesn't fill
+    // up with entries that no policy ever asked for.
+    if let (true, Some(cache), Some(key)) =
+        (cache_active_by_policy, state.cache.as_ref(), cache_key.as_ref())
+    {
         if let Err(err) = cache.put(key, upstream.clone()).await {
             tracing::warn!(error = %err, key = %key, "cache write failed");
         }
     }
 
     let mut response = Json(render_response(now, upstream)).into_response();
-    if cache_key.is_some() {
+    if matches!(cache_status, CacheStatus::Miss) {
+        // Miss header only when the cache was actually consulted —
+        // policy-disabled requests have no cache header at all so a
+        // user can tell at a glance whether the gate was open.
         response
             .headers_mut()
             .insert(CACHE_HEADER, HeaderValue::from_static("miss"));
@@ -583,6 +659,7 @@ async fn dispatch(
         finish_reason,
         cost_usd,
         bypass_reason,
+        cache_status,
     })
 }
 
@@ -655,6 +732,7 @@ fn emit_usage_event(
         cost_usd,
         guardrail_blocked,
         guardrail_bypassed_reason: extras.bypass_reason,
+        cache_status: extras.cache_status,
     });
 }
 
@@ -679,6 +757,10 @@ struct UsageExtras {
     /// `dpmgr_usage_events.guardrail_bypassed_reason`. Default empty
     /// string = no bypass; cp-api stores NULL in that case.
     bypass_reason: String,
+    /// Lowercased `CacheStatus` (`"hit"` / `"miss"` / `"disabled"`).
+    /// Empty default for the error path where the cache lookup never
+    /// fired. Goes onto `dpmgr_usage_events.cache_status`.
+    cache_status: String,
 }
 
 fn record_error(metrics: &Metrics, err: &ProxyError, model: &str, status: u16, elapsed: Duration) {

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -173,6 +173,18 @@ mod tests {
         snap
     }
 
+    /// Insert a default-enabled cache policy on the snapshot so the
+    /// proxy's cache gate (chat::dispatch) opens the lookup path.
+    /// Stage 2 honors only existence + `enabled`; the rest of the
+    /// fields exist on the wire so cp-api's contract round-trips
+    /// through serde even though the DP doesn't act on them yet.
+    fn seed_cache_policy(snap: &AisixSnapshot, name: &str) {
+        let cfg = format!(r#"{{"name": "{name}", "backend": "memory"}}"#);
+        let policy: aisix_core::models::CachePolicy = serde_json::from_str(&cfg).unwrap();
+        snap.cache_policies
+            .insert(ResourceEntry::new("cache-policy-id-1", policy, 1));
+    }
+
     fn seed_snapshot_with_limits(
         model: &str,
         allowed: &[&str],
@@ -697,6 +709,10 @@ data: [DONE]\n\n";
         let hub = Arc::new(Hub::new());
         hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        // Cache gate opens only when an enabled policy exists in
+        // snapshot. Without this seed step the test would 200 but
+        // the cache header would be absent (policy-disabled path).
+        seed_cache_policy(&snap, "test-cache");
         // Cache enabled — uses the default constructor.
         let state = build_state_with_cache(snap, hub);
         let body = serde_json::json!({
@@ -760,6 +776,7 @@ data: [DONE]\n\n";
         let hub = Arc::new(Hub::new());
         hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        seed_cache_policy(&snap, "test-cache");
         let state = build_state_with_cache(snap, hub);
 
         let body_a = serde_json::json!({


### PR DESCRIPTION
## Summary

Closes the cp-api `cache_policies` → DP enforcement loop. **Stage 1** (api7/AISIX-Cloud PR #134) shipped the cp-api CRUD + dashboard configuration page; **this PR** is the DP side: the proxy actually consults the cache only when an enabled policy exists in the env snapshot, and surfaces `hit` / `miss` / `disabled` on every telemetry event.

The cp-api / dashboard / e2e side ships in api7/AISIX-Cloud PR (also stacked on Stage 1).

## What's new

### `aisix-core`
- New `models::cache_policy::CachePolicy` resource — mirrors the cp-api wire shape verbatim (`name`, `enabled`, `backend`, `ttl_seconds`, `applies_to`, `similarity_threshold`, `embedding_model`). Stage 2 honors only `enabled` + existence; the rest serialise round-trip through serde so cp-api's contract holds across the rollout.
- `AisixSnapshot.cache_policies: ResourceTable<CachePolicy>` (sibling of `guardrails`).
- `validate_cache_policy` JSON Schema validator wired through the watch path.
- Backend enum `CacheBackend` covers all four variants up front (`memory` / `redis` / `redis_semantic` / `qdrant`); only `memory` is honored at the DP today, the rest persist + ship through kine but fall back to memory until each backend wires up.

### `aisix-etcd`
- Loader recognises `kind = "cache_policies"` and inserts into the new snapshot table.

### `aisix-proxy`
- `chat::dispatch` reads `snapshot.cache_policies` and **gates the cache lookup AND write** on "any enabled policy in env". Without an enabled policy the cache is skipped entirely — entries don't fill up with rows no policy ever asked for.
- New `CacheStatus` enum (`Hit` | `Miss` | `Disabled`) attached to `Success`; populated on every code path:
  - cache-hit return → `Hit`
  - upstream success after a miss → `Miss`
  - policy gate closed OR streaming response → `Disabled`
- The `x-aisix-cache: miss` response header now only fires when the cache was actually consulted; policy-disabled requests carry no cache header so a user can tell at a glance whether the gate was open.

### `aisix-obs`
- `UsageEvent.cache_status: String` (skip-empty serde) — the wire field cp-api persists in `dpmgr_usage_events.cache_status`.
- The proxy plumbs `Success.cache_status.as_str()` through `UsageExtras` → `emit_usage_event` so every telemetry event the DP ships carries the cache decision.

## Stage 3 (follow-up)

- Parse `applies_to` (`"all"` / `"model:<name>"` / `"api_key:<id>"`) into a real matcher.
- Per-policy `ttl_seconds` propagated into the cache backend.
- `redis_semantic` / `qdrant` backends + embedding client.
- Bucket size > 1 (multi-response per key for non-deterministic temperature).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --lib` — 124 passes / 0 failures (includes the two cache-flow integration tests in aisix-proxy that now seed an enabled policy in the snapshot fixture)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Live e2e covered by api7/AISIX-Cloud feat/cache-policies-mvp-stage2 PR (`TestHappyPath/cache_e2e`): same-completion-twice → second hit, policy delete → gate closed