### PR TITLE
fix(chat): accept array `content` in /v1/chat/completions for vision input

### DIFF
--- a/crates/aisix-cache/src/key.rs
+++ b/crates/aisix-cache/src/key.rs
@@ -124,7 +124,18 @@ fn canonicalise(value: &serde_json::Value) -> serde_json::Value {
 }
 
 fn message_pair(m: &ChatMessage) -> (String, String) {
-    (role_str(m.role).to_string(), m.content.clone())
+    // For text-only messages, fingerprint on the role + content string.
+    // For vision/multimodal messages (typed-block array form), the
+    // raw `content_blocks` value is what distinguishes the request —
+    // two messages with the same query text but different image URLs
+    // MUST produce distinct fingerprints. Canonicalise the blocks
+    // (sorted keys at every nesting level) so JSON-key-order
+    // differences don't cause spurious cache misses.
+    let content_repr = match m.content_blocks.as_ref() {
+        Some(blocks) => canonical_json_string(&serde_json::Value::Array(blocks.clone())),
+        None => m.content.clone(),
+    };
+    (role_str(m.role).to_string(), content_repr)
 }
 
 fn role_str(role: Role) -> &'static str {
@@ -178,6 +189,54 @@ mod tests {
         assert_ne!(
             CacheKey::from_request(&a).fingerprint(),
             CacheKey::from_request(&b).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn vision_messages_with_different_image_urls_have_distinct_fingerprints() {
+        // Regression test for the cache-key collision found in PR #184
+        // audit (C1): with the typed-block array form of `content`,
+        // `m.content` only carries the concatenated TEXT (e.g.
+        // "What's in this image?"); the image URL lives in
+        // `content_blocks`. Two requests asking the same question
+        // about different images would produce the same `(role,
+        // content)` pair if `message_pair` didn't include the blocks.
+        // The cache would then return the cat-photo response when a
+        // user asks about a dog photo. message_pair must canonicalise
+        // and include the raw blocks.
+        let mk = |url: &str| {
+            let mut msg = ChatMessage::user("What's in this image?");
+            msg.content_blocks = Some(vec![
+                serde_json::json!({"type": "text", "text": "What's in this image?"}),
+                serde_json::json!({"type": "image_url", "image_url": {"url": url}}),
+            ]);
+            req("m", vec![msg], None)
+        };
+        let a = mk("https://example.com/cat.jpg");
+        let b = mk("https://example.com/dog.jpg");
+        assert_ne!(
+            CacheKey::from_request(&a).fingerprint(),
+            CacheKey::from_request(&b).fingerprint(),
+            "vision requests with different images must NOT share a cache slot",
+        );
+    }
+
+    #[test]
+    fn vision_messages_with_identical_blocks_share_a_fingerprint() {
+        // Sibling to the test above: same image, same question, same
+        // model — must hit the same cache slot. Sanity-check that the
+        // canonicalisation isn't introducing spurious cache misses.
+        let mk = || {
+            let mut msg = ChatMessage::user("describe");
+            msg.content_blocks = Some(vec![
+                serde_json::json!({"type": "text", "text": "describe"}),
+                serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/x.jpg"}}),
+            ]);
+            req("m", vec![msg], None)
+        };
+        assert_eq!(
+            CacheKey::from_request(&mk()).fingerprint(),
+            CacheKey::from_request(&mk()).fingerprint(),
         );
     }
 

--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -90,11 +90,21 @@ pub struct ChatMessage {
 /// string OR null OR array per OpenAI's documented shape; we
 /// deserialize through this struct and split into the `(text, blocks)`
 /// pair on the way to [`ChatMessage`].
+///
+/// `content_blocks` is also accepted on the wire for round-trip
+/// safety: the derived `Serialize` on [`ChatMessage`] emits both
+/// `content` and `content_blocks` as separate top-level fields, so
+/// re-deserialising must capture them both. (Without this, a cache
+/// store-then-load round-trip would silently drop the typed blocks
+/// into `extra` and the OpenAI bridge would forward only the
+/// concatenated text, defeating vision.)
 #[derive(Debug, Deserialize)]
 struct ChatMessageRaw {
     role: Role,
     #[serde(default)]
     content: Value,
+    #[serde(default)]
+    content_blocks: Option<Vec<Value>>,
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
@@ -105,7 +115,12 @@ struct ChatMessageRaw {
 
 impl From<ChatMessageRaw> for ChatMessage {
     fn from(raw: ChatMessageRaw) -> Self {
-        let (content, content_blocks) = split_content(raw.content);
+        let (content, derived_blocks) = split_content(raw.content);
+        // If the wire form supplied `content_blocks` explicitly
+        // (round-trip from a previous serialization), prefer it over
+        // anything we'd derive from `content`. Otherwise use the
+        // blocks extracted from the array-form of `content`.
+        let content_blocks = raw.content_blocks.or(derived_blocks);
         Self {
             role: raw.role,
             content,
@@ -498,6 +513,36 @@ mod tests {
         )
         .unwrap();
         assert_eq!(m.content, "line one\nline two");
+    }
+
+    #[test]
+    fn content_blocks_round_trip_through_serialization() {
+        // Regression test for PR #184 audit (C2): without this, a
+        // cache store-then-load (or any debug serialise→deserialise)
+        // would silently drop `content_blocks` into `extra` and the
+        // OpenAI bridge would forward only the concatenated text,
+        // defeating vision. ChatMessageRaw must accept
+        // `content_blocks` on the wire.
+        let original: ChatMessage = serde_json::from_str(
+            r#"{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert!(original.content_blocks.is_some());
+
+        // Serialise → string → deserialise. Blocks must survive.
+        let json = serde_json::to_string(&original).unwrap();
+        let round_tripped: ChatMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_tripped.content, original.content);
+        assert_eq!(round_tripped.content_blocks, original.content_blocks);
+        // `content_blocks` MUST NOT have leaked into `extra` (which
+        // would happen if ChatMessageRaw didn't capture the field).
+        assert!(!round_tripped.extra.contains_key("content_blocks"));
     }
 
     #[test]

--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -12,7 +12,8 @@
 //! that don't map cleanly to a specific upstream become the provider's
 //! responsibility to drop or translate.
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Role of a chat message. Matches OpenAI's taxonomy; providers that only
 /// support system/user/assistant are expected to reject `Tool` at their
@@ -37,19 +38,41 @@ pub enum Role {
 /// land in [`Self::extra`] via `flatten` so providers that care
 /// (currently the OpenAI bridge) can forward them verbatim.
 ///
-/// `content` accepts JSON `null` in addition to a string. OpenAI's
-/// assistant-with-tool_calls shape uses `"content": null`; we collapse
-/// that to an empty string for the gateway's internal representation,
-/// which preserves serialisability for downstreams that don't accept
-/// `null` (Anthropic, Gemini). Information loss is bounded — if the
-/// upstream behaves differently for `""` vs `null`, the OpenAI bridge
-/// can synthesise `null` from an empty string + a `tool_calls` entry in
-/// `extra` at request-build time. See issue #110.
+/// `content` accepts three wire shapes per
+/// <https://platform.openai.com/docs/api-reference/chat/create>:
+///   * a string (the common case);
+///   * JSON `null` (OpenAI's assistant-with-tool_calls history shape);
+///   * an array of typed content blocks
+///     (`[{type: "text", text}, {type: "image_url", image_url: {url}}]` —
+///     used by vision/multimodal callers).
+///
+/// We split the array form across two fields so existing call sites
+/// keep their `&str` access path:
+///   * [`Self::content`] holds the concatenated **text** of any text
+///     blocks. For non-array shapes this is the original string (or
+///     `""` for `null`). Bridges that don't speak content blocks
+///     (Anthropic / Gemini cross-provider translation today) read this
+///     and silently skip non-text blocks per docs §4.5.
+///   * [`Self::content_blocks`] holds the **raw array** verbatim when
+///     the caller sent the typed-block form. Bridges that DO support
+///     content blocks (the OpenAI-compat bridge) forward this verbatim
+///     to the upstream so vision input reaches OpenAI / Gemini /
+///     DeepSeek upstreams unchanged.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "ChatMessageRaw")]
 pub struct ChatMessage {
     pub role: Role,
-    #[serde(default, deserialize_with = "deserialize_content_string")]
     pub content: String,
+    /// Raw content-block array when the caller sent
+    /// `content: [{type, ...}, ...]`. `None` for the bare-string and
+    /// `null` content shapes. Bridges that support content blocks
+    /// (the OpenAI-compat bridge) forward this verbatim to upstream;
+    /// bridges that don't (Anthropic / Gemini cross-provider
+    /// translation today) consult only `content` (concatenated text)
+    /// per docs §4.5 ("skip non-text blocks silently on the inbound
+    /// parse").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_blocks: Option<Vec<Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -63,15 +86,70 @@ pub struct ChatMessage {
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
-/// Deserialize a `content` field that may be a string OR JSON `null`.
-/// `null` collapses to `""`. The type stays `String` (not `Option<String>`)
-/// so every existing caller — and every cross-provider bridge — keeps
-/// working without an Option dance. The `null` case only matters for
-/// OpenAI assistant-with-tool_calls history replay, where empty content
-/// is also accepted by the upstream API; see
-/// <https://platform.openai.com/docs/api-reference/chat/create>.
-fn deserialize_content_string<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Error> {
-    Ok(Option::<String>::deserialize(d)?.unwrap_or_default())
+/// Wire-shape mirror for [`ChatMessage`]. The `content` field accepts
+/// string OR null OR array per OpenAI's documented shape; we
+/// deserialize through this struct and split into the `(text, blocks)`
+/// pair on the way to [`ChatMessage`].
+#[derive(Debug, Deserialize)]
+struct ChatMessageRaw {
+    role: Role,
+    #[serde(default)]
+    content: Value,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    tool_call_id: Option<String>,
+    #[serde(default, flatten)]
+    extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl From<ChatMessageRaw> for ChatMessage {
+    fn from(raw: ChatMessageRaw) -> Self {
+        let (content, content_blocks) = split_content(raw.content);
+        Self {
+            role: raw.role,
+            content,
+            content_blocks,
+            name: raw.name,
+            tool_call_id: raw.tool_call_id,
+            extra: raw.extra,
+        }
+    }
+}
+
+/// Split a wire-form `content` value into the gateway's
+/// `(extracted_text, raw_blocks)` representation:
+///   * String → (string, None)
+///   * null → ("", None) — OpenAI's assistant-with-tool_calls history
+///     shape per <https://platform.openai.com/docs/api-reference/chat/create>
+///   * Array → (concatenated text from `{type:"text", text}` blocks,
+///     Some(raw array)) — vision / multimodal input. Non-text blocks
+///     (e.g. `image_url`) are skipped on the text-extraction path but
+///     preserved verbatim in the raw array for forwarding.
+///   * Anything else → ("", None) — defensive default; unexpected
+///     shapes don't fail the request, they degrade to an empty text
+///     so the bridge can still dispatch.
+fn split_content(v: Value) -> (String, Option<Vec<Value>>) {
+    match v {
+        Value::String(s) => (s, None),
+        Value::Null => (String::new(), None),
+        Value::Array(blocks) => {
+            let text = blocks
+                .iter()
+                .filter_map(|b| {
+                    let ty = b.get("type").and_then(Value::as_str)?;
+                    if ty == "text" {
+                        b.get("text").and_then(Value::as_str).map(str::to_owned)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            (text, Some(blocks))
+        }
+        _ => (String::new(), None),
+    }
 }
 
 impl ChatMessage {
@@ -79,6 +157,7 @@ impl ChatMessage {
         Self {
             role: Role::System,
             content: content.into(),
+            content_blocks: None,
             name: None,
             tool_call_id: None,
             extra: serde_json::Map::new(),
@@ -89,6 +168,7 @@ impl ChatMessage {
         Self {
             role: Role::User,
             content: content.into(),
+            content_blocks: None,
             name: None,
             tool_call_id: None,
             extra: serde_json::Map::new(),
@@ -99,6 +179,7 @@ impl ChatMessage {
         Self {
             role: Role::Assistant,
             content: content.into(),
+            content_blocks: None,
             name: None,
             tool_call_id: None,
             extra: serde_json::Map::new(),
@@ -348,6 +429,75 @@ mod tests {
     fn is_streaming_defaults_to_false_when_unset() {
         let f = ChatFormat::new("m", vec![]);
         assert!(!f.is_streaming());
+    }
+
+    #[test]
+    fn content_accepts_string() {
+        let m: ChatMessage = serde_json::from_str(r#"{"role": "user", "content": "hi"}"#).unwrap();
+        assert_eq!(m.content, "hi");
+        assert!(m.content_blocks.is_none());
+    }
+
+    #[test]
+    fn content_accepts_null_collapsing_to_empty_string() {
+        let m: ChatMessage =
+            serde_json::from_str(r#"{"role": "assistant", "content": null}"#).unwrap();
+        assert_eq!(m.content, "");
+        assert!(m.content_blocks.is_none());
+    }
+
+    #[test]
+    fn content_accepts_typed_block_array_for_vision() {
+        // OpenAI vision request shape per
+        // <https://platform.openai.com/docs/guides/vision>.
+        let m: ChatMessage = serde_json::from_str(
+            r#"{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What's in this image?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}
+                ]
+            }"#,
+        )
+        .unwrap();
+        // Concatenated text from text blocks (non-text blocks skipped).
+        assert_eq!(m.content, "What's in this image?");
+        // Raw blocks preserved verbatim for forwarding.
+        let blocks = m.content_blocks.expect("blocks should be Some");
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[1]["type"], "image_url");
+        assert_eq!(blocks[1]["image_url"]["url"], "https://example.com/cat.jpg");
+    }
+
+    #[test]
+    fn content_array_with_only_image_blocks_yields_empty_text_but_keeps_blocks() {
+        let m: ChatMessage = serde_json::from_str(
+            r#"{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "https://example.com/x.jpg"}}
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(m.content, "");
+        assert!(m.content_blocks.is_some());
+    }
+
+    #[test]
+    fn content_array_concatenates_multiple_text_blocks() {
+        let m: ChatMessage = serde_json::from_str(
+            r#"{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "line one\n"},
+                    {"type": "text", "text": "line two"}
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(m.content, "line one\nline two");
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -424,6 +424,7 @@ mod tests {
             vec![ChatMessage {
                 role: Role::Tool,
                 content: "tool output".into(),
+                content_blocks: None,
                 name: None,
                 tool_call_id: Some("tc_1".into()),
                 extra: serde_json::Map::new(),

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -214,6 +214,7 @@ pub(crate) fn response_into_chat_response(raw: AnthropicResponse) -> ChatRespons
         message: ChatMessage {
             role: Role::Assistant,
             content: text,
+            content_blocks: None,
             name: None,
             tool_call_id: None,
             extra: serde_json::Map::new(),
@@ -790,6 +791,7 @@ mod tests {
             vec![ChatMessage {
                 role: Role::Tool,
                 content: "x".into(),
+                content_blocks: None,
                 name: None,
                 tool_call_id: None,
                 extra: serde_json::Map::new(),

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -34,7 +34,12 @@ pub(crate) struct OpenAiRequest<'a> {
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct OpenAiMessage<'a> {
     pub role: &'a str,
-    pub content: &'a str,
+    /// `content` accepts string OR typed-block array per OpenAI's
+    /// vision spec; we forward whichever the caller sent. The
+    /// `untagged` enum makes `OpenAiContent::Blocks([...])`
+    /// serialise as a bare array and `OpenAiContent::Text("...")`
+    /// as a bare string — matching the OpenAI wire shape.
+    pub content: OpenAiContent<'a>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -46,6 +51,18 @@ pub(crate) struct OpenAiMessage<'a> {
     /// without the gateway having to model every OpenAI field.
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: &'a serde_json::Map<String, serde_json::Value>,
+}
+
+/// Wire-shape of an OpenAI message's `content` field. OpenAI accepts
+/// either a string (text-only message) or an array of typed content
+/// blocks (vision / multimodal); we forward whichever the gateway's
+/// [`ChatMessage`] carried in. See
+/// <https://platform.openai.com/docs/guides/vision>.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub(crate) enum OpenAiContent<'a> {
+    Text(&'a str),
+    Blocks(&'a [serde_json::Value]),
 }
 
 /// Build the upstream request from the gateway's normalised format.
@@ -74,7 +91,16 @@ pub(crate) fn messages_from(req: &ChatFormat) -> Vec<OpenAiMessage<'_>> {
         .iter()
         .map(|m| OpenAiMessage {
             role: role_str(m.role),
-            content: &m.content,
+            // Vision / multimodal callers send `content` as an array
+            // of typed blocks; OpenAI accepts the array form natively
+            // (no translation needed for OpenAI / Gemini-OpenAI-compat /
+            // DeepSeek-OpenAI-compat upstreams). When present forward
+            // the raw blocks verbatim; otherwise forward the bare
+            // string. See `ChatMessage::content_blocks` doc.
+            content: match m.content_blocks.as_deref() {
+                Some(blocks) => OpenAiContent::Blocks(blocks),
+                None => OpenAiContent::Text(&m.content),
+            },
             name: m.name.as_deref(),
             tool_call_id: m.tool_call_id.as_deref(),
             extra: &m.extra,
@@ -162,6 +188,7 @@ pub(crate) fn response_into_chat_response(mut raw: OpenAiResponse) -> ChatRespon
             ChatMessage {
                 role: role_from_str(&c.message.role),
                 content: c.message.content.unwrap_or_default(),
+                content_blocks: None,
                 name: None,
                 tool_call_id: None,
                 extra: serde_json::Map::new(),

--- a/tests/e2e/src/cases/vision-input-e2e.test.ts
+++ b/tests/e2e/src/cases/vision-input-e2e.test.ts
@@ -1,0 +1,233 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: vision input pass-through on the OpenAI-native path.
+// Multimodal callers attach images to chat completions via the
+// OpenAI `messages[].content` array of typed content blocks per
+// <https://platform.openai.com/docs/guides/vision>. When the
+// resolved Model's provider is OpenAI (native, no translation),
+// the gateway must forward the content array byte-for-byte to the
+// upstream — including both `image_url` blocks (URL form) and
+// `text` blocks interleaved.
+//
+// Two shapes pinned:
+//
+//   1. Image-URL form — `image_url: { url: "https://..." }`
+//   2. Base64 data-URL form — `image_url: { url: "data:image/png;base64,..." }`
+//
+// Both are documented in OpenAI's vision guide as accepted forms.
+// A regression that re-encoded, re-shaped, or dropped the
+// content-block array would break every multimodal caller.
+//
+// Cross-provider vision translation (caller's image_url →
+// Anthropic image content block) is documented as a known gap in
+// `docs/api-proxy.md` §4.5 ("image blocks ... skip non-text blocks
+// silently on the inbound parse") and is out of scope for this
+// PR — the OpenAI-native path is the most-used vision path and a
+// regression there breaks the largest callers.
+//
+// References:
+// - OpenAI Vision guide
+//   <https://platform.openai.com/docs/guides/vision>
+// - OpenAI Chat Completions content-block spec
+//   <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
+
+const CALLER_PLAINTEXT = "sk-vision-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// Tiny 1×1 transparent PNG, base64-encoded. Works as a real
+// data-URL the SDK will accept; small enough to keep the test
+// fixture compact.
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+const TINY_PNG_DATA_URL = `data:image/png;base64,${TINY_PNG_BASE64}`;
+const REMOTE_IMAGE_URL = "https://example.com/test-image.jpg";
+
+describe("vision input e2e: OpenAI-native image content blocks pass through to upstream", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-vision",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "I see a 1x1 transparent pixel.",
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 12, completion_tokens: 7, total_tokens: 19 },
+      },
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "vision-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "vision-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["vision-e2e"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("remote image_url + text blocks reach upstream byte-for-byte", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.chat.completions.create({
+          model: "vision-e2e",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    // OpenAI vision request shape: content is an array of typed
+    // blocks instead of a bare string. Per
+    // <https://platform.openai.com/docs/guides/vision>.
+    const completion = await client.chat.completions.create({
+      model: "vision-e2e",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What's in this image?" },
+            { type: "image_url", image_url: { url: REMOTE_IMAGE_URL } },
+          ],
+        },
+      ],
+    });
+
+    expect(completion.choices[0]?.message.role).toBe("assistant");
+    expect(completion.choices[0]?.message.content).toBe(
+      "I see a 1x1 transparent pixel.",
+    );
+
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/chat/completions");
+    expect(testCalls).toHaveLength(1);
+
+    // Wire-shape contract: content array reaches upstream with
+    // both blocks intact. A regression that flattened to a bare
+    // string (e.g. concatenating text and discarding the image)
+    // would break vision entirely.
+    const sentBody = JSON.parse(testCalls[0]!.body) as {
+      messages?: Array<{
+        role?: string;
+        content?: Array<{ type?: string; text?: string; image_url?: { url?: string } }>;
+      }>;
+    };
+    const userMessage = sentBody.messages?.[0];
+    expect(userMessage?.role).toBe("user");
+    expect(Array.isArray(userMessage?.content)).toBe(true);
+    expect(userMessage?.content).toHaveLength(2);
+    expect(userMessage?.content?.[0]?.type).toBe("text");
+    expect(userMessage?.content?.[0]?.text).toBe("What's in this image?");
+    expect(userMessage?.content?.[1]?.type).toBe("image_url");
+    // The remote URL must reach upstream verbatim — a regression
+    // that re-encoded, signed, or proxied the URL would break
+    // upstream's ability to fetch the image.
+    expect(userMessage?.content?.[1]?.image_url?.url).toBe(REMOTE_IMAGE_URL);
+  });
+
+  test("base64 data-URL image reaches upstream byte-for-byte", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    // Base64 data-URL form. Common path for callers who don't
+    // want to host images on a public URL.
+    await client.chat.completions.create({
+      model: "vision-e2e",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe the embedded image." },
+            { type: "image_url", image_url: { url: TINY_PNG_DATA_URL } },
+          ],
+        },
+      ],
+    });
+
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/chat/completions");
+    expect(testCalls).toHaveLength(1);
+
+    // The base64 payload must reach upstream byte-for-byte. A
+    // regression that re-encoded the base64 (e.g. unwrapped + re-
+    // wrapped through internal buffers) could corrupt the image.
+    const sentBody = JSON.parse(testCalls[0]!.body) as {
+      messages?: Array<{
+        content?: Array<{ type?: string; image_url?: { url?: string } }>;
+      }>;
+    };
+    const imageBlock = sentBody.messages?.[0]?.content?.[1];
+    expect(imageBlock?.type).toBe("image_url");
+    expect(imageBlock?.image_url?.url).toBe(TINY_PNG_DATA_URL);
+  });
+});


### PR DESCRIPTION
Closes #171.

## Problem

Per OpenAI's [documented Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages), \`messages[].content\` is \`Union[str, List[ContentBlock]]\` — string for text-only messages, array of typed blocks for vision/multimodal input.

The gateway only accepted the string form. Vision requests hit:
\`\`\`
422 Failed to deserialize the JSON body into the target type:
  messages[0].content: invalid type: sequence, expected a string
\`\`\`

The request never reached the dispatcher, so **vision did not work on any provider**.

## Fix

\`ChatMessage\` deserialization now accepts string, null, OR typed-block array. The wire shape is split into two internal fields:

| Field | Holds |
|-------|-------|
| \`content: String\` | Concatenated text from \`{type:"text", text}\` blocks (or the bare string / \`""\` for null). Bridges without content-block support read this and silently skip non-text blocks per docs §4.5. |
| \`content_blocks: Option<Vec<Value>>\` | Raw array verbatim when present. The OpenAI-compat bridge forwards this directly to the upstream so vision input reaches OpenAI / Gemini-compat / DeepSeek-compat upstreams byte-for-byte. |

\`OpenAiMessage.content\` is now an \`#[serde(untagged)]\` enum that serializes as either string OR array, picked from \`content_blocks\`'s presence.

The cache-key fingerprint (\`aisix-cache::key::message_pair\`) consults \`content_blocks\` when present so two vision requests with the same query text but different image URLs produce distinct fingerprints — without this, the cache would return the wrong image's response.

## Tests

**6 new Rust unit tests** (\`crates/aisix-gateway/src/chat.rs\`):
- \`content_accepts_string\`
- \`content_accepts_null_collapsing_to_empty_string\`
- \`content_accepts_typed_block_array_for_vision\` — pins the OpenAI vision shape from the docs
- \`content_array_with_only_image_blocks_yields_empty_text_but_keeps_blocks\`
- \`content_array_concatenates_multiple_text_blocks\`
- \`content_blocks_round_trip_through_serialization\` — pins that store-then-load preserves typed blocks

**2 new cache-key regression tests** (\`crates/aisix-cache/src/key.rs\`):
- \`vision_messages_with_different_image_urls_have_distinct_fingerprints\` — pins no cross-image cache pollution
- \`vision_messages_with_identical_blocks_share_a_fingerprint\` — sanity-check no spurious misses

**1 new e2e test** (\`tests/e2e/src/cases/vision-input-e2e.test.ts\`) — restored from the held-back queue. Two cases:
- Remote \`image_url\` form: caller sends \`{url: "https://..."}\`; assertion pins that the array reaches upstream byte-for-byte with text + image blocks in order, URL preserved.
- Base64 data-URL form: caller sends \`{url: "data:image/png;base64,..."}\`; same assertion against the embedded payload.

## Verification

- \`cargo test -p aisix-gateway --lib\`: **42/42 passing** (+6 new)
- \`cargo test -p aisix-cache --lib\`: **20/20 passing** (+2 new)
- \`cargo clippy --workspace -- -D warnings\`: clean
- Full e2e suite: **41/41 passing** (was 39 on main; +2 from vision-input-e2e)

## Out of scope

- **Anthropic upstream cross-provider vision translation** — image blocks → Anthropic's \`{type:"image", source:{...}}\` content shape — is documented as a known gap in \`docs/api-proxy.md\` §4.5 ("image blocks land in a follow-up"), and **#170** tracks the related tool_use translation gap. This PR fixes only the parser-level rejection and the OpenAI-compat-upstream forwarding path, which is what unblocks the most-used vision callers (OpenAI native, Gemini, DeepSeek).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI-style multimodal message content: typed content blocks are preserved and text blocks are concatenated for display.

* **Bug Fixes**
  * Cache keys now account for multimodal content so distinct images produce distinct fingerprints.

* **Tests**
  * Added unit and end-to-end tests validating parsing, serialization round-trips, and exact pass-through of vision/multimodal messages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/184)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->