### PR TITLE
test(e2e): cache policy hit/miss short-circuits identical request

### DIFF
--- a/tests/e2e/src/cases/cache-policy-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-policy-e2e.test.ts
@@ -1,0 +1,126 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: prompt-response cache policy, identical-request short-circuit.
+// With a `CachePolicy{applies_to: "all", enabled: true}` in scope, two
+// identical chat completions must result in the upstream being hit only
+// once — the second response is served from cache. The unit-level
+// `cache_hit_short_circuits_upstream_and_sets_header` test covers the
+// in-process path; this case proves the wire-level contract end-to-end
+// (real binary, real etcd watch propagation, real client SDK).
+//
+// Reference: OpenAI Chat Completions API spec
+// (https://platform.openai.com/docs/api-reference/chat/create); the
+// gateway's CachePolicy schema lives in
+// `crates/aisix-core/src/models/cache_policy.rs`.
+
+const CALLER_PLAINTEXT = "sk-cache-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("cache policy e2e: identical request hits cache", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "cache-e2e-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "cache-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["cache-e2e"],
+    });
+    // CachePolicy is not exposed on AdminClient yet — call the JSON
+    // helper directly. Schema mirrors `aisix-core::CachePolicy`:
+    // name + enabled + applies_to is enough to enable the policy.
+    await admin.json("POST", "/admin/v1/cache_policies", {
+      name: "cache-e2e-policy",
+      enabled: true,
+      applies_to: "all",
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("second identical request is served from cache, upstream not re-hit", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+    });
+
+    // Wait for the snapshot to carry the Model + ProviderKey + ApiKey
+    // + CachePolicy. The probe uses a distinct message so it doesn't
+    // pollute the cache fingerprint we're about to test against.
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: "cache-e2e",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    // Baseline includes the probe (and any retries during propagation).
+    const baseline = upstream.receivedRequests.length;
+
+    // First call with a fresh fingerprint — cache miss, upstream hit.
+    const first = await client.chat.completions.create({
+      model: "cache-e2e",
+      messages: [{ role: "user", content: "cached prompt" }],
+    });
+    expect(upstream.receivedRequests.length).toBe(baseline + 1);
+
+    // Second identical call — cache hit, upstream NOT re-hit.
+    const second = await client.chat.completions.create({
+      model: "cache-e2e",
+      messages: [{ role: "user", content: "cached prompt" }],
+    });
+    expect(upstream.receivedRequests.length).toBe(baseline + 1);
+
+    // Cache must replay the original response, not synthesize a new
+    // one — caller can't distinguish cache hit from upstream re-call.
+    expect(second.choices[0]?.message.content).toBe(
+      first.choices[0]?.message.content,
+    );
+    expect(second.choices[0]?.message.role).toBe("assistant");
+  });
+});


### PR DESCRIPTION
## Summary
New e2e case (`tests/e2e/src/cases/cache-policy-e2e.test.ts`) proving the prompt-response cache policy works end-to-end — real binary, real etcd watch propagation, real OpenAI SDK client — not just at the in-process unit-test level (existing `cache_hit_short_circuits_upstream_and_sets_header` covers that).

**The contract pinned:**
- `CachePolicy{applies_to:"all", enabled:true}` in scope
- Two identical chat completions issued via the official `openai` npm SDK
- Upstream **must be hit exactly once** — the second response is served from cache
- Cached response replays the original byte-for-byte (same `choices[0].message.content`)

**One assertion does the heavy lifting:** `expect(upstream.receivedRequests.length).toBe(baseline + 1)` after the second call. A regression that bypasses the cache would fire as `baseline + 2`.

## Implementation notes
- `AdminClient` doesn't yet expose a typed `createCachePolicy()` wrapper, so the test calls `admin.json("POST", "/admin/v1/cache_policies", {...})` directly. Adding a typed wrapper to `harness/admin.ts` is fine future cleanup but out of scope for this PR.
- The probe inside `waitConfigPropagation` uses a distinct message (`"ready-probe"`) so it doesn't pollute the cache fingerprint of the actual test prompt.

## References
- OpenAI Chat Completions API spec: <https://platform.openai.com/docs/api-reference/chat/create>
- `crates/aisix-core/src/models/cache_policy.rs` — schema source of truth (`name` + `enabled` + `applies_to: "all"` is the minimal enable form)

## Test plan
- [x] `cd tests/e2e && npx vitest run` — **5/5 pass** (smoke 2 + sdk-compat 2 + cache 1) in 4.00s
- [x] `cd tests/e2e && npx tsc --noEmit` — clean
- [x] Skips gracefully when `etcd` is unreachable

Refs #127 (G7 — Expand E2E ≥10 cases, cache subset).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* **Tests**
  * Added end-to-end test validating prompt-response caching for identical chat completion requests, ensuring duplicate requests are efficiently cached and do not result in redundant upstream server calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->