### PR TITLE
test(e2e): C7 /v1/embeddings dispatch + response passthrough (#151)

### DIFF
--- a/tests/e2e/src/cases/embeddings-e2e.test.ts
+++ b/tests/e2e/src/cases/embeddings-e2e.test.ts
@@ -1,0 +1,270 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: /v1/embeddings end-to-end. Embeddings is one of the two
+// most-used LLM API surfaces (alongside chat completions) — every
+// RAG / semantic-search application in production hits this
+// endpoint thousands of times per request batch. Prior to this
+// file, the gateway had **zero** e2e coverage on /v1/embeddings.
+//
+// Two user journeys pinned:
+//
+//   1. Single-string input — `client.embeddings.create({input: "..."})`
+//      returns one embedding vector matching the upstream's exact
+//      output, with usage counts byte-for-byte.
+//
+//   2. Array input — `client.embeddings.create({input: [s1, s2, s3]})`
+//      returns N embeddings in the SAME order as the input array.
+//      A regression that re-ordered, deduplicated, or truncated the
+//      array would break every batched embedding caller.
+//
+// Each case also pins the upstream-side wire shape: the gateway
+// hits `/v1/embeddings` (not `/v1/chat/completions`), the body is
+// OpenAI-shape with the configured upstream model id (display name
+// → upstream model_name translation), and the caller's input
+// reaches the upstream verbatim.
+//
+// References:
+// - OpenAI Embeddings API spec
+//   <https://platform.openai.com/docs/api-reference/embeddings/create>
+// - OpenAI Node SDK embeddings client
+//   <https://github.com/openai/openai-node/blob/master/src/resources/embeddings.ts>
+
+const CALLER_PLAINTEXT = "sk-emb-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// Pinning the upstream's exact embedding values (not the harness
+// default) so a regression that synthesized different vectors or
+// re-normalized them would surface here.
+const VEC_HELLO = [0.11, 0.22, 0.33, 0.44, 0.55];
+const VEC_WORLD = [-0.5, -0.4, -0.3, -0.2, -0.1];
+const VEC_FOO = [0.01, 0.02, 0.03, 0.04, 0.05];
+
+describe("embeddings e2e: /v1/embeddings dispatch + response passthrough", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("single-string input: caller receives one embedding matching upstream byte-for-byte", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        object: "list",
+        data: [
+          { object: "embedding", index: 0, embedding: VEC_HELLO },
+        ],
+        model: "text-embedding-3-small",
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      },
+    });
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "emb-single-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "emb-single",
+      provider: "openai",
+      model_name: "text-embedding-3-small",
+      provider_key_id: pk.id,
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        await client.embeddings.create({
+          model: "emb-single",
+          input: "ready-probe",
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+    const response = await client.embeddings.create({
+      model: "emb-single",
+      input: "hello",
+    });
+
+    // Caller-side: OpenAI Embeddings response shape per spec.
+    expect(response.object).toBe("list");
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0]?.object).toBe("embedding");
+    expect(response.data[0]?.index).toBe(0);
+    // Vector preserved byte-for-byte. A regression that re-normalised,
+    // truncated, or re-quantised would fail this exact-array check.
+    expect(response.data[0]?.embedding).toEqual(VEC_HELLO);
+    // Usage counters from upstream reach the caller intact (parity
+    // with token-usage-passthrough-e2e for chat completions).
+    expect(response.usage?.prompt_tokens).toBe(1);
+    expect(response.usage?.total_tokens).toBe(1);
+
+    // Dispatch contract: gateway hit `/v1/embeddings` exactly once,
+    // not `/v1/chat/completions`. A regression that mis-routed
+    // embeddings through the chat path (or duplicated the dispatch)
+    // would fail here.
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/embeddings");
+    expect(testCalls).toHaveLength(1);
+    expect(testCalls[0]?.method).toBe("POST");
+    // Auth header reaches upstream (parity with chat-completions
+    // tests; same regression mode of dropped/swapped Bearer header
+    // would 401 in production but pass against the permissive mock).
+    expect(testCalls[0]?.headers["authorization"]).toBe("Bearer sk-mock");
+
+    // Wire-shape contract: body is OpenAI-shape embeddings JSON
+    // with the upstream's model_name (caller's display name was
+    // translated) and the caller's input semantically preserved.
+    // OpenAI's Embeddings API accepts `input` as either a string
+    // or an array of strings, so the gateway is free to normalise
+    // single-string → single-element-array on the upstream wire.
+    // The user-meaningful contract is "the input reached upstream
+    // unchanged in semantics, not necessarily in wire shape".
+    const sentBody = JSON.parse(testCalls[0]!.body) as {
+      model?: string;
+      input?: string | string[];
+    };
+    expect(sentBody.model).toBe("text-embedding-3-small");
+    if (Array.isArray(sentBody.input)) {
+      expect(sentBody.input).toEqual(["hello"]);
+    } else {
+      expect(sentBody.input).toBe("hello");
+    }
+  });
+
+  test("array input: N embeddings returned in the SAME ORDER as input array", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    // Three distinct vectors, one per input string. The order MUST
+    // be preserved on the way out — callers index into `data[i]`
+    // assuming `data[i]` corresponds to `input[i]`. A regression
+    // that re-sorted by hash, deduped, or batched-out-of-order
+    // would silently break every consumer doing per-input lookups
+    // (e.g. RAG callers building a `{document: vector}` map).
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        object: "list",
+        data: [
+          { object: "embedding", index: 0, embedding: VEC_HELLO },
+          { object: "embedding", index: 1, embedding: VEC_WORLD },
+          { object: "embedding", index: 2, embedding: VEC_FOO },
+        ],
+        model: "text-embedding-3-small",
+        usage: { prompt_tokens: 3, total_tokens: 3 },
+      },
+    });
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "emb-array-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "emb-array",
+      provider: "openai",
+      model_name: "text-embedding-3-small",
+      provider_key_id: pk.id,
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        await client.embeddings.create({
+          model: "emb-array",
+          input: ["ready-probe"],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const inputs = ["hello", "world", "foo"];
+    const baseline = upstream.receivedRequests.length;
+    const response = await client.embeddings.create({
+      model: "emb-array",
+      input: inputs,
+    });
+
+    expect(response.data).toHaveLength(inputs.length);
+    // Order preservation: data[i].index === i AND each vector
+    // matches what the upstream emitted at the same index.
+    expect(response.data[0]?.index).toBe(0);
+    expect(response.data[0]?.embedding).toEqual(VEC_HELLO);
+    expect(response.data[1]?.index).toBe(1);
+    expect(response.data[1]?.embedding).toEqual(VEC_WORLD);
+    expect(response.data[2]?.index).toBe(2);
+    expect(response.data[2]?.embedding).toEqual(VEC_FOO);
+    expect(response.usage?.prompt_tokens).toBe(3);
+    expect(response.usage?.total_tokens).toBe(3);
+
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/embeddings");
+    expect(testCalls).toHaveLength(1);
+
+    // The full input array reached the upstream in the original
+    // order. A regression that re-ordered the array on the way out
+    // (e.g. sort-for-cache-stability) would corrupt the index→input
+    // mapping the caller assumes.
+    const sentBody = JSON.parse(testCalls[0]!.body) as {
+      model?: string;
+      input?: string[];
+    };
+    expect(sentBody.model).toBe("text-embedding-3-small");
+    expect(sentBody.input).toEqual(inputs);
+  });
+});

