### PR TITLE
test(audit): fix #143 follow-up findings + codify audit rule (CLAUDE.md §8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,27 @@ the customer tries.
   upstream doc URL or SDK file/line. Don't invent field names that
   "feel right" — the ecosystem has already chosen one.
 
+## 8. Independent Audit Before Merge
+
+**Every PR pushed must be reviewed by an independent third-party audit agent. Merge is blocked until all HIGH/MEDIUM findings are resolved or explicitly justified.**
+
+After every `gh pr create` or force-push that updates an existing PR, immediately spawn an `Agent` (`general-purpose` subagent) with no shared context. Brief it cold with the PR URL and the contract the PR claims to pin. The agent must review from these angles, each treated as a blocking concern:
+
+- **Correctness** — does the change actually do what the description claims? Are assertions strong enough that a real regression would fail?
+- **Reliability** — race conditions, error handling, retry/timeout behavior, propagation timing on slow CI runners
+- **Security** — auth/authz checks, input validation at boundaries, injection vectors, header forwarding (and what's deliberately *not* forwarded)
+- **Sensitive-information leakage** — secrets in logs/error messages, internal taxonomy bleeding into client-visible output, upstream-provider details in user-facing fields, tokens/PII in test fixtures
+- **Breaking changes** — public API shape, on-disk format, wire protocol, default-behavior shifts; if the change is breaking, is it gated/versioned?
+- **E2E test coverage** — does the change have e2e coverage of the user-visible contract, not just unit-level happy-path? Are mocks tight enough that a regression on the unverified side (request body, headers) couldn't sneak through?
+
+Audit agent output: HIGH / MEDIUM / LOW per finding, with **concrete suggested code** (the actual line to add), not vague "consider".
+
+**Merge gate:** every HIGH and MEDIUM must be either (a) addressed by a code change, or (b) explicitly justified in the PR — e.g. "this exposes a feature gap, filed as #N for separate work, agreed not to block merge". "Looks fine" or silent merge is not enough.
+
+For findings that surface gateway/product behavior gaps (not test-author oversight), file separate feature/bug issues and link from the PR.
+
+This rule exists because the author cannot see their own blind spots — self-review without an independent agent has shipped real gaps (e.g. a cross-provider e2e PR that verified response translation while never asserting the gateway sent a request in the upstream's wire shape).
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -116,6 +116,15 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
       }
     });
 
+    // Baseline-isolate the readiness probe so the request-shape
+    // assertions below match the test call's request, not the probe's.
+    // The probe also targets `an-e2e` and so also lands on
+    // `/v1/messages`; without slicing from baseline, `find()` over
+    // `receivedRequests` would return the probe and the assertions
+    // would verify the wrong request — a regression that broke ONLY
+    // the test call's translation would slip through.
+    const baseline = upstream.receivedRequests.length;
+
     const completion = await client.chat.completions.create({
       model: "an-e2e",
       messages: [{ role: "user", content: "hi" }],
@@ -135,13 +144,11 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
     expect(completion.usage?.completion_tokens).toBe(4);
     expect(completion.usage?.total_tokens).toBe(9);
 
-    // Confirm the gateway actually hit the Anthropic Messages endpoint
-    // (not /v1/chat/completions). A regression that mis-routed an
-    // anthropic-provider Model through the OpenAI bridge would never
-    // land on /v1/messages.
-    const messagesReq = upstream.receivedRequests.find((r) =>
-      r.path.startsWith("/v1/messages"),
-    );
+    // Confirm the gateway hit /v1/messages on the test call (slice
+    // from baseline so the probe's earlier hit cannot stand in).
+    const messagesReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path.startsWith("/v1/messages"));
     expect(messagesReq).toBeDefined();
 
     // Wire-shape on the request side: the gateway must speak Anthropic
@@ -161,8 +168,20 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
     // Anthropic's API requires `max_tokens`; OpenAI's doesn't. The
     // gateway must inject a value when crossing the boundary.
     expect(typeof sentBody.max_tokens).toBe("number");
-    // Caller's user message must reach the upstream, role intact.
+    // Caller's user message must reach the upstream, role + content
+    // intact — pin to the test call's content (`"hi"`), not the probe's
+    // (`"ready-probe"`). This doubles as a baseline-isolation check.
     expect(sentBody.messages?.[0]?.role).toBe("user");
+    // Anthropic API serialises content as an array of typed blocks
+    // (`[{type:"text", text:"hi"}]`), not a bare string — gateway
+    // converts on the way out. The OpenAI-side input was a string,
+    // so a regression that dropped the content (or sent the wrong
+    // text) would no longer match.
+    expect(sentBody.messages?.[0]?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text", text: "hi" }),
+      ]),
+    );
 
     // Auth shape: Anthropic uses `x-api-key` + `anthropic-version`,
     // not `Authorization: Bearer`. A regression that forwarded the

--- a/tests/e2e/src/cases/fallback-e2e.test.ts
+++ b/tests/e2e/src/cases/fallback-e2e.test.ts
@@ -126,23 +126,45 @@ describe("fallback e2e: virtual routing fails over from 5xx to next target", () 
       maxRetries: 0,
     });
 
