### PR TITLE
docs(admin): expand OpenAPI document to cover every mounted route

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,17 @@ Surfaces and capabilities currently in main:
 
 - **Providers** — OpenAI, Anthropic, Gemini, DeepSeek (one bridge crate per vendor; OpenAI-shape `model: "<provider>/<id>"` selects the bridge)
 
-- **Admin API (`:3001`)** — CRUD on every entity, JSON-Schema validated, OpenAPI 3 + Scalar UI at `/admin/openapi-scalar`
+- **Admin API (`:3001`)** — CRUD on the routing-related entities, JSON-Schema validated, OpenAPI 3 + Scalar UI at `/admin/openapi-scalar`
   - `/admin/v1/models`
   - `/admin/v1/apikeys` (+ `POST .../rotate`)
   - `/admin/v1/provider_keys`
-  - `/admin/v1/guardrails`
-  - `/admin/v1/cache_policies`
-  - `/admin/v1/observability_exporters`
   - `/admin/v1/health` — per-model upstream health (Healthy / Degraded / Down)
-  - `/admin/v1/spend` — current-month USD per ApiKey
   - `/playground/chat/completions` — in-process forward to the proxy router
+
+  Guardrails, cache policies, and observability exporters exist as
+  resource types in `aisix-core` and are honoured at runtime, but
+  standalone CRUD over those still goes through direct etcd writes
+  today — Admin handlers will follow.
 
 - **Config plane** — etcd with watch-driven `ArcSwap` snapshot. Lock-free reads on the hot path. Schema-rejected rows logged + skipped, never fatal.
 

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1,10 +1,10 @@
-//! Minimal OpenAPI document + Scalar mount.
+//! Hand-written OpenAPI 3.1 document + Scalar mount.
 //!
-//! Only the admin CRUD endpoints are described here today. The proxy
-//! `/v1/chat/completions` surface is OpenAI-compatible and operators
-//! refer to OpenAI's published spec for that — duplicating it here adds
-//! drift risk without adding signal. Future PRs that introduce
-//! aisix-specific request/response shapes can extend the spec inline.
+//! Covers every route mounted in `crate::build_router` so what you see
+//! at `/admin/openapi-scalar` matches what the binary actually serves.
+//! The proxy `/v1/chat/completions` surface is OpenAI-compatible and
+//! operators refer to OpenAI's published spec for that — duplicating
+//! it here adds drift risk without adding signal.
 //!
 //! The Scalar UI is a single static HTML page that loads the JSON spec
 //! over HTTP — no JS bundling required.
@@ -15,40 +15,260 @@ use axum::response::{Html, IntoResponse, Response};
 /// Hand-written JSON spec. Small enough that maintaining it by hand is
 /// less effort than wiring `utoipa` derive macros across every handler;
 /// the surface is stable enough that drift is easy to spot in review.
