### PR TITLE
test(e2e): user-journey gaps batch 2a — auth baseline + fallback edges + cache miss (#151)

### DIFF
--- a/tests/e2e/src/cases/auth-baseline-e2e.test.ts
+++ b/tests/e2e/src/cases/auth-baseline-e2e.test.ts
@@ -1,0 +1,226 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: caller-authentication baseline. The four user journeys
+// pinned here are the gateway's entry contract — every other
+// e2e test assumes the caller is authenticated, but nothing
+// previously verified what happens when the auth handshake fails.
+//
+// Pinned scenarios (all caller-side, all expecting an OpenAI-shape
+// error envelope without the upstream ever being touched):
+//
+//   1. No `Authorization` header at all
+//   2. `Authorization` header present but malformed (not `Bearer …`)
+//   3. `Bearer <plaintext>` where the plaintext is not a registered
+//      ApiKey hash
+//   4. The admin API rejects a wrong admin bearer
+//
+// Reference:
+// - OpenAI Chat Completions API spec
+//   <https://platform.openai.com/docs/api-reference/chat/create>
+// - OpenAI authentication doc
+//   <https://platform.openai.com/docs/api-reference/authentication>
+// - RFC 6750 §3 Bearer token error format
+//   <https://datatracker.ietf.org/doc/html/rfc6750#section-3>
+
+const VALID_PLAINTEXT = "sk-auth-baseline-valid";
+const VALID_KEY_HASH = createHash("sha256")
+  .update(VALID_PLAINTEXT)
+  .digest("hex");
+const UNKNOWN_PLAINTEXT = "sk-auth-baseline-unregistered";
+
+describe("auth baseline e2e: missing/malformed/unknown bearer all fail closed", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // A single Model + ProviderKey + ApiKey configured. The valid
+    // ApiKey is what makes the negative cases meaningful: failing
+    // auth must happen even though a valid key exists; failing auth
+    // must NOT degrade to "any-key-works".
+    const pk = await admin.createProviderKey({
+      display_name: "auth-baseline-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "auth-baseline",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: VALID_KEY_HASH,
+      allowed_models: ["auth-baseline"],
+    });
+
+    // Confirm config has propagated by exercising the happy path
+    // with the valid bearer once. If this never goes 200, the
+    // negative tests below would race against propagation and
+    // produce 401-from-no-snapshot rather than 401-from-bad-auth.
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${VALID_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "auth-baseline",
+          messages: [{ role: "user", content: "ready-probe" }],
+        }),
+      });
+      await res.text();
+      return res.status === 200;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("missing Authorization header → 401, upstream untouched", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "auth-baseline",
+        messages: [{ role: "user", content: "no auth header" }],
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: { type?: unknown; message?: unknown } };
+    // OpenAI error envelope: `error.type` is a non-empty string,
+    // `error.message` is human-readable. Don't pin specific values
+    // (the gateway's exact vocabulary is its own contract); just
+    // verify the SDK-required shape is honoured.
+    expect(typeof body.error?.type).toBe("string");
+    expect((body.error?.type as string).length).toBeGreaterThan(0);
+    expect(typeof body.error?.message).toBe("string");
+    expect((body.error?.message as string).length).toBeGreaterThan(0);
+
+    // Hard contract: an unauthenticated request must never reach
+    // the upstream. A regression that authenticated post-dispatch
+    // (or that 401'd only after burning an upstream call) would
+    // inflate this counter.
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+  });
+
+  test("malformed Authorization (not 'Bearer …') → 401, upstream untouched", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    // Three malformed shapes a real client might emit by accident:
+    // raw token (no scheme), wrong scheme (Basic), and Bearer with
+    // empty token. Per RFC 6750, only `Bearer <token>` is valid for
+    // OpenAI-compatible APIs.
+    const malformed = [
+      VALID_PLAINTEXT, // raw, no scheme
+      `Basic ${Buffer.from(`${VALID_PLAINTEXT}:`).toString("base64")}`, // wrong scheme
+      "Bearer ", // empty token
+    ];
+
+    for (const auth of malformed) {
+      const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: auth,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "auth-baseline",
+          messages: [{ role: "user", content: "malformed auth" }],
+        }),
+      });
+      expect(res.status, `auth=${JSON.stringify(auth)}`).toBe(401);
+      await res.text();
+    }
+
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+  });
+
+  test("Bearer with unregistered token → 401 (distinct from 403 disallowed-model)", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${UNKNOWN_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        // Targets a registered model — this rules out "401 because
+        // we couldn't even resolve the model" and pins that the
+        // 401 originates from the auth layer specifically.
+        model: "auth-baseline",
+        messages: [{ role: "user", content: "unknown caller key" }],
+      }),
+    });
+
+    // 401 (not 403) is the correct status: 403 is reserved for
+    // "authenticated but not authorized for this resource", which
+    // is what allowed-models-e2e covers. A regression that 403'd
+    // here would be visible to clients as "your key works but you
+    // can't use this model" — misleading and would mask key-rotation
+    // mistakes during incident response.
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: { type?: unknown } };
+    expect(typeof body.error?.type).toBe("string");
+
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+  });
+
+  test("admin API rejects wrong admin bearer → 401", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await fetch(`${app.adminUrl}/admin/v1/models`, {
+      method: "GET",
+      headers: { authorization: "Bearer not-the-admin-key" },
+    });
+    expect(res.status).toBe(401);
+    await res.text();
+
+    // No bearer at all — same outcome.
+    const noAuthRes = await fetch(`${app.adminUrl}/admin/v1/models`, {
+      method: "GET",
+    });
+    expect(noAuthRes.status).toBe(401);
+    await noAuthRes.text();
+  });
+});

