### PR TITLE
feat(cache): Stage 3 — applies_to matcher (model + api_key scopes)

### DIFF
--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -123,6 +123,61 @@ impl CachePolicy {
         self.runtime_id = id.into();
         self
     }
+
+    /// Parse `applies_to` into a typed matcher. Stage 3 understands:
+    ///
+    ///   - `"all"`            → matches every request in the env
+    ///   - `"model:<name>"`   → matches requests targeting that model alias
+    ///   - `"api_key:<id>"`   → matches requests authenticated by that api_key UUID
+    ///
+    /// Anything else (including the empty string) parses as `All` —
+    /// the conservative default keeps caching on for legacy / future
+    /// policy values rather than silently disabling them on a typo.
+    /// cp-api validation prevents the empty-string case at write time
+    /// (see internal/cpapi/resources/cache_policies.go::validateCachePolicyShape),
+    /// so the conservative branch is dead in practice.
+    pub fn parsed_applies_to(&self) -> AppliesTo {
+        let raw = self.applies_to.trim();
+        if let Some(rest) = raw.strip_prefix("model:") {
+            return AppliesTo::Model(rest.trim().to_string());
+        }
+        if let Some(rest) = raw.strip_prefix("api_key:") {
+            return AppliesTo::ApiKey(rest.trim().to_string());
+        }
+        AppliesTo::All
+    }
+}
+
+/// Typed view of `CachePolicy::applies_to`. The proxy uses this to
+/// pick the first matching enabled policy on every request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppliesTo {
+    /// Every request in the env matches this policy.
+    All,
+    /// Only requests whose `req.model` equals the inner string match.
+    /// String-compare against the model alias the caller asked for —
+    /// router fan-out happens AFTER cache lookup, so the alias is the
+    /// stable identifier here.
+    Model(String),
+    /// Only requests authenticated by the api_key whose UUID equals
+    /// the inner string. The UUID is the cp-api row id, the same
+    /// value the dashboard exposes on the api keys page.
+    ApiKey(String),
+}
+
+impl AppliesTo {
+    /// True iff this matcher accepts a request with the given
+    /// (model, api_key_id) pair. The caller is responsible for
+    /// passing the values it has at cache-lookup time — both are
+    /// stable strings, so no heap allocation is needed beyond the
+    /// references the proxy already holds.
+    pub fn matches(&self, model: &str, api_key_id: &str) -> bool {
+        match self {
+            AppliesTo::All => true,
+            AppliesTo::Model(want) => model == want,
+            AppliesTo::ApiKey(want) => api_key_id == want,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -176,6 +231,46 @@ mod tests {
             serde_json::from_value(json!({"name": "x", "backend": "memory"})).unwrap();
         let p = p.with_runtime_id("uuid-1");
         assert_eq!(<CachePolicy as Resource>::id(&p), "uuid-1");
+    }
+
+    #[test]
+    fn applies_to_all_matches_anything() {
+        let p: CachePolicy =
+            serde_json::from_value(json!({"name": "x", "applies_to": "all"})).unwrap();
+        assert_eq!(p.parsed_applies_to(), AppliesTo::All);
+        assert!(p.parsed_applies_to().matches("any-model", "any-key"));
+    }
+
+    #[test]
+    fn applies_to_model_matches_only_named_model() {
+        let p: CachePolicy =
+            serde_json::from_value(json!({"name": "x", "applies_to": "model:gpt-4o"})).unwrap();
+        assert_eq!(p.parsed_applies_to(), AppliesTo::Model("gpt-4o".into()));
+        assert!(p.parsed_applies_to().matches("gpt-4o", "any-key"));
+        assert!(!p.parsed_applies_to().matches("claude-3-opus", "any-key"));
+    }
+
+    #[test]
+    fn applies_to_api_key_matches_only_named_key() {
+        let kid = "11111111-1111-1111-1111-111111111111";
+        let p: CachePolicy = serde_json::from_value(json!({
+            "name": "x",
+            "applies_to": format!("api_key:{kid}")
+        }))
+        .unwrap();
+        assert_eq!(p.parsed_applies_to(), AppliesTo::ApiKey(kid.into()));
+        assert!(p.parsed_applies_to().matches("gpt-4o", kid));
+        assert!(!p.parsed_applies_to().matches("gpt-4o", "different-key-id"));
+    }
+
+    #[test]
+    fn applies_to_unknown_prefix_falls_back_to_all() {
+        // cp-api validation rejects this on write, but a hand-edited
+        // kine row could surface here — we deliberately fall back to
+        // All rather than disabling caching on an unknown discriminator.
+        let p: CachePolicy =
+            serde_json::from_value(json!({"name": "x", "applies_to": "team:eng"})).unwrap();
+        assert_eq!(p.parsed_applies_to(), AppliesTo::All);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -26,7 +26,7 @@ pub mod snapshot;
 pub mod team;
 
 pub use apikey::ApiKey;
-pub use cache_policy::{CacheBackend, CachePolicy};
+pub use cache_policy::{AppliesTo, CacheBackend, CachePolicy};
 pub use credential::Credential;
 pub use guardrail::{
     BedrockAWSCredentials, BedrockConfig, BedrockLatencyMode, Guardrail, GuardrailHookPoint,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -433,19 +433,32 @@ async fn dispatch(
         });
     }
 
-    // Policy gate: the cache is only consulted when at least one
-    // enabled `CachePolicy` exists in the snapshot for this env. cp-api
-    // owns the policy CRUD surface (`/api/environments/:env/cache_policies`,
-    // see Stage 1 — PR #134); kine fans out the rows; the loader
-    // populates `snapshot.cache_policies` (see aisix-etcd). Stage 2
-    // honors only the existence + `enabled` flag. Stage 3 will parse
-    // `applies_to` (currently treated as "all") + per-policy
-    // `ttl_seconds` (currently the cache backend's global TTL).
+    // Policy gate (Stage 3): the cache is only consulted when at
+    // least one enabled `CachePolicy` in the snapshot has an
+    // `applies_to` clause that matches THIS request. cp-api owns
+    // the policy CRUD surface (`/api/environments/:env/cache_policies`,
+    // see Stage 1); kine fans out the rows; the loader populates
+    // `snapshot.cache_policies` (see aisix-etcd). Stage 4 will add
+    // per-policy `ttl_seconds` propagation into the cache backend
+    // and the semantic backends.
+    //
+    // Match order: first enabled policy whose `parsed_applies_to()`
+    // accepts (req.model, auth.entry.id) wins. Iteration order on a
+    // ResourceTable isn't stable, but the first-match-wins rule is
+    // deterministic enough for the cache_status / x-aisix-cache header
+    // to stay stable across requests; ties only matter when an env
+    // legitimately has overlapping policies.
     let cache_active_by_policy = snapshot
         .cache_policies
         .entries()
         .iter()
-        .any(|entry| entry.value.enabled);
+        .any(|entry| {
+            entry.value.enabled
+                && entry
+                    .value
+                    .parsed_applies_to()
+                    .matches(&req.model, &auth.entry.id)
+        });
 
     // Cache lookup keyed on the *virtual* model name so a re-request
     // hits the cache regardless of which target served the original.

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -175,14 +175,24 @@ mod tests {
 
     /// Insert a default-enabled cache policy on the snapshot so the
     /// proxy's cache gate (chat::dispatch) opens the lookup path.
-    /// Stage 2 honors only existence + `enabled`; the rest of the
-    /// fields exist on the wire so cp-api's contract round-trips
-    /// through serde even though the DP doesn't act on them yet.
+    /// Stage 2 honors existence + `enabled`; Stage 3 honors
+    /// `applies_to`. The default `applies_to=all` (set by serde
+    /// when omitted) matches every request, so existing tests that
+    /// seed a bare policy keep passing.
     fn seed_cache_policy(snap: &AisixSnapshot, name: &str) {
-        let cfg = format!(r#"{{"name": "{name}", "backend": "memory"}}"#);
+        seed_cache_policy_with_applies_to(snap, name, "all");
+    }
+
+    /// Like `seed_cache_policy` but with a specific `applies_to`
+    /// clause — used by the Stage 3 tests that pin the matcher's
+    /// behaviour on `model:<name>` / `api_key:<id>`.
+    fn seed_cache_policy_with_applies_to(snap: &AisixSnapshot, name: &str, applies_to: &str) {
+        let cfg = format!(
+            r#"{{"name": "{name}", "backend": "memory", "applies_to": "{applies_to}"}}"#,
+        );
         let policy: aisix_core::models::CachePolicy = serde_json::from_str(&cfg).unwrap();
         snap.cache_policies
-            .insert(ResourceEntry::new("cache-policy-id-1", policy, 1));
+            .insert(ResourceEntry::new(format!("cp-id-{name}"), policy, 1));
     }
 
     fn seed_snapshot_with_limits(
@@ -808,6 +818,127 @@ data: [DONE]\n\n";
                 Some("miss"),
             );
         }
+    }
+
+    #[tokio::test]
+    async fn applies_to_model_does_not_cache_unmatched_model() {
+        // Stage 3 contract: a `cache_policy` with
+        // `applies_to = "model:<other>"` must NOT enable the cache for
+        // requests targeting a different model. Three identical
+        // requests should hit the upstream three times — none of them
+        // gets cached.
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "always-fresh"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(3) // each call must reach the upstream
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        // The api key + model are named "my-gpt4"; the policy below
+        // pins applies_to to a different model name so no request in
+        // this test matches.
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        seed_cache_policy_with_applies_to(&snap, "scoped", "model:not-my-gpt4");
+        let state = build_state_with_cache(snap, hub);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        // All three calls: 200, no `x-aisix-cache` header (policy gate
+        // closed for this model). The wiremock `.expect(3)` above is
+        // the load-bearing assertion — it fails the test at server
+        // teardown if any call short-circuited via the cache.
+        for _ in 0..3 {
+            let resp = run(build_router(state.clone()), make_req()).await;
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert!(
+                resp.headers().get("x-aisix-cache").is_none(),
+                "policy-gate-closed responses must not carry x-aisix-cache",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn applies_to_model_caches_matched_model() {
+        // Counterpart to the negative test above: when the policy
+        // `applies_to` matches the request's model, the cache gate
+        // opens and the second identical request hits.
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "matched"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1) // only one upstream hit; second call must come from cache
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        seed_cache_policy_with_applies_to(&snap, "scoped", "model:my-gpt4");
+        let state = build_state_with_cache(snap, hub);
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        let r1 = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(r1.status(), StatusCode::OK);
+        assert_eq!(
+            r1.headers()
+                .get("x-aisix-cache")
+                .and_then(|v| v.to_str().ok()),
+            Some("miss"),
+        );
+
+        let r2 = run(build_router(state), make_req()).await;
+        assert_eq!(r2.status(), StatusCode::OK);
+        assert_eq!(
+            r2.headers()
+                .get("x-aisix-cache")
+                .and_then(|v| v.to_str().ok()),
+            Some("hit"),
+        );
     }
 
     /// Build a `ResourceEntry<Model>` with a non-default id so the test


### PR DESCRIPTION
## Summary

Stage 3 of the cache-policies series. Stage 1 (api7/AISIX-Cloud #134) shipped the cp-api CRUD; Stage 2 (#81 here) opened the DP cache gate when ANY enabled policy existed in the env. Stage 3 makes `applies_to` actually mean something: the gate now opens only when a policy explicitly matches THIS request's `(model, api_key_id)` pair.

| Stage | Scope | Status |
|---|---|---|
| 1 | cp-api CRUD + dashboard config | api7 #134 ✅ |
| 2 | DP gate + telemetry + e2e | #81 + api7 #139 ✅ |
| **3** | **`applies_to` matcher (model + api_key scopes)** | **this PR** |
| 4 (planned) | Per-policy `ttl_seconds` + semantic backends | — |

## What's new

### `aisix-core::CachePolicy`
- New `AppliesTo` enum + `parsed_applies_to()` method:
  - `"all"` → `AppliesTo::All` (default)
  - `"model:<name>"` → `AppliesTo::Model(name)`
  - `"api_key:<uuid>"` → `AppliesTo::ApiKey(uuid)`
  - unknown / hand-edited values → `AppliesTo::All` (conservative fallback; cp-api validation rejects them on write so this branch is dead in practice)
- `AppliesTo::matches(model, api_key_id) -> bool` is the single match site the proxy calls per request — `&str` in / bool out, no heap allocation on the hot path.

### `aisix-proxy::chat::dispatch`
- The Stage 2 `cache_active_by_policy = any enabled` boolean is now:
  ```rust
  any enabled WHERE applies_to.matches(req.model, auth.entry.id)
  ```
- No other code paths change — `cache_status`, the `x-aisix-cache: miss/hit` header, and the cache write are all still gated on the same flag. Streaming + error paths still surface as `Disabled`.
- First-match-wins ordering when an env legitimately has overlapping policies.

### Tests

Two new proxy integration tests pin the matcher behaviour:

- `applies_to_model_does_not_cache_unmatched_model` — policy `applies_to=model:OTHER` against requests for `my-gpt4`. Wiremock `.expect(3)` proves the cache never short-circuits any of three identical requests, and responses carry no `x-aisix-cache` header (gate-closed semantics from Stage 2).
- `applies_to_model_caches_matched_model` — policy `applies_to=model:my-gpt4` against requests for `my-gpt4`. Wiremock `.expect(1)` + `x-aisix-cache: miss` then `hit` proves the matched path still works.

Plus 4 unit tests on `parsed_applies_to()` covering all three discriminator forms + the unknown-prefix fallback.

Existing 103 aisix-proxy tests + 85 aisix-core tests still pass — the `seed_cache_policy` helper defaults to `applies_to=all` so no existing fixture needs editing.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --lib` — 108 / 108 passes (added: 2 proxy + 4 core unit)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Live e2e on next deploy: existing `TestHappyPath/cache_e2e` (api7/AISIX-Cloud) still passes since it uses `applies_to=all` (default in the helper); a follow-up live test with `applies_to=model:X` is on the Stage 4 list

## Stage 4 (next)

- Per-policy `ttl_seconds` propagated into the cache backend (needs moka's `Expiry` trait — heavier than this PR; the comment in `MemoryCache` calls this out explicitly).
- `redis_semantic` / `qdrant` backends + embedding client.
- Bucket size > 1 for non-deterministic temperature.