-const OPENAPI_JSON: &str = r#"{
+/// Update this whenever a route is added/removed in `lib.rs`.
+const OPENAPI_JSON: &str = r##"{
   "openapi": "3.1.0",
   "info": {
     "title": "aisix admin API",
     "version": "0.1.0",
-    "description": "CRUD for Models and ApiKeys. All endpoints require Bearer admin-key auth. Errors use {error_msg}."
+    "description": "Admin surface for the standalone aisix gateway. All `/admin/v1/*` routes require Bearer admin-key auth (configured via `admin.admin_keys`). Errors use {\"error_msg\": \"...\"}.\n\nIn managed mode (aisix.cloud tenant) the admin listener is not bound — the dashboard owns CRUD via the AISIX-Cloud control plane."
   },
   "paths": {
+    "/health": {
+      "get": {
+        "summary": "process health + snapshot counts",
+        "security": [],
+        "responses": {"200": {"description": "OK"}}
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Prometheus metrics (text/plain; version=0.0.4)",
+        "security": [],
+        "responses": {
+          "200": {"description": "OK"},
+          "503": {"description": "metrics recorder not configured"}
+        }
+      }
+    },
+    "/admin/openapi.json": {
+      "get": {
+        "summary": "this OpenAPI document",
+        "security": [],
+        "responses": {"200": {"description": "OK"}}
+      }
+    },
+    "/admin/openapi-scalar": {
+      "get": {
+        "summary": "Scalar UI (HTML) for browsing this spec",
+        "security": [],
+        "responses": {"200": {"description": "OK"}}
+      }
+    },
     "/admin/v1/models": {
-      "get":  { "summary": "list models",  "responses": {"200": {"description": "OK"}} },
-      "post": { "summary": "create model", "responses": {"200": {"description": "OK"}, "409": {"description": "duplicate name"}} }
+      "get": {
+        "summary": "list models",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/ModelEntry"}}}}
+          }
+        }
+      },
+      "post": {
+        "summary": "create model",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Model"}}}},
+        "responses": {
+          "200": {"description": "OK", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ModelEntry"}}}},
+          "400": {"description": "schema validation failed"},
+          "409": {"description": "duplicate display_name"}
+        }
+      }
     },
     "/admin/v1/models/{id}": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
       "get":    { "summary": "get model",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
-      "put":    { "summary": "update model", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}, "409": {"description": "duplicate name"}} },
+      "put":    {
+        "summary": "update model",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Model"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "404": {"description": "not found"}, "409": {"description": "duplicate display_name"}}
+      },
       "delete": { "summary": "delete model", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
     },
     "/admin/v1/apikeys": {
       "get":  { "summary": "list api keys",  "responses": {"200": {"description": "OK"}} },
-      "post": { "summary": "create api key", "responses": {"200": {"description": "OK"}, "409": {"description": "duplicate key"}} }
+      "post": {
+        "summary": "create api key",
+        "description": "Body carries `key_hash` (SHA-256 of plaintext). The plaintext is generated client-side; the gateway never sees it.",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiKey"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "409": {"description": "duplicate key_hash"}}
+      }
     },
     "/admin/v1/apikeys/{id}": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
       "get":    { "summary": "get api key",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
-      "put":    { "summary": "update api key", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}, "409": {"description": "duplicate key"}} },
+      "put":    {
+        "summary": "update api key",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiKey"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "404": {"description": "not found"}, "409": {"description": "duplicate key_hash"}}
+      },
       "delete": { "summary": "delete api key", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
+    },
+    "/admin/v1/apikeys/{id}/rotate": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+      "post": {
+        "summary": "rotate api key",
+        "description": "Generates a new plaintext bearer, persists its SHA-256 hash, and returns the plaintext **once** under `plaintext`. Caller MUST capture — subsequent GETs only expose the hash.",
+        "responses": {
+          "200": {"description": "OK", "content": {"application/json": {"schema": {
+            "type": "object",
+            "required": ["entry", "plaintext"],
+            "properties": {
+              "entry":     {"$ref": "#/components/schemas/ApiKeyEntry"},
+              "plaintext": {"type": "string", "example": "sk-abcd1234ef567890"}
+            }
+          }}}},
+          "404": {"description": "not found"}
+        }
+      }
+    },
+    "/admin/v1/provider_keys": {
+      "get":  { "summary": "list provider keys",  "responses": {"200": {"description": "OK"}} },
+      "post": {
+        "summary": "create provider key",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ProviderKey"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "409": {"description": "duplicate display_name"}}
+      }
+    },
+    "/admin/v1/provider_keys/{id}": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+      "get":    { "summary": "get provider key",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
+      "put":    {
+        "summary": "update provider key",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ProviderKey"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "404": {"description": "not found"}, "409": {"description": "duplicate display_name"}}
+      },
+      "delete": { "summary": "delete provider key", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
+    },
+    "/admin/v1/health": {
+      "get": {
+        "summary": "per-Model upstream health",
+        "description": "Returns each Model's health level: 0=Healthy, 1=Degraded (4-7 consecutive upstream failures), 2=Down (8+).",
+        "responses": {"200": {"description": "OK"}}
+      }
+    },
+    "/playground/chat/completions": {
+      "post": {
+        "summary": "in-process forward to the proxy router",
+        "description": "Forwards a chat completion through the proxy in-process — no extra network hop, but the request is fully audited as if it had arrived on the proxy listener. Auth is a **proxy** ApiKey (`Authorization: Bearer sk-aisix-...`), not an admin key — the proxy middleware validates it inside the forwarded request.",
+        "security": [{"ProxyBearer": []}],
+        "responses": {"200": {"description": "OK (OpenAI-shape chat completion)"}, "401": {"description": "missing/invalid api key"}}
+      }
     }
   },
   "components": {
     "securitySchemes": {
-      "AdminBearer": { "type": "http", "scheme": "bearer" }
+      "AdminBearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Admin key from `config.admin.admin_keys`. Required for every `/admin/v1/*` route."
+      },
+      "ProxyBearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Proxy ApiKey (`sk-aisix-...`) — only used by `/playground/chat/completions`."
+      }
+    },
+    "schemas": {
+      "Model": {
+        "type": "object",
+        "required": ["display_name"],
+        "properties": {
+          "display_name":    {"type": "string", "example": "my-gpt4"},
+          "provider":        {"type": "string", "enum": ["openai","anthropic","gemini","deepseek"]},
+          "model_name":      {"type": "string", "example": "gpt-4o"},
+          "provider_key_id": {"type": "string", "example": "11111111-1111-1111-1111-111111111111"},
+          "timeout":         {"type": "integer", "minimum": 0, "description": "Request timeout in milliseconds. Absent or 0 = no timeout."},
+          "rate_limit":      {"$ref": "#/components/schemas/RateLimit"},
+          "routing":         {"$ref": "#/components/schemas/Routing"},
+          "cost":            {"$ref": "#/components/schemas/ModelCost"}
+        },
+        "description": "A direct model ships `provider` + `model_name` + `provider_key_id`; a routing model ships `routing` and omits the upstream triple."
+      },
+      "ModelEntry": {
+        "type": "object",
+        "required": ["id", "value", "revision"],
+        "properties": {
+          "id":       {"type": "string"},
+          "value":    {"$ref": "#/components/schemas/Model"},
+          "revision": {"type": "integer"}
+        }
+      },
+      "ApiKey": {
+        "type": "object",
+        "required": ["key_hash", "allowed_models"],
+        "properties": {
+          "key_hash":       {"type": "string", "description": "SHA-256 hex of the plaintext bearer. Lowercase.", "example": "91ed2dbc407561556f3e7be98ba0bd2a57986d6a868c482d867d19c6d40d201c"},
+          "allowed_models": {"type": "array", "items": {"type": "string"}, "description": "Allowed Model display_names. `[\"*\"]` for all; `[]` denies everything."},
+          "rate_limit":     {"$ref": "#/components/schemas/RateLimit"},
+          "max_budget_usd": {"type": "number", "minimum": 0, "description": "Per-month USD spend cap. Absent = unlimited."}
+        }
+      },
+      "ApiKeyEntry": {
+        "type": "object",
+        "required": ["id", "value", "revision"],
+        "properties": {
+          "id":       {"type": "string"},
+          "value":    {"$ref": "#/components/schemas/ApiKey"},
+          "revision": {"type": "integer"}
+        }
+      },
+      "ProviderKey": {
+        "type": "object",
+        "required": ["display_name", "secret"],
+        "properties": {
+          "display_name": {"type": "string", "example": "openai-prod"},
+          "secret":       {"type": "string", "description": "Upstream provider API key, plaintext.", "example": "sk-prod-xxxx"},
+          "api_base":     {"type": "string", "description": "Override for the upstream base URL. Empty/absent uses the provider default."}
+        }
+      },
+      "RateLimit": {
+        "type": "object",
+        "properties": {
+          "tpm":         {"type": "integer", "minimum": 0, "description": "Tokens per minute"},
+          "tpd":         {"type": "integer", "minimum": 0, "description": "Tokens per day"},
+          "rpm":         {"type": "integer", "minimum": 0, "description": "Requests per minute"},
+          "rpd":         {"type": "integer", "minimum": 0, "description": "Requests per day"},
+          "concurrency": {"type": "integer", "minimum": 0, "description": "Max in-flight"}
+        }
+      },
+      "Routing": {
+        "type": "object",
+        "required": ["targets"],
+        "properties": {
+          "strategy":     {"type": "string", "enum": ["round_robin", "weighted", "failover"]},
+          "targets": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["model"],
+              "properties": {
+                "model":  {"type": "string", "description": "Target Model.display_name"},
+                "weight": {"type": "integer", "minimum": 0}
+              }
+            }
+          },
+          "retry_budget": {"type": "integer", "minimum": 0}
+        }
+      },
+      "ModelCost": {
+        "type": "object",
+        "required": ["input_per_1k", "output_per_1k"],
+        "properties": {
+          "input_per_1k":  {"type": "number", "minimum": 0, "description": "USD per 1,000 input (prompt) tokens"},
+          "output_per_1k": {"type": "number", "minimum": 0, "description": "USD per 1,000 output (completion) tokens"}
+        }
+      },
+      "AdminError": {
+        "type": "object",
+        "required": ["error_msg"],
+        "properties": {"error_msg": {"type": "string"}}
+      }
     }
   },
   "security": [{ "AdminBearer": [] }]