--- a/tests/e2e/src/cases/auth-baseline-e2e.test.ts
+++ b/tests/e2e/src/cases/auth-baseline-e2e.test.ts
@@ -197,8 +197,20 @@ describe("auth baseline e2e: missing/malformed/unknown bearer all fail closed", 
     // can't use this model" — misleading and would mask key-rotation
     // mistakes during incident response.
     expect(res.status).toBe(401);
-    const body = (await res.json()) as { error?: { type?: unknown } };
+    const body = (await res.json()) as {
+      error?: { type?: unknown; message?: unknown };
+    };
     expect(typeof body.error?.type).toBe("string");
+    // Discriminate auth-layer 401 from a snapshot-not-loaded 401 or
+    // a model-resolution 401. Same envelope-discrimination pattern
+    // allowed-models-e2e uses. The error message must NOT read like
+    // "model not found" — that would mean the test passed because
+    // the gateway couldn't even resolve the model, not because the
+    // auth layer rejected the unregistered token.
+    expect(typeof body.error?.message).toBe("string");
+    expect((body.error?.message as string).toLowerCase()).not.toContain(
+      "not found",
+    );
 
     expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
   });

--- a/tests/e2e/src/cases/cache-scenarios-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-scenarios-e2e.test.ts
@@ -123,14 +123,16 @@ describe("cache scenarios e2e: different prompt → miss", () => {
     // Caller-observable header signal: each MISS must be marked as
     // such. A stale-cache regression that hit on every prompt would
     // emit `hit` here while still using the wrong cached answer.
+    // Pin upstream count too — a regression that served from cache
+    // but reported `miss` in the header would slip past a header-
+    // only check.
+    const headerCheckBaseline = upstream.receivedRequests.length;
     const headerCheckHeaders = {
       authorization: `Bearer ${CALLER_PLAINTEXT}`,
       "content-type": "application/json",
     };
-    for (const prompt of [
-      "header-prompt-A",
-      "header-prompt-B",
-    ]) {
+    const headerPrompts = ["header-prompt-A", "header-prompt-B"];
+    for (const prompt of headerPrompts) {
       const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
         method: "POST",
         headers: headerCheckHeaders,
@@ -143,6 +145,9 @@ describe("cache scenarios e2e: different prompt → miss", () => {
       expect(res.headers.get("x-aisix-cache")).toBe("miss");
       await res.text();
     }
+    expect(upstream.receivedRequests.length - headerCheckBaseline).toBe(
+      headerPrompts.length,
+    );
   });
 
 });

--- a/tests/e2e/src/cases/cache-scenarios-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-scenarios-e2e.test.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: cache scenarios beyond the identical-prompt happy path.
+// The existing cache-policy-e2e covers "identical request → hit";
+// this file fills the opposing user journey:
+//
+//   - Different prompt → MISS — proves the cache fingerprint isn't
+//     a trivial always-hit (a regression that fingerprinted on
+//     anything constant would silently turn every request into a
+//     hit, returning stale answers to different questions).
+//
+// (The "policy enabled=false → bypass" case is tracked as a
+// separate test pending a product fix; see follow-up issue.)
+//
+// Reference: OpenAI Chat Completions API spec
+// (https://platform.openai.com/docs/api-reference/chat/create) for
+// the request/response shape; the gateway's `x-aisix-cache:
+// hit|miss|disabled` response header is its own published contract
+// (depended on by cp-api / dashboard `/logs`).
+
+const CALLER_PLAINTEXT = "sk-cache-scen-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("cache scenarios e2e: different prompt → miss", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  // Each test owns its own upstream + Model so request-count assertions
+  // are isolated across cases.
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("different prompt → MISS (cache fingerprint reflects the request)", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startOpenAiUpstream();
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "cache-diff-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "cache-diff",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.json("POST", "/admin/v1/cache_policies", {
+      name: "cache-diff-policy",
+      enabled: true,
+      applies_to: "all",
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: "cache-diff",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    // Send three DIFFERENT prompts back-to-back. Each should be a
+    // cache miss because the fingerprint is supposed to include the
+    // prompt content. A regression that hashed on (model, caller)
+    // alone would turn the second + third call into hits and the
+    // upstream would only see one request — caller would receive
+    // the FIRST prompt's answer for the next two prompts.
+    const prompts = ["question one", "question two", "question three"];
+    for (const prompt of prompts) {
+      await client.chat.completions.create({
+        model: "cache-diff",
+        messages: [{ role: "user", content: prompt }],
+      });
+    }
+    expect(upstream.receivedRequests.length - baseline).toBe(prompts.length);
+
+    // Caller-observable header signal: each MISS must be marked as
+    // such. A stale-cache regression that hit on every prompt would
+    // emit `hit` here while still using the wrong cached answer.
+    const headerCheckHeaders = {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    };
+    for (const prompt of [
+      "header-prompt-A",
+      "header-prompt-B",
+    ]) {
+      const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: headerCheckHeaders,
+        body: JSON.stringify({
+          model: "cache-diff",
+          messages: [{ role: "user", content: prompt }],
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-aisix-cache")).toBe("miss");
+      await res.text();
+    }
+  });
+
+});

