### PR TITLE
feat(admin): CRUD handlers for guardrails / cache_policies / observability_exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,15 @@ Surfaces and capabilities currently in main:
 
 - **Providers** — OpenAI, Anthropic, Gemini, DeepSeek (one bridge crate per vendor; OpenAI-shape `model: "<provider>/<id>"` selects the bridge)
 
-- **Admin API (`:3001`)** — CRUD on the routing-related entities, JSON-Schema validated, OpenAPI 3 + Scalar UI at `/admin/openapi-scalar`
+- **Admin API (`:3001`)** — CRUD on every routing entity, JSON-Schema validated, OpenAPI 3 + Scalar UI at `/admin/openapi-scalar`
   - `/admin/v1/models`
   - `/admin/v1/apikeys` (+ `POST .../rotate`)
   - `/admin/v1/provider_keys`
+  - `/admin/v1/guardrails`
+  - `/admin/v1/cache_policies`
+  - `/admin/v1/observability_exporters`
   - `/admin/v1/health` — per-model upstream health (Healthy / Degraded / Down)
   - `/playground/chat/completions` — in-process forward to the proxy router
-
-  Guardrails, cache policies, and observability exporters exist as
-  resource types in `aisix-core` and are honoured at runtime, but
-  standalone CRUD over those still goes through direct etcd writes
-  today — Admin handlers will follow.
 
 - **Config plane** — etcd with watch-driven `ArcSwap` snapshot. Lock-free reads on the hot path. Schema-rejected rows logged + skipped, never fatal.
 

--- a/crates/aisix-admin/src/cache_policies_handlers.rs
+++ b/crates/aisix-admin/src/cache_policies_handlers.rs
@@ -1,0 +1,107 @@
+//! CRUD handlers for `/admin/v1/cache_policies`.
+//!
+//! Same shape as the Models / ApiKeys / ProviderKeys handlers:
+//! validate against the JSON schema, reject duplicate names (409),
+//! generate a uuid v4 on POST, bump revision on PUT.
+
+use aisix_core::models::validate_cache_policy;
+use aisix_core::resource::ResourceEntry;
+use aisix_core::CachePolicy;
+use axum::extract::{Path, State};
+use axum::Json;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::auth::AdminAuth;
+use crate::error::AdminError;
+use crate::state::AdminState;
+
+const STARTING_REVISION: i64 = 1;
+
+pub async fn list_cache_policies(
+    _auth: AdminAuth,
+    State(state): State<AdminState>,
+) -> Result<Json<Vec<ResourceEntry<CachePolicy>>>, AdminError> {
+    let entries = state.store.list_cache_policies().await?;
+    Ok(Json(entries))
+}
+
+pub async fn get_cache_policy(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+) -> Result<Json<ResourceEntry<CachePolicy>>, AdminError> {
+    let entry = state
+        .store
+        .get_cache_policy(&id)
+        .await?
+        .ok_or(AdminError::NotFound)?;
+    Ok(Json(entry))
+}
+
+pub async fn create_cache_policy(
+    _auth: AdminAuth,
+    State(state): State<AdminState>,
+    Json(raw): Json<Value>,
+) -> Result<Json<ResourceEntry<CachePolicy>>, AdminError> {
+    let cache_policy = decode(&raw)?;
+    let all = state.store.list_cache_policies().await?;
+    assert_unique_name(&all, &cache_policy.name, None)?;
+
+    let id = Uuid::new_v4().to_string();
+    let entry = ResourceEntry::new(&id, cache_policy, STARTING_REVISION);
+    state.store.put_cache_policy(entry.clone()).await?;
+    Ok(Json(entry))
+}
+
+pub async fn update_cache_policy(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+    Json(raw): Json<Value>,
+) -> Result<Json<ResourceEntry<CachePolicy>>, AdminError> {
+    let existing = state
+        .store
+        .get_cache_policy(&id)
+        .await?
+        .ok_or(AdminError::NotFound)?;
+    let cache_policy = decode(&raw)?;
+
+    let all = state.store.list_cache_policies().await?;
+    assert_unique_name(&all, &cache_policy.name, Some(&id))?;
+
+    let entry = ResourceEntry::new(&id, cache_policy, existing.revision + 1);
+    state.store.put_cache_policy(entry.clone()).await?;
+    Ok(Json(entry))
+}
+
+pub async fn delete_cache_policy(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+) -> Result<Json<Value>, AdminError> {
+    let removed = state.store.delete_cache_policy(&id).await?;
+    if !removed {
+        return Err(AdminError::NotFound);
+    }
+    Ok(Json(serde_json::json!({"deleted": true, "id": id})))
+}
+
+fn decode(raw: &Value) -> Result<CachePolicy, AdminError> {
+    validate_cache_policy(raw)?;
+    serde_json::from_value(raw.clone())
+        .map_err(|e| AdminError::BadRequest(format!("malformed CachePolicy payload: {e}")))
+}
+
+fn assert_unique_name(
+    existing: &[ResourceEntry<CachePolicy>],
+    name: &str,
+    self_id: Option<&str>,
+) -> Result<(), AdminError> {
+    for e in existing {
+        if e.value.name == name && self_id.is_none_or(|sid| sid != e.id) {
+            return Err(AdminError::Conflict(name.to_string()));
+        }
+    }
+    Ok(())
+}

