### PR TITLE
fix(proxy): streaming chat commits actual tokens at end-of-stream

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -380,8 +380,19 @@ async fn dispatch(
             .chat_stream(req, &ctx)
             .await
             .map_err(|e| with_model(ProxyError::Bridge(e)))?;
-        reservation.commit_tokens(0);
-        let sse_stream = build_sse_stream(upstream, now);
+        // Drop the reservation now: concurrency releases (the SSE
+        // stream that follows is driven by the client, not by the
+        // proxy holding open an upstream-bound future), and RPM was
+        // already counted by pre_commit. TPM is updated retroactively
+        // on stream-end by `add_tokens_post_stream` — see issue #108.
+        // Pre-fix this path called commit_tokens(0) and never came
+        // back, leaving TPM caps blind for all streaming traffic.
+        drop(reservation);
+        let limiter = Arc::clone(&state.limiter);
+        let post_stream_key = rl_key.clone();
+        let sse_stream = build_sse_stream(upstream, now, move |total_tokens| {
+            limiter.add_tokens_post_stream(&post_stream_key, total_tokens);
+        });
         let response =
             Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
         return Ok(Success {
@@ -859,15 +870,49 @@ fn created_ts() -> i64 {
         .unwrap_or(0)
 }
 
-fn build_sse_stream(
+/// Build the SSE stream for a streaming chat response.
+///
+/// As chunks flow through, we observe each chunk's `usage` field. The
+/// upstream typically emits the final usage block on the *last* chunk
+/// (OpenAI when `stream_options.include_usage=true`; Anthropic on the
+/// `message_delta` carrying `output_tokens`). We carry forward the
+/// most recently seen `total_tokens` and, on stream end, hand it to
+/// `on_complete` so the caller can post-account it against TPM/TPD.
+///
+/// Pre-fix the streaming path called `reservation.commit_tokens(0)`
+/// up front and never revisited the counter, leaving TPM caps silently
+/// bypassed for all streaming traffic and the cost/usage telemetry
+/// reporting `$0`. See issue #108.
+///
+/// `on_complete` runs **once** at end-of-stream. It also runs on the
+/// disconnect path (the Drop of the upstream Stream returning `None`
+/// — the same loop exit). Errors mid-stream still terminate the loop
+/// normally, so partial-response cases commit whatever tokens were
+/// observed.
+fn build_sse_stream<F>(
     upstream: aisix_gateway::ChatChunkStream,
     created: i64,
-) -> impl Stream<Item = Result<Event, Infallible>> {
+    on_complete: F,
+) -> impl Stream<Item = Result<Event, Infallible>>
+where
+    F: FnOnce(u64) + Send + 'static,
+{
     async_stream::stream! {
         futures::pin_mut!(upstream);
+        // Track the largest `total_tokens` we've seen on any chunk's
+        // usage block. Providers typically populate this on the
+        // terminal chunk only; using "max" rather than "last" makes
+        // the bookkeeping robust to a provider that double-emits.
+        let mut total_tokens: u64 = 0;
         while let Some(item) = upstream.next().await {
             let ev = match item {
                 Ok(chunk) => {
+                    if let Some(u) = chunk.usage.as_ref() {
+                        let t = u.total_tokens as u64;
+                        if t > total_tokens {
+                            total_tokens = t;
+                        }
+                    }
                     let rendered = render_chunk(created, chunk);
                     match serde_json::to_string(&rendered) {
                         Ok(json) => Event::default().data(json),
@@ -882,6 +927,10 @@ fn build_sse_stream(
             };
             yield Ok::<_, Infallible>(ev);
         }
+        // Stream done — account for the upstream's reported tokens.
+        // For providers that don't emit usage in the stream this stays
+        // 0; on_complete is responsible for treating 0 as "no signal".
+        on_complete(total_tokens);
         yield Ok::<_, Infallible>(Event::default().data("[DONE]"));
     }
 }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -554,6 +554,92 @@ data: [DONE]\n\n";
         assert_eq!(v["error"]["type"], "rate_limit_exceeded");
     }
 
+    /// Regression for issue #108: streaming chat used to commit
+    /// `0` tokens up front and never look at the upstream's terminal
+    /// usage frame. TPM caps were silently bypassed for all streaming
+    /// traffic. The fix: build_sse_stream now passes the largest
+    /// `total_tokens` seen on any chunk to a callback that calls
+    /// `Limiter::add_tokens_post_stream`, after the SSE stream
+    /// completes. This test exercises that path end-to-end:
+    ///
+    /// 1. Issue one streaming request whose terminal SSE chunk
+    ///    carries `usage.total_tokens = 1500`. Pre-fix this would
+    ///    leave TPM at 0; post-fix TPM should be 1500.
+    /// 2. Issue a second streaming request with the same key.
+    ///    With TPM cap at 1000, this must 429 (not 200) — the
+    ///    pre-emptive `tpm.is_exceeded` check on pre_commit catches
+    ///    the over-shoot left by the previous request.
+    #[tokio::test]
+    async fn streaming_chat_tpm_cap_enforced_after_post_stream_commit_issue_108() {
+        let upstream = MockServer::start().await;
+        // Final SSE chunk carries usage. OpenAI emits this when the
+        // client sets `stream_options.include_usage=true`; the proxy
+        // doesn't yet add that on the streamed leg, but the OpenAI
+        // bridge does parse `usage` off any chunk that has one — so
+        // our mock can include it on the terminal chunk and the
+        // bridge will surface it.
+        let sse = "\
+data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":500,\"completion_tokens\":1000,\"total_tokens\":1500}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot_with_limits(
+            "my-gpt4",
+            &["my-gpt4"],
+            &upstream.uri(),
+            serde_json::json!({"tpm": 1000}),
+        );
+        let state = build_state(snap, hub);
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        // First streaming request succeeds. Drive the body to
+        // completion so build_sse_stream's on_complete fires.
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut body_stream = resp.into_body().into_data_stream();
+        while let Some(chunk) = body_stream.next().await {
+            let _ = chunk.unwrap();
+        }
+
+        // Second request must 429 — TPM is now over-shot at 1500/1000.
+        // Pre-fix TPM stayed at 0 and this would have been a 200.
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "streaming chat must commit upstream tokens to TPM (issue #108); \
+             pre-fix this returned 200 and the cap was bypassed",
+        );
+        let body_bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(v["error"]["type"], "rate_limit_exceeded");
+    }
+
     #[tokio::test]
     async fn rate_limit_rpm_returns_429_with_retry_after_header() {
         let upstream = MockServer::start().await;

--- a/crates/aisix-ratelimit/src/limiter.rs
+++ b/crates/aisix-ratelimit/src/limiter.rs
@@ -130,6 +130,31 @@ impl<C: Clock> Limiter<C> {
         })
     }
 
+    /// Add `tokens` to the post-deduct TPM/TPD counters for `key`
+    /// without going through a [`Reservation`]. Used by the streaming
+    /// chat path: at `pre_commit` time we don't yet know how many
+    /// tokens the upstream will return, so the Reservation is dropped
+    /// (releasing the concurrency permit + leaving TPM at 0). When the
+    /// SSE stream finishes, the proxy parses the upstream's terminal
+    /// usage frame and calls this method to retroactively account for
+    /// the tokens. Without it, TPM caps are silently bypassed for all
+    /// streaming traffic — issue #108.
+    ///
+    /// No-op when `tokens == 0` (avoids creating an empty per-key
+    /// counter for keys that never streamed). Otherwise, lazily
+    /// initialises the per-key state via [`Self::state_for`] so the
+    /// first streamed-after-restart request still gets accounted for.
+    pub fn add_tokens_post_stream(&self, key: &str, tokens: u64) {
+        if tokens == 0 {
+            return;
+        }
+        let now = self.clock.unix_secs();
+        let state = self.state_for(key);
+        let mut s = state.lock();
+        s.tpm.add(now, tokens);
+        s.tpd.add(now, tokens);
+    }
+
     fn state_for(&self, key: &str) -> Arc<Mutex<KeyState>> {
         if let Some(entry) = self.states.get(key) {
             return entry.clone();
@@ -511,6 +536,83 @@ mod tests {
         assert_eq!(
             status.rpm_used, 5,
             "rpd rejection wiped concurrent rpm increments"
+        );
+    }
+
+    // ---- regression coverage for issue #108 -------------------------
+    // Streaming chat commits 0 tokens up front because total_tokens
+    // isn't known until the upstream's terminal usage frame. The fix
+    // exposes `Limiter::add_tokens_post_stream` so the SSE driver can
+    // retroactively account for tokens at end-of-stream. The tests
+    // below pin (1) the post-stream add bumps TPM, (2) zero-token
+    // calls don't create empty per-key state, (3) once enough tokens
+    // accumulate the next pre_commit fails on TPM.
+
+    #[test]
+    fn add_tokens_post_stream_increments_tpm() {
+        let clock = TestClock::new(100);
+        let limiter = Limiter::with_clock(clock);
+        let l = limits(Some(10), Some(1_000), None);
+
+        // Pre-commit + drop (mirrors the streaming chat path: rpm
+        // counted, concurrency released, tpm = 0 at this point).
+        {
+            let _r = limiter.pre_commit("k1", &l).unwrap();
+        }
+        assert_eq!(
+            limiter.peek("k1", &l).unwrap().tpm_used,
+            0,
+            "TPM should be 0 right after pre_commit + drop",
+        );
+
+        // Streaming reports 750 tokens at end-of-stream.
+        limiter.add_tokens_post_stream("k1", 750);
+        assert_eq!(
+            limiter.peek("k1", &l).unwrap().tpm_used,
+            750,
+            "TPM should reflect the post-stream commit",
+        );
+    }
+
+    #[test]
+    fn add_tokens_post_stream_zero_is_a_noop() {
+        let clock = TestClock::new(100);
+        let limiter = Limiter::with_clock(clock);
+        // No pre_commit — peek would otherwise return None for an
+        // unknown key. add_tokens_post_stream(0) must NOT create an
+        // empty state entry.
+        limiter.add_tokens_post_stream("never-seen", 0);
+        assert!(
+            limiter.peek("never-seen", &RateLimit::default()).is_none(),
+            "add_tokens_post_stream(0) should not lazily-create state",
+        );
+    }
+
+    #[test]
+    fn streaming_path_tpm_cap_blocks_next_request_after_post_stream_commit() {
+        // Drives the issue #108 exploit shape end-to-end at the
+        // limiter level: streaming "looks free" pre-fix because
+        // commit_tokens(0) skipped TPM. With the fix, the post-
+        // stream add should exhaust TPM and the next pre_commit
+        // must refuse on TPM.
+        let clock = TestClock::new(100);
+        let limiter = Limiter::with_clock(clock);
+        let l = limits(Some(100), Some(1_000), None);
+
+        // Mimic a successful streaming round: pre_commit + drop, then
+        // post-stream add that overshoots the cap. The "overshoot is
+        // allowed for the in-flight request" rule is the same as
+        // commit_tokens — see tpm_blocks_next_request_once_previous_exhausted_the_window.
+        {
+            let _r = limiter.pre_commit("k1", &l).unwrap();
+        }
+        limiter.add_tokens_post_stream("k1", 1_500);
+
+        // Next request sees tpm > 1000 and refuses.
+        let err = limiter.pre_commit("k1", &l).unwrap_err();
+        assert!(
+            matches!(err, RateLimitError::Tokens { .. }),
+            "TPM cap should block the next request after streaming over-shoot; got {err:?}",
         );
     }
 }


### PR DESCRIPTION
## Summary

The streaming chat path called `reservation.commit_tokens(0)` right
after kicking off the upstream stream and **never came back** to
account for what actually flowed through. Net effect:

- **TPM caps silently bypassed for all streaming traffic.**
- **Cost telemetry reported `\$0`** for the majority of LLM traffic
  in production.

The non-streaming path was correct (`commit_tokens(total)`); the
cache-hit path was correct (`0` by design — no upstream tokens
consumed); only the streaming success path was broken. Two of three
paths in the same function got it right.

## Fix

- **`aisix-ratelimit`** — new `Limiter::add_tokens_post_stream(key, n)`.
  Bumps TPM/TPD without going through a `Reservation`. No-op on
  `n == 0` so handlers don't lazily-create empty per-key state for
  keys that streamed and got nothing back.

- **`aisix-proxy/src/chat.rs`** —
  - `build_sse_stream` now takes an `on_complete: FnOnce(u64)`
    callback. The stream tracks the largest `total_tokens` seen on
    any chunk's `usage` block (providers typically populate this on
    the terminal chunk only — OpenAI when
    `stream_options.include_usage=true`, Anthropic on the
    `message_delta` carrying `output_tokens`). At end-of-stream the
    callback fires with the accumulated total.
  - `dispatch`'s streaming branch drops the reservation up front
    (concurrency releases; RPM was already counted by `pre_commit`)
    and hands the stream a closure that calls
    `state.limiter.add_tokens_post_stream` on completion.

## Test plan

### Limiter unit tests

- [x] `add_tokens_post_stream_increments_tpm` — `pre_commit` + drop
      leaves TPM at 0; the post-stream call brings it up.
- [x] `add_tokens_post_stream_zero_is_a_noop` — unknown keys don't
      get empty state on a 0-token stream.
- [x] `streaming_path_tpm_cap_blocks_next_request_after_post_stream_commit`
      — drives the exploit shape at the limiter level.

### End-to-end proxy regression

- [x] **`streaming_chat_tpm_cap_enforced_after_post_stream_commit_issue_108`**
      — wiremock SSE upstream emits a terminal chunk with
      `usage.total_tokens = 1500`. API key `tpm = 1000`. First
      streaming request → 200. Second → **429** (TPM over-shot from
      the first). Pre-fix this was 200/200 and the cap was bypassed.

### Tooling

- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` all green (no regressions; 129 in
      proxy, 24 in ratelimit).
- [x] `cargo clippy -p aisix-proxy -p aisix-ratelimit -- -D warnings`
      clean.
- [x] `cargo fmt --all -- --check` clean.

## Notes

For providers that don't emit `usage` in the stream, `total_tokens`
stays 0 and `add_tokens_post_stream` is a no-op (no information lost,
no over-counting). Wiring the proxy to set
`stream_options.include_usage=true` on outbound OpenAI streams is a
small follow-up; today the bridge already parses `usage` off any
chunk that carries it, which is enough to validate the fix path
end-to-end.

Closes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed rate-limit token accounting for streaming chat completions. Token usage from completed streams is now correctly recorded and enforced against TPM (tokens per minute) caps on subsequent requests. Resolves issue where rate limits were not enforced for streaming responses.

* **Tests**
  * Added regression test to verify streaming chat completions properly enforce TPM rate limits following stream completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->