### PR TITLE
feat(health): expose etcd watch freshness in /admin/v1/health

### DIFF
--- a/crates/aisix-admin/src/health_handler.rs
+++ b/crates/aisix-admin/src/health_handler.rs
@@ -12,7 +12,11 @@
 //!   "models": [
 //!     {"id": "m-uuid", "name": "my-gpt4", "health": 0},
 //!     {"id": "m-uuid-2", "name": "claude", "health": 1}
-//!   ]
+//!   ],
+//!   "config": {
+//!     "snapshot_revision": 1234567,
+//!     "snapshot_age_seconds": 5
+//!   }
 //! }
 //! ```
 //!
@@ -20,6 +24,12 @@
 //! - `0` — Healthy (no recent failures)
 //! - `1` — Degraded (4–7 consecutive upstream failures)
 //! - `2` — Down (8+ consecutive upstream failures)
+//!
+//! The `config` block surfaces the etcd watch supervisor's freshness
+//! state — without it a wedged watch can let the gateway serve a
+//! frozen snapshot for hours while still reporting healthy. See
+//! issue #114. The block is omitted when the supervisor isn't wired
+//! (legacy / test deployments).
 
 use axum::extract::State;
 use axum::Json;
@@ -37,12 +47,32 @@ pub struct ModelHealth {
     pub health: u8,
 }
 
+/// Etcd watch supervisor freshness, surfaced so operators can detect
+/// a wedged config stream. `snapshot_age_seconds` is `None` before the
+/// supervisor's first apply (boot) — the JSON serialises that as
+/// `null`, distinct from `0` (just-applied).
+#[derive(Debug, Serialize)]
+pub struct ConfigStatus {
+    /// Highest etcd revision currently reflected in the snapshot. Zero
+    /// before first apply.
+    pub snapshot_revision: i64,
+    /// Wall-clock seconds since the supervisor last applied an event.
+    /// `null` when the supervisor has not yet completed its first
+    /// cycle — a fresh boot before etcd is reachable. A large value
+    /// (e.g. > 300) suggests a stalled watch.
+    pub snapshot_age_seconds: Option<u64>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct HealthResponse {
     /// Overall gateway status — always "ok" at the protocol level; operators
     /// should look at individual model health levels for actionable signal.
     pub status: &'static str,
     pub models: Vec<ModelHealth>,
+    /// Etcd watch supervisor freshness. Omitted when the supervisor
+    /// isn't wired into AdminState.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<ConfigStatus>,
 }
 
 pub async fn get_health(
@@ -74,9 +104,18 @@ pub async fn get_health(
         })
         .collect();
 
+    let config = state.watch_status.as_ref().map(|ws| {
+        let snap = ws.snapshot();
+        ConfigStatus {
+            snapshot_revision: snap.revision,
+            snapshot_age_seconds: snap.last_apply_age.map(|d| d.as_secs()),
+        }
+    });
+
     Ok(Json(HealthResponse {
         status: "ok",
         models,
+        config,
     }))
 }
 
