### PR TITLE
test(e2e): C10 streaming edges — client abort mid-stream

### DIFF
--- a/tests/e2e/src/cases/streaming-edges-e2e.test.ts
+++ b/tests/e2e/src/cases/streaming-edges-e2e.test.ts
@@ -12,29 +12,31 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: streaming-edge cases. Two production failure modes that
-// prior coverage didn't pin:
+// E2E: streaming-edge case. One production failure mode pinned
+// here, derived from `docs/api-proxy.md` §5:
 //
-//   1. Client abort mid-stream — caller starts a streaming chat
-//      completion, then aborts the request before the upstream
-//      finishes. The gateway must propagate the disconnect so the
-//      upstream stops generating (releases its capacity slot, stops
-//      billing tokens). After the abort the gateway must remain
-//      healthy: subsequent requests from the same caller succeed.
+//   - Client abort mid-stream — caller starts a streaming chat
+//     completion, then aborts the request via AbortSignal. After
+//     the abort the gateway must remain HEALTHY: subsequent
+//     streaming calls from the same caller run to completion.
+//     This pins the "no resource leak / no parser corruption"
+//     property that's externally observable from the client.
 //
-//   2. Upstream disconnect mid-stream — mock upstream sends some
-//      SSE chunks then closes the TCP connection without emitting
-//      `[DONE]`. The caller's SDK iteration must surface the
-//      premature close cleanly (an error, not silent truncation
-//      or protocol garbage). The chunks the upstream DID emit
-//      must reach the caller intact.
+// (The "upstream disconnect mid-stream" case — partial chunks
+// reach the caller, then iterator surfaces error per docs §5
+// "aisix sends a final error chunk and closes without [DONE]" —
+// is held back. The gateway today short-circuits to a request-
+// time 502 instead of forwarding partial chunks. See follow-up
+// issue.)
 //
-// Per gateway docs `docs/api-proxy.md` §5 ("Streaming protocol
-// details"), the gateway preserves the upstream SSE wire byte-for-
-// byte: one `data:` line per chunk, terminated by `\n\n`,
-// terminal `data: [DONE]` on clean upstream completion. A
-// premature upstream close should produce a caller-visible error,
-// NOT a fake [DONE].
+// Note on scope: this case verifies gateway LIVENESS post-abort,
+// not upstream-side disconnect propagation. The harness has no
+// signal for "upstream observed the client disconnect", so a
+// regression where the gateway holds the upstream connection open
+// (silently consuming chunks after the client aborted) would
+// pass this test. Filing that as a separate harness-extension
+// task; today's coverage is "gateway stays alive", which is the
+// load-bearing user-visible contract.
 //
 // References:
 // - Gateway's own streaming contract: `docs/api-proxy.md` §5
@@ -48,7 +50,7 @@ const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
 
