### PR TITLE
feat(managed): cert-bundle bootstrap path — api7ee parity (P2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "wiremock",
+ "x509-parser",
 ]
 
 [[package]]
@@ -439,6 +440,45 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -1484,6 +1524,20 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "deranged"
@@ -2864,6 +2918,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,6 +3673,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -5441,6 +5513,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "xattr"

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -165,6 +165,46 @@ pub struct ManagedConfig {
     #[serde(default)]
     pub cp_ca_cert_file: Option<String>,
 
+    /// Inline PEM-encoded leaf certificate for the api7ee-parity
+    /// cert-via-env-var bootstrap path (cp-api's
+    /// /api/environments/:id/gateway_certificates endpoint, dashboard
+    /// CertIssueCard). When all three of `cp_cert_pem` / `cp_key_pem`
+    /// / `cp_ca_pem` are set, the DP skips `/dp/register` entirely:
+    /// the operator has already minted the bundle on the dashboard
+    /// and inlined it here. env_id is parsed from the cert's URI SAN
+    /// (`x-aisix://env/<env_id>`).
+    ///
+    /// File-based variants below let operators store PEMs on disk
+    /// (e.g. systemd unit on a host VM) instead of inlining into env
+    /// vars. Inline-PEM and file-path variants are mutually exclusive
+    /// per pair (cert/key/ca); mixing them is a config error caught
+    /// at boot.
+    #[serde(default)]
+    pub cp_cert_pem: Option<String>,
+
+    /// Inline PEM-encoded private key paired with `cp_cert_pem`.
+    /// Mutually exclusive with `cp_key_file`.
+    #[serde(default)]
+    pub cp_key_pem: Option<String>,
+
+    /// Inline PEM-encoded CA certificate paired with `cp_cert_pem`.
+    /// The DP installs this as the trust anchor for outbound mTLS
+    /// to dp-manager. Mutually exclusive with `cp_ca_file`.
+    #[serde(default)]
+    pub cp_ca_pem: Option<String>,
+
+    /// File-path variant of `cp_cert_pem`.
+    #[serde(default)]
+    pub cp_cert_file: Option<String>,
+
+    /// File-path variant of `cp_key_pem`.
+    #[serde(default)]
+    pub cp_key_file: Option<String>,
+
+    /// File-path variant of `cp_ca_pem`.
+    #[serde(default)]
+    pub cp_ca_file: Option<String>,
+
     /// Directory where the DP persists `ca.crt`, `client.crt`,
     /// `client.key` received from the register response. Files are
     /// written `0600`. Parent directory must already exist and be
@@ -204,6 +244,23 @@ impl ManagedConfig {
             .as_deref()
             .is_some_and(|s| !s.is_empty())
             && self.cp_base_url.as_deref().is_some_and(|s| !s.is_empty())
+    }
+
+    /// True when the operator pre-provisioned a cert/key/CA bundle
+    /// via the api7ee-parity dashboard flow — either inlined as
+    /// PEM env vars (`cp_cert_pem` / `cp_key_pem` / `cp_ca_pem`) or
+    /// referenced by file path (`cp_cert_file` / `cp_key_file` /
+    /// `cp_ca_file`). All three slots in the same triplet must be
+    /// present together; mixing inline-and-file forms within a
+    /// single role is rejected at boot for clarity.
+    pub fn cert_bundle_provided(&self) -> bool {
+        let has_pem = self.cp_cert_pem.as_deref().is_some_and(|s| !s.is_empty())
+            && self.cp_key_pem.as_deref().is_some_and(|s| !s.is_empty())
+            && self.cp_ca_pem.as_deref().is_some_and(|s| !s.is_empty());
+        let has_file = self.cp_cert_file.as_deref().is_some_and(|s| !s.is_empty())
+            && self.cp_key_file.as_deref().is_some_and(|s| !s.is_empty())
+            && self.cp_ca_file.as_deref().is_some_and(|s| !s.is_empty());
+        has_pem || has_file
     }
 
     fn default_mtls_dir() -> String {

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -47,6 +47,7 @@ etcd-client.workspace = true
 reqwest.workspace = true
 rcgen.workspace = true
 chrono.workspace = true
+x509-parser = "0.16"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aisix-server/src/cert_bundle.rs
+++ b/crates/aisix-server/src/cert_bundle.rs
@@ -1,0 +1,372 @@
+//! Pre-provisioned mTLS bundle bootstrap path (api7ee parity).
+//!
+//! Counterpart to `register.rs`. When the operator mints a cert via
+//! the dashboard's `CertIssueCard` (see AISIX-Cloud cp-api's
+//! `POST /api/environments/:env_id/gateway_certificates`), the
+//! resulting cert + key + CA PEM trio is inlined into the DP's
+//! environment vars (or written to disk for systemd / k8s Secret
+//! mounts). The DP boots, materialises the bundle to `mtls_dir`,
+//! parses `env_id` out of the leaf cert's URI SAN, and proceeds
+//! straight to the etcd connect — no `/dp/register` round-trip.
+//!
+//! Wire shape, three required PEMs:
+//!
+//!   AISIX_MANAGED__CP_CERT_PEM   — leaf certificate
+//!   AISIX_MANAGED__CP_KEY_PEM    — SEC1 EC private key paired with
+//!                                  the leaf
+//!   AISIX_MANAGED__CP_CA_PEM     — CA cert the DP installs as the
+//!                                  trust anchor for dp-manager mTLS
+//!
+//! `_FILE` variants take the same content but load from disk; useful
+//! for systemd hosts where pasting multi-line PEMs into env vars is
+//! awkward. Inline and file variants are mutually exclusive per
+//! triplet; mixing gets a hard error at boot rather than a silent
+//! pick-one.
+//!
+//! The cert's URI SAN encodes `x-aisix://env/<env_id>` per cp-api's
+//! `internal/dpmgr/certmgr/issue.go`. We parse it out and plant it
+//! into `cfg.etcd.env_id` so `effective_prefix()` returns
+//! `/aisix/<env_id>/` — the same scoping the legacy register-derived
+//! `r.env_id` used to populate.
+
+use std::path::{Path, PathBuf};
+
+use aisix_core::ManagedConfig;
+use anyhow::{anyhow, bail, Context};
+use x509_parser::extensions::GeneralName;
+use x509_parser::pem::parse_x509_pem;
+use x509_parser::prelude::{FromDer, X509Certificate};
+
+/// Outcome of materialising a pre-provisioned bundle. Mirrors
+/// `register::Registered` minus the metadata cp-api would have
+/// returned (we don't have a register response to crib from).
+#[derive(Debug, Clone)]
+pub struct Provisioned {
+    /// env_id parsed from the leaf cert's URI SAN
+    /// (`x-aisix://env/<env_id>`). Plumbed into `cfg.etcd.env_id` so
+    /// every Range/Watch lands on `/aisix/<env_id>/`.
+    pub env_id: String,
+    /// dp_id parsed from the leaf cert's URI SAN
+    /// (`x-aisix://dp/<dp_id>`). Used for heartbeat payload + log
+    /// correlation.
+    pub dp_id: String,
+    /// On-disk path to the materialised CA cert.
+    pub ca_cert_path: PathBuf,
+    /// On-disk path to the materialised leaf cert.
+    pub client_cert_path: PathBuf,
+    /// On-disk path to the materialised leaf private key.
+    pub client_key_path: PathBuf,
+}
+
+/// Load + materialise a pre-provisioned bundle. Reads PEM contents
+/// from either the inline env-var fields (`cp_cert_pem` etc.) or
+/// the file-path fields (`cp_cert_file` etc.), writes them
+/// atomically to `mtls_dir`, parses the leaf cert's SAN to extract
+/// (env_id, dp_id), and returns paths the caller plumbs into
+/// `cfg.etcd.tls`.
+///
+/// Idempotent: re-running with the same inputs over an existing
+/// `mtls_dir` is safe; the atomic-write helper truncates+rewrites
+/// the targets.
+pub async fn provision(cfg: &ManagedConfig) -> anyhow::Result<Provisioned> {
+    let cert_pem = load_pem("cert", cfg.cp_cert_pem.as_deref(), cfg.cp_cert_file.as_deref()).await?;
+    let key_pem = load_pem("key", cfg.cp_key_pem.as_deref(), cfg.cp_key_file.as_deref()).await?;
+    let ca_pem = load_pem("ca", cfg.cp_ca_pem.as_deref(), cfg.cp_ca_file.as_deref()).await?;
+
+    let (env_id, dp_id) = parse_san_uris(&cert_pem)
+        .with_context(|| "parse env_id + dp_id from leaf cert SAN URIs")?;
+    if env_id.is_empty() {
+        bail!("leaf cert is missing the `x-aisix://env/<uuid>` SAN URI");
+    }
+    if dp_id.is_empty() {
+        bail!("leaf cert is missing the `x-aisix://dp/<uuid>` SAN URI");
+    }
+
+    let mtls_dir = Path::new(&cfg.mtls_dir);
+    if !mtls_dir.exists() {
+        tokio::fs::create_dir_all(mtls_dir)
+            .await
+            .with_context(|| format!("create mtls_dir at {mtls_dir:?}"))?;
+    }
+    let ca_path = ca_cert_path(mtls_dir);
+    let cert_path = client_cert_path(mtls_dir);
+    let key_path = client_key_path(mtls_dir);
+    write_atomic(&ca_path, ca_pem.as_bytes(), 0o644)
+        .await
+        .with_context(|| format!("write CA cert to {ca_path:?}"))?;
+    write_atomic(&cert_path, cert_pem.as_bytes(), 0o644)
+        .await
+        .with_context(|| format!("write client cert to {cert_path:?}"))?;
+    write_atomic(&key_path, key_pem.as_bytes(), 0o600)
+        .await
+        .with_context(|| format!("write client key to {key_path:?}"))?;
+
+    Ok(Provisioned {
+        env_id,
+        dp_id,
+        ca_cert_path: ca_path,
+        client_cert_path: cert_path,
+        client_key_path: key_path,
+    })
+}
+
+/// Resolve PEM content from either the inline `pem_arg` (env-var
+/// form) or the `file_arg` (path-on-disk form). Setting both is a
+/// boot-time error — the operator made a mistake we should not
+/// silently paper over.
+async fn load_pem(
+    role: &str,
+    pem_arg: Option<&str>,
+    file_arg: Option<&str>,
+) -> anyhow::Result<String> {
+    let inline = pem_arg.filter(|s| !s.is_empty());
+    let file = file_arg.filter(|s| !s.is_empty());
+    match (inline, file) {
+        (Some(p), None) => Ok(p.to_string()),
+        (None, Some(path)) => {
+            let bytes = tokio::fs::read(path)
+                .await
+                .with_context(|| format!("read {role} PEM from {path:?}"))?;
+            String::from_utf8(bytes).with_context(|| format!("{role} PEM at {path:?} is not UTF-8"))
+        }
+        (Some(_), Some(_)) => bail!(
+            "managed config sets BOTH cp_{role}_pem and cp_{role}_file — pick one (inline or path)",
+        ),
+        (None, None) => bail!("managed config is missing cp_{role}_pem / cp_{role}_file"),
+    }
+}
+
+/// Parse a leaf cert's URI SANs and return `(env_id, dp_id)`. The
+/// cert manager (`internal/dpmgr/certmgr/issue.go`) encodes them
+/// as:
+///
+///   x-aisix://env/<env_id>
+///   x-aisix://dp/<dp_id>
+fn parse_san_uris(pem: &str) -> anyhow::Result<(String, String)> {
+    let (_, p) = parse_x509_pem(pem.as_bytes())
+        .map_err(|e| anyhow!("decode PEM: {e:?}"))?;
+    let (_, cert) = X509Certificate::from_der(&p.contents)
+        .map_err(|e| anyhow!("parse X.509: {e:?}"))?;
+    let san = cert
+        .subject_alternative_name()
+        .map_err(|e| anyhow!("read SAN ext: {e:?}"))?
+        .ok_or_else(|| anyhow!("leaf cert has no SubjectAlternativeName extension"))?;
+    let mut env_id = String::new();
+    let mut dp_id = String::new();
+    for name in &san.value.general_names {
+        if let GeneralName::URI(uri) = name {
+            if let Some(rest) = uri.strip_prefix("x-aisix://env/") {
+                env_id = rest.to_string();
+            } else if let Some(rest) = uri.strip_prefix("x-aisix://dp/") {
+                dp_id = rest.to_string();
+            }
+        }
+    }
+    Ok((env_id, dp_id))
+}
+
+pub fn ca_cert_path(mtls_dir: impl AsRef<Path>) -> PathBuf {
+    mtls_dir.as_ref().join("ca.crt")
+}
+pub fn client_cert_path(mtls_dir: impl AsRef<Path>) -> PathBuf {
+    mtls_dir.as_ref().join("client.crt")
+}
+pub fn client_key_path(mtls_dir: impl AsRef<Path>) -> PathBuf {
+    mtls_dir.as_ref().join("client.key")
+}
+
+#[cfg(unix)]
+async fn write_atomic(path: &Path, data: &[u8], mode: u32) -> anyhow::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("path {path:?} has no parent dir"))?;
+    let tmp = parent.join(format!(
+        ".aisix-tmp-{}.{}",
+        path.file_name().and_then(|n| n.to_str()).unwrap_or("blob"),
+        std::process::id()
+    ));
+    {
+        let mut f = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(mode)
+            .open(&tmp)
+            .await
+            .with_context(|| format!("open tmp file {tmp:?}"))?;
+        f.write_all(data).await?;
+        f.flush().await?;
+        f.sync_all().await?;
+    }
+    tokio::fs::rename(&tmp, path)
+        .await
+        .with_context(|| format!("atomic rename {tmp:?} → {path:?}"))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn write_atomic(_path: &Path, _data: &[u8], _mode: u32) -> anyhow::Result<()> {
+    bail!("non-Unix file write is not implemented; managed-mode bundle bootstrap requires Unix")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{
+        CertificateParams, DistinguishedName, IsCa, KeyIdMethod, KeyPair, KeyUsagePurpose, SanType,
+    };
+    use tempfile::TempDir;
+
+    /// Generate a self-signed cert with the same SAN URI shape cp-
+    /// api's certmgr signs, so we can test the SAN parsing path
+    /// without touching cp-api at all.
+    fn synth_leaf(env_id: &str, dp_id: &str) -> (String, String) {
+        let mut params = CertificateParams::default();
+        params.distinguished_name = DistinguishedName::new();
+        params.is_ca = IsCa::NoCa;
+        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        params.key_identifier_method = KeyIdMethod::Sha256;
+        params.subject_alt_names = vec![
+            SanType::URI(format!("x-aisix://env/{env_id}").try_into().unwrap()),
+            SanType::URI(format!("x-aisix://dp/{dp_id}").try_into().unwrap()),
+        ];
+        let key = KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        (cert.pem(), key.serialize_pem())
+    }
+
+    #[test]
+    fn parse_san_uris_extracts_env_and_dp() {
+        let (cert_pem, _) = synth_leaf("env-uuid-123", "dp-uuid-456");
+        let (env, dp) = parse_san_uris(&cert_pem).unwrap();
+        assert_eq!(env, "env-uuid-123");
+        assert_eq!(dp, "dp-uuid-456");
+    }
+
+    #[test]
+    fn parse_san_uris_rejects_cert_without_uri_san() {
+        // Only DNS SAN, no URI — should fail to find env/dp.
+        let mut params = CertificateParams::default();
+        params.distinguished_name = DistinguishedName::new();
+        params.is_ca = IsCa::NoCa;
+        params.subject_alt_names = vec![SanType::DnsName("dp.example.com".try_into().unwrap())];
+        let key = KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        let (env, dp) = parse_san_uris(&cert.pem()).unwrap();
+        assert!(env.is_empty());
+        assert!(dp.is_empty());
+    }
+
+    #[tokio::test]
+    async fn provision_writes_three_files_with_san_extracted() {
+        let tmp = TempDir::new().unwrap();
+        let (cert_pem, key_pem) = synth_leaf("env-1", "dp-1");
+        // Reuse the leaf as the "CA" PEM — the path doesn't validate
+        // the chain, just shovels bytes to disk.
+        let ca_pem = cert_pem.clone();
+
+        let cfg = ManagedConfig {
+            enabled: true,
+            mtls_dir: tmp.path().to_string_lossy().into_owned(),
+            cp_cert_pem: Some(cert_pem.clone()),
+            cp_key_pem: Some(key_pem),
+            cp_ca_pem: Some(ca_pem),
+            ..ManagedConfig::default()
+        };
+
+        let p = provision(&cfg).await.unwrap();
+        assert_eq!(p.env_id, "env-1");
+        assert_eq!(p.dp_id, "dp-1");
+        assert!(p.ca_cert_path.exists());
+        assert!(p.client_cert_path.exists());
+        assert!(p.client_key_path.exists());
+
+        // Verify perms on the key file: 0600 on Unix.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let m = std::fs::metadata(&p.client_key_path).unwrap();
+            assert_eq!(m.permissions().mode() & 0o777, 0o600);
+        }
+    }
+
+    #[tokio::test]
+    async fn provision_rejects_mixed_inline_and_file_for_same_role() {
+        let tmp = TempDir::new().unwrap();
+        let (cert_pem, key_pem) = synth_leaf("env-1", "dp-1");
+
+        // cert role: BOTH inline and file. Should error.
+        let cert_file = tmp.path().join("cert.pem");
+        tokio::fs::write(&cert_file, &cert_pem).await.unwrap();
+        let cfg = ManagedConfig {
+            mtls_dir: tmp.path().to_string_lossy().into_owned(),
+            cp_cert_pem: Some(cert_pem),
+            cp_cert_file: Some(cert_file.to_string_lossy().into_owned()),
+            cp_key_pem: Some(key_pem.clone()),
+            cp_ca_pem: Some(key_pem),
+            ..ManagedConfig::default()
+        };
+
+        let err = provision(&cfg).await.unwrap_err();
+        assert!(err.to_string().contains("BOTH"), "err: {err}");
+    }
+
+    #[tokio::test]
+    async fn provision_loads_from_files_when_inline_unset() {
+        let tmp = TempDir::new().unwrap();
+        let (cert_pem, key_pem) = synth_leaf("env-2", "dp-2");
+        let cert_file = tmp.path().join("cert.pem");
+        let key_file = tmp.path().join("key.pem");
+        let ca_file = tmp.path().join("ca.pem");
+        tokio::fs::write(&cert_file, &cert_pem).await.unwrap();
+        tokio::fs::write(&key_file, &key_pem).await.unwrap();
+        tokio::fs::write(&ca_file, &cert_pem).await.unwrap();
+
+        let cfg = ManagedConfig {
+            mtls_dir: tmp.path().join("bundle").to_string_lossy().into_owned(),
+            cp_cert_file: Some(cert_file.to_string_lossy().into_owned()),
+            cp_key_file: Some(key_file.to_string_lossy().into_owned()),
+            cp_ca_file: Some(ca_file.to_string_lossy().into_owned()),
+            ..ManagedConfig::default()
+        };
+
+        let p = provision(&cfg).await.unwrap();
+        assert_eq!(p.env_id, "env-2");
+        assert_eq!(p.dp_id, "dp-2");
+    }
+
+    #[test]
+    fn cert_bundle_provided_inline_only() {
+        let cfg = ManagedConfig {
+            cp_cert_pem: Some("cert".into()),
+            cp_key_pem: Some("key".into()),
+            cp_ca_pem: Some("ca".into()),
+            ..ManagedConfig::default()
+        };
+        assert!(cfg.cert_bundle_provided());
+    }
+
+    #[test]
+    fn cert_bundle_provided_file_only() {
+        let cfg = ManagedConfig {
+            cp_cert_file: Some("/x/cert".into()),
+            cp_key_file: Some("/x/key".into()),
+            cp_ca_file: Some("/x/ca".into()),
+            ..ManagedConfig::default()
+        };
+        assert!(cfg.cert_bundle_provided());
+    }
+
+    #[test]
+    fn cert_bundle_provided_partial_inline_is_false() {
+        let cfg = ManagedConfig {
+            cp_cert_pem: Some("cert".into()),
+            cp_key_pem: Some("key".into()),
+            // missing ca
+            ..ManagedConfig::default()
+        };
+        assert!(!cfg.cert_bundle_provided());
+    }
+}

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -16,6 +16,7 @@ use std::error::Error as StdError;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+mod cert_bundle;
 mod heartbeat;
 mod register;
 mod telemetry;