--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -19,7 +19,7 @@
 //! deterministic behaviour continue to use [`crate::InMemoryStore`].
 
 use aisix_core::resource::ResourceEntry;
-use aisix_core::{ApiKey, Model, ProviderKey};
+use aisix_core::{ApiKey, CachePolicy, Guardrail, Model, ObservabilityExporter, ProviderKey};
 use etcd_client::{Client, DeleteOptions, GetOptions};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -32,6 +32,9 @@ use crate::store::{ConfigStore, StoreError};
 pub const MODELS_SUBKEY: &str = "models";
 pub const APIKEYS_SUBKEY: &str = "api_keys";
 pub const PROVIDER_KEYS_SUBKEY: &str = "provider_keys";
+pub const GUARDRAILS_SUBKEY: &str = "guardrails";
+pub const CACHE_POLICIES_SUBKEY: &str = "cache_policies";
+pub const OBSERVABILITY_EXPORTERS_SUBKEY: &str = "observability_exporters";
 
 pub struct EtcdConfigStore {
     client: Mutex<Client>,
@@ -234,6 +237,100 @@ impl ConfigStore for EtcdConfigStore {
 
     async fn delete_provider_key(&self, id: &str) -> Result<bool, StoreError> {
         self.delete_one(&self.key_for(PROVIDER_KEYS_SUBKEY, id))
+            .await
+    }
+
+    async fn put_guardrail(&self, entry: ResourceEntry<Guardrail>) -> Result<(), StoreError> {
+        let key = self.key_for(GUARDRAILS_SUBKEY, &entry.id);
+        self.put_json(&key, &entry.value).await
+    }
+
+    async fn get_guardrail(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<Guardrail>>, StoreError> {
+        let key = self.key_for(GUARDRAILS_SUBKEY, id);
+        Ok(self
+            .get_one::<Guardrail>(&key)
+            .await?
+            .map(|(v, rev)| ResourceEntry::new(id, v, rev)))
+    }
+
+    async fn list_guardrails(&self) -> Result<Vec<ResourceEntry<Guardrail>>, StoreError> {
+        Ok(self
+            .list_range::<Guardrail>(GUARDRAILS_SUBKEY)
+            .await?
+            .into_iter()
+            .map(|(id, v, rev)| ResourceEntry::new(id, v, rev))
+            .collect())
+    }
+
+    async fn delete_guardrail(&self, id: &str) -> Result<bool, StoreError> {
+        self.delete_one(&self.key_for(GUARDRAILS_SUBKEY, id)).await
+    }
+
+    async fn put_cache_policy(&self, entry: ResourceEntry<CachePolicy>) -> Result<(), StoreError> {
+        let key = self.key_for(CACHE_POLICIES_SUBKEY, &entry.id);
+        self.put_json(&key, &entry.value).await
+    }
+
+    async fn get_cache_policy(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<CachePolicy>>, StoreError> {
+        let key = self.key_for(CACHE_POLICIES_SUBKEY, id);
+        Ok(self
+            .get_one::<CachePolicy>(&key)
+            .await?
+            .map(|(v, rev)| ResourceEntry::new(id, v, rev)))
+    }
+
+    async fn list_cache_policies(&self) -> Result<Vec<ResourceEntry<CachePolicy>>, StoreError> {
+        Ok(self
+            .list_range::<CachePolicy>(CACHE_POLICIES_SUBKEY)
+            .await?
+            .into_iter()
+            .map(|(id, v, rev)| ResourceEntry::new(id, v, rev))
+            .collect())
+    }
+
+    async fn delete_cache_policy(&self, id: &str) -> Result<bool, StoreError> {
+        self.delete_one(&self.key_for(CACHE_POLICIES_SUBKEY, id))
+            .await
+    }
+
+    async fn put_observability_exporter(
+        &self,
+        entry: ResourceEntry<ObservabilityExporter>,
+    ) -> Result<(), StoreError> {
+        let key = self.key_for(OBSERVABILITY_EXPORTERS_SUBKEY, &entry.id);
+        self.put_json(&key, &entry.value).await
+    }
+
+    async fn get_observability_exporter(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<ObservabilityExporter>>, StoreError> {
+        let key = self.key_for(OBSERVABILITY_EXPORTERS_SUBKEY, id);
+        Ok(self
+            .get_one::<ObservabilityExporter>(&key)
+            .await?
+            .map(|(v, rev)| ResourceEntry::new(id, v, rev)))
+    }
+
+    async fn list_observability_exporters(
+        &self,
+    ) -> Result<Vec<ResourceEntry<ObservabilityExporter>>, StoreError> {
+        Ok(self
+            .list_range::<ObservabilityExporter>(OBSERVABILITY_EXPORTERS_SUBKEY)
+            .await?
+            .into_iter()
+            .map(|(id, v, rev)| ResourceEntry::new(id, v, rev))
+            .collect())
+    }
+
+    async fn delete_observability_exporter(&self, id: &str) -> Result<bool, StoreError> {
+        self.delete_one(&self.key_for(OBSERVABILITY_EXPORTERS_SUBKEY, id))
             .await
     }
 }

--- a/crates/aisix-admin/src/guardrails_handlers.rs
+++ b/crates/aisix-admin/src/guardrails_handlers.rs
@@ -1,0 +1,107 @@
+//! CRUD handlers for `/admin/v1/guardrails`.
+//!
+//! Same shape as the Models / ApiKeys / ProviderKeys handlers:
+//! validate against the JSON schema, reject duplicate names (409),
+//! generate a uuid v4 on POST, bump revision on PUT.
+
+use aisix_core::models::validate_guardrail;
+use aisix_core::resource::ResourceEntry;
+use aisix_core::Guardrail;
+use axum::extract::{Path, State};
+use axum::Json;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::auth::AdminAuth;
+use crate::error::AdminError;
+use crate::state::AdminState;
+
+const STARTING_REVISION: i64 = 1;
+
+pub async fn list_guardrails(
+    _auth: AdminAuth,
+    State(state): State<AdminState>,
+) -> Result<Json<Vec<ResourceEntry<Guardrail>>>, AdminError> {
+    let entries = state.store.list_guardrails().await?;
+    Ok(Json(entries))
+}
+
+pub async fn get_guardrail(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+) -> Result<Json<ResourceEntry<Guardrail>>, AdminError> {
+    let entry = state
+        .store
+        .get_guardrail(&id)
+        .await?
+        .ok_or(AdminError::NotFound)?;
+    Ok(Json(entry))
+}
+
+pub async fn create_guardrail(
+    _auth: AdminAuth,
+    State(state): State<AdminState>,
+    Json(raw): Json<Value>,
+) -> Result<Json<ResourceEntry<Guardrail>>, AdminError> {
+    let guardrail = decode(&raw)?;
+    let all = state.store.list_guardrails().await?;
+    assert_unique_name(&all, &guardrail.name, None)?;
+
+    let id = Uuid::new_v4().to_string();
+    let entry = ResourceEntry::new(&id, guardrail, STARTING_REVISION);
+    state.store.put_guardrail(entry.clone()).await?;
+    Ok(Json(entry))
+}
+
+pub async fn update_guardrail(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+    Json(raw): Json<Value>,
+) -> Result<Json<ResourceEntry<Guardrail>>, AdminError> {
+    let existing = state
+        .store
+        .get_guardrail(&id)
+        .await?
+        .ok_or(AdminError::NotFound)?;
+    let guardrail = decode(&raw)?;
+
+    let all = state.store.list_guardrails().await?;
+    assert_unique_name(&all, &guardrail.name, Some(&id))?;
+
+    let entry = ResourceEntry::new(&id, guardrail, existing.revision + 1);
+    state.store.put_guardrail(entry.clone()).await?;
+    Ok(Json(entry))
+}
+
+pub async fn delete_guardrail(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+) -> Result<Json<Value>, AdminError> {
+    let removed = state.store.delete_guardrail(&id).await?;
+    if !removed {
+        return Err(AdminError::NotFound);
+    }
+    Ok(Json(serde_json::json!({"deleted": true, "id": id})))
+}
+
+fn decode(raw: &Value) -> Result<Guardrail, AdminError> {
+    validate_guardrail(raw)?;
+    serde_json::from_value(raw.clone())
+        .map_err(|e| AdminError::BadRequest(format!("malformed Guardrail payload: {e}")))
+}
+
+fn assert_unique_name(
+    existing: &[ResourceEntry<Guardrail>],
+    name: &str,
+    self_id: Option<&str>,
+) -> Result<(), AdminError> {
+    for e in existing {
+        if e.value.name == name && self_id.is_none_or(|sid| sid != e.id) {
+            return Err(AdminError::Conflict(name.to_string()));
+        }
+    }
+    Ok(())
+}

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -8,6 +8,12 @@
 //! - `GET|PUT|DELETE      /admin/v1/apikeys/:id`
 //! - `GET|POST            /admin/v1/provider_keys`
 //! - `GET|PUT|DELETE      /admin/v1/provider_keys/:id`
+//! - `GET|POST            /admin/v1/guardrails`
+//! - `GET|PUT|DELETE      /admin/v1/guardrails/:id`
+//! - `GET|POST            /admin/v1/cache_policies`
+//! - `GET|PUT|DELETE      /admin/v1/cache_policies/:id`
+//! - `GET|POST            /admin/v1/observability_exporters`
+//! - `GET|PUT|DELETE      /admin/v1/observability_exporters/:id`
 //!
 //! Writes validate against the JSON Schemas from `aisix-core` and reject
 //! duplicate names (409). The storage layer is pluggable via the
@@ -22,10 +28,13 @@
 
 mod apikeys_handlers;
 mod auth;
+mod cache_policies_handlers;
 mod error;
 pub mod etcd_store;
+mod guardrails_handlers;
 mod health_handler;
 mod models_handlers;
+mod observability_exporters_handlers;
 mod openapi;
 mod playground_handler;
 mod provider_keys_handlers;
@@ -84,6 +93,39 @@ pub fn build_router(state: AdminState) -> Router {
             get(provider_keys_handlers::get_provider_key)
                 .put(provider_keys_handlers::update_provider_key)
                 .delete(provider_keys_handlers::delete_provider_key),
+        )
+        .route(
+            "/admin/v1/guardrails",
+            get(guardrails_handlers::list_guardrails)
+                .post(guardrails_handlers::create_guardrail),
+        )
+        .route(
+            "/admin/v1/guardrails/:id",
+            get(guardrails_handlers::get_guardrail)
+                .put(guardrails_handlers::update_guardrail)
+                .delete(guardrails_handlers::delete_guardrail),
+        )
+        .route(
+            "/admin/v1/cache_policies",
+            get(cache_policies_handlers::list_cache_policies)
+                .post(cache_policies_handlers::create_cache_policy),
+        )
+        .route(
+            "/admin/v1/cache_policies/:id",
+            get(cache_policies_handlers::get_cache_policy)
+                .put(cache_policies_handlers::update_cache_policy)
+                .delete(cache_policies_handlers::delete_cache_policy),
+        )
+        .route(
+            "/admin/v1/observability_exporters",
+            get(observability_exporters_handlers::list_observability_exporters)
+                .post(observability_exporters_handlers::create_observability_exporter),
+        )
+        .route(
+            "/admin/v1/observability_exporters/:id",
+            get(observability_exporters_handlers::get_observability_exporter)
+                .put(observability_exporters_handlers::update_observability_exporter)
+                .delete(observability_exporters_handlers::delete_observability_exporter),
         )
         // Health — per-model upstream health levels (0/1/2).
         .route("/admin/v1/health", get(health_handler::get_health))
@@ -669,6 +711,220 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ──────────────────── Guardrails CRUD ────────────────────
+
+    fn guardrail_payload(name: &str) -> Value {
+        json!({
+            "name": name,
+            "kind": "keyword",
+            "patterns": [{"kind": "literal", "value": "secret"}]
+        })
+    }
+
+    #[tokio::test]
+    async fn guardrail_crud_create_list_get_update_delete() {
+        let state = build_state();
+
+        // Create.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req(
+                "POST",
+                "/admin/v1/guardrails",
+                Some(guardrail_payload("g-1")),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+        // Duplicate name → 409.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req(
+                "POST",
+                "/admin/v1/guardrails",
+                Some(guardrail_payload("g-1")),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        // List sees one.
+        let app = build_router(state.clone());
+        let resp = run(app, auth_req("GET", "/admin/v1/guardrails", None)).await;
+        assert_eq!(body_json(resp).await.as_array().unwrap().len(), 1);
+
+        // Update bumps revision.
+        let app = build_router(state.clone());
+        let updated = json!({
+            "name": "g-1",
+            "kind": "keyword",
+            "patterns": [{"kind": "literal", "value": "topsecret"}]
+        });
+        let resp = run(
+            app,
+            auth_req("PUT", &format!("/admin/v1/guardrails/{id}"), Some(updated)),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_json(resp).await["revision"], 2);
+
+        // Delete + 404.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("DELETE", &format!("/admin/v1/guardrails/{id}"), None),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let app = build_router(state);
+        let resp = run(
+            app,
+            auth_req("GET", &format!("/admin/v1/guardrails/{id}"), None),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn guardrail_create_with_invalid_schema_returns_400() {
+        let app = build_router(build_state());
+        // Missing required `kind` field.
+        let resp = run(
+            app,
+            auth_req("POST", "/admin/v1/guardrails", Some(json!({"name": "g-1"}))),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // ──────────────────── CachePolicy CRUD ────────────────────
+
+    fn cache_policy_payload(name: &str) -> Value {
+        json!({
+            "name": name,
+            "enabled": true,
+            "ttl_seconds": 600
+        })
+    }
+
+    #[tokio::test]
+    async fn cache_policy_crud_create_list_delete() {
+        let state = build_state();
+
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req(
+                "POST",
+                "/admin/v1/cache_policies",
+                Some(cache_policy_payload("p-1")),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+        // Duplicate → 409.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req(
+                "POST",
+                "/admin/v1/cache_policies",
+                Some(cache_policy_payload("p-1")),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        // Get round-trip.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("GET", &format!("/admin/v1/cache_policies/{id}"), None),
+        )
+        .await;
+        assert_eq!(body_json(resp).await["value"]["name"], "p-1");
+
+        // Delete.
+        let app = build_router(state);
+        let resp = run(
+            app,
+            auth_req("DELETE", &format!("/admin/v1/cache_policies/{id}"), None),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ──────────────────── ObservabilityExporter CRUD ────────────────────
+
+    fn exporter_payload(name: &str) -> Value {
+        json!({
+            "name": name,
+            "kind": "otlp_http",
+            "endpoint": "https://otel.example.com/v1/traces"
+        })
+    }
+
+    #[tokio::test]
+    async fn observability_exporter_crud_create_list_delete() {
+        let state = build_state();
+
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req(
+                "POST",
+                "/admin/v1/observability_exporters",
+                Some(exporter_payload("oe-1")),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("GET", "/admin/v1/observability_exporters", None),
+        )
+        .await;
+        assert_eq!(body_json(resp).await.as_array().unwrap().len(), 1);
+
+        let app = build_router(state);
+        let resp = run(
+            app,
+            auth_req(
+                "DELETE",
+                &format!("/admin/v1/observability_exporters/{id}"),
+                None,
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn observability_exporter_rejects_http_endpoint_unless_loopback() {
+        let app = build_router(build_state());
+        let bad = json!({
+            "name": "oe-1",
+            "kind": "otlp_http",
+            "endpoint": "http://attacker.example.com/v1/traces"
+        });
+        let resp = run(
+            app,
+            auth_req("POST", "/admin/v1/observability_exporters", Some(bad)),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     // ──────────────────── Health endpoint ────────────────────

--- a/crates/aisix-admin/src/observability_exporters_handlers.rs
+++ b/crates/aisix-admin/src/observability_exporters_handlers.rs
@@ -1,0 +1,114 @@
+//! CRUD handlers for `/admin/v1/observability_exporters`.
+//!
+//! Same shape as the Models / ApiKeys / ProviderKeys handlers:
+//! validate against the JSON schema, reject duplicate names (409),
+//! generate a uuid v4 on POST, bump revision on PUT.
+
+use aisix_core::models::validate_observability_exporter;
+use aisix_core::resource::ResourceEntry;
+use aisix_core::ObservabilityExporter;
+use axum::extract::{Path, State};
+use axum::Json;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::auth::AdminAuth;
+use crate::error::AdminError;
+use crate::state::AdminState;
+
+const STARTING_REVISION: i64 = 1;
+
+pub async fn list_observability_exporters(
+    _auth: AdminAuth,
+    State(state): State<AdminState>,
+) -> Result<Json<Vec<ResourceEntry<ObservabilityExporter>>>, AdminError> {
+    let entries = state.store.list_observability_exporters().await?;
+    Ok(Json(entries))
+}
+
+pub async fn get_observability_exporter(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+) -> Result<Json<ResourceEntry<ObservabilityExporter>>, AdminError> {
+    let entry = state
+        .store
+        .get_observability_exporter(&id)
+        .await?
+        .ok_or(AdminError::NotFound)?;
+    Ok(Json(entry))
+}
+
+pub async fn create_observability_exporter(
+    _auth: AdminAuth,
+    State(state): State<AdminState>,
+    Json(raw): Json<Value>,
+) -> Result<Json<ResourceEntry<ObservabilityExporter>>, AdminError> {
+    let exporter = decode(&raw)?;
+    let all = state.store.list_observability_exporters().await?;
+    assert_unique_name(&all, &exporter.name, None)?;
+
+    let id = Uuid::new_v4().to_string();
+    let entry = ResourceEntry::new(&id, exporter, STARTING_REVISION);
+    state
+        .store
+        .put_observability_exporter(entry.clone())
+        .await?;
+    Ok(Json(entry))
+}
+
+pub async fn update_observability_exporter(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+    Json(raw): Json<Value>,
+) -> Result<Json<ResourceEntry<ObservabilityExporter>>, AdminError> {
+    let existing = state
+        .store
+        .get_observability_exporter(&id)
+        .await?
+        .ok_or(AdminError::NotFound)?;
+    let exporter = decode(&raw)?;
+
+    let all = state.store.list_observability_exporters().await?;
+    assert_unique_name(&all, &exporter.name, Some(&id))?;
+
+    let entry = ResourceEntry::new(&id, exporter, existing.revision + 1);
+    state
+        .store
+        .put_observability_exporter(entry.clone())
+        .await?;
+    Ok(Json(entry))
+}
+
+pub async fn delete_observability_exporter(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+) -> Result<Json<Value>, AdminError> {
+    let removed = state.store.delete_observability_exporter(&id).await?;
+    if !removed {
+        return Err(AdminError::NotFound);
+    }
+    Ok(Json(serde_json::json!({"deleted": true, "id": id})))
+}
+
+fn decode(raw: &Value) -> Result<ObservabilityExporter, AdminError> {
+    validate_observability_exporter(raw)?;
+    serde_json::from_value(raw.clone()).map_err(|e| {
+        AdminError::BadRequest(format!("malformed ObservabilityExporter payload: {e}"))
+    })
+}
+
+fn assert_unique_name(
+    existing: &[ResourceEntry<ObservabilityExporter>],
+    name: &str,
+    self_id: Option<&str>,
+) -> Result<(), AdminError> {
+    for e in existing {
+        if e.value.name == name && self_id.is_none_or(|sid| sid != e.id) {
+            return Err(AdminError::Conflict(name.to_string()));
+        }
+    }
+    Ok(())
+}

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -140,6 +140,60 @@ const OPENAPI_JSON: &str = r##"{
       },
       "delete": { "summary": "delete provider key", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
     },
+    "/admin/v1/guardrails": {
+      "get":  { "summary": "list guardrails", "responses": {"200": {"description": "OK"}} },
+      "post": {
+        "summary": "create guardrail",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Guardrail"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "409": {"description": "duplicate name"}}
+      }
+    },
+    "/admin/v1/guardrails/{id}": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+      "get":    { "summary": "get guardrail",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
+      "put":    {
+        "summary": "update guardrail",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Guardrail"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "404": {"description": "not found"}, "409": {"description": "duplicate name"}}
+      },
+      "delete": { "summary": "delete guardrail", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
+    },
+    "/admin/v1/cache_policies": {
+      "get":  { "summary": "list cache policies", "responses": {"200": {"description": "OK"}} },
+      "post": {
+        "summary": "create cache policy",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CachePolicy"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "409": {"description": "duplicate name"}}
+      }
+    },
+    "/admin/v1/cache_policies/{id}": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+      "get":    { "summary": "get cache policy",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
+      "put":    {
+        "summary": "update cache policy",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CachePolicy"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "404": {"description": "not found"}, "409": {"description": "duplicate name"}}
+      },
+      "delete": { "summary": "delete cache policy", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
+    },
+    "/admin/v1/observability_exporters": {
+      "get":  { "summary": "list observability exporters", "responses": {"200": {"description": "OK"}} },
+      "post": {
+        "summary": "create observability exporter",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ObservabilityExporter"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "409": {"description": "duplicate name"}}
+      }
+    },
+    "/admin/v1/observability_exporters/{id}": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+      "get":    { "summary": "get observability exporter",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
+      "put":    {
+        "summary": "update observability exporter",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ObservabilityExporter"}}}},
+        "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "404": {"description": "not found"}, "409": {"description": "duplicate name"}}
+      },
+      "delete": { "summary": "delete observability exporter", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
+    },
     "/admin/v1/health": {
       "get": {
         "summary": "per-Model upstream health",
@@ -260,6 +314,43 @@ const OPENAPI_JSON: &str = r##"{
           "output_per_1k": {"type": "number", "minimum": 0, "description": "USD per 1,000 output (completion) tokens"}
         }
       },
+      "Guardrail": {
+        "type": "object",
+        "required": ["name", "kind"],
+        "properties": {
+          "name":       {"type": "string", "example": "block-pii"},
+          "enabled":    {"type": "boolean", "default": true},
+          "hook_point": {"type": "string", "enum": ["input", "output", "both"], "description": "Where in the request lifecycle the guardrail fires."},
+          "fail_open":  {"type": "boolean", "description": "Only honoured for kind=bedrock. true → request through on remote-API failure (with telemetry annotation); false → 422."},
+          "kind":       {"type": "string", "enum": ["keyword", "bedrock"]}
+        },
+        "description": "Discriminated by `kind`. `keyword` carries a `patterns` array of literal/regex blocklist entries. `bedrock` carries `guardrail_id`, `guardrail_version`, `region`, `aws_credentials`, `latency_mode`. See `aisix-core::Guardrail` for the per-kind shape.",
+        "additionalProperties": true
+      },
+      "CachePolicy": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name":                 {"type": "string", "minLength": 1, "maxLength": 120, "example": "expensive-prompts"},
+          "enabled":              {"type": "boolean", "default": true, "description": "Soft kill switch. Disabled policies stay in the snapshot but the cache gate skips them."},
+          "backend":              {"type": "string", "enum": ["memory", "redis", "redis_semantic", "qdrant"], "default": "memory"},
+          "ttl_seconds":          {"type": "integer", "minimum": 1, "maximum": 604800, "default": 3600},
+          "applies_to":           {"type": "string", "minLength": 1, "maxLength": 255, "description": "Optional scope filter (e.g. `model:my-gpt4`, `api_key:k-1`). Absent = all chat completions."},
+          "similarity_threshold": {"type": "number", "minimum": 0, "maximum": 1, "description": "redis_semantic / qdrant only."},
+          "embedding_model":      {"type": "string", "minLength": 1, "maxLength": 120, "description": "redis_semantic / qdrant only."}
+        }
+      },
+      "ObservabilityExporter": {
+        "type": "object",
+        "required": ["name", "kind"],
+        "properties": {
+          "name":     {"type": "string", "minLength": 1, "maxLength": 120, "example": "honeycomb"},
+          "enabled":  {"type": "boolean", "default": true},
+          "kind":     {"type": "string", "enum": ["otlp_http"]},
+          "endpoint": {"type": "string", "description": "Full URL of the OTLP/HTTP traces endpoint, including the `/v1/traces` path. Required when kind=otlp_http."},
+          "headers":  {"type": "object", "additionalProperties": {"type": "string"}, "description": "Static headers attached to every export. Plaintext at MVP — kine wire is mTLS-only."}
+        }
+      },
       "AdminError": {
         "type": "object",
         "required": ["error_msg"],
@@ -319,6 +410,12 @@ mod tests {
             "/admin/v1/apikeys/{id}/rotate",
             "/admin/v1/provider_keys",
             "/admin/v1/provider_keys/{id}",
+            "/admin/v1/guardrails",
+            "/admin/v1/guardrails/{id}",
+            "/admin/v1/cache_policies",
+            "/admin/v1/cache_policies/{id}",
+            "/admin/v1/observability_exporters",
+            "/admin/v1/observability_exporters/{id}",
             "/admin/v1/health",
             "/playground/chat/completions",
         ] {
@@ -334,6 +431,9 @@ mod tests {
             "ApiKey",
             "ApiKeyEntry",
             "ProviderKey",
+            "Guardrail",
+            "CachePolicy",
+            "ObservabilityExporter",
             "RateLimit",
             "Routing",
             "ModelCost",

--- a/crates/aisix-admin/src/store.rs
+++ b/crates/aisix-admin/src/store.rs
@@ -7,7 +7,7 @@
 //! in the handler layer so the store stays dumb and fast.
 
 use aisix_core::resource::ResourceEntry;
-use aisix_core::{ApiKey, Model, ProviderKey};
+use aisix_core::{ApiKey, CachePolicy, Guardrail, Model, ObservabilityExporter, ProviderKey};
 use dashmap::DashMap;
 use std::sync::Arc;
 
@@ -38,6 +38,33 @@ pub trait ConfigStore: Send + Sync + 'static {
     ) -> Result<Option<ResourceEntry<ProviderKey>>, StoreError>;
     async fn list_provider_keys(&self) -> Result<Vec<ResourceEntry<ProviderKey>>, StoreError>;
     async fn delete_provider_key(&self, id: &str) -> Result<bool, StoreError>;
+
+    async fn put_guardrail(&self, entry: ResourceEntry<Guardrail>) -> Result<(), StoreError>;
+    async fn get_guardrail(&self, id: &str)
+        -> Result<Option<ResourceEntry<Guardrail>>, StoreError>;
+    async fn list_guardrails(&self) -> Result<Vec<ResourceEntry<Guardrail>>, StoreError>;
+    async fn delete_guardrail(&self, id: &str) -> Result<bool, StoreError>;
+
+    async fn put_cache_policy(&self, entry: ResourceEntry<CachePolicy>) -> Result<(), StoreError>;
+    async fn get_cache_policy(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<CachePolicy>>, StoreError>;
+    async fn list_cache_policies(&self) -> Result<Vec<ResourceEntry<CachePolicy>>, StoreError>;
+    async fn delete_cache_policy(&self, id: &str) -> Result<bool, StoreError>;
+
+    async fn put_observability_exporter(
+        &self,
+        entry: ResourceEntry<ObservabilityExporter>,
+    ) -> Result<(), StoreError>;
+    async fn get_observability_exporter(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<ObservabilityExporter>>, StoreError>;
+    async fn list_observability_exporters(
+        &self,
+    ) -> Result<Vec<ResourceEntry<ObservabilityExporter>>, StoreError>;
+    async fn delete_observability_exporter(&self, id: &str) -> Result<bool, StoreError>;
 }
 
 /// In-memory store. Thread-safe via DashMap; mainly used by tests, but
@@ -47,6 +74,9 @@ pub struct InMemoryStore {
     models: DashMap<String, ResourceEntry<Model>>,
     apikeys: DashMap<String, ResourceEntry<ApiKey>>,
     provider_keys: DashMap<String, ResourceEntry<ProviderKey>>,
+    guardrails: DashMap<String, ResourceEntry<Guardrail>>,
+    cache_policies: DashMap<String, ResourceEntry<CachePolicy>>,
+    observability_exporters: DashMap<String, ResourceEntry<ObservabilityExporter>>,
 }
 
 impl InMemoryStore {
@@ -109,6 +139,75 @@ impl ConfigStore for InMemoryStore {
 
     async fn delete_provider_key(&self, id: &str) -> Result<bool, StoreError> {
         Ok(self.provider_keys.remove(id).is_some())
+    }
+
+    async fn put_guardrail(&self, entry: ResourceEntry<Guardrail>) -> Result<(), StoreError> {
+        self.guardrails.insert(entry.id.clone(), entry);
+        Ok(())
+    }
+
+    async fn get_guardrail(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<Guardrail>>, StoreError> {
+        Ok(self.guardrails.get(id).map(|r| r.clone()))
+    }
+
+    async fn list_guardrails(&self) -> Result<Vec<ResourceEntry<Guardrail>>, StoreError> {
+        Ok(self.guardrails.iter().map(|r| r.clone()).collect())
+    }
+
+    async fn delete_guardrail(&self, id: &str) -> Result<bool, StoreError> {
+        Ok(self.guardrails.remove(id).is_some())
+    }
+
+    async fn put_cache_policy(&self, entry: ResourceEntry<CachePolicy>) -> Result<(), StoreError> {
+        self.cache_policies.insert(entry.id.clone(), entry);
+        Ok(())
+    }
+
+    async fn get_cache_policy(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<CachePolicy>>, StoreError> {
+        Ok(self.cache_policies.get(id).map(|r| r.clone()))
+    }
+
+    async fn list_cache_policies(&self) -> Result<Vec<ResourceEntry<CachePolicy>>, StoreError> {
+        Ok(self.cache_policies.iter().map(|r| r.clone()).collect())
+    }
+
+    async fn delete_cache_policy(&self, id: &str) -> Result<bool, StoreError> {
+        Ok(self.cache_policies.remove(id).is_some())
+    }
+
+    async fn put_observability_exporter(
+        &self,
+        entry: ResourceEntry<ObservabilityExporter>,
+    ) -> Result<(), StoreError> {
+        self.observability_exporters.insert(entry.id.clone(), entry);
+        Ok(())
+    }
+
+    async fn get_observability_exporter(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<ObservabilityExporter>>, StoreError> {
+        Ok(self.observability_exporters.get(id).map(|r| r.clone()))
+    }
+
+    async fn list_observability_exporters(
+        &self,
+    ) -> Result<Vec<ResourceEntry<ObservabilityExporter>>, StoreError> {
+        Ok(self
+            .observability_exporters
+            .iter()
+            .map(|r| r.clone())
+            .collect())
+    }
+
+    async fn delete_observability_exporter(&self, id: &str) -> Result<bool, StoreError> {
+        Ok(self.observability_exporters.remove(id).is_some())
     }
 }
 

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -30,10 +30,11 @@ pub use error::{
     AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,
 };
 pub use models::{
-    validate_apikey, validate_guardrail, validate_model, validate_provider_key, AisixSnapshot,
-    ApiKey, Guardrail, GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern, Model,
-    Provider, ProviderConfig, ProviderKey, RateLimit, Routing, RoutingStrategy, RoutingTarget,
-    SchemaError,
+    validate_apikey, validate_cache_policy, validate_guardrail, validate_model,
+    validate_observability_exporter, validate_provider_key, AisixSnapshot, ApiKey, CachePolicy,
+    ExporterKind, Guardrail, GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern,
+    Model, ObservabilityExporter, Provider, ProviderConfig, ProviderKey, RateLimit, Routing,
+    RoutingStrategy, RoutingTarget, SchemaError,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};


### PR DESCRIPTION
## Summary

Brings the standalone Admin API up to parity with the resource types that `aisix-core` already models and the gateway already honours at runtime. Before this PR, those three resources existed as snapshot tables and runtime hooks but had no admin endpoint — operators had to hand-write etcd keys to configure them.

## What's new

- **3 handler files**: `guardrails_handlers.rs`, `cache_policies_handlers.rs`, `observability_exporters_handlers.rs` — same template as `provider_keys_handlers.rs` (validate JSON, reject duplicate name with 409, uuid v4 on POST, bump revision on PUT).
- **12 new `ConfigStore` trait methods** (4 per resource), implemented on both `InMemoryStore` and `EtcdConfigStore`.
- **6 new routes** wired into `build_router`:
  - `/admin/v1/guardrails[/:id]`
  - `/admin/v1/cache_policies[/:id]`
  - `/admin/v1/observability_exporters[/:id]`
- **3 etcd subkey constants** (`guardrails`, `cache_policies`, `observability_exporters`) — match the kind segments `aisix-etcd::loader` already dispatches on, so admin writes land in the same prefix the watch supervisor reads.
- **OpenAPI doc expanded** to include the new paths + component schemas (`Guardrail`, `CachePolicy`, `ObservabilityExporter`). The forcing-function test from #96 walks the new entries.
- **5 integration tests** covering happy path + duplicate-name 409 + bad-payload 400 + the loopback-only http-endpoint guard on observability exporters.

Re-exports `CachePolicy`, `ObservabilityExporter`, `ExporterKind`, `validate_cache_policy`, `validate_observability_exporter` at the `aisix_core` crate root so handlers don't have to reach into `aisix_core::models::*`.

## Drive-by

README's "Admin handlers will follow" caveat from #96 is removed — the list is now accurate.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test -p aisix-admin` — 51 passed (+5 new integration tests)
- [x] OpenAPI forcing-function test asserts every new path + schema exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin API now supports full CRUD operations for guardrails, cache policies, and observability exporters via `/admin/v1/` endpoints with schema validation and duplicate name enforcement.

* **Documentation**
  * Updated README and OpenAPI spec to reflect newly available admin routes and entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->