### PR TITLE
test(routing): pin weighted_pick aggregate-distribution intent

### DIFF
--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -241,6 +241,36 @@ mod tests {
         assert_eq!(weighted_pick(&targets), 0);
     }
 
+    /// Soft property: across many trials, a 99/1 weight bias must
+    /// measurably favor the heavy target. The existing
+    /// `weighted_picks_from_targets_and_falls_back_in_order` only
+    /// checks order *shape* (both targets present) — it cannot tell
+    /// a weighted impl from a uniform-random one. This test pins the
+    /// *intent* of `Weighted`: weight actually steers the picks.
+    ///
+    /// Tolerance is intentionally loose: `entropy()` is sub-second
+    /// wall-clock + `Instant::now().elapsed()` (see comment in
+    /// `entropy`), so short-loop nanos can cluster. We assert "weight
+    /// 99 dominates uniform 50/50" with a ≥ 60 % lower bound, which
+    /// is robust to the weak entropy source while still failing on a
+    /// weight-blind implementation (uniform RNG → ~50 %).
+    #[test]
+    fn weighted_pick_aggregate_distribution_favors_heavier_weight() {
+        let targets = vec![
+            RoutingTarget::new("a").with_weight(99),
+            RoutingTarget::new("b").with_weight(1),
+        ];
+        let n = 5_000;
+        let a_count = (0..n).filter(|_| weighted_pick(&targets) == 0).count();
+        // Uniform 50/50 → ~2500. Weighted 99/1 → ~4950 in theory.
+        // 60 % threshold (3000) is a wide safety margin against weak
+        // entropy while still rejecting weight-blind implementations.
+        assert!(
+            a_count * 100 / n >= 60,
+            "weight=99 target should dominate aggregate picks; got {a_count}/{n}",
+        );
+    }
+
     #[test]
     fn budget_one_disables_fallback() {
         let reg = RoutingRegistry::new();


### PR DESCRIPTION
## Summary
- Add a single **soft property** test for `weighted_pick`'s aggregate behavior
- Existing `weighted_picks_from_targets_and_falls_back_in_order` only checks order *shape* (both targets present, length 2) — it cannot tell a correctly weighted impl from a uniform-random one
- New test runs 5000 trials with `weight=99/1` and asserts the heavy target is picked at least **60%** of the time. This rejects weight-blind implementations (uniform → ~50%) while staying robust to the deliberately weak entropy source

## Why a soft threshold instead of strict %?
`entropy()` is sub-second wall-clock + `Instant::now().elapsed()` (see comment in `entropy()`); the existing weighted test explicitly notes "We don't assert exact distribution (entropy is sub-second wall-clock)". A tight 95–99% bound would be flaky on slow CI. The 60% lower bound is wide enough to absorb entropy clustering yet narrow enough to fail a real regression.

## Test plan
- [x] `cargo test --package aisix-proxy --lib -- routing` — 17 passed, 0 failed (5000-sample test runs in <0.01s)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --tests -- -D warnings` — zero warnings

Refs #127 (G6 — Weighted routing distribution validation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for existing routing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->