### PR TITLE
test(e2e): C9 inter-caller rate-limit isolation

### DIFF
--- a/tests/e2e/src/cases/concurrency-e2e.test.ts
+++ b/tests/e2e/src/cases/concurrency-e2e.test.ts
@@ -1,0 +1,228 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: concurrency / inter-caller isolation. Per docs
+// `docs/api-proxy.md` §2 status→error.type table:
+//
+//   | 429 | rate_limit_exceeded / concurrency_limit_exceeded /
+//   |     | budget_exceeded | RPM/TPM/concurrency/budget cap |
+//
+// One contract pinned here:
+//
+//   - Per-caller rate-limit isolation — when caller A is rate-
+//     limited, caller B's quota is unaffected. Rate limits are
+//     per-ApiKey, not global. Without this contract, a single
+//     noisy customer could exhaust the gateway's quota for
+//     everyone else.
+//
+// (The concurrency-cap case — second simultaneous request →
+// `429 concurrency_limit_exceeded` — is held back pending a
+// product fix. Today the gateway emits the wrong error.type for
+// concurrency rejections, conflating with RPM `rate_limit_exceeded`
+// per docs §2's distinct taxonomy. See follow-up issue.)
+//
+// Prior to this file, the gateway had **zero** e2e coverage on
+// inter-caller isolation — the existing `ratelimit-e2e.test.ts`
+// covers per-RPM-rejection for a single caller but not isolation
+// across callers.
+//
+// References:
+// - Gateway's own §2 status→type table:
+//   `docs/api-proxy.md` §2 (line ~52)
+// - Gateway's `rate_limit.concurrency` schema:
+//   `docs/api-admin.md` §4.2 example
+//   (`"rate_limit": {"rpm": 60, "concurrency": 10}`)
+// - OpenAI error envelope:
+//   <https://platform.openai.com/docs/guides/error-codes/api-errors>
+
+const CALLER_A_PLAINTEXT = "sk-conc-caller-a";
+const CALLER_A_KEY_HASH = createHash("sha256")
+  .update(CALLER_A_PLAINTEXT)
+  .digest("hex");
+const CALLER_B_PLAINTEXT = "sk-conc-caller-b";
+const CALLER_B_KEY_HASH = createHash("sha256")
+  .update(CALLER_B_PLAINTEXT)
+  .digest("hex");
+const CALLER_C_PLAINTEXT = "sk-conc-caller-c";
+const CALLER_C_KEY_HASH = createHash("sha256")
+  .update(CALLER_C_PLAINTEXT)
+  .digest("hex");
+
+describe("concurrency e2e: rate-limit isolation across callers", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("inter-caller rate-limit isolation: caller A's RPM exhaustion does NOT affect caller B", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startOpenAiUpstream();
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "conc-iso-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "conc-iso",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    // Both callers have RPM=1; the cap is per-ApiKey, so caller
+    // A burning their slot must NOT consume caller B's slot.
+    await admin.createApiKey({
+      key_hash: CALLER_A_KEY_HASH,
+      allowed_models: ["conc-iso"],
+      rate_limit: { rpm: 1 },
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_B_KEY_HASH,
+      allowed_models: ["conc-iso"],
+      rate_limit: { rpm: 1 },
+    });
+
+    const clientA = new OpenAI({
+      apiKey: CALLER_A_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+    const clientB = new OpenAI({
+      apiKey: CALLER_B_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Readiness gate: caller A's first call succeeds.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await clientA.chat.completions.create({
+          model: "conc-iso",
+          messages: [{ role: "user", content: "ready-probe-a" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+    // Caller A has now consumed their RPM=1 slot via the probe.
+    // Caller B's slot must still be available. Confirm B can fire
+    // before continuing — this also gates caller B's snapshot
+    // propagation independently.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await clientB.chat.completions.create({
+          model: "conc-iso",
+          messages: [{ role: "user", content: "ready-probe-b" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+    // Both callers have now consumed their slot. Caller A's next
+    // call must 429; we'll verify A is rate-limited AND B is
+    // also rate-limited (separately) — not that B benefits from
+    // A's rejection.
+
+    // Caller A: second call within minute → 429.
+    let caughtA: unknown;
+    try {
+      await clientA.chat.completions.create({
+        model: "conc-iso",
+        messages: [{ role: "user", content: "second-A" }],
+      });
+    } catch (e) {
+      caughtA = e;
+    }
+    expect(caughtA).toBeInstanceOf(APIError);
+    if (!(caughtA instanceof APIError)) {
+      throw new Error("unreachable: caughtA is not APIError");
+    }
+    expect(caughtA.status).toBe(429);
+    // Per docs §2: 429 → rate_limit_exceeded for RPM cap.
+    expect((caughtA.error as { type?: unknown })?.type).toBe(
+      "rate_limit_exceeded",
+    );
+
+    // Caller B: second call within minute → ALSO 429 (B's own
+    // slot was burned in the probe). Critical assertion: B's 429
+    // is from B's own quota, NOT a side effect of A being
+    // rate-limited globally. We pin this by checking B's 429 also
+    // surfaces with `rate_limit_exceeded` (proving the limit
+    // engaged), but the load-bearing assertion is the next test
+    // step: SLEEP nothing; instead reset by issuing a request
+    // through caller C who has NEVER been rate-limited.
+    let caughtB: unknown;
+    try {
+      await clientB.chat.completions.create({
+        model: "conc-iso",
+        messages: [{ role: "user", content: "second-B" }],
+      });
+    } catch (e) {
+      caughtB = e;
+    }
+    expect(caughtB).toBeInstanceOf(APIError);
+    if (!(caughtB instanceof APIError)) {
+      throw new Error("unreachable: caughtB is not APIError");
+    }
+    expect(caughtB.status).toBe(429);
+
+    // Bring up a third caller C with their own RPM=1. C has never
+    // sent a request, so C's first call must succeed even though
+    // A and B are both currently rate-limited. This is the
+    // load-bearing isolation assertion: a fresh caller's quota is
+    // genuinely independent of other callers'.
+    await admin.createApiKey({
+      key_hash: CALLER_C_KEY_HASH,
+      allowed_models: ["conc-iso"],
+      rate_limit: { rpm: 1 },
+    });
+    const clientC = new OpenAI({
+      apiKey: CALLER_C_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await clientC.chat.completions.create({
+          model: "conc-iso",
+          messages: [{ role: "user", content: "first-C" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch (e) {
+        // 401 = ApiKey not yet propagated; keep polling.
+        return false;
+      }
+    });
+  });
+
+});

--- a/tests/e2e/src/cases/concurrency-e2e.test.ts
+++ b/tests/e2e/src/cases/concurrency-e2e.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   AdminClient,
   EtcdClient,
+  ProxyClient,
   spawnApp,
   startOpenAiUpstream,
   waitConfigPropagation,
@@ -195,6 +196,14 @@ describe("concurrency e2e: rate-limit isolation across callers", () => {
       throw new Error("unreachable: caughtB is not APIError");
     }
     expect(caughtB.status).toBe(429);
+    // Pin B's rejection type symmetrically with A. A regression
+    // where B's 429 came from a different rejection path (e.g.
+    // concurrency cap leaking into the RPM rejection codepath)
+    // would change the error.type even though the status stayed
+    // 429.
+    expect((caughtB.error as { type?: unknown })?.type).toBe(
+      "rate_limit_exceeded",
+    );
 
     // Bring up a third caller C with their own RPM=1. C has never
     // sent a request, so C's first call must succeed even though
@@ -206,23 +215,38 @@ describe("concurrency e2e: rate-limit isolation across callers", () => {
       allowed_models: ["conc-iso"],
       rate_limit: { rpm: 1 },
     });
+
+    // Use a slot-non-consuming probe (`/v1/models` does not burn
+    // the RPM=1 slot) to gate on C's snapshot propagation. This
+    // separates the propagation-readiness check from the load-
+    // bearing rate-limit-isolation assertion below — without
+    // this split, a real isolation regression (C wrongly 429s)
+    // would surface as a misleading "waitConfigPropagation:
+    // condition not met within 10s" rather than as a clean 429
+    // body the test can inspect.
+    const probeC = new ProxyClient(app.proxyUrl, CALLER_C_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const r = await probeC.listModels();
+      if (r.status !== 200) return false;
+      const data = (r.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "conc-iso");
+    });
+
+    // Load-bearing assertion: C's first chat-completion succeeds
+    // even while A and B are rate-limited. A regression that
+    // scoped the rate-limit counter incorrectly (per-Model or
+    // global instead of per-ApiKey) would 429 here, surfacing
+    // explicitly with the response body intact rather than as a
+    // generic propagation timeout.
     const clientC = new OpenAI({
       apiKey: CALLER_C_PLAINTEXT,
       baseURL: `${app.proxyUrl}/v1`,
       maxRetries: 0,
     });
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await clientC.chat.completions.create({
-          model: "conc-iso",
-          messages: [{ role: "user", content: "first-C" }],
-        });
-        return r.choices[0]?.message.role === "assistant";
-      } catch (e) {
-        // 401 = ApiKey not yet propagated; keep polling.
-        return false;
-      }
+    const okC = await clientC.chat.completions.create({
+      model: "conc-iso",
+      messages: [{ role: "user", content: "first-C" }],
     });
+    expect(okC.choices[0]?.message.role).toBe("assistant");
   });
-
 });


### PR DESCRIPTION
## Summary

First sub-area of #151's C9 row (concurrency / inter-caller isolation). The second sub-area (concurrency cap) surfaced a product gap and is held back:

- 🐛 #173 — concurrency cap rejection emits \`rate_limit_exceeded\` instead of \`concurrency_limit_exceeded\` (docs §2 publishes distinct error types).

## What's pinned

| Case | User journey | Asserts |
|------|--------------|---------|
| Inter-caller rate-limit isolation | Three callers A/B/C each with \`rate_limit: { rpm: 1 }\` | A's RPM exhaustion does NOT consume B's quota; both A and B's second calls correctly 429 with \`rate_limit_exceeded\`; **a fresh caller C gets a clean 200 even while A and B are rate-limited** (load-bearing assertion that the limit is per-ApiKey, not global) |

## Why this matters

Without this contract, a single noisy customer would exhaust the gateway's quota for everyone else. The existing \`ratelimit-e2e.test.ts\` covers single-caller RPM rejection (one caller hitting their cap) but NOT cross-caller isolation. This PR fills that critical gap.

The "fresh caller C" pattern is the load-bearing assertion: A and B can both be hitting 429s, but C's first-ever request — sent on a freshly-created ApiKey — must still succeed. A regression that scoped the rate-limit counter incorrectly (e.g. global, or per-Model rather than per-ApiKey) would fail this assertion.

## Source-blind discipline

Every assertion derives from external contracts:
- Gateway's own §2 status→\`error.type\` table: \`docs/api-proxy.md\` (line 52)
- Per-ApiKey \`rate_limit\` schema: \`docs/api-admin.md\` §4.2 example
- OpenAI error envelope: <https://platform.openai.com/docs/guides/error-codes/api-errors>

No internal Rust paths or struct field names referenced.

## Test plan

- [x] \`npm test\` (full e2e suite) — **36/36 passing locally** (was 35 on main; +1 from this PR)
- [x] No mock-data-only paths: case exercises the real \`aisix\` binary, real etcd config propagation, real OpenAI Node SDK reverse-call across three independent ApiKeys
- [ ] CI green

Refs #151.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new E2E test suite to verify rate-limit isolation: ensures rate limits applied to individual API keys operate independently without affecting other callers' quota usage.
  * Validates proper error response behavior and quota enforcement across multiple concurrent API requests from different callers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/174)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->