### PR TITLE
test(audit): tighten 5 HIGH e2e assertions across cases

### DIFF
--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -139,10 +139,37 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
     // (not /v1/chat/completions). A regression that mis-routed an
     // anthropic-provider Model through the OpenAI bridge would never
     // land on /v1/messages.
-    expect(
-      upstream.receivedRequests.some((r) =>
-        r.path.startsWith("/v1/messages"),
-      ),
-    ).toBe(true);
+    const messagesReq = upstream.receivedRequests.find((r) =>
+      r.path.startsWith("/v1/messages"),
+    );
+    expect(messagesReq).toBeDefined();
+
+    // Wire-shape on the request side: the gateway must speak Anthropic
+    // Messages, not OpenAI Chat Completions. Without these assertions
+    // the mock would happily 200 even on an OpenAI-shaped body, so
+    // the response-side translation could pass while the request-side
+    // translation was completely broken (the regression that prompted
+    // this audit pass).
+    const sentBody = JSON.parse(messagesReq!.body) as {
+      model?: string;
+      max_tokens?: unknown;
+      messages?: Array<{ role?: string; content?: unknown }>;
+    };
+    // model_name from the Model resource (Anthropic's id), not the
+    // gateway's display_name "an-e2e".
+    expect(sentBody.model).toBe("claude-3-5-haiku-20241022");
+    // Anthropic's API requires `max_tokens`; OpenAI's doesn't. The
+    // gateway must inject a value when crossing the boundary.
+    expect(typeof sentBody.max_tokens).toBe("number");
+    // Caller's user message must reach the upstream, role intact.
+    expect(sentBody.messages?.[0]?.role).toBe("user");
+
+    // Auth shape: Anthropic uses `x-api-key` + `anthropic-version`,
+    // not `Authorization: Bearer`. A regression that forwarded the
+    // OpenAI auth shape to the Anthropic upstream would 401 in
+    // production but pass against the permissive mock here without
+    // these explicit header assertions.
+    expect(messagesReq!.headers["x-api-key"]).toBe("sk-ant-mock");
+    expect(messagesReq!.headers["anthropic-version"]).toBeDefined();
   });
 });

--- a/tests/e2e/src/cases/cache-policy-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-policy-e2e.test.ts
@@ -122,5 +122,37 @@ describe("cache policy e2e: identical request hits cache", () => {
       first.choices[0]?.message.content,
     );
     expect(second.choices[0]?.message.role).toBe("assistant");
+
+    // Caller-observable cache signaling — the gateway emits an
+    // `x-aisix-cache: hit|miss|disabled` header that cp-api and the
+    // dashboard's /logs view depend on. The OpenAI SDK swallows
+    // response headers, so drop down to fetch directly to verify.
+    // Use a fresh prompt so this header check doesn't reuse the cache
+    // entry built up by the SDK calls above.
+    const headerCheckHeaders = {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    };
+    const headerCheckBody = JSON.stringify({
+      model: "cache-e2e",
+      messages: [{ role: "user", content: "header-check-prompt" }],
+    });
+    const missResp = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: headerCheckHeaders,
+      body: headerCheckBody,
+    });
+    expect(missResp.status).toBe(200);
+    expect(missResp.headers.get("x-aisix-cache")).toBe("miss");
+    await missResp.text();
+
+    const hitResp = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: headerCheckHeaders,
+      body: headerCheckBody,
+    });
+    expect(hitResp.status).toBe(200);
+    expect(hitResp.headers.get("x-aisix-cache")).toBe("hit");
+    await hitResp.text();
   });
 });

--- a/tests/e2e/src/cases/fallback-e2e.test.ts
+++ b/tests/e2e/src/cases/fallback-e2e.test.ts
@@ -98,9 +98,13 @@ describe("fallback e2e: virtual routing fails over from 5xx to next target", () 
         targets: [{ model: "fb-bad" }, { model: "fb-good" }],
       },
     });
