### PR TITLE
fix(proxy): tolerate `…/v1` api_base in responses/rerank/audio/messages URL builders

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -49,7 +49,9 @@ pub async fn transcriptions(
         &state,
         &auth,
         multipart,
-        "/v1/audio/transcriptions",
+        // Version-independent path — multipart_dispatch's URL builder
+        // (build_v1_url) owns the `/v1` prefix.
+        "/audio/transcriptions",
         &request_id,
     )
     .await
@@ -117,7 +119,9 @@ pub async fn translations(
         &state,
         &auth,
         multipart,
-        "/v1/audio/translations",
+        // Version-independent path — multipart_dispatch's URL builder
+        // (build_v1_url) owns the `/v1` prefix.
+        "/audio/translations",
         &request_id,
     )
     .await
@@ -290,7 +294,10 @@ async fn multipart_dispatch(
     let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
 
     let base = crate::dispatch::resolve_base_url(provider, &pk_entry.value);
-    let url = format!("{base}{upstream_path}");
+    // build_v1_url owns the /v1 prefix; callers pass the suffix
+    // (e.g. `/audio/transcriptions`) so this code is agnostic to
+    // whether the customer's api_base ends in /v1 or not.
+    let url = crate::dispatch::build_v1_url(&base, upstream_path);
     let provider_label = format!("{provider:?}").to_lowercase();
 
     // Rebuild the multipart form with `model` rewritten.
@@ -393,7 +400,7 @@ async fn speech_dispatch(
 
     let client = crate::http_client::client();
     let resp = client
-        .post(format!("{base}/v1/audio/speech"))
+        .post(crate::dispatch::build_v1_url(&base, "/audio/speech"))
         .header(header::AUTHORIZATION, format!("Bearer {api_key}"))
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-aisix-request-id", request_id)

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -76,6 +76,45 @@ pub(crate) fn resolve_base_url(provider: Provider, provider_key: &ProviderKey) -
     }
 }
 
+/// Build a `/v1`-prefixed upstream URL while tolerating either
+/// convention for the configured `api_base`:
+///
+/// * `https://api.openai.com` builds `…/v1/<path>` — the provider
+///   default convention used by `Provider::Openai.default_base_url()`
+///   and `aisix-proxy`'s pre-existing handlers.
+/// * `https://api.openai.com/v1` also builds `…/v1/<path>` — the
+///   OpenAI SDK convention every published example uses, and the
+///   exact placeholder the dashboard's provider-keys form pre-fills.
+///
+/// Without this normalization, a customer who follows OpenAI SDK
+/// docs (api_base = `…/v1`) hits `…/v1/v1/responses` upstream — the
+/// upstream 404s, the DP wraps it as 502 upstream_error, and the
+/// failure surfaces as "intermittent SDK-incompatible behaviour"
+/// (chat works because aisix-provider-openai/src/bridge.rs uses
+/// the OpenAI-SDK convention; the proxy crate handlers — responses,
+/// rerank, audio — follow the provider-default convention, so the
+/// customer's api_base satisfies one but not the other).
+///
+/// `path` MUST start with `/` and SHOULD start with the version-
+/// independent route (e.g. `/responses`, not `/v1/responses`); this
+/// helper owns the `/v1` prefix.
+pub(crate) fn build_v1_url(base: &str, path: &str) -> String {
+    // assert!, not debug_assert! — the cost of a single bounds check
+    // per upstream dispatch is negligible compared to the network
+    // round-trip, and a release-mode caller passing a malformed path
+    // would silently produce a wrong URL (e.g. `…/v1responses`).
+    assert!(
+        path.starts_with('/'),
+        "build_v1_url path must start with /, got {path:?}",
+    );
+    let trimmed = base.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        format!("{trimmed}{path}")
+    } else {
+        format!("{trimmed}/v1{path}")
+    }
+}
+
 /// The upstream API key — `provider_key.secret`. Empty string is
 /// treated as a config error (ProviderKey rows shouldn't be empty,
 /// but a hand-edited kine row could surface one).
