### PR TITLE
test(e2e): upstream usage tokens propagate byte-for-byte to client

### DIFF
--- a/tests/e2e/src/cases/token-usage-passthrough-e2e.test.ts
+++ b/tests/e2e/src/cases/token-usage-passthrough-e2e.test.ts
@@ -1,0 +1,115 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: precise token-usage pass-through. The mock upstream returns a
+// canned `usage` block (`prompt_tokens: 5`, `completion_tokens: 3`,
+// `total_tokens: 8`); the OpenAI SDK client must surface those exact
+// numbers to the caller, byte-for-byte. Existing sdk-compat case
+// only asserts `total_tokens > 0`, which would still pass under a
+// regression that synthesized different counts.
+//
+// This is the wire foundation that downstream usage-tracking and
+// billing pipelines build on — caller-visible usage MUST equal what
+// the upstream actually billed for.
+//
+// Reference: OpenAI Chat Completions API spec
+// (https://platform.openai.com/docs/api-reference/chat/create) for
+// the `usage` object shape; ai-gateway's response renderer at
+// `crates/aisix-proxy/src/render.rs` passes prompt_tokens /
+// completion_tokens / total_tokens straight through from the
+// upstream's ChatResponse.
+
+const CALLER_PLAINTEXT = "sk-tu-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// These match the mock upstream's default `nonStreamBody` in
+// `harness/upstream-openai.ts`. If that default ever changes, this
+// test will fail loudly — which is the point.
+const EXPECTED_PROMPT_TOKENS = 5;
+const EXPECTED_COMPLETION_TOKENS = 3;
+const EXPECTED_TOTAL_TOKENS = 8;
+
+describe("token usage e2e: upstream usage block reaches client byte-for-byte", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "tu-e2e-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "tu-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["tu-e2e"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("usage.prompt_tokens / completion_tokens / total_tokens equal upstream's exact counts", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.chat.completions.create({
+          model: "tu-e2e",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+
+    const completion = await client.chat.completions.create({
+      model: "tu-e2e",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    // Strict equality on all three counters. Upstream said {5, 3, 8};
+    // anything else is the gateway tampering with billing-critical
+    // data on the way out.
+    expect(completion.usage?.prompt_tokens).toBe(EXPECTED_PROMPT_TOKENS);
+    expect(completion.usage?.completion_tokens).toBe(EXPECTED_COMPLETION_TOKENS);
+    expect(completion.usage?.total_tokens).toBe(EXPECTED_TOTAL_TOKENS);
+  });
+});


### PR DESCRIPTION
## Summary
New e2e case (`tests/e2e/src/cases/token-usage-passthrough-e2e.test.ts`) proving the gateway forwards the upstream's `usage` block exactly as received — no munging, no rounding, no local recomputation.

**The contract pinned:**
- Mock upstream returns `usage = { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 }`
- OpenAI SDK client receives `completion.usage` with those exact three values
- Strict equality (`toBe(N)`) on all three counters — not "greater than zero"

## Why a separate case from `openai-sdk-compat`?
The existing sdk-compat case asserts only `usage?.total_tokens > 0`, which is too weak: a regression that recomputes counts locally (or pads them, or zeroes one but not the others) would still satisfy `> 0`. Downstream usage-tracking and billing pipelines depend on these numbers being the upstream's verbatim counts; this case tightens the contract.

## References
- OpenAI Chat Completions API spec: <https://platform.openai.com/docs/api-reference/chat/create> (the `usage` object shape)
- Renderer source: `crates/aisix-proxy/src/render.rs` (passes `prompt_tokens` / `completion_tokens` / `total_tokens` straight from the upstream's `ChatResponse`)

## Test plan
- [x] `cd tests/e2e && npx vitest run` — **8/8 pass** (smoke 2 + sdk-compat 2 + cache 1 + ratelimit 1 + fallback 1 + token-usage 1) in 6.99s
- [x] `cd tests/e2e && npx tsc --noEmit` — clean
- [x] Skips gracefully when `etcd` is unreachable

Refs #127 (G7 — Expand E2E ≥10 cases, usage pass-through subset).