-}"#;
+}"##;
 
 const SCALAR_HTML: &str = r#"<!DOCTYPE html>
 <html lang="en">
@@ -86,8 +306,67 @@ mod tests {
         // Validate by parsing — guards against typos in the literal block.
         let parsed: serde_json::Value =
             serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
-        assert!(parsed["paths"]["/admin/v1/models"].is_object());
-        assert!(parsed["paths"]["/admin/v1/apikeys/{id}"].is_object());
+        // Every route mounted in build_router should be documented.
+        for path in [
+            "/health",
+            "/metrics",
+            "/admin/openapi.json",
+            "/admin/openapi-scalar",
+            "/admin/v1/models",
+            "/admin/v1/models/{id}",
+            "/admin/v1/apikeys",
+            "/admin/v1/apikeys/{id}",
+            "/admin/v1/apikeys/{id}/rotate",
+            "/admin/v1/provider_keys",
+            "/admin/v1/provider_keys/{id}",
+            "/admin/v1/health",
+            "/playground/chat/completions",
+        ] {
+            assert!(
+                parsed["paths"][path].is_object(),
+                "OPENAPI_JSON missing path {path}"
+            );
+        }
+        // Reusable schemas referenced from the path bodies.
+        for schema in [
+            "Model",
+            "ModelEntry",
+            "ApiKey",
+            "ApiKeyEntry",
+            "ProviderKey",
+            "RateLimit",
+            "Routing",
+            "ModelCost",
+            "AdminError",
+        ] {
+            assert!(
+                parsed["components"]["schemas"][schema].is_object(),
+                "OPENAPI_JSON missing schema {schema}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn openapi_unauthenticated_routes_carry_empty_security() {
+        // /health, /metrics, and the openapi self-references are public
+        // (mirrors the `unauthenticated like /metrics` design note in
+        // build_router). The spec must mark them with security: [] so
+        // Scalar's "Try it" doesn't prompt for an admin key on those
+        // routes.
+        let parsed: serde_json::Value =
+            serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
+        for path in [
+            "/health",
+            "/metrics",
+            "/admin/openapi.json",
+            "/admin/openapi-scalar",
+        ] {
+            let security = &parsed["paths"][path]["get"]["security"];
+            assert!(
+                security.is_array() && security.as_array().unwrap().is_empty(),
+                "{path} should declare security: [] but got {security:?}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The hand-written OpenAPI document at `/admin/openapi.json` was stuck at the original two resources (Models + ApiKeys). After PR #95 added ProviderKey, several routes that exist in `build_router` weren't reflected in the spec — meaning Scalar UI users had no way to discover them.

## What's documented now

Every route mounted in `crate::build_router` (`lib.rs` lines 47–96):

- `/health` — process health + snapshot counts
- `/metrics` — Prometheus
- `/admin/openapi.json` + `/admin/openapi-scalar` — self-references
- `/admin/v1/models` — CRUD
- `/admin/v1/apikeys` — CRUD + `POST .../rotate`
- `/admin/v1/provider_keys` — CRUD
- `/admin/v1/health` — per-Model upstream health
- `/playground/chat/completions` — proxy in-process

## Reusable schemas added

`Model` (new shape: `display_name` + `provider` + `model_name` + `provider_key_id`), `ApiKey`, `ProviderKey`, `RateLimit`, `Routing`, `ModelCost`, `AdminError`, plus `ModelEntry` / `ApiKeyEntry` wrappers for the `{id, value, revision}` response envelope.

## Public-route security

`/health`, `/metrics`, `/admin/openapi.json`, `/admin/openapi-scalar` are marked with `security: []` so Scalar's "Try it" doesn't prompt for an admin key on them. Mirrors the design comment in `lib.rs` ("OpenAPI scalar UI is unauthenticated like /metrics").

## Drive-by: README correction

The previous README overpromised `/admin/v1/guardrails`, `/admin/v1/cache_policies`, `/admin/v1/observability_exporters`, and `/admin/v1/spend` as if those were live admin routes. They aren't — those resources exist as core types and are honoured at runtime, but standalone CRUD goes through direct etcd writes today. Listed accurately with a one-line "handlers will follow" note.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test -p aisix-admin` green (46 passed; includes two new openapi assertions: path coverage + public-route security)
- [x] New unit test walks every documented path + every reusable schema and fails on first missing entry, so future route adds get a forcing function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Admin API availability in standalone mode, focusing on routing-related resource operations
  * Expanded OpenAPI specification with comprehensive endpoint documentation, including parameters, request schemas, and detailed response definitions
  * Enhanced API descriptions and summaries for improved clarity

* **Tests**
  * Strengthened API specification validation tests to verify endpoint documentation completeness and schema integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->