### PR TITLE
test(e2e): G14 cross-provider matrix — gemini + deepseek × non-stream/stream

### DIFF
--- a/tests/e2e/src/cases/cross-provider-matrix-e2e.test.ts
+++ b/tests/e2e/src/cases/cross-provider-matrix-e2e.test.ts
@@ -94,34 +94,6 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
     await Promise.all(upstreams.map((u) => u.close()));
   });
 
-  // Scrape `/metrics` from the admin port and assert the gateway emitted
-  // `provider="<name>"` for at least one request labelled with this
-  // dispatch's provider. The gateway records `chosen_provider` from the
-  // `Provider` enum (lowercased) into `aisix_requests_total{provider=...}`.
-  // Without this check, a regression that wired e.g. `Provider::Gemini`
-  // through the OpenAI bridge without re-labelling would still produce a
-  // valid OpenAI-shape upstream call (the wire is identical), but billing
-  // and dashboards would silently classify gemini traffic as "openai".
-  async function expectProviderLabel(
-    spawnedApp: SpawnedApp,
-    provider: Provider,
-  ): Promise<void> {
-    const res = await fetch(`${spawnedApp.adminUrl}/metrics`, {
-      headers: { authorization: `Bearer ${spawnedApp.adminKey}` },
-    });
-    expect(res.status).toBe(200);
-    const text = await res.text();
-    const labelRe = new RegExp(
-      `aisix_requests_total\\{[^}]*provider="${provider}"[^}]*\\}\\s+([0-9.]+)`,
-    );
-    const match = text.match(labelRe);
-    expect(
-      match,
-      `expected aisix_requests_total{provider="${provider}",...} > 0; got:\n${text}`,
-    ).not.toBeNull();
-    expect(Number(match![1])).toBeGreaterThan(0);
-  }
-
   for (const tc of CASES) {
     test(`${tc.provider} upstream — non-streaming`, async (ctx) => {
       if (!etcdReachable || !app || !admin) {
@@ -227,11 +199,6 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
       expect(body.messages?.[0]?.role).toBe("user");
       expect(body.messages?.[0]?.content).toBe("hi");
       expect(body.stream ?? false).toBe(false);
-
-      // Provider-identity contract: gateway labelled this request with
-      // the matching `Provider` enum, not "openai" (which a mis-wire
-      // through the OpenAI bridge without relabelling would emit).
-      await expectProviderLabel(app, tc.provider);
     });
 
     test(`${tc.provider} upstream — streaming`, async (ctx) => {
@@ -330,8 +297,6 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
       expect(body.messages?.[0]?.role).toBe("user");
       expect(body.messages?.[0]?.content).toBe("hi");
       expect(body.stream).toBe(true);
-
-      await expectProviderLabel(app, tc.provider);
     });
   }
 });

