### PR TITLE
feat(cache): cost-saved telemetry — cache_hit_saved_*_tokens on hits

### DIFF
--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -147,6 +147,24 @@ pub struct UsageEvent {
     /// `aisix_proxy::chat::CacheStatus::as_str`.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub cache_status: String,
+
+    /// On a cache HIT, the prompt tokens of the cached response — i.e.
+    /// the input tokens the request *would* have spent on the upstream
+    /// if the cache hadn't served it. Zero on miss / disabled / error.
+    ///
+    /// cp-api derives `cost_saved_usd` server-side by multiplying these
+    /// counters by the model's pricing (same pattern as `cost_usd` on
+    /// non-cache rows — the DP doesn't own the pricing catalog).
+    /// Surfacing tokens (not USD) here keeps pricing changes a cp-api-
+    /// only deploy and lets the dashboard show "tokens saved" too.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub cache_hit_saved_input_tokens: u32,
+
+    /// On a cache HIT, the completion tokens of the cached response.
+    /// Zero on miss / disabled / error. See `cache_hit_saved_input_tokens`
+    /// for the full pricing-derivation story.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub cache_hit_saved_output_tokens: u32,
 }
 
 #[inline]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -104,6 +104,8 @@ pub async fn chat_completions(
                     finish_reason: success.finish_reason.clone(),
                     bypass_reason: success.bypass_reason.clone().unwrap_or_default(),
                     cache_status: success.cache_status.as_str().to_string(),
+                    cache_hit_saved_input_tokens: success.cache_hit_saved_input_tokens,
+                    cache_hit_saved_output_tokens: success.cache_hit_saved_output_tokens,
                 },
                 success.cost_usd,
                 /* guardrail_blocked */ false,
@@ -244,6 +246,14 @@ struct Success {
     /// the dashboard's /logs column. See `aisix-core::CachePolicy`
     /// (Stage 2) and `aisix-cache::Cache` for the source of truth.
     cache_status: CacheStatus,
+    /// On a cache HIT, the prompt + completion tokens of the cached
+    /// response — the work the upstream would have repeated had the
+    /// cache not served the request. Both 0 on miss / disabled. cp-api
+    /// multiplies these by its pricing catalog to derive
+    /// `cost_saved_usd` on ingestion (matches the existing `cost_usd`
+    /// pattern: DP records tokens, cp-api owns pricing). See #88.
+    cache_hit_saved_input_tokens: u32,
+    cache_hit_saved_output_tokens: u32,
 }
 
 /// Cache decision attached to every successful request. Wire shape
@@ -434,6 +444,8 @@ async fn dispatch(
             // crates/aisix-cache/src/lib.rs and Phase 2 above. Always
             // surface as `disabled` on the streaming path.
             cache_status: CacheStatus::Disabled,
+            cache_hit_saved_input_tokens: 0,
+            cache_hit_saved_output_tokens: 0,
         });
     }
 
@@ -540,6 +552,14 @@ async fn dispatch(
                     cost_usd: 0.0,
                     bypass_reason: bypass_reason.clone(),
                     cache_status: CacheStatus::Hit,
+                    // The whole point of #88: cache hit replays the
+                    // upstream's prompt + completion tokens. Surfacing
+                    // them as a dedicated counter (rather than relying
+                    // on the existing prompt_tokens column + cache_status
+                    // filter) lets cp-api compute `cost_saved_usd`
+                    // without joining on the status enum.
+                    cache_hit_saved_input_tokens: prompt.try_into().unwrap_or(u32::MAX),
+                    cache_hit_saved_output_tokens: completion.try_into().unwrap_or(u32::MAX),
                 });
             }
             Ok(None) => {}
@@ -689,6 +709,10 @@ async fn dispatch(
         cost_usd,
         bypass_reason,
         cache_status,
+        // Cache-saved counters are zero on the upstream-served path —
+        // the request *did* hit the upstream, no work was saved.
+        cache_hit_saved_input_tokens: 0,
+        cache_hit_saved_output_tokens: 0,
     })
 }
 
@@ -763,6 +787,8 @@ fn emit_usage_event(
         guardrail_blocked,
         guardrail_bypassed_reason: extras.bypass_reason,
         cache_status: extras.cache_status,
+        cache_hit_saved_input_tokens: extras.cache_hit_saved_input_tokens,
+        cache_hit_saved_output_tokens: extras.cache_hit_saved_output_tokens,
     };
     state.usage_sink.try_emit(event.clone());
     // Per-env OTLP/HTTP fan-out. The snapshot's exporter table is