@@ -98,6 +137,61 @@ mod tests {
         assert_eq!(d, 1);
         let down: u8 = u8::from(HealthLevel::Down);
         assert_eq!(down, 2);
+    }
+
+    /// Regression for issue #114: HealthResponse with no watch_status
+    /// wired must not include a "config" key at all (older clients
+    /// that use the legacy schema must keep parsing). With watch_status,
+    /// "config.snapshot_revision" + "config.snapshot_age_seconds" must
+    /// appear with the right values.
+    #[test]
+    fn response_serialisation_omits_config_when_watch_status_unwired() {
+        use super::HealthResponse;
+        let r = HealthResponse {
+            status: "ok",
+            models: vec![],
+            config: None,
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert!(json.get("config").is_none());
+    }
+
+    #[test]
+    fn response_serialisation_carries_config_when_watch_status_wired() {
+        use super::{ConfigStatus, HealthResponse};
+        let r = HealthResponse {
+            status: "ok",
+            models: vec![],
+            config: Some(ConfigStatus {
+                snapshot_revision: 1234567,
+                snapshot_age_seconds: Some(5),
+            }),
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(json["config"]["snapshot_revision"], 1234567);
+        assert_eq!(json["config"]["snapshot_age_seconds"], 5);
+    }
+
+    #[test]
+    fn response_serialises_age_as_null_pre_first_apply() {
+        // The supervisor hasn't applied anything yet → age is None →
+        // JSON null, distinct from `0` (just-applied). Operators can
+        // distinguish "boot, etcd unreached" from "fresh, healthy".
+        use super::{ConfigStatus, HealthResponse};
+        let r = HealthResponse {
+            status: "ok",
+            models: vec![],
+            config: Some(ConfigStatus {
+                snapshot_revision: 0,
+                snapshot_age_seconds: None,
+            }),
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert!(
+            json["config"]["snapshot_age_seconds"].is_null(),
+            "pre-first-apply age should serialise as null, got {}",
+            json["config"]["snapshot_age_seconds"]
+        );
     }
 
     #[test]

--- a/crates/aisix-admin/src/state.rs
+++ b/crates/aisix-admin/src/state.rs
@@ -13,6 +13,7 @@
 
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AdminConfig, AisixSnapshot};
+use aisix_etcd::WatchStatus;
 use aisix_obs::Metrics;
 use aisix_proxy::HealthTracker;
 use axum::Router;
@@ -29,6 +30,12 @@ pub struct AdminState {
     /// Shared in-process health tracker from the proxy. Used by the
     /// `/admin/v1/health` endpoint to report per-model health status.
     pub health_tracker: Option<Arc<HealthTracker>>,
+    /// Watch supervisor's freshness state. When wired, the
+    /// `/admin/v1/health` endpoint includes etcd revision +
+    /// snapshot age so operators can detect a frozen / wedged config
+    /// stream that would otherwise let the gateway serve a stale
+    /// snapshot indefinitely. See issue #114.
+    pub watch_status: Option<WatchStatus>,
     /// Proxy router shared for the `/playground/chat/completions` endpoint.
     /// The playground handler calls `router.oneshot(req)` so the request
     /// goes through the full proxy middleware stack (auth, rate-limit, bridge)
@@ -48,8 +55,17 @@ impl AdminState {
             store,
             metrics: None,
             health_tracker: None,
+            watch_status: None,
             proxy_router: None,
         }
+    }
+
+    /// Attach the watch supervisor's freshness status. When set, the
+    /// `/admin/v1/health` response includes etcd revision + snapshot
+    /// age so operators can spot a wedged config stream.
+    pub fn with_watch_status(mut self, status: WatchStatus) -> Self {
+        self.watch_status = Some(status);
+        self
     }
 
     /// Attach a metrics handle. Production wires the same handle that

--- a/crates/aisix-etcd/src/lib.rs
+++ b/crates/aisix-etcd/src/lib.rs
@@ -36,4 +36,4 @@ pub use key::{parse as parse_key, KeyError, ResourceKey};
 pub use loader::{build_snapshot, BuildStats};
 pub use provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 pub use snapshot_cache::SnapshotCache;
-pub use supervisor::Supervisor;
+pub use supervisor::{Supervisor, WatchStatus, WatchStatusSnapshot};

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -19,9 +19,10 @@ use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::AisixSnapshot;
 use futures::StreamExt;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 
 use crate::backoff::ExpBackoff;
@@ -29,6 +30,92 @@ use crate::key;
 use crate::loader::{self, BuildStats};
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 use crate::snapshot_cache::SnapshotCache;
+
+/// Cheap clonable handle for the watch supervisor's freshness state —
+/// the etcd revision the snapshot reflects, and how long ago the
+/// supervisor last applied an event. Read by `/admin/v1/health` so
+/// operators can tell at a glance whether the gateway is serving from
+/// a frozen snapshot (etcd partition or watch supervisor wedged) vs
+/// from a live config stream. See issue #114.
+///
+/// The previous health endpoint only reported per-model upstream
+/// connectivity; it was silent on the gateway's own freshness, so a
+/// dead etcd watch could go unnoticed for hours while the proxy kept
+/// serving the last-known config.
+#[derive(Debug, Default, Clone)]
+pub struct WatchStatus {
+    inner: Arc<WatchStatusInner>,
+}
+
+#[derive(Debug)]
+struct WatchStatusInner {
+    /// Highest revision the supervisor has applied to its snapshot.
+    /// Atomically updated on every load_once / apply_put / apply_delete /
+    /// apply_resync. Zero before first apply.
+    revision: AtomicI64,
+    /// Wall-clock instant of the most recent apply. `None` means the
+    /// supervisor has not yet completed its first cycle — boot state.
+    /// `Mutex<Option<Instant>>` over `parking_lot` would be marginally
+    /// cheaper, but std::sync::Mutex is uncontended here (one writer,
+    /// multiple readers) so the overhead is irrelevant.
+    last_apply_at: Mutex<Option<Instant>>,
+}
+
+impl Default for WatchStatusInner {
+    fn default() -> Self {
+        Self {
+            revision: AtomicI64::new(0),
+            last_apply_at: Mutex::new(None),
+        }
+    }
+}
+
+impl WatchStatus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that the supervisor just applied an event at `revision`.
+    /// `revision` is the etcd revision the resulting snapshot reflects;
+    /// caller stamps the highest revision it's seen so concurrent /
+    /// out-of-order updates don't downgrade the published view.
+    pub(crate) fn record_apply(&self, revision: i64) {
+        let prev = self.inner.revision.load(Ordering::Relaxed);
+        if revision > prev {
+            self.inner.revision.store(revision, Ordering::Relaxed);
+        }
+        *self.inner.last_apply_at.lock().unwrap() = Some(Instant::now());
+    }
+
+    /// Snapshot the current freshness state. Returns the revision and
+    /// the age (wall-clock duration since last apply); `None` for age
+    /// means the supervisor has not yet successfully completed a cycle.
+    pub fn snapshot(&self) -> WatchStatusSnapshot {
+        let revision = self.inner.revision.load(Ordering::Relaxed);
+        let last_apply_age = self
+            .inner
+            .last_apply_at
+            .lock()
+            .unwrap()
+            .map(|t| t.elapsed());
+        WatchStatusSnapshot {
+            revision,
+            last_apply_age,
+        }
+    }
+}
+
+/// Point-in-time read of [`WatchStatus`].
+#[derive(Debug, Clone, Copy)]
+pub struct WatchStatusSnapshot {
+    /// Highest etcd revision currently reflected in the snapshot. Zero
+    /// before first apply.
+    pub revision: i64,
+    /// How long ago the supervisor last applied an event. `None` means
+    /// no apply has happened yet (boot, or DP started in disconnected
+    /// mode without a usable snapshot cache).
+    pub last_apply_age: Option<Duration>,
+}
 
 /// One supervisor instance. Consumers call [`Supervisor::run`] once and
 /// drop the returned handle on shutdown.
@@ -43,6 +130,12 @@ pub struct Supervisor<P: ConfigProvider> {
     state: Mutex<HashMap<String, RawEntry>>,
     revision: Mutex<i64>,
     cache: SnapshotCache,
+
+    /// Freshness signal exposed to /admin/v1/health. Updated on every
+    /// successful apply path (load_once / apply_put / apply_delete /
+    /// apply_resync). `Clone` produces a cheap read handle for the
+    /// admin handler.
+    status: WatchStatus,
 
     // JoinHandles for in-flight `flush_cache` writes. Tests use
     // [`Self::await_pending_cache_writes`] to deterministically wait
@@ -74,8 +167,16 @@ impl<P: ConfigProvider> Supervisor<P> {
             state: Mutex::new(HashMap::new()),
             revision: Mutex::new(0),
             cache,
+            status: WatchStatus::new(),
             pending_writes: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Cheap clonable handle to the supervisor's freshness state.
+    /// Read by /admin/v1/health to surface "etcd watch alive" /
+    /// "snapshot age" metrics. See [`WatchStatus`].
+    pub fn watch_status(&self) -> WatchStatus {
+        self.status.clone()
     }
 
     /// Drain the JoinHandles for any in-flight cache writes spawned
@@ -148,12 +249,15 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// Bump the recorded revision floor. Used by the cycle path to
     /// stamp the cache with the etcd `load_all` revision even when the
     /// resulting entry set is empty (so the file still reflects when
-    /// the DP last successfully reached the CP).
+    /// the DP last successfully reached the CP). Also stamps
+    /// `WatchStatus.last_apply_at` so `/health` reflects the
+    /// successful round-trip with etcd even on an empty config.
     fn set_revision_floor(&self, revision: i64) {
         let mut rev = self.revision.lock().unwrap();
         if revision > *rev {
             *rev = revision;
         }
+        self.status.record_apply(revision);
     }
 
     /// Apply a single Put event on top of the current snapshot.
@@ -215,6 +319,9 @@ impl<P: ConfigProvider> Supervisor<P> {
                 *rev = entry.revision;
             }
         }
+        // /health reads this — record the apply so `last_apply_age`
+        // resets on every event we successfully process.
+        self.status.record_apply(entry.revision);
         self.flush_cache();
         true
     }
@@ -286,6 +393,13 @@ impl<P: ConfigProvider> Supervisor<P> {
             new
         });
         self.state.lock().unwrap().remove(key_str);
