### PR TITLE
test(e2e): G6 weighted routing distribution — 70/30 split holds

### DIFF
--- a/tests/e2e/src/cases/weighted-routing-distribution-e2e.test.ts
+++ b/tests/e2e/src/cases/weighted-routing-distribution-e2e.test.ts
@@ -239,5 +239,9 @@ describe("weighted routing distribution e2e: 70/30 split lands inside [60,80] / 
     expect(aDelta).toBeLessThanOrEqual(HEAVY_HI);
     expect(bDelta).toBeGreaterThanOrEqual(LIGHT_LO);
     expect(bDelta).toBeLessThanOrEqual(LIGHT_HI);
-  });
+    // Per-test timeout lifted to 90s. The default suite timeout
+    // (60s, vitest.config.ts) is tight for 100 sequential round-trips
+    // when upstream latency drifts above ~50ms/call; 90s leaves
+    // headroom without changing the global cap for other cases.
+  }, 90_000);
 });

--- a/tests/e2e/src/cases/weighted-routing-distribution-e2e.test.ts
+++ b/tests/e2e/src/cases/weighted-routing-distribution-e2e.test.ts
@@ -1,0 +1,243 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: weighted routing distribution. A virtual Model carries a
+// Routing block with `strategy: "weighted"` and two targets — `wr-a`
+// (weight 70) and `wr-b` (weight 30). Per docs `api-admin.md` §4.1
+// (direct vs routing two-mode split) and the routing schema enum
+// `["round_robin", "weighted", "failover"]`, the gateway is expected
+// to dispatch incoming traffic in a 70:30 ratio across the two
+// targets.
+//
+// One contract pinned here:
+//
+//   - Weighted strategy honours the integer `weight` field per
+//     target. After N requests the observed split lands inside a
+//     statistically reasonable tolerance window around the declared
+//     ratio. A regression that ignored `weight` and round-robined
+//     instead would fail (each side would land ~50%, well outside
+//     [60, 80] / [20, 40]).
+//
+// Reference: OpenAI Chat Completions API spec for the shape the
+// caller sees (https://platform.openai.com/docs/api-reference/chat).
+//
+// The 100-request count and the [60, 80] / [20, 40] tolerance are
+// chosen so that even a moderately uneven scheduler (drift of a few
+// percent within a 100-sample window) still passes, while a scheduler
+// that completely ignores weight (e.g. round-robins, or pins to one
+// target) cannot. Two independent binomial windows: 70±10 and 30±10
+// comfortably covers a 99% interval at p=0.7 over n=100 (σ≈4.6).
+
+const CALLER_PLAINTEXT = "sk-wr-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const TOTAL_REQUESTS = 100;
+const HEAVY_WEIGHT = 70;
+const LIGHT_WEIGHT = 30;
+// Tolerance: weight ±10 absolute on a 100-sample window.
+const HEAVY_LO = 60;
+const HEAVY_HI = 80;
+const LIGHT_LO = 20;
+const LIGHT_HI = 40;
+
+describe("weighted routing distribution e2e: 70/30 split lands inside [60,80] / [20,40]", () => {
+  let app: SpawnedApp | undefined;
+  let upstreamA: OpenAiUpstream | undefined;
+  let upstreamB: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstreamA = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-wr-a",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "served by A" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    upstreamB = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-wr-b",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "served by B" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // Two distinct ProviderKeys so each Model points at its own
+    // upstream — necessary for receivedRequests counts to be
+    // attributable per side.
+    const pkA = await admin.createProviderKey({
+      display_name: "wr-a-pk",
+      secret: "sk-mock",
+      api_base: `${upstreamA.baseUrl}/v1`,
+    });
+    const pkB = await admin.createProviderKey({
+      display_name: "wr-b-pk",
+      secret: "sk-mock",
+      api_base: `${upstreamB.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "wr-a",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pkA.id,
+    });
+    await admin.createModel({
+      display_name: "wr-b",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pkB.id,
+    });
+    // Virtual Model: routing-only, weighted strategy. Per the schema
+    // enum the gateway publishes (round_robin / weighted / failover),
+    // `weighted` should honour each target's `weight` integer.
+    await admin.createModel({
+      display_name: "wr-virtual",
+      routing: {
+        strategy: "weighted",
+        targets: [
+          { model: "wr-a", weight: HEAVY_WEIGHT },
+          { model: "wr-b", weight: LIGHT_WEIGHT },
+        ],
+      },
+    });
+    // Caller is allowed all three Models so the readiness probes can
+    // hit the leaves directly without firing the weighted dispatcher.
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["wr-virtual", "wr-a", "wr-b"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstreamA?.close();
+    await upstreamB?.close();
+  });
+
+  test("100 sequential calls split inside the declared 70/30 tolerance window", async (ctx) => {
+    if (!etcdReachable || !app || !upstreamA || !upstreamB) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Two-stage readiness gate: probe each leaf Model directly so
+    // both ProviderKey registrations are observed by the proxy
+    // before we exercise the virtual router. Probing through
+    // `wr-virtual` here would fire the weighted dispatcher and
+    // pollute the count baseline.
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "wr-a",
+          messages: [{ role: "user", content: "ready-probe-a" }],
+        });
+        return probe.choices[0]?.message.content === "served by A";
+      } catch {
+        return false;
+      }
+    });
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "wr-b",
+          messages: [{ role: "user", content: "ready-probe-b" }],
+        });
+        return probe.choices[0]?.message.content === "served by B";
+      } catch {
+        return false;
+      }
+    });
+    // One probe through the virtual Model so the weighted
+    // dispatcher's lazy state (if any — schedulers often build the
+    // weight wheel on first dispatch) is constructed before we start
+    // counting.
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "wr-virtual",
+          messages: [{ role: "user", content: "ready-probe-virtual" }],
+        });
+        const content = probe.choices[0]?.message.content;
+        return content === "served by A" || content === "served by B";
+      } catch {
+        return false;
+      }
+    });
+
+    // Snapshot upstream counts AFTER probes so the assertion
+    // measures only the effect of the weighted-distribution batch.
+    const aBaseline = upstreamA.receivedRequests.length;
+    const bBaseline = upstreamB.receivedRequests.length;
+
+    for (let i = 0; i < TOTAL_REQUESTS; i++) {
+      const completion = await client.chat.completions.create({
+        model: "wr-virtual",
+        messages: [{ role: "user", content: `req-${i}` }],
+      });
+      // Sanity: every dispatch lands on one of the two upstreams,
+      // returning the canned content from whichever served the call.
+      const content = completion.choices[0]?.message.content;
+      expect(content === "served by A" || content === "served by B").toBe(true);
+    }
+
+    const aDelta = upstreamA.receivedRequests.length - aBaseline;
+    const bDelta = upstreamB.receivedRequests.length - bBaseline;
+
+    // Total call accounting: every test request hit exactly one
+    // upstream (no double-dispatch, no retries). Without this gate
+    // a regression that quietly retried each call against both
+    // upstreams could still appear "balanced" by ratio.
+    expect(aDelta + bDelta).toBe(TOTAL_REQUESTS);
+
+    // Distribution assertion: heavy side ~70, light side ~30, both
+    // inside ±10. A round-robin regression (50/50) fails both gates;
+    // a pin-to-one regression (100/0) fails both gates.
+    expect(aDelta).toBeGreaterThanOrEqual(HEAVY_LO);
+    expect(aDelta).toBeLessThanOrEqual(HEAVY_HI);
+    expect(bDelta).toBeGreaterThanOrEqual(LIGHT_LO);
+    expect(bDelta).toBeLessThanOrEqual(LIGHT_HI);
+  });
+});


### PR DESCRIPTION
## Summary

First DP-only e2e for [issue #127](https://github.com/api7/ai-gateway/issues/127) **G6** (currently \`[ ]\` Missing per the [2026-05-10 audit comment](https://github.com/api7/ai-gateway/issues/127#issuecomment-4412955037)).

Pins one externally-observable contract: when a virtual Model declares \`routing.strategy = "weighted"\` with two targets at weights 70 and 30 (per the schema enum \`["round_robin", "weighted", "failover"]\`), 100 sequential calls land in roughly that ratio.

## Test shape

- Two distinct mock OpenAI upstreams (\`A\`, \`B\`), each behind its own ProviderKey + direct-mode Model so \`receivedRequests\` counts are attributable per side.
- Virtual Model \`wr-virtual\` carries the weighted routing block.
- Three readiness probes (one per leaf Model + one through the virtual router) so the dispatcher's lazy state is constructed before the count baseline is captured.
- 100 sequential calls through \`wr-virtual\`. Total-call accounting (\`aDelta + bDelta == 100\`) gates against silent double-dispatch.
- Distribution assertion: heavy side in \`[60, 80]\`, light side in \`[20, 40]\` — covers a 99% binomial interval at \`p=0.7\` for \`n=100\` (σ≈4.6) so a healthy weighted scheduler passes, while a round-robin regression (50/50) and a pin-to-one regression (100/0) both fail.

## Source-blind contract design

Per CLAUDE.md §5, the tolerance bounds and total-call accounting were derived from the **declared weights + statistical reasoning**, not from reading the routing implementation. Specifically:

- Heavy/light tolerance: weight ±10 absolute on a 100-sample window. At \`p=0.7, n=100\`, σ≈4.6, so ±10 covers ~99%.
- Total-call gate: every dispatch lands on exactly one upstream — derived from the OpenAI API contract that one chat completion request returns one response.
- Pre-baseline probes: necessary because per-leaf probes are also needed to confirm the ProviderKey + direct-Model registrations propagated; if we did not snapshot baselines after probes, probe traffic would pollute the distribution count.

## Out of scope

The other recommended next-cases from the #127 audit comment (G1 streaming-usage-accumulation, G2 streaming-tool-calls, G3 circuit-breaker, G8 vision) are separate follow-up PRs.

## Test plan

- [x] File compiles in the existing TypeScript harness (uses only \`OpenAI\`, \`AdminClient\`, \`EtcdClient\`, \`spawnApp\`, \`startOpenAiUpstream\`, \`waitConfigPropagation\` — no new deps).
- [x] Mirrors the structure of \`fallback-e2e.test.ts\` (the existing routing-block test) for harness familiarity.
- [ ] Run locally against etcd + binary; the file will skip silently in environments without etcd, matching the rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test validating weighted routing distribution across upstream providers. It sends sequential requests through a virtual routing model, verifies responses come from expected sources, checks per-upstream traffic falls within configured tolerance windows, ensures no duplicate dispatching occurs, includes readiness probing, and skips when prerequisites are unavailable (90s test timeout).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/183)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->