-describe("streaming edges e2e: client abort + upstream disconnect", () => {
+describe("streaming edges e2e: client abort mid-stream", () => {
   let app: SpawnedApp | undefined;
   let admin: AdminClient | undefined;
   let etcdReachable = false;
@@ -111,20 +113,17 @@ describe("streaming edges e2e: client abort + upstream disconnect", () => {
       maxRetries: 0,
     });
 
+    // Use ProxyClient.listModels for snapshot-readiness gating
+    // (matches concurrency-e2e / streaming-disconnect convention).
+    // A streaming chat probe would burn ≥200ms per attempt due to
+    // eventDelayMs; listModels is faster and consistent with how
+    // other tests gate readiness against a streaming-only mock.
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
     await waitConfigPropagation(async () => {
-      try {
-        const probe = await client.chat.completions.create({
-          model: "stream-abort",
-          messages: [{ role: "user", content: "ready-probe" }],
-          stream: true,
-        });
-        for await (const _chunk of probe) {
-          break;
-        }
-        return true;
-      } catch {
-        return false;
-      }
+      const r = await probe.listModels();
+      if (r.status !== 200) return false;
+      const data = (r.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "stream-abort");
     });
 
     // Start streaming, abort after the first chunk via
@@ -185,110 +184,4 @@ describe("streaming edges e2e: client abort + upstream disconnect", () => {
     expect(followupFinishReason).toBe("stop");
   });
 
-  test("upstream disconnects mid-stream: caller-side iteration surfaces error, partial chunks intact", async (ctx) => {
-    if (!etcdReachable || !app || !admin) {
-      ctx.skip();
-      return;
-    }
-
-    // Mock upstream emits 2 SSE chunks then drops the connection
-    // (`disconnectAfterEvents: 2`). No `finish_reason: stop`,
-    // no `[DONE]` — premature close.
-    const upstream = await startOpenAiUpstream({
-      streamEvents: [
-        '{"id":"disc","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
-        '{"id":"disc","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"partial "},"finish_reason":null}]}',
-        // The disconnect happens before chunk 3 — these are
-        // never emitted:
-        '{"id":"disc","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"never "},"finish_reason":null}]}',
-        '{"id":"disc","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
-        "[DONE]",
-      ],
-      disconnectAfterEvents: 2,
-    });
-    upstreams.push(upstream);
-
-    const pk = await admin.createProviderKey({
-      display_name: "stream-disc-pk",
-      secret: "sk-mock",
-      api_base: `${upstream.baseUrl}/v1`,
-    });
-    await admin.createModel({
-      display_name: "stream-disc",
-      provider: "openai",
-      model_name: "gpt-4o-mini",
-      provider_key_id: pk.id,
-    });
-
-    const client = new OpenAI({
-      apiKey: CALLER_PLAINTEXT,
-      baseURL: `${app.proxyUrl}/v1`,
-      maxRetries: 0,
-    });
-
-    // Use ProxyClient.listModels for snapshot-readiness gating —
-    // chat-completions probes don't work cleanly here because the
-    // mock upstream is configured for streaming with
-    // disconnectAfterEvents, so any chat-completions probe (with
-    // or without `stream: true`) would match the streaming-cutoff
-    // failure mode the test itself is meant to verify.
-    // listModels validates Model + ApiKey snapshot loading
-    // without dispatching to the broken upstream at all.
-    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    await waitConfigPropagation(async () => {
-      const r = await probe.listModels();
-      if (r.status !== 200) return false;
-      const data = (r.body as { data?: Array<{ id?: string }> }).data ?? [];
-      return data.some((m) => m.id === "stream-disc");
-    });
-
-    // The user-meaningful contract on premature upstream close:
-    // the caller MUST see a failure signal — either a 5xx error
-    // response from the gateway (gateway short-circuited) OR an
-    // iteration-time error after some chunks (gateway forwarded
-    // partial then propagated the close). What's NOT acceptable
-    // is a silent success (synthetic [DONE], fake `finish_reason:
-    // "stop"`, or hang).
-    const collected: string[] = [];
-    let saw_finish = false;
-    let failureSignal: "request-time-error" | "iterator-error" | "none" = "none";
-
-    try {
-      const stream = await client.chat.completions.create({
-        model: "stream-disc",
-        messages: [{ role: "user", content: "give me content" }],
-        stream: true,
-      });
-      try {
-        for await (const chunk of stream) {
-          const delta = chunk.choices[0]?.delta;
-          if (delta?.content) collected.push(delta.content);
-          if (chunk.choices[0]?.finish_reason) saw_finish = true;
-        }
-      } catch {
-        // Premature close surfaced during iteration — gateway
-        // forwarded chunks then propagated the close as an error.
-        failureSignal = "iterator-error";
-      }
-    } catch {
-      // Premature close surfaced before streaming started —
-      // gateway buffered or short-circuited and returned a 5xx
-      // error response.
-      failureSignal = "request-time-error";
-    }
-
-    // The caller saw SOME failure signal — not a silent success.
-    // A regression that synthesized a fake [DONE] or a clean
-    // finish_reason on premature close (silent corruption) would
-    // leave failureSignal === "none" AND saw_finish === true.
-    expect(failureSignal).not.toBe("none");
-    // No fake completion signal injected. The upstream's mid-
-    // stream close happened BEFORE chunk 4 (which carries
-    // `finish_reason: "stop"`), so a real `finish_reason: "stop"`
-    // never reached the gateway. If the caller still saw one,
-    // the gateway synthesized it — a silent-corruption regression
-    // that turns truncated responses into apparently-complete
-    // ones.
-    expect(saw_finish).toBe(false);
-  });
 });

--- a/tests/e2e/src/cases/streaming-edges-e2e.test.ts
+++ b/tests/e2e/src/cases/streaming-edges-e2e.test.ts
@@ -1,0 +1,294 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: streaming-edge cases. Two production failure modes that
+// prior coverage didn't pin:
+//
+//   1. Client abort mid-stream — caller starts a streaming chat
+//      completion, then aborts the request before the upstream
+//      finishes. The gateway must propagate the disconnect so the
+//      upstream stops generating (releases its capacity slot, stops
+//      billing tokens). After the abort the gateway must remain
+//      healthy: subsequent requests from the same caller succeed.
+//
+//   2. Upstream disconnect mid-stream — mock upstream sends some
+//      SSE chunks then closes the TCP connection without emitting
+//      `[DONE]`. The caller's SDK iteration must surface the
+//      premature close cleanly (an error, not silent truncation
+//      or protocol garbage). The chunks the upstream DID emit
+//      must reach the caller intact.
+//
+// Per gateway docs `docs/api-proxy.md` §5 ("Streaming protocol
+// details"), the gateway preserves the upstream SSE wire byte-for-
+// byte: one `data:` line per chunk, terminated by `\n\n`,
+// terminal `data: [DONE]` on clean upstream completion. A
+// premature upstream close should produce a caller-visible error,
+// NOT a fake [DONE].
+//
+// References:
+// - Gateway's own streaming contract: `docs/api-proxy.md` §5
+// - OpenAI Chat Completions streaming spec
+//   <https://platform.openai.com/docs/api-reference/chat/streaming>
+// - OpenAI Node SDK stream-cancel pattern via AbortSignal
+//   <https://github.com/openai/openai-node#canceling-a-request>
+
+const CALLER_PLAINTEXT = "sk-stream-edge-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("streaming edges e2e: client abort + upstream disconnect", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("client aborts mid-stream: gateway stays healthy, subsequent request succeeds", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    // Mock upstream emits 5 SSE chunks with 200ms between each →
+    // the full response takes >1s. The caller will abort after
+    // receiving the first chunk (well before the upstream finishes).
+    const upstream = await startOpenAiUpstream({
+      streamEvents: [
+        '{"id":"abrt","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+        '{"id":"abrt","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"chunk-1 "},"finish_reason":null}]}',
+        '{"id":"abrt","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"chunk-2 "},"finish_reason":null}]}',
+        '{"id":"abrt","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"chunk-3 "},"finish_reason":null}]}',
+        '{"id":"abrt","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+        "[DONE]",
+      ],
+      eventDelayMs: 200,
+    });
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "stream-abort-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "stream-abort",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "stream-abort",
+          messages: [{ role: "user", content: "ready-probe" }],
+          stream: true,
+        });
+        for await (const _chunk of probe) {
+          break;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    // Start streaming, abort after the first chunk via
+    // AbortSignal. The OpenAI Node SDK forwards the abort to
+    // the underlying fetch; the gateway sees the client
+    // connection close.
+    const controller = new AbortController();
+    const stream = await client.chat.completions.create(
+      {
+        model: "stream-abort",
+        messages: [{ role: "user", content: "abort me early" }],
+        stream: true,
+      },
+      { signal: controller.signal },
+    );
+
+    // Iterate until we've received the first chunk, then abort
+    // and break. Whether the iterator subsequently throws or
+    // silently ends is SDK-internal and not part of the
+    // gateway's externally-observable contract — what IS
+    // observable is "the gateway is still healthy after the
+    // abort", which we verify with a follow-up request below.
+    let firstChunkSeen = false;
+    try {
+      for await (const _chunk of stream) {
+        firstChunkSeen = true;
+        controller.abort();
+        break;
+      }
+    } catch {
+      // Iterator may throw on abort or may not, depending on
+      // SDK timing. Both are acceptable — the load-bearing
+      // assertion is the followup call below.
+    }
+    expect(firstChunkSeen).toBe(true);
+
+    // Load-bearing: gateway must remain healthy after the
+    // mid-stream abort. A regression that left a dangling
+    // upstream connection, leaked a per-caller resource, or
+    // corrupted shared parser state would surface as the next
+    // call hanging or 5xx-ing. Use a streaming followup since
+    // the mock upstream is configured for streaming responses.
+    const followupStream = await client.chat.completions.create({
+      model: "stream-abort",
+      messages: [{ role: "user", content: "still alive?" }],
+      stream: true,
+    });
+    let followupChunkCount = 0;
+    let followupFinishReason: string | null | undefined;
+    for await (const chunk of followupStream) {
+      followupChunkCount++;
+      followupFinishReason ??= chunk.choices[0]?.finish_reason ?? undefined;
+    }
+    // The followup ran to completion (saw all chunks AND the
+    // finish_reason), proving the gateway is fully functional
+    // post-abort.
+    expect(followupChunkCount).toBeGreaterThan(0);
+    expect(followupFinishReason).toBe("stop");
+  });
+
+  test("upstream disconnects mid-stream: caller-side iteration surfaces error, partial chunks intact", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    // Mock upstream emits 2 SSE chunks then drops the connection
+    // (`disconnectAfterEvents: 2`). No `finish_reason: stop`,
+    // no `[DONE]` — premature close.
+    const upstream = await startOpenAiUpstream({
+      streamEvents: [
+        '{"id":"disc","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+        '{"id":"disc","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"partial "},"finish_reason":null}]}',
+        // The disconnect happens before chunk 3 — these are
+        // never emitted:
+        '{"id":"disc","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"never "},"finish_reason":null}]}',
+        '{"id":"disc","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+        "[DONE]",
+      ],
+      disconnectAfterEvents: 2,
+    });
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "stream-disc-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "stream-disc",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Use ProxyClient.listModels for snapshot-readiness gating —
+    // chat-completions probes don't work cleanly here because the
+    // mock upstream is configured for streaming with
+    // disconnectAfterEvents, so any chat-completions probe (with
+    // or without `stream: true`) would match the streaming-cutoff
+    // failure mode the test itself is meant to verify.
+    // listModels validates Model + ApiKey snapshot loading
+    // without dispatching to the broken upstream at all.
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const r = await probe.listModels();
+      if (r.status !== 200) return false;
+      const data = (r.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "stream-disc");
+    });
+
+    // The user-meaningful contract on premature upstream close:
+    // the caller MUST see a failure signal — either a 5xx error
+    // response from the gateway (gateway short-circuited) OR an
+    // iteration-time error after some chunks (gateway forwarded
+    // partial then propagated the close). What's NOT acceptable
+    // is a silent success (synthetic [DONE], fake `finish_reason:
+    // "stop"`, or hang).
+    const collected: string[] = [];
+    let saw_finish = false;
+    let failureSignal: "request-time-error" | "iterator-error" | "none" = "none";
+
+    try {
+      const stream = await client.chat.completions.create({
+        model: "stream-disc",
+        messages: [{ role: "user", content: "give me content" }],
+        stream: true,
+      });
+      try {
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta;
+          if (delta?.content) collected.push(delta.content);
+          if (chunk.choices[0]?.finish_reason) saw_finish = true;
+        }
+      } catch {
+        // Premature close surfaced during iteration — gateway
+        // forwarded chunks then propagated the close as an error.
+        failureSignal = "iterator-error";
+      }
+    } catch {
+      // Premature close surfaced before streaming started —
+      // gateway buffered or short-circuited and returned a 5xx
+      // error response.
+      failureSignal = "request-time-error";
+    }
+
+    // The caller saw SOME failure signal — not a silent success.
+    // A regression that synthesized a fake [DONE] or a clean
+    // finish_reason on premature close (silent corruption) would
+    // leave failureSignal === "none" AND saw_finish === true.
+    expect(failureSignal).not.toBe("none");
+    // No fake completion signal injected. The upstream's mid-
+    // stream close happened BEFORE chunk 4 (which carries
+    // `finish_reason: "stop"`), so a real `finish_reason: "stop"`
+    // never reached the gateway. If the caller still saw one,
+    // the gateway synthesized it — a silent-corruption regression
+    // that turns truncated responses into apparently-complete
+    // ones.
+    expect(saw_finish).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

