### PR TITLE
test(e2e): source-blind cleanup + tighten weakened assertions (#151 batch 1)

### DIFF
--- a/tests/e2e/src/cases/allowed-models-e2e.test.ts
+++ b/tests/e2e/src/cases/allowed-models-e2e.test.ts
@@ -14,14 +14,13 @@ import {
 // E2E: ApiKey.allowed_models enforcement. The caller's key permits
 // only `am-allowed`; calling `am-forbidden` (a model that exists in
 // the snapshot but is NOT in the key's allowed list) must return 403
-// without ever touching the upstream. The unit-level
-// `forbidden_model_returns_403` covers the in-process path; this
-// case proves the wire contract holds with a real binary, etcd
-// watch, and OpenAI SDK surfacing the 403 as APIError.
+// without ever touching the upstream. The OpenAI SDK surfaces the
+// 403 as APIError.
 //
 // Reference: OpenAI Chat Completions API spec
-// (https://platform.openai.com/docs/api-reference/chat/create); the
-// ApiKey schema lives at `crates/aisix-core/src/models/apikey.rs`.
+// (https://platform.openai.com/docs/api-reference/chat/create) and
+// OpenAI error-envelope spec
+// (https://platform.openai.com/docs/guides/error-codes/api-errors).
 
 const CALLER_PLAINTEXT = "sk-am-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -104,19 +103,42 @@ describe("allowed_models e2e: 403 on disallowed model, upstream untouched", () =
 
     const upstreamHitsBeforeBlock = upstream.receivedRequests.length;
 
-    // Disallowed model: SDK surfaces 403 as APIError.
-    await expect(
-      client.chat.completions.create({
+    // Disallowed model: SDK surfaces 403 as APIError. Status alone
+    // is not enough — a regression that 403'd via a different path
+    // (e.g. the caller key looked malformed) would still match
+    // `status: 403` but reach a confusing user-visible error. Pin
+    // the OpenAI-shape error envelope so the caller's error handling
+    // can distinguish authz-block from "no such model".
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
         model: "am-forbidden",
         messages: [{ role: "user", content: "should be blocked" }],
-      }),
-    ).rejects.toBeInstanceOf(APIError);
-    await expect(
-      client.chat.completions.create({
-        model: "am-forbidden",
-        messages: [{ role: "user", content: "should be blocked" }],
-      }),
-    ).rejects.toMatchObject({ status: 403 });
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      throw new Error("unreachable: caught is not APIError");
+    }
+    expect(caught.status).toBe(403);
+    // OpenAI error-envelope spec: `error.type` is a non-empty string
+    // identifying the error class. The exact value is the gateway's
+    // public error vocabulary; this assertion guards against an empty
+    // or missing field that would break clients doing
+    // type-discrimination on the error.
+    expect(caught.error).toBeDefined();
+    const errType = (caught.error as { type?: unknown } | undefined)?.type;
+    expect(typeof errType).toBe("string");
+    expect((errType as string).length).toBeGreaterThan(0);
+    // The error message must indicate this is an *authorization*
+    // failure — not "model not found" (the model `am-forbidden`
+    // does exist in the snapshot; the caller just isn't allowed).
+    const errMsg = (caught.error as { message?: unknown } | undefined)
+      ?.message;
+    expect(typeof errMsg).toBe("string");
+    expect((errMsg as string).toLowerCase()).not.toContain("not found");
 
     // The forbidden call never reaches the upstream. A regression
     // that authorized post-dispatch (or skipped the allowed_models

--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -20,10 +20,7 @@ import {
 // `choices[0].message.content`, `choices[0].finish_reason`,
 // `usage: {prompt_tokens, completion_tokens, total_tokens}`).
 //
-// The unit-level matrix_openai_in_anthropic_upstream_non_streaming
-// covers this in process; this case proves the wire contract holds
-// against a real binary, etcd watch, and the official OpenAI SDK
-// client. The mock-upstream harness's body is path-agnostic so
+// The mock-upstream harness's body is path-agnostic so
 // `startOpenAiUpstream` doubles as the Anthropic mock when fed an
 // Anthropic-shaped `nonStreamBody`. The Anthropic bridge appends
 // `/v1/messages` to the api_base on its own, so we still reach the
@@ -34,8 +31,6 @@ import {
 //   <https://platform.openai.com/docs/api-reference/chat/create>
 // - Anthropic Messages API spec:
 //   <https://docs.anthropic.com/en/api/messages>
-// - In-process counterpart:
-//   `crates/aisix-proxy/src/lib.rs::matrix_openai_in_anthropic_upstream_non_streaming`
 
 const CALLER_PLAINTEXT = "sk-an-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")

--- a/tests/e2e/src/cases/cache-policy-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-policy-e2e.test.ts
@@ -14,15 +14,14 @@ import {
 // E2E: prompt-response cache policy, identical-request short-circuit.
 // With a `CachePolicy{applies_to: "all", enabled: true}` in scope, two
 // identical chat completions must result in the upstream being hit only
-// once — the second response is served from cache. The unit-level
-// `cache_hit_short_circuits_upstream_and_sets_header` test covers the
-// in-process path; this case proves the wire-level contract end-to-end
-// (real binary, real etcd watch propagation, real client SDK).
+// once — the second response is served from cache. The gateway also
+// emits a public `x-aisix-cache: hit|miss|disabled` response header
+// (depended on by cp-api and the dashboard's /logs view) which the
+// caller must observe.
 //
 // Reference: OpenAI Chat Completions API spec
-// (https://platform.openai.com/docs/api-reference/chat/create); the
-// gateway's CachePolicy schema lives in
-// `crates/aisix-core/src/models/cache_policy.rs`.
+// (https://platform.openai.com/docs/api-reference/chat/create) for
+// the request/response shape.
 
 const CALLER_PLAINTEXT = "sk-cache-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -59,8 +58,8 @@ describe("cache policy e2e: identical request hits cache", () => {
       allowed_models: ["cache-e2e"],
     });
     // CachePolicy is not exposed on AdminClient yet — call the JSON
-    // helper directly. Schema mirrors `aisix-core::CachePolicy`:
-    // name + enabled + applies_to is enough to enable the policy.
+    // helper directly. The admin API requires `name`, `enabled`, and
+    // `applies_to` to enable a policy.
     await admin.json("POST", "/admin/v1/cache_policies", {
       name: "cache-e2e-policy",
       enabled: true,

--- a/tests/e2e/src/cases/fallback-e2e.test.ts
+++ b/tests/e2e/src/cases/fallback-e2e.test.ts
@@ -15,14 +15,11 @@ import {
 // with two targets — `fb-bad` (returns 502) and `fb-good` (returns
 // 200). The default `failover` strategy starts at the first target;
 // when `fb-bad` returns a retryable upstream error, dispatch falls
-// back to `fb-good` and the caller never sees the failure. This
-// pins the same contract the in-process
-// `routing_failover_retries_to_second_target_when_first_5xxs` covers,
-// but end-to-end through a real binary, etcd watch, and OpenAI SDK.
+// back to `fb-good` and the caller never sees the failure.
 //
 // Reference: OpenAI Chat Completions API spec
-// (https://platform.openai.com/docs/api-reference/chat/create); the
-// Routing schema lives at `crates/aisix-core/src/models/routing.rs`.
+// (https://platform.openai.com/docs/api-reference/chat/create) for
+// the request/response shape the caller sees.
 
 const CALLER_PLAINTEXT = "sk-fb-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")

--- a/tests/e2e/src/cases/guardrail-keyword-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-keyword-e2e.test.ts
@@ -13,16 +13,14 @@ import {
 
 // E2E: keyword guardrail blocks an input that contains the literal
 // pattern, and 422-rejects the request without ever calling the
-// upstream. The unit-level
-// `input_guardrail_block_returns_422_and_skips_upstream` covers this
-// in process; this case proves the wire contract end-to-end (real
-// binary, real etcd watch, real OpenAI SDK surfacing the 422 as
-// APIError).
+// upstream. The OpenAI SDK surfaces the 422 as APIError; the
+// gateway emits an OpenAI-shape error envelope with
+// `error.type: "content_filter"`.
 //
 // Reference: OpenAI Chat Completions API spec
-// (https://platform.openai.com/docs/api-reference/chat/create); the
-// Guardrail schema lives at `crates/aisix-core/src/models/guardrail.rs`
-// and the keyword runtime at `crates/aisix-guardrails/src/keyword.rs`.
+// (https://platform.openai.com/docs/api-reference/chat/create) and
+// OpenAI / Azure OpenAI content-filter error type
+// (https://learn.microsoft.com/azure/ai-services/openai/concepts/content-filter).
 
 const CALLER_PLAINTEXT = "sk-gr-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -128,8 +126,8 @@ describe("guardrail e2e: keyword block returns 422 and skips upstream", () => {
     // the `content_filter` envelope before dispatch. Status alone is
     // not enough — a regression that 422'd via a different path (e.g.
     // generic input validation) would still match `status: 422`. The
-    // type field pins the contract to the guardrail specifically (see
-    // `crates/aisix-proxy/src/error.rs::ProxyError::ContentFiltered`).
+    // type field pins the contract to the guardrail specifically per
+    // the OpenAI / Azure content-filter convention.
     await expect(
       client.chat.completions.create({
         model: "gr-e2e",

--- a/tests/e2e/src/cases/openai-sdk-compat.test.ts
+++ b/tests/e2e/src/cases/openai-sdk-compat.test.ts
@@ -140,11 +140,9 @@ describe("openai SDK compat: drive gateway through real client", () => {
     // path. The absolute-count form rejects regressions that double-fire
     // or short-circuit and silently fall through to a stray route.
     expect(nonStreamUpstream.receivedRequests.length - baseline).toBe(1);
-    expect(
-      nonStreamUpstream.receivedRequests[baseline]?.path.startsWith(
-        "/v1/chat/completions",
-      ),
-    ).toBe(true);
+    expect(nonStreamUpstream.receivedRequests[baseline]?.path).toBe(
+      "/v1/chat/completions",
+    );
   });
 
   test("openai.chat.completions.create({stream:true}) — streaming", async (ctx) => {
@@ -174,30 +172,40 @@ describe("openai SDK compat: drive gateway through real client", () => {
       }
     });
 
+    // Baseline-isolate the readiness probe so the count + path
+    // assertions below measure only the test call's effect.
+    const baseline = streamUpstream.receivedRequests.length;
     const stream = await client.chat.completions.create({
       model: "sdk-compat-stream",
       messages: [{ role: "user", content: "say hello" }],
       stream: true,
     });
 
-    let collected = "";
-    let finishReason: string | null | undefined;
+    // Capture chunks in arrival order so a regression that reordered
+    // SSE events (e.g. finish_reason landing mid-stream) is visible.
+    const chunks: Array<{ content: string; finish: string | null }> = [];
     for await (const chunk of stream) {
-      const delta = chunk.choices[0]?.delta;
-      if (delta?.content) collected += delta.content;
-      finishReason ??= chunk.choices[0]?.finish_reason ?? undefined;
+      const choice = chunk.choices[0];
+      chunks.push({
+        content: choice?.delta?.content ?? "",
+        finish: choice?.finish_reason ?? null,
+      });
     }
 
     // The SDK must reconstruct the streamed text correctly — wire
     // mismatches (chunked encoding, content-type, SSE framing, [DONE]
-    // sentinel handling) would surface here with truncated `collected`
-    // or a missing finish_reason.
+    // sentinel handling) would surface here with truncated content
+    // or a missing / mid-stream finish_reason.
+    const collected = chunks.map((c) => c.content).join("");
     expect(collected).toBe("hello world");
-    expect(finishReason).toBe("stop");
-    expect(
-      streamUpstream.receivedRequests.some((r) =>
-        r.path.startsWith("/v1/chat/completions"),
-      ),
-    ).toBe(true);
+    const finishIdx = chunks.findIndex((c) => c.finish === "stop");
+    expect(finishIdx).toBeGreaterThanOrEqual(0);
+    expect(finishIdx).toBe(chunks.length - 1);
+
+    const testCalls = streamUpstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/chat/completions");
+    expect(testCalls).toHaveLength(1);
+    expect(testCalls[0]?.method).toBe("POST");
   });
 });

--- a/tests/e2e/src/cases/ratelimit-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-e2e.test.ts
@@ -12,18 +12,15 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: per-model RPM=1 rate limit. The first chat completion in a
+// E2E: per-ApiKey RPM=1 rate limit. The first chat completion in a
 // minute window succeeds; the second surfaces to the OpenAI SDK as
-// `APIError` with `.status === 429`. Pinned end-to-end (real binary,
-// real etcd watch, real OpenAI SDK with auto-retry disabled) — the
-// existing in-process `rate_limit_rpm_returns_429_with_retry_after_header`
-// covers the unit-level path; this case ensures the wire contract
-// holds for a real SDK client.
+// `APIError` with `.status === 429` and a populated `Retry-After`
+// header (the load-bearing contract for SDK exponential back-off).
 //
 // Reference: OpenAI Chat Completions API spec
-// (https://platform.openai.com/docs/api-reference/chat/create); the
-// gateway's RateLimit schema lives at
-// `crates/aisix-core/src/models/rate_limit.rs`.
+// (https://platform.openai.com/docs/api-reference/chat/create) and
+// RFC 7231 §7.1.3 for the `Retry-After` header semantics
+// (https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3).
 
 const CALLER_PLAINTEXT = "sk-rl-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -104,11 +101,10 @@ describe("rate limit e2e: RPM=1 second call gets 429", () => {
 
     // Second call within the minute → APIError with status 429 AND a
     // populated `Retry-After` header. The header is the load-bearing
-    // contract for SDK back-off (in-process counterpart is named
-    // `rate_limit_rpm_returns_429_with_retry_after_header` for a
-    // reason — drop the assertion and the test would still pass on a
-    // gateway that returned 429 with no `Retry-After`, breaking every
-    // SDK that relies on it for exponential back-off.
+    // contract for SDK back-off — drop the assertion and the test
+    // would still pass on a gateway that returned 429 with no
+    // `Retry-After`, breaking every SDK that relies on it for
+    // exponential back-off.
     let caught: unknown;
     try {
       await client.chat.completions.create({
@@ -129,6 +125,11 @@ describe("rate limit e2e: RPM=1 second call gets 429", () => {
     // is the canonical access path.
     const retryAfter = caught.headers?.["retry-after"];
     expect(retryAfter).toBeDefined();
-    expect(Number.parseInt(String(retryAfter), 10)).toBeGreaterThan(0);
+    const retryAfterSeconds = Number.parseInt(String(retryAfter), 10);
+    // RPM=1 means the window is at most 60 seconds; a value above
+    // that is either a unit confusion or a wall-clock leak. Below 1
+    // would tell the SDK to retry immediately, defeating the limit.
+    expect(retryAfterSeconds).toBeGreaterThan(0);
+    expect(retryAfterSeconds).toBeLessThanOrEqual(60);
   });
 });

--- a/tests/e2e/src/cases/smoke.test.ts
+++ b/tests/e2e/src/cases/smoke.test.ts
@@ -108,6 +108,10 @@ describe("smoke: admin write → proxy read", () => {
       const msg = JSON.stringify(probe.body);
       return !msg.includes("unknown provider_key_id");
     });
+
+    // Baseline-isolate the readiness probe so the assertion below
+    // measures only the test call's effect on the upstream.
+    const baseline = upstream.receivedRequests.length;
     const { status, body } = await proxy.chat({
       model: "smoke-gpt",
       messages: [{ role: "user", content: "hello" }],
@@ -127,13 +131,14 @@ describe("smoke: admin write → proxy read", () => {
       ]),
     });
 
-    const seen = upstream.receivedRequests.some((r) =>
-      r.path.startsWith("/v1/chat/completions"),
-    );
-    if (!seen) {
-      throw new Error(
-        `upstream did not receive /v1/chat/completions; saw paths: ${JSON.stringify(upstream.receivedRequests.map((r) => `${r.method} ${r.path}`))}`,
-      );
-    }
+    // Test call hit the upstream exactly once at the OpenAI Chat
+    // Completions path. `some()` would let a regression that double-
+    // fires (or short-circuits and leaks through a stray route)
+    // silently pass.
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/chat/completions");
+    expect(testCalls).toHaveLength(1);
+    expect(testCalls[0]?.method).toBe("POST");
   });
 });

--- a/tests/e2e/src/cases/token-usage-passthrough-e2e.test.ts
+++ b/tests/e2e/src/cases/token-usage-passthrough-e2e.test.ts
@@ -24,19 +24,17 @@ import {
 //
 // Reference: OpenAI Chat Completions API spec
 // (https://platform.openai.com/docs/api-reference/chat/create) for
-// the `usage` object shape; ai-gateway's response renderer at
-// `crates/aisix-proxy/src/render.rs` passes prompt_tokens /
-// completion_tokens / total_tokens straight through from the
-// upstream's ChatResponse.
+// the `usage` object shape (prompt_tokens / completion_tokens /
+// total_tokens).
 
 const CALLER_PLAINTEXT = "sk-tu-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
 
-// These match the mock upstream's default `nonStreamBody` in
-// `harness/upstream-openai.ts`. If that default ever changes, this
-// test will fail loudly — which is the point.
+// Test owns its fixture: explicit `nonStreamBody` below pins the
+// numbers the upstream emits, so any silent change to the harness
+// default cannot make this test pass on a regressed gateway.
 const EXPECTED_PROMPT_TOKENS = 5;
 const EXPECTED_COMPLETION_TOKENS = 3;
 const EXPECTED_TOTAL_TOKENS = 8;
@@ -51,7 +49,26 @@ describe("token usage e2e: upstream usage block reaches client byte-for-byte", (
     etcdReachable = await new EtcdClient().ping();
     if (!etcdReachable) return;
 
-    upstream = await startOpenAiUpstream();
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-tu-e2e",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: {
+          prompt_tokens: EXPECTED_PROMPT_TOKENS,
+          completion_tokens: EXPECTED_COMPLETION_TOKENS,
+          total_tokens: EXPECTED_TOTAL_TOKENS,
+        },
+      },
+    });
     app = await spawnApp();
     admin = new AdminClient(app.adminUrl, app.adminKey);
 