@@ -92,34 +93,117 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let heartbeat_cfg: Option<heartbeat::HeartbeatConfig> = if cfg.managed.is_managed() {
         let bundle_on_disk = register::bundle_exists(&cfg.managed.mtls_dir);
         let can_register = cfg.managed.registration_enabled();
+        let bundle_provided = cfg.managed.cert_bundle_provided();
         // Log the branch inputs so operators don't have to guess why
         // their DP didn't register (or why it tried to).
         tracing::info!(
             bundle_exists = bundle_on_disk,
             registration_enabled = can_register,
+            cert_bundle_provided = bundle_provided,
             mtls_dir = %cfg.managed.mtls_dir,
             "managed-mode bootstrap branch inputs",
         );
-        if !bundle_on_disk && !can_register {
-            // In managed mode we MUST have either a persisted bundle or
-            // enough config to go get one. Silently proceeding with the
-            // placeholder etcd endpoint from config.managed.yaml turns
-            // into an opaque gRPC "dns error" minutes later — instead,
-            // fail the boot loudly with exactly what's missing.
+        if !bundle_on_disk && !can_register && !bundle_provided {
+            // In managed mode we MUST have at least one of:
+            //   - a persisted bundle in mtls_dir (subsequent boot)
+            //   - registration_token + cp_base_url (legacy /dp/register)
+            //   - cert + key + CA PEMs (api7ee parity, dashboard mint)
+            // Silently proceeding with the placeholder etcd endpoint
+            // from config.managed.yaml turns into an opaque gRPC "dns
+            // error" minutes later — instead, fail the boot loudly
+            // with exactly what's missing.
             anyhow::bail!(
-                "managed mode is enabled but registration is not possible: \
-                 registration_token={}, cp_base_url={}; set both \
-                 AISIX_MANAGED__REGISTRATION_TOKEN and AISIX_MANAGED__CP_BASE_URL, \
+                "managed mode is enabled but no boot path is available: \
+                 registration_token={}, cp_base_url={}, cert_bundle_provided={}; \
+                 set AISIX_MANAGED__CP_CERT_PEM + _KEY_PEM + _CA_PEM (recommended) \
+                 OR AISIX_MANAGED__REGISTRATION_TOKEN + _CP_BASE_URL (legacy), \
                  or persist an mTLS bundle at {:?}",
                 cfg.managed
                     .registration_token
                     .as_deref()
                     .unwrap_or("<unset>"),
                 cfg.managed.cp_base_url.as_deref().unwrap_or("<unset>"),
+                bundle_provided,
                 cfg.managed.mtls_dir,
             );
         }
-        if !bundle_on_disk && can_register {
+        if !bundle_on_disk && bundle_provided {
+            // api7ee-parity bootstrap: operator minted a cert via the
+            // dashboard, inlined the three PEMs into env vars (or
+            // referenced files on disk). Materialise the bundle to
+            // `mtls_dir`, parse env_id + dp_id from the leaf SAN, and
+            // populate cfg.etcd.* exactly like the register branch
+            // does. No /dp/register round-trip.
+            tracing::info!("managed mode: provisioning from supplied cert bundle (api7ee parity)");
+            let p = cert_bundle::provision(&cfg.managed)
+                .await
+                .map_err(|e| anyhow::anyhow!("DP cert-bundle provisioning failed: {e:#}"))?;
+            // The cert-bundle path requires cp_base_url for the
+            // heartbeat worker but skips registration_token. cp-api
+            // also needs cp_etcd_endpoint to be set (cmux serves
+            // gRPC + REST on the same port, but the etcd-client
+            // crate wants a host:port string). We accept the same
+            // endpoint as the cp_base_url's host:port if
+            // cp_etcd_endpoint is unset.
+            let cp_base = cfg
+                .managed
+                .cp_base_url
+                .clone()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "managed.cp_base_url required when cert bundle is provided",
+                    )
+                })?;
+            let cp_etcd = cfg
+                .managed
+                .cp_etcd_endpoint
+                .clone()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| {
+                    cp_base
+                        .trim_start_matches("https://")
+                        .trim_start_matches("http://")
+                        .to_string()
+                });
+            tracing::info!(
+                dp_id = %p.dp_id,
+                env_id = %p.env_id,
+                etcd = %cp_etcd,
+                "provisioned with dashboard-issued cert bundle",
+            );
+            cfg.etcd.endpoints = vec![format!("https://{cp_etcd}")];
+            cfg.etcd.env_id = p.env_id.clone();
+            cfg.etcd.tls = Some(EtcdTlsConfig {
+                ca_cert_file: p.ca_cert_path.to_string_lossy().into_owned(),
+                client_cert_file: p.client_cert_path.to_string_lossy().into_owned(),
+                client_key_file: p.client_key_path.to_string_lossy().into_owned(),
+                domain_name: None,
+            });
+            // Persist dp_id + env_id to the same on-disk paths the
+            // register branch uses, so subsequent boots take the
+            // bundle-on-disk path without re-running provisioning
+            // (which would be a no-op anyway, but the dp_id_file
+            // path is what the heartbeat-restore helper reads).
+            register::persist_dp_id_for_provisioning(&cfg.managed, &p.dp_id, &p.env_id)
+                .await
+                .map_err(|e| anyhow::anyhow!("persist dp_id/env_id sidecars: {e:#}"))?;
+            // Heartbeat — same shape as register branch. The
+            // heartbeat path under cp_base_url is fixed
+            // (`/dp/heartbeat`); we don't need a server response to
+            // know it.
+            Some(heartbeat::HeartbeatConfig::sanitised(
+                format!("{}/dp/heartbeat", cp_base.trim_end_matches('/')),
+                p.dp_id,
+                std::time::Duration::from_secs(15),
+                heartbeat::MtlsBundle {
+                    ca_cert_path: p.ca_cert_path,
+                    client_cert_path: p.client_cert_path,
+                    client_key_path: p.client_key_path,
+                    extra_ca_pem: extra_ca_pem.clone(),
+                },
+            ))
+        } else if !bundle_on_disk && can_register {
             tracing::info!("managed mode: registering with aisix.cloud CP");
             let cp_etcd = cfg
                 .managed

--- a/crates/aisix-server/src/register.rs
+++ b/crates/aisix-server/src/register.rs
@@ -333,6 +333,23 @@ async fn persist_dp_id(path: &str, id: &str) -> anyhow::Result<()> {
     write_atomic(&path, id.as_bytes(), 0o600).await
 }
 
+/// Persist dp_id (to `cfg.dp_id_file`) and env_id (sibling file in
+/// `mtls_dir`) for the api7ee-parity provisioning path. Mirrors what
+/// `persist_dp_id` + `persist_env_id` do at the end of
+/// `register_and_persist`, but exposed publicly so `cert_bundle::
+/// provision`'s caller (main.rs) can write the same sidecar files.
+/// Subsequent boots then take the `bundle_exists` branch and read
+/// dp_id + env_id straight off disk like the legacy register flow.
+pub async fn persist_dp_id_for_provisioning(
+    cfg: &ManagedConfig,
+    dp_id: &str,
+    env_id: &str,
+) -> anyhow::Result<()> {
+    persist_dp_id(&cfg.dp_id_file, dp_id).await?;
+    persist_env_id(&cfg.mtls_dir, env_id).await?;
+    Ok(())
+}
+
 /// Persist `env_id` to `<mtls_dir>/env_id` atomically. `mtls_dir` is
 /// already created by `persist_mtls`, but we re-create defensively in
 /// case this helper is called in isolation.
@@ -471,6 +488,7 @@ mod tests {
             mtls_dir: mtls_dir.to_string_lossy().into_owned(),
             dp_id_file: dp_id_file.to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
+        ..ManagedConfig::default()
         };
 
         let out = register_and_persist(&cfg).await.expect("register");
@@ -566,6 +584,7 @@ mod tests {
             mtls_dir: dir.path().join("mtls").to_string_lossy().into_owned(),
             dp_id_file: dir.path().join("dp_id").to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
+        ..ManagedConfig::default()
         };
         register_and_persist(&cfg).await.expect("register");
     }
