### PR TITLE
feat(etcd+heartbeat): forward loader rejections to cp-api

### DIFF
--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -20,18 +20,94 @@ use aisix_core::resource::ResourceEntry;
 use aisix_core::AisixSnapshot;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::key::{self, ResourceKey};
 use crate::provider::RawEntry;
 
-/// Counts of rejected entries during a build, useful for metrics.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+/// Why the loader skipped an entry. Surfaced in [`RejectedEntry`] so
+/// the heartbeat / health surface can tell operators what kind of
+/// problem hit each row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectionKind {
+    /// Key didn't match the `<prefix>/<kind>/<id>` shape.
+    BadKey,
+    /// Value bytes didn't parse as JSON.
+    NonJson,
+    /// JSON parsed but failed the kind's JSON Schema.
+    SchemaFailed,
+    /// JSON Schema passed but `serde_json::from_value` refused — usually
+    /// a `deny_unknown_fields` mismatch between schema and Rust struct.
+    ParseFailed,
+    /// Key referenced a `kind` segment we don't know about. Logged at
+    /// debug normally but counted here so unknown kinds show up too.
+    UnknownKind,
+}
+
+impl RejectionKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BadKey => "bad_key",
+            Self::NonJson => "non_json",
+            Self::SchemaFailed => "schema_failed",
+            Self::ParseFailed => "parse_failed",
+            Self::UnknownKind => "unknown_kind",
+        }
+    }
+}
+
+/// One rejected etcd entry. Captured by the loader on every skip path
+/// so the data plane can report back to the control plane via heartbeat
+/// — without this signal a user who saved an invalid row in the
+/// dashboard sees "Saved successfully" but has no way to learn the DP
+/// dropped it. See issue #115.
+///
+/// `timestamp_unix_secs` is wall-clock seconds-since-epoch so the
+/// heartbeat / dashboard can age-out old rejections without parsing
+/// a [`SystemTime`] across the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectedEntry {
+    pub key: String,
+    pub kind: RejectionKind,
+    pub error: String,
+    pub timestamp_unix_secs: u64,
+}
+
+impl RejectedEntry {
+    fn new(key: impl Into<String>, kind: RejectionKind, error: impl Into<String>) -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Self {
+            key: key.into(),
+            kind,
+            error: error.into(),
+            timestamp_unix_secs: now,
+        }
+    }
+}
+
+/// Counts of rejected entries during a build, plus the rejection
+/// list itself. The counts stay handy for metrics; the list is what
+/// the heartbeat sends upstream so the dashboard can show "your DP
+/// rejected these resources, here's why."
+///
+/// `Copy` is dropped because the rejections vec can be large; existing
+/// call sites that took `BuildStats` by value continue to work via
+/// the auto-derived `Clone` (only invoked explicitly when needed).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct BuildStats {
     pub accepted: usize,
     pub schema_rejected: usize,
     pub parse_rejected: usize,
     pub unknown_kind: usize,
     pub key_rejected: usize,
+    /// Detailed reject list. One entry per skipped row, in the order
+    /// the loader processed them. Capacity is whatever the caller's
+    /// upstream provider feeds in; the supervisor caps its retained
+    /// buffer separately.
+    pub rejections: Vec<RejectedEntry>,
 }
 
 /// Build a fresh snapshot from raw entries. Never fails — bad rows are
@@ -47,6 +123,11 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
             Err(err) => {
                 tracing::warn!(key = %raw.key, error = %err, "skipping etcd entry with bad key");
                 stats.key_rejected += 1;
+                stats.rejections.push(RejectedEntry::new(
+                    raw.key.clone(),
+                    RejectionKind::BadKey,
+                    err.to_string(),
+                ));
                 continue;
             }
         };
@@ -56,6 +137,11 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
             Err(err) => {
                 tracing::warn!(key = %raw.key, error = %err, "skipping non-JSON etcd entry");
                 stats.parse_rejected += 1;
+                stats.rejections.push(RejectedEntry::new(
+                    raw.key.clone(),
+                    RejectionKind::NonJson,
+                    err.to_string(),
+                ));
                 continue;
             }
         };