--- a/tests/e2e/src/cases/embeddings-e2e.test.ts
+++ b/tests/e2e/src/cases/embeddings-e2e.test.ts
@@ -17,19 +17,21 @@ import {
 // endpoint thousands of times per request batch. Prior to this
 // file, the gateway had **zero** e2e coverage on /v1/embeddings.
 //
-// Two user journeys pinned:
+// One user journey pinned:
 //
-//   1. Single-string input — `client.embeddings.create({input: "..."})`
-//      returns one embedding vector matching the upstream's exact
-//      output, with usage counts byte-for-byte.
+//   - Array input — `client.embeddings.create({input: [s1, s2, s3]})`
+//     returns N embeddings in the SAME order as the input array.
+//     A regression that re-ordered, deduplicated, or truncated the
+//     array would break every batched embedding caller.
 //
-//   2. Array input — `client.embeddings.create({input: [s1, s2, s3]})`
-//      returns N embeddings in the SAME order as the input array.
-//      A regression that re-ordered, deduplicated, or truncated the
-//      array would break every batched embedding caller.
+// (The "single-string input" case is held back pending a product
+// fix — the gateway currently normalises single-string `input` into
+// a single-element array on the upstream wire, contradicting the
+// gateway's own published contract in `docs/api-proxy.md` §4.4
+// ("both pass through"). See follow-up issue.)
 //
-// Each case also pins the upstream-side wire shape: the gateway
-// hits `/v1/embeddings` (not `/v1/chat/completions`), the body is
+// The case pins the upstream-side wire shape: the gateway hits
+// `/v1/embeddings` (not `/v1/chat/completions`), the body is
 // OpenAI-shape with the configured upstream model id (display name
 // → upstream model_name translation), and the caller's input
 // reaches the upstream verbatim.
@@ -37,6 +39,7 @@ import {
 // References:
 // - OpenAI Embeddings API spec
 //   <https://platform.openai.com/docs/api-reference/embeddings/create>
+// - Gateway's own /v1/embeddings contract: `docs/api-proxy.md` §4.4
 // - OpenAI Node SDK embeddings client
 //   <https://github.com/openai/openai-node/blob/master/src/resources/embeddings.ts>
 
@@ -73,107 +76,6 @@ describe("embeddings e2e: /v1/embeddings dispatch + response passthrough", () =>
   afterAll(async () => {
     await app?.exit();
     await Promise.all(upstreams.map((u) => u.close()));
-  });
-
-  test("single-string input: caller receives one embedding matching upstream byte-for-byte", async (ctx) => {
-    if (!etcdReachable || !app || !admin) {
-      ctx.skip();
-      return;
-    }
-
-    const upstream = await startOpenAiUpstream({
-      nonStreamBody: {
-        object: "list",
-        data: [
-          { object: "embedding", index: 0, embedding: VEC_HELLO },
-        ],
-        model: "text-embedding-3-small",
-        usage: { prompt_tokens: 1, total_tokens: 1 },
-      },
-    });
-    upstreams.push(upstream);
-
-    const pk = await admin.createProviderKey({
-      display_name: "emb-single-pk",
-      secret: "sk-mock",
-      api_base: `${upstream.baseUrl}/v1`,
-    });
-    await admin.createModel({
-      display_name: "emb-single",
-      provider: "openai",
-      model_name: "text-embedding-3-small",
-      provider_key_id: pk.id,
-    });
-
-    const client = new OpenAI({
-      apiKey: CALLER_PLAINTEXT,
-      baseURL: `${app.proxyUrl}/v1`,
-      maxRetries: 0,
-    });
-
-    await waitConfigPropagation(async () => {
-      try {
-        await client.embeddings.create({
-          model: "emb-single",
-          input: "ready-probe",
-        });
-        return true;
-      } catch {
-        return false;
-      }
-    });
-
-    const baseline = upstream.receivedRequests.length;
-    const response = await client.embeddings.create({
-      model: "emb-single",
-      input: "hello",
-    });
-
-    // Caller-side: OpenAI Embeddings response shape per spec.
-    expect(response.object).toBe("list");
-    expect(response.data).toHaveLength(1);
-    expect(response.data[0]?.object).toBe("embedding");
-    expect(response.data[0]?.index).toBe(0);
-    // Vector preserved byte-for-byte. A regression that re-normalised,
-    // truncated, or re-quantised would fail this exact-array check.
-    expect(response.data[0]?.embedding).toEqual(VEC_HELLO);
-    // Usage counters from upstream reach the caller intact (parity
-    // with token-usage-passthrough-e2e for chat completions).
-    expect(response.usage?.prompt_tokens).toBe(1);
-    expect(response.usage?.total_tokens).toBe(1);
-
-    // Dispatch contract: gateway hit `/v1/embeddings` exactly once,
-    // not `/v1/chat/completions`. A regression that mis-routed
-    // embeddings through the chat path (or duplicated the dispatch)
-    // would fail here.
-    const testCalls = upstream.receivedRequests
-      .slice(baseline)
-      .filter((r) => r.path === "/v1/embeddings");
-    expect(testCalls).toHaveLength(1);
-    expect(testCalls[0]?.method).toBe("POST");
-    // Auth header reaches upstream (parity with chat-completions
-    // tests; same regression mode of dropped/swapped Bearer header
-    // would 401 in production but pass against the permissive mock).
-    expect(testCalls[0]?.headers["authorization"]).toBe("Bearer sk-mock");
-
-    // Wire-shape contract: body is OpenAI-shape embeddings JSON
-    // with the upstream's model_name (caller's display name was
-    // translated) and the caller's input semantically preserved.
-    // OpenAI's Embeddings API accepts `input` as either a string
-    // or an array of strings, so the gateway is free to normalise
-    // single-string → single-element-array on the upstream wire.
-    // The user-meaningful contract is "the input reached upstream
-    // unchanged in semantics, not necessarily in wire shape".
-    const sentBody = JSON.parse(testCalls[0]!.body) as {
-      model?: string;
-      input?: string | string[];
-    };
-    expect(sentBody.model).toBe("text-embedding-3-small");
-    if (Array.isArray(sentBody.input)) {
-      expect(sentBody.input).toEqual(["hello"]);
-    } else {
-      expect(sentBody.input).toBe("hello");
-    }
   });
 
   test("array input: N embeddings returned in the SAME ORDER as input array", async (ctx) => {
@@ -222,11 +124,14 @@ describe("embeddings e2e: /v1/embeddings dispatch + response passthrough", () =>
 
     await waitConfigPropagation(async () => {
       try {
-        await client.embeddings.create({
+        const r = await client.embeddings.create({
           model: "emb-array",
           input: ["ready-probe"],
         });
-        return true;
+        // Shape-check the probe response so a half-propagated
+        // snapshot (e.g. 200 OK with a malformed body) doesn't
+        // falsely report ready.
+        return r.object === "list" && Array.isArray(r.data) && r.data.length > 0;
       } catch {
         return false;
       }
@@ -241,11 +146,18 @@ describe("embeddings e2e: /v1/embeddings dispatch + response passthrough", () =>
 
     expect(response.data).toHaveLength(inputs.length);
     // Order preservation: data[i].index === i AND each vector
-    // matches what the upstream emitted at the same index.
+    // matches what the upstream emitted at the same index. Pin
+    // `object: "embedding"` on every element per OpenAI Embeddings
+    // spec — a regression that emitted the field on only some
+    // elements (or substituted the wrong literal) would slip past
+    // a single-element check.
+    expect(response.data[0]?.object).toBe("embedding");
     expect(response.data[0]?.index).toBe(0);
     expect(response.data[0]?.embedding).toEqual(VEC_HELLO);
+    expect(response.data[1]?.object).toBe("embedding");
     expect(response.data[1]?.index).toBe(1);
     expect(response.data[1]?.embedding).toEqual(VEC_WORLD);
+    expect(response.data[2]?.object).toBe("embedding");
     expect(response.data[2]?.index).toBe(2);
     expect(response.data[2]?.embedding).toEqual(VEC_FOO);
     expect(response.usage?.prompt_tokens).toBe(3);


### PR DESCRIPTION
## Summary

First endpoint covered from #151's C7 row. Embeddings is one of the two most-used LLM API surfaces (every RAG / semantic-search app hits it heavily). Prior to this PR the gateway had **zero** e2e coverage on \`/v1/embeddings\`.

This PR ships **one** of the two originally-planned cases. The single-string input case surfaced a real product bug while the audit ran — held back as #162, same pattern as #153 / #154 / #159:

- 🐛 #162 — \`/v1/embeddings\` single-string \`input\` normalised to single-element array on the upstream wire, contradicting \`docs/api-proxy.md\` §4.4 ("both pass through").

## What's pinned

| Case | User journey | Asserts |
|------|--------------|---------|
| Array input | \`client.embeddings.create({input: [s1, s2, s3]})\` | N embeddings returned in the SAME ORDER as input; each \`data[i].object: "embedding"\`, \`data[i].index === i\`, vector equals upstream's emitted vector at the same index; usage counts byte-for-byte; gateway hits \`/v1/embeddings\` exactly once with \`Bearer sk-mock\` and translated \`model_name\`; full input array reached upstream verbatim |

## Why this matters

The two real-world failure modes that prior coverage couldn't catch:

- A regression that **mis-routed embeddings through \`/v1/chat/completions\`** would crash differently against real upstreams (chat schema rejects \`input\`) but not show up without a path assertion.
- A regression that **re-ordered or deduplicated the input array** would silently corrupt every RAG caller's \`{document: vector}\` map. The strict per-index assertion catches this.

## Source-blind discipline

Every assertion derives from external contracts:
- OpenAI Embeddings API spec: <https://platform.openai.com/docs/api-reference/embeddings/create>
- Gateway's own \`/v1/embeddings\` contract: \`docs/api-proxy.md\` §4.4 (the contract violated by #162)
- OpenAI Node SDK embeddings client source

No internal Rust paths or struct field names referenced.

## Independent audit

Per CLAUDE.md §8, an independent audit agent reviewed the initial commit (87cb959). Resolution log:

| Finding | Severity | Resolution |
|---------|----------|------------|
| Loose "accept either input shape" assertion masked the gateway's own docs-vs-behavior contract divergence (\`docs/api-proxy.md\` §4.4 says "both pass through") | HIGH | Filed #162; removed the single-string case from this PR; held back to be added once product + docs are aligned (fb784db) |
| Probe was "doesn't throw"; could pass on a half-propagated 200-with-malformed-body | MEDIUM | Probe now shape-checks \`object: "list"\` + \`data\` array (fb784db) |
| Per-element \`object: "embedding"\` only asserted on first element | LOW | All three elements now pinned (fb784db) |

The HIGH finding was the most important: my initial PR loosened a wire-shape assertion to "accept either string or single-element array" with the rationale "OpenAI's spec accepts both". The audit checked \`docs/api-proxy.md\` §4.4 — which I had not — and found the gateway's own published contract is **narrower** than the OpenAI spec ("both pass through"). The loose assertion was masking a real product-vs-docs gap. Per principle #2 ("test failure = code bug"), the strict assertion was correct and my loosening was incorrect.

## Test plan

- [x] \`npm test\` (full e2e suite) — **28/28 passing locally** (was 27)
- [x] No mock-data-only paths: each case still exercises the real \`aisix\` binary, real etcd config propagation, and real OpenAI Node SDK \`client.embeddings.create()\` reverse-call
- [ ] CI green

Refs #151.