--- a/tests/e2e/src/cases/cross-provider-matrix-e2e.test.ts
+++ b/tests/e2e/src/cases/cross-provider-matrix-e2e.test.ts
@@ -1,0 +1,285 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: cross-provider dispatch matrix for OpenAI-compat upstreams.
+// The OpenAI / Gemini / DeepSeek provider bridges all speak the
+// OpenAI wire shape upstream, so the test surface is "did the gateway
+// dispatch through the right bridge for the right Provider enum?"
+// rather than "did wire translation succeed?" (translation is covered
+// in `anthropic-upstream-e2e.test.ts` for the Anthropic case).
+//
+// Existing coverage filled by other test files:
+// - openai (non-stream + stream):   sdk-compat (#134)
+// - anthropic non-stream:           anthropic-upstream-e2e (#141)
+// - anthropic stream:                NOT YET (mock harness's `streamEvents`
+//                                   only writes `data:` SSE lines, not the
+//                                   `event:`/`data:` typed-event pairs that
+//                                   the Anthropic streaming wire requires;
+//                                   harness extension needed first).
+//
+// This file fills the remaining four combos: gemini and deepseek,
+// each in non-streaming and streaming form. Together with the existing
+// per-provider e2e cases, this nails the matrix at 4×{non,stream} = 8
+// for OpenAI-compat upstreams.
+//
+// Reference: OpenAI Chat Completions wire format
+// (https://platform.openai.com/docs/api-reference/chat/create) — both
+// Gemini and DeepSeek bridges proxy this shape verbatim.
+
+const CALLER_PLAINTEXT = "sk-matrix-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+type Provider = "gemini" | "deepseek";
+
+interface MatrixCase {
+  readonly provider: Provider;
+  readonly upstreamModelId: string;
+  readonly displayPrefix: string;
+  readonly expectedContent: string;
+}
+
+const CASES: ReadonlyArray<MatrixCase> = [
+  {
+    provider: "gemini",
+    upstreamModelId: "gemini-2.0-flash",
+    displayPrefix: "matrix-gemini",
+    expectedContent: "Hello from Gemini!",
+  },
+  {
+    provider: "deepseek",
+    upstreamModelId: "deepseek-chat",
+    displayPrefix: "matrix-deepseek",
+    expectedContent: "Hello from DeepSeek!",
+  },
+];
+
+describe("cross-provider matrix: OpenAI-compat upstreams", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  // Each test creates its own upstream mock (per provider × streaming
+  // variant). Track them so `afterAll` can close every one.
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // Wildcard `allowed_models: ["*"]` lets the same caller key reach
+    // every model the per-test setup creates, without re-creating the
+    // ApiKey per case.
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    for (const u of upstreams) {
+      await u.close();
+    }
+  });
+
+  for (const tc of CASES) {
+    test(`${tc.provider} upstream — non-streaming`, async (ctx) => {
+      if (!etcdReachable || !app || !admin) {
+        ctx.skip();
+        return;
+      }
+
+      // Upstream returns a canned OpenAI-shape completion. Both the
+      // Gemini and DeepSeek bridges forward this shape verbatim to
+      // the caller; the test pins that the caller-visible content
+      // round-trips byte-for-byte.
+      const upstream = await startOpenAiUpstream({
+        nonStreamBody: {
+          id: `cmpl-${tc.provider}`,
+          object: "chat.completion",
+          created: Math.floor(Date.now() / 1000),
+          model: tc.upstreamModelId,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: tc.expectedContent,
+              },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 5, completion_tokens: 4, total_tokens: 9 },
+        },
+      });
+      upstreams.push(upstream);
+
+      const pk = await admin.createProviderKey({
+        display_name: `${tc.displayPrefix}-pk-non-stream`,
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      const modelName = `${tc.displayPrefix}-non-stream`;
+      await admin.createModel({
+        display_name: modelName,
+        provider: tc.provider,
+        model_name: tc.upstreamModelId,
+        provider_key_id: pk.id,
+      });
+
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+
+      await waitConfigPropagation(async () => {
+        try {
+          await client.chat.completions.create({
+            model: modelName,
+            messages: [{ role: "user", content: "ready-probe" }],
+          });
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      const baseline = upstream.receivedRequests.length;
+      const completion = await client.chat.completions.create({
+        model: modelName,
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      expect(completion.object).toBe("chat.completion");
+      expect(completion.choices[0]?.message.role).toBe("assistant");
+      expect(completion.choices[0]?.message.content).toBe(tc.expectedContent);
+      expect(completion.choices[0]?.finish_reason).toBe("stop");
+      expect(completion.usage?.total_tokens).toBe(9);
+
+      // Dispatch contract: gateway hit `/v1/chat/completions` (the
+      // OpenAI-compat path the Gemini/DeepSeek bridges use). A
+      // regression that mis-routed through Anthropic bridge would
+      // hit `/v1/messages` instead.
+      const testCall = upstream.receivedRequests
+        .slice(baseline)
+        .find((r) => r.path.startsWith("/v1/chat/completions"));
+      expect(testCall).toBeDefined();
+      expect(testCall?.method).toBe("POST");
+      // Wire-shape contract: body reaches upstream as OpenAI Chat
+      // Completions JSON. `model` is rewritten to the upstream's own
+      // id (caller-visible name → `upstreamModelId`). `stream` is
+      // absent or false on the non-stream path.
+      const body = JSON.parse(testCall?.body ?? "{}") as {
+        model?: string;
+        messages?: Array<{ role: string; content: string }>;
+        stream?: boolean;
+      };
+      expect(body.model).toBe(tc.upstreamModelId);
+      expect(body.messages?.[0]?.role).toBe("user");
+      expect(body.messages?.[0]?.content).toBe("hi");
+      expect(body.stream ?? false).toBe(false);
+    });
+
+    test(`${tc.provider} upstream — streaming`, async (ctx) => {
+      if (!etcdReachable || !app || !admin) {
+        ctx.skip();
+        return;
+      }
+
+      // Three OpenAI-shape SSE chunks — role delta, content delta,
+      // finish_reason — followed by `[DONE]`. The OpenAI Node SDK
+      // assembles `chunk.choices[0].delta.content` across deltas.
+      const sseEvents = [
+        `{"id":"c1","object":"chat.completion.chunk","model":"${tc.upstreamModelId}","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+        `{"id":"c1","object":"chat.completion.chunk","model":"${tc.upstreamModelId}","choices":[{"index":0,"delta":{"content":${JSON.stringify(tc.expectedContent)}},"finish_reason":null}]}`,
+        `{"id":"c1","object":"chat.completion.chunk","model":"${tc.upstreamModelId}","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+        "[DONE]",
+      ];
+      const upstream = await startOpenAiUpstream({ streamEvents: sseEvents });
+      upstreams.push(upstream);
+
+      const pk = await admin.createProviderKey({
+        display_name: `${tc.displayPrefix}-pk-stream`,
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      const modelName = `${tc.displayPrefix}-stream`;
+      await admin.createModel({
+        display_name: modelName,
+        provider: tc.provider,
+        model_name: tc.upstreamModelId,
+        provider_key_id: pk.id,
+      });
+
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+
+      await waitConfigPropagation(async () => {
+        try {
+          const probe = await client.chat.completions.create({
+            model: modelName,
+            messages: [{ role: "user", content: "ready-probe" }],
+            stream: true,
+          });
+          for await (const _chunk of probe) {
+            break;
+          }
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      const baseline = upstream.receivedRequests.length;
+      const stream = await client.chat.completions.create({
+        model: modelName,
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      });
+
+      let collected = "";
+      let finishReason: string | null | undefined;
+      for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta;
+        if (delta?.content) collected += delta.content;
+        finishReason ??= chunk.choices[0]?.finish_reason ?? undefined;
+      }
+
+      expect(collected).toBe(tc.expectedContent);
+      expect(finishReason).toBe("stop");
+
+      const testCall = upstream.receivedRequests
+        .slice(baseline)
+        .find((r) => r.path.startsWith("/v1/chat/completions"));
+      expect(testCall).toBeDefined();
+      expect(testCall?.method).toBe("POST");
+      const body = JSON.parse(testCall?.body ?? "{}") as {
+        model?: string;
+        messages?: Array<{ role: string; content: string }>;
+        stream?: boolean;
+      };
+      expect(body.model).toBe(tc.upstreamModelId);
+      expect(body.messages?.[0]?.role).toBe("user");
+      expect(body.messages?.[0]?.content).toBe("hi");
+      expect(body.stream).toBe(true);
+    });
+  }
+});

--- a/tests/e2e/src/cases/cross-provider-matrix-e2e.test.ts
+++ b/tests/e2e/src/cases/cross-provider-matrix-e2e.test.ts
@@ -91,10 +91,36 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
 
   afterAll(async () => {
     await app?.exit();
-    for (const u of upstreams) {
-      await u.close();
-    }
+    await Promise.all(upstreams.map((u) => u.close()));
   });
+
+  // Scrape `/metrics` from the admin port and assert the gateway emitted
+  // `provider="<name>"` for at least one request labelled with this
+  // dispatch's provider. The gateway records `chosen_provider` from the
+  // `Provider` enum (lowercased) into `aisix_requests_total{provider=...}`.
+  // Without this check, a regression that wired e.g. `Provider::Gemini`
+  // through the OpenAI bridge without re-labelling would still produce a
+  // valid OpenAI-shape upstream call (the wire is identical), but billing
+  // and dashboards would silently classify gemini traffic as "openai".
+  async function expectProviderLabel(
+    spawnedApp: SpawnedApp,
+    provider: Provider,
+  ): Promise<void> {
+    const res = await fetch(`${spawnedApp.adminUrl}/metrics`, {
+      headers: { authorization: `Bearer ${spawnedApp.adminKey}` },
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const labelRe = new RegExp(
+      `aisix_requests_total\\{[^}]*provider="${provider}"[^}]*\\}\\s+([0-9.]+)`,
+    );
+    const match = text.match(labelRe);
+    expect(
+      match,
+      `expected aisix_requests_total{provider="${provider}",...} > 0; got:\n${text}`,
+    ).not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThan(0);
+  }
 
   for (const tc of CASES) {
     test(`${tc.provider} upstream — non-streaming`, async (ctx) => {
@@ -171,20 +197,28 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
       expect(completion.choices[0]?.finish_reason).toBe("stop");
       expect(completion.usage?.total_tokens).toBe(9);
 
-      // Dispatch contract: gateway hit `/v1/chat/completions` (the
-      // OpenAI-compat path the Gemini/DeepSeek bridges use). A
-      // regression that mis-routed through Anthropic bridge would
-      // hit `/v1/messages` instead.
-      const testCall = upstream.receivedRequests
+      // Dispatch contract: gateway hit `/v1/chat/completions` exactly
+      // once (the OpenAI-compat path the Gemini/DeepSeek bridges use).
+      // A regression that mis-routed through Anthropic bridge would
+      // hit `/v1/messages` instead; a regression that introduced a
+      // retry loop would land >1 matching call here.
+      const testCalls = upstream.receivedRequests
         .slice(baseline)
-        .find((r) => r.path.startsWith("/v1/chat/completions"));
-      expect(testCall).toBeDefined();
-      expect(testCall?.method).toBe("POST");
+        .filter((r) => r.path === "/v1/chat/completions");
+      expect(testCalls).toHaveLength(1);
+      const testCall = testCalls[0]!;
+      expect(testCall.method).toBe("POST");
+      // Auth header: gateway forwards the upstream's secret as
+      // `Authorization: Bearer <secret>`. The mock accepts any auth,
+      // so without this assertion an upstream-401 regression (header
+      // dropped, swapped, or rewritten with the caller's key) would
+      // pass against the mock but fail in production.
+      expect(testCall.headers["authorization"]).toBe("Bearer sk-mock");
       // Wire-shape contract: body reaches upstream as OpenAI Chat
       // Completions JSON. `model` is rewritten to the upstream's own
       // id (caller-visible name → `upstreamModelId`). `stream` is
       // absent or false on the non-stream path.
-      const body = JSON.parse(testCall?.body ?? "{}") as {
+      const body = JSON.parse(testCall.body) as {
         model?: string;
         messages?: Array<{ role: string; content: string }>;
         stream?: boolean;
@@ -193,6 +227,11 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
       expect(body.messages?.[0]?.role).toBe("user");
       expect(body.messages?.[0]?.content).toBe("hi");
       expect(body.stream ?? false).toBe(false);
+
+      // Provider-identity contract: gateway labelled this request with
+      // the matching `Provider` enum, not "openai" (which a mis-wire
+      // through the OpenAI bridge without relabelling would emit).
+      await expectProviderLabel(app, tc.provider);
     });
 
     test(`${tc.provider} upstream — streaming`, async (ctx) => {
@@ -255,23 +294,34 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
         stream: true,
       });
 
-      let collected = "";
-      let finishReason: string | null | undefined;
+      // Capture chunks in arrival order — a regression that reordered
+      // SSE events (finish_reason before content, or content split
+      // across the wrong chunks) needs the order to be visible, not
+      // just summed.
+      const chunks: Array<{ content: string; finish: string | null }> = [];
       for await (const chunk of stream) {
-        const delta = chunk.choices[0]?.delta;
-        if (delta?.content) collected += delta.content;
-        finishReason ??= chunk.choices[0]?.finish_reason ?? undefined;
+        const choice = chunk.choices[0];
+        chunks.push({
+          content: choice?.delta?.content ?? "",
+          finish: choice?.finish_reason ?? null,
+        });
       }
-
+      const collected = chunks.map((c) => c.content).join("");
       expect(collected).toBe(tc.expectedContent);
-      expect(finishReason).toBe("stop");
+      // finish_reason must arrive on the LAST chunk that carries it,
+      // never mid-stream.
+      const finishIdx = chunks.findIndex((c) => c.finish === "stop");
+      expect(finishIdx).toBeGreaterThanOrEqual(0);
+      expect(finishIdx).toBe(chunks.length - 1);
 
-      const testCall = upstream.receivedRequests
+      const testCalls = upstream.receivedRequests
         .slice(baseline)
-        .find((r) => r.path.startsWith("/v1/chat/completions"));
-      expect(testCall).toBeDefined();
-      expect(testCall?.method).toBe("POST");
-      const body = JSON.parse(testCall?.body ?? "{}") as {
+        .filter((r) => r.path === "/v1/chat/completions");
+      expect(testCalls).toHaveLength(1);
+      const testCall = testCalls[0]!;
+      expect(testCall.method).toBe("POST");
+      expect(testCall.headers["authorization"]).toBe("Bearer sk-mock");
+      const body = JSON.parse(testCall.body) as {
         model?: string;
         messages?: Array<{ role: string; content: string }>;
         stream?: boolean;
@@ -280,6 +330,8 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
       expect(body.messages?.[0]?.role).toBe("user");
       expect(body.messages?.[0]?.content).toBe("hi");
       expect(body.stream).toBe(true);
+
+      await expectProviderLabel(app, tc.provider);
     });
   }
 });


### PR DESCRIPTION
## Summary

Fills G14 from #127 — the four remaining combos in the **OpenAI-compat upstream dispatch matrix** that prior per-provider e2e cases left uncovered:

- `gemini × non-streaming`
- `gemini × streaming`
- `deepseek × non-streaming`
- `deepseek × streaming`

Combined with #134 (openai non-stream + stream) and #141 (anthropic non-stream), this nails the OpenAI-caller-shape × upstream-provider matrix at **7 of 8 cells**. The remaining cell — caller-OpenAI-shape × upstream-Anthropic × **streaming** — is blocked on the mock harness extending its SSE writer to emit `event:`/`data:` typed-event pairs (the OpenAI-compat path uses a single `data:` line per chunk; Anthropic's wire requires typed events). Tracked separately.

## Why these assertions

The OpenAI / Gemini / DeepSeek bridges all proxy the OpenAI [Chat Completions](https://platform.openai.com/docs/api-reference/chat/create) wire shape verbatim, so the test surface is **dispatch correctness**, not wire translation. Each test pins (all derivable from upstream-vendor wire docs without reading product source):

1. **Path & method** — exactly one POST to `/v1/chat/completions` lands upstream after the test's baseline marker. A mis-route through the Anthropic bridge would land on `/v1/messages`; a regression that introduced retries would land >1.
2. **Auth header** — `Authorization: Bearer sk-mock` reaches upstream (Bearer auth is required by all OpenAI-compat upstream APIs). Catches upstream-401 regressions where the gateway dropped, swapped, or rewrote the header — the mock accepts any auth, so the assertion is the only line of defence.
3. **Body shape** — parses as OpenAI Chat Completions JSON; `model` is rewritten to the upstream id; `messages[0].content` matches the caller's input; `stream` flag matches the call.
4. **Streaming chunk order** — `finish_reason === "stop"` arrives on the LAST chunk only; intermediate chunks must not carry it.
5. **Caller-visible response** — content / `finish_reason` / `usage` round-trip byte-for-byte for non-stream; deltas reassemble to the canned content for stream.

Each test case spins its own mock upstream so `receivedRequests` is uncontested between cases. A wildcard `allowed_models: [\"*\"]` ApiKey at the suite level lets one caller key reach every per-test model without re-issuing keys.

## Independent audit

Per CLAUDE.md §8, an independent audit agent reviewed the initial commit. Resolution log:

| Finding | Severity | Resolution |
|---------|----------|------------|
| `find()` allows N>1 dispatch regressions | HIGH | Switched to `filter().length === 1` (d191a6c) |
| Provider-identity mis-wire could pass with correct wire shape | HIGH | Audit suggested scraping `/metrics` for `provider=\"<name>\"` label — but that derivation required reading `crates/aisix-proxy/src/lib.rs:929`, which is out-of-scope for black-box e2e. **Reverted** in 5c4ee57. If a metric-label regression matters, file as a separate metric-contract test. The dispatch-path / body / auth-header assertions in this PR are sufficient to catch a *wire* regression from black-box observation. |
| Missing Authorization header assertion (vs. #141) | MEDIUM | Added `Bearer sk-mock` assertion (d191a6c) |
| Streaming chunk reorder undetectable | MEDIUM | Capture chunks in order; assert `finish_reason` on last chunk only (d191a6c) |
| Streaming `usage` chunk passthrough not covered | MEDIUM | Filed as #149 (feature-coverage gap, not test-author oversight) |
| `?? \"{}\"` body fallback is dead code after `testCall` asserted | LOW | Dropped (d191a6c) |
| `startsWith` is brittle vs. base-URL changes | LOW | Tightened to exact path equality (d191a6c) |
| Serialized `upstreams[*].close()` in afterAll | LOW | Parallelized via `Promise.all` (d191a6c) |
| PR body's \"8 of 10\" arithmetic was wrong | LOW | Corrected to \"7 of 8\" |

## Test plan

- [x] `npm run test` (full e2e suite) — **15/15 passing locally** (was 11/15 before this PR)
- [x] New `cross-provider-matrix-e2e.test.ts` — 4/4 passing
- [x] No mock-data-only paths: each case exercises the real `aisix` binary, real etcd config propagation, and real OpenAI Node SDK reverse-call client
- [ ] CI green