### PR TITLE
chore(comments): remove third-party project name mentions

### DIFF
--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -57,9 +57,8 @@ impl ApiKey {
 
     /// True if this key is allowed to call the given Model.
     ///
-    /// A wildcard entry `"*"` grants access to every model, matching
-    /// LiteLLM's convention.  An empty `allowed_models` list denies
-    /// everything (spec §3 authz rule).
+    /// A wildcard entry `"*"` grants access to every model. An empty
+    /// `allowed_models` list denies everything (spec §3 authz rule).
     pub fn can_access(&self, model_name: &str) -> bool {
         self.allowed_models
             .iter()

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -354,10 +354,8 @@ impl StreamState {
 // is handled by `split_system` + `build_request` for the
 // Anthropic-upstream case above.
 //
-// Pattern lifted from LiteLLM's experimental_pass_through adapter
-// (`transformation.py::translate_anthropic_to_openai`), trimmed to the
-// MVP fields aisix supports today (text content blocks; tool_use,
-// image, and thinking blocks land in a follow-up PR).
+// Trimmed to the MVP fields aisix supports today (text content blocks;
+// tool_use, image, and thinking blocks land in a follow-up PR).
 
 #[derive(Debug, thiserror::Error)]
 pub enum AnthropicInboundError {
@@ -525,7 +523,7 @@ pub fn chat_response_into_anthropic_json(
 // Streaming SSE encoder — internal ChatChunk stream  →  Anthropic
 // SSE events.
 //
-// State machine (mirrors LiteLLM's `AnthropicStreamWrapper`):
+// State machine:
 //   1. First chunk that carries content or a finish_reason → emit
 //      `message_start`. If it carries content, also emit
 //      `content_block_start` + `content_block_delta`.

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -16,8 +16,7 @@
 //!   stream as Anthropic JSON or Anthropic SSE events
 //!   (`message_start` / `content_block_*` / `message_delta` /
 //!   `message_stop`). The translation helpers live in
-//!   `aisix-provider-anthropic::wire`. Pattern lifted from LiteLLM's
-//!   experimental_pass_through adapter, scoped to text content blocks
+//!   `aisix-provider-anthropic::wire`. Scoped to text content blocks
 //!   today (tool_use / thinking / image blocks land in a follow-up).
 //!
 //! Both paths share the same auth, model lookup, allowed_models check,


### PR DESCRIPTION
## Summary
Comments-only cleanup: remove inline references to a competitor LLM gateway project name. The behaviors and conventions described stand on their own; the third-party attributions add no useful context for readers of our code.

Three files touched, all comment-only:
- **`crates/aisix-core/src/models/apikey.rs`** — `allowed_models` wildcard `*` convention. The existing spec §3 reference is the authoritative one.
- **`crates/aisix-provider-anthropic/src/wire.rs`** — two spots: (a) the Anthropic-inbound translation adapter header; (b) the streaming SSE encoder state-machine header.
- **`crates/aisix-proxy/src/messages.rs`** — module doc pointer to the wire helpers.

## Test plan
- [x] `cargo check --workspace --tests` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests -- -D warnings` — zero warnings
- [x] `grep -ri "litellm" crates/` — no matches

No behavior changes; comments only.