@@ -136,6 +222,11 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
             other => {
                 tracing::debug!(key = %raw.key, kind = %other, "unknown etcd kind; skipping");
                 stats.unknown_kind += 1;
+                stats.rejections.push(RejectedEntry::new(
+                    raw.key.clone(),
+                    RejectionKind::UnknownKind,
+                    format!("unknown kind {other:?}"),
+                ));
             }
         }
     }
@@ -157,6 +248,11 @@ where
     if let Err(err) = validate(value) {
         tracing::warn!(key = %key, error = %err, "schema validation failed; skipping");
         stats.schema_rejected += 1;
+        stats.rejections.push(RejectedEntry::new(
+            key,
+            RejectionKind::SchemaFailed,
+            err.to_string(),
+        ));
         return None;
     }
 
@@ -170,6 +266,11 @@ where
             // mismatch. Treat as schema-rejected for stats purposes.
             tracing::warn!(key = %key, error = %err, "serde parse failed after schema pass");
             stats.parse_rejected += 1;
+            stats.rejections.push(RejectedEntry::new(
+                key,
+                RejectionKind::ParseFailed,
+                err.to_string(),
+            ));
             None
         }
     }
@@ -259,6 +360,58 @@ mod tests {
         let entries = vec![raw("/other/models/a", VALID_MODEL, 1)];
         let (_snap, stats) = build_snapshot("/aisix", &entries);
         assert_eq!(stats.key_rejected, 1);
+    }
+
+    // ---- regression coverage for issue #115 -------------------------
+    // The loader used to log a warning and silently skip invalid rows.
+    // Customers who saved an invalid resource in the dashboard saw
+    // "Saved" but the DP dropped the row — no signal back. The fix
+    // attaches a `RejectedEntry` per skip path so the heartbeat can
+    // surface the failure to cp-api.
+
+    #[test]
+    fn rejection_records_bad_key_with_kind_and_error_message() {
+        let entries = vec![raw("/wrong/models/x", VALID_MODEL, 1)];
+        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        assert_eq!(stats.rejections.len(), 1);
+        assert_eq!(stats.rejections[0].kind, RejectionKind::BadKey);
+        assert_eq!(stats.rejections[0].key, "/wrong/models/x");
+        assert!(!stats.rejections[0].error.is_empty());
+    }
+
+    #[test]
+    fn rejection_records_non_json_payload() {
+        let entries = vec![raw("/aisix/models/m1", b"not-json", 1)];
+        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        assert_eq!(stats.rejections.len(), 1);
+        assert_eq!(stats.rejections[0].kind, RejectionKind::NonJson);
+    }
+
+    #[test]
+    fn rejection_records_schema_failure() {
+        let entries = vec![raw(
+            "/aisix/models/bad",
+            br#"{"display_name":"x","provider":"mistral","model_name":"l","provider_key_id":"pk"}"#,
+            1,
+        )];
+        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        assert_eq!(stats.rejections.len(), 1);
+        assert_eq!(stats.rejections[0].kind, RejectionKind::SchemaFailed);
+    }
+
+    #[test]
+    fn rejection_records_unknown_kind() {
+        let entries = vec![raw("/aisix/unknown_kind/x-1", b"{}", 1)];
+        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        assert_eq!(stats.rejections.len(), 1);
+        assert_eq!(stats.rejections[0].kind, RejectionKind::UnknownKind);
+    }
+
+    #[test]
+    fn happy_entries_have_no_rejections() {
+        let entries = vec![raw("/aisix/models/m-1", VALID_MODEL, 1)];
+        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        assert!(stats.rejections.is_empty());
     }
 
     #[test]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -27,7 +27,7 @@ use tokio::task::JoinHandle;
 
 use crate::backoff::ExpBackoff;
 use crate::key;
-use crate::loader::{self, BuildStats};
+use crate::loader::{self, BuildStats, RejectedEntry};
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 use crate::snapshot_cache::SnapshotCache;
 
@@ -117,6 +117,12 @@ pub struct WatchStatusSnapshot {
     pub last_apply_age: Option<Duration>,
 }
 