@@ -595,6 +614,7 @@ mod tests {
             mtls_dir: dir.path().join("mtls").to_string_lossy().into_owned(),
             dp_id_file: dir.path().join("dp_id").to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
+        ..ManagedConfig::default()
         };
         register_and_persist(&cfg).await.expect("register");
 
@@ -633,6 +653,7 @@ mod tests {
             mtls_dir: dir.path().join("mtls").to_string_lossy().into_owned(),
             dp_id_file: dir.path().join("dp_id").to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
+        ..ManagedConfig::default()
         };
         let err = register_and_persist(&cfg).await.unwrap_err();
         let s = format!("{err:#}");
@@ -665,6 +686,7 @@ mod tests {
             mtls_dir: dir.path().join("mtls").to_string_lossy().into_owned(),
             dp_id_file: dir.path().join("dp_id").to_string_lossy().into_owned(),
             snapshot_cache_path: String::new(),
+        ..ManagedConfig::default()
         };
         let err = register_and_persist(&cfg).await.unwrap_err();
         let s = format!("{err:#}");


### PR DESCRIPTION
## Summary

Adds the DP-side bootstrap branch that pairs with AISIX-Cloud's gateway-certificate endpoint (cp-api PR #164) + dashboard CertIssueCard (cp-api PR #165). When the operator mints a cert via the dashboard and inlines the three PEMs into env vars, the DP boots straight to etcd without a \`/dp/register\` round-trip.

