### PR TITLE
ci: migrate runners to ubicloud-standard-2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   lint:
     name: lint (fmt + clippy)
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -30,7 +30,7 @@ jobs:
 
   rust-unit:
     name: rust unit + coverage
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     services:
       redis:
         image: redis:7-alpine
@@ -87,7 +87,7 @@ jobs:
 
   build-bin:
     name: build aisix (instrumented)
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     env:
       RUSTFLAGS: "-C instrument-coverage"
       LLVM_PROFILE_FILE: "coverage/aisix-%p-%m.profraw"
@@ -113,7 +113,7 @@ jobs:
   e2e:
     name: e2e (vitest) + coverage
     needs: [build-bin]
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     # Soft gate while the harness stabilises across CI runners (etcd
     # service startup, port detection, undici quirks). Flip to `false`
     # once we have ~5 consecutive green runs on main.
@@ -169,7 +169,7 @@ jobs:
   coverage-gate:
     name: coverage >= 90%
     needs: [rust-unit, e2e]
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Switch all 5 jobs in `.github/workflows/ci.yml` (`lint`, `rust-unit`, `build-bin`, `e2e`, `coverage-gate`) from `ubuntu-latest` to `ubicloud-standard-2`, matching AISIX-Cloud's CI runner.
- Pure runner swap. No changes to the job graph, `services:` (redis / etcd), cache config (`Swatinem/rust-cache@v2`), coverage gate, or any step.
- `docker-image.yml` is intentionally left on `ubuntu-latest` — out of scope for this PR.

## Why
AISIX-Cloud already runs on `ubicloud-standard-2`. Aligning ai-gateway gives us consistent runner infra across both repos.

## Test plan
- [ ] All 5 jobs run on `ubicloud-standard-2` and complete successfully
- [ ] `services.redis` and `services.etcd` containers come up and are reachable on the ubicloud runner (port 6379 / 2379)
- [ ] `Swatinem/rust-cache` first run is a cold miss (expected); subsequent runs hit cache
- [ ] `arduino/setup-protoc` and `taiki-e/install-action@cargo-llvm-cov` install cleanly
- [ ] `pnpm` e2e job picks up the artifact and runs (current `continue-on-error: true` still applies — soft gate)
- [ ] Coverage artifact upload/download chain works across the new runner