### PR DESCRIPTION
## Summary

Batch 1 of #151 — pure cleanup, no new test scenarios. Establishes a clean source-blind baseline before adding new e2e cases on top.

Two principles applied across the existing 9 e2e files (matrix-e2e was already source-blind from #148):

1. **Source-blind design** — assertions derive only from upstream-vendor wire docs, the gateway's published OpenAPI / response-header surface, or other external contracts. Reading product source to design assertions over-specifies the test against implementation.
2. **Test failure = code bug** — failing e2e tests should drive product fixes, not assertion weakening.

## What changed

### Category A — drop comments referencing internal Rust paths

Implementation-leaking discoverability links that signaled source-derived test design. Removed from:

- \`allowed-models-e2e.test.ts\` — \`crates/aisix-core/src/models/apikey.rs\`
- \`anthropic-upstream-e2e.test.ts\` — \`crates/aisix-proxy/src/lib.rs::matrix_openai_in_anthropic_upstream_non_streaming\`
- \`cache-policy-e2e.test.ts\` — \`crates/aisix-core/src/models/cache_policy.rs\`
- \`fallback-e2e.test.ts\` — \`crates/aisix-core/src/models/routing.rs\`
- \`guardrail-keyword-e2e.test.ts\` — \`crates/aisix-guardrails/src/keyword.rs\`, \`crates/aisix-proxy/src/error.rs::ProxyError::ContentFiltered\`
- \`ratelimit-e2e.test.ts\` — \`crates/aisix-core/src/models/rate_limit.rs\`
- \`token-usage-passthrough-e2e.test.ts\` — \`crates/aisix-proxy/src/render.rs\`

Retained: \`smoke.test.ts\` (SHA-256-of-plaintext is a published admin-API input convention) and \`openai-sdk-compat.test.ts\` (vendor SDK source IS the contract).

### Category B — tighten weakened assertions

| File | Before | After |
|------|--------|-------|
| \`smoke.test.ts\` | \`receivedRequests.some(...)\` | baseline + filter + \`length === 1\` + exact path |
| \`openai-sdk-compat.test.ts\` non-stream | \`path.startsWith(...)\` | \`path === \"/v1/chat/completions\"\` |
| \`openai-sdk-compat.test.ts\` streaming | \`some()\`, no baseline, no chunk-order pin | baseline + filter+length, capture chunks in order, \`finish_reason\` on LAST chunk |
| \`token-usage-passthrough-e2e.test.ts\` | constants coupled to harness default | explicit \`nonStreamBody\` in test fixture |
| \`allowed-models-e2e.test.ts\` | only \`status: 403\` | + \`error.type\` non-empty string + \`error.message\` doesn't contain \"not found\" (distinguish authz-block from missing-model) |
| \`ratelimit-e2e.test.ts\` | \`Retry-After > 0\` | + \`≤ 60s\` (RPM=1 window upper bound) |

## Test plan

- [x] \`npm test\` (full e2e suite) — **15/15 passing locally** (unchanged green count, fewer silent passes on hypothetical regressions)
- [x] No mock-data-only paths: each case still exercises the real \`aisix\` binary, real etcd config propagation, and real OpenAI Node SDK reverse-call client
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test validations for error handling, upstream routing, and response contracts.
  * Improved test precision for streaming responses and rate-limit header verification.
  * Strengthened determinism in token usage tracking tests.
  * Updated test documentation for clarity on expected gateway behavior across caching, guardrails, and fallback scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->