### PR TITLE
fix(gateway): SSE decoder buffers across chunks for valid UTF-8

### DIFF
--- a/crates/aisix-gateway/src/sse.rs
+++ b/crates/aisix-gateway/src/sse.rs
@@ -37,7 +37,19 @@ pub enum SseEvent {
 
 #[derive(Debug, Default)]
 pub struct SseDecoder {
+    /// Raw bytes that have not yet decoded into a complete UTF-8
+    /// sequence. We hold these across feeds so a multi-byte codepoint
+    /// (CJK = 3 bytes, emoji = 4 bytes) split across HTTP chunk
+    /// boundaries doesn't get corrupted into U+FFFD. The *previous*
+    /// implementation called `String::from_utf8_lossy` per chunk,
+    /// which replaced every truncated head-of-sequence byte with the
+    /// replacement character — visible mid-stream as `好` rendering as
+    /// `�` in any Chinese / Japanese / Korean / emoji response. See
+    /// issue #111.
+    byte_buf: Vec<u8>,
+    /// Already-decoded text awaiting the `\n\n` event terminator.
     buffer: String,
+    /// Concatenated `data:` payload of the in-progress event.
     current_data: String,
 }
 
@@ -51,11 +63,8 @@ impl SseDecoder {
     /// subsequent call supplies the rest.
     pub fn feed<'a>(&mut self, bytes: impl Into<Cow<'a, [u8]>>) -> Vec<SseEvent> {
         let bytes = bytes.into();
-        // Non-UTF-8 bytes are replaced rather than erroring — upstreams
-        // that break encoding still surface a best-effort event so a
-        // single bad byte doesn't kill the whole stream.
-        let chunk = String::from_utf8_lossy(&bytes);
-        self.buffer.push_str(&chunk);
+        self.byte_buf.extend_from_slice(&bytes);
+        self.decode_buffered_bytes();
 
         let mut events = Vec::new();
         // Event terminator is \n\n; process one message at a time.
@@ -69,6 +78,18 @@ impl SseDecoder {
     /// Flush any buffered trailing bytes as the final event. Call once
     /// the HTTP body has ended; returns `None` if nothing is buffered.
     pub fn finish(&mut self) -> Option<SseEvent> {
+        // Force a lossy decode of any trailing bytes we kept around
+        // hoping for the rest of a multi-byte sequence — at end-of-
+        // stream they're definitively malformed, so replace them with
+        // U+FFFD now and surface whatever we have. This matches the
+        // pre-fix behaviour for genuinely-invalid UTF-8 at EOF (no
+        // information loss compared to the old per-chunk lossy decode).
+        if !self.byte_buf.is_empty() {
+            let tail = String::from_utf8_lossy(&self.byte_buf).into_owned();
+            self.byte_buf.clear();
+            self.buffer.push_str(&tail);
+        }
+
         if self.buffer.trim().is_empty() && self.current_data.is_empty() {
             return None;
         }
@@ -78,6 +99,57 @@ impl SseDecoder {
         let mut events = Vec::new();
         self.decode_message(&format!("{tail}\n\n"), &mut events);
         events.into_iter().next()
+    }
+
+    /// Drain `byte_buf` of every byte that's part of a fully-formed
+    /// UTF-8 sequence (push them onto `buffer`), and keep any trailing
+    /// truncated multi-byte sequence in `byte_buf` for the next feed.
+    /// Mid-buffer invalid bytes (0xFF, lone 0x80, etc.) collapse to
+    /// U+FFFD and we keep going — matching the pre-fix lossy contract
+    /// for genuinely-invalid encodings.
+    fn decode_buffered_bytes(&mut self) {
+        let mut start = 0;
+        loop {
+            let remaining = &self.byte_buf[start..];
+            match std::str::from_utf8(remaining) {
+                Ok(s) => {
+                    self.buffer.push_str(s);
+                    start = self.byte_buf.len();
+                    break;
+                }
+                Err(e) => {
+                    let valid_up_to = e.valid_up_to();
+                    // The crate forbids `unsafe`, so we re-validate
+                    // the prefix even though `Utf8Error::valid_up_to`
+                    // guarantees it. This is a single re-scan over a
+                    // bounded-size leftover buffer per chunk, not per
+                    // byte, so the cost is negligible compared to the
+                    // bug it would otherwise reintroduce.
+                    let valid_prefix = std::str::from_utf8(&remaining[..valid_up_to])
+                        .expect("Utf8Error::valid_up_to bytes must be valid UTF-8");
+                    self.buffer.push_str(valid_prefix);
+                    match e.error_len() {
+                        Some(len) => {
+                            // Definitive decode error mid-buffer (e.g.
+                            // a stray 0xFF). Emit U+FFFD and step past
+                            // the offending sequence; continue trying
+                            // to decode the rest of byte_buf.
+                            self.buffer.push('\u{FFFD}');
+                            start += valid_up_to + len;
+                        }
+                        None => {
+                            // Truncated multi-byte sequence at the
+                            // tail of the buffer. Keep those bytes for
+                            // the next feed — that's the whole point
+                            // of the byte buffer.
+                            start += valid_up_to;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        self.byte_buf.drain(..start);
     }
 
     fn decode_message(&mut self, message: &str, out: &mut Vec<SseEvent>) {
@@ -188,6 +260,81 @@ mod tests {
     fn finish_on_empty_buffer_returns_none() {
         let mut d = SseDecoder::new();
         assert!(d.finish().is_none());
+    }
+
+    // ---- regression coverage for issue #111 -------------------------
+    // Multi-byte UTF-8 (CJK = 3 bytes, emoji = 4 bytes) split across
+    // HTTP chunk boundaries used to surface as U+FFFD because each
+    // chunk got passed through `from_utf8_lossy` independently. The
+    // tests below split a known-good payload at every internal byte
+    // index — only an actual byte-buffered decoder passes all of them.
+
+    #[test]
+    fn cjk_split_across_feeds_round_trips_intact() {
+        // "你好世界" — 12 bytes in UTF-8, every codepoint is 3 bytes.
+        let payload = "你好世界";
+        let event = format!("data: {{\"content\":\"{payload}\"}}\n\n");
+        let raw = event.as_bytes();
+        // Split at every interior byte; every split must produce the
+        // same final event. The bug: splitting between bytes 2-3 of any
+        // codepoint corrupts that codepoint into U+FFFD.
+        for split in 1..raw.len() {
+            let mut d = SseDecoder::new();
+            d.feed(&raw[..split]);
+            let events = d.feed(&raw[split..]);
+            assert_eq!(events.len(), 1, "split={split}");
+            let SseEvent::Data(s) = &events[0] else {
+                panic!("expected Data event at split={split}");
+            };
+            assert_eq!(
+                s,
+                &format!("{{\"content\":\"{payload}\"}}"),
+                "split={split} corrupted CJK",
+            );
+            assert!(
+                !s.contains('\u{FFFD}'),
+                "split={split} produced U+FFFD: {s}",
+            );
+        }
+    }
+
+    #[test]
+    fn emoji_split_across_feeds_round_trips_intact() {
+        // 4-byte emoji per codepoint.
+        let payload = "🙂🚀";
+        let event = format!("data: {{\"content\":\"{payload}\"}}\n\n");
+        let raw = event.as_bytes();
+        for split in 1..raw.len() {
+            let mut d = SseDecoder::new();
+            d.feed(&raw[..split]);
+            let events = d.feed(&raw[split..]);
+            assert_eq!(events.len(), 1, "split={split}");
+            let SseEvent::Data(s) = &events[0] else {
+                panic!("expected Data event at split={split}");
+            };
+            assert_eq!(s, &format!("{{\"content\":\"{payload}\"}}"));
+            assert!(!s.contains('\u{FFFD}'), "split={split} produced U+FFFD");
+        }
+    }
+
+    #[test]
+    fn truncated_multibyte_at_eof_is_replaced_on_finish() {
+        // Stream ends mid-codepoint (e.g. upstream connection dropped).
+        // The pending byte cannot complete; finish() must surface what
+        // we have (U+FFFD for the truncated bytes) rather than dropping
+        // them silently.
+        let mut d = SseDecoder::new();
+        d.feed(b"data: ".as_slice());
+        // First two bytes of the 3-byte sequence for "你" — no third byte ever arrives.
+        d.feed(&[0xE4_u8, 0xBD][..]);
+        let final_event = d.finish().expect("trailing bytes should surface");
+        let SseEvent::Data(s) = final_event else {
+            panic!("expected Data event");
+        };
+        assert!(
+            s.contains('\u{FFFD}'),
+            "truncated tail at EOF should be replaced with U+FFFD: {s:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The SSE decoder was calling `String::from_utf8_lossy(&bytes)` on every
HTTP chunk independently. Multi-byte UTF-8 codepoints split across
HTTP-chunk boundaries got the head-of-sequence bytes replaced with
**U+FFFD**:

| Char | Bytes (UTF-8)              | If split between bytes 1-2: |
|------|----------------------------|------------------------------|
| `好` | `E5 A5 BD` (3)             | `好` → `好` becomes `�`      |
| `🙂` | `F0 9F 99 82` (4)          | `🙂` → `🙂` becomes `�`      |

End-user impact: streaming Chinese / Japanese / Korean / emoji
responses surfaced random `�` characters mid-stream — visible to
anyone using a non-ASCII prompt.

Same bug class as the historical incident `df3c8c78` in
api7-ee-3-gateway (\"misaligned HTTP chunk and SSE event boundaries\").
The Lua port had been fixed; the Rust port carried the original bug.

## Fix

Hold raw bytes in `byte_buf` across feeds:

1. Extend the buffer with new bytes.
2. Decode the longest valid UTF-8 prefix; push to `buffer`.
3. Keep any trailing truncated multi-byte sequence in `byte_buf` for
   the next feed.
4. Mid-buffer invalid bytes (genuinely malformed encoding, not just
   truncated) still collapse to U+FFFD — preserves the existing
   `invalid_utf8_is_lossily_decoded` contract.
5. `finish()` lossily decodes leftover bytes — at EOF truncated
   sequences are definitively malformed.

The crate has `#![forbid(unsafe_code)]`, so the prefix is re-validated
through `std::str::from_utf8` instead of `from_utf8_unchecked`. The
cost is one re-scan over the leftover bytes per chunk, not per byte.

## Test plan

- [x] `cjk_split_across_feeds_round_trips_intact` — splits a
      known-good `\"你好世界\"` payload at **every interior byte index**;
      every split must produce an event identical to the unsplit
      version with no U+FFFD anywhere. The previous code failed at
      every split landing inside a 3-byte codepoint.
- [x] `emoji_split_across_feeds_round_trips_intact` — same shape on
      `\"🙂🚀\"` (4-byte codepoints).
- [x] `truncated_multibyte_at_eof_is_replaced_on_finish` — pins the
      \"stream ended mid-codepoint\" behaviour so trailing bytes still
      surface as U+FFFD rather than being silently dropped.
- [x] Existing `invalid_utf8_is_lossily_decoded` still passes —
      mid-buffer 0xFF still collapses to U+FFFD.
- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` all green (no regressions).
- [x] `cargo clippy -p aisix-gateway -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

Closes #111