C10 row from #151. One of two originally-planned cases shipped here. The other surfaced a docs-vs-implementation gap and is held back:

- 🐛 #177 — upstream mid-stream disconnect produces request-time 502 instead of partial chunks + final error chunk per docs §5.

## What's pinned

| Case | User journey | Asserts |
|------|--------------|---------|
| Client abort mid-stream | Caller starts streaming, receives 1st chunk, aborts via AbortSignal | Gateway stays HEALTHY: a follow-up streaming call from the same client runs to completion (all chunks + \`finish_reason: "stop"\`). A regression leaving a dangling upstream connection, leaked per-caller resource, or corrupted shared parser state would surface as the followup hanging or 5xx-ing |

## Held back as #177

🐛 **#177 — upstream mid-stream disconnect**. Per docs §5 lines 218-221: *"If the upstream stream terminates abnormally, aisix sends a final error chunk and closes the response without \`[DONE]\`."* Today the gateway short-circuits to a request-time 502 instead of forwarding the partial chunks the upstream emitted before the close. Case 2's strict assertion (forward-then-error pattern) will return once #177 is fixed.

## Note on scope (corrected from initial PR description)

This case verifies **gateway liveness post-abort**, not upstream-side disconnect propagation. The harness has no signal for "upstream observed the client disconnect", so a regression where the gateway holds the upstream connection open (silently consuming chunks after the client aborted) would NOT be caught by this test. That's tracked as a separate harness-extension task; today's coverage is "gateway stays alive after abort", which is the load-bearing user-visible contract.

## Source-blind discipline

Every assertion derives from external contracts:
- Gateway streaming protocol: \`docs/api-proxy.md\` §5
- OpenAI Chat Completions streaming spec: <https://platform.openai.com/docs/api-reference/chat/streaming>
- OpenAI Node SDK abort pattern: <https://github.com/openai/openai-node#canceling-a-request>

No internal Rust paths or struct field names referenced.

## Independent audit

Per CLAUDE.md §8, an independent audit agent reviewed commit a546329. Result: 2 HIGH, 2 MEDIUM, 3 LOW. Resolution log:

| Finding | Severity | Resolution |
|---------|----------|------------|
| Case 2 accepted request-time 5xx as valid failure signal, contradicting docs §5 unconditional "forward-then-error" contract | HIGH | Held back case 2; filed #177; will re-add post-fix with strict assertion (c8ed822) |
| Initial PR description claimed case 1 pins upstream-side disconnect propagation; test only verifies gateway liveness | HIGH | Scope-corrected the file's header comment + this PR description (c8ed822) |
| Case 1 readiness probe used a streaming chat-completion (≥200ms per attempt) | LOW (escalated to applied) | Replaced with \`ProxyClient.listModels\` probe matching suite convention (c8ed822) |
| MEDIUM-1 \`saw_finish\` snake_case naming | MEDIUM | N/A after case 2 removal |
| MEDIUM-2 test-count claim was off by 3 | MEDIUM | Recomputed: 39/39 (was 38; +1 from case 1) |

## Test plan

- [x] \`npm test\` (full e2e suite) — **39/39 passing locally** (was 38 on main; +1 from this PR's case 1)
- [x] No mock-data-only paths: case exercises the real \`aisix\` binary, real etcd config propagation, real OpenAI Node SDK reverse-call with AbortSignal
- [ ] CI green

Refs #151.