### PR TITLE
feat(proxy): /v1/messages now serves any upstream — Anthropic protocol → OpenAI/Gemini/DeepSeek bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,8 @@ dependencies = [
  "aisix-guardrails",
  "aisix-obs",
  "aisix-provider-anthropic",
+ "aisix-provider-deepseek",
+ "aisix-provider-gemini",
  "aisix-provider-openai",
  "aisix-ratelimit",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Surfaces and capabilities currently in main:
 
 - **Proxy API (`:3000`)** — OpenAI-compatible
   - Chat completions: `POST /v1/chat/completions` with native SSE streaming
-  - Anthropic-shape: `POST /v1/messages` (Claude SDK works against `base_url`)
+  - Anthropic-shape: `POST /v1/messages` (Claude SDK works against `base_url`) — works against **any** configured upstream (OpenAI / Gemini / DeepSeek / Anthropic). When the targeted Model points at a non-Anthropic upstream, the gateway translates the Anthropic body → ChatFormat → bridge → response back to Anthropic JSON / SSE.
   - OpenAI Responses: `POST /v1/responses`
   - Embeddings: `POST /v1/embeddings`
   - Rerank: `POST /v1/rerank`

--- a/crates/aisix-provider-anthropic/src/lib.rs
+++ b/crates/aisix-provider-anthropic/src/lib.rs
@@ -16,3 +16,19 @@ mod bridge;
 mod wire;
 
 pub use bridge::{AnthropicBridge, ANTHROPIC_DEFAULT_BASE, ANTHROPIC_VERSION};
+
+/// Inbound Anthropic-protocol translation surface — used by the
+/// proxy's `/v1/messages` handler when the targeted Model points at
+/// a non-Anthropic upstream. The flow is symmetric to the existing
+/// outbound path:
+///
+/// - [`parse_inbound_request`] turns the request body into
+///   `ChatFormat` so any Bridge can dispatch it.
+/// - [`chat_response_into_anthropic_json`] renders the bridge's
+///   `ChatResponse` back as Anthropic JSON.
+/// - [`AnthropicSseEncoder`] re-encodes the bridge's `ChatChunk`
+///   stream as Anthropic typed SSE events.
+pub use wire::{
+    chat_response_into_anthropic_json, parse_inbound_request, AnthropicInboundError,
+    AnthropicSseEncoder, AnthropicSseEvent,
+};

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -344,6 +344,407 @@ impl StreamState {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Inbound translation — Anthropic protocol  →  internal ChatFormat.
+//
+// Used by the proxy's /v1/messages handler when the Model targeted by
+// the request points at a non-Anthropic upstream: we accept the
+// Anthropic-shaped body, translate to ChatFormat, and dispatch through
+// the Hub. The reverse direction (ChatFormat → Anthropic wire request)
+// is handled by `split_system` + `build_request` for the
+// Anthropic-upstream case above.
+//
+// Pattern lifted from LiteLLM's experimental_pass_through adapter
+// (`transformation.py::translate_anthropic_to_openai`), trimmed to the
+// MVP fields aisix supports today (text content blocks; tool_use,
+// image, and thinking blocks land in a follow-up PR).
+
+#[derive(Debug, thiserror::Error)]
+pub enum AnthropicInboundError {
+    #[error("body is not a JSON object")]
+    NotAnObject,
+    #[error("missing or non-string `model` field")]
+    MissingModel,
+    #[error("missing or non-array `messages` field")]
+    MissingMessages,
+    #[error("messages[{idx}] missing `role`")]
+    MessageMissingRole { idx: usize },
+    #[error("messages[{idx}] role {role:?} is not 'user' or 'assistant'")]
+    UnsupportedRole { idx: usize, role: String },
+    #[error("messages[{idx}].content must be a string or an array of text blocks")]
+    UnsupportedContent { idx: usize },
+    #[error("`system` field must be a string or an array of text blocks")]
+    UnsupportedSystem,
+}
+
+/// Parse an Anthropic `POST /v1/messages` JSON body into the gateway's
+/// internal [`ChatFormat`]. The `system` field is folded into a leading
+/// system message; content blocks are concatenated text-only (non-text
+/// blocks are skipped). Unrecognized top-level keys (`metadata`,
+/// `tools`, `tool_choice`, etc.) flow into `ChatFormat::extra` so a
+/// future tools-aware bridge can read them.
+pub fn parse_inbound_request(
+    body: &serde_json::Value,
+) -> Result<ChatFormat, AnthropicInboundError> {
+    use serde_json::Value;
+    let obj = body.as_object().ok_or(AnthropicInboundError::NotAnObject)?;
+
+    let model = obj
+        .get("model")
+        .and_then(Value::as_str)
+        .ok_or(AnthropicInboundError::MissingModel)?
+        .to_string();
+
+    let raw_messages = obj
+        .get("messages")
+        .and_then(Value::as_array)
+        .ok_or(AnthropicInboundError::MissingMessages)?;
+
+    let mut messages: Vec<ChatMessage> = Vec::with_capacity(raw_messages.len() + 1);
+
+    // `system`: prepend as leading system message. Anthropic accepts
+    // string OR array of text blocks; we accept both shapes.
+    if let Some(system) = obj.get("system") {
+        let system_text = match system {
+            Value::String(s) => s.clone(),
+            Value::Array(blocks) => {
+                let mut parts = Vec::new();
+                for block in blocks {
+                    if let Some(text) = block.get("text").and_then(Value::as_str) {
+                        parts.push(text);
+                    }
+                }
+                parts.join("\n")
+            }
+            Value::Null => String::new(),
+            _ => return Err(AnthropicInboundError::UnsupportedSystem),
+        };
+        if !system_text.is_empty() {
+            messages.push(ChatMessage::system(system_text));
+        }
+    }
+
+    for (idx, m) in raw_messages.iter().enumerate() {
+        let role = m
+            .get("role")
+            .and_then(Value::as_str)
+            .ok_or(AnthropicInboundError::MessageMissingRole { idx })?;
+
+        let content = match m.get("content") {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Array(blocks)) => {
+                let mut parts = Vec::new();
+                for block in blocks {
+                    if let Some(text) = block.get("text").and_then(Value::as_str) {
+                        parts.push(text);
+                    }
+                }
+                parts.join("")
+            }
+            _ => return Err(AnthropicInboundError::UnsupportedContent { idx }),
+        };
+
+        match role {
+            "user" => messages.push(ChatMessage::user(content)),
+            "assistant" => messages.push(ChatMessage::assistant(content)),
+            other => {
+                return Err(AnthropicInboundError::UnsupportedRole {
+                    idx,
+                    role: other.to_string(),
+                })
+            }
+        }
+    }
+
+    let mut chat = ChatFormat::new(model, messages);
+
+    if let Some(t) = obj.get("temperature").and_then(Value::as_f64) {
+        chat.temperature = Some(t as f32);
+    }
+    if let Some(t) = obj.get("top_p").and_then(Value::as_f64) {
+        chat.top_p = Some(t as f32);
+    }
+    if let Some(t) = obj.get("max_tokens").and_then(Value::as_u64) {
+        chat.max_tokens = Some(t as u32);
+    }
+    if let Some(s) = obj.get("stream").and_then(Value::as_bool) {
+        chat.stream = Some(s);
+    }
+
+    // Pass remaining keys through `extra` so future bridges can use
+    // them. We deliberately don't whitelist — bridges that don't
+    // understand a key just ignore it.
+    for (key, value) in obj {
+        if !matches!(
+            key.as_str(),
+            "model" | "messages" | "system" | "temperature" | "top_p" | "max_tokens" | "stream"
+        ) {
+            chat.extra.insert(key.clone(), value.clone());
+        }
+    }
+
+    Ok(chat)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Outbound translation — internal ChatResponse  →  Anthropic JSON.
+
+/// Render an internal [`ChatResponse`] as the JSON an Anthropic
+/// `/v1/messages` client expects. The reverse of
+/// `response_into_chat_response`. `model_display_name` is the
+/// operator-facing model name the client requested — we echo it back
+/// rather than leaking the actual upstream id (e.g. `gpt-4o`) when
+/// the underlying provider isn't Anthropic.
+pub fn chat_response_into_anthropic_json(
+    resp: &ChatResponse,
+    model_display_name: &str,
+) -> serde_json::Value {
+    let stop_reason = match &resp.finish_reason {
+        FinishReason::Stop => "end_turn",
+        FinishReason::Length => "max_tokens",
+        FinishReason::ContentFilter => "stop_sequence",
+        FinishReason::ToolCalls => "tool_use",
+        FinishReason::Other(_) => "end_turn",
+    };
+    serde_json::json!({
+        "id": resp.id,
+        "type": "message",
+        "role": "assistant",
+        "model": model_display_name,
+        "content": [{"type": "text", "text": resp.message.content}],
+        "stop_reason": stop_reason,
+        "stop_sequence": serde_json::Value::Null,
+        "usage": {
+            "input_tokens": resp.usage.prompt_tokens,
+            "output_tokens": resp.usage.completion_tokens,
+        },
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Streaming SSE encoder — internal ChatChunk stream  →  Anthropic
+// SSE events.
+//
+// State machine (mirrors LiteLLM's `AnthropicStreamWrapper`):
+//   1. First chunk that carries content or a finish_reason → emit
+//      `message_start`. If it carries content, also emit
+//      `content_block_start` + `content_block_delta`.
+//   2. Mid-stream chunks with content → `content_block_delta`.
+//   3. Chunk carrying `finish_reason` → emit `content_block_stop`
+//      (only if a content block was opened), `message_delta` (with
+//      stop_reason + final usage), then `message_stop`. After
+//      `finished` flips true the encoder is silent.
+//
+// Reference: https://docs.anthropic.com/en/api/streaming
+
+/// One Anthropic SSE event, ready to be written to the wire as
+/// `event: {event}\ndata: {data}\n\n`.
+#[derive(Debug, Clone)]
+pub struct AnthropicSseEvent {
+    pub event: &'static str,
+    pub data: serde_json::Value,
+}
+
+impl AnthropicSseEvent {
+    pub fn to_sse_string(&self) -> String {
+        format!(
+            "event: {}\ndata: {}\n\n",
+            self.event,
+            serde_json::to_string(&self.data).expect("serde_json::Value always serializes"),
+        )
+    }
+}
+
+/// State machine for re-encoding a stream of internal `ChatChunk`s as
+/// Anthropic SSE events.
+#[derive(Debug)]
+pub struct AnthropicSseEncoder {
+    message_id: String,
+    model_display_name: String,
+    initial_input_tokens: u32,
+    sent_message_start: bool,
+    sent_content_block_start: bool,
+    finished: bool,
+}
+
+impl AnthropicSseEncoder {
+    /// `message_id` is echoed in `message_start.message.id`.
+    /// `model_display_name` is the operator-facing model name the
+    /// client originally sent in `req.model`.
+    /// `initial_input_tokens` is the best-known-at-stream-open input
+    /// token count; pass 0 if unknown.
+    pub fn new(
+        message_id: impl Into<String>,
+        model_display_name: impl Into<String>,
+        initial_input_tokens: u32,
+    ) -> Self {
+        Self {
+            message_id: message_id.into(),
+            model_display_name: model_display_name.into(),
+            initial_input_tokens,
+            sent_message_start: false,
+            sent_content_block_start: false,
+            finished: false,
+        }
+    }
+
+    /// Translate one chunk into the Anthropic SSE events to emit.
+    /// Returns an empty Vec on no-op chunks (e.g. usage-only).
+    pub fn next_events(&mut self, chunk: &ChatChunk) -> Vec<AnthropicSseEvent> {
+        if self.finished {
+            return Vec::new();
+        }
+
+        let mut events = Vec::new();
+
+        let has_content = chunk
+            .delta
+            .content
+            .as_deref()
+            .is_some_and(|s| !s.is_empty());
+        let has_finish = chunk.finish_reason.is_some();
+
+        if !self.sent_message_start && (has_content || has_finish) {
+            events.push(self.message_start_event());
+            self.sent_message_start = true;
+        }
+
+        if !self.sent_content_block_start && has_content {
+            events.push(content_block_start_event());
+            self.sent_content_block_start = true;
+        }
+
+        if has_content {
+            events.push(AnthropicSseEvent {
+                event: "content_block_delta",
+                data: serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {
+                        "type": "text_delta",
+                        "text": chunk.delta.content.clone().unwrap_or_default(),
+                    },
+                }),
+            });
+        }
+
+        if let Some(fr) = &chunk.finish_reason {
+            if self.sent_content_block_start {
+                events.push(content_block_stop_event());
+            }
+            let stop_reason = match fr {
+                FinishReason::Stop => "end_turn",
+                FinishReason::Length => "max_tokens",
+                FinishReason::ContentFilter => "stop_sequence",
+                FinishReason::ToolCalls => "tool_use",
+                FinishReason::Other(_) => "end_turn",
+            };
+            let output_tokens = chunk
+                .usage
+                .as_ref()
+                .map(|u| u.completion_tokens)
+                .unwrap_or(0);
+            events.push(AnthropicSseEvent {
+                event: "message_delta",
+                data: serde_json::json!({
+                    "type": "message_delta",
+                    "delta": {
+                        "stop_reason": stop_reason,
+                        "stop_sequence": serde_json::Value::Null,
+                    },
+                    "usage": {"output_tokens": output_tokens},
+                }),
+            });
+            events.push(AnthropicSseEvent {
+                event: "message_stop",
+                data: serde_json::json!({"type": "message_stop"}),
+            });
+            self.finished = true;
+        }
+
+        events
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
+    /// Force-close the stream when the upstream ended without
+    /// emitting a chunk with `finish_reason`. Emits the closing trio
+    /// with `stop_reason: "end_turn"` and `output_tokens: 0`.
+    /// Idempotent.
+    pub fn force_finish(&mut self) -> Vec<AnthropicSseEvent> {
+        if self.finished {
+            return Vec::new();
+        }
+        let mut events = Vec::new();
+        if !self.sent_message_start {
+            events.push(self.message_start_event());
+            self.sent_message_start = true;
+        }
+        if self.sent_content_block_start {
+            events.push(content_block_stop_event());
+        }
+        events.push(AnthropicSseEvent {
+            event: "message_delta",
+            data: serde_json::json!({
+                "type": "message_delta",
+                "delta": {
+                    "stop_reason": "end_turn",
+                    "stop_sequence": serde_json::Value::Null,
+                },
+                "usage": {"output_tokens": 0},
+            }),
+        });
+        events.push(AnthropicSseEvent {
+            event: "message_stop",
+            data: serde_json::json!({"type": "message_stop"}),
+        });
+        self.finished = true;
+        events
+    }
+
+    fn message_start_event(&self) -> AnthropicSseEvent {
+        AnthropicSseEvent {
+            event: "message_start",
+            data: serde_json::json!({
+                "type": "message_start",
+                "message": {
+                    "id": self.message_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": self.model_display_name,
+                    "stop_reason": serde_json::Value::Null,
+                    "stop_sequence": serde_json::Value::Null,
+                    "usage": {
+                        "input_tokens": self.initial_input_tokens,
+                        "output_tokens": 0,
+                    },
+                },
+            }),
+        }
+    }
+}
+
+fn content_block_start_event() -> AnthropicSseEvent {
+    AnthropicSseEvent {
+        event: "content_block_start",
+        data: serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        }),
+    }
+}
+
+fn content_block_stop_event() -> AnthropicSseEvent {
+    AnthropicSseEvent {
+        event: "content_block_stop",
+        data: serde_json::json!({"type": "content_block_stop", "index": 0}),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -563,5 +964,270 @@ mod tests {
         let chunk = state.to_chunk(&end).unwrap();
         assert_eq!(chunk.finish_reason, Some(FinishReason::Stop));
         assert_eq!(chunk.usage.unwrap().completion_tokens, 3);
+    }
+
+    // ─── parse_inbound_request ────────────────────────────────────
+
+    #[test]
+    fn parse_inbound_minimal_user_only() {
+        let body = serde_json::json!({
+            "model": "claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        });
+        let chat = parse_inbound_request(&body).unwrap();
+        assert_eq!(chat.model, "claude-sonnet-4-5");
+        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.messages[0].role, Role::User);
+        assert_eq!(chat.messages[0].content, "hi");
+        assert_eq!(chat.max_tokens, Some(100));
+    }
+
+    #[test]
+    fn parse_inbound_system_string_folds_to_leading_message() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": "you are helpful",
+            "messages": [{"role": "user", "content": "hi"}],
+        });
+        let chat = parse_inbound_request(&body).unwrap();
+        assert_eq!(chat.messages.len(), 2);
+        assert_eq!(chat.messages[0].role, Role::System);
+        assert_eq!(chat.messages[0].content, "you are helpful");
+        assert_eq!(chat.messages[1].role, Role::User);
+    }
+
+    #[test]
+    fn parse_inbound_system_block_array_concatenates_with_newline() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": [
+                {"type": "text", "text": "line1"},
+                {"type": "text", "text": "line2"},
+            ],
+            "messages": [{"role": "user", "content": "hi"}],
+        });
+        let chat = parse_inbound_request(&body).unwrap();
+        assert_eq!(chat.messages[0].role, Role::System);
+        assert_eq!(chat.messages[0].content, "line1\nline2");
+    }
+
+    #[test]
+    fn parse_inbound_content_block_array_concatenates_text_only() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello "},
+                    {"type": "image", "source": {"type": "base64", "data": "xx"}},
+                    {"type": "text", "text": "world"},
+                ],
+            }],
+        });
+        let chat = parse_inbound_request(&body).unwrap();
+        // Image block silently skipped; text concatenates.
+        assert_eq!(chat.messages[0].content, "hello world");
+    }
+
+    #[test]
+    fn parse_inbound_unknown_top_level_keys_flow_to_extra() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "messages": [{"role": "user", "content": "hi"}],
+            "metadata": {"user_id": "abc"},
+            "tools": [{"name": "get_weather"}],
+        });
+        let chat = parse_inbound_request(&body).unwrap();
+        assert!(chat.extra.contains_key("metadata"));
+        assert!(chat.extra.contains_key("tools"));
+        assert!(!chat.extra.contains_key("model"));
+        assert!(!chat.extra.contains_key("messages"));
+    }
+
+    #[test]
+    fn parse_inbound_rejects_unknown_role() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "messages": [{"role": "tool", "content": "x"}],
+        });
+        let err = parse_inbound_request(&body).unwrap_err();
+        assert!(matches!(err, AnthropicInboundError::UnsupportedRole { .. }));
+    }
+
+    #[test]
+    fn parse_inbound_rejects_missing_model() {
+        let body = serde_json::json!({"messages": []});
+        assert!(matches!(
+            parse_inbound_request(&body).unwrap_err(),
+            AnthropicInboundError::MissingModel,
+        ));
+    }
+
+    // ─── chat_response_into_anthropic_json ────────────────────────
+
+    #[test]
+    fn render_anthropic_response_basic_shape() {
+        let resp = ChatResponse {
+            id: "cmpl-1".into(),
+            model: "gpt-4o".into(), // upstream — should NOT leak into output
+            message: ChatMessage::assistant("hello"),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(7, 3),
+        };
+        let json = chat_response_into_anthropic_json(&resp, "my-claude-alias");
+        assert_eq!(json["id"], "cmpl-1");
+        assert_eq!(json["type"], "message");
+        assert_eq!(json["role"], "assistant");
+        assert_eq!(json["model"], "my-claude-alias");
+        assert_eq!(json["content"][0]["type"], "text");
+        assert_eq!(json["content"][0]["text"], "hello");
+        assert_eq!(json["stop_reason"], "end_turn");
+        assert!(json["stop_sequence"].is_null());
+        assert_eq!(json["usage"]["input_tokens"], 7);
+        assert_eq!(json["usage"]["output_tokens"], 3);
+    }
+
+    #[test]
+    fn render_anthropic_response_finish_reason_mappings() {
+        let mk = |fr: FinishReason| {
+            let resp = ChatResponse {
+                id: "x".into(),
+                model: "u".into(),
+                message: ChatMessage::assistant(""),
+                finish_reason: fr,
+                usage: UsageStats::new(0, 0),
+            };
+            chat_response_into_anthropic_json(&resp, "m")["stop_reason"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        };
+        assert_eq!(mk(FinishReason::Stop), "end_turn");
+        assert_eq!(mk(FinishReason::Length), "max_tokens");
+        assert_eq!(mk(FinishReason::ContentFilter), "stop_sequence");
+        assert_eq!(mk(FinishReason::ToolCalls), "tool_use");
+        assert_eq!(mk(FinishReason::Other("vendor".into())), "end_turn");
+    }
+
+    // ─── AnthropicSseEncoder ──────────────────────────────────────
+
+    fn delta_chunk(text: &str) -> ChatChunk {
+        ChatChunk {
+            id: "cmpl-1".into(),
+            model: "u".into(),
+            delta: ChatDelta {
+                role: None,
+                content: Some(text.into()),
+            },
+            finish_reason: None,
+            usage: None,
+        }
+    }
+
+    fn finish_chunk(out_tokens: u32) -> ChatChunk {
+        ChatChunk {
+            id: "cmpl-1".into(),
+            model: "u".into(),
+            delta: ChatDelta::default(),
+            finish_reason: Some(FinishReason::Stop),
+            usage: Some(UsageStats::new(0, out_tokens)),
+        }
+    }
+
+    #[test]
+    fn sse_encoder_first_content_chunk_emits_message_start_then_block_start_then_delta() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "claude-alias", 5);
+        let events = enc.next_events(&delta_chunk("hello"));
+        let kinds: Vec<_> = events.iter().map(|e| e.event).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                "message_start",
+                "content_block_start",
+                "content_block_delta"
+            ]
+        );
+        assert_eq!(
+            events[0].data["message"]["usage"]["input_tokens"], 5,
+            "initial input_tokens echoed in message_start"
+        );
+        assert_eq!(events[0].data["message"]["model"], "claude-alias");
+        assert_eq!(events[2].data["delta"]["text"], "hello");
+    }
+
+    #[test]
+    fn sse_encoder_subsequent_chunks_only_emit_deltas() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "alias", 0);
+        let _ = enc.next_events(&delta_chunk("hel"));
+        let events = enc.next_events(&delta_chunk("lo"));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event, "content_block_delta");
+        assert_eq!(events[0].data["delta"]["text"], "lo");
+    }
+
+    #[test]
+    fn sse_encoder_finish_chunk_after_content_emits_stop_trio() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "alias", 0);
+        let _ = enc.next_events(&delta_chunk("hi"));
+        let events = enc.next_events(&finish_chunk(2));
+        let kinds: Vec<_> = events.iter().map(|e| e.event).collect();
+        assert_eq!(
+            kinds,
+            vec!["content_block_stop", "message_delta", "message_stop"]
+        );
+        assert_eq!(events[1].data["delta"]["stop_reason"], "end_turn");
+        assert_eq!(events[1].data["usage"]["output_tokens"], 2);
+        assert!(enc.is_finished());
+        // Subsequent chunks are silent.
+        assert!(enc.next_events(&delta_chunk("ignored")).is_empty());
+    }
+
+    #[test]
+    fn sse_encoder_finish_only_chunk_skips_content_block_stop() {
+        // Finish without prior content (e.g. blocked by guardrail) —
+        // we still emit message_start + message_delta + message_stop
+        // but NOT content_block_start/stop.
+        let mut enc = AnthropicSseEncoder::new("msg_01", "alias", 0);
+        let events = enc.next_events(&finish_chunk(0));
+        let kinds: Vec<_> = events.iter().map(|e| e.event).collect();
+        assert_eq!(
+            kinds,
+            vec!["message_start", "message_delta", "message_stop"]
+        );
+    }
+
+    #[test]
+    fn sse_encoder_force_finish_after_content_emits_full_close() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "alias", 3);
+        let _ = enc.next_events(&delta_chunk("hi"));
+        let events = enc.force_finish();
+        let kinds: Vec<_> = events.iter().map(|e| e.event).collect();
+        assert_eq!(
+            kinds,
+            vec!["content_block_stop", "message_delta", "message_stop"]
+        );
+        assert!(enc.is_finished());
+    }
+
+    #[test]
+    fn sse_encoder_force_finish_on_empty_stream_emits_message_start_then_close() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "alias", 0);
+        let events = enc.force_finish();
+        let kinds: Vec<_> = events.iter().map(|e| e.event).collect();
+        assert_eq!(
+            kinds,
+            vec!["message_start", "message_delta", "message_stop"]
+        );
+    }
+
+    #[test]
+    fn sse_event_renders_as_event_data_pair() {
+        let ev = AnthropicSseEvent {
+            event: "content_block_delta",
+            data: serde_json::json!({"x": 1}),
+        };
+        let s = ev.to_sse_string();
+        assert_eq!(s, "event: content_block_delta\ndata: {\"x\":1}\n\n");
     }
 }

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -11,6 +11,13 @@ description = "aisix: /v1/* proxy router (OpenAI-compatible) + middleware + hook
 [dependencies]
 aisix-core = { path = "../aisix-core" }
 aisix-gateway = { path = "../aisix-gateway" }