-    // Probe via `fb-good` directly (single-target, no fallback path)
-    // so the readiness check doesn't pre-warm the bad→good route or
-    // risk inflating either upstream's baseline. A 200 means
-    // Model + ProviderKey + ApiKey are all loaded; routing-block
-    // propagation for `fb-virtual` is on the same etcd watch loop, so
-    // by the time `fb-good` is callable, `fb-virtual` is too.
+    // Two-stage readiness gate. The previous version probed only
+    // `fb-good` and assumed the routing block for `fb-virtual` would
+    // be loaded by the time `fb-good` was callable — that's plausible
+    // (single etcd watch loop) but unverified by the test itself. The
+    // second probe explicitly gates on `fb-virtual` so the test call
+    // cannot fire while the routing dispatcher is still missing the
+    // virtual model. The probe traffic is folded into the baseline
+    // captured below it.
     await waitConfigPropagation(async () => {
       try {
         const probe = await client.chat.completions.create({
           model: "fb-good",
-          messages: [{ role: "user", content: "ready-probe" }],
+          messages: [{ role: "user", content: "ready-probe-good" }],
         });
         return probe.choices[0]?.message.content === "fallback worked";
       } catch {
         return false;
       }
     });
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "fb-virtual",
+          messages: [{ role: "user", content: "ready-probe-virtual" }],
+        });
+        return probe.choices[0]?.message.content === "fallback worked";
+      } catch {
+        return false;
+      }
+    });
+
+    // The fb-virtual probe stage above DOES exercise the bad→good
+    // fallback path, so the bad upstream MUST have received at least
+    // one request during probing. Surface this as an explicit
+    // assertion (rather than letting it hide inside the baseline)
+    // so a regression that silently routes fb-virtual past the bad
+    // target — making the entire test trivially pass on the good
+    // upstream — is caught here.
+    expect(badUpstream.receivedRequests.length).toBeGreaterThanOrEqual(1);
 
     // Snapshot upstream counts AFTER the probe so the assertions below
     // measure only the effect of the actual test call, not the probe.

--- a/tests/e2e/src/cases/ratelimit-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-e2e.test.ts
@@ -124,11 +124,10 @@ describe("rate limit e2e: RPM=1 second call gets 429", () => {
       throw new Error("unreachable: caught is not APIError");
     }
     expect(caught.status).toBe(429);
-    // OpenAI Node SDK exposes the response headers via `.headers`.
-    // HTTP header lookup is case-insensitive but the SDK surfaces them
-    // lowercased; cover both just in case.
-    const retryAfter =
-      caught.headers?.["retry-after"] ?? caught.headers?.["Retry-After"];
+    // OpenAI Node SDK 4.x's APIError.headers is a Proxy that lowercases
+    // lookups (createResponseHeaders in core.js), so the lowercase form
+    // is the canonical access path.
+    const retryAfter = caught.headers?.["retry-after"];
     expect(retryAfter).toBeDefined();
     expect(Number.parseInt(String(retryAfter), 10)).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary

After #143 merged, an independent post-merge audit pass found a **HIGH** gap (the audit it was meant to satisfy was satisfied against the wrong request) plus two related issues. This PR fixes them and formalises the audit workflow as `CLAUDE.md §8`.

### Test fixes

| Severity | File | Finding | Fix |
|----------|------|---------|-----|
| **HIGH** | `anthropic-upstream-e2e.test.ts` | `.find()` over `receivedRequests` returned the readiness probe's `/v1/messages` hit, NOT the test call's. The new wire-shape assertions verified the wrong request — a regression that broke ONLY the test call's translation would slip through. | Snapshot baseline after `waitConfigPropagation`; `.slice(baseline).find(...)`. Also pin content to `"hi"` using `arrayContaining([objectContaining({type:"text", text:"hi"})])` since Anthropic serialises content as typed blocks, not a bare string. |
| **MEDIUM** | `fallback-e2e.test.ts` | Probing `fb-good` alone left a window where `fb-virtual`'s routing block was still unloaded. | Add a second probe stage that explicitly gates on `fb-virtual` returning the good upstream's content before snapshotting baselines. |
| **LOW** | `ratelimit-e2e.test.ts` | `?? caught.headers?.["Retry-After"]` was dead code — SDK 4.x's `APIError.headers` is a `createResponseHeaders` Proxy that lowercases lookups. | Drop the fallback; keep only `caught.headers?.["retry-after"]`. |

### CLAUDE.md §8 (new)

Codifies the rule the user upgraded to a hard merge gate: every PR pushed must be reviewed by an independent third-party agent across **correctness / reliability / security / sensitive-info-leakage / breaking-changes / e2e-coverage** angles. HIGH/MEDIUM findings block merge until resolved or explicitly justified. Same rule lands on `api7/AISIX-Cloud` as §7 in a sibling PR.

## References

- OpenAI Chat Completions API spec: <https://platform.openai.com/docs/api-reference/chat/create>
- Anthropic Messages API spec: <https://docs.anthropic.com/en/api/messages>
- OpenAI Node SDK error class: <https://github.com/openai/openai-node/blob/master/src/error.ts>

## Test plan

- [x] `cd tests/e2e && npx vitest run src/cases/{anthropic-upstream,fallback,ratelimit}-e2e.test.ts` — **3/3 pass**
- [x] `cd tests/e2e && npx tsc --noEmit` — clean
- [x] All cases skip gracefully when `etcd` is unreachable

Refs #127, #143.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a formal independent-audit policy for PRs: mandatory third‑party audits, required remediation or documented exceptions for HIGH/MEDIUM findings, and tracked follow‑up or non-author maintainer sign‑off before merge.

* **Tests**
  * Strengthened end‑to‑end readiness gating and baseline isolation so actual test requests are validated and fallback paths are exercised.
  * Tightened message-serialization assertions and normalized rate‑limit header lookup to lowercase.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/146)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->