@@ -801,6 +827,11 @@ struct UsageExtras {
     /// Empty default for the error path where the cache lookup never
     /// fired. Goes onto `dpmgr_usage_events.cache_status`.
     cache_status: String,
+    /// On a cache HIT, the cached response's prompt + completion
+    /// tokens. Zero otherwise. cp-api derives `cost_saved_usd` on
+    /// ingest from these + its pricing catalog (see #88).
+    cache_hit_saved_input_tokens: u32,
+    cache_hit_saved_output_tokens: u32,
 }
 
 fn record_error(metrics: &Metrics, err: &ProxyError, model: &str, status: u16, elapsed: Duration) {

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -762,6 +762,80 @@ data: [DONE]\n\n";
         assert_eq!(v["choices"][0]["message"]["content"], "cached");
     }
 
+    /// Regression for #88. On a cache hit the DP must surface the
+    /// cached response's prompt + completion tokens on a dedicated
+    /// `cache_hit_saved_*` pair so cp-api can multiply by its pricing
+    /// catalog server-side and report `cost_saved_usd` on `/usage`.
+    /// Miss rows must keep the saved counters at zero.
+    #[tokio::test]
+    async fn cache_hit_emits_saved_token_counters_on_telemetry_event() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "cached"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 7, "completion_tokens": 11, "total_tokens": 18}
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        seed_cache_policy(&snap, "test-cache");
+        let state = build_state_with_cache(snap, hub).with_usage_sink(UsageSink::new(tx));
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        // Miss: saved counters must be zero (the request paid the upstream).
+        let _ = run(build_router(state.clone()), make_req()).await;
+        let miss_event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("miss event was never emitted")
+            .expect("sender dropped");
+        assert_eq!(miss_event.cache_status, "miss");
+        assert_eq!(miss_event.cache_hit_saved_input_tokens, 0);
+        assert_eq!(miss_event.cache_hit_saved_output_tokens, 0);
+
+        // Hit: saved counters must mirror the cached response's usage.
+        let _ = run(build_router(state), make_req()).await;
+        let hit_event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("hit event was never emitted")
+            .expect("sender dropped");
+        assert_eq!(hit_event.cache_status, "hit");
+        assert_eq!(hit_event.cache_hit_saved_input_tokens, 7);
+        assert_eq!(hit_event.cache_hit_saved_output_tokens, 11);
+        // `prompt_tokens` keeps mirroring the cached usage too — the
+        // existing dashboard rollups stay correct. The new field is
+        // additive, not a substitute.
+        assert_eq!(hit_event.prompt_tokens, 7);
+        assert_eq!(hit_event.completion_tokens, 11);
+    }
+
     #[tokio::test]
     async fn cache_miss_when_request_payload_differs() {
         let upstream = MockServer::start().await;


### PR DESCRIPTION
Closes #88.

## Summary

Adds two new fields to the per-request `UsageEvent`:

- `cache_hit_saved_input_tokens`  — cached `usage.prompt_tokens` on hit, zero otherwise
- `cache_hit_saved_output_tokens` — cached `usage.completion_tokens` on hit, zero otherwise

Threaded through `Success` → `UsageExtras` → `emit_usage_event` so every hit-path code path populates them and every miss / disabled / streaming / error path defaults them to zero.

## Why tokens, not USD

cp-api already owns the pricing catalog and recomputes `cost_usd` server-side on ingestion (see the existing `chat.rs:629` comment: *"cp-api recomputes cost server-side from its pricing catalog when ingesting telemetry; the DP just records 0.0 on the wire"*). Keeping `cost_saved_usd` derivation on the cp-api side matches that pattern:

- A price change = single cp-api deploy, no DP rollout
- Dashboard gets both "tokens saved" and "USD saved" out of the same column
- The DP stays free of pricing tables, just like for `cost_usd`

cp-api will derive `cost_saved_usd = cache_hit_saved_input_tokens × input_price + cache_hit_saved_output_tokens × output_price` in a follow-up PR; that work is out of scope for this DP-side change.

## Why a dedicated column instead of reusing prompt_tokens

`prompt_tokens` / `completion_tokens` are still populated on hit rows (matches existing dashboard rollups, no wire-format break). But adding the explicit `cache_hit_saved_*` pair means:

- Dashboard "USD saved this week" tile is `SUM(cache_hit_saved_*_tokens × price)` with no `cache_status='hit'` filter
- Avoids the silent trap where tokens that didn't actually cost anything sit in the same bucket as tokens that did, requiring every aggregator to know to filter

Existing fields are untouched — this is purely additive.

## Tests

New regression test in `aisix-proxy/src/lib.rs`:

  `cache_hit_emits_saved_token_counters_on_telemetry_event`

exercises the live router with a capturing `UsageSink` and asserts:
- miss event: `cache_status="miss"`, both saved counters = 0
- hit event: `cache_status="hit"`, saved counters = (7, 11) mirroring the mocked upstream's usage block
- `prompt_tokens` / `completion_tokens` on the hit event also still mirror the cached usage (additive contract)

## Test plan

- [x] `cargo test -p aisix-proxy --lib cache_hit_emits` (1/1 green)
- [x] `cargo test --workspace --lib` (469 / 469 green; was 468 + 1 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check` (rustfmt 1.8.0)
- [ ] CI green