--- a/tests/e2e/src/cases/fallback-edges-e2e.test.ts
+++ b/tests/e2e/src/cases/fallback-edges-e2e.test.ts
@@ -1,0 +1,310 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: routing failover edge cases. The existing fallback-e2e covers
+// the happy path (5xx → fallback → 200). Two real user pain points
+// that prior coverage didn't pin:
+//
+//   1. Non-retryable client errors (400 bad request) MUST NOT trigger
+//      fallback. The caller's bug should surface immediately, not get
+//      silently re-routed to a different upstream that might 200 on a
+//      different prompt — that would mask request bugs and is a real
+//      production debugging trap.
+//
+//   2. When all targets fail, the caller must see a clean error
+//      envelope. Hangs or generic 500s break SDK error-handling
+//      assumptions.
+//
+// Reference: OpenAI Chat Completions API spec
+// (https://platform.openai.com/docs/api-reference/chat/create) for
+// the request/response shape; the gateway's fallback policy is its
+// own contract.
+
+const CALLER_PLAINTEXT = "sk-fb-edges-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("fallback edge cases e2e", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  // Each test sets up its own pair/triple of mock upstreams so the
+  // request-count assertions stay isolated across cases.
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // Wildcard ApiKey lets the same caller reach every per-test
+    // virtual model without re-issuing keys.
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("non-retryable 4xx (400) does NOT trigger fallback — caller sees the 4xx", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    // First target returns a 400 with an OpenAI-shape error envelope.
+    // The point of fallback is to insulate callers from upstream
+    // *infrastructure* failures (timeouts, 5xx, connection resets) —
+    // not from the caller's own bad input. A 400 means "your request
+    // is malformed"; falling over to a different upstream and getting
+    // a 200 there would tell the caller "you know what, try again, it
+    // worked the second time" — which is misleading.
+    const badRequestUpstream = await startOpenAiUpstream({
+      status: 400,
+      errorBody: {
+        error: {
+          message: "Invalid 'model' parameter",
+          type: "invalid_request_error",
+          code: "invalid_model",
+        },
+      },
+    });
+    const goodUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-good",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "should NOT be reached" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    upstreams.push(badRequestUpstream, goodUpstream);
+
+    const badPk = await admin.createProviderKey({
+      display_name: "fb-edges-400-pk",
+      secret: "sk-mock",
+      api_base: `${badRequestUpstream.baseUrl}/v1`,
+    });
+    const goodPk = await admin.createProviderKey({
+      display_name: "fb-edges-400-good-pk",
+      secret: "sk-mock",
+      api_base: `${goodUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "fb-edges-400-bad",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: badPk.id,
+    });
+    await admin.createModel({
+      display_name: "fb-edges-400-good",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: goodPk.id,
+    });
+    await admin.createModel({
+      display_name: "fb-edges-400-virtual",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "fb-edges-400-bad" },
+          { model: "fb-edges-400-good" },
+        ],
+      },
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: "fb-edges-400-good",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const badBaseline = badRequestUpstream.receivedRequests.length;
+    const goodBaseline = goodUpstream.receivedRequests.length;
+
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
+        model: "fb-edges-400-virtual",
+        messages: [{ role: "user", content: "trigger 400" }],
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    // The caller MUST see the 400 propagated, not a 200 from the
+    // fallback target. If the gateway silently re-routed, this
+    // assertion would fail because the call would have succeeded.
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      throw new Error("unreachable: caught is not APIError");
+    }
+    expect(caught.status).toBe(400);
+
+    // Bad target was called exactly once (the dispatch attempt).
+    // Good target was NOT called: a 4xx is not a retryable signal,
+    // so dispatch must short-circuit instead of walking the list.
+    expect(badRequestUpstream.receivedRequests.length - badBaseline).toBe(1);
+    expect(goodUpstream.receivedRequests.length - goodBaseline).toBe(0);
+  });
+
+  test("all targets fail → caller sees a clean error envelope, not hang", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    // Both targets return retryable 5xx — fallback walks the list,
+    // exhausts options, must surface a clean error to the caller.
+    // A regression that hung indefinitely or returned a non-OpenAI-
+    // shape generic 500 would break SDK error handling.
+    const bad1 = await startOpenAiUpstream({
+      status: 503,
+      errorBody: { error: { message: "bad1 down", type: "server_error" } },
+    });
+    const bad2 = await startOpenAiUpstream({
+      status: 502,
+      errorBody: { error: { message: "bad2 down", type: "server_error" } },
+    });
+    upstreams.push(bad1, bad2);
+
+    const pk1 = await admin.createProviderKey({
+      display_name: "fb-edges-allfail-1-pk",
+      secret: "sk-mock",
+      api_base: `${bad1.baseUrl}/v1`,
+    });
+    const pk2 = await admin.createProviderKey({
+      display_name: "fb-edges-allfail-2-pk",
+      secret: "sk-mock",
+      api_base: `${bad2.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "fb-edges-allfail-1",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk1.id,
+    });
+    await admin.createModel({
+      display_name: "fb-edges-allfail-2",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk2.id,
+    });
+    await admin.createModel({
+      display_name: "fb-edges-allfail-virtual",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "fb-edges-allfail-1" },
+          { model: "fb-edges-allfail-2" },
+        ],
+      },
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      // Aggressive timeout: if the gateway hangs instead of
+      // returning a clean error, the SDK will time out and that's
+      // also a test failure (just a slower one).
+      timeout: 10_000,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      // Probe via the virtual model directly. Both real targets are
+      // down; the only positive outcome the test cares about is the
+      // routing block being loaded so the dispatcher can walk both
+      // targets. A 5xx from the SDK proves snapshot is loaded; a
+      // 4xx (e.g. unknown model) means routing config hasn't landed
+      // yet.
+      try {
+        await client.chat.completions.create({
+          model: "fb-edges-allfail-virtual",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return false; // unexpected 200
+      } catch (e) {
+        return e instanceof APIError && (e.status ?? 0) >= 500;
+      }
+    });
+
+    const bad1Baseline = bad1.receivedRequests.length;
+    const bad2Baseline = bad2.receivedRequests.length;
+
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
+        model: "fb-edges-allfail-virtual",
+        messages: [{ role: "user", content: "all should fail" }],
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      throw new Error("unreachable: caught is not APIError");
+    }
+    // 5xx is the correct family: dispatch was attempted, all upstreams
+    // failed, the gateway gives up and reports a server-side error.
+    // Anything in the 4xx family would mislead callers into thinking
+    // their request was malformed.
+    expect(caught.status).toBeGreaterThanOrEqual(500);
+    expect(caught.status).toBeLessThan(600);
+
+    // OpenAI-shape error envelope: `error.type` and `error.message`
+    // both populated. A regression that surfaced a Rust panic
+    // wrapped in a generic Axum 500 would have empty / missing
+    // fields here.
+    expect(typeof caught.error).toBe("object");
+    const errType = (caught.error as { type?: unknown })?.type;
+    const errMsg = (caught.error as { message?: unknown })?.message;
+    expect(typeof errType).toBe("string");
+    expect((errType as string).length).toBeGreaterThan(0);
+    expect(typeof errMsg).toBe("string");
+    expect((errMsg as string).length).toBeGreaterThan(0);
+
+    // Both targets were tried exactly once each (the failover walk).
+    // A regression that bailed after the first failure (or hammered
+    // the same target twice) would inflate / deflate these counts.
+    expect(bad1.receivedRequests.length - bad1Baseline).toBe(1);
+    expect(bad2.receivedRequests.length - bad2Baseline).toBe(1);
+  });
+});