+    // Permit the caller for `fb-good` too so the readiness probe can
+    // hit a single-target Model directly, instead of probing through
+    // `fb-virtual` (which fires the bad→good fallback on every retry
+    // and risks off-by-one when an iteration partially succeeds).
     await admin.createApiKey({
       key_hash: CALLER_KEY_HASH,
-      allowed_models: ["fb-virtual"],
+      allowed_models: ["fb-virtual", "fb-good"],
     });
   });
 
@@ -122,15 +126,16 @@ describe("fallback e2e: virtual routing fails over from 5xx to next target", () 
       maxRetries: 0,
     });
 
-    // Routing models don't surface on /v1/models (they're an
-    // implementation detail per `crates/aisix-proxy/src/models.rs`),
-    // so probe with a chat call to fb-virtual itself. A 200 with the
-    // good upstream's content means the full path is ready: admin →
-    // etcd → DP snapshot → routing dispatcher → bad fallback to good.
+    // Probe via `fb-good` directly (single-target, no fallback path)
+    // so the readiness check doesn't pre-warm the bad→good route or
+    // risk inflating either upstream's baseline. A 200 means
+    // Model + ProviderKey + ApiKey are all loaded; routing-block
+    // propagation for `fb-virtual` is on the same etcd watch loop, so
+    // by the time `fb-good` is callable, `fb-virtual` is too.
     await waitConfigPropagation(async () => {
       try {
         const probe = await client.chat.completions.create({
-          model: "fb-virtual",
+          model: "fb-good",
           messages: [{ role: "user", content: "ready-probe" }],
         });
         return probe.choices[0]?.message.content === "fallback worked";

--- a/tests/e2e/src/cases/openai-sdk-compat.test.ts
+++ b/tests/e2e/src/cases/openai-sdk-compat.test.ts
@@ -119,6 +119,12 @@ describe("openai SDK compat: drive gateway through real client", () => {
       }
     });
 
+    // Baseline-isolate the propagation probe so the assertion below
+    // measures only the effect of the actual test call. Without this,
+    // tightening to an absolute count (e.g. `length === 1`) would
+    // silently break — the probe consumes one slot in receivedRequests.
+    const baseline = nonStreamUpstream.receivedRequests.length;
+
     const completion = await client.chat.completions.create({
       model: "sdk-compat-sync",
       messages: [{ role: "user", content: "hello" }],
@@ -129,13 +135,14 @@ describe("openai SDK compat: drive gateway through real client", () => {
     expect(typeof completion.choices[0]?.message.content).toBe("string");
     expect(completion.usage?.total_tokens).toBeGreaterThan(0);
 
-    // Belt-and-suspenders: prove the SDK actually hit our mock and not
-    // some other route. Without this, an environment with a stray
-    // proxy could pass the response-shape assertions while never
-    // exercising the gateway.
+    // Belt-and-suspenders: the test call hit the upstream exactly once
+    // (delta from baseline) and that hit landed on the chat-completions
+    // path. The absolute-count form rejects regressions that double-fire
+    // or short-circuit and silently fall through to a stray route.
+    expect(nonStreamUpstream.receivedRequests.length - baseline).toBe(1);
     expect(
-      nonStreamUpstream.receivedRequests.some((r) =>
-        r.path.startsWith("/v1/chat/completions"),
+      nonStreamUpstream.receivedRequests[baseline]?.path.startsWith(
+        "/v1/chat/completions",
       ),
     ).toBe(true);
   });

--- a/tests/e2e/src/cases/ratelimit-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-e2e.test.ts
@@ -102,18 +102,34 @@ describe("rate limit e2e: RPM=1 second call gets 429", () => {
     });
     expect(ok.choices[0]?.message.role).toBe("assistant");
 
-    // Second call within the minute → APIError with status 429.
-    await expect(
-      client.chat.completions.create({
+    // Second call within the minute → APIError with status 429 AND a
+    // populated `Retry-After` header. The header is the load-bearing
+    // contract for SDK back-off (in-process counterpart is named
+    // `rate_limit_rpm_returns_429_with_retry_after_header` for a
+    // reason — drop the assertion and the test would still pass on a
+    // gateway that returned 429 with no `Retry-After`, breaking every
+    // SDK that relies on it for exponential back-off.
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
         model: "rl-e2e",
         messages: [{ role: "user", content: "second" }],
-      }),
-    ).rejects.toBeInstanceOf(APIError);
-    await expect(
-      client.chat.completions.create({
-        model: "rl-e2e",
-        messages: [{ role: "user", content: "third" }],
-      }),
-    ).rejects.toMatchObject({ status: 429 });
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      // Narrows TS; the expect above already failed if this hits.
+      throw new Error("unreachable: caught is not APIError");
+    }
+    expect(caught.status).toBe(429);
+    // OpenAI Node SDK exposes the response headers via `.headers`.
+    // HTTP header lookup is case-insensitive but the SDK surfaces them
+    // lowercased; cover both just in case.
+    const retryAfter =
+      caught.headers?.["retry-after"] ?? caught.headers?.["Retry-After"];
+    expect(retryAfter).toBeDefined();
+    expect(Number.parseInt(String(retryAfter), 10)).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
Five HIGH-severity findings from an independent audit pass over the recently-merged e2e cases, addressed in one PR. One related finding (streaming `Content-Type`/`Transfer-Encoding`) is deferred — it needs a separate raw-fetch path that the SDK doesn't naturally expose.

| File | Finding | Fix |
|------|---------|-----|
| `openai-sdk-compat.test.ts` (#134) | Probe pollutes baseline | Baseline-isolate probe; assert absolute delta `=== 1` |
| `cache-policy-e2e.test.ts` (#135) | `x-aisix-cache` header (load-bearing for cp-api/dashboard) untested | Raw `fetch` round-trip to verify `miss` → `hit` transition |
| `ratelimit-e2e.test.ts` (#136) | `Retry-After` header on 429 untested | Catch `APIError`, assert `headers["retry-after"]` is a positive integer |
| `fallback-e2e.test.ts` (#137) | Probe via `fb-virtual` fires fallback path on every retry | Permit caller for `fb-good`; probe via `fb-good` directly (single-target, no fallback) |
| `anthropic-upstream-e2e.test.ts` (#141) | Mock accepted any body — request-side wire shape never verified | Inspect `upstream.receivedRequests`: assert Anthropic-shape body (`model`, `max_tokens`, `messages[0].role`) and headers (`x-api-key`, `anthropic-version`) |

## Notable design decisions

- **Cache header check uses raw `fetch`, not the SDK.** The OpenAI Node SDK swallows response headers; the cleanest minimal-invasion change is a separate raw fetch to verify the header, with a fresh prompt (`"header-check-prompt"`) so it doesn't collide with the SDK calls' cache fingerprint.
- **Ratelimit narrows error type via `instanceof`.** TypeScript was unhappy with `as APIError`; a runtime narrow is cleaner anyway and lets later assertions access `.headers` without optional-chain noise.
- **Fallback probe via `fb-good` direct.** Routing-block propagation rides the same etcd watch loop as Models — by the time `fb-good` answers, `fb-virtual` does too — so no test correctness loss.

## References
- OpenAI Chat Completions API spec: <https://platform.openai.com/docs/api-reference/chat/create>
- Anthropic Messages API spec: <https://docs.anthropic.com/en/api/messages>
- OpenAI Node SDK error class: <https://github.com/openai/openai-node/blob/master/src/error.ts>

## Test plan
- [x] `cd tests/e2e && npx vitest run` — **10/10 pass** (anthropic 1, sdk-compat 2, fallback 1, cache 1, smoke 2, token-usage 1, ratelimit 1, allowed-models 1) in 11.69s
- [x] `cd tests/e2e && npx tsc --noEmit` — clean
- [x] All cases skip gracefully when `etcd` is unreachable

Refs #127.