### PR TITLE
feat(cache): honor applies_to scope on the policy gate

### DIFF
--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -123,6 +123,38 @@ impl CachePolicy {
         self.runtime_id = id.into();
         self
     }
+
+    /// Returns true when this policy's `applies_to` string targets the
+    /// given (model name, api_key uuid) pair.
+    ///
+    /// Grammar:
+    /// - `""` or `"all"` — matches every request
+    /// - `"model:<display_name>"` — matches when the request's
+    ///   resolved model name is exactly `<display_name>`
+    /// - `"api_key:<uuid>"` — matches when the authenticated
+    ///   ApiKey row's id is `<uuid>`
+    /// - anything else — **does not match anything**
+    ///
+    /// The "unknown prefix → no match" default is deliberately strict.
+    /// cp-api accepts any non-empty string today, so an operator who
+    /// writes `applies_to = "production"` (a free-form label) would
+    /// have silently been treated as "all" pre-Stage-3. Strict feedback
+    /// (cache stays disabled, dashboard's `cache_status="disabled"`
+    /// surfaces it) is safer than silently caching every request in
+    /// the env.
+    pub fn applies_to_request(&self, model_name: &str, api_key_id: &str) -> bool {
+        let s = self.applies_to.as_str().trim();
+        if s.is_empty() || s == "all" {
+            return true;
+        }
+        if let Some(rest) = s.strip_prefix("model:") {
+            return rest == model_name;
+        }
+        if let Some(rest) = s.strip_prefix("api_key:") {
+            return rest == api_key_id;
+        }
+        false
+    }
 }
 
 #[cfg(test)]
@@ -189,5 +221,57 @@ mod tests {
         });
         let p: CachePolicy = serde_json::from_value(v).unwrap();
         assert_eq!(p.name, "future");
+    }
+
+    fn policy_with_applies_to(s: &str) -> CachePolicy {
+        let mut p: CachePolicy =
+            serde_json::from_value(json!({"name": "x", "backend": "memory"})).unwrap();
+        p.applies_to = s.to_string();
+        p
+    }
+
+    #[test]
+    fn applies_to_all_matches_everything() {
+        assert!(policy_with_applies_to("all").applies_to_request("gpt-4o", "ak-1"));
+        assert!(policy_with_applies_to("").applies_to_request("anything", ""));
+        // Whitespace-only also collapses to All — operators paste freely.
+        assert!(policy_with_applies_to("   ").applies_to_request("gpt-4o", "ak-1"));
+    }
+
+    #[test]
+    fn applies_to_model_matches_only_exact_name() {
+        let p = policy_with_applies_to("model:gpt-4o");
+        assert!(p.applies_to_request("gpt-4o", "any-key"));
+        assert!(!p.applies_to_request("gpt-4o-mini", "any-key"));
+        assert!(!p.applies_to_request("", "any-key"));
+        // Case sensitive — Bedrock/OpenAI model ids are case-sensitive
+        // upstream so we don't normalise here.
+        assert!(!p.applies_to_request("GPT-4O", "any-key"));
+    }
+
+    #[test]
+    fn applies_to_api_key_matches_only_exact_uuid() {
+        let p = policy_with_applies_to("api_key:11111111-2222-3333-4444-555555555555");
+        assert!(p.applies_to_request("any-model", "11111111-2222-3333-4444-555555555555"));
+        assert!(!p.applies_to_request("any-model", "other-uuid"));
+        assert!(!p.applies_to_request("any-model", ""));
+    }
+
+    #[test]
+    fn applies_to_unknown_prefix_matches_nothing() {
+        // Strict: free-form labels like "production" or "team:foo" no
+        // longer accidentally cache every request in the env.
+        // Operators see cache_status=disabled and learn to fix it.
+        let p = policy_with_applies_to("production");
+        assert!(!p.applies_to_request("gpt-4o", "ak-1"));
+
+        let p = policy_with_applies_to("team:platform");
+        assert!(!p.applies_to_request("gpt-4o", "ak-1"));
+
+        let p = policy_with_applies_to("model:");
+        // Empty model name: only matches a request with literally
+        // empty model name (which the proxy rejects upstream anyway).
+        assert!(p.applies_to_request("", "ak-1"));
+        assert!(!p.applies_to_request("gpt-4o", "ak-1"));
     }
 }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -438,18 +438,25 @@ async fn dispatch(
     }
 
     // Policy gate: the cache is only consulted when at least one