Customer flow now matches api7ee:

1. Open dashboard \`/data-planes\`, click **Issue certificate** — dashboard returns cert + key + CA.
2. Paste them into \`docker run -e AISIX_MANAGED__CP_CERT_PEM=... -e AISIX_MANAGED__CP_KEY_PEM=... -e AISIX_MANAGED__CP_CA_PEM=...\` (or \`_FILE\` variants for k8s Secret + systemd hosts).
3. DP boots, parses env_id + dp_id from the leaf SAN, connects to dp-manager mTLS, watches etcd. No \`/dp/register\`.

## Branch order in main.rs

The new branch runs first in the managed-mode cascade:

1. **Cert bundle provided & no on-disk bundle yet → provision (NEW)**
2. \`registration_token + cp_base_url\` & no on-disk bundle yet → legacy \`/dp/register\`
3. On-disk bundle exists → restore from disk

Order matters: customers who set BOTH a bundle and a registration_token (during migration) get the new flow; legacy deployments without bundle keep working untouched.

## Test plan

- [x] \`cargo test\` — full workspace green (328+ tests across all crates, 8 new in \`cert_bundle\`)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] **NEW** \`crates/aisix-server/src/cert_bundle.rs\` unit tests:
  1. \`parse_san_uris_extracts_env_and_dp\` — happy path
  2. \`parse_san_uris_rejects_cert_without_uri_san\` — DNS-only SAN returns empty (caller bails)
  3. \`provision_writes_three_files_with_san_extracted\` — atomic file writes; key file is 0o600
  4. \`provision_rejects_mixed_inline_and_file_for_same_role\` — clear error
  5. \`provision_loads_from_files_when_inline_unset\` — file-mode loading
  6. \`cert_bundle_provided_inline_only\`
  7. \`cert_bundle_provided_file_only\`
  8. \`cert_bundle_provided_partial_inline_is_false\`

## Follow-up

After this image lands, AISIX-Cloud's e2e harness can drop \`/dp/register\` calls from \`v3-end-to-end-flows\` + \`customer-demo-walkthrough\` specs and switch to the cert flow end-to-end. cp-api's \`/dp/register\` handler stays alive in the meantime so already-deployed DPs continue working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added flexible TLS/MTLS certificate configuration supporting both inline PEM and file-based certificate bundles.
  * Introduced managed-mode support for automatic provisioning of client mTLS certificates from operator-provided bundles.
  * Enhanced bootstrap flow to validate and provision certificate bundles with automatic service identity extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->