+/// Maximum rejected entries the supervisor retains in memory. The
+/// heartbeat path drains and re-fills this on each tick, but if the
+/// CP is unreachable for a while we don't want to leak unbounded
+/// memory. Newest rejection wins on overflow (drops the oldest).
+const MAX_RETAINED_REJECTIONS: usize = 256;
+
 /// One supervisor instance. Consumers call [`Supervisor::run`] once and
 /// drop the returned handle on shutdown.
 pub struct Supervisor<P: ConfigProvider> {
@@ -136,6 +142,16 @@ pub struct Supervisor<P: ConfigProvider> {
     /// apply_resync). `Clone` produces a cheap read handle for the
     /// admin handler.
     status: WatchStatus,
+
+    /// Most recent loader rejections, capped at
+    /// [`MAX_RETAINED_REJECTIONS`]. Read by the heartbeat path so the
+    /// CP can surface "your DP rejected these resources" in the
+    /// dashboard. Newest at the back; on overflow the oldest entries
+    /// are dropped — see issue #115. The buffer is replaced (not
+    /// appended-to) on every load_once / apply_resync because those
+    /// re-process the full entry set; apply_put / apply_delete append
+    /// per-event because they only see one row.
+    rejections: Mutex<Vec<RejectedEntry>>,
 
     // JoinHandles for in-flight `flush_cache` writes. Tests use
     // [`Self::await_pending_cache_writes`] to deterministically wait
@@ -168,6 +184,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             revision: Mutex::new(0),
             cache,
             status: WatchStatus::new(),
+            rejections: Mutex::new(Vec::new()),
             pending_writes: Mutex::new(Vec::new()),
         }
     }
@@ -177,6 +194,36 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// "snapshot age" metrics. See [`WatchStatus`].
     pub fn watch_status(&self) -> WatchStatus {
         self.status.clone()
+    }
+
+    /// Snapshot of the most recent loader rejections (capped). Used by
+    /// the heartbeat path to forward "DP rejected these resources" to
+    /// cp-api. Returns a clone so the caller doesn't hold the lock
+    /// across the heartbeat HTTP call.
+    pub fn recent_rejections(&self) -> Vec<RejectedEntry> {
+        self.rejections.lock().unwrap().clone()
+    }
+
+    /// Replace the retained rejection buffer wholesale. Called by the
+    /// resync paths (load_once / apply_resync) which re-process every
+    /// entry — old per-key rejections are no longer accurate.
+    fn set_rejections(&self, mut new: Vec<RejectedEntry>) {
+        if new.len() > MAX_RETAINED_REJECTIONS {
+            // Keep the *newest* entries; tail of the vec is freshest.
+            new.drain(..new.len() - MAX_RETAINED_REJECTIONS);
+        }
+        *self.rejections.lock().unwrap() = new;
+    }
+
+    /// Append one rejection from a per-event apply path (apply_put).
+    /// Drops the oldest on overflow. apply_delete doesn't reject —
+    /// it's not represented here.
+    fn push_rejection(&self, r: RejectedEntry) {
+        let mut guard = self.rejections.lock().unwrap();
+        if guard.len() >= MAX_RETAINED_REJECTIONS {
+            guard.remove(0);
+        }
+        guard.push(r);
     }
 
     /// Drain the JoinHandles for any in-flight cache writes spawned