-    // enabled `CachePolicy` exists in the snapshot for this env. cp-api
-    // owns the policy CRUD surface (`/api/environments/:env/cache_policies`,
-    // see Stage 1 — PR #134); kine fans out the rows; the loader
-    // populates `snapshot.cache_policies` (see aisix-etcd). Stage 2
-    // honors only the existence + `enabled` flag. Stage 3 will parse
-    // `applies_to` (currently treated as "all") + per-policy
-    // `ttl_seconds` (currently the cache backend's global TTL).
-    let cache_active_by_policy = snapshot
-        .cache_policies
-        .entries()
-        .iter()
-        .any(|entry| entry.value.enabled);
+    // enabled `CachePolicy` whose `applies_to` matches THIS request
+    // exists in the snapshot. cp-api owns the policy CRUD surface
+    // (`/api/environments/:env/cache_policies`, see Stage 1 PR #134);
+    // kine fans out the rows; the loader populates
+    // `snapshot.cache_policies` (see aisix-etcd).
+    //
+    // Match grammar (see CachePolicy::applies_to_request):
+    //   - "all" / ""       — every request in the env
+    //   - "model:<name>"   — only when the resolved model name matches
+    //   - "api_key:<id>"   — only when the authenticated key id matches
+    //
+    // Per-policy `ttl_seconds` still falls back to the cache backend's
+    // global TTL — that gap is tracked in P0b (moka Expiry trait).
+    let req_model = req.model.as_str();
+    let api_key_id = auth.entry.id.as_str();
+    let cache_active_by_policy =
+        snapshot.cache_policies.entries().iter().any(|entry| {
+            entry.value.enabled && entry.value.applies_to_request(req_model, api_key_id)
+        });
 
     // Cache lookup keyed on the *virtual* model name so a re-request
     // hits the cache regardless of which target served the original.

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -175,11 +175,18 @@ mod tests {
 
     /// Insert a default-enabled cache policy on the snapshot so the
     /// proxy's cache gate (chat::dispatch) opens the lookup path.
-    /// Stage 2 honors only existence + `enabled`; the rest of the
-    /// fields exist on the wire so cp-api's contract round-trips
-    /// through serde even though the DP doesn't act on them yet.
+    /// Stage 2 honors existence + `enabled`; Stage 3 (this PR) also
+    /// honors `applies_to` (defaults to `"all"` here).
     fn seed_cache_policy(snap: &AisixSnapshot, name: &str) {
-        let cfg = format!(r#"{{"name": "{name}", "backend": "memory"}}"#);
+        seed_cache_policy_with_applies_to(snap, name, "all");
+    }
+
+    /// Like `seed_cache_policy` but lets the caller pin `applies_to`.
+    /// Used by the matcher tests to verify that a policy with a
+    /// non-matching scope leaves the cache disabled.
+    fn seed_cache_policy_with_applies_to(snap: &AisixSnapshot, name: &str, applies_to: &str) {
+        let cfg =
+            format!(r#"{{"name": "{name}", "backend": "memory", "applies_to": "{applies_to}"}}"#);
         let policy: aisix_core::models::CachePolicy = serde_json::from_str(&cfg).unwrap();
         snap.cache_policies
             .insert(ResourceEntry::new("cache-policy-id-1", policy, 1));
@@ -808,6 +815,127 @@ data: [DONE]\n\n";
                 Some("miss"),
             );
         }
+    }
+
+    /// `applies_to` matcher: a policy scoped to a *different* model
+    /// must NOT open the cache gate for our request. Same-payload
+    /// requests therefore both miss (and both forward to the upstream
+    /// — the wiremock's `expect(2)` enforces it).
+    #[tokio::test]
+    async fn cache_disabled_when_applies_to_targets_other_model() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            // Two identical payloads → expect TWO upstream calls, NOT
+            // one + a cache replay. If the matcher regresses to "any
+            // enabled policy → cache opens" the second call would be
+            // intercepted and this expectation would fail.
+            .expect(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        // Policy targets a DIFFERENT model name. The seeded request
+        // uses model="my-gpt4", so this policy's applies_to=model:gpt-4o
+        // must NOT match → cache stays disabled.
+        seed_cache_policy_with_applies_to(&snap, "scoped-cache", "model:gpt-4o");
+        let state = build_state_with_cache(snap, hub);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        // Both requests must succeed AND both must lack the cache
+        // header (policy-disabled path emits no x-aisix-cache).
+        let r1 = run(build_router(state.clone()), make_req()).await;
+        let r2 = run(build_router(state), make_req()).await;
+        for r in [r1, r2] {
+            assert_eq!(r.status(), StatusCode::OK);
+            assert!(
+                r.headers().get("x-aisix-cache").is_none(),
+                "applies_to mismatch must leave the cache header absent",
+            );
+        }
+    }
+
+    /// Mirror of the test above but with `applies_to=model:my-gpt4`,
+    /// which DOES target the seeded request's model. Cache must engage
+    /// — same behaviour as the unscoped `applies_to=all` case.
+    #[tokio::test]
+    async fn cache_engages_when_applies_to_matches_request_model() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "scoped"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1) // exactly one upstream hit; second request hits cache
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        seed_cache_policy_with_applies_to(&snap, "scoped-cache", "model:my-gpt4");
+        let state = build_state_with_cache(snap, hub);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        let r1 = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(
+            r1.headers()
+                .get("x-aisix-cache")
+                .and_then(|v| v.to_str().ok()),
+            Some("miss"),
+        );
+        let r2 = run(build_router(state), make_req()).await;
+        assert_eq!(
+            r2.headers()
+                .get("x-aisix-cache")
+                .and_then(|v| v.to_str().ok()),
+            Some("hit"),
+        );
     }
 
     /// Build a `ResourceEntry<Model>` with a non-default id so the test


### PR DESCRIPTION
P0a from the cache-policies audit. CachePolicy.applies_to was promised in the dashboard since Stage 1 but the DP gate ignored it. This PR adds CachePolicy::applies_to_request(model, api_key_id) and gates the cache by it. Strict semantics: unknown prefix → no match (was: silently 'all'). 6 new tests. cargo test + clippy + fmt clean.