--- a/tests/e2e/src/cases/fallback-edges-e2e.test.ts
+++ b/tests/e2e/src/cases/fallback-edges-e2e.test.ts
@@ -147,11 +147,31 @@ describe("fallback edge cases e2e", () => {
       try {
         await client.chat.completions.create({
           model: "fb-edges-400-good",
-          messages: [{ role: "user", content: "ready-probe" }],
+          messages: [{ role: "user", content: "ready-probe-good" }],
         });
         return true;
       } catch {
         return false;
+      }
+    });
+    // Second propagation gate on the virtual model itself. Without
+    // this, a slow CI that loaded `fb-edges-400-good` first but
+    // hadn't yet registered the routing block could still emit a
+    // 400 here — but from "unknown virtual model", not from the bad
+    // target's 400 the test is meant to verify. The "good upstream
+    // count == 0" assertion would then trivially pass on a broken
+    // gateway. The expected outcome here is APIError 400 (the bad
+    // target propagating up); 200 means the bad target wasn't
+    // tried, which is the wrong config state.
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: "fb-edges-400-virtual",
+          messages: [{ role: "user", content: "ready-probe-virtual" }],
+        });
+        return false; // 200 means bad target wasn't reached
+      } catch (e) {
+        return e instanceof APIError && e.status === 400;
       }
     });
 