@@ -264,8 +311,15 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// Returns `true` if the apply succeeded (schema + parse passed).
     pub fn apply_put(&self, entry: &RawEntry) -> bool {
         // Build a tiny snapshot out of just the new entry, then merge.
-        let (tiny, stats) = loader::build_snapshot(&self.prefix, std::slice::from_ref(entry));
+        let (tiny, mut stats) = loader::build_snapshot(&self.prefix, std::slice::from_ref(entry));
         if stats.accepted == 0 {
+            // The loader already attached a RejectedEntry for whatever
+            // path failed (bad key / non-JSON / schema / parse). Move
+            // them into the supervisor's retained buffer so the next
+            // heartbeat surfaces the failure to cp-api. See issue #115.
+            for r in stats.rejections.drain(..) {
+                self.push_rejection(r);
+            }
             return false;
         }
 
@@ -432,6 +486,10 @@ impl<P: ConfigProvider> Supervisor<P> {
         // revision floor so the operator sees recent activity).
         let cur_rev = *self.revision.lock().unwrap();
         self.status.record_apply(cur_rev);
+        // Resync re-processes the entire entry set so the prior
+        // per-key rejection list is no longer accurate — replace it
+        // wholesale with what this build produced (issue #115).
+        self.set_rejections(stats.rejections.clone());
         self.flush_cache();
         stats
     }
@@ -1033,6 +1091,71 @@ mod tests {
             later > first,
             "last_apply_age should monotonically grow without new events; \
              first={first:?} later={later:?}",
+        );
+    }
+
+    // ---- regression coverage for issue #115 -------------------------
+    // The supervisor now retains the loader's rejected-entry list so
+    // the heartbeat path can forward "DP rejected these resources" to
+    // cp-api. Tests pin (1) apply_resync replaces the buffer wholesale,
+    // (2) apply_put with a bad row appends to the buffer, (3) the
+    // buffer survives a successful apply_put after a rejection so the
+    // heartbeat doesn't lose signal.
+
+    const BAD_PROVIDER_MODEL: &[u8] = br#"{
+        "display_name":"x",
+        "provider":"mistral",
+        "model_name":"l",
+        "provider_key_id":"pk"
+    }"#;
+
+    #[tokio::test]
+    async fn recent_rejections_replaced_by_apply_resync() {
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+
+        // Seed the buffer with a bad apply_put.
+        assert!(!sup.apply_put(&entry("/aisix/models/m-bad", BAD_PROVIDER_MODEL, 1)));
+        assert_eq!(sup.recent_rejections().len(), 1);
+
+        // A clean apply_resync should wipe the buffer.
+        sup.apply_resync(&[entry("/aisix/models/m-good", VALID_MODEL, 2)]);
+        assert!(
+            sup.recent_rejections().is_empty(),
+            "apply_resync with a clean entry set must reset the rejection buffer",
+        );
+    }
+
+    #[tokio::test]
+    async fn recent_rejections_accumulates_across_apply_puts() {
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+
+        assert!(!sup.apply_put(&entry("/aisix/models/m-bad-1", BAD_PROVIDER_MODEL, 1)));
+        assert!(!sup.apply_put(&entry("/aisix/models/m-bad-2", b"not-json", 2)));
+        let rejections = sup.recent_rejections();
+        assert_eq!(rejections.len(), 2);
+        assert_eq!(rejections[0].kind, loader::RejectionKind::SchemaFailed);
+        assert_eq!(rejections[1].kind, loader::RejectionKind::NonJson);
+    }
+
+    #[tokio::test]
+    async fn recent_rejections_survives_a_successful_subsequent_put() {
+        // The buffer is the heartbeat's only signal; a successful put
+        // *after* a rejection must NOT clear it (the dashboard banner
+        // would race the user — we leave clearing to the next resync,
+        // which is what cp-api triggers when the user fixes the row).
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+        assert!(!sup.apply_put(&entry("/aisix/models/m-bad", BAD_PROVIDER_MODEL, 1)));
+        assert_eq!(sup.recent_rejections().len(), 1);
+
+        // A different model succeeds.
+        assert!(sup.apply_put(&entry("/aisix/models/m-good", VALID_MODEL, 2)));
+        assert_eq!(
+            sup.recent_rejections().len(),
+            1,
+            "successful put must not silently drop earlier rejections",
         );
     }
 }

--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -22,9 +22,20 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use aisix_etcd::loader::RejectedEntry;
 use anyhow::{anyhow, Context};
 use serde::Serialize;
 use tokio::sync::watch;
+
+/// Cheap clonable callback the heartbeat invokes once per tick to pull
+/// the supervisor's most recent loader rejections. Returning a clone
+/// (not borrowing) lets the heartbeat send the list over the wire
+/// without holding the supervisor's lock across the HTTP call.
+///
+/// Pre-fix the loader logged a warning and silently moved on. Customers
+/// who saved an invalid resource in the dashboard saw "Saved" but the
+/// DP dropped the row — no signal back. See issue #115.
+pub type RejectionFetcher = Arc<dyn Fn() -> Vec<RejectedEntry> + Send + Sync>;
 
 /// File paths to the on-disk mTLS bundle the heartbeat client presents
 /// to cp-api. Same three files written by `register::register_and_persist`
@@ -50,12 +61,34 @@ pub struct MtlsBundle {
 /// Configuration captured at register time. `url`, `dp_id`, `interval`
 /// come from the register response (or are synthesised on bundle-on-disk
 /// boots); `mtls` points at the persisted bundle.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HeartbeatConfig {
     pub url: String,
     pub dp_id: String,
     pub interval: Duration,
     pub mtls: MtlsBundle,
+    /// Optional source of supervisor-reported loader rejections. When
+    /// set, every heartbeat includes a `rejected_resources` array so
+    /// cp-api can surface "your DP rejected these resources" in the
+    /// dashboard. None means the legacy schema (no rejection field) —
+    /// kept for tests / managed-mode configs that don't have a
+    /// supervisor wired in. See issue #115.
+    pub rejection_fetcher: Option<RejectionFetcher>,
+}
+
+impl std::fmt::Debug for HeartbeatConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HeartbeatConfig")
+            .field("url", &self.url)
+            .field("dp_id", &self.dp_id)
+            .field("interval", &self.interval)
+            .field("mtls", &self.mtls)
+            .field(
+                "rejection_fetcher",
+                &self.rejection_fetcher.as_ref().map(|_| "<fn>"),
+            )
+            .finish()
+    }
 }
 
 impl HeartbeatConfig {
@@ -70,7 +103,15 @@ impl HeartbeatConfig {
             dp_id,
             interval,
             mtls,
+            rejection_fetcher: None,
         }
+    }
+
+    /// Wire a supervisor's rejection callback. The closure is cloned
+    /// per-heartbeat call (cheap — it's an Arc).
+    pub fn with_rejection_fetcher(mut self, fetcher: RejectionFetcher) -> Self {
+        self.rejection_fetcher = Some(fetcher);
+        self
     }
 }
 
@@ -133,9 +174,46 @@ struct HeartbeatBody<'a> {
     dp_id: &'a str,
     uptime_seconds: i64,
     version: &'a str,
+    /// Loader rejections the supervisor has accumulated since last
+    /// drain. Omitted from the wire when empty so legacy / managed-mode
+    /// CP endpoints (which don't yet parse this field) still see the
+    /// historical body shape. See issue #115.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    rejected_resources: Vec<RejectedResourceWire>,
+}
+
+/// On-the-wire shape for one rejection. Kept as a separate type from
+/// `aisix_etcd::loader::RejectedEntry` so the loader's internal
+/// representation can evolve without forcing a wire bump. The two
+/// converge today; `kind` is serialised as a string ("bad_key",
+/// "non_json", "schema_failed", "parse_failed", "unknown_kind") so
+/// cp-api can match without depending on Rust enum repr.
+#[derive(Debug, Serialize)]
+struct RejectedResourceWire {
+    key: String,
+    kind: &'static str,
+    error: String,
+    timestamp_unix_secs: u64,
+}
+
+impl From<&RejectedEntry> for RejectedResourceWire {
+    fn from(r: &RejectedEntry) -> Self {
+        Self {
+            key: r.key.clone(),
+            kind: r.kind.as_str(),
+            error: r.error.clone(),
+            timestamp_unix_secs: r.timestamp_unix_secs,
+        }
+    }
 }
 
 async fn send(client: &reqwest::Client, cfg: &HeartbeatConfig, uptime: i64) -> anyhow::Result<()> {
+    let rejections: Vec<RejectedResourceWire> = cfg
+        .rejection_fetcher
+        .as_ref()
+        .map(|fetcher| fetcher().iter().map(RejectedResourceWire::from).collect())
+        .unwrap_or_default();
+
     let resp = client
         .post(&cfg.url)
         // No bearer header — cp-api authenticates via the peer
@@ -144,6 +222,7 @@ async fn send(client: &reqwest::Client, cfg: &HeartbeatConfig, uptime: i64) -> a
             dp_id: &cfg.dp_id,
             uptime_seconds: uptime,
             version: env!("CARGO_PKG_VERSION"),
+            rejected_resources: rejections,
         })
         .send()
         .await

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -407,7 +407,18 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             }
         }
     });