+        // Stamp /health freshness on a successful delete. We
+        // don't have a per-event revision on the wire delete
+        // (the etcd watch revision is held at the cycle level);
+        // call record_apply with the current revision so age
+        // resets even if the revision number doesn't move.
+        let cur_rev = *self.revision.lock().unwrap();
+        self.status.record_apply(cur_rev);
         self.flush_cache();
         true
     }
@@ -306,12 +420,18 @@ impl<P: ConfigProvider> Supervisor<P> {
         // Resync revision is the max of any entry; if the caller has a
         // separate "load_all revision" they pass it via the cycle path
         // (see `cycle`), this branch just covers the watch Resync event.
-        if let Some(max_rev) = entries.iter().map(|e| e.revision).max() {
+        let max_rev = entries.iter().map(|e| e.revision).max();
+        if let Some(rev_val) = max_rev {
             let mut rev = self.revision.lock().unwrap();
-            if max_rev > *rev {
-                *rev = max_rev;
+            if rev_val > *rev {
+                *rev = rev_val;
             }
         }
+        // /health: stamp freshness on every resync, even when the
+        // resulting entry set is empty (record_apply with the current
+        // revision floor so the operator sees recent activity).
+        let cur_rev = *self.revision.lock().unwrap();
+        self.status.record_apply(cur_rev);
         self.flush_cache();
         stats
     }
@@ -845,5 +965,74 @@ mod tests {
         let (entries, _) = cache.load().expect("cache file present");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].key, "/aisix/models/m-2");
+    }
+
+    // ---- regression coverage for issue #114 -------------------------
+    // /admin/v1/health needs to surface "etcd watch staleness". The
+    // tests below pin: (1) WatchStatus reflects each apply path, and
+    // (2) without an apply, last_apply_age stays None so the handler
+    // can mark the supervisor as not-yet-warmed-up rather than
+    // reporting age 0.
+
+    #[tokio::test]
+    async fn watch_status_starts_as_unset_before_any_apply() {
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+        let snap = sup.watch_status().snapshot();
+        assert_eq!(snap.revision, 0);
+        assert!(
+            snap.last_apply_age.is_none(),
+            "last_apply_age should be None pre-first-apply; got {:?}",
+            snap.last_apply_age,
+        );
+    }
+
+    #[tokio::test]
+    async fn watch_status_records_apply_on_load_and_put_and_delete() {
+        let provider = Arc::new(FakeProvider::new(
+            vec![entry("/aisix/models/m-init", VALID_MODEL, 4)],
+            7,
+        ));
+        let sup = Supervisor::new(provider, "/aisix");
+
+        // load_once → set_revision_floor(7) → record_apply(7)
+        sup.load_once().await.unwrap();
+        let snap = sup.watch_status().snapshot();
+        assert_eq!(
+            snap.revision, 7,
+            "load_once should advance revision to load_all's revision",
+        );
+        assert!(snap.last_apply_age.is_some());
+
+        // apply_put with a higher revision advances the recorded one.
+        assert!(sup.apply_put(&entry("/aisix/models/m-2", VALID_MODEL, 12)));
+        let snap = sup.watch_status().snapshot();
+        assert_eq!(snap.revision, 12);
+
+        // apply_delete keeps the revision (no per-event revision on
+        // the wire) but resets the apply timestamp.
+        assert!(sup.apply_delete("/aisix/models/m-2"));
+        let snap = sup.watch_status().snapshot();
+        assert!(snap.last_apply_age.is_some());
+        assert_eq!(snap.revision, 12);
+    }
+
+    #[tokio::test]
+    async fn watch_status_age_grows_when_no_events_arrive() {
+        // Pin the freshness signal: after an apply, the age is small;
+        // wait briefly and observe it has grown. This is what the
+        // /health handler reads to detect a wedged watch — without
+        // this signal the proxy could serve stale config indefinitely.
+        let provider = Arc::new(FakeProvider::new(vec![], 5));
+        let sup = Supervisor::new(provider, "/aisix");
+        sup.load_once().await.unwrap();
+        let first = sup.watch_status().snapshot().last_apply_age.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+        let later = sup.watch_status().snapshot().last_apply_age.unwrap();
+        assert!(
+            later > first,
+            "last_apply_age should monotonically grow without new events; \
+             first={first:?} later={later:?}",
+        );
     }
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -483,6 +483,11 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // Share the health tracker so /admin/v1/health reflects live
             // per-model upstream failure counts.
             .with_health_tracker(health_tracker)
