### PR TITLE
chore: remove deferred semantic-cache stubs (DP side of #116)

### DIFF
--- a/crates/aisix-cache/src/lib.rs
+++ b/crates/aisix-cache/src/lib.rs
@@ -11,8 +11,7 @@
 //! - Redis backend lands in a follow-up PR behind the `redis` feature.
 //!
 //! Streaming responses aren't cached at this layer — the upstream stream
-//! has no terminal value to store. A separate semantic-cache PR may add
-//! a "first chunk" cache later.
+//! has no terminal value to store.
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -472,7 +472,6 @@ impl Default for OtlpTracingConfig {
 pub struct CacheConfig {
     pub backend: CacheBackend,
     pub redis: Option<RedisCacheConfig>,
-    pub qdrant: Option<QdrantCacheConfig>,
 }
 
 impl Default for CacheConfig {
@@ -480,7 +479,6 @@ impl Default for CacheConfig {
         Self {
             backend: CacheBackend::Memory,
             redis: None,
-            qdrant: None,
         }
     }
 }
@@ -490,7 +488,6 @@ impl Default for CacheConfig {
 pub enum CacheBackend {
     Memory,
     Redis,
-    Qdrant,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -505,13 +502,6 @@ impl RedisCacheConfig {
     fn default_mode() -> String {
         "single".into()
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct QdrantCacheConfig {
-    pub url: String,
-    pub collection: String,
 }
 
 impl Config {

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -3,18 +3,10 @@
 //! `/aisix/<env>/cache_policies/<uuid>`; the DP loads them on watch
 //! and `aisix-proxy::cache_gate` consults them on every chat request.
 //!
-//! Stage 2 (this PR) honors only:
-//!   - `enabled` — flag the policy on/off
-//!   - existence of any matching policy enables / disables the cache
-//!     for the request
-//!
-//! Stage 3+ extensions:
-//!   - `applies_to` parsed into a real matcher (currently treated as
-//!     "all" if any policy is present)
-//!   - `ttl_seconds` propagated into the cache backend per entry
-//!   - `backend` switching between memory / redis / redis_semantic
-//!   - semantic-mode (`similarity_threshold` + `embedding_model`) once
-//!     the embedding client + pgvector backend land
+//! Backends supported: `memory` + `redis`. Semantic backends were
+//! removed pending DP-side wiring of the embedding client +
+//! chat-dispatch integration — see ai-gateway issue #116 and the
+//! TODO issue tracking re-introduction.
 //!
 //! See `crates/aisix-cache` for the cache backend itself; this module
 //! is the wire shape only.
@@ -23,24 +15,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::resource::Resource;
 
-/// Cache backend choice. Stage 2 only enforces `Memory`. The other
-/// variants persist in cp-api + ship through kine but the DP falls
-/// back to memory until each backend wires up.
+/// Cache backend choice. `Memory` is enforced by the DP today;
+/// `Redis` is the kine-level wire-shape stub for the upcoming
+/// shared-cluster backend (DP enforcement pending).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CacheBackend {
     #[default]
     Memory,
     Redis,
-    RedisSemantic,
-    Qdrant,
 }
 
 /// Top-level `CachePolicy` resource shape. Mirrors what cp-api writes
 /// to kine. `name` is operator-facing; `enabled` flips the policy on
-/// without delete + recreate. `applies_to` is parsed by the cache
-/// gate (Stage 3); for now any enabled policy is treated as
-/// "applies to all chat completions in this env".
+/// without delete + recreate. `applies_to` is parsed into a typed
+/// matcher (see `parsed_applies_to`).
 ///
 /// `deny_unknown_fields` is intentionally NOT set so cp-api can ship
 /// new fields ahead of a DP rollout without a hard reject. New
@@ -56,33 +45,22 @@ pub struct CachePolicy {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
-    /// Backend hint. Stage 2 enforces `memory` only; other variants
-    /// fall back to memory at the DP and surface "configured but
-    /// not yet enforced" in the dashboard.
+    /// Backend hint. `memory` is the only enforced backend today;
+    /// `redis` parses + persists but the DP currently falls back
+    /// to memory until that backend wires up.
     #[serde(default)]
     pub backend: CacheBackend,
 
-    /// TTL hint in seconds. Stage 2 honors the cache backend's
-    /// configured TTL globally; per-policy TTL lands in Stage 3.
-    /// Default 3600 matches the cp-api validator.
+    /// TTL hint in seconds. Per-policy TTL is honored by the cache
+    /// backend on each entry. Default 3600 matches the cp-api
+    /// validator.
     #[serde(default = "default_ttl_seconds")]
     pub ttl_seconds: u32,
 
     /// Free-form scope. v1 understands "all", "model:<name>",
-    /// "api_key:<id>". Stage 2 treats any non-empty value as "all"
-    /// — applies_to parsing lands in Stage 3.
+    /// "api_key:<id>". See `parsed_applies_to`.
     #[serde(default = "default_applies_to")]
     pub applies_to: String,
-
-    /// Semantic-mode similarity floor. Required by cp-api for
-    /// `redis_semantic` / `qdrant`; ignored by the DP until those
-    /// backends wire up.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub similarity_threshold: Option<f32>,
-
-    /// Semantic-mode embedding model. Same Stage-3-or-later note.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub embedding_model: Option<String>,
 
     /// Set by the loader from the kine path's UUID segment. The DP
     /// uses this for metric labels + log correlation; not part of
@@ -197,27 +175,22 @@ mod tests {
         assert_eq!(p.backend, CacheBackend::Memory);
         assert_eq!(p.ttl_seconds, 3600);
         assert_eq!(p.applies_to, "all");
-        assert!(p.similarity_threshold.is_none());
     }
 
     #[test]
-    fn deserialises_full_semantic_policy() {
+    fn deserialises_redis_policy_with_overrides() {
         let v = json!({
-            "name": "semantic-experiment",
+            "name": "shared-cluster",
             "enabled": false,
-            "backend": "redis_semantic",
+            "backend": "redis",
             "ttl_seconds": 600,
-            "applies_to": "model:gpt-4o",
-            "similarity_threshold": 0.92,
-            "embedding_model": "text-embedding-3-small"
+            "applies_to": "model:gpt-4o"
         });
         let p: CachePolicy = serde_json::from_value(v).unwrap();
         assert!(!p.enabled);
-        assert_eq!(p.backend, CacheBackend::RedisSemantic);
+        assert_eq!(p.backend, CacheBackend::Redis);
         assert_eq!(p.ttl_seconds, 600);
         assert_eq!(p.applies_to, "model:gpt-4o");
-        assert_eq!(p.similarity_threshold, Some(0.92));
-        assert_eq!(p.embedding_model.as_deref(), Some("text-embedding-3-small"));
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -327,6 +327,10 @@ fn guardrail_schema() -> Value {
 // forward-compatible: cp-api can ship new optional fields ahead of a DP
 // rollout without locking the gateway out.
 fn cache_policy_schema() -> Value {
+    // Backends: memory + redis. Semantic backends were removed
+    // pending DP-side wiring — see ai-gateway issue #116. The schema
+    // stays `additionalProperties: true` so a newer cp-api can ship
+    // forward-compat fields without locking out an older DP.
     json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -335,15 +339,9 @@ fn cache_policy_schema() -> Value {
         "properties": {
             "name":        { "type": "string", "minLength": 1, "maxLength": 120 },
             "enabled":     { "type": "boolean" },
-            "backend":     {
-                "enum": ["memory", "redis", "redis_semantic", "qdrant"]
-            },
+            "backend":     { "enum": ["memory", "redis"] },
             "ttl_seconds": { "type": "integer", "minimum": 1, "maximum": 604800 },
-            "applies_to":  { "type": "string", "minLength": 1, "maxLength": 255 },
-            "similarity_threshold": {
-                "type": "number", "minimum": 0, "maximum": 1
-            },
-            "embedding_model": { "type": "string", "minLength": 1, "maxLength": 120 }
+            "applies_to":  { "type": "string", "minLength": 1, "maxLength": 255 }
         }
     })
 }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -420,8 +420,7 @@ async fn dispatch(
     // the policy CRUD surface (`/api/environments/:env/cache_policies`,
     // see Stage 1); kine fans out the rows; the loader populates
     // `snapshot.cache_policies` (see aisix-etcd). Stage 4 will add
-    // per-policy `ttl_seconds` propagation into the cache backend
-    // and the semantic backends.
+    // per-policy `ttl_seconds` propagation into the cache backend.
     //
     // Match order: first enabled policy whose `parsed_applies_to()`
     // accepts (req.model, auth.entry.id) wins. We grab the WHOLE

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -421,7 +421,6 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let limiter = Arc::new(Limiter::new());
     let metrics = Arc::new(Metrics::new(true));
     // Cache backend selection. Memory by default; Redis when configured.
-    // Qdrant / semantic backends drop in here in a follow-up PR.
     let cache: Option<Arc<dyn Cache>> = match cfg.cache.backend {
         CacheBackend::Memory => Some(Arc::new(MemoryCache::with_defaults())),
         CacheBackend::Redis => {
@@ -436,10 +435,6 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 .await
                 .map_err(|e| anyhow::anyhow!("redis cache connect failed (url={url}): {e}"))?;
             Some(Arc::new(redis) as Arc<dyn Cache>)
-        }
-        CacheBackend::Qdrant => {
-            tracing::warn!(target: "aisix::cache", "qdrant cache not yet implemented — falling back to in-memory");
-            Some(Arc::new(MemoryCache::with_defaults()))
         }
     };
 


### PR DESCRIPTION
## Summary

Trims the speculative cache-backend variants the DP never enforced.
Counterpart to AISIX-Cloud PR #198 (the cp-api side that drops the
\`/dp/cache/{lookup,put}\` mTLS surface).

The dashboard exposed Semantic as an option but the wiring on this
side was never built — \`CacheBackend::RedisSemantic\` and
\`CacheBackend::Qdrant\` parsed-and-fell-back-to-memory, and the
config crate carried a \`QdrantCacheConfig\` that was never used.

## What was removed

**`aisix-core::models::cache_policy`**:
- `CacheBackend::RedisSemantic`, `CacheBackend::Qdrant`
- `CachePolicy::similarity_threshold`, `embedding_model` fields
- `deserialises_full_semantic_policy` test → `deserialises_redis_policy_with_overrides`

**`aisix-core::models::schema`**:
- `cache_policy_schema` backend enum trimmed to `[\"memory\", \"redis\"]`
- `similarity_threshold` + `embedding_model` property definitions

**`aisix-core::config`**:
- `QdrantCacheConfig` struct
- `CacheBackend::Qdrant` variant + `CacheConfig.qdrant` field

**`aisix-server::main`**:
- `CacheBackend::Qdrant` match arm
- \"qdrant cache not yet implemented\" warn-and-fall-back path

Stale doc comments cleaned up in `aisix-cache/src/lib.rs` and
`aisix-proxy/src/chat.rs`.

## What stayed (functional)

- `memory` backend (enforced today)
- `redis` backend (kine wire-shape ready; DP enforcement pending)
- `AppliesTo` matcher (model: / api_key: / all)
- `cache_policies` kine projection + loader path

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` all green (no regressions)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Cross-repo sequencing

This PR lands **after** AISIX-Cloud PR #198 — that one stops cp-api
from writing rows with `redis_semantic` / `qdrant` / `pgvector` to
kine, so the DP can drop the parser variants without losing
configurations in flight.

PR #126 (the abandoned Draft \`SemanticBackend\` HTTP client) will be
closed alongside this PR going to review — see the TODO issue for
what's needed to bring semantic cache back.

Refs: #116, AISIX-Cloud#198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified cache backend support to memory and Redis only; removed support for Qdrant cache backend and semantic caching features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->