### PR TITLE
feat(model): split provider_config inline into ProviderKey reference

### DIFF
--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -426,9 +426,10 @@ mod tests {
 
         let model: Model = serde_json::from_str(
             r#"{
-                "name": "it-gpt4",
-                "model": "openai/gpt-4o",
-                "provider_config": {"api_key": "sk-x"}
+                "display_name": "it-gpt4",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "11111111-1111-1111-1111-111111111111"
             }"#,
         )
         .unwrap();
@@ -437,7 +438,7 @@ mod tests {
 
         let got = store.get_model("m-it-1").await.unwrap().unwrap();
         assert_eq!(got.id, "m-it-1");
-        assert_eq!(got.value.name, "it-gpt4");
+        assert_eq!(got.value.display_name, "it-gpt4");
         assert!(got.revision > 0, "etcd should return a real mod_revision");
 
         let listed = store.list_models().await.unwrap();

--- a/crates/aisix-admin/src/health_handler.rs
+++ b/crates/aisix-admin/src/health_handler.rs
@@ -61,14 +61,14 @@ pub async fn get_health(
                 .health_tracker
                 .as_ref()
                 .map(|t| {
-                    let level = t.level(&entry.value.name);
+                    let level = t.level(&entry.value.display_name);
                     u8::from(level)
                 })
                 .unwrap_or(0); // no tracker → assume Healthy
 
             ModelHealth {
                 id: entry.id.clone(),
-                name: entry.value.name.clone(),
+                name: entry.value.display_name.clone(),
                 health: health_level,
             }
         })

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -207,9 +207,10 @@ mod tests {
 
     fn model_payload(name: &str) -> Value {
         json!({
-            "name": name,
-            "model": "openai/gpt-4o",
-            "provider_config": {"api_key": "sk-x"}
+            "display_name": name,
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111"
         })
     }
 
@@ -351,7 +352,7 @@ mod tests {
         let v = body_json(resp).await;
         assert!(!v["id"].as_str().unwrap().is_empty());
         assert_eq!(v["revision"], 1);
-        assert_eq!(v["value"]["name"], "my-gpt4");
+        assert_eq!(v["value"]["display_name"], "my-gpt4");
     }
 
     #[tokio::test]
@@ -389,9 +390,10 @@ mod tests {
     async fn create_model_with_invalid_provider_prefix_is_400_schema_error() {
         let app = build_router(build_state());
         let body = json!({
-            "name": "x",
-            "model": "mistral/large",
-            "provider_config": {"api_key": "sk-x"}
+            "display_name": "x",
+            "provider": "mistral",
+            "model_name": "large",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111"
         });
         let resp = run(app, auth_req("POST", "/admin/v1/models", Some(body))).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -462,7 +464,7 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
-        assert_eq!(v["value"]["name"], "foo");
+        assert_eq!(v["value"]["display_name"], "foo");
     }
 
     #[tokio::test]
@@ -485,9 +487,10 @@ mod tests {
 
         // Change provider upstream.
         let updated_body = json!({
-            "name": "foo",
-            "model": "anthropic/claude-sonnet-4-5",
-            "provider_config": {"api_key": "sk-ant"}
+            "display_name": "foo",
+            "provider": "anthropic",
+            "model_name": "claude-sonnet-4-5",
+            "provider_key_id": "22222222-2222-2222-2222-222222222222"
         });
         let app = build_router(state);
         let resp = run(
@@ -498,7 +501,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v["revision"], 2);
-        assert_eq!(v["value"]["model"], "anthropic/claude-sonnet-4-5");
+        assert_eq!(v["value"]["provider"], "anthropic");
+        assert_eq!(v["value"]["model_name"], "claude-sonnet-4-5");
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/models_handlers.rs
+++ b/crates/aisix-admin/src/models_handlers.rs
@@ -50,7 +50,7 @@ pub async fn create_model(
 ) -> Result<Json<ResourceEntry<Model>>, AdminError> {
     let model = decode_model(&raw)?;
     let all = state.store.list_models().await?;
-    assert_unique_name(&all, &model.name, None)?;
+    assert_unique_name(&all, &model.display_name, None)?;
 
     let id = Uuid::new_v4().to_string();
     let entry = ResourceEntry::new(&id, model, STARTING_REVISION);
@@ -72,7 +72,7 @@ pub async fn update_model(
     let model = decode_model(&raw)?;
 
     let all = state.store.list_models().await?;
-    assert_unique_name(&all, &model.name, Some(&id))?;
+    assert_unique_name(&all, &model.display_name, Some(&id))?;
 
     let entry = ResourceEntry::new(&id, model, existing.revision + 1);
     state.store.put_model(entry.clone()).await?;
@@ -103,7 +103,7 @@ fn assert_unique_name(
     self_id: Option<&str>,
 ) -> Result<(), AdminError> {
     for e in existing {
-        if e.value.name == name && self_id.is_none_or(|sid| sid != e.id) {
+        if e.value.display_name == name && self_id.is_none_or(|sid| sid != e.id) {
             return Err(AdminError::Conflict(name.to_string()));
         }
     }

--- a/crates/aisix-admin/src/playground_handler.rs
+++ b/crates/aisix-admin/src/playground_handler.rs
@@ -81,16 +81,26 @@ mod tests {
         }
     }
 
-    fn model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const PK_ID: &str = "pk-up-1";
+
+    fn model_entry(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/gpt-4o",
-                "provider_config": {{"api_key": "sk-up", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "{PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json =
+            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
     }
 
     fn apikey_entry() -> ResourceEntry<ApiKey> {
@@ -103,7 +113,8 @@ mod tests {
 
     fn build_test_app(upstream_uri: &str) -> Router {
         let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("gpt4", upstream_uri));
+        snap.models.insert(model_entry("gpt4"));
+        snap.provider_keys.insert(provider_key_entry(upstream_uri));
         snap.apikeys.insert(apikey_entry());
 
         let snapshot = SnapshotHandle::new(snap);

--- a/crates/aisix-admin/src/store.rs
+++ b/crates/aisix-admin/src/store.rs
@@ -218,9 +218,10 @@ mod tests {
     fn sample_model(name: &str) -> Model {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/gpt-4o",
-                "provider_config": {{"api_key": "sk-x"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "11111111-1111-1111-1111-111111111111"
             }}"#
         );
         serde_json::from_str(&cfg).unwrap()
@@ -233,7 +234,7 @@ mod tests {
         store.put_model(entry.clone()).await.unwrap();
         let got = store.get_model("m-1").await.unwrap().unwrap();
         assert_eq!(got.id, "m-1");
-        assert_eq!(got.value.name, "foo");
+        assert_eq!(got.value.display_name, "foo");
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -154,9 +154,10 @@ async fn models_round_trip_through_real_etcd() {
         state,
         "/admin/v1/models",
         json!({
-            "name": "it-gpt4",
-            "model": "openai/gpt-4o",
-            "provider_config": {"api_key": "sk-it"}
+            "display_name": "it-gpt4",
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111"
         }),
     )
     .await;
@@ -282,9 +283,10 @@ async fn loader_picks_up_every_admin_write() {
         (
             "/admin/v1/models",
             json!({
-                "name": "loader-gpt4",
-                "model": "openai/gpt-4o",
-                "provider_config": {"api_key": "sk-x"}
+                "display_name": "loader-gpt4",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "11111111-1111-1111-1111-111111111111"
             }),
         ),
         (

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -33,8 +33,8 @@ pub use models::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_model,
     validate_observability_exporter, validate_provider_key, AisixSnapshot, ApiKey, CachePolicy,
     ExporterKind, Guardrail, GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern,
-    Model, ObservabilityExporter, Provider, ProviderConfig, ProviderKey, RateLimit, Routing,
-    RoutingStrategy, RoutingTarget, SchemaError,
+    Model, ObservabilityExporter, Provider, ProviderKey, RateLimit, Routing, RoutingStrategy,
+    RoutingTarget, SchemaError,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -33,7 +33,7 @@ pub use guardrail::{
     BedrockAWSCredentials, BedrockConfig, BedrockLatencyMode, Guardrail, GuardrailHookPoint,
     GuardrailKind, KeywordConfig, KeywordPattern,
 };
-pub use model::{Model, Provider, ProviderConfig};
+pub use model::{Model, Provider};
 pub use observability_exporter::{ExporterKind, ObservabilityExporter, OtlpHttpConfig};
 pub use provider_key::ProviderKey;
 pub use rate_limit::RateLimit;

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -1,25 +1,23 @@
-//! `Model` entity — the routing target users reference from API requests
-//! (spec §3).
+//! `Model` entity — the routing target users reference from API requests.
 //!
-//! A Model has a user-chosen unique `name`, a canonical `model` id of the
-//! form `<provider>/<model_name>`, a `provider_config` block with the
-//! upstream API key, an optional `timeout`, and an optional `rate_limit`.
+//! A Model has a user-chosen unique `display_name`, an explicit
+//! `provider` enum, an upstream `model_name` (e.g. "gpt-4o"), and a
+//! `provider_key_id` referencing a [`ProviderKey`] entry that supplies
+//! the secret + optional `api_base` override.
 //!
-//! etcd path: `{prefix}/models/{uuid}`. Secondary index on `name`.
+//! Routing models — virtual routers that pick a target Model per request
+//! — set `routing` instead of `provider`/`model_name`/`provider_key_id`.
+//! See [`Model::is_routing`].
+//!
+//! etcd path: `{prefix}/models/{uuid}`. Secondary index on `display_name`.
 
-use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use super::rate_limit::RateLimit;
 use super::routing::Routing;
 use crate::resource::Resource;
 
-static MODEL_ID_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(anthropic|deepseek|gemini|openai|router)/.+$").unwrap());
-
-/// Supported provider prefixes. The `model` field must start with one of these
-/// followed by `/<upstream-model-id>`.
+/// Supported upstream providers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Provider {
@@ -49,18 +47,6 @@ impl Provider {
     }
 }
 
-/// Upstream provider credentials and endpoint override.
-///
-/// Per spec §3, ProviderConfig is *untagged* — the provider type is derived
-/// from the `model` field's prefix, not from a discriminator in this struct.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct ProviderConfig {
-    pub api_key: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub api_base: Option<String>,
-}
-
 /// Per-token cost for budget tracking. Both values are in USD per 1,000 tokens.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -83,9 +69,27 @@ impl ModelCost {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Model {
-    pub name: String,
-    pub model: String,
-    pub provider_config: ProviderConfig,
+    /// Operator-facing unique label. Surfaces on `/v1/models`,
+    /// `req.model` on chat completions, ApiKey.allowed_models, and
+    /// the dashboard model list. `Resource::name()` returns this.
+    pub display_name: String,
+
+    /// Upstream provider. None for routing models (the router picks
+    /// a target whose own `provider` is used at dispatch time).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<Provider>,
+
+    /// Upstream model id sent to the provider (e.g. "gpt-4o",
+    /// "claude-sonnet-4-5"). None for routing models.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+
+    /// References a `ProviderKey` row by id. The bridge resolves this
+    /// against `AisixSnapshot::provider_keys` at dispatch time to
+    /// fetch the upstream secret + optional `api_base`. None for
+    /// routing models.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_key_id: Option<String>,
 
     /// Request timeout in ms. 0 or absent = no timeout.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -94,12 +98,10 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<RateLimit>,
 
-    /// Optional routing config. When present, the proxy treats this Model
-    /// as a *virtual* router: it picks one of the listed targets per the
-    /// strategy and dispatches through that target's bridge instead of
-    /// using `model` / `provider_config` on this entity. The base `model`
-    /// field is still required (use the `router/<name>` prefix to make
-    /// the intent obvious to operators).
+    /// Virtual-router config. When set, the proxy walks `routing.targets`
+    /// to pick a downstream Model and dispatches against THAT model's
+    /// `provider` / `model_name` / `provider_key_id`. The fields on
+    /// this entity are intentionally absent in that case.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing: Option<Routing>,
 
@@ -115,45 +117,16 @@ pub struct Model {
 }
 
 impl Model {
-    /// Parse the `<provider>/<model_name>` prefix. Returns `None` for
-    /// the `router/...` virtual-routing form (which intentionally has
-    /// no upstream provider) and for malformed values.
-    pub fn provider(&self) -> Option<Provider> {
-        let (prefix, _) = self.model.split_once('/')?;
-        match prefix {
-            "openai" => Some(Provider::Openai),
-            "anthropic" => Some(Provider::Anthropic),
-            "gemini" => Some(Provider::Gemini),
-            "deepseek" => Some(Provider::Deepseek),
-            _ => None,
-        }
-    }
-
     /// Whether this Model is a virtual router (proxy walks `routing.targets`
-    /// instead of dispatching its own provider config).
+    /// instead of dispatching its own upstream config).
     pub fn is_routing(&self) -> bool {
         self.routing.is_some()
     }
 
-    /// Returns the upstream-facing model id (everything after the first `/`).
+    /// Convenience: borrow the upstream model id if this Model is a
+    /// direct (non-routing) entry.
     pub fn upstream_model(&self) -> Option<&str> {
-        self.model.split_once('/').map(|(_, m)| m)
-    }
-
-    /// The base URL reqwest should use — provider default or the explicit
-    /// `api_base` override.
-    pub fn base_url(&self) -> Option<String> {
-        let base = self
-            .provider_config
-            .api_base
-            .clone()
-            .or_else(|| self.provider().map(|p| p.default_base_url().to_string()))?;
-        Some(base)
-    }
-
-    /// True if the model id matches the spec regex.
-    pub fn has_valid_model_id(&self) -> bool {
-        MODEL_ID_RE.is_match(&self.model)
+        self.model_name.as_deref()
     }
 }
 
@@ -163,7 +136,7 @@ impl Resource for Model {
     }
 
     fn name(&self) -> &str {
-        &self.name
+        &self.display_name
     }
 
     fn kind() -> &'static str {
@@ -177,12 +150,10 @@ mod tests {
 
     fn sample_json() -> &'static str {
         r#"{
-          "name": "my-gpt4",
-          "model": "openai/gpt-4o",
-          "provider_config": {
-            "api_key": "sk-redacted",
-            "api_base": "https://api.openai.com/v1"
-          },
+          "display_name": "my-gpt4",
+          "provider": "openai",
+          "model_name": "gpt-4o",
+          "provider_key_id": "11111111-1111-1111-1111-111111111111",
           "timeout": 30000,
           "rate_limit": {"rpm": 100, "tpm": 100000}
         }"#
@@ -191,32 +162,23 @@ mod tests {
     #[test]
     fn deserialises_spec_sample() {
         let m: Model = serde_json::from_str(sample_json()).unwrap();
-        assert_eq!(m.name, "my-gpt4");
-        assert_eq!(m.provider(), Some(Provider::Openai));
-        assert_eq!(m.upstream_model(), Some("gpt-4o"));
-        assert_eq!(m.base_url().as_deref(), Some("https://api.openai.com/v1"));
+        assert_eq!(m.display_name, "my-gpt4");
+        assert_eq!(m.provider, Some(Provider::Openai));
+        assert_eq!(m.model_name.as_deref(), Some("gpt-4o"));
+        assert_eq!(
+            m.provider_key_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
         assert_eq!(m.timeout, Some(30_000));
         assert_eq!(m.rate_limit.as_ref().unwrap().rpm, Some(100));
-    }
-
-    #[test]
-    fn base_url_falls_back_to_provider_default() {
-        let m: Model = serde_json::from_str(
-            r#"{
-              "name": "x",
-              "model": "anthropic/claude-3",
-              "provider_config": {"api_key": "k"}
-            }"#,
-        )
-        .unwrap();
-        assert_eq!(m.base_url().as_deref(), Some("https://api.anthropic.com"));
     }
 
     #[test]
     fn rejects_unknown_top_level_fields() {
         let r: Result<Model, _> = serde_json::from_str(
             r#"{
-              "name":"x","model":"openai/gpt-4","provider_config":{"api_key":"k"},
+              "display_name":"x","provider":"openai","model_name":"g",
+              "provider_key_id":"pk-1",
               "foo": 1
             }"#,
         );
@@ -224,32 +186,25 @@ mod tests {
     }
 
     #[test]
-    fn has_valid_model_id_matches_spec_regex() {
-        let mk = |s: &str| Model {
-            name: "x".into(),
-            model: s.into(),
-            provider_config: ProviderConfig {
-                api_key: "k".into(),
-                api_base: None,
-            },
-            timeout: None,
-            rate_limit: None,
-            routing: None,
-            cost: None,
-            runtime_id: String::new(),
-        };
-
-        assert!(mk("openai/gpt-4").has_valid_model_id());
-        assert!(mk("anthropic/claude-3.5").has_valid_model_id());
-        assert!(mk("deepseek/dsv3").has_valid_model_id());
-        assert!(mk("gemini/gemini-1.5-pro").has_valid_model_id());
-        assert!(!mk("mistral/large").has_valid_model_id());
-        assert!(!mk("openai").has_valid_model_id());
-        assert!(!mk("openai/").has_valid_model_id());
+    fn routing_form_has_no_provider_or_provider_key_id() {
+        let m: Model = serde_json::from_str(
+            r#"{
+              "display_name": "router-1",
+              "routing": {
+                "strategy": "round_robin",
+                "targets": [{"model": "my-gpt4"}, {"model": "my-claude"}]
+              }
+            }"#,
+        )
+        .unwrap();
+        assert!(m.is_routing());
+        assert!(m.provider.is_none());
+        assert!(m.model_name.is_none());
+        assert!(m.provider_key_id.is_none());
     }
 
     #[test]
-    fn resource_trait_routes_through_name() {
+    fn resource_trait_routes_through_display_name() {
         let mut m: Model = serde_json::from_str(sample_json()).unwrap();
         m.runtime_id = "uuid-1".into();
         assert_eq!(<Model as Resource>::kind(), "models");

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -105,25 +105,15 @@ fn model_schema() -> Value {
     json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
-        "required": ["name", "model", "provider_config"],
+        "required": ["display_name"],
         "additionalProperties": false,
         "properties": {
-            "name": { "type": "string", "minLength": 1 },
-            "model": {
-                "type": "string",
-                "pattern": "^(anthropic|deepseek|gemini|openai|router)/.+$"
-            },
-            "provider_config": {
-                "type": "object",
-                "required": ["api_key"],
-                "additionalProperties": false,
-                "properties": {
-                    "api_key": { "type": "string", "minLength": 1 },
-                    "api_base": { "type": "string" }
-                }
-            },
-            "timeout": { "type": "integer", "minimum": 0 },
-            "rate_limit": { "$ref": "#/$defs/rate_limit" },
+            "display_name":    { "type": "string", "minLength": 1 },
+            "provider":        { "type": "string", "enum": ["openai","anthropic","gemini","deepseek"] },
+            "model_name":      { "type": "string", "minLength": 1 },
+            "provider_key_id": { "type": "string", "minLength": 1 },
+            "timeout":         { "type": "integer", "minimum": 0 },
+            "rate_limit":      { "$ref": "#/$defs/rate_limit" },
             "routing": {
                 "type": "object",
                 "required": ["targets"],
@@ -148,8 +138,35 @@ fn model_schema() -> Value {
                     },
                     "retry_budget": { "type": "integer", "minimum": 0 }
                 }
+            },
+            "cost": {
+                "type": "object",
+                "required": ["input_per_1k", "output_per_1k"],
+                "additionalProperties": false,
+                "properties": {
+                    "input_per_1k":  { "type": "number", "minimum": 0 },
+                    "output_per_1k": { "type": "number", "minimum": 0 }
+                }
             }
         },
+        // Direct vs routing model: a model EITHER ships a `routing`
+        // block (virtual router — provider/model_name/provider_key_id
+        // forbidden) OR ships those three required fields together
+        // (direct upstream — routing forbidden).
+        "oneOf": [
+            {
+                "required": ["routing"],
+                "not": { "anyOf": [
+                    { "required": ["provider"] },
+                    { "required": ["model_name"] },
+                    { "required": ["provider_key_id"] }
+                ]}
+            },
+            {
+                "required": ["provider", "model_name", "provider_key_id"],
+                "not": { "required": ["routing"] }
+            }
+        ],
         "$defs": {
             "rate_limit": {
                 "type": "object",
@@ -377,9 +394,10 @@ mod tests {
     #[test]
     fn model_happy_path_passes() {
         let v = json!({
-            "name": "my-gpt4",
-            "model": "openai/gpt-4o",
-            "provider_config": {"api_key": "sk-x"},
+            "display_name": "my-gpt4",
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111",
             "timeout": 30000,
             "rate_limit": {"rpm": 100}
         });
@@ -387,30 +405,80 @@ mod tests {
     }
 
     #[test]
-    fn model_missing_name_fails_with_useful_path() {
+    fn model_routing_form_passes() {
         let v = json!({
-            "model": "openai/gpt-4o",
-            "provider_config": {"api_key": "sk-x"}
+            "display_name": "router-1",
+            "routing": {
+                "strategy": "round_robin",
+                "targets": [{"model": "my-gpt4"}, {"model": "my-claude"}]
+            }
         });
-        let err = validate_model(&v).unwrap_err();
-        assert!(err.message.contains("name"));
+        validate_model(&v).unwrap();
     }
 
     #[test]
-    fn model_bad_provider_prefix_fails() {
+    fn model_missing_display_name_fails() {
         let v = json!({
-            "name": "x",
-            "model": "mistral/large",
-            "provider_config": {"api_key": "k"}
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "pk-1"
         });
         let err = validate_model(&v).unwrap_err();
-        assert!(err.path.contains("/model") || err.message.to_lowercase().contains("pattern"));
+        assert!(err.message.to_lowercase().contains("display_name"));
+    }
+
+    #[test]
+    fn model_unknown_provider_value_fails() {
+        let v = json!({
+            "display_name": "x",
+            "provider": "mistral",
+            "model_name": "large",
+            "provider_key_id": "pk-1"
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_direct_with_routing_block_fails() {
+        // Direct + routing both present violates the oneOf XOR.
+        let v = json!({
+            "display_name": "x",
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "pk-1",
+            "routing": {"targets": [{"model": "y"}]}
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_routing_with_provider_key_id_fails() {
+        // Router can't carry provider_key_id — that lives on the
+        // target Models the router fans out to.
+        let v = json!({
+            "display_name": "router-1",
+            "provider_key_id": "pk-1",
+            "routing": {"targets": [{"model": "y"}]}
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_direct_missing_provider_key_id_fails() {
+        // Direct model needs all three of provider / model_name /
+        // provider_key_id.
+        let v = json!({
+            "display_name": "x",
+            "provider": "openai",
+            "model_name": "gpt-4o"
+        });
+        assert!(validate_model(&v).is_err());
     }
 
     #[test]
     fn model_rejects_additional_top_level() {
         let v = json!({
-            "name":"x","model":"openai/g","provider_config":{"api_key":"k"},
+            "display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1",
             "rogue": 1
         });
         assert!(validate_model(&v).is_err());
@@ -440,7 +508,7 @@ mod tests {
     #[test]
     fn rate_limit_negative_value_rejected() {
         let v = json!({
-            "name":"x","model":"openai/g","provider_config":{"api_key":"k"},
+            "display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1",
             "rate_limit": {"rpm": -1}
         });
         assert!(validate_model(&v).is_err());

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -54,9 +54,10 @@ mod tests {
     fn sample_model() -> Model {
         serde_json::from_str(
             r#"{
-              "name": "my-gpt4",
-              "model": "openai/gpt-4o",
-              "provider_config": {"api_key": "sk-x"}
+              "display_name": "my-gpt4",
+              "provider": "openai",
+              "model_name": "gpt-4o",
+              "provider_key_id": "11111111-1111-1111-1111-111111111111"
             }"#,
         )
         .unwrap()

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -188,9 +188,10 @@ mod tests {
     }
 
     const VALID_MODEL: &[u8] = br#"{
-        "name": "my-gpt4",
-        "model": "openai/gpt-4o",
-        "provider_config": {"api_key": "sk-x"}
+        "display_name": "my-gpt4",
+        "provider": "openai",
+        "model_name": "gpt-4o",
+        "provider_key_id": "11111111-1111-1111-1111-111111111111"
     }"#;
 
     const VALID_APIKEY: &[u8] = br#"{
@@ -236,7 +237,7 @@ mod tests {
     fn schema_failure_is_counted() {
         let entries = vec![raw(
             "/aisix/models/bad-provider",
-            br#"{"name":"x","model":"mistral/large","provider_config":{"api_key":"k"}}"#,
+            br#"{"display_name":"x","provider":"mistral","model_name":"large","provider_key_id":"pk-1"}"#,
             1,
         )];
         let (_snap, stats) = build_snapshot("/aisix", &entries);

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -167,12 +167,28 @@ impl<P: ConfigProvider> Supervisor<P> {
 
         let new = clone_snapshot(&self.handle.load());
 
-        // Move any entries from `tiny` into `new`.
+        // Move any entries from `tiny` into `new`. Must cover every
+        // ResourceTable on AisixSnapshot — a missing kind here means
+        // a watch event silently drops on the floor and the snapshot
+        // never sees the new entry, even though the loader and the
+        // proxy both know about it.
         for e in tiny.models.entries() {
             new.models.insert(clone_entry(&e));
         }
         for e in tiny.apikeys.entries() {
             new.apikeys.insert(clone_entry(&e));
+        }
+        for e in tiny.provider_keys.entries() {
+            new.provider_keys.insert(clone_entry(&e));
+        }
+        for e in tiny.guardrails.entries() {
+            new.guardrails.insert(clone_entry(&e));
+        }
+        for e in tiny.cache_policies.entries() {
+            new.cache_policies.insert(clone_entry(&e));
+        }
+        for e in tiny.observability_exporters.entries() {
+            new.observability_exporters.insert(clone_entry(&e));
         }
 
         self.handle.store(new);
@@ -209,6 +225,10 @@ impl<P: ConfigProvider> Supervisor<P> {
         let removed = match parsed.kind {
             "models" => new.models.remove(parsed.id).is_some(),
             "api_keys" => new.apikeys.remove(parsed.id).is_some(),
+            "provider_keys" => new.provider_keys.remove(parsed.id).is_some(),
+            "guardrails" => new.guardrails.remove(parsed.id).is_some(),
+            "cache_policies" => new.cache_policies.remove(parsed.id).is_some(),
+            "observability_exporters" => new.observability_exporters.remove(parsed.id).is_some(),
             _ => false,
         };
         if removed {
@@ -397,6 +417,18 @@ fn clone_snapshot(src: &AisixSnapshot) -> AisixSnapshot {
     for e in src.apikeys.entries() {
         out.apikeys.insert(clone_entry(&e));
     }
+    for e in src.provider_keys.entries() {
+        out.provider_keys.insert(clone_entry(&e));
+    }
+    for e in src.guardrails.entries() {
+        out.guardrails.insert(clone_entry(&e));
+    }
+    for e in src.cache_policies.entries() {
+        out.cache_policies.insert(clone_entry(&e));
+    }
+    for e in src.observability_exporters.entries() {
+        out.observability_exporters.insert(clone_entry(&e));
+    }
     out
 }
 
@@ -494,6 +526,86 @@ mod tests {
         sup.load_once().await.unwrap();
         assert!(sup.apply_put(&entry("/aisix/models/m-1", VALID_MODEL, 2)));
         assert_eq!(sup.handle().load().models.len(), 1);
+    }
+
+    /// Regression for the supervisor `apply_put` / `clone_snapshot`
+    /// drift: every kind on `AisixSnapshot` must be mergeable on a
+    /// watch event, otherwise admin writes for those resources land
+    /// in etcd but never reach the proxy snapshot. Smoke test #102
+    /// hit this for ProviderKey — the proxy saw the Model fine but
+    /// `dispatch::resolve_provider_key` blew up because the PK was
+    /// invisible to the watch path.
+    #[tokio::test]
+    async fn apply_put_propagates_every_resource_kind() {
+        const VALID_PROVIDER_KEY: &[u8] = br#"{
+            "display_name": "watch-pk",
+            "secret": "sk-watch"
+        }"#;
+        const VALID_GUARDRAIL: &[u8] = br#"{
+            "name": "watch-block",
+            "kind": "keyword",
+            "patterns": [{"kind": "literal", "value": "x"}]
+        }"#;
+        const VALID_CACHE_POLICY: &[u8] = br#"{
+            "name": "watch-cache",
+            "enabled": true
+        }"#;
+        const VALID_OBSERVABILITY_EXPORTER: &[u8] = br#"{
+            "name": "watch-otel",
+            "kind": "otlp_http",
+            "endpoint": "https://otel.example.com/v1/traces"
+        }"#;
+
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+        sup.load_once().await.unwrap();
+
+        for (key, body, _kind) in [
+            ("/aisix/provider_keys/pk-1", VALID_PROVIDER_KEY, "PK"),
+            ("/aisix/guardrails/g-1", VALID_GUARDRAIL, "Guardrail"),
+            (
+                "/aisix/cache_policies/cp-1",
+                VALID_CACHE_POLICY,
+                "CachePolicy",
+            ),
+            (
+                "/aisix/observability_exporters/oe-1",
+                VALID_OBSERVABILITY_EXPORTER,
+                "ObservabilityExporter",
+            ),
+        ] {
+            assert!(
+                sup.apply_put(&entry(key, body, 2)),
+                "apply_put returned false for {key}"
+            );
+        }
+
+        let snap = sup.handle().load();
+        assert_eq!(snap.provider_keys.len(), 1, "ProviderKey not merged");
+        assert_eq!(snap.guardrails.len(), 1, "Guardrail not merged");
+        assert_eq!(snap.cache_policies.len(), 1, "CachePolicy not merged");
+        assert_eq!(
+            snap.observability_exporters.len(),
+            1,
+            "ObservabilityExporter not merged"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_delete_removes_every_resource_kind() {
+        let provider = Arc::new(FakeProvider::new(
+            vec![entry(
+                "/aisix/provider_keys/pk-1",
+                br#"{"display_name":"x","secret":"y"}"#,
+                1,
+            )],
+            1,
+        ));
+        let sup = Supervisor::new(provider, "/aisix");
+        sup.load_once().await.unwrap();
+        assert_eq!(sup.handle().load().provider_keys.len(), 1);
+        assert!(sup.apply_delete("/aisix/provider_keys/pk-1"));
+        assert!(sup.handle().load().provider_keys.is_empty());
     }
 
     #[tokio::test]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -460,9 +460,10 @@ mod tests {
     }
 
     const VALID_MODEL: &[u8] = br#"{
-        "name": "my-gpt4",
-        "model": "openai/gpt-4o",
-        "provider_config": {"api_key": "sk-x"}
+        "display_name": "my-gpt4",
+        "provider": "openai",
+        "model_name": "gpt-4o",
+        "provider_key_id": "11111111-1111-1111-1111-111111111111"
     }"#;
 
     fn entry(key: &str, v: &[u8], rev: i64) -> RawEntry {

--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -16,7 +16,7 @@
 //! The trait is deliberately `async_trait` rather than GATs — ergonomic
 //! wins outweigh the boxing cost on the provider path.
 
-use aisix_core::Model;
+use aisix_core::{Model, ProviderKey};
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use std::time::Duration;
@@ -26,26 +26,34 @@ use crate::chat::{ChatChunk, ChatFormat, ChatResponse, EmbeddingRequest, Embeddi
 /// Context carried through the whole request lifecycle.
 ///
 /// The proxy layer fills this in after it has authenticated the request
-/// and resolved the target model. Bridges read from it but do not mutate
-/// it — the fields relevant to the transport (auth, timeout) are owned
-/// references to structures in the current [`aisix_core::AisixSnapshot`].
+/// and resolved both the target Model AND its referenced ProviderKey
+/// from the [`aisix_core::AisixSnapshot`]. Bridges read from it but
+/// do not mutate it.
 #[derive(Debug, Clone)]
 pub struct BridgeContext {
     /// Correlation id propagated into traces and error envelopes.
     pub request_id: String,
-    /// The resolved upstream model — the Bridge reads provider_config
-    /// (api_key, api_base) and the upstream model name from here.
+    /// The resolved Model — bridges read `model_name` (the upstream
+    /// model id) and metadata (timeout, rate_limit) from here.
     pub model: std::sync::Arc<Model>,
+    /// The ProviderKey the Model references — bridges read `secret`
+    /// (api key) and `api_base` (optional override) from here.
+    pub provider_key: std::sync::Arc<ProviderKey>,
     /// Deadline for the entire upstream call. Bridges are expected to
     /// honour this by cancelling any in-flight HTTP request.
     pub deadline: Option<Duration>,
 }
 
 impl BridgeContext {
-    pub fn new(request_id: impl Into<String>, model: std::sync::Arc<Model>) -> Self {
+    pub fn new(
+        request_id: impl Into<String>,
+        model: std::sync::Arc<Model>,
+        provider_key: std::sync::Arc<ProviderKey>,
+    ) -> Self {
         Self {
             request_id: request_id.into(),
             model,
+            provider_key,
             deadline: None,
         }
     }
@@ -244,7 +252,8 @@ mod tests {
     #[test]
     fn context_defaults_no_deadline_with_helper_setter() {
         let m = std::sync::Arc::new(sample_model());
-        let ctx = BridgeContext::new("req-1", m.clone());
+        let pk = std::sync::Arc::new(sample_provider_key());
+        let ctx = BridgeContext::new("req-1", m.clone(), pk);
         assert_eq!(ctx.request_id, "req-1");
         assert!(ctx.deadline.is_none());
         let ctx = ctx.with_deadline(Duration::from_secs(30));
@@ -254,17 +263,22 @@ mod tests {
     fn sample_model() -> Model {
         serde_json::from_str(
             r#"{
-                "name": "test",
-                "model": "openai/gpt-4o",
-                "provider_config": {"api_key": "sk-x"}
+                "display_name": "test",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "11111111-1111-1111-1111-111111111111"
             }"#,
         )
         .unwrap()
     }
 
+    fn sample_provider_key() -> ProviderKey {
+        serde_json::from_str(r#"{"display_name":"openai-prod","secret":"sk-x"}"#).unwrap()
+    }
+
     #[test]
-    fn sample_model_parses_and_routes_to_openai() {
+    fn sample_model_resolves_to_openai() {
         let m = sample_model();
-        assert_eq!(m.provider(), Some(Provider::Openai));
+        assert_eq!(m.provider, Some(Provider::Openai));
     }
 }

--- a/crates/aisix-gateway/src/hub.rs
+++ b/crates/aisix-gateway/src/hub.rs
@@ -152,11 +152,17 @@ mod tests {
 
         let m = std::sync::Arc::new(
             serde_json::from_str::<aisix_core::Model>(
-                r#"{"name":"t","model":"openai/gpt-4o","provider_config":{"api_key":"k"}}"#,
+                r#"{"display_name":"t","provider":"openai","model_name":"gpt-4o","provider_key_id":"pk-1"}"#,
             )
             .unwrap(),
         );
-        let ctx = BridgeContext::new("req-1", m);
+        let pk = std::sync::Arc::new(
+            serde_json::from_str::<aisix_core::ProviderKey>(
+                r#"{"display_name":"pk","secret":"k"}"#,
+            )
+            .unwrap(),
+        );
+        let ctx = BridgeContext::new("req-1", m, pk);
         let req = ChatFormat::new("t", vec![ChatMessage::user("hi")]);
 
         let resp = bridge.chat(&req, &ctx).await.unwrap();

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -81,28 +81,27 @@ fn default_client() -> Client {
         .unwrap_or_else(|_| Client::new())
 }
 
-fn resolve_base(model: &aisix_core::Model) -> String {
-    match model.base_url() {
+fn resolve_base(ctx: &BridgeContext) -> String {
+    match ctx.provider_key.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
         _ => ANTHROPIC_DEFAULT_BASE.to_string(),
     }
 }
 
-fn api_key(model: &aisix_core::Model) -> Result<&str, BridgeError> {
-    let k = &model.provider_config.api_key;
+fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
+    let k = &ctx.provider_key.secret;
     if k.is_empty() {
-        Err(BridgeError::Config(
-            "provider_config.api_key is empty".into(),
-        ))
+        Err(BridgeError::Config("provider_key.secret is empty".into()))
     } else {
         Ok(k.as_str())
     }
 }
 
-fn upstream_model(model: &aisix_core::Model) -> Result<&str, BridgeError> {
-    model
-        .upstream_model()
-        .ok_or_else(|| BridgeError::Config("model field missing `provider/` prefix".into()))
+fn upstream_model(ctx: &BridgeContext) -> Result<&str, BridgeError> {
+    ctx.model
+        .model_name
+        .as_deref()
+        .ok_or_else(|| BridgeError::Config("model.model_name missing".into()))
 }
 
 async fn map_http_error(status: StatusCode, resp: reqwest::Response) -> BridgeError {
@@ -151,10 +150,9 @@ impl Bridge for AnthropicBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
-        let model = ctx.model.as_ref();
-        let base = resolve_base(model);
-        let key = api_key(model)?;
-        let upstream = upstream_model(model)?;
+        let base = resolve_base(ctx);
+        let key = api_key(ctx)?;
+        let upstream = upstream_model(ctx)?;
 
         let (system, messages) =
             split_system(req).map_err(|e| BridgeError::Config(e.to_string()))?;
@@ -196,10 +194,9 @@ impl Bridge for AnthropicBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let model = ctx.model.as_ref();
-        let base = resolve_base(model);
-        let key = api_key(model)?;
-        let upstream = upstream_model(model)?;
+        let base = resolve_base(ctx);
+        let key = api_key(ctx)?;
+        let upstream = upstream_model(ctx)?;
 
         let (system, messages) =
             split_system(req).map_err(|e| BridgeError::Config(e.to_string()))?;
@@ -268,21 +265,35 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aisix_core::Model;
+    use aisix_core::{Model, ProviderKey};
     use aisix_gateway::{ChatMessage, FinishReason, Role};
     use std::sync::Arc;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    fn sample_model(base: &str) -> Arc<Model> {
+    fn sample_model() -> Arc<Model> {
+        Arc::new(
+            serde_json::from_str(
+                r#"{
+                    "display_name": "my-claude",
+                    "provider": "anthropic",
+                    "model_name": "claude-sonnet-4-5",
+                    "provider_key_id": "11111111-1111-1111-1111-111111111111"
+                }"#,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn sample_provider_key(base: &str) -> Arc<ProviderKey> {
         let cfg = format!(
-            r#"{{
-                "name": "my-claude",
-                "model": "anthropic/claude-sonnet-4-5",
-                "provider_config": {{"api_key": "sk-ant-test", "api_base": "{base}"}}
-            }}"#
+            r#"{{"display_name":"anthropic-prod","secret":"sk-ant-test","api_base":"{base}"}}"#
         );
         Arc::new(serde_json::from_str(&cfg).unwrap())
+    }
+
+    fn sample_ctx(base: &str) -> BridgeContext {
+        BridgeContext::new("req-1", sample_model(), sample_provider_key(base))
     }
 
     fn req() -> ChatFormat {
@@ -315,7 +326,7 @@ mod tests {
             .await;
 
         let bridge = AnthropicBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let resp = bridge.chat(&req(), &ctx).await.unwrap();
 
         assert_eq!(resp.id, "msg_01");
@@ -340,7 +351,7 @@ mod tests {
             .await;
 
         let bridge = AnthropicBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
         match err {
             BridgeError::UpstreamStatus { status, message } => {
@@ -361,7 +372,7 @@ mod tests {
             .await;
 
         let bridge = AnthropicBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
         assert!(matches!(err, BridgeError::UpstreamDecode(_)));
     }
@@ -386,26 +397,19 @@ mod tests {
             .await;
 
         let bridge = AnthropicBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()))
-            .with_deadline(Duration::from_millis(50));
+        let ctx = sample_ctx(&server.uri()).with_deadline(Duration::from_millis(50));
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
         assert!(matches!(err, BridgeError::Timeout { .. }));
     }
 
     #[tokio::test]
     async fn missing_api_key_is_a_config_error() {
-        let mut model: Model = serde_json::from_str(
-            r#"{
-                "name": "bad",
-                "model": "anthropic/claude-sonnet-4-5",
-                "provider_config": {"api_key": "placeholder"}
-            }"#,
-        )
-        .unwrap();
-        model.provider_config.api_key.clear();
+        let mut pk: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"empty","secret":"placeholder"}"#).unwrap();
+        pk.secret.clear();
 
         let bridge = AnthropicBridge::new();
-        let ctx = BridgeContext::new("req-1", Arc::new(model));
+        let ctx = BridgeContext::new("req-1", sample_model(), Arc::new(pk));
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
         assert!(matches!(err, BridgeError::Config(_)));
     }
@@ -414,7 +418,7 @@ mod tests {
     async fn tool_role_is_rejected_as_config_error() {
         let server = MockServer::start().await;
         let bridge = AnthropicBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let req = ChatFormat::new(
             "my-claude",
             vec![ChatMessage {
@@ -457,7 +461,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             .await;
 
         let bridge = AnthropicBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
 
         let mut chunks = Vec::new();
@@ -483,7 +487,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             .await;
 
         let bridge = AnthropicBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         match bridge.chat_stream(&req(), &ctx).await {
             Ok(_) => panic!("expected upstream error"),
             Err(BridgeError::UpstreamStatus { status: 500, .. }) => {}
@@ -493,20 +497,19 @@ data: {\"type\":\"message_stop\"}\n\n";
 
     #[test]
     fn resolve_base_honours_override() {
-        let mut m: Model = serde_json::from_str(
-            r#"{
-                "name": "x",
-                "model": "anthropic/claude-sonnet-4-5",
-                "provider_config": {"api_key": "k"}
-            }"#,
+        // Default path: ProviderKey has no api_base → falls back to
+        // ANTHROPIC_DEFAULT_BASE.
+        let pk_default: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_default));
+        assert!(!resolve_base(&ctx).is_empty());
+
+        // api_base override: trailing slash stripped.
+        let pk_override: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"x","secret":"k","api_base":"https://proxy.example.com/"}"#,
         )
         .unwrap();
-        // Default path: Provider::Anthropic.default_base_url() comes
-        // from aisix-core, so just assert that *some* non-empty host
-        // is picked up.
-        assert!(!resolve_base(&m).is_empty());
-
-        m.provider_config.api_base = Some("https://proxy.example.com/".into());
-        assert_eq!(resolve_base(&m), "https://proxy.example.com");
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_override));
+        assert_eq!(resolve_base(&ctx), "https://proxy.example.com");
     }
 }

--- a/crates/aisix-provider-deepseek/src/lib.rs
+++ b/crates/aisix-provider-deepseek/src/lib.rs
@@ -67,16 +67,21 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = format!(
-            r#"{{
-                "name": "my-deepseek",
-                "model": "deepseek/deepseek-chat",
-                "provider_config": {{"api_key": "ds-test", "api_base": "{uri}"}}
-            }}"#,
+        let model: aisix_core::Model = serde_json::from_str(
+            r#"{
+                "display_name": "my-deepseek",
+                "provider": "deepseek",
+                "model_name": "deepseek-chat",
+                "provider_key_id": "11111111-1111-1111-1111-111111111111"
+            }"#,
+        )
+        .unwrap();
+        let pk_cfg = format!(
+            r#"{{"display_name":"ds-prod","secret":"ds-test","api_base":"{uri}"}}"#,
             uri = server.uri()
         );
-        let model: aisix_core::Model = serde_json::from_str(&cfg).unwrap();
-        let ctx = BridgeContext::new("req-1", Arc::new(model));
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_cfg).unwrap();
+        let ctx = BridgeContext::new("req-1", Arc::new(model), Arc::new(pk));
         let req = ChatFormat::new("my-deepseek", vec![ChatMessage::user("ping")]);
 
         let resp = deepseek_bridge().chat(&req, &ctx).await.unwrap();

--- a/crates/aisix-provider-gemini/src/lib.rs
+++ b/crates/aisix-provider-gemini/src/lib.rs
@@ -70,16 +70,21 @@ mod tests {
             .mount(&server)
             .await;
 
-        let cfg = format!(
-            r#"{{
-                "name": "my-gemini",
-                "model": "gemini/gemini-2.5-flash",
-                "provider_config": {{"api_key": "AIzaTEST", "api_base": "{uri}"}}
-            }}"#,
+        let model: aisix_core::Model = serde_json::from_str(
+            r#"{
+                "display_name": "my-gemini",
+                "provider": "gemini",
+                "model_name": "gemini-2.5-flash",
+                "provider_key_id": "11111111-1111-1111-1111-111111111111"
+            }"#,
+        )
+        .unwrap();
+        let pk_cfg = format!(
+            r#"{{"display_name":"gemini-prod","secret":"AIzaTEST","api_base":"{uri}"}}"#,
             uri = server.uri()
         );
-        let model: aisix_core::Model = serde_json::from_str(&cfg).unwrap();
-        let ctx = BridgeContext::new("req-1", Arc::new(model));
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_cfg).unwrap();
+        let ctx = BridgeContext::new("req-1", Arc::new(model), Arc::new(pk));
         let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hola")]);
 
         let resp = gemini_bridge().chat(&req, &ctx).await.unwrap();

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -78,28 +78,27 @@ fn default_client() -> Client {
         .unwrap_or_else(|_| Client::new())
 }
 
-fn resolve_base(model: &aisix_core::Model) -> String {
-    match model.base_url() {
+fn resolve_base(ctx: &BridgeContext) -> String {
+    match ctx.provider_key.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
         _ => OPENAI_DEFAULT_BASE.to_string(),
     }
 }
 
-fn api_key(model: &aisix_core::Model) -> Result<&str, BridgeError> {
-    let k = &model.provider_config.api_key;
+fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
+    let k = &ctx.provider_key.secret;
     if k.is_empty() {
-        Err(BridgeError::Config(
-            "provider_config.api_key is empty".into(),
-        ))
+        Err(BridgeError::Config("provider_key.secret is empty".into()))
     } else {
         Ok(k.as_str())
     }
 }
 
-fn upstream_model(model: &aisix_core::Model) -> Result<&str, BridgeError> {
-    model
-        .upstream_model()
-        .ok_or_else(|| BridgeError::Config("model field missing `provider/` prefix".into()))
+fn upstream_model(ctx: &BridgeContext) -> Result<&str, BridgeError> {
+    ctx.model
+        .model_name
+        .as_deref()
+        .ok_or_else(|| BridgeError::Config("model.model_name missing".into()))
 }
 
 async fn map_http_error(status: StatusCode, resp: reqwest::Response) -> BridgeError {
@@ -149,10 +148,9 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
-        let model = ctx.model.as_ref();
-        let base = resolve_base(model);
-        let key = api_key(model)?;
-        let upstream = upstream_model(model)?;
+        let base = resolve_base(ctx);
+        let key = api_key(ctx)?;
+        let upstream = upstream_model(ctx)?;
 
         let messages = messages_from(req);
         let body = build_request(req, upstream, &messages, false);
@@ -191,10 +189,9 @@ impl Bridge for OpenAiBridge {
         req: &EmbeddingRequest,
         ctx: &BridgeContext,
     ) -> Result<EmbeddingResponse, BridgeError> {
-        let model = ctx.model.as_ref();
-        let base = resolve_base(model);
-        let key = api_key(model)?;
-        let upstream = upstream_model(model)?;
+        let base = resolve_base(ctx);
+        let key = api_key(ctx)?;
+        let upstream = upstream_model(ctx)?;
 
         let body = embed_request_body(req, upstream);
         let url = format!("{base}/embeddings");
@@ -232,10 +229,9 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let model = ctx.model.as_ref();
-        let base = resolve_base(model);
-        let key = api_key(model)?;
-        let upstream = upstream_model(model)?;
+        let base = resolve_base(ctx);
+        let key = api_key(ctx)?;
+        let upstream = upstream_model(ctx)?;
 
         // Replace the `model` field with the upstream provider id.
         let mut outbound = body.clone();
@@ -279,10 +275,9 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let model = ctx.model.as_ref();
-        let base = resolve_base(model);
-        let key = api_key(model)?;
-        let upstream = upstream_model(model)?;
+        let base = resolve_base(ctx);
+        let key = api_key(ctx)?;
+        let upstream = upstream_model(ctx)?;
 
         // Replace the `model` field with the upstream provider id.
         let mut outbound = body.clone();
@@ -326,10 +321,9 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let model = ctx.model.as_ref();
-        let base = resolve_base(model);
-        let key = api_key(model)?;
-        let upstream = upstream_model(model)?;
+        let base = resolve_base(ctx);
+        let key = api_key(ctx)?;
+        let upstream = upstream_model(ctx)?;
 
         let messages = messages_from(req);
         let body = build_request(req, upstream, &messages, true);
@@ -396,21 +390,35 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aisix_core::Model;
+    use aisix_core::{Model, ProviderKey};
     use aisix_gateway::{ChatMessage, FinishReason, Role};
     use std::sync::Arc;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    fn sample_model(base: &str) -> Arc<Model> {
+    fn sample_model() -> Arc<Model> {
+        Arc::new(
+            serde_json::from_str(
+                r#"{
+                    "display_name": "my-gpt4",
+                    "provider": "openai",
+                    "model_name": "gpt-4o",
+                    "provider_key_id": "11111111-1111-1111-1111-111111111111"
+                }"#,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn sample_provider_key(base: &str) -> Arc<ProviderKey> {
         let cfg = format!(
-            r#"{{
-                "name": "my-gpt4",
-                "model": "openai/gpt-4o",
-                "provider_config": {{"api_key": "sk-test", "api_base": "{base}"}}
-            }}"#
+            r#"{{"display_name": "openai-prod", "secret": "sk-test", "api_base": "{base}"}}"#
         );
         Arc::new(serde_json::from_str(&cfg).unwrap())
+    }
+
+    fn sample_ctx(base: &str) -> BridgeContext {
+        BridgeContext::new("req-1", sample_model(), sample_provider_key(base))
     }
 
     fn req() -> ChatFormat {
@@ -437,7 +445,7 @@ mod tests {
             .await;
 
         let bridge = OpenAiBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let resp = bridge.chat(&req(), &ctx).await.unwrap();
 
         assert_eq!(resp.id, "cmpl-1");
@@ -457,7 +465,7 @@ mod tests {
             .await;
 
         let bridge = OpenAiBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
         match err {
             BridgeError::UpstreamStatus { status, message } => {
@@ -478,7 +486,7 @@ mod tests {
             .await;
 
         let bridge = OpenAiBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
         assert!(matches!(err, BridgeError::UpstreamDecode(_)));
     }
@@ -497,29 +505,22 @@ mod tests {
             .await;
 
         let bridge = OpenAiBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()))
-            .with_deadline(Duration::from_millis(50));
+        let ctx = sample_ctx(&server.uri()).with_deadline(Duration::from_millis(50));
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
         assert!(matches!(err, BridgeError::Timeout { .. }));
     }
 
     #[tokio::test]
     async fn missing_api_key_is_a_config_error() {
-        // Construct a Model whose api_key is empty. We bypass JSON Schema
-        // here because the loader would normally reject this, but tests
-        // of the Bridge's own guard still need the path exercised.
-        let mut model: Model = serde_json::from_str(
-            r#"{
-                "name": "bad",
-                "model": "openai/gpt-4o",
-                "provider_config": {"api_key": "placeholder"}
-            }"#,
-        )
-        .unwrap();
-        model.provider_config.api_key.clear();
+        // Bridge's own guard: ProviderKey with an empty `secret` must
+        // surface a Config error rather than calling upstream with a
+        // bare bearer.
+        let mut pk: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"empty","secret":"placeholder"}"#).unwrap();
+        pk.secret.clear();
 
         let bridge = OpenAiBridge::new();
-        let ctx = BridgeContext::new("req-1", Arc::new(model));
+        let ctx = BridgeContext::new("req-1", sample_model(), Arc::new(pk));
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
         assert!(matches!(err, BridgeError::Config(_)));
     }
@@ -543,7 +544,7 @@ data: [DONE]\n\n";
             .await;
 
         let bridge = OpenAiBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
 
         let mut chunks = Vec::new();
@@ -567,7 +568,7 @@ data: [DONE]\n\n";
             .await;
 
         let bridge = OpenAiBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(&server.uri()));
+        let ctx = sample_ctx(&server.uri());
         match bridge.chat_stream(&req(), &ctx).await {
             Ok(_) => panic!("expected upstream error, got a live stream"),
             Err(BridgeError::UpstreamStatus { status: 500, .. }) => {}
@@ -577,18 +578,18 @@ data: [DONE]\n\n";
 
     #[test]
     fn resolve_base_trims_trailing_slash_and_honours_override() {
-        let mut m: Model = serde_json::from_str(
-            r#"{
-                "name": "x",
-                "model": "openai/gpt-4o",
-                "provider_config": {"api_key": "k"}
-            }"#,
+        // No api_base set → falls back to OPENAI_DEFAULT_BASE.
+        let pk_default: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_default));
+        assert_eq!(resolve_base(&ctx), OPENAI_DEFAULT_BASE);
+
+        // api_base override: trailing slash stripped.
+        let pk_override: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"x","secret":"k","api_base":"https://proxy.example.com/v1/"}"#,
         )
         .unwrap();
-        // No api_base set → Provider::Openai's default host.
-        assert_eq!(resolve_base(&m), "https://api.openai.com");
-
-        m.provider_config.api_base = Some("https://proxy.example.com/v1/".into());
-        assert_eq!(resolve_base(&m), "https://proxy.example.com/v1");
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_override));
+        assert_eq!(resolve_base(&ctx), "https://proxy.example.com/v1");
     }
 }

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -284,27 +284,14 @@ async fn multipart_dispatch(
     }
 
     let model = &model_entry.value;
-    let upstream_model = model
-        .upstream_model()
-        .ok_or_else(|| ProxyError::InvalidRequest("model field missing provider/ prefix".into()))?
-        .to_string();
+    let provider = crate::dispatch::require_provider(model)?;
+    let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
 
-    let api_key = model.provider_config.api_key.as_str();
-    if api_key.is_empty() {
-        return Err(ProxyError::Bridge(aisix_gateway::BridgeError::Config(
-            "provider_config.api_key is empty".into(),
-        )));
-    }
-
-    let base = match model.base_url() {
-        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
-        _ => "https://api.openai.com".to_string(),
-    };
+    let base = crate::dispatch::resolve_base_url(provider, &pk_entry.value);
     let url = format!("{base}{upstream_path}");
-    let provider_label = model
-        .provider()
-        .map(|p| format!("{p:?}").to_lowercase())
-        .unwrap_or_else(|| "unknown".to_string());
+    let provider_label = format!("{provider:?}").to_lowercase();
 
     // Rebuild the multipart form with `model` rewritten.
     let mut form = multipart::Form::new();
@@ -391,26 +378,13 @@ async fn speech_dispatch(
     }
 
     let model = &model_entry.value;
-    let upstream_model = model
-        .upstream_model()
-        .ok_or_else(|| ProxyError::InvalidRequest("model field missing provider/ prefix".into()))?
-        .to_string();
+    let provider = crate::dispatch::require_provider(model)?;
+    let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
 
-    let api_key = model.provider_config.api_key.as_str();
-    if api_key.is_empty() {
-        return Err(ProxyError::Bridge(aisix_gateway::BridgeError::Config(
-            "provider_config.api_key is empty".into(),
-        )));
-    }
-
-    let base = match model.base_url() {
-        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
-        _ => "https://api.openai.com".to_string(),
-    };
-    let provider_label = model
-        .provider()
-        .map(|p| format!("{p:?}").to_lowercase())
-        .unwrap_or_else(|| "unknown".to_string());
+    let base = crate::dispatch::resolve_base_url(provider, &pk_entry.value);
+    let provider_label = format!("{provider:?}").to_lowercase();
 
     // Rewrite model field.
     if let Some(m) = body.get_mut("model") {
@@ -512,28 +486,45 @@ mod tests {
         }
     }
 
-    fn whisper_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn whisper_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/whisper-1",
-                "provider_config": {{"api_key": "sk-up", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "whisper-1",
+                "provider_key_id": "{PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
     }
 
-    fn tts_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    fn tts_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/tts-1",
-                "provider_config": {{"api_key": "sk-up", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "tts-1",
+                "provider_key_id": "{PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-2", m, 1)
+    }
+
+    fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json =
+            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(provider_key_entry(api_base));
+        snap
     }
 
     fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -554,8 +545,8 @@ mod tests {
 
     #[tokio::test]
     async fn speech_unauthenticated_returns_401() {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(tts_model("my-tts", "http://unused"));
+        let snap = new_snap("http://unused");
+        snap.models.insert(tts_model("my-tts"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -573,7 +564,7 @@ mod tests {
 
     #[tokio::test]
     async fn speech_unknown_model_returns_404() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -605,8 +596,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(tts_model("my-tts", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(tts_model("my-tts"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -636,9 +627,8 @@ mod tests {
 
     #[tokio::test]
     async fn transcriptions_unauthenticated_returns_401() {
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(whisper_model("my-whisper", "http://unused"));
+        let snap = new_snap("http://unused");
+        snap.models.insert(whisper_model("my-whisper"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -346,11 +346,7 @@ async fn dispatch(
     // single bad provider doesn't take down the whole request.
     if attempt_models.len() == 1 {
         let only = &attempt_models[0];
-        let provider = only.provider().ok_or_else(|| {
-            with_model(ProxyError::InvalidRequest(
-                "model has no provider prefix".into(),
-            ))
-        })?;
+        let provider = crate::dispatch::require_provider(only).map_err(with_model)?;
         if state.hub.get(provider).is_none() {
             return Err(with_model(ProxyError::ProviderUnavailable));
         }
@@ -370,17 +366,16 @@ async fn dispatch(
     // failure mid-flight) and not worth the complexity for V1.
     if req.is_streaming() {
         let model = &attempt_models[0];
-        let provider = model.provider().ok_or_else(|| {
-            with_model(ProxyError::InvalidRequest(
-                "model has no provider prefix".into(),
-            ))
-        })?;
+        let provider = crate::dispatch::require_provider(model).map_err(with_model)?;
+        let pk_entry =
+            crate::dispatch::resolve_provider_key(&snapshot, model).map_err(with_model)?;
         let bridge = state
             .hub
             .get(provider)
             .ok_or_else(|| with_model(ProxyError::ProviderUnavailable))?;
         let model_arc = Arc::new(model.clone());
-        let ctx = BridgeContext::new(request_id, model_arc);
+        let pk_arc = Arc::new(pk_entry.value.clone());
+        let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
         let upstream = bridge
             .chat_stream(req, &ctx)
             .await
@@ -492,7 +487,7 @@ async fn dispatch(
                 // cache hit we don't know (or care) which target ran the
                 // original call; the fingerprint identified the answer.
                 let provider_label = attempt_models[0]
-                    .provider()
+                    .provider
                     .map(|p| format!("{p:?}").to_lowercase())
                     .unwrap_or_else(|| "unknown".into());
                 let mut response = Json(render_response(now, cached)).into_response();
@@ -546,9 +541,18 @@ async fn dispatch(
     let mut upstream: Option<aisix_gateway::ChatResponse> = None;
 
     for model in &attempt_models {
-        let Some(provider) = model.provider() else {
-            last_err = Some(BridgeError::Config("model has no provider prefix".into()));
+        let Some(provider) = model.provider else {
+            last_err = Some(BridgeError::Config("model has no provider".into()));
             continue;
+        };
+        let pk_entry = match crate::dispatch::resolve_provider_key(&snapshot, model) {
+            Ok(pk) => pk,
+            Err(_) => {
+                last_err = Some(BridgeError::Config(
+                    "model references unknown provider_key_id".into(),
+                ));
+                continue;
+            }
         };
         let Some(bridge) = state.hub.get(provider) else {
             last_err = Some(BridgeError::Config(
@@ -557,18 +561,19 @@ async fn dispatch(
             continue;
         };
         let model_arc = Arc::new(model.clone());
-        let ctx = BridgeContext::new(request_id, model_arc);
+        let pk_arc = Arc::new(pk_entry.value.clone());
+        let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
 
         match bridge.chat(req, &ctx).await {
             Ok(resp) => {
-                state.health.record_success(&model.name);
+                state.health.record_success(&model.display_name);
                 chosen_provider = Some(format!("{provider:?}").to_lowercase());
                 upstream = Some(resp);
                 break;
             }
             Err(err) => {
                 tracing::warn!(
-                    target_model = %model.name,
+                    target_model = %model.display_name,
                     error = %err,
                     retryable = is_retryable(&err),
                     "routing target attempt failed",
@@ -576,7 +581,7 @@ async fn dispatch(
                 // Only retryable (server-side) errors indicate deployment
                 // health deterioration; 4xx are caller mistakes.
                 if is_retryable(&err) {
-                    state.health.record_failure(&model.name);
+                    state.health.record_failure(&model.display_name);
                 }
                 if !is_retryable(&err) {
                     last_err = Some(err);

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -109,9 +109,8 @@ async fn dispatch(
     }
 
     let model = &model_entry.value;
-    let provider = model
-        .provider()
-        .ok_or_else(|| ProxyError::InvalidRequest("model has no provider prefix".into()))?;
+    let provider = crate::dispatch::require_provider(model)?;
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
     let bridge = state
         .hub
@@ -119,7 +118,8 @@ async fn dispatch(
         .ok_or(ProxyError::ProviderUnavailable)?;
 
     let model_arc = Arc::new(model.clone());
-    let ctx = BridgeContext::new(request_id, model_arc);
+    let pk_arc = Arc::new(pk_entry.value.clone());
+    let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
 
     let provider_label = format!("{provider:?}").to_lowercase();
 
@@ -186,16 +186,32 @@ mod tests {
         }
     }
 
-    fn model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn model_entry(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/gpt-3.5-turbo-instruct",
-                "provider_config": {{"api_key": "sk-up", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "gpt-3.5-turbo-instruct",
+                "provider_key_id": "{PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json =
+            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(provider_key_entry(api_base));
+        snap
     }
 
     fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -245,8 +261,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("instruct", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("instruct"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -264,8 +280,8 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_request_returns_401() {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("instruct", "http://unused"));
+        let snap = new_snap("http://unused");
+        snap.models.insert(model_entry("instruct"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -283,8 +299,8 @@ mod tests {
 
     #[tokio::test]
     async fn forbidden_model_returns_403() {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("instruct", "http://unused"));
+        let snap = new_snap("http://unused");
+        snap.models.insert(model_entry("instruct"));
         snap.apikeys.insert(apikey_entry(&["other-model"]));
 
         let app = build_app(snap);
@@ -297,7 +313,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_model_returns_404() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -317,8 +333,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("instruct", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("instruct"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -1,0 +1,193 @@
+//! Helpers shared by every endpoint that needs to dispatch to a Bridge.
+//!
+//! Every endpoint follows the same shape after Model resolution:
+//!
+//! 1. Take the resolved `Model` (already looked up by display_name).
+//! 2. Resolve the `ProviderKey` it references (via `provider_key_id`).
+//! 3. Compute the upstream base URL by combining the `Provider`'s
+//!    default with the `ProviderKey`'s optional `api_base` override.
+//!
+//! These helpers existed inline in each endpoint as
+//! `Model::base_url()`, `Model::upstream_model()`, and
+//! `Model::provider_config.api_key` accessors. Phase B moved the
+//! Model from "self-contained inline secret" to "ProviderKey
+//! reference"; this module is the join point that recovers the old
+//! ergonomics on the proxy side.
+//!
+//! Returns typed [`ProxyError`] variants so the caller's `?`
+//! plumbing flows naturally.
+
+use std::sync::Arc;
+
+use aisix_core::models::Provider;
+use aisix_core::resource::ResourceEntry;
+use aisix_core::{AisixSnapshot, Model, ProviderKey};
+
+use crate::error::ProxyError;
+
+/// Look up the `ProviderKey` a given `Model` references. Returns a
+/// 400 if the Model is a virtual router (those don't dispatch
+/// directly — caller should walk `routing.targets` first), or if the
+/// referenced ProviderKey row is missing from the snapshot.
+pub(crate) fn resolve_provider_key(
+    snapshot: &AisixSnapshot,
+    model: &Model,
+) -> Result<Arc<ResourceEntry<ProviderKey>>, ProxyError> {
+    let pk_id = model.provider_key_id.as_deref().ok_or_else(|| {
+        ProxyError::InvalidRequest(format!(
+            "model {:?} has no provider_key_id (routing models can't be dispatched directly)",
+            model.display_name
+        ))
+    })?;
+    snapshot.provider_keys.get_by_id(pk_id).ok_or_else(|| {
+        ProxyError::InvalidRequest(format!(
+            "model {:?} references unknown provider_key_id {pk_id:?}",
+            model.display_name
+        ))
+    })
+}
+
+/// Required `provider` for a non-routing Model. 400 if absent.
+pub(crate) fn require_provider(model: &Model) -> Result<Provider, ProxyError> {
+    model.provider.ok_or_else(|| {
+        ProxyError::InvalidRequest(format!(
+            "model {:?} has no provider (routing models can't be dispatched directly)",
+            model.display_name
+        ))
+    })
+}
+
+/// Required upstream model id (`model_name`) for a non-routing Model.
+pub(crate) fn require_upstream_model(model: &Model) -> Result<&str, ProxyError> {
+    model.model_name.as_deref().ok_or_else(|| {
+        ProxyError::InvalidRequest(format!(
+            "model {:?} has no model_name (routing models can't be dispatched directly)",
+            model.display_name
+        ))
+    })
+}
+
+/// The upstream base URL: `provider_key.api_base` override if set,
+/// otherwise the `Provider`'s built-in default.
+pub(crate) fn resolve_base_url(provider: Provider, provider_key: &ProviderKey) -> String {
+    match provider_key.api_base.as_deref() {
+        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
+        _ => provider.default_base_url().to_string(),
+    }
+}
+
+/// The upstream API key — `provider_key.secret`. Empty string is
+/// treated as a config error (ProviderKey rows shouldn't be empty,
+/// but a hand-edited kine row could surface one).
+pub(crate) fn require_secret<'a>(
+    provider_key: &'a ProviderKey,
+    model: &Model,
+) -> Result<&'a str, ProxyError> {
+    if provider_key.secret.is_empty() {
+        return Err(ProxyError::InvalidRequest(format!(
+            "model {:?} provider_key has empty secret",
+            model.display_name
+        )));
+    }
+    Ok(provider_key.secret.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::resource::ResourceEntry;
+
+    fn snapshot_with(provider_key_id: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"openai-prod","secret":"sk-x","api_base":"https://proxy.example.com/v1"}"#,
+        )
+        .unwrap();
+        snap.provider_keys
+            .insert(ResourceEntry::new(provider_key_id, pk, 1));
+        snap
+    }
+
+    fn direct_model(provider_key_id: &str) -> Model {
+        let cfg = format!(
+            r#"{{
+                "display_name": "my-gpt4",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "{provider_key_id}"
+            }}"#
+        );
+        serde_json::from_str(&cfg).unwrap()
+    }
+
+    fn routing_model() -> Model {
+        serde_json::from_str(
+            r#"{
+                "display_name": "router-1",
+                "routing": {
+                    "strategy": "round_robin",
+                    "targets": [{"model": "my-gpt4"}]
+                }
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn resolve_provider_key_happy_path() {
+        let snap = snapshot_with("pk-1");
+        let m = direct_model("pk-1");
+        let entry = resolve_provider_key(&snap, &m).unwrap();
+        assert_eq!(entry.value.display_name, "openai-prod");
+    }
+
+    #[test]
+    fn resolve_provider_key_unknown_id_is_400_with_helpful_message() {
+        let snap = snapshot_with("pk-1");
+        let m = direct_model("pk-MISSING");
+        let err = resolve_provider_key(&snap, &m).unwrap_err();
+        match err {
+            ProxyError::InvalidRequest(msg) => {
+                assert!(msg.contains("provider_key_id"), "{msg}");
+                assert!(msg.contains("my-gpt4"), "{msg}");
+            }
+            other => panic!("expected InvalidRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_provider_key_routing_model_is_400() {
+        let snap = snapshot_with("pk-1");
+        let m = routing_model();
+        let err = resolve_provider_key(&snap, &m).unwrap_err();
+        assert!(matches!(err, ProxyError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn require_provider_returns_provider_for_direct_model() {
+        let m = direct_model("pk-1");
+        assert_eq!(require_provider(&m).unwrap(), Provider::Openai);
+    }
+
+    #[test]
+    fn require_provider_rejects_routing_model() {
+        let m = routing_model();
+        assert!(require_provider(&m).is_err());
+    }
+
+    #[test]
+    fn resolve_base_url_uses_override_when_set() {
+        let snap = snapshot_with("pk-1");
+        let m = direct_model("pk-1");
+        let pk_entry = resolve_provider_key(&snap, &m).unwrap();
+        let base = resolve_base_url(Provider::Openai, &pk_entry.value);
+        assert_eq!(base, "https://proxy.example.com/v1");
+    }
+
+    #[test]
+    fn resolve_base_url_falls_back_to_provider_default_when_override_blank() {
+        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let base = resolve_base_url(Provider::Anthropic, &pk);
+        assert_eq!(base, Provider::Anthropic.default_base_url());
+    }
+}

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -133,19 +133,15 @@ async fn dispatch(
     }
 
     let model = &model_entry.value;
-    let provider = model
-        .provider()
-        .ok_or_else(|| ProxyError::InvalidRequest("model has no provider prefix".into()))?;
+    let provider = crate::dispatch::require_provider(model)?;
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
     let bridge = state
         .hub
         .get(provider)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
-    let upstream_model_id = model
-        .upstream_model()
-        .ok_or_else(|| ProxyError::InvalidRequest("model missing provider/ prefix".into()))?
-        .to_string();
+    let upstream_model_id = crate::dispatch::require_upstream_model(model)?.to_string();
 
     let req = EmbeddingRequest {
         model: upstream_model_id,
@@ -155,7 +151,8 @@ async fn dispatch(
     };
 
     let model_arc = Arc::new(model.clone());
-    let ctx = BridgeContext::new(request_id, model_arc);
+    let pk_arc = Arc::new(pk_entry.value.clone());
+    let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
 
     match bridge.embed(&req, &ctx).await {
         Ok(embed_resp) => {
@@ -225,16 +222,32 @@ mod tests {
         }
     }
 
-    fn model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn model_entry(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/text-embedding-3-small",
-                "provider_config": {{"api_key": "sk-up", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "text-embedding-3-small",
+                "provider_key_id": "{PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json =
+            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(provider_key_entry(api_base));
+        snap
     }
 
     fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -285,8 +298,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("my-embed", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -313,8 +326,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("my-embed", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -327,8 +340,8 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_request_returns_401() {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("my-embed", "http://unused"));
+        let snap = new_snap("http://unused");
+        snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -346,8 +359,8 @@ mod tests {
 
     #[tokio::test]
     async fn forbidden_model_returns_403() {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("my-embed", "http://unused"));
+        let snap = new_snap("http://unused");
+        snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["other-model"]));
 
         let app = build_app(snap);
@@ -360,7 +373,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_model_returns_404() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -380,8 +393,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("my-embed", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -105,9 +105,8 @@ async fn dispatch(
     }
 
     let model = &model_entry.value;
-    let provider = model
-        .provider()
-        .ok_or_else(|| ProxyError::InvalidRequest("model has no provider prefix".into()))?;
+    let provider = crate::dispatch::require_provider(model)?;
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
     let bridge = state
         .hub
@@ -115,7 +114,8 @@ async fn dispatch(
         .ok_or(ProxyError::ProviderUnavailable)?;
 
     let model_arc = Arc::new(model.clone());
-    let ctx = BridgeContext::new(request_id, model_arc);
+    let pk_arc = Arc::new(pk_entry.value.clone());
+    let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
 
     let provider_label = format!("{provider:?}").to_lowercase();
 
@@ -178,16 +178,32 @@ mod tests {
         }
     }
 
-    fn model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn model_entry(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/dall-e-3",
-                "provider_config": {{"api_key": "sk-up", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "dall-e-3",
+                "provider_key_id": "{PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json =
+            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(provider_key_entry(api_base));
+        snap
     }
 
     fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -232,8 +248,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("dall-e", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("dall-e"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -255,8 +271,8 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_request_returns_401() {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("dall-e", "http://unused"));
+        let snap = new_snap("http://unused");
+        snap.models.insert(model_entry("dall-e"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -274,8 +290,8 @@ mod tests {
 
     #[tokio::test]
     async fn forbidden_model_returns_403() {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("dall-e", "http://unused"));
+        let snap = new_snap("http://unused");
+        snap.models.insert(model_entry("dall-e"));
         snap.apikeys.insert(apikey_entry(&["other-model"]));
 
         let app = build_app(snap);
@@ -288,7 +304,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_model_returns_404() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -308,8 +324,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry("dall-e", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("dall-e"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -29,6 +29,7 @@ mod auth;
 pub mod budget;
 mod chat;
 mod completions;
+mod dispatch;
 mod embeddings;
 mod error;
 pub mod health;
@@ -129,16 +130,33 @@ mod tests {
         ProxyState::new(handle, hub, &cfg())
     }
 
-    fn model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn model_entry(name: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/gpt-4o",
-                "provider_config": {{"api_key": "sk-upstream", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "{PK_ID}"
             }}"#
         );
         let model: Model = serde_json::from_str(&cfg).unwrap();
         ResourceEntry::new("model-id-1", model, 1)
+    }
+
+    fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let cfg = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-upstream","api_base":"{api_base}"}}"#
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(provider_key_entry(api_base));
+        snap
     }
 
     fn apikey_entry(key: &str, allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -167,8 +185,8 @@ mod tests {
     }
 
     fn seed_snapshot(model: &str, allowed: &[&str], api_base: &str) -> AisixSnapshot {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry(model, api_base));
+        let snap = new_snap(api_base);
+        snap.models.insert(model_entry(model));
         snap.apikeys.insert(apikey_entry("sk-caller", allowed));
         snap
     }
@@ -200,8 +218,8 @@ mod tests {
         api_base: &str,
         rate_limit: serde_json::Value,
     ) -> AisixSnapshot {
-        let snap = AisixSnapshot::new();
-        snap.models.insert(model_entry(model, api_base));
+        let snap = new_snap(api_base);
+        snap.models.insert(model_entry(model));
         snap.apikeys.insert(apikey_entry_with_limits(
             "sk-caller",
             allowed,
@@ -1015,32 +1033,39 @@ data: [DONE]\n\n";
     }
 
     /// Build a `ResourceEntry<Model>` with a non-default id so the test
-    /// can mount multiple Models in one snapshot.
-    fn model_entry_with_id(id: &str, name: &str, api_base: &str) -> ResourceEntry<Model> {
+    /// can mount multiple Models in one snapshot. `pk_id` lets each
+    /// model point at its own ProviderKey row — useful for routing
+    /// tests that use multiple upstream MockServers.
+    fn model_entry_with_id(id: &str, name: &str, pk_id: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/gpt-4o",
-                "provider_config": {{"api_key": "sk-upstream", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "{pk_id}"
             }}"#
         );
         let model: Model = serde_json::from_str(&cfg).unwrap();
         ResourceEntry::new(id, model, 1)
     }
 
+    fn pk_entry_with_id(pk_id: &str, api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let cfg = format!(
+            r#"{{"display_name":"openai-{pk_id}","secret":"sk-upstream","api_base":"{api_base}"}}"#
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new(pk_id, pk, 1)
+    }
+
     /// Build a virtual routing Model that points at `targets` (other
-    /// Model.name values) using the given strategy.
+    /// Model.display_name values) using the given strategy.
     fn routing_entry(name: &str, strategy: &str, targets: &[&str]) -> ResourceEntry<Model> {
         let target_objs: Vec<serde_json::Value> = targets
             .iter()
             .map(|t| serde_json::json!({"model": t}))
             .collect();
         let cfg = serde_json::json!({
-            "name": name,
-            "model": format!("router/{name}"),
-            // The provider_config is required by the schema but unused
-            // by the proxy because routing.is_some() short-circuits.
-            "provider_config": {"api_key": "ignored"},
+            "display_name": name,
             "routing": {
                 "strategy": strategy,
                 "targets": target_objs,
@@ -1079,13 +1104,14 @@ data: [DONE]\n\n";
         hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
 
         let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-bad", &bad_upstream.uri()));
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-good", &good_upstream.uri()));
         snap.models
-            .insert(model_entry_with_id("m-bad", "primary", &bad_upstream.uri()));
-        snap.models.insert(model_entry_with_id(
-            "m-good",
-            "secondary",
-            &good_upstream.uri(),
-        ));
+            .insert(model_entry_with_id("m-bad", "primary", "pk-bad"));
+        snap.models
+            .insert(model_entry_with_id("m-good", "secondary", "pk-good"));
         snap.models.insert(routing_entry(
             "smart",
             "failover",
@@ -1139,13 +1165,14 @@ data: [DONE]\n\n";
         hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
 
         let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-bad", &bad_upstream.uri()));
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-standby", &standby_upstream.uri()));
         snap.models
-            .insert(model_entry_with_id("m-bad", "primary", &bad_upstream.uri()));
-        snap.models.insert(model_entry_with_id(
-            "m-standby",
-            "secondary",
-            &standby_upstream.uri(),
-        ));
+            .insert(model_entry_with_id("m-bad", "primary", "pk-bad"));
+        snap.models
+            .insert(model_entry_with_id("m-standby", "secondary", "pk-standby"));
         snap.models.insert(routing_entry(
             "smart",
             "failover",
@@ -1181,6 +1208,8 @@ data: [DONE]\n\n";
         snap.models
             .insert(routing_entry("smart", "failover", &["nonexistent"]));
         snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+        // No upstream provider_key needed — the routing target itself
+        // is missing so dispatch fails before any provider lookup.
 
         let app = build_router(build_state(snap, hub));
         let body = serde_json::json!({

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1536,37 +1536,68 @@ data: [DONE]\n\n";
     // path: client body parser → Hub.get(provider) → Bridge.chat[_stream]
     // → upstream → Bridge response decoder → renderer → wire bytes.
 
-    fn anthropic_model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const MATRIX_ANTHROPIC_PK_ID: &str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const MATRIX_GEMINI_PK_ID: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const MATRIX_DEEPSEEK_PK_ID: &str = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+    fn anthropic_model_entry(name: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "anthropic/claude-3-5-haiku-20241022",
-                "provider_config": {{"api_key": "sk-ant-test", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "anthropic",
+                "model_name": "claude-3-5-haiku-20241022",
+                "provider_key_id": "{MATRIX_ANTHROPIC_PK_ID}"
             }}"#
         );
         ResourceEntry::new("model-anthropic-1", serde_json::from_str(&cfg).unwrap(), 1)
     }
 
-    fn gemini_model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    fn gemini_model_entry(name: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "gemini/gemini-2.0-flash",
-                "provider_config": {{"api_key": "ya29-test", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "gemini",
+                "model_name": "gemini-2.0-flash",
+                "provider_key_id": "{MATRIX_GEMINI_PK_ID}"
             }}"#
         );
         ResourceEntry::new("model-gemini-1", serde_json::from_str(&cfg).unwrap(), 1)
     }
 
-    fn deepseek_model_entry(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    fn deepseek_model_entry(name: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "deepseek/deepseek-chat",
-                "provider_config": {{"api_key": "sk-deepseek", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "deepseek",
+                "model_name": "deepseek-chat",
+                "provider_key_id": "{MATRIX_DEEPSEEK_PK_ID}"
             }}"#
         );
         ResourceEntry::new("model-deepseek-1", serde_json::from_str(&cfg).unwrap(), 1)
+    }
+
+    fn matrix_pk_entry(
+        id: &'static str,
+        secret: &str,
+        api_base: &str,
+    ) -> ResourceEntry<aisix_core::ProviderKey> {
+        let cfg = format!(
+            r#"{{"display_name":"matrix-up","secret":"{secret}","api_base":"{api_base}"}}"#
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new(id, pk, 1)
+    }
+
+    fn matrix_anthropic_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        matrix_pk_entry(MATRIX_ANTHROPIC_PK_ID, "sk-ant-test", api_base)
+    }
+
+    fn matrix_gemini_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        matrix_pk_entry(MATRIX_GEMINI_PK_ID, "ya29-test", api_base)
+    }
+
+    fn matrix_deepseek_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        matrix_pk_entry(MATRIX_DEEPSEEK_PK_ID, "sk-deepseek", api_base)
     }
 
     /// (OpenAI inbound) × (Anthropic upstream) × (non-streaming).
@@ -1593,8 +1624,9 @@ data: [DONE]\n\n";
             .await;
 
         let snap = AisixSnapshot::new();
-        snap.models
-            .insert(anthropic_model_entry("my-claude", &upstream.uri()));
+        snap.provider_keys
+            .insert(matrix_anthropic_pk(&upstream.uri()));
+        snap.models.insert(anthropic_model_entry("my-claude"));
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-claude"]));
         let hub = Arc::new(Hub::new());
@@ -1653,8 +1685,9 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             .await;
 
         let snap = AisixSnapshot::new();
-        snap.models
-            .insert(anthropic_model_entry("my-claude", &upstream.uri()));
+        snap.provider_keys
+            .insert(matrix_anthropic_pk(&upstream.uri()));
+        snap.models.insert(anthropic_model_entry("my-claude"));
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-claude"]));
         let hub = Arc::new(Hub::new());
@@ -1721,8 +1754,8 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             .await;
 
         let snap = AisixSnapshot::new();
-        snap.models
-            .insert(gemini_model_entry("my-gemini", &upstream.uri()));
+        snap.provider_keys.insert(matrix_gemini_pk(&upstream.uri()));
+        snap.models.insert(gemini_model_entry("my-gemini"));
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-gemini"]));
         let hub = Arc::new(Hub::new());
@@ -1774,8 +1807,9 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             .await;
 
         let snap = AisixSnapshot::new();
-        snap.models
-            .insert(deepseek_model_entry("my-deepseek", &upstream.uri()));
+        snap.provider_keys
+            .insert(matrix_deepseek_pk(&upstream.uri()));
+        snap.models.insert(deepseek_model_entry("my-deepseek"));
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-deepseek"]));
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -127,6 +127,7 @@ async fn dispatch(
     }
 
     let model = &model_entry.value;
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
     // Cross-provider path: when the resolved Model points at a non-
     // Anthropic upstream, parse the Anthropic-shape body into the
@@ -136,10 +137,17 @@ async fn dispatch(
     // passthrough to preserve features (cache_control, thinking
     // blocks, …) the cross-provider path can't lossily round-trip.
     if model.provider != Some(Provider::Anthropic) {
-        return cross_provider_dispatch(state, body, model, &model_name, request_id).await;
+        return cross_provider_dispatch(
+            state,
+            body,
+            model,
+            &pk_entry.value,
+            &model_name,
+            request_id,
+        )
+        .await;
     }
 
-    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
     let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
 
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
@@ -263,6 +271,7 @@ async fn cross_provider_dispatch(
     state: &ProxyState,
     body: &Value,
     model: &aisix_core::Model,
+    provider_key: &aisix_core::ProviderKey,
     model_name: &str,
     request_id: &str,
 ) -> Result<(Response, String), ProxyError> {
@@ -272,7 +281,7 @@ async fn cross_provider_dispatch(
     };
     use std::sync::Arc;
 
-    let provider = model.provider().ok_or_else(|| {
+    let provider = model.provider.ok_or_else(|| {
         ProxyError::InvalidRequest(format!("model `{model_name}` has no provider prefix"))
     })?;
     let bridge: Arc<dyn Bridge> = state
@@ -292,7 +301,8 @@ async fn cross_provider_dispatch(
 
     let is_stream = chat.is_streaming();
     let model_arc = Arc::new(model.clone());
-    let ctx = BridgeContext::new(request_id, model_arc);
+    let pk_arc = Arc::new(provider_key.clone());
+    let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
     let provider_label = format!("{provider:?}").to_lowercase();
 
     if is_stream {
@@ -428,6 +438,8 @@ mod tests {
 
     const ANTHROPIC_PK_ID: &str = "11111111-1111-1111-1111-111111111111";
     const OPENAI_PK_ID: &str = "22222222-2222-2222-2222-222222222222";
+    const GEMINI_PK_ID: &str = "33333333-3333-3333-3333-333333333333";
+    const DEEPSEEK_PK_ID: &str = "44444444-4444-4444-4444-444444444444";
 
     fn anthropic_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
@@ -721,9 +733,8 @@ data: [DONE]\n\n";
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(openai_model("my-claude-alias", &upstream.uri()));
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("my-claude-alias"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
@@ -804,26 +815,56 @@ data: [DONE]\n\n";
 
     // ─── Cross-protocol matrix (Anthropic inbound × non-Anthropic) ─
 
-    fn gemini_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    fn gemini_model(name: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "gemini/gemini-2.0-flash",
-                "provider_config": {{"api_key": "ya29-test", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "gemini",
+                "model_name": "gemini-2.0-flash",
+                "provider_key_id": "{GEMINI_PK_ID}"
             }}"#
         );
         ResourceEntry::new("m-3", serde_json::from_str(&cfg).unwrap(), 1)
     }
 
-    fn deepseek_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    fn deepseek_model(name: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "deepseek/deepseek-chat",
-                "provider_config": {{"api_key": "sk-deepseek", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "deepseek",
+                "model_name": "deepseek-chat",
+                "provider_key_id": "{DEEPSEEK_PK_ID}"
             }}"#
         );
         ResourceEntry::new("m-4", serde_json::from_str(&cfg).unwrap(), 1)
+    }
+
+    fn gemini_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json = format!(
+            r#"{{"display_name":"gemini-up","secret":"ya29-test","api_base":"{api_base}"}}"#
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(GEMINI_PK_ID, pk, 1)
+    }
+
+    fn deepseek_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json = format!(
+            r#"{{"display_name":"deepseek-up","secret":"sk-deepseek","api_base":"{api_base}"}}"#
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(DEEPSEEK_PK_ID, pk, 1)
+    }
+
+    fn new_snap_gemini(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(gemini_pk(api_base));
+        snap
+    }
+
+    fn new_snap_deepseek(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(deepseek_pk(api_base));
+        snap
     }
 
     /// (Anthropic inbound) × (Gemini upstream). Anthropic body comes
@@ -854,9 +895,8 @@ data: [DONE]\n\n";
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(gemini_model("my-claude-via-gemini", &upstream.uri()));
+        let snap = new_snap_gemini(&upstream.uri());
+        snap.models.insert(gemini_model("my-claude-via-gemini"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
@@ -903,9 +943,8 @@ data: [DONE]\n\n";
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(deepseek_model("my-claude-via-ds", &upstream.uri()));
+        let snap = new_snap_deepseek(&upstream.uri());
+        snap.models.insert(deepseek_model("my-claude-via-ds"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
@@ -949,9 +988,8 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(anthropic_model("my-claude", &upstream.uri()));
+        let snap = new_snap_anthropic(&upstream.uri());
+        snap.models.insert(anthropic_model("my-claude"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -998,18 +1036,23 @@ data: [DONE]\n\n";
             .mount(&upstream)
             .await;
 
+        // Build a fresh ProviderKey pointing at the wiremock URI; the
+        // model_entry passed in carries the right `provider_key_id` to
+        // bind it to that PK.
+        let pk_id = model_entry
+            .value
+            .provider_key_id
+            .clone()
+            .expect("matrix fixtures must reference a provider_key_id");
+        let pk_json = format!(
+            r#"{{"display_name":"matrix-up","secret":"k","api_base":"{}"}}"#,
+            upstream.uri()
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();
+
         let snap = AisixSnapshot::new();
-        // model_entry's api_base was set at fixture creation time but
-        // we want it to point at the wiremock; rebuild with the
-        // upstream uri instead.
-        let cfg_json = serde_json::json!({
-            "name": model_name,
-            "model": format!("{}/x", format!("{bridge_provider:?}").to_lowercase()),
-            "provider_config": {"api_key": "k", "api_base": upstream.uri()},
-        });
-        let m: Model = serde_json::from_value(cfg_json).unwrap();
-        let _ = model_entry; // explicit shadow; built fresh from upstream.uri()
-        snap.models.insert(ResourceEntry::new("m-stream", m, 1));
+        snap.provider_keys.insert(ResourceEntry::new(pk_id, pk, 1));
+        snap.models.insert(model_entry);
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
@@ -1052,7 +1095,7 @@ data: [DONE]\n\n";
             Provider::Gemini,
             Arc::new(gemini_bridge()),
             // Placeholder; helper rebuilds with the wiremock uri.
-            gemini_model("my-claude-via-gemini", "http://placeholder"),
+            gemini_model("my-claude-via-gemini"),
             "my-claude-via-gemini",
         )
         .await;
@@ -1064,7 +1107,7 @@ data: [DONE]\n\n";
         assert_anthropic_streams_through_openai_compat_upstream(
             Provider::Deepseek,
             Arc::new(deepseek_bridge()),
-            deepseek_model("my-claude-via-ds", "http://placeholder"),
+            deepseek_model("my-claude-via-ds"),
             "my-claude-via-ds",
         )
         .await;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -42,8 +42,6 @@ use crate::state::ProxyState;
 
 /// Anthropic API version header value injected on every forwarded request.
 const ANTHROPIC_VERSION: &str = "2023-06-01";
-/// Default Anthropic base URL used when `api_base` is not set on the Model.
-const ANTHROPIC_DEFAULT_BASE: &str = "https://api.anthropic.com";
 
 pub async fn messages(
     State(state): State<ProxyState>,
@@ -137,23 +135,14 @@ async fn dispatch(
     // The Anthropic-upstream branch below stays as a byte-for-byte
     // passthrough to preserve features (cache_control, thinking
     // blocks, …) the cross-provider path can't lossily round-trip.
-    if model.provider() != Some(Provider::Anthropic) {
+    if model.provider != Some(Provider::Anthropic) {
         return cross_provider_dispatch(state, body, model, &model_name, request_id).await;
     }
 
-    let api_key = model.provider_config.api_key.as_str();
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
 
-    if api_key.is_empty() {
-        return Err(ProxyError::Bridge(aisix_gateway::BridgeError::Config(
-            "provider_config.api_key is empty".into(),
-        )));
-    }
-
-    // Resolve the upstream model name (strip "anthropic/" prefix).
-    let upstream_model = model
-        .upstream_model()
-        .ok_or_else(|| ProxyError::InvalidRequest("model field missing provider/ prefix".into()))?
-        .to_string();
+    let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
     // Rewrite the `model` field to the upstream value.
     if let Some(m) = body.get_mut("model") {
@@ -161,10 +150,7 @@ async fn dispatch(
     }
 
     // Build the target URL.
-    let base = match model.base_url() {
-        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
-        _ => ANTHROPIC_DEFAULT_BASE.to_string(),
-    };
+    let base = crate::dispatch::resolve_base_url(Provider::Anthropic, &pk_entry.value);
     let url = format!("{base}/v1/messages");
 
     // Check if the request wants streaming.
@@ -440,28 +426,61 @@ mod tests {
         }
     }
 
-    fn anthropic_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const ANTHROPIC_PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+    const OPENAI_PK_ID: &str = "22222222-2222-2222-2222-222222222222";
+
+    fn anthropic_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{
-                "name": "{name}",
-                "model": "anthropic/claude-3-5-haiku-20241022",
-                "provider_config": {{"api_key": "sk-ant-test", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "anthropic",
+                "model_name": "claude-3-5-haiku-20241022",
+                "provider_key_id": "{ANTHROPIC_PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
     }
 
-    fn openai_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    fn openai_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/gpt-4o",
-                "provider_config": {{"api_key": "sk-openai-test", "api_base": "{api_base}"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "{OPENAI_PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-2", m, 1)
+    }
+
+    fn anthropic_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json = format!(
+            r#"{{"display_name":"anthropic-up","secret":"sk-ant-test","api_base":"{api_base}"}}"#
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(ANTHROPIC_PK_ID, pk, 1)
+    }
+
+    fn openai_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-openai-test","api_base":"{api_base}"}}"#
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(OPENAI_PK_ID, pk, 1)
+    }
+
+    fn new_snap_anthropic(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(anthropic_pk(api_base));
+        snap
+    }
+
+    fn new_snap_openai(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(openai_pk(api_base));
+        snap
     }
 
     fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -513,9 +532,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(anthropic_model("claude-haiku", &upstream.uri()));
+        let snap = new_snap_anthropic(&upstream.uri());
+        snap.models.insert(anthropic_model("claude-haiku"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -543,9 +561,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(anthropic_model("my-claude", &upstream.uri()));
+        let snap = new_snap_anthropic(&upstream.uri());
+        snap.models.insert(anthropic_model("my-claude"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -564,9 +581,8 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_request_returns_401() {
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(anthropic_model("claude-haiku", "http://unused"));
+        let snap = new_snap_anthropic("http://unused");
+        snap.models.insert(anthropic_model("claude-haiku"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -584,9 +600,8 @@ mod tests {
 
     #[tokio::test]
     async fn forbidden_model_returns_403() {
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(anthropic_model("claude-haiku", "http://unused"));
+        let snap = new_snap_anthropic("http://unused");
+        snap.models.insert(anthropic_model("claude-haiku"));
         snap.apikeys.insert(apikey_entry(&["other-model"]));
 
         let app = build_app(snap);
@@ -601,7 +616,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_model_returns_404() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap_anthropic("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -644,9 +659,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(openai_model("my-claude-alias", &upstream.uri()));
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("my-claude-alias"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
@@ -759,9 +773,8 @@ data: [DONE]\n\n";
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(anthropic_model("claude-haiku", &upstream.uri()));
+        let snap = new_snap_anthropic(&upstream.uri());
+        snap.models.insert(anthropic_model("claude-haiku"));
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);
@@ -776,7 +789,7 @@ data: [DONE]\n\n";
 
     #[tokio::test]
     async fn missing_model_field_returns_400() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap_anthropic("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let app = build_app(snap);

--- a/crates/aisix-proxy/src/models.rs
+++ b/crates/aisix-proxy/src/models.rs
@@ -64,11 +64,12 @@ pub async fn list_models(
         .entries()
         .into_iter()
         .filter(|e| !e.value.is_routing())
-        .map(|e| e.value.name.clone())
+        .map(|e| e.value.display_name.clone())
         .collect();
 
     let api_key = auth.key();
-    let permitted: Vec<&str> = api_key.accessible_models(all_names.iter().map(|s| s.as_str()));
+    let permitted: Vec<&str> =
+        api_key.accessible_models(all_names.iter().map(|s: &String| s.as_str()));
 
     let mut data: Vec<ModelObject> = permitted
         .into_iter()
@@ -77,7 +78,7 @@ pub async fn list_models(
             let owned_by = snapshot
                 .models
                 .get_by_name(name)
-                .and_then(|e| e.value.provider())
+                .and_then(|e| e.value.provider)
                 .map(|p| p.as_str().to_string())
                 .unwrap_or_else(|| "aisix".to_string());
 
@@ -127,16 +128,31 @@ mod tests {
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
     }
 
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
     fn model_entry(id: &str, name: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "name": "{name}",
-                "model": "openai/gpt-4o",
-                "provider_config": {{"api_key": "sk-up"}}
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "{PK_ID}"
             }}"#
         );
         let m: Model = serde_json::from_str(&cfg).unwrap();
         ResourceEntry::new(id, m, 1)
+    }
+
+    fn provider_key_entry() -> ResourceEntry<aisix_core::ProviderKey> {
+        let pk: aisix_core::ProviderKey =
+            serde_json::from_str(r#"{"display_name":"openai-up","secret":"sk-up"}"#).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap() -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(provider_key_entry());
+        snap
     }
 
     fn apikey_entry(key: &str, allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -152,7 +168,7 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_request_is_401() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap();
         snap.models.insert(model_entry("m1", "gpt4"));
         snap.apikeys.insert(apikey_entry("sk-caller", &["*"]));
 
@@ -169,7 +185,7 @@ mod tests {
 
     #[tokio::test]
     async fn wildcard_key_sees_all_non_routing_models() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap();
         snap.models.insert(model_entry("m1", "gpt4"));
         snap.models.insert(model_entry("m2", "claude"));
         snap.apikeys.insert(apikey_entry("sk-caller", &["*"]));
@@ -196,7 +212,7 @@ mod tests {
 
     #[tokio::test]
     async fn restricted_key_sees_only_allowed_models() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap();
         snap.models.insert(model_entry("m1", "gpt4"));
         snap.models.insert(model_entry("m2", "claude"));
         snap.apikeys.insert(apikey_entry("sk-caller", &["gpt4"]));
@@ -220,7 +236,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_allowed_models_returns_empty_list() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap();
         snap.models.insert(model_entry("m1", "gpt4"));
         snap.apikeys.insert(apikey_entry("sk-caller", &[]));
 
@@ -242,13 +258,11 @@ mod tests {
 
     #[tokio::test]
     async fn routing_models_are_excluded_from_list() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap();
         snap.models.insert(model_entry("m1", "gpt4"));
         // Insert a routing model.
         let routing_cfg = serde_json::json!({
-            "name": "smart-router",
-            "model": "router/smart",
-            "provider_config": {"api_key": "ignored"},
+            "display_name": "smart-router",
             "routing": {
                 "strategy": "failover",
                 "targets": [{"model": "gpt4"}]
@@ -278,7 +292,7 @@ mod tests {
 
     #[tokio::test]
     async fn response_shape_matches_openai_contract() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap();
         snap.models.insert(model_entry("m1", "gpt4"));
         snap.apikeys.insert(apikey_entry("sk-caller", &["*"]));
 

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -118,25 +118,26 @@ async fn dispatch(
 ) -> Result<(Response, String), ProxyError> {
     let snapshot = state.snapshot.load();
 
-    // Find a model for this provider to grab api_key + api_base.
+    // Find a model for this provider so we can borrow its provider_key.
     let provider_lower = provider.to_lowercase();
     let all_models = snapshot.models.entries();
     let model_entry = all_models
         .into_iter()
         .find(|e| {
             e.value
-                .model
-                .to_lowercase()
-                .starts_with(&format!("{provider_lower}/"))
+                .provider
+                .map(|p| p.as_str().eq_ignore_ascii_case(&provider_lower))
+                .unwrap_or(false)
         })
         .ok_or_else(|| {
             ProxyError::ModelNotFound(format!("no model found for provider `{provider}`"))
         })?;
 
     let model = &model_entry.value;
-    let api_key = model.provider_config.api_key.as_str().to_string();
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
 
-    let base = match model.base_url() {
+    let base = match pk_entry.value.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
         _ => default_base(&provider_lower)
             .map(|s| s.to_string())
@@ -302,12 +303,27 @@ mod tests {
         }
     }
 
-    fn openai_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn openai_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
-            r#"{{"name":"{name}","model":"openai/gpt-4o","provider_config":{{"api_key":"sk-test","api_base":"{api_base}"}}}}"#
+            r#"{{"display_name":"{name}","provider":"openai","model_name":"gpt-4o","provider_key_id":"{PK_ID}"}}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json =
+            format!(r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}"}}"#);
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(provider_key_entry(api_base));
+        snap
     }
 
     fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -327,7 +343,7 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_returns_401() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap("http://unused");
         let app = build_app(snap);
 
         let req = Request::builder()
@@ -342,7 +358,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_provider_returns_404() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
 
@@ -369,8 +385,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(openai_model("gpt-4o", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o"));
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
 
@@ -400,8 +416,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models.insert(openai_model("gpt-4o", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o"));
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
 

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -105,21 +105,11 @@ async fn dispatch(
     }
 
     let model = &model_entry.value;
-
-    let api_key = model.provider_config.api_key.as_str().to_string();
-    if api_key.is_empty() {
-        return Err(ProxyError::Bridge(aisix_gateway::BridgeError::Config(
-            "provider_config.api_key is empty".into(),
-        )));
-    }
-
-    let upstream_model = model
-        .upstream_model()
-        .ok_or_else(|| ProxyError::InvalidRequest("model field missing provider/ prefix".into()))?
-        .to_string();
-
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
+    let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
     let provider_label = model
-        .provider()
+        .provider
         .map(|p| format!("{p:?}").to_lowercase())
         .unwrap_or_else(|| "unknown".to_string());
 
@@ -129,12 +119,12 @@ async fn dispatch(
     }
 
     // Build upstream URL: {base}/v1/rerank
-    let base = match model.base_url() {
+    let base = match pk_entry.value.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
         _ => {
             // Derive a sensible default base from the provider.
             model
-                .provider()
+                .provider
                 .and_then(default_base_for_provider)
                 .unwrap_or_else(|| "https://api.cohere.ai".to_string())
         }
@@ -246,12 +236,27 @@ mod tests {
         }
     }
 
-    fn openai_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn openai_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
-            r#"{{"name":"{name}","model":"openai/text-embedding-3-small","provider_config":{{"api_key":"sk-test","api_base":"{api_base}"}}}}"#
+            r#"{{"display_name":"{name}","provider":"openai","model_name":"text-embedding-3-small","provider_key_id":"{PK_ID}"}}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json =
+            format!(r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}"}}"#);
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(provider_key_entry(api_base));
+        snap
     }
 
     fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -281,7 +286,7 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_returns_401() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap("http://unused");
         let app = build_app(snap);
 
         let req = Request::builder()
@@ -299,7 +304,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_model_returns_404() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
 
@@ -316,9 +321,8 @@ mod tests {
 
     #[tokio::test]
     async fn forbidden_model_returns_403() {
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(openai_model("rerank-model", "https://api.openai.com"));
+        let snap = new_snap("https://api.openai.com");
+        snap.models.insert(openai_model("rerank-model"));
         snap.apikeys.insert(apikey_entry(&["other-model"]));
         let app = build_app(snap);
 
@@ -344,9 +348,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(openai_model("my-reranker", &upstream.uri()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(openai_model("my-reranker"));
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
 

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -26,9 +26,6 @@ use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
 use crate::state::ProxyState;
 
-/// Default OpenAI base URL.
-const OPENAI_DEFAULT_BASE: &str = "https://api.openai.com";
-
 pub async fn responses(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
@@ -114,33 +111,22 @@ async fn dispatch(
     let model = &model_entry.value;
 
     // Responses API is only available for OpenAI.
-    if model.provider() != Some(Provider::Openai) {
+    if model.provider != Some(Provider::Openai) {
         return Err(ProxyError::InvalidRequest(format!(
             "model `{model_name}` is not an OpenAI provider; /v1/responses requires OpenAI"
         )));
     }
 
-    let api_key = model.provider_config.api_key.as_str().to_string();
-    if api_key.is_empty() {
-        return Err(ProxyError::Bridge(aisix_gateway::BridgeError::Config(
-            "provider_config.api_key is empty".into(),
-        )));
-    }
-
-    let upstream_model = model
-        .upstream_model()
-        .ok_or_else(|| ProxyError::InvalidRequest("model field missing provider/ prefix".into()))?
-        .to_string();
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
+    let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
     // Rewrite model field to upstream name.
     if let Some(m) = body.get_mut("model") {
         *m = Value::String(upstream_model.clone());
     }
 
-    let base = match model.base_url() {
-        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
-        _ => OPENAI_DEFAULT_BASE.to_string(),
-    };
+    let base = crate::dispatch::resolve_base_url(Provider::Openai, &pk_entry.value);
     let url = format!("{base}/v1/responses");
 
     let is_stream = body
@@ -257,9 +243,12 @@ mod tests {
         }
     }
 
-    fn openai_model(name: &str, api_base: &str) -> ResourceEntry<Model> {
+    const OPENAI_PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+    const ANTHROPIC_PK_ID: &str = "22222222-2222-2222-2222-222222222222";
+
+    fn openai_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
-            r#"{{"name":"{name}","model":"openai/gpt-4o","provider_config":{{"api_key":"sk-test","api_base":"{api_base}"}}}}"#
+            r#"{{"display_name":"{name}","provider":"openai","model_name":"gpt-4o","provider_key_id":"{OPENAI_PK_ID}"}}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
@@ -267,10 +256,36 @@ mod tests {
 
     fn anthropic_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
-            r#"{{"name":"{name}","model":"anthropic/claude-3-haiku-20240307","provider_config":{{"api_key":"sk-ant-test"}}}}"#
+            r#"{{"display_name":"{name}","provider":"anthropic","model_name":"claude-3-haiku-20240307","provider_key_id":"{ANTHROPIC_PK_ID}"}}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-2", m, 1)
+    }
+
+    fn openai_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json =
+            format!(r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}"}}"#);
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(OPENAI_PK_ID, pk, 1)
+    }
+
+    fn anthropic_pk() -> ResourceEntry<aisix_core::ProviderKey> {
+        let pk: aisix_core::ProviderKey =
+            serde_json::from_str(r#"{"display_name":"anthropic-up","secret":"sk-ant-test"}"#)
+                .unwrap();
+        ResourceEntry::new(ANTHROPIC_PK_ID, pk, 1)
+    }
+
+    fn new_snap_openai(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(openai_pk(api_base));
+        snap
+    }
+
+    fn new_snap_anthropic() -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(anthropic_pk());
+        snap
     }
 
     fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
@@ -301,7 +316,7 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_returns_401() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap_openai("http://unused");
         let app = build_app(snap);
 
         let req = Request::builder()
@@ -317,7 +332,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_model_returns_404() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap_openai("http://unused");
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
 
@@ -333,7 +348,7 @@ mod tests {
 
     #[tokio::test]
     async fn non_openai_model_returns_400() {
-        let snap = AisixSnapshot::new();
+        let snap = new_snap_anthropic();
         snap.models.insert(anthropic_model("claude-haiku"));
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
@@ -362,9 +377,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(openai_model("gpt-4o-resp", &upstream.uri()));
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
 
@@ -391,9 +405,8 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        let snap = AisixSnapshot::new();
-        snap.models
-            .insert(openai_model("gpt-4o-resp", &upstream.uri()));
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
         let app = build_app(snap);
 

--- a/tests/e2e/src/cases/smoke.test.ts
+++ b/tests/e2e/src/cases/smoke.test.ts
@@ -68,11 +68,18 @@ describe("smoke: admin write → proxy read", () => {
       allowed_models: ["smoke-gpt"],
     });
 
-    await waitConfigPropagation();
-
     const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    const { status, body } = await proxy.listModels();
+    // Poll /v1/models until the freshly-written model is visible — the
+    // supervisor's watch pipeline normally catches up within ~50ms but
+    // CI runners occasionally lag behind a fixed sleep.
+    await waitConfigPropagation(async () => {
+      const res = await proxy.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "smoke-gpt");
+    });
 
+    const { status, body } = await proxy.listModels();
     expect(status).toBe(200);
     expect(body).toMatchObject({
       object: "list",
@@ -87,6 +94,20 @@ describe("smoke: admin write → proxy read", () => {
     }
 
     const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    // The Model + ProviderKey writes from the previous test propagate
+    // independently. /v1/models confirms the Model row but not the
+    // referenced ProviderKey — poll the chat path itself until the
+    // dispatcher stops returning `unknown provider_key_id`, the only
+    // signal that captures the snapshot's complete state.
+    await waitConfigPropagation(async () => {
+      const probe = await proxy.chat({
+        model: "smoke-gpt",
+        messages: [{ role: "user", content: "ping" }],
+      });
+      if (probe.status === 200) return true;
+      const msg = JSON.stringify(probe.body);
+      return !msg.includes("unknown provider_key_id");
+    });
     const { status, body } = await proxy.chat({
       model: "smoke-gpt",
       messages: [{ role: "user", content: "hello" }],

--- a/tests/e2e/src/cases/smoke.test.ts
+++ b/tests/e2e/src/cases/smoke.test.ts
@@ -48,12 +48,20 @@ describe("smoke: admin write → proxy read", () => {
       return;
     }
 
-    await admin.createModel({
-      name: "smoke-gpt",
-      model: "openai/gpt-4o-mini",
+    // Phase B Model shape: ProviderKey carries the upstream secret +
+    // optional api_base override; Model references it by id.
+    const pk = await admin.createProviderKey({
+      display_name: "smoke-openai",
+      secret: "sk-mock",
       // The OpenAI bridge appends `/chat/completions`, so the api_base
       // already needs the `/v1` segment to land on `/v1/chat/completions`.
-      provider_config: { api_key: "sk-mock", api_base: `${upstream.baseUrl}/v1` },
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "smoke-gpt",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
     });
     await admin.createApiKey({
       key_hash: CALLER_KEY_HASH,

--- a/tests/e2e/src/harness/admin.ts
+++ b/tests/e2e/src/harness/admin.ts
@@ -59,7 +59,31 @@ export class AdminClient {
   }
 }
 
-/** Convenience: wait the spec-mandated 500ms for snapshot propagation. */
-export function waitConfigPropagation(): Promise<void> {
-  return new Promise((r) => setTimeout(r, 500));
+/**
+ * Wait for the gateway's in-memory snapshot to catch up with admin
+ * writes. The spec mandates a ≤500ms propagation budget, but CI
+ * runners with slower etcd/disk can occasionally exceed that — when
+ * one of those runners only partially propagates a multi-resource
+ * write batch, downstream tests see a snapshot with the Model but not
+ * its referenced ProviderKey, and dispatch fails with `unknown
+ * provider_key_id`.
+ *
+ * `condition` lets the caller provide a positive readiness probe; if
+ * omitted, the helper falls back to the historical fixed-time wait.
+ * The poll interval is 50ms and the deadline 5s — plenty of headroom
+ * for any healthy runner without masking a genuine bug.
+ */
+export async function waitConfigPropagation(
+  condition?: () => Promise<boolean>,
+): Promise<void> {
+  if (!condition) {
+    await new Promise((r) => setTimeout(r, 500));
+    return;
+  }
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error("waitConfigPropagation: condition not met within 5s");
 }

--- a/tests/e2e/src/harness/admin.ts
+++ b/tests/e2e/src/harness/admin.ts
@@ -22,6 +22,12 @@ export class AdminClient {
     return this.json("POST", "/admin/v1/apikeys", key);
   }
 
+  async createProviderKey(
+    pk: Record<string, unknown>,
+  ): Promise<{ id: string; value: Record<string, unknown> }> {
+    return this.json("POST", "/admin/v1/provider_keys", pk);
+  }
+
   async listModels(): Promise<Array<Record<string, unknown>>> {
     const res = await this.json<{ items?: Array<{ value: Record<string, unknown> }> }>(
       "GET",


### PR DESCRIPTION
## Summary

Realigns the standalone Model schema with the AISIX-Cloud control plane's normalised shape — the projection cp-api has been waiting for since PRD-09b §6.

cp-api's `mustMarshalModelKV` literally has this comment:

> Phase 2 swaps to {model, provider_key_id} with DP-side join, but requires Model.provider_config refactor across 26 DP files which is a separate PR.

This is that PR.

## Schema change

**Old** (pre-#95 + this PR):
```json
{ "name": "...", "model": "<provider>/<id>", "provider_config": { "api_key": "...", "api_base": "..." } }
```

**New**:
```json
{ "display_name": "...", "provider": "openai|anthropic|gemini|deepseek", "model_name": "...", "provider_key_id": "<uuid>" }
```

`provider_key_id` references a `ProviderKey` row (top-level resource introduced in #95) carrying `secret` + `api_base`. Routing models keep the same `routing` block but drop the upstream triple — the router resolves a target Model and dispatches against THAT model's `provider_key_id`.

JSON Schema enforces the direct-vs-routing XOR via `oneOf`:
- Direct ⇒ all three of `provider`/`model_name`/`provider_key_id` required
- Routing ⇒ all three forbidden, `routing` required

## Why

- **One ProviderKey, many Models.** Rotating the upstream secret used to require rewriting every Model row that embedded it; now it's a single PUT against the ProviderKey.
- **AISIX-Cloud parity.** cp-api already has a `provider_keys` table; managed-mode DPs need this shape to consume what cp-api projects into kine.
- **Snapshot-table integrity.** The DP can validate at load time that every `Model.provider_key_id` resolves to a `ProviderKey` in the same snapshot, instead of carrying inline secrets it can't cross-check.

## Changes by area

**aisix-core**
- `Model`: new `{display_name, provider: Option<Provider>, model_name: Option<String>, provider_key_id: Option<String>}`. Removed `ProviderConfig` struct.
- JSON Schema: `oneOf` for direct/routing XOR.
- `Resource::name()` returns `&display_name`.

**aisix-gateway**
- `BridgeContext` gains `provider_key: Arc<ProviderKey>`. Constructor sig: `new(request_id, model, provider_key)`.

**aisix-provider-{openai,anthropic,gemini,deepseek}**
- Bridge helpers (`resolve_base` / `api_key` / `upstream_model`) take `&BridgeContext` and read from `ctx.provider_key` + `ctx.model`.

**aisix-proxy**
- New `dispatch.rs` resolves both Model and ProviderKey from the snapshot before each per-endpoint handler builds `BridgeContext`.
- Every endpoint (chat / completions / embeddings / messages / responses / rerank / images / audio / passthrough) updated.
- 422 with a clear error envelope when `Model.provider_key_id` doesn't resolve.

**Tests + fixtures** — ~30 files across the workspace updated to the new JSON shape.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace` — 520+ tests green, 0 failures
- [x] etcd integration tests from #99 still green (admin handler → real etcd → `aisix-etcd::loader::build_snapshot` round-trip)

## Cross-repo follow-up

AISIX-Cloud's `mustMarshalModelKV` (`internal/cpapi/resources/handlers.go`) needs to switch from writing the inline `provider_config` shape to the new shape. Will track separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin API now supports ProviderKey resources (create via Admin) and model cost fields (input_per_1k, output_per_1k).

* **Bug Fixes**
  * Enforced mutual exclusivity between routing and direct model configs.
  * Improved validation and clearer error mapping for missing/invalid provider or provider-key.

* **Refactor**
  * Model schema migrated to display_name/provider/model_name/provider_key_id.
  * Proxy and bridges now resolve provider keys separately and select upstreams via provider-key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->