### PR TITLE
feat(config): bedrock_endpoint_url as Config field, not std::env::var

### DIFF
--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -49,6 +49,23 @@ pub struct Config {
     /// Missing or `enabled = false` runs standalone.
     #[serde(default)]
     pub managed: ManagedConfig,
+    /// Deployment-wide override for the AWS Bedrock endpoint URL,
+    /// applied to every kind=bedrock guardrail dispatcher built from
+    /// the snapshot. Unset (the default) → SDK default (real AWS).
+    ///
+    /// Set this when pointing the DP at a local Bedrock-compatible
+    /// service (LocalStack, a fakecloud / WireMock sidecar in e2e),
+    /// or when an outbound HTTP proxy needs to terminate the call.
+    /// Empty string is treated as unset so a `docker run -e
+    /// AISIX_BEDROCK_ENDPOINT_URL=` doesn't accidentally redirect.
+    ///
+    /// Top-level on purpose — overriding the Bedrock endpoint is a
+    /// deployment concern, not a per-guardrail-row configuration that
+    /// a tenant should be able to set. The matching env var
+    /// `AISIX_BEDROCK_ENDPOINT_URL` is what gets picked up by
+    /// config-rs via the `AISIX_` prefix.
+    #[serde(default)]
+    pub bedrock_endpoint_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -789,6 +806,49 @@ managed:
     // need std::env::set_var (forbidden by the crate-level
     // #![forbid(unsafe_code)]) or an extra dev-dep for a guarded
     // env helper; the downstream integration coverage is enough.
+
+    #[test]
+    fn bedrock_endpoint_url_defaults_to_none_when_unset() {
+        // Minimal config without bedrock_endpoint_url → field should
+        // be `None`, matching "real AWS Bedrock" semantics.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert!(cfg.bedrock_endpoint_url.is_none());
+    }
+
+    #[test]
+    fn bedrock_endpoint_url_round_trips_through_yaml() {
+        // Operators set this when pointing the DP at LocalStack /
+        // fakecloud / a Bedrock-compatible mock; pin that the field
+        // makes it through `deny_unknown_fields` and back out.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+bedrock_endpoint_url: "http://fakecloud:8000"
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(
+            cfg.bedrock_endpoint_url.as_deref(),
+            Some("http://fakecloud:8000"),
+        );
+    }
 
     #[test]
     fn parses_etcd_tls_block() {

--- a/crates/aisix-guardrails/src/bedrock.rs
+++ b/crates/aisix-guardrails/src/bedrock.rs
@@ -44,20 +44,6 @@ use aws_smithy_runtime_api::http::Response;
 
 use crate::{Guardrail, GuardrailVerdict};
 
-/// Deployment-wide override for the Bedrock endpoint URL. Read by
-/// `BedrockGuardrail::new` (production code path); unset means the
-/// SDK default (real AWS) is used.
-///
-/// Set this in `e2e/compose.yml` to point the DP at a local
-/// fakecloud / LocalStack instance. Operators of self-hosted
-/// stacks behind an outbound HTTP proxy can also use this to route
-/// through their proxy.
-///
-/// Scoped to the env var name (not a per-guardrail config field)
-/// because endpoint overrides are a deployment concern, not a
-/// per-row configuration that a tenant should be able to set.
-pub const BEDROCK_ENDPOINT_URL_ENV_VAR: &str = "AISIX_BEDROCK_ENDPOINT_URL";
-
 /// One Bedrock guardrail row, materialised into a request-time
 /// dispatcher. Built once per snapshot from
 /// [`aisix_core::models::Guardrail`] + plaintext credentials.
@@ -80,7 +66,14 @@ pub struct BedrockGuardrail {
 impl BedrockGuardrail {
     /// Build the dispatcher from a parsed [`BedrockConfig`]. Caller
     /// owns the row's `name`, `hook_point`, and `fail_open` (they
-    /// live on the outer Guardrail struct, not on the kind config).
+    /// live on the outer Guardrail struct, not on the kind config),
+    /// plus the optional deployment-wide `endpoint_url` override
+    /// (sourced from `aisix_core::Config::bedrock_endpoint_url` —
+    /// `None` means the SDK default, i.e. real AWS Bedrock).
+    ///
+    /// Empty-string overrides are treated as unset by the caller so
+    /// a `docker run -e AISIX_BEDROCK_ENDPOINT_URL=` doesn't
+    /// accidentally redirect; this constructor doesn't filter again.
     ///
     /// Synchronous on purpose: the snapshot rebuild path is sync (a
     /// blocking call from inside the etcd-watch supervisor's
@@ -93,16 +86,8 @@ impl BedrockGuardrail {
         cfg: &BedrockConfig,
         hook_point: GuardrailHookPoint,
         fail_open: bool,
+        endpoint_url: Option<String>,
     ) -> Self {
-        // Honor the deployment-wide endpoint override. This lets the
-        // e2e suite point at fakecloud (or any AWS-compatible local
-        // mock) without changing the cp-api wire shape, and lets a
-        // self-hosted operator route Bedrock through a proxy. Empty
-        // string is treated as unset so a `docker run -e
-        // AISIX_BEDROCK_ENDPOINT_URL=` doesn't accidentally redirect.
-        let endpoint_url = std::env::var(BEDROCK_ENDPOINT_URL_ENV_VAR)
-            .ok()
-            .filter(|s| !s.is_empty());
         if let Some(url) = endpoint_url.as_ref() {
             // Visible at INFO so an operator inspecting DP logs sees
             // "Bedrock isn't talking to AWS" without having to grep
@@ -111,17 +96,16 @@ impl BedrockGuardrail {
             tracing::info!(
                 endpoint = %url,
                 guardrail_id = %cfg.guardrail_id,
-                "BedrockGuardrail using endpoint URL override (AISIX_BEDROCK_ENDPOINT_URL)",
+                "BedrockGuardrail using endpoint URL override (Config.bedrock_endpoint_url)",
             );
         }
         Self::with_endpoint(row_name, cfg, hook_point, fail_open, endpoint_url)
     }
 
     /// Internal constructor that accepts an optional `endpoint_url`
-    /// override. Production calls `new()` (None → real AWS Bedrock);
-    /// tests pass a wiremock URL to point the SDK at a local
-    /// canned-response server. Also used by anyone wiring Bedrock
-    /// against a self-hosted gateway / proxy.
+    /// override. Production calls `new()` with the value forwarded
+    /// from `Config::bedrock_endpoint_url`; tests pass a wiremock
+    /// URL to point the SDK at a local canned-response server.
     fn with_endpoint(
         row_name: impl Into<String>,
         cfg: &BedrockConfig,
@@ -414,7 +398,16 @@ mod tests {
     }
 
     fn build_test(fail_open: bool) -> BedrockGuardrail {
-        BedrockGuardrail::new("test-row", &cfg(), GuardrailHookPoint::Both, fail_open)
+        // None → SDK default endpoint (we never call .apply() in
+        // these tests, so it doesn't matter that it would point at
+        // real AWS).
+        BedrockGuardrail::new(
+            "test-row",
+            &cfg(),
+            GuardrailHookPoint::Both,
+            fail_open,
+            None,
+        )
     }
 
     // --- wiremock integration tests --------------------------------
@@ -592,21 +585,15 @@ mod tests {
         }
     }
 
-    // The env-var path (`new()` reads `AISIX_BEDROCK_ENDPOINT_URL`)
-    // isn't unit-tested here because:
-    //   1. `aisix-guardrails` declares `#![forbid(unsafe_code)]` and
-    //      `std::env::set_var` is unsafe in modern Rust; the
-    //      forbidden lint can't be relaxed for a single test without
-    //      moving it to a separate `tests/` integration binary.
-    //   2. The override logic is two lines of trivial mapping
-    //      (`env::var().ok().filter(non-empty)`) → `with_endpoint`,
-    //      which the wiremock tests above already exercise
-    //      thoroughly.
-    //   3. The deployment-wide override is verified end-to-end by
-    //      `dashboard/tests/e2e/bedrock-live.spec.ts` against a real
-    //      fakecloud sidecar — see PRD-09c §6.7 + the e2e compose
-    //      file. That's the contract test that catches a regression
-    //      where the env var stops being read.
+    // The endpoint-override pass-through (Config field →
+    // BedrockGuardrail::new → with_endpoint) is exercised by the
+    // wiremock tests above, which thread the URL in via the public
+    // `new()` constructor. The Config-loading side (env var
+    // `AISIX_BEDROCK_ENDPOINT_URL` → `Config::bedrock_endpoint_url`)
+    // is covered by `aisix-core`'s config tests. The end-to-end
+    // contract — operator sets env var, DP redirects Bedrock calls —
+    // is verified by the downstream e2e suite against a real
+    // fakecloud sidecar.
 
     /// `latency_mode=timed` + Bedrock takes longer than the timeout
     /// → tagged `bedrock_timeout`. wiremock's `set_delay` makes the

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -30,7 +30,16 @@ use crate::{Guardrail, GuardrailChain, GuardrailVerdict};
 /// row produces at most one runtime `dyn Guardrail`. Failures
 /// (invalid regex, etc.) are logged and the row is skipped — same
 /// contract the loader uses for malformed etcd rows.
-pub fn build_chain_from_snapshot(table: &ResourceTable<DomainGuardrail>) -> GuardrailChain {
+///
+/// `bedrock_endpoint_url` is the deployment-wide override for the
+/// AWS Bedrock endpoint URL (sourced from
+/// `aisix_core::Config::bedrock_endpoint_url`). `None` → SDK
+/// default (real AWS Bedrock); `Some(url)` → every kind=bedrock
+/// dispatcher built from this snapshot is pointed at `url`.
+pub fn build_chain_from_snapshot(
+    table: &ResourceTable<DomainGuardrail>,
+    bedrock_endpoint_url: Option<&str>,
+) -> GuardrailChain {
     let mut chain: Vec<Arc<dyn Guardrail>> = Vec::new();
 
     let entries = table.entries();
@@ -39,7 +48,7 @@ pub fn build_chain_from_snapshot(table: &ResourceTable<DomainGuardrail>) -> Guar
         if !row.enabled {
             continue;
         }
-        match build_one(row) {
+        match build_one(row, bedrock_endpoint_url) {
             Ok(Some(g)) => chain.push(g),
             Ok(None) => {
                 // Rule was technically valid but inert (e.g. empty
@@ -60,7 +69,10 @@ pub fn build_chain_from_snapshot(table: &ResourceTable<DomainGuardrail>) -> Guar
     GuardrailChain::new(chain)
 }
 
-fn build_one(row: &DomainGuardrail) -> Result<Option<Arc<dyn Guardrail>>, BuildError> {
+fn build_one(
+    row: &DomainGuardrail,
+    bedrock_endpoint_url: Option<&str>,
+) -> Result<Option<Arc<dyn Guardrail>>, BuildError> {
     match &row.config {
         GuardrailKind::Keyword(cfg) => {
             if cfg.patterns.is_empty() {
@@ -95,12 +107,14 @@ fn build_one(row: &DomainGuardrail) -> Result<Option<Arc<dyn Guardrail>>, BuildE
             // Phase 2: build the AWS-SDK-backed dispatcher. cp-api
             // already decrypted the secret at projection time, so
             // the BedrockConfig in the snapshot carries plaintext
-            // credentials.
+            // credentials. The endpoint URL is forwarded from
+            // bootstrap config (Config.bedrock_endpoint_url).
             let g = crate::bedrock::BedrockGuardrail::new(
                 row.name.clone(),
                 cfg,
                 row.hook_point,
                 row.fail_open,
+                bedrock_endpoint_url.map(str::to_owned),
             );
             Ok(Some(Arc::new(g)))
         }
@@ -143,8 +157,14 @@ enum BuildError {
 /// Compilation only happens on the first call after each snapshot
 /// store from the etcd supervisor — typical run is one or zero
 /// rebuilds per minute even on a chatty configuration.
+///
+/// `bedrock_endpoint_url` is captured at construct time and reused
+/// on every rebuild; this is a deployment-wide setting (sourced
+/// from `aisix_core::Config::bedrock_endpoint_url`) and doesn't
+/// change while the DP is running.
 pub struct LiveGuardrailChain {
     snapshot: SnapshotHandle<AisixSnapshot>,
+    bedrock_endpoint_url: Option<String>,
     cache: Mutex<Cache>,
 }
 
@@ -160,17 +180,24 @@ struct Cache {
 }
 
 impl LiveGuardrailChain {
-    pub fn new(snapshot: SnapshotHandle<AisixSnapshot>) -> Arc<Self> {
+    pub fn new(
+        snapshot: SnapshotHandle<AisixSnapshot>,
+        bedrock_endpoint_url: Option<String>,
+    ) -> Arc<Self> {
         // Eager-build at construct time so the very first chat
         // doesn't pay the rebuild cost. The pointer recorded here
         // is the snapshot at construct time — a subsequent store
         // from the supervisor flips the cache miss bit on next
         // check.
         let snap = snapshot.load();
-        let chain = Arc::new(build_chain_from_snapshot(&snap.guardrails));
+        let chain = Arc::new(build_chain_from_snapshot(
+            &snap.guardrails,
+            bedrock_endpoint_url.as_deref(),
+        ));
         let last_snapshot_addr = Arc::as_ptr(&snap) as usize;
         Arc::new(Self {
             snapshot,
+            bedrock_endpoint_url,
             cache: Mutex::new(Cache {
                 last_snapshot_addr,
                 chain,
@@ -186,7 +213,10 @@ impl LiveGuardrailChain {
             .lock()
             .expect("LiveGuardrailChain mutex poisoned");
         if cache.last_snapshot_addr != cur_ptr {
-            cache.chain = Arc::new(build_chain_from_snapshot(&snap.guardrails));
+            cache.chain = Arc::new(build_chain_from_snapshot(
+                &snap.guardrails,
+                self.bedrock_endpoint_url.as_deref(),
+            ));
             cache.last_snapshot_addr = cur_ptr;
         }
         Arc::clone(&cache.chain)
@@ -245,7 +275,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table);
+        let chain = build_chain_from_snapshot(&table, None);
         assert_eq!(chain.len(), 1);
         let v = chain.check_input(&req("here is AKIAEXAMPLE")).await;
         assert!(v.is_block());
@@ -268,7 +298,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table);
+        let chain = build_chain_from_snapshot(&table, None);
         assert_eq!(chain.len(), 0);
     }
 
@@ -286,7 +316,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table);
+        let chain = build_chain_from_snapshot(&table, None);
         assert_eq!(chain.len(), 0, "empty list adds nothing to the chain");
     }
 
@@ -320,7 +350,7 @@ mod tests {
             ),
         ));
 
-        let chain = build_chain_from_snapshot(&table);
+        let chain = build_chain_from_snapshot(&table, None);
         // Only the good row makes it in.
         assert_eq!(chain.len(), 1);
         let v = chain.check_input(&req("ok")).await;
@@ -366,7 +396,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table);
+        let chain = build_chain_from_snapshot(&table, None);
         // Both rows compose. We don't probe the bedrock arm — its
         // own tests cover the dispatch path; this one only pins the
         // chain composition contract.
@@ -377,7 +407,7 @@ mod tests {
     async fn live_chain_rebuilds_on_snapshot_swap() {
         let initial = AisixSnapshot::new();
         let handle = SnapshotHandle::new(initial);
-        let live = LiveGuardrailChain::new(handle.clone());
+        let live = LiveGuardrailChain::new(handle.clone(), None);
 
         // Empty snapshot → no rules → input passes.
         assert!(!live.check_input(&req("AKIA-EXAMPLE")).await.is_block());
@@ -419,7 +449,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table);
+        let chain = build_chain_from_snapshot(&table, None);
         // input check fires...
         assert!(chain.check_input(&req("secret")).await.is_block());
         // ...but output check is a noop on this rule.

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -462,8 +462,15 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // adding the wrapper costs one mutex + ptr-compare per chat,
     // never a regex compile on the hot path. See
     // `aisix_guardrails::LiveGuardrailChain`.
+    //
+    // `bedrock_endpoint_url` is the deployment-wide override for
+    // kind=bedrock guardrails; empty string is normalized to
+    // `None` so a `docker run -e AISIX_BEDROCK_ENDPOINT_URL=`
+    // doesn't accidentally redirect Bedrock calls into thin air.
+    let bedrock_endpoint_url = cfg.bedrock_endpoint_url.clone().filter(|s| !s.is_empty());
     proxy_state = proxy_state.with_guardrails(aisix_guardrails::LiveGuardrailChain::new(
         snapshot_handle.clone(),
+        bedrock_endpoint_url,
     ));
     // Clone shared trackers before consuming proxy_state in build_router.
     let health_tracker = proxy_state.health.clone();


### PR DESCRIPTION
## Summary

`BedrockGuardrail::new` reads `AISIX_BEDROCK_ENDPOINT_URL` directly out of the process env at snapshot rebuild time. This works on the happy path but creates two real problems:

### 1. `Config` rejects the variable at boot (`deny_unknown_fields`)

The bootstrap loader scrapes every `AISIX_<UPPER>__<UPPER>` shaped env var via config-rs:

```rust
Environment::with_prefix("AISIX")
    .prefix_separator("_")
    .separator("__")
```

Setting `AISIX_BEDROCK_ENDPOINT_URL=…` makes config-rs try to deserialize a top-level `bedrock_endpoint_url` field, but `Config` is `#[serde(deny_unknown_fields)]` — so the DP fails to boot before the bedrock guardrail layer is ever built. Operators have been working around it by setting the variable only in the bedrock subprocess scope, which is awkward and fragile.

### 2. Library code reading process env is hard to test

`aisix-guardrails` declares `#![forbid(unsafe_code)]`, and `std::env::set_var` is unsafe in modern Rust, so the env-var path can't be unit-tested in-crate. The existing `with_endpoint` internal constructor exists exactly to dodge this; tests call it directly and the public `new()` codepath was effectively untested.

## Fix

Promote the override to a real `Config` field — `bedrock_endpoint_url: Option<String>`, top-level, `#[serde(default)]` — and thread it from bootstrap → `LiveGuardrailChain::new` → `build_chain_from_snapshot` → `BedrockGuardrail::new`.

The `AISIX_BEDROCK_ENDPOINT_URL` env var keeps working byte-for-byte: config-rs maps it onto the new field automatically. But it now flows through the normal config loader instead of being read out of band, which means:

- `deny_unknown_fields` no longer rejects it.
- Empty string is normalized to `None` in `aisix-server::run` so a stray `docker run -e AISIX_BEDROCK_ENDPOINT_URL=` doesn't redirect Bedrock calls into thin air.
- `BedrockGuardrail::new` becomes pure: it takes the URL as a parameter, prints the same INFO log when present, and tests can pass `None` directly without touching the process environment.

## Wire shape

Both YAML and env continue to work:

```yaml
# Optional — set when the DP needs to call Bedrock through a
# local mock (LocalStack, an AWS-compatible sidecar) or an
# outbound HTTP proxy.
bedrock_endpoint_url: \"http://localstack:4566\"
```

```bash
# Equivalent — config-rs picks this up via the AISIX_ prefix
AISIX_BEDROCK_ENDPOINT_URL=http://localstack:4566 ./aisix --config config.yaml
```

## Changes by area

**aisix-core**
- `Config`: new `bedrock_endpoint_url: Option<String>` (top-level, `#[serde(default)]`).
- 2 new tests pin default-`None` and explicit-value YAML round-trip.

**aisix-guardrails**
- `BedrockGuardrail::new` takes `endpoint_url: Option<String>` as a parameter; deletes the internal `std::env::var` read and the `BEDROCK_ENDPOINT_URL_ENV_VAR` constant.
- `build_chain_from_snapshot(table, bedrock_endpoint_url: Option<&str>)` — second arg threaded down to the bedrock arm.
- `LiveGuardrailChain::new(snapshot, bedrock_endpoint_url: Option<String>)` — captures the URL once at construct time and reuses on every snapshot rebuild (it's a deployment-wide setting and doesn't change while the DP is running).

**aisix-server**
- Bootstrap pulls `cfg.bedrock_endpoint_url`, filters empty strings to `None`, passes into `LiveGuardrailChain::new`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --features bedrock -- -D warnings` clean
- [x] `cargo test -p aisix-core` — 2 new tests, all 11 pass
- [x] `cargo test -p aisix-guardrails --features bedrock` — 42 tests pass (including the 5 wiremock integration tests for `BedrockGuardrail::with_endpoint` which already cover the override-pass-through path)
- [x] `cargo test --workspace --features bedrock` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Bedrock endpoint URL at the deployment level through the configuration file, enabling flexible endpoint customization across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->