@@ -189,5 +228,65 @@ mod tests {
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let base = resolve_base_url(Provider::Anthropic, &pk);
         assert_eq!(base, Provider::Anthropic.default_base_url());
+    }
+
+    // ---------------------------------------------------------------
+    // build_v1_url — the path-doubling regression fixture.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn build_v1_url_appends_v1_when_base_lacks_it() {
+        // Provider-default convention (Provider::Openai.default_base_url()
+        // returns `https://api.openai.com`, no /v1).
+        assert_eq!(
+            build_v1_url("https://api.openai.com", "/responses"),
+            "https://api.openai.com/v1/responses",
+        );
+    }
+
+    #[test]
+    fn build_v1_url_skips_v1_when_base_already_has_it() {
+        // Customer follows the OpenAI SDK convention + the dashboard's
+        // provider-keys form pre-fill (`https://api.openai.com/v1`).
+        // A naive `format!("{base}/v1/responses")` would produce
+        // `https://api.openai.com/v1/v1/responses` and 404 upstream.
+        assert_eq!(
+            build_v1_url("https://api.openai.com/v1", "/responses"),
+            "https://api.openai.com/v1/responses",
+        );
+    }
+
+    #[test]
+    fn build_v1_url_strips_trailing_slash() {
+        assert_eq!(
+            build_v1_url("https://api.openai.com/", "/rerank"),
+            "https://api.openai.com/v1/rerank",
+        );
+        assert_eq!(
+            build_v1_url("https://api.openai.com/v1/", "/rerank"),
+            "https://api.openai.com/v1/rerank",
+        );
+    }
+
+    #[test]
+    fn build_v1_url_handles_nested_paths() {
+        // /audio/speech, /audio/transcriptions, /audio/translations all
+        // pass nested paths — make sure the helper doesn't try to be
+        // clever about them.
+        assert_eq!(
+            build_v1_url("https://api.openai.com", "/audio/speech"),
+            "https://api.openai.com/v1/audio/speech",
+        );
+        assert_eq!(
+            build_v1_url("https://api.openai.com/v1", "/audio/transcriptions"),
+            "https://api.openai.com/v1/audio/transcriptions",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "build_v1_url path must start with /")]
+    fn build_v1_url_rejects_path_without_leading_slash() {
+        // Misuse — handlers should always pass a `/`-prefixed path.
+        let _ = build_v1_url("https://api.openai.com", "responses");
     }
 }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -191,9 +191,12 @@ async fn dispatch(
         *m = Value::String(upstream_model.clone());
     }
 
-    // Build the target URL.
+    // Build the target URL. build_v1_url tolerates the rare case
+    // where the customer mistakenly puts `/v1` in the Anthropic
+    // api_base (the dashboard placeholder uses the OpenAI form, so
+    // this is a copy-paste hazard).
     let base = crate::dispatch::resolve_base_url(Provider::Anthropic, &pk_entry.value);
-    let url = format!("{base}/v1/messages");
+    let url = crate::dispatch::build_v1_url(&base, "/messages");
 
     // Check if the request wants streaming.
     let is_stream = body

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -118,7 +118,10 @@ async fn dispatch(
         *m = Value::String(upstream_model.clone());
     }
 
-    // Build upstream URL: {base}/v1/rerank
+    // Build upstream URL. build_v1_url tolerates either base form —
+    // `https://api.cohere.ai` (Cohere convention, no /v1) and
+    // `https://api.openai.com/v1` (OpenAI-SDK convention, with /v1)
+    // both end up at `…/v1/rerank` instead of `…/v1/v1/rerank`.
     let base = match pk_entry.value.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
         _ => {
@@ -129,7 +132,7 @@ async fn dispatch(
                 .unwrap_or_else(|| "https://api.cohere.ai".to_string())
         }
     };
