### PR TITLE
fix(error): drop unsupported concurrency_limit_exceeded error code

### DIFF
--- a/crates/aisix-core/src/error.rs
+++ b/crates/aisix-core/src/error.rs
@@ -270,5 +270,4 @@ mod tests {
         assert!(body.get("error_msg").is_some());
         assert!(body.get("error").is_none());
     }
-
 }

--- a/crates/aisix-core/src/error.rs
+++ b/crates/aisix-core/src/error.rs
@@ -39,9 +39,6 @@ pub enum ProxyError {
         retry_after_secs: Option<u64>,
     },
 
-    #[error("concurrency limit exceeded")]
-    ConcurrencyLimitExceeded,
-
     #[error("budget exceeded")]
     BudgetExceeded,
 
@@ -64,7 +61,6 @@ pub enum ProxyError {
 pub enum RateLimitScope {
     Requests,
     Tokens,
-    Concurrency,
 }
 
 impl std::fmt::Display for RateLimitScope {
@@ -72,7 +68,6 @@ impl std::fmt::Display for RateLimitScope {
         f.write_str(match self {
             Self::Requests => "requests",
             Self::Tokens => "tokens",
-            Self::Concurrency => "concurrency",
         })
     }
 }
@@ -85,9 +80,7 @@ impl ProxyError {
             Self::ModelNotFound(_) | Self::InvalidRequest(_) => 400,
             Self::ModelAccessForbidden(_) | Self::ContentPolicyViolation => 403,
             Self::PayloadTooLarge => 413,
-            Self::RateLimitExceeded { .. }
-            | Self::ConcurrencyLimitExceeded
-            | Self::BudgetExceeded => 429,
+            Self::RateLimitExceeded { .. } | Self::BudgetExceeded => 429,
             Self::RequestTimeout(_) => 504,
             Self::ProviderError(_) => 502,
             Self::Internal(_) => 500,
@@ -103,7 +96,6 @@ impl ProxyError {
             Self::PayloadTooLarge => "invalid_request_error",
             Self::InvalidRequest(_) => "invalid_request_error",
             Self::RateLimitExceeded { .. } => "rate_limit_error",
-            Self::ConcurrencyLimitExceeded => "rate_limit_error",
             Self::BudgetExceeded => "billing_error",
             Self::RequestTimeout(_) => "api_error",
             Self::ProviderError(_) => "api_error",
@@ -123,9 +115,7 @@ impl ProxyError {
             Self::RateLimitExceeded { scope, .. } => match scope {
                 RateLimitScope::Requests => "rate_limit_exceeded",
                 RateLimitScope::Tokens => "token_limit_exceeded",
-                RateLimitScope::Concurrency => "concurrency_limit_exceeded",
             },
-            Self::ConcurrencyLimitExceeded => "concurrency_limit_exceeded",
             Self::BudgetExceeded => "budget_exceeded",
             Self::RequestTimeout(_) => "request_timeout",
             Self::ProviderError(_) => "provider_error",
@@ -281,15 +271,4 @@ mod tests {
         assert!(body.get("error").is_none());
     }
 
-    #[test]
-    fn retry_after_only_set_for_rpm_tpm_not_concurrency() {
-        let rpm = ProxyError::RateLimitExceeded {
-            scope: RateLimitScope::Requests,
-            retry_after_secs: Some(12),
-        };
-        assert_eq!(rpm.retry_after_secs(), Some(12));
-
-        let conc = ProxyError::ConcurrencyLimitExceeded;
-        assert_eq!(conc.retry_after_secs(), None);
-    }
 }

--- a/crates/aisix-ratelimit/src/error.rs
+++ b/crates/aisix-ratelimit/src/error.rs
@@ -26,7 +26,7 @@ impl RateLimitError {
         match self {
             RateLimitError::Requests { scope, .. } => *scope,
             RateLimitError::Tokens { scope, .. } => *scope,
-            RateLimitError::Concurrency => RateLimitScope::Concurrency,
+            RateLimitError::Concurrency => RateLimitScope::Requests,
         }
     }
 
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn concurrency_has_no_retry_after_hint() {
         let e = RateLimitError::Concurrency;
-        assert_eq!(e.scope(), RateLimitScope::Concurrency);
+        assert_eq!(e.scope(), RateLimitScope::Requests);
         assert!(e.retry_after_secs().is_none());
     }
 }

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -49,7 +49,7 @@ Errors follow the OpenAI shape so SDK error handlers light up:
 | 404 | `model_not_found` | `req.model` does not resolve in the snapshot |
 | 413 | `request_too_large` | Body exceeds `proxy.request_body_limit_bytes` (default 10 MB) |
 | 422 | `invalid_request_error` | Schema-valid JSON but semantically wrong (e.g. empty `messages`) |
-| 429 | `rate_limit_exceeded` / `concurrency_limit_exceeded` / `budget_exceeded` | RPM/TPM/concurrency/budget cap |
+| 429 | `rate_limit_exceeded` / `budget_exceeded` | RPM/TPM/concurrency/budget cap |
 | 502 | `provider_error` | Upstream returned 5xx or invalid wire format |
 | 503 | `service_unavailable` | No bridge registered for the resolved Model's provider |
 | 504 | `request_timeout` | Upstream exceeded `Model.timeout` ms |

--- a/tests/e2e/src/cases/concurrency-e2e.test.ts
+++ b/tests/e2e/src/cases/concurrency-e2e.test.ts
@@ -15,8 +15,8 @@ import {
 // E2E: concurrency / inter-caller isolation. Per docs
 // `docs/api-proxy.md` §2 status→error.type table:
 //
-//   | 429 | rate_limit_exceeded / concurrency_limit_exceeded /
-//   |     | budget_exceeded | RPM/TPM/concurrency/budget cap |
+//   | 429 | rate_limit_exceeded / budget_exceeded |
+//   |     | RPM/TPM/concurrency/budget cap |
 //
 // One contract pinned here:
 //
@@ -26,11 +26,10 @@ import {
 //     noisy customer could exhaust the gateway's quota for
 //     everyone else.
 //
-// (The concurrency-cap case — second simultaneous request →
-// `429 concurrency_limit_exceeded` — is held back pending a
-// product fix. Today the gateway emits the wrong error.type for
-// concurrency rejections, conflating with RPM `rate_limit_exceeded`
-// per docs §2's distinct taxonomy. See follow-up issue.)
+// (Concurrency-cap rejections deliberately surface as the same
+// `429 rate_limit_exceeded` as RPM/TPM caps — the gateway does
+// not distinguish concurrency from request rate at the wire-error
+// level. See PR #178 / issue #173.)
 //
 // Prior to this file, the gateway had **zero** e2e coverage on
 // inter-caller isolation — the existing `ratelimit-e2e.test.ts`


### PR DESCRIPTION
Closes #173.

## Summary

The product does not differentiate concurrency cap rejections from RPM/TPM rejections at the wire-error level: all 429s emit `error.type` `"rate_limit_error"` with `error.code` `"rate_limit_exceeded"`. The docs and `aisix-core` taxonomy still carried a separate `concurrency_limit_exceeded` code that was never reachable from the proxy surface, and a `RateLimitScope::Concurrency` metrics dimension that operators do not need. This PR drops both.

Per the product decision, issue #173 (which originally proposed the opposite — adding the distinct error type) is closed by removing the unused taxonomy instead of implementing it.

## Changes

- `crates/aisix-core/src/error.rs`
  - Drop `ProxyError::ConcurrencyLimitExceeded` variant and its `status()` / `error_type()` / `error_code()` arms.
  - Drop `RateLimitScope::Concurrency` variant + its `Display` arm.
  - Drop the variant-specific unit test (`retry_after_only_set_for_rpm_tpm_not_concurrency`).
- `crates/aisix-ratelimit/src/error.rs`
  - `RateLimitError::Concurrency.scope()` now returns `RateLimitScope::Requests` so the metrics label is uniformly `"requests"` for every rate-limit rejection (operators no longer separate concurrency saturation from RPM exhaustion in dashboards).
- `docs/api-proxy.md`
  - Remove `concurrency_limit_exceeded` from the §2 status→error.type table.

## Behavioral impact

- Wire contract: **unchanged**. `aisix-proxy::ProxyError::kind()` already returned `"rate_limit_exceeded"` for every `RateLimit(_)` cause, including concurrency rejections. Clients see the same response.
- Metrics: `record_ratelimit_rejection` label collapses from `{requests, tokens, concurrency}` to `{requests, tokens}` — concurrency-cap and RPM-cap rejections now share the `requests` bucket. Confirmed acceptable per product decision.
- `x-ratelimit-*-concurrent` response headers are unaffected — they read from `LimiterStatus.concurrency_limit`, not `RateLimitScope`.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace --lib` passes
- [x] `grep -rn 'concurrency_limit_exceeded\|ConcurrencyLimitExceeded' --include='*.rs' --include='*.md'` returns no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Concurrency limit rejections now surface as `rate_limit_exceeded` errors (429 HTTP status), consolidating the error response taxonomy and simplifying client-side error handling.

* **Documentation**
  * Updated API documentation to reflect that all rate limiting scenarios, including concurrency caps, return `rate_limit_exceeded` error responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/178)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->