### PR TITLE
docs(architecture): fix metric names and drop nonexistent Cohere bridge

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ API surface see [`api-proxy.md`](./api-proxy.md) and
                 │           ▼                                  │
                 │       Hub  ──►  Bridge (per provider)  ──►   │── upstream
                 │           │     (OpenAI, Anthropic, Gemini,  │   provider
-                │           │      DeepSeek, Cohere…)          │
+                │           │      DeepSeek)                   │
                 │           │                                  │
                 │       ┌───┴────────────────────┐             │
                 │       │     ProxyState         │             │
@@ -285,14 +285,16 @@ durability across replicas.
   blocks on a slow customer receiver. See
   `aisix-obs::OtlpHttpFanOut`.
 
-Five canonical metrics:
+Four canonical metrics (defined in `aisix-obs::metrics`):
 
-- `aisix_request_count` — labelled by provider, model, status, outcome.
-- `aisix_request_latency` — histogram, end-to-end including body drain.
-- `aisix_llm_latency` — histogram, upstream-only (excludes our own work).
-- `aisix_token_count` — by direction (input / output) and model.
-- `aisix_first_token_latency` — histogram, populated only for streaming
-  requests (recorded at `idx == 0`).
+- `aisix_requests_total{provider,model,status,outcome}` — counter,
+  every completed request.
+- `aisix_request_duration_seconds{provider,model,status}` — histogram,
+  end-to-end including body drain.
+- `aisix_ratelimit_rejections_total{scope}` — counter, every 429
+  rejection labelled by which quota engaged (`requests` or `tokens`).
+- `aisix_tokens_consumed_total{provider,model}` — counter, post-deduct
+  token usage from the upstream `usage` field.
 
 ## 9. Bootstrap & shutdown
 


### PR DESCRIPTION
## Summary

Two drift fixes against current code in `docs/architecture.md`. Surfaced by an audit of all five doc files vs the 14-crate codebase (companion to issue #127 / #173 cleanup work).

### 1. Wrong metric names (§8 Observability)

The doc claimed five canonical metrics: \`aisix_request_count\`, \`aisix_request_latency\`, \`aisix_llm_latency\`, \`aisix_token_count\`, \`aisix_first_token_latency\`. **None exist in the code.** The four real metrics defined in \`crates/aisix-obs/src/metrics.rs:24-27\` are:

- \`aisix_requests_total{provider,model,status,outcome}\`
- \`aisix_request_duration_seconds{provider,model,status}\`
- \`aisix_ratelimit_rejections_total{scope}\`
- \`aisix_tokens_consumed_total{provider,model}\`

A Prometheus dashboard or alert grepping the doc-listed names matched zero series.

### 2. Cohere not actually a Bridge (§2 component diagram)

The diagram listed \`(OpenAI, Anthropic, Gemini, DeepSeek, Cohere…)\` as per-provider Bridges. There is no \`aisix-provider-cohere\` crate; only the four named providers ship as native Bridges. Cohere appears only as a passthrough target on \`/v1/rerank\`, not as a Hub Bridge.

## Out of scope (will be follow-up PRs)

- \`docs/api-proxy.md\` error.type and header-name drift (every \`type\` value is wrong; \`x-aisix-call-id\` vs \`x-aisix-request-id\` split). Stacked behind #178.
- \`docs/api-admin.md\` schema-truth pass (every example body fails validation).
- \`docs/managed-mode.md\` cert-bundle bootstrap path (entire path missing).
- \`docs/testing.md\` npm→pnpm + etcd version + phantom build-ui job.

## Test plan

- [x] No code changes; drift-only fix
- [x] Cited line numbers in code verified (\`aisix-obs/src/metrics.rs\`, crate dir listing for provider crates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated observability metrics documentation with revised metric definitions and labeling semantics for monitoring requests, latency, rate limiting, and token consumption.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->