-    let url = format!("{base}/v1/rerank");
+    let url = crate::dispatch::build_v1_url(&base, "/rerank");
 
     let client = crate::http_client::client();
     let upstream_resp = client

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -127,7 +127,12 @@ async fn dispatch(
     }
 
     let base = crate::dispatch::resolve_base_url(Provider::Openai, &pk_entry.value);
-    let url = format!("{base}/v1/responses");
+    // build_v1_url tolerates both `https://api.openai.com` (provider
+    // default) and `https://api.openai.com/v1` (the OpenAI-SDK form
+    // the dashboard's provider-keys placeholder pre-fills). Without
+    // it, the SDK convention double-prefixes to `/v1/v1/responses`
+    // and 404s.
+    let url = crate::dispatch::build_v1_url(&base, "/responses");
 
     let is_stream = body
         .get("stream")


### PR DESCRIPTION
## Summary

The proxy crate's per-handler upstream URL builders prepend `/v1/` to
the configured `api_base` unconditionally:

```
responses.rs    format!("{base}/v1/responses")
rerank.rs       format!("{base}/v1/rerank")
audio.rs        format!("{base}/v1/audio/speech")
                format!("{base}{upstream_path}")    // upstream_path = "/v1/audio/transcriptions" | "/v1/audio/translations"
messages.rs     format!("{base}/v1/messages")
```

`base` is `provider_key.api_base` (override) or the `Provider`'s default.
The defaults are bare hosts (`https://api.openai.com`,
`https://api.anthropic.com`), so the format produces the right URL —
**but every published OpenAI SDK example, plus the dashboard's
provider-keys form pre-fill, ends `api_base` with `/v1`** (e.g.
`https://api.openai.com/v1`). Customers who follow that convention hit
`/v1/v1/responses` etc. upstream and 404. The DP wraps the 404 as a 502
upstream_error; the failure surfaces as "Responses / rerank / audio
APIs intermittently fail through the gateway" while chat-completions
keeps working —  `aisix-provider-openai/src/bridge.rs` uses the
OpenAI-SDK convention (`OPENAI_DEFAULT_BASE = "…/v1"`, appends
`/chat/completions` without `/v1`), so it's already on the correct side.

This patch makes the proxy crate tolerant of either base form via a new
`build_v1_url(base, "/responses")` helper in `dispatch.rs` —  produces
`…/v1/responses` whether `base` ends in `/v1` or not. Five handlers
swap their inline `format!` calls for it; `messages.rs` gets the same
treatment for defence-in-depth (Anthropic users could copy-paste the
OpenAI form placeholder and hit the same trap).

Surfaced by AISIX-Cloud PR #160 e2e specs that exercise the affected
endpoints end-to-end through a real DP container.

## Test plan

- [x] 5 new unit tests in `dispatch::tests::build_v1_url_*` pin the
  helper across both base conventions, trailing slashes, nested paths,
  and the leading-slash precondition (`assert!`, not `debug_assert!` —
  release builds pay one branch per dispatch but silently producing a
  malformed URL there is much worse).
- [x] All 128 existing `aisix-proxy` tests continue to pass (responses,
  rerank, audio speech / transcriptions / translations, messages
  including the cross-provider Anthropic-in-{Openai,Gemini,Deepseek}-
  upstream matrix).
- [x] `cargo check --workspace` clean.
- [ ] AISIX-Cloud PR #160 e2e suite — once a fresh DP image with this
  fix is published, unskip `dp-openai-extras-roundtrip-live` and
  `dp-messages-anthropic-roundtrip-live` and confirm round-trip 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upstream URL construction for audio, messaging, rerank, and responses to avoid double "/v1" prefix and resulting 404s when the API base already includes "/v1". This normalization preserves existing request/response behavior (including streaming, headers, and model resolution) and is covered by additional unit tests to ensure consistent routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->