+            // Share the supervisor's freshness state so /admin/v1/health
+            // exposes etcd watch staleness — without this, a wedged
+            // watch lets the gateway serve stale config indefinitely
+            // while reporting healthy. See issue #114.
+            .with_watch_status(supervisor.watch_status())
             // Share the proxy router so the playground endpoint can forward
             // requests in-process without an extra network hop.
             .with_proxy_router(proxy_router.clone());


### PR DESCRIPTION
## Summary

`/admin/v1/health` reported per-model upstream connectivity but was
**silent on the gateway's own config freshness**. If the etcd watch
died — network partition, supervisor panic, watch stream wedged — the
proxy kept serving the last-known config from `ArcSwap` with no
signal to operators. Customers saw \"old behavior\" while
`/health` stayed green for hours.

## Fix

Surface the watch supervisor's freshness state alongside model
health.

- **`aisix-etcd`** — new `WatchStatus` cheap-clonable handle owned
  by `Supervisor`. Tracks `(revision, last_apply_at)` atomically;
  updated on every `load_once` / `apply_put` / `apply_delete` /
  `apply_resync` / `set_revision_floor` path so wall-clock age
  resets on each successful round-trip with etcd.
- **`aisix-admin`** — `AdminState::with_watch_status` wires the
  handle. `/admin/v1/health` adds an optional `config` block:
  ```json
  {
    "status": "ok",
    "models": [...],
    "config": {
      "snapshot_revision": 1234567,
      "snapshot_age_seconds": 5
    }
  }
  ```
  - `snapshot_age_seconds` is **`null`** when the supervisor hasn't
    completed its first cycle (boot, etcd unreached) — distinct from
    `0` (just-applied). Operators can tell \"never warmed up\" apart
    from \"freshly applied\".
  - The whole `config` block is **omitted** when `AdminState` wasn't
    given a `WatchStatus`. Preserves the legacy schema for any
    callers that don't yet wire the supervisor.
