### PR TITLE
feat(cache): per-policy ttl_seconds via moka Expiry

### DIFF
--- a/crates/aisix-cache/src/cache.rs
+++ b/crates/aisix-cache/src/cache.rs
@@ -9,6 +9,7 @@
 
 use aisix_gateway::ChatResponse;
 use async_trait::async_trait;
+use std::time::Duration;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CacheError {
@@ -37,6 +38,22 @@ impl CacheOutcome {
 pub trait Cache: Send + Sync + 'static {
     async fn get(&self, key: &str) -> Result<Option<ChatResponse>, CacheError>;
     async fn put(&self, key: &str, value: ChatResponse) -> Result<(), CacheError>;
+
+    /// Insert with an explicit TTL override. Used by the proxy when
+    /// the matching `CachePolicy` carries a `ttl_seconds` value, so
+    /// each entry expires according to its own policy rather than the
+    /// cache backend's global TTL. Backends that can't honor
+    /// per-entry TTL must document the gap; the default impl falls
+    /// back to `put` (= the backend's global TTL) so adding a new
+    /// backend doesn't have to ship per-entry support up front.
+    async fn put_with_ttl(
+        &self,
+        key: &str,
+        value: ChatResponse,
+        _ttl: Duration,
+    ) -> Result<(), CacheError> {
+        self.put(key, value).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/aisix-cache/src/memory.rs
+++ b/crates/aisix-cache/src/memory.rs
@@ -1,30 +1,63 @@
 //! In-memory backend backed by `moka`.
 //!
-//! TTL is per-cache (set at construction); per-entry overrides are not
-//! supported by moka's TTL eviction strategy, which fits our model —
-//! every entry expires the same way.
+//! TTL strategy:
+//! - The constructor's `ttl` argument is the **fallback** TTL — used
+//!   when the proxy calls `put` (no per-policy override available).
+//! - When the proxy calls `put_with_ttl` it ships the matching
+//!   `CachePolicy::ttl_seconds`. Each entry then expires according to
+//!   its own policy. moka's `Expiry` trait reads the per-entry TTL
+//!   we stash next to the response.
 
 use aisix_gateway::ChatResponse;
 use async_trait::async_trait;
 use moka::future::Cache as MokaCache;
-use std::time::Duration;
+use moka::Expiry;
+use std::time::{Duration, Instant};
 
 use crate::cache::{Cache, CacheError};
 
 pub const DEFAULT_TTL: Duration = Duration::from_secs(300);
 pub const DEFAULT_CAPACITY: u64 = 10_000;
 
+/// What we actually store inside moka — the response plus the TTL the
+/// caller asked for. The Expiry impl below reads the second field on
+/// `expire_after_create` to set the per-entry deadline.
+#[derive(Debug, Clone)]
+struct Entry {
+    response: ChatResponse,
+    ttl: Duration,
+}
+
 #[derive(Debug)]
 pub struct MemoryCache {
-    inner: MokaCache<String, ChatResponse>,
+    inner: MokaCache<String, Entry>,
+    /// Fallback TTL used by the no-override `put` path. Kept for the
+    /// `ttl()` accessor + tests; not consulted by the Expiry impl.
     ttl: Duration,
+}
+
+/// Per-entry expiry that defers to the value's stashed `ttl`.
+/// `expire_after_read` / `expire_after_update` return `None` so reads
+/// don't extend an entry's life (semantic is "expires N seconds from
+/// insert", not "expires N seconds from last access").
+struct PerEntryExpiry;
+
+impl Expiry<String, Entry> for PerEntryExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &String,
+        value: &Entry,
+        _current_time: Instant,
+    ) -> Option<Duration> {
+        Some(value.ttl)
+    }
 }
 
 impl MemoryCache {
     pub fn new(ttl: Duration, capacity: u64) -> Self {
         let inner = MokaCache::builder()
             .max_capacity(capacity)
-            .time_to_live(ttl)
+            .expire_after(PerEntryExpiry)
             .build();
         Self { inner, ttl }
     }
@@ -47,11 +80,37 @@ impl Default for MemoryCache {
 #[async_trait]
 impl Cache for MemoryCache {
     async fn get(&self, key: &str) -> Result<Option<ChatResponse>, CacheError> {
-        Ok(self.inner.get(key).await)
+        Ok(self.inner.get(key).await.map(|e| e.response))
     }
 
     async fn put(&self, key: &str, value: ChatResponse) -> Result<(), CacheError> {
-        self.inner.insert(key.to_string(), value).await;
+        self.inner
+            .insert(
+                key.to_string(),
+                Entry {
+                    response: value,
+                    ttl: self.ttl,
+                },
+            )
+            .await;
+        Ok(())
+    }
+
+    async fn put_with_ttl(
+        &self,
+        key: &str,
+        value: ChatResponse,
+        ttl: Duration,
+    ) -> Result<(), CacheError> {
+        self.inner
+            .insert(
+                key.to_string(),
+                Entry {
+                    response: value,
+                    ttl,
+                },
+            )
+            .await;
         Ok(())
     }
 }
@@ -109,5 +168,42 @@ mod tests {
         cache.put("k", updated).await.unwrap();
         let got = cache.get("k").await.unwrap().unwrap();
         assert_eq!(got.message.content, "second");
+    }
+
+    /// Per-entry TTL: two keys inserted at the same time with
+    /// different TTLs must expire independently. Without the
+    /// `Expiry` impl moka would use one global TTL and either both
+    /// entries survive or both die — this test catches that
+    /// regression.
+    #[tokio::test]
+    async fn put_with_ttl_uses_per_entry_expiry() {
+        // Long-fallback cache so a regression that ignores the
+        // per-entry TTL doesn't accidentally pass by global eviction.
+        let cache = MemoryCache::new(Duration::from_secs(300), 100);
+        cache
+            .put_with_ttl("short", sample_response(), Duration::from_millis(50))
+            .await
+            .unwrap();
+        cache
+            .put_with_ttl("long", sample_response(), Duration::from_secs(60))
+            .await
+            .unwrap();
+
+        // Both alive immediately after insert.
+        assert!(cache.get("short").await.unwrap().is_some());
+        assert!(cache.get("long").await.unwrap().is_some());
+
+        // Wait past the short TTL only.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        cache.inner.run_pending_tasks().await;
+
+        assert!(
+            cache.get("short").await.unwrap().is_none(),
+            "short-TTL entry should have expired",
+        );
+        assert!(
+            cache.get("long").await.unwrap().is_some(),
+            "long-TTL entry must survive past the short TTL",
+        );
     }
 }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -447,22 +447,26 @@ async fn dispatch(
     // and the semantic backends.
     //
     // Match order: first enabled policy whose `parsed_applies_to()`
-    // accepts (req.model, auth.entry.id) wins. Iteration order on a
-    // ResourceTable isn't stable, but the first-match-wins rule is
-    // deterministic enough for the cache_status / x-aisix-cache header
-    // to stay stable across requests; ties only matter when an env
-    // legitimately has overlapping policies.
-    let cache_active_by_policy = snapshot
+    // accepts (req.model, auth.entry.id) wins. We grab the WHOLE
+    // matching entry (not just `any`) so the post-call write below
+    // can use that policy's `ttl_seconds` via `put_with_ttl`. When
+    // multiple policies match the same request, the entry-table
+    // iteration order decides — that's an unspecified-but-stable
+    // tiebreak we'll formalise (probably "narrowest scope wins") in a
+    // follow-up if operators ever care.
+    let matched_policy_ttl = snapshot
         .cache_policies
         .entries()
         .iter()
-        .any(|entry| {
+        .find(|entry| {
             entry.value.enabled
                 && entry
                     .value
                     .parsed_applies_to()
                     .matches(&req.model, &auth.entry.id)
-        });
+        })
+        .map(|entry| Duration::from_secs(u64::from(entry.value.ttl_seconds)));
+    let cache_active_by_policy = matched_policy_ttl.is_some();
 
     // Cache lookup keyed on the *virtual* model name so a re-request
     // hits the cache regardless of which target served the original.
@@ -641,15 +645,19 @@ async fn dispatch(
     }
 
     // Cache write is gated on the same policy as the lookup at the
-    // top of dispatch — without an enabled cache_policy in snapshot,
-    // we skip both read AND write so the cache backend doesn't fill
-    // up with entries that no policy ever asked for.
-    if let (true, Some(cache), Some(key)) = (
-        cache_active_by_policy,
-        state.cache.as_ref(),
-        cache_key.as_ref(),
-    ) {
-        if let Err(err) = cache.put(key, upstream.clone()).await {
+    // top of dispatch — without a matching enabled cache_policy in
+    // snapshot, we skip both read AND write so the cache backend
+    // doesn't fill up with entries that no policy ever asked for.
+    //
+    // `matched_policy_ttl` carries the policy's `ttl_seconds`; we feed
+    // it to `put_with_ttl` so each entry expires per its own policy,
+    // not the cache backend's global fallback. Backends without
+    // per-entry support (defined via `Cache::put_with_ttl`'s default
+    // impl) silently fall back to `put`.
+    if let (Some(ttl), Some(cache), Some(key)) =
+        (matched_policy_ttl, state.cache.as_ref(), cache_key.as_ref())
+    {
+        if let Err(err) = cache.put_with_ttl(key, upstream.clone(), ttl).await {
             tracing::warn!(error = %err, key = %key, "cache write failed");
         }
     }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -187,9 +187,8 @@ mod tests {
     /// clause — used by the Stage 3 tests that pin the matcher's
     /// behaviour on `model:<name>` / `api_key:<id>`.
     fn seed_cache_policy_with_applies_to(snap: &AisixSnapshot, name: &str, applies_to: &str) {
-        let cfg = format!(
-            r#"{{"name": "{name}", "backend": "memory", "applies_to": "{applies_to}"}}"#,
-        );
+        let cfg =
+            format!(r#"{{"name": "{name}", "backend": "memory", "applies_to": "{applies_to}"}}"#,);
         let policy: aisix_core::models::CachePolicy = serde_json::from_str(&cfg).unwrap();
         snap.cache_policies
             .insert(ResourceEntry::new(format!("cp-id-{name}"), policy, 1));


### PR DESCRIPTION
Stage 4-ish: per-policy TTL on the cache. Stage 3's `applies_to` matcher landed in #82 (independently); this PR is the natural follow-up that closes the gap dashboard PR #142 had to take down — operators set TTL in the UI but the cache honored its global construction-time TTL instead.

## What changes

- New `Cache::put_with_ttl(&self, key, value, ttl)` trait method with default impl delegating to `put`. Backends without per-entry support (eventual Redis PoC) silently fall back to the backend's global TTL until they catch up.
- `MemoryCache` swaps the global `time_to_live` for a `PerEntryExpiry: Expiry<String, Entry>` that reads ttl off the value at insert time. `expire_after_read`/`update` return `None` so reads don't extend an entry's life — semantic stays "expires N seconds from insert".
- `chat::dispatch` swaps the gate's `.any()` for `.find()` so the post-call write can use the matched policy's `ttl_seconds` via `put_with_ttl`. Reuses #82's `parsed_applies_to().matches(...)` API. Multiple matching policies tiebreak by entry-table iteration order.

## Tests

- aisix-cache: 13 passing (was 12). New: `put_with_ttl_uses_per_entry_expiry` — two keys with 50ms vs 60s TTLs inserted at the same time; after 120ms short is gone, long survives. Without the `Expiry` impl moka would either keep both alive (global TTL = 300s) or expire both (global TTL = 50ms).
- aisix-proxy: 105 passing — existing cache + applies_to integration tests stay green with the per-entry TTL path.
- `cargo test --workspace --lib`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

## Follow-up

Once this lands, restore the TTL field in dashboard's `/cache-policies` form (was taken down in api7/AISIX-Cloud #142 because the DP didn't honor it). The cp-api column already exists and round-trips on read; only the UI needs to add the input back. Tracking as a separate PR after merge.