@@ -176,6 +196,14 @@ describe("fallback edge cases e2e", () => {
       throw new Error("unreachable: caught is not APIError");
     }
     expect(caught.status).toBe(400);
+    // Disambiguate "bad target's 400 propagated" from "unknown
+    // virtual model 400" — same envelope-discrimination pattern
+    // allowed-models-e2e uses. The bad target's mock body declares
+    // type `invalid_request_error`; a "model not found" 400 would
+    // contain that phrase in the message.
+    const errMsg = (caught.error as { message?: unknown })?.message;
+    expect(typeof errMsg).toBe("string");
+    expect((errMsg as string).toLowerCase()).not.toContain("not found");
 
     // Bad target was called exactly once (the dispatch attempt).
     // Good target was NOT called: a 4xx is not a retryable signal,
@@ -240,10 +268,11 @@ describe("fallback edge cases e2e", () => {
     const client = new OpenAI({
       apiKey: CALLER_PLAINTEXT,
       baseURL: `${app.proxyUrl}/v1`,
-      // Aggressive timeout: if the gateway hangs instead of
-      // returning a clean error, the SDK will time out and that's
-      // also a test failure (just a slower one).
-      timeout: 10_000,
+      // 30s leaves headroom for dispatch + retry walk + envelope
+      // render even on a constrained CI runner; small enough that
+      // a true gateway hang still surfaces as a test failure within
+      // a reasonable bound rather than running indefinitely.
+      timeout: 30_000,
       maxRetries: 0,
     });
 


### PR DESCRIPTION
## Summary

Batch 2a of #151. Adds **7 new e2e cases across 3 new files** covering high-pain user journeys that prior coverage left unverified.

Two more cases drafted for this batch surfaced **real product bugs** while running and are held back as batch 2b until the product fixes land:

- 🐛 #153 — output guardrail's caller-visible error message echoes the matched forbidden literal back (information leak)
- 🐛 #154 — \`CachePolicy{enabled: false}\` still caches and reports \`x-aisix-cache: miss\` instead of \`disabled\`

Both bug issues have draft test code attached for the regression verification once fixed. Per the source-blind discipline (#151 Cat C / CLAUDE.md §5), failing tests are interpreted as product bugs to fix, not assertions to weaken.

## What's in this PR

### C1 — Auth/identity baseline (\`auth-baseline-e2e.test.ts\`, 4 cases)

The gateway's entry contract had **zero e2e coverage** before this. Every other e2e test assumed auth worked; now the handshake itself is pinned.

- [x] Missing \`Authorization\` header → 401 with OpenAI-shape error envelope, upstream untouched
- [x] Malformed \`Authorization\` (raw token / wrong scheme / empty bearer) → 401 in all three shapes, upstream untouched
- [x] \`Bearer\` with unregistered token → **401, not 403** (distinct from disallowed-model — important for incident-response clarity: rotated-key bugs should look like auth failures, not authz failures)
- [x] Wrong admin bearer on admin API → 401

### C2 — Fallback edge cases (\`fallback-edges-e2e.test.ts\`, 2 cases)

Existing \`fallback-e2e.test.ts\` only covered the 5xx → fallback happy path. Two real production-debugging traps now pinned:

- [x] **Non-retryable 4xx does NOT trigger fallback** — caller sees the 400 directly. A silent re-route to a different upstream that 200s on the same prompt would mask request bugs and is a real production debugging trap.
- [x] **All targets fail → clean error**, not hang or generic 500. Caller sees 5xx with populated OpenAI-shape \`error.type\` / \`error.message\`. Both targets tried exactly once.

### C4 — Cache scenarios (\`cache-scenarios-e2e.test.ts\`, 1 case)

Existing \`cache-policy-e2e.test.ts\` only covered identical-prompt → hit. Filling the inverse:

- [x] Three distinct prompts → 3 upstream hits + 3 \`x-aisix-cache: miss\` headers. A regression that fingerprinted on \`(model, caller)\` independent of prompt content would silently return one prompt's answer for all three.

## Source-blind discipline

Every assertion in this PR derives from external contracts:
- Status codes per OpenAI / RFC 6750 (\`401\` for missing-auth, \`401\` for bad-bearer)
- Error envelope shape per OpenAI Chat Completions spec
- \`x-aisix-cache\` header values per the gateway's published header doc (referenced in \`cache-policy-e2e.test.ts\`)
- No internal Rust paths or struct field names referenced.

## Independent audit

Per CLAUDE.md §8, an independent audit agent reviewed the initial commit (fae569f). Resolution log:

| Finding | Severity | Resolution |
|---------|----------|------------|
| fb-edges-400 propagation race — \`fb-edges-400-virtual\` not gated could let "unknown model 400" masquerade as bad-target 400 | HIGH | Added second propagation gate + envelope discrimination via \`not.toContain("not found")\` (4cd97f7) |
| auth-baseline unregistered-token 401 doesn't disambiguate from snapshot-not-loaded 401 | HIGH | Added \`error.message\` envelope discrimination (4cd97f7) |
| All-fail SDK timeout 10s borderline on slow CI | MEDIUM | Bumped to 30s (4cd97f7) |
| Cache header-fetch pair didn't pin upstream count | MEDIUM | Added \`headerCheckBaseline\` + length assertion (4cd97f7) |
| Probe loop SDK version concern (\`APIConnectionError extends APIError\`) | MEDIUM | Non-issue — repo pins \`openai 4.65.0\` where the inheritance holds |
| L1-L4 informational | LOW | Not addressed (not blocking) |

## Test plan

- [x] \`npm test\` (full e2e suite) — **22/22 passing locally** (was 15)
- [x] No mock-data-only paths: each case still exercises the real \`aisix\` binary, real etcd config propagation, and real OpenAI Node SDK / fetch reverse-call client
- [ ] CI green