- **`aisix-server`** — wire `supervisor.watch_status()` into
  `AdminState`.

## Test plan

- [x] `watch_status_starts_as_unset_before_any_apply` — pre-apply,
      `last_apply_age` is `None`.
- [x] `watch_status_records_apply_on_load_and_put_and_delete` —
      `load_once` advances revision; `apply_put` advances; `apply_delete`
      keeps revision but resets the apply timestamp.
- [x] `watch_status_age_grows_when_no_events_arrive` — sleeps 60 ms
      then asserts age strictly increased. **This is the signal
      `/health` uses** to detect a wedged watch.
- [x] `response_serialisation_omits_config_when_watch_status_unwired`
      — legacy schema preserved.
- [x] `response_serialisation_carries_config_when_watch_status_wired`
      — happy path.
- [x] `response_serialises_age_as_null_pre_first_apply` — pins
      \"never warmed up\" distinct from \"just applied\".
- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` all green (no regressions).
- [x] `cargo clippy -p aisix-etcd -p aisix-admin -p aisix-server -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

## Out of scope

The issue mentions a follow-up to return **HTTP 503** when
`snapshot_age_seconds > max_acceptable_staleness_seconds` so K8s
liveness/readiness can react. That belongs in a separate PR — the
operator needs to choose the threshold + verify that flipping to 503
won't take down a fleet during normal control-plane upgrades. This
PR ships the visibility layer; the alerting layer can land on top.

Closes #114