-    let heartbeat_task = heartbeat_cfg.map(|h| heartbeat::spawn(h, cancel_rx.clone()));
+    // Issue #115: supply the supervisor's rejection callback so each
+    // heartbeat carries the loader's most recent failures up to cp-api.
+    // Pre-fix the loader logged a warning and silently moved on —
+    // dashboard customers saw "Saved successfully" but the DP had
+    // dropped the row.
+    let heartbeat_task = heartbeat_cfg.map(|mut h| {
+        let supervisor_for_heartbeat = Arc::clone(&supervisor);
+        h = h.with_rejection_fetcher(Arc::new(move || {
+            supervisor_for_heartbeat.recent_rejections()
+        }));
+        heartbeat::spawn(h, cancel_rx.clone())
+    });
     let (usage_sink, telemetry_task) = match telemetry_cfg {
         Some(cfg) => {
             let (sink, handle) = telemetry::spawn(cfg, cancel_rx.clone());


### PR DESCRIPTION
## Summary

The etcd loader used to log a `tracing::warn!` and silently `continue`
on every malformed key / non-JSON body / schema-validation failure.
**No feedback channel back to cp-api / dashboard** — a customer who
saved an invalid resource saw \"Saved successfully\" while the DP had
dropped the row. Same root pattern as historical incidents
`api7ee-3` #922 Bug B / #1118.

This PR closes the DP→CP signal loop. The cp-api / dashboard side
(persistence + banner UI) lands in a follow-up; this PR is the wire
that unblocks them.

## Fix

### `aisix-etcd::loader`

- New `RejectedEntry { key, kind, error, timestamp_unix_secs }`.
- New `RejectionKind { BadKey, NonJson, SchemaFailed, ParseFailed,
  UnknownKind }` with stable `as_str()` for the wire (cp-api can
  match by string without depending on Rust enum repr).
- `BuildStats` gains `rejections: Vec<RejectedEntry>` (drops `Copy`).
  Every existing skip path now pushes a structured `RejectedEntry`.

### `aisix-etcd::supervisor`

- `Mutex<Vec<RejectedEntry>>` on the Supervisor, capped at 256
  (MAX_RETAINED_REJECTIONS). `apply_resync` replaces wholesale
  (re-processes the full set); `apply_put` appends per-event when
  `accepted == 0`; oldest dropped on overflow.
- New `pub fn recent_rejections() -> Vec<RejectedEntry>` — callers
  clone out without holding the lock across IO.

### `aisix-server::heartbeat`

- `HeartbeatBody` gains `rejected_resources` with
  `#[serde(skip_serializing_if = \"Vec::is_empty\")]` so legacy cp-api
  endpoints still see the historical body shape.
- `HeartbeatConfig` gains `rejection_fetcher: Option<RejectionFetcher>`
  + `with_rejection_fetcher` builder.
- `aisix-server/src/main.rs` wires `supervisor.recent_rejections()`
  in.

## Test plan

### Loader

- [x] `rejection_records_bad_key_with_kind_and_error_message`
- [x] `rejection_records_non_json_payload`
- [x] `rejection_records_schema_failure`
- [x] `rejection_records_unknown_kind`
- [x] `happy_entries_have_no_rejections` — green path stays clean.

### Supervisor

- [x] `recent_rejections_replaced_by_apply_resync` — clean resync
      wipes a previously-seeded bad apply_put.
- [x] `recent_rejections_accumulates_across_apply_puts` — two bad
      puts in a row surface, ordering preserved.
- [x] `recent_rejections_survives_a_successful_subsequent_put` —
      a green put after a bad one must **not** clear the signal
      (clearing is the resync path's job; the dashboard banner can't
      race the user).

### Tooling

- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` all green (no regressions; 46 in etcd).
- [x] `cargo clippy -p aisix-etcd -p aisix-server -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

## Out of scope (tracked in #115)

- cp-api persistence into a `dp_rejected_resources` table.
- Dashboard banner that surfaces rejected resources.
- Auto-clear on user-edits-and-saves (cp-api triggers a resync).

These are cp-api / dashboard side; this PR ships the DP→CP wire that
unblocks them.

Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed recording of rejected resources (kind, key, error message, timestamp) for failed imports.
  * Supervisor API to retrieve recent rejection entries with size-capped retention.
  * Heartbeat now includes recent rejected-resources in its payload for monitoring.

* **Tests**
  * New coverage verifying rejection recording, supervisor retention/replacement behavior, and heartbeat reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->