+# /v1/messages handler reaches into the Anthropic wire helpers
+# (parse_inbound_request / chat_response_into_anthropic_json /
+# AnthropicSseEncoder) so it can translate Anthropic-protocol
+# requests into ChatFormat for any upstream and back. This is the
+# only provider crate the proxy depends on directly — others stay
+# behind the Bridge trait.
+aisix-provider-anthropic = { path = "../aisix-provider-anthropic" }
 aisix-obs = { path = "../aisix-obs" }
 aisix-ratelimit = { path = "../aisix-ratelimit" }
 aisix-cache = { path = "../aisix-cache" }
@@ -39,5 +46,8 @@ uuid.workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
 aisix-provider-openai = { path = "../aisix-provider-openai" }
-aisix-provider-anthropic = { path = "../aisix-provider-anthropic" }
+# aisix-provider-anthropic moved to [dependencies] so the /v1/messages
+# handler can use its inbound wire helpers in non-test builds too.
+aisix-provider-deepseek = { path = "../aisix-provider-deepseek" }
+aisix-provider-gemini = { path = "../aisix-provider-gemini" }
 wiremock.workspace = true

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -104,7 +104,7 @@ mod tests {
     use futures::StreamExt;
     use std::sync::Arc;
     use tower::ServiceExt;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn cfg() -> ProxyConfig {
@@ -1494,5 +1494,284 @@ data: [DONE]\n\n";
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "billing_error");
         assert_eq!(v["error"]["code"], "budget_exceeded");
+    }
+
+    // ─── Cross-protocol × upstream matrix ─────────────────────────
+    //
+    // Closes the gap noted in earlier review: the per-bridge wiremock
+    // tests prove each Bridge translates ChatFormat ↔ its wire shape,
+    // and the proxy lib tests above prove `/v1/chat/completions` end-
+    // to-end against an OpenAi upstream — but the *integration* of an
+    // OpenAI-protocol inbound request hitting an Anthropic / Gemini /
+    // DeepSeek upstream had zero coverage. These tests pin the full
+    // path: client body parser → Hub.get(provider) → Bridge.chat[_stream]
+    // → upstream → Bridge response decoder → renderer → wire bytes.
+
+    fn anthropic_model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "name": "{name}",
+                "model": "anthropic/claude-3-5-haiku-20241022",
+                "provider_config": {{"api_key": "sk-ant-test", "api_base": "{api_base}"}}
+            }}"#
+        );
+        ResourceEntry::new("model-anthropic-1", serde_json::from_str(&cfg).unwrap(), 1)
+    }
+
+    fn gemini_model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "name": "{name}",
+                "model": "gemini/gemini-2.0-flash",
+                "provider_config": {{"api_key": "ya29-test", "api_base": "{api_base}"}}
+            }}"#
+        );
+        ResourceEntry::new("model-gemini-1", serde_json::from_str(&cfg).unwrap(), 1)
+    }
+
+    fn deepseek_model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "name": "{name}",
+                "model": "deepseek/deepseek-chat",
+                "provider_config": {{"api_key": "sk-deepseek", "api_base": "{api_base}"}}
+            }}"#
+        );
+        ResourceEntry::new("model-deepseek-1", serde_json::from_str(&cfg).unwrap(), 1)
+    }
+
+    /// (OpenAI inbound) × (Anthropic upstream) × (non-streaming).
+    /// The most valuable cross-protocol cell — exercises real wire-shape
+    /// translation in both directions inside `AnthropicBridge::chat`.
+    #[tokio::test]
+    async fn matrix_openai_in_anthropic_upstream_non_streaming() {
+        use aisix_provider_anthropic::AnthropicBridge;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .and(header("x-api-key", "sk-ant-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "msg_01",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hello from Claude!"}],
+                "model": "claude-3-5-haiku-20241022",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 4}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(anthropic_model_entry("my-claude", &upstream.uri()));
+        snap.apikeys
+            .insert(apikey_entry("sk-caller", &["my-claude"]));
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "my-claude",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
+        // OpenAI-shape wire on the way out.
+        assert_eq!(v["object"], "chat.completion");
+        assert_eq!(v["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(v["choices"][0]["message"]["content"], "Hello from Claude!");
+        assert_eq!(v["choices"][0]["finish_reason"], "stop");
+        assert_eq!(v["usage"]["prompt_tokens"], 5);
+        assert_eq!(v["usage"]["completion_tokens"], 4);
+    }
+
+    /// (OpenAI inbound) × (Anthropic upstream) × (streaming).
+    /// Pin the SSE event-stream translation: AnthropicBridge ingests
+    /// typed Anthropic events (message_start / content_block_delta /
+    /// message_delta / message_stop) and emits flat OpenAI deltas.
+    #[tokio::test]
+    async fn matrix_openai_in_anthropic_upstream_streaming() {
+        use aisix_provider_anthropic::AnthropicBridge;
+
+        let upstream = MockServer::start().await;
+        let sse = "\
+event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3-5-haiku-20241022\",\"stop_reason\":null,\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n\
+event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hel\"}}\n\n\
+event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"lo\"}}\n\n\
+event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":2}}\n\n\
+event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(anthropic_model_entry("my-claude", &upstream.uri()));
+        snap.apikeys
+            .insert(apikey_entry("sk-caller", &["my-claude"]));
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "my-claude",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true,
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream"),
+        );
+        let body =
+            String::from_utf8(to_bytes(resp.into_body(), 65536).await.unwrap().to_vec()).unwrap();
+        // OpenAI-shape SSE deltas on the way out.
+        assert!(
+            body.contains("\"object\":\"chat.completion.chunk\""),
+            "missing OpenAI chunk envelope in:\n{body}"
+        );
+        assert!(body.contains("\"content\":\"hel\""));
+        assert!(body.contains("\"content\":\"lo\""));
+        assert!(body.contains("\"finish_reason\":\"stop\""));
+        assert!(body.contains("data: [DONE]"));
+    }
+
+    /// (OpenAI inbound) × (Gemini upstream). Gemini's bridge is a
+    /// thin wrapper around the OpenAi-compat `/chat/completions`
+    /// endpoint, so the upstream wire is OpenAI-shape — but the
+    /// `Hub.get(Provider::Gemini)` lookup must still resolve to the
+    /// Gemini-specific bridge instance (different metrics label,
+    /// different default base URL behavior).
+    #[tokio::test]
+    async fn matrix_openai_in_gemini_upstream_non_streaming() {
+        use aisix_provider_gemini::gemini_bridge;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-gemini",
+                "model": "gemini-2.0-flash",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello from Gemini!"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 5, "total_tokens": 9}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(gemini_model_entry("my-gemini", &upstream.uri()));
+        snap.apikeys
+            .insert(apikey_entry("sk-caller", &["my-gemini"]));
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Gemini, Arc::new(gemini_bridge()));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "my-gemini",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
+        assert_eq!(v["choices"][0]["message"]["content"], "Hello from Gemini!");
+        assert_eq!(v["usage"]["total_tokens"], 9);
+    }
+
+    /// (OpenAI inbound) × (DeepSeek upstream). Mirrors the Gemini
+    /// case: DeepSeek's bridge is OpenAi-compat with Bearer auth +
+    /// a different `name()` for metrics. The integration test pins
+    /// that `Provider::Deepseek` resolves correctly.
+    #[tokio::test]
+    async fn matrix_openai_in_deepseek_upstream_non_streaming() {
+        use aisix_provider_deepseek::deepseek_bridge;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer sk-deepseek"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-deepseek",
+                "model": "deepseek-chat",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello from DeepSeek!"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 6, "completion_tokens": 7, "total_tokens": 13}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(deepseek_model_entry("my-deepseek", &upstream.uri()));
+        snap.apikeys
+            .insert(apikey_entry("sk-caller", &["my-deepseek"]));
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Deepseek, Arc::new(deepseek_bridge()));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "my-deepseek",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
+        assert_eq!(
+            v["choices"][0]["message"]["content"],
+            "Hello from DeepSeek!"
+        );
+        assert_eq!(v["usage"]["total_tokens"], 13);
     }
 }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -788,4 +788,272 @@ data: [DONE]\n\n";
         // 400 Bad Request — `model` field missing.
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
+
+    // ─── Cross-protocol matrix (Anthropic inbound × non-Anthropic) ─
+
+    fn gemini_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "name": "{name}",
+                "model": "gemini/gemini-2.0-flash",
+                "provider_config": {{"api_key": "ya29-test", "api_base": "{api_base}"}}
+            }}"#
+        );
+        ResourceEntry::new("m-3", serde_json::from_str(&cfg).unwrap(), 1)
+    }
+
+    fn deepseek_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "name": "{name}",
+                "model": "deepseek/deepseek-chat",
+                "provider_config": {{"api_key": "sk-deepseek", "api_base": "{api_base}"}}
+            }}"#
+        );
+        ResourceEntry::new("m-4", serde_json::from_str(&cfg).unwrap(), 1)
+    }
+
+    /// (Anthropic inbound) × (Gemini upstream). Anthropic body comes
+    /// in, the gateway translates → ChatFormat, dispatches via the
+    /// Gemini bridge (OpenAi-compat wire), translates the response
+    /// back to Anthropic JSON. Together with the OpenAI-upstream test
+    /// above this proves the cross-provider path works for every
+    /// non-Anthropic Bridge in the workspace.
+    #[tokio::test]
+    async fn matrix_anthropic_in_gemini_upstream_non_streaming() {
+        use aisix_provider_gemini::gemini_bridge;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-gemini",
+                "object": "chat.completion",
+                "created": 1_715_000_000_u64,
+                "model": "gemini-2.0-flash",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello from Gemini!"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 8, "completion_tokens": 4, "total_tokens": 12}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(gemini_model("my-claude-via-gemini", &upstream.uri()));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register(Provider::Gemini, Arc::new(gemini_bridge()));
+        let handle = SnapshotHandle::new(snap);
+        let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
+
+        let body = serde_json::json!({
+            "model": "my-claude-via-gemini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["model"], "my-claude-via-gemini");
+        assert_eq!(v["content"][0]["text"], "Hello from Gemini!");
+        assert_eq!(v["stop_reason"], "end_turn");
+        assert_eq!(v["usage"]["input_tokens"], 8);
+        assert_eq!(v["usage"]["output_tokens"], 4);
+    }
+
+    /// (Anthropic inbound) × (DeepSeek upstream).
+    #[tokio::test]
+    async fn matrix_anthropic_in_deepseek_upstream_non_streaming() {
+        use aisix_provider_deepseek::deepseek_bridge;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-deepseek",
+                "model": "deepseek-chat",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello from DeepSeek!"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 6, "completion_tokens": 5, "total_tokens": 11}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(deepseek_model("my-claude-via-ds", &upstream.uri()));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register(Provider::Deepseek, Arc::new(deepseek_bridge()));
+        let handle = SnapshotHandle::new(snap);
+        let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
+
+        let body = serde_json::json!({
+            "model": "my-claude-via-ds",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["content"][0]["text"], "Hello from DeepSeek!");
+    }
+
+    /// (Anthropic inbound) × (Anthropic upstream) × (streaming).
+    /// The existing happy-path covers non-streaming passthrough; this
+    /// one pins that the SSE byte stream from the Anthropic upstream
+    /// is forwarded verbatim — the typed events stay typed, no
+    /// translation layer in between.
+    #[tokio::test]
+    async fn matrix_anthropic_in_anthropic_upstream_streaming() {
+        let upstream = MockServer::start().await;
+        let sse = "\
+event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3-5-haiku-20241022\",\"stop_reason\":null,\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n\
+event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n\
+event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(anthropic_model("my-claude", &upstream.uri()));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({
+            "model": "my-claude",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "stream": true,
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body =
+            String::from_utf8(to_bytes(resp.into_body(), 65536).await.unwrap().to_vec()).unwrap();
+        // Verbatim Anthropic typed events on the way out (passthrough,
+        // not re-encoded by AnthropicSseEncoder).
+        assert!(body.contains("event: message_start"));
+        assert!(body.contains("event: content_block_delta"));
+        assert!(body.contains("\"text\":\"hi\""));
+        assert!(body.contains("event: message_stop"));
+    }
+
+    /// Helper for the streaming variants of (Anthropic inbound) ×
+    /// (Gemini | DeepSeek upstream). Both upstreams expose the
+    /// OpenAi-compat `/chat/completions` endpoint with OpenAi-shape
+    /// SSE deltas, so the assertion shape is identical.
+    async fn assert_anthropic_streams_through_openai_compat_upstream(
+        bridge_provider: Provider,
+        bridge: Arc<dyn aisix_gateway::Bridge>,
+        model_entry: ResourceEntry<Model>,
+        model_name: &str,
+    ) {
+        let upstream = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"cmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1715000000,\"model\":\"x\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1715000000,\"model\":\"x\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"yo\"},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        // model_entry's api_base was set at fixture creation time but
+        // we want it to point at the wiremock; rebuild with the
+        // upstream uri instead.
+        let cfg_json = serde_json::json!({
+            "name": model_name,
+            "model": format!("{}/x", format!("{bridge_provider:?}").to_lowercase()),
+            "provider_config": {"api_key": "k", "api_base": upstream.uri()},
+        });
+        let m: Model = serde_json::from_value(cfg_json).unwrap();
+        let _ = model_entry; // explicit shadow; built fresh from upstream.uri()
+        snap.models.insert(ResourceEntry::new("m-stream", m, 1));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register(bridge_provider, bridge);
+        let handle = SnapshotHandle::new(snap);
+        let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
+
+        let body = serde_json::json!({
+            "model": model_name,
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "stream": true,
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream"),
+        );
+        let body =
+            String::from_utf8(to_bytes(resp.into_body(), 65536).await.unwrap().to_vec()).unwrap();
+        // Anthropic-typed SSE events on the way out, regardless of
+        // upstream wire shape.
+        assert!(
+            body.contains("event: message_start"),
+            "missing message_start"
+        );
+        assert!(body.contains("event: content_block_delta"));
+        assert!(body.contains("\"text\":\"yo\""));
+        assert!(body.contains("event: message_stop"));
+    }
+
+    #[tokio::test]
+    async fn matrix_anthropic_in_gemini_upstream_streaming() {
+        use aisix_provider_gemini::gemini_bridge;
+        assert_anthropic_streams_through_openai_compat_upstream(
+            Provider::Gemini,
+            Arc::new(gemini_bridge()),
+            // Placeholder; helper rebuilds with the wiremock uri.
+            gemini_model("my-claude-via-gemini", "http://placeholder"),
+            "my-claude-via-gemini",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn matrix_anthropic_in_deepseek_upstream_streaming() {
+        use aisix_provider_deepseek::deepseek_bridge;
+        assert_anthropic_streams_through_openai_compat_upstream(
+            Provider::Deepseek,
+            Arc::new(deepseek_bridge()),
+            deepseek_model("my-claude-via-ds", "http://placeholder"),
+            "my-claude-via-ds",
+        )
+        .await;
+    }
 }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1,22 +1,27 @@
-//! `POST /v1/messages` — Anthropic native Messages API pass-through.
+//! `POST /v1/messages` — Anthropic Messages API, any upstream.
 //!
-//! This endpoint lets callers that already speak the Anthropic SDK send
-//! requests directly without going through the OpenAI-compat Hub
-//! translation layer. The gateway:
+//! Two dispatch paths share this entry point:
 //!
-//! 1. Authenticates the proxy API key and authorises model access.
-//! 2. Resolves the model name to a `Model` in the snapshot.
-//! 3. Enforces that the model uses the `anthropic/` provider — non-Anthropic
-//!    models are rejected with 422 ("model is not an Anthropic provider").
-//! 4. Rewrites the `model` field to the upstream model name (strips the
-//!    `anthropic/` prefix).
-//! 5. Forwards the body to `{api_base}/v1/messages` with the correct
-//!    `x-api-key` and `anthropic-version` headers.
-//! 6. Returns the response verbatim — both streaming (SSE) and non-streaming
-//!    are supported transparently.
+//! - **Anthropic upstream** (`Model.provider == anthropic`) — byte-for-byte
+//!   passthrough to `{api_base}/v1/messages`. Preserves features the
+//!   gateway-internal `ChatFormat` can't lossily round-trip (cache_control,
+//!   thinking blocks, tool_use, image blocks). Adds `x-api-key` +
+//!   `anthropic-version` headers, rewrites the `model` field to the
+//!   upstream id, and streams the SSE response verbatim.
 //!
-//! Rate-limiting and metrics are recorded using the same hooks as chat
-//! completions.
+//! - **Non-Anthropic upstream** (`Model.provider == openai|gemini|deepseek`)
+//!   — translates the Anthropic-shape body to the gateway's internal
+//!   [`ChatFormat`], dispatches through the [`Hub`] to the matching
+//!   [`Bridge`], and re-encodes the bridge's [`ChatResponse`] / chunk
+//!   stream as Anthropic JSON or Anthropic SSE events
+//!   (`message_start` / `content_block_*` / `message_delta` /
+//!   `message_stop`). The translation helpers live in
+//!   `aisix-provider-anthropic::wire`. Pattern lifted from LiteLLM's
+//!   experimental_pass_through adapter, scoped to text content blocks
+//!   today (tool_use / thinking / image blocks land in a follow-up).
+//!
+//! Both paths share the same auth, model lookup, allowed_models check,
+//! access-log emission, metrics labels, and health tracker hooks.
 //!
 //! Errors use the standard OpenAI-style envelope so clients on the proxy
 //! side can handle them consistently regardless of which endpoint was used.
@@ -125,11 +130,15 @@ async fn dispatch(
 
     let model = &model_entry.value;
 
-    // Validate the model is Anthropic — this endpoint is native-only.
+    // Cross-provider path: when the resolved Model points at a non-
+    // Anthropic upstream, parse the Anthropic-shape body into the
+    // gateway's internal ChatFormat, dispatch through the Hub, and
+    // re-encode the bridge's response as Anthropic JSON or SSE.
+    // The Anthropic-upstream branch below stays as a byte-for-byte
+    // passthrough to preserve features (cache_control, thinking
+    // blocks, …) the cross-provider path can't lossily round-trip.
     if model.provider() != Some(Provider::Anthropic) {
-        return Err(ProxyError::InvalidRequest(format!(
-            "model `{model_name}` is not an Anthropic provider; use /v1/chat/completions instead"
-        )));
+        return cross_provider_dispatch(state, body, model, &model_name, request_id).await;
     }
 
     let api_key = model.provider_config.api_key.as_str();
@@ -250,6 +259,134 @@ async fn dispatch(
 
         Ok((Json(json_body).into_response(), provider_label))
     }
+}
+
+/// Anthropic-protocol input → non-Anthropic upstream output.
+///
+/// Symmetric to `chat.rs::dispatch` but with Anthropic wire shapes on
+/// both ends of the gateway:
+///
+/// 1. parse_inbound_request(body) → ChatFormat (gateway-internal)
+/// 2. hub.get(model.provider) → Bridge for the configured upstream
+/// 3. For non-streaming: bridge.chat → ChatResponse →
+///    chat_response_into_anthropic_json
+/// 4. For streaming: bridge.chat_stream → AnthropicSseEncoder pumps
+///    each ChatChunk through the message_start / content_block_* /
+///    message_* state machine and writes SSE bytes
+async fn cross_provider_dispatch(
+    state: &ProxyState,
+    body: &Value,
+    model: &aisix_core::Model,
+    model_name: &str,
+    request_id: &str,
+) -> Result<(Response, String), ProxyError> {
+    use aisix_gateway::{Bridge, BridgeContext};
+    use aisix_provider_anthropic::{
+        chat_response_into_anthropic_json, parse_inbound_request, AnthropicSseEncoder,
+    };
+    use std::sync::Arc;
+
+    let provider = model.provider().ok_or_else(|| {
+        ProxyError::InvalidRequest(format!("model `{model_name}` has no provider prefix"))
+    })?;
+    let bridge: Arc<dyn Bridge> = state
+        .hub
+        .get(provider)
+        .ok_or(ProxyError::ProviderUnavailable)?;
+
+    // Parse the Anthropic-shape body into the gateway's normalised
+    // ChatFormat. Errors here are 400 — the request is malformed
+    // before it even hits the bridge.
+    let mut chat = parse_inbound_request(body)
+        .map_err(|e| ProxyError::InvalidRequest(format!("invalid Anthropic body: {e}")))?;
+    // Force the bridge dispatch to use the operator's display name
+    // (`model_name`) so the bridge can re-resolve the upstream id
+    // through `ctx.model.upstream_model()` exactly like chat.rs does.
+    chat.model = model_name.to_string();
+
+    let is_stream = chat.is_streaming();
+    let model_arc = Arc::new(model.clone());
+    let ctx = BridgeContext::new(request_id, model_arc);
+    let provider_label = format!("{provider:?}").to_lowercase();
+
+    if is_stream {
+        let upstream = bridge
+            .chat_stream(&chat, &ctx)
+            .await
+            .map_err(ProxyError::Bridge)?;
+        state.health.record_success(model_name);
+
+        let message_id = format!("msg_{}", Uuid::new_v4().simple());
+        let encoder = AnthropicSseEncoder::new(message_id, model_name, 0);
+        let sse_body = build_anthropic_sse_stream(upstream, encoder);
+
+        let mut response = axum::response::Response::new(sse_body);
+        response.headers_mut().insert(
+            axum::http::header::CONTENT_TYPE,
+            HeaderValue::from_static("text/event-stream"),
+        );
+        response.headers_mut().insert(
+            axum::http::header::CACHE_CONTROL,
+            HeaderValue::from_static("no-cache"),
+        );
+        if let Ok(hv) = HeaderValue::from_str(request_id) {
+            response
+                .headers_mut()
+                .insert(HeaderName::from_static("x-aisix-request-id"), hv);
+        }
+        return Ok((response, provider_label));
+    }
+
+    // Non-streaming.
+    let resp = bridge.chat(&chat, &ctx).await.map_err(ProxyError::Bridge)?;
+    state.health.record_success(model_name);
+
+    let json = chat_response_into_anthropic_json(&resp, model_name);
+    Ok((Json(json).into_response(), provider_label))
+}
+
+/// Pump `ChatChunk`s through an `AnthropicSseEncoder` and emit each
+/// resulting `AnthropicSseEvent` as `event: …\ndata: …\n\n` bytes.
+/// Errors in the stream surface as a final `event: error` frame so
+/// SSE clients see something actionable rather than a half-complete
+/// stream.
+fn build_anthropic_sse_stream(
+    upstream: aisix_gateway::ChatChunkStream,
+    encoder: aisix_provider_anthropic::AnthropicSseEncoder,
+) -> axum::body::Body {
+    use futures::StreamExt;
+
+    let mut encoder = encoder;
+    let stream = async_stream::stream! {
+        let mut upstream = upstream;
+        while let Some(item) = upstream.next().await {
+            match item {
+                Ok(chunk) => {
+                    for ev in encoder.next_events(&chunk) {
+                        yield Ok::<_, std::io::Error>(bytes::Bytes::from(ev.to_sse_string()));
+                    }
+                    if encoder.is_finished() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let frame = format!(
+                        "event: error\ndata: {{\"type\":\"error\",\"error\":{{\"type\":\"{}\",\"message\":{}}}}}\n\n",
+                        e.error_type(),
+                        serde_json::to_string(&e.to_string()).unwrap_or_else(|_| "\"error\"".into()),
+                    );
+                    yield Ok(bytes::Bytes::from(frame));
+                    return;
+                }
+            }
+        }
+        if !encoder.is_finished() {
+            for ev in encoder.force_finish() {
+                yield Ok(bytes::Bytes::from(ev.to_sse_string()));
+            }
+        }
+    };
+    axum::body::Body::from_stream(stream)
 }
 
 fn emit_access_log(
@@ -477,21 +614,140 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
+    /// Cross-provider path: client speaks Anthropic protocol but the
+    /// resolved Model points at an OpenAI upstream. The handler now
+    /// translates Anthropic body → ChatFormat, dispatches through the
+    /// OpenAi bridge, and re-encodes the OpenAI response as
+    /// Anthropic-shape JSON (`{type:"message", role:"assistant",
+    /// content:[{type:"text",...}], stop_reason, usage}`).
     #[tokio::test]
-    async fn non_anthropic_model_returns_400() {
+    async fn non_anthropic_model_dispatches_through_bridge_and_returns_anthropic_shape() {
+        use aisix_provider_openai::OpenAiBridge;
+
+        let upstream = MockServer::start().await;
+        // Mock an OpenAI /chat/completions response. The proxy will
+        // translate it back to Anthropic shape on the way out.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-XYZ",
+                "object": "chat.completion",
+                "created": 1_715_000_000_u64,
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello from GPT!"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+            })))
+            .mount(&upstream)
+            .await;
+
         let snap = AisixSnapshot::new();
-        snap.models.insert(openai_model("gpt-4o", "http://unused"));
+        snap.models
+            .insert(openai_model("my-claude-alias", &upstream.uri()));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
-        let app = build_app(snap);
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
+
+        // Anthropic-shape inbound body.
         let body = serde_json::json!({
-            "model": "gpt-4o",
+            "model": "my-claude-alias",
             "messages": [{"role": "user", "content": "hi"}],
-            "max_tokens": 10
+            "max_tokens": 100
         });
         let resp = app.oneshot(make_req(body)).await.unwrap();
-        // 400 Bad Request — model is not an Anthropic provider.
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        // Anthropic-shape envelope.
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["role"], "assistant");
+        assert_eq!(
+            v["model"], "my-claude-alias",
+            "echoes operator alias, not upstream id"
+        );
+        assert_eq!(v["content"][0]["type"], "text");
+        assert_eq!(v["content"][0]["text"], "Hello from GPT!");
+        assert_eq!(
+            v["stop_reason"], "end_turn",
+            "OpenAI 'stop' → Anthropic 'end_turn'"
+        );
+        assert_eq!(v["usage"]["input_tokens"], 7);
+        assert_eq!(v["usage"]["output_tokens"], 3);
+    }
+
+    /// Streaming variant: the client asks for SSE; we translate
+    /// OpenAI delta chunks to Anthropic message_start /
+    /// content_block_delta / message_stop events.
+    #[tokio::test]
+    async fn non_anthropic_model_streams_anthropic_sse_events() {
+        use aisix_provider_openai::OpenAiBridge;
+
+        let upstream = MockServer::start().await;
+        // OpenAI-style SSE stream with two content deltas + a done marker.
+        let sse = "\
+data: {\"id\":\"cmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1715000000,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1715000000,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1715000000,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.models
+            .insert(openai_model("my-claude-alias", &upstream.uri()));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
+
+        let body = serde_json::json!({
+            "model": "my-claude-alias",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "stream": true,
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream"),
+        );
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+
+        // Anthropic-shape SSE event sequence.
+        assert!(
+            body.contains("event: message_start"),
+            "missing message_start in:\n{body}"
+        );
+        assert!(body.contains("event: content_block_start"));
+        assert!(body.contains("event: content_block_delta"));
+        assert!(body.contains("\"text\":\"hel\""));
+        assert!(body.contains("\"text\":\"lo\""));
+        assert!(body.contains("event: content_block_stop"));
+        assert!(body.contains("event: message_delta"));
+        assert!(body.contains("\"stop_reason\":\"end_turn\""));
+        assert!(body.contains("event: message_stop"));
     }
 
     #[tokio::test]

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -141,12 +141,30 @@ Forwards to the configured Model's `/v1/embeddings` endpoint.
 {"model": "my-embeddings", "input": ["foo", "bar"]}
 ```
 
-### 4.5 `POST /v1/messages` (Anthropic native)
+### 4.5 `POST /v1/messages` (Anthropic Messages — any upstream)
 
-Native Anthropic Messages API path. The body is forwarded with the
-`model` field rewritten to the upstream Anthropic model id. Use this
-when your client already speaks Anthropic and you want zero
-translation overhead.
+Native Anthropic Messages API path. Works against any configured
+upstream — Anthropic, OpenAI, Gemini, DeepSeek — based on the
+resolved `Model.provider`:
+
+- **Anthropic upstream** — byte-for-byte passthrough. The body is
+  forwarded with the `model` field rewritten to the upstream
+  Anthropic model id. SSE streamed verbatim. This preserves features
+  the gateway-internal `ChatFormat` can't lossily round-trip
+  (`cache_control`, thinking blocks, image blocks, tool_use blocks).
+- **Non-Anthropic upstream** — the gateway parses the Anthropic body
+  into its internal `ChatFormat` (folding `system` into a leading
+  system message, concatenating text content blocks), dispatches
+  through the `Hub` to the matching `Bridge`, and re-encodes the
+  bridge's response as Anthropic JSON or Anthropic SSE
+  (`message_start` / `content_block_start` / `content_block_delta` /
+  `content_block_stop` / `message_delta` / `message_stop`). The
+  `model` field in the response echoes the operator alias the client
+  sent, not the underlying upstream id.
+
+Today's translation supports text content blocks. Tool_use, image,
+and thinking blocks are scoped to a follow-up; current behavior is
+to skip non-text blocks silently on the inbound parse.
 
 ### 4.6 `POST /v1/responses` (OpenAI Responses)
 
@@ -210,6 +228,12 @@ possible:
 | Anthropic | `/v1/messages` | `/v1/chat/completions` (full translation) | The Hub maps content blocks ↔ messages, tool_use ↔ tool_calls, system extraction, cache_control passthrough, stop_reason normalisation |
 | Gemini | `/v1/chat/completions` (OpenAI-compat endpoint) | (same) | Uses Gemini's OpenAI-compatible base URL with `x-goog-api-key` auth |
 | DeepSeek | `/v1/chat/completions` (OpenAI-compat endpoint) | (same) | Uses Bearer auth, OpenAI-compatible payloads |
+
+`/v1/messages` is symmetric to `/v1/chat/completions` for the
+**inbound** axis: an Anthropic-SDK client can target an OpenAI /
+Gemini / DeepSeek upstream and the gateway translates both
+directions (text content blocks today; tool_use / image / thinking
+blocks land in a follow-up).
 
 For `gemini` and `deepseek` there is no separate "native" endpoint —
 both providers expose OpenAI-compatible APIs and the Bridge is a thin


### PR DESCRIPTION
## Summary

Closes the symmetry gap on the proxy's protocol-conversion surface.

**Before**: `/v1/chat/completions` accepted **any** upstream (OpenAI / Anthropic / Gemini / DeepSeek), but `/v1/messages` rejected anything that wasn't an Anthropic upstream with 422.

**After**: both endpoints support all four upstreams. Clients pick the protocol that fits their SDK; the gateway translates.

## Implementation pattern

Lifted from LiteLLM's experimental_pass_through adapter:

- [`transformation.py`](https://github.com/BerriAI/litellm/blob/main/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py) → request parser + non-streaming response renderer
- [`streaming_iterator.py`](https://github.com/BerriAI/litellm/blob/main/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py) → SSE state-machine pattern (message_start → content_block_* → message_delta → message_stop)

Trimmed to text content blocks (tool_use / image / thinking blocks land in a follow-up — current behavior skips them silently on parse).

## New surface (`aisix-provider-anthropic`)

- `parse_inbound_request(body) → ChatFormat` — folds `system` into a leading system message, concatenates text content blocks, surfaces unrecognized keys via `extra`
- `chat_response_into_anthropic_json(resp, alias) → Value` — non-streaming response renderer
- `AnthropicSseEncoder` + `AnthropicSseEvent` — state machine for the streaming SSE event sequence
- `AnthropicInboundError` for 400-class translation errors

## Handler change (`aisix-proxy::messages`)

Branches on `model.provider`:

- **Anthropic upstream** — existing byte-for-byte passthrough (preserves cache_control / thinking / tool_use blocks the gateway-internal `ChatFormat` can't round-trip)
- **Non-Anthropic** — `cross_provider_dispatch` parses → `Hub.get(provider)` → `bridge.chat` or `bridge.chat_stream` → re-encode to Anthropic JSON / SSE

The response `model` field echoes the operator alias (`my-claude-alias`) rather than the upstream id (`gpt-4o`), so callers see a stable identifier across upstream swaps.

Streaming uses `async-stream` to pump bridge chunks through the SSE encoder. Upstream errors surface as `event: error` SSE frames so Anthropic SDKs raise rather than silently truncating.

## Tests

- **17 new unit tests** in `wire.rs`: parser (system shapes / unknown role / missing model / content blocks string vs array / extra keys), response encoder (shape + every finish_reason mapping), SSE encoder (first-chunk bootstrap / mid-stream deltas / finish trio / force-close / finish-without-content)
- **2 new integration tests** in `messages.rs`: non-streaming + streaming, both with a wiremock OpenAI upstream and full Anthropic-shape assertions on the response

| Crate | Before | After |
|---|---|---|
| aisix-provider-anthropic | 33 | 36 |
| aisix-proxy | 105 | 107 |

(Replaces the obsolete `non_anthropic_model_returns_400` pin.)

## Dependency change

`aisix-provider-anthropic` moves from `[dev-dependencies]` to `[dependencies]` in `aisix-proxy/Cargo.toml`. Proxy is the only consumer of the new public translation surface; other providers stay behind the Bridge trait.

## Docs

- README hero entry for `/v1/messages` reflects "any upstream"
- `docs/api-proxy.md` §4.5 expanded with the two-path explanation
- `crates/aisix-proxy/src/messages.rs` file-header comment rewritten

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` green (full suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic Messages API (POST /v1/messages) now accepts Anthropic/Claude-shaped requests and can proxy them to non-Anthropic upstreams (OpenAI, Gemini, DeepSeek), returning Anthropic-compatible JSON or SSE streams.

* **Documentation**
  * API docs updated to describe symmetric inbound/outbound translation behavior and supported content blocks.

* **Tests**
  * Expanded cross-provider and streaming test coverage for translation and SSE behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->