### PR TITLE
fix(schema): allow max_budget_usd in ApiKey admin POST

### DIFF
--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -195,7 +195,8 @@ fn apikey_schema() -> Value {
                 "type": "array",
                 "items": { "type": "string" }
             },
-            "rate_limit": { "$ref": "#/$defs/rate_limit" }
+            "rate_limit": { "$ref": "#/$defs/rate_limit" },
+            "max_budget_usd": { "type": "number", "minimum": 0 }
         },
         "$defs": {
             "rate_limit": {
@@ -501,6 +502,26 @@ mod tests {
         // Schema permits []; runtime ApiKey::can_access enforces deny-all.
         let v = json!({"key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20","allowed_models":[]});
         validate_apikey(&v).unwrap();
+    }
+
+    #[test]
+    fn apikey_with_max_budget_usd_passes() {
+        let v = json!({
+            "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
+            "allowed_models":["a","b"],
+            "max_budget_usd": 500.0
+        });
+        validate_apikey(&v).unwrap();
+    }
+
+    #[test]
+    fn apikey_negative_max_budget_usd_rejected() {
+        let v = json!({
+            "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
+            "allowed_models":["a"],
+            "max_budget_usd": -1.0
+        });
+        assert!(validate_apikey(&v).is_err());
     }
 
     #[test]

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -133,7 +133,8 @@ curl -X POST http://localhost:3001/admin/v1/apikeys \
   -d '{
     "key_hash": "'"$KEY_HASH"'",
     "allowed_models": ["my-gpt4"],
-    "rate_limit": {"rpm": 60, "concurrency": 10}
+    "rate_limit": {"rpm": 60, "concurrency": 10},
+    "max_budget_usd": 500.0
   }'
 ```
 
@@ -175,22 +176,12 @@ curl -X POST http://localhost:3001/admin/v1/provider_keys \
 ### 4.4 Budgets
 
 Per-ApiKey USD spend caps live inline on the ApiKey resource
-(`max_budget_usd` field on the Rust struct) — there is no separate
-`/admin/v1/budgets` collection. The proxy reads the budget at
-request start (pre-check) and adds the cost at end of request.
-
-> ⚠️ **Known gap**: the JSON Schema in
-> `crates/aisix-core/src/models/schema.rs::apikey_schema()` does not
-> currently list `max_budget_usd` and is `additionalProperties: false`,
-> so admin POST/PUT will reject the field. In standalone mode the
-> field is therefore unreachable through the admin API today; in
-> managed mode the CP populates ApiKey rows in etcd directly and the
-> field flows through. Tracking issue covers adding the property to
-> the schema so standalone operators can set budgets via the admin
-> API as well.
+(`max_budget_usd` field) — there is no separate `/admin/v1/budgets`
+collection. The proxy reads the budget at request start (pre-check)
+and adds the cost at end of request.
 
 Team-level budgets are a SaaS-tier feature; standalone deployments
-do per-key budgeting only (subject to the gap noted above).
+do per-key budgeting only.
 
 ### 4.5 Health — `GET /admin/v1/health`
 

--- a/tests/e2e/src/cases/apikey-budget-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-budget-e2e.test.ts
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: max_budget_usd round-trips through the admin API. Closes the
+// gap that PR #182 surfaced — the JSON schema previously rejected
+// max_budget_usd, making the field unreachable from a standalone
+// admin POST. This test pins the documented §4.2 contract: a body
+// carrying max_budget_usd is accepted, persisted, and returned by
+// GET unchanged. A regression that re-tightens the schema (or
+// re-adds additionalProperties: false without re-listing the field)
+// fails here loudly.
+//
+// Reference: docs/api-admin.md §4.2 (the example body now includes
+// "max_budget_usd": 500.0).
+
+const PLAINTEXT = "sk-budget-e2e";
+const KEY_HASH = createHash("sha256").update(PLAINTEXT).digest("hex");
+
+describe("apikey max_budget_usd e2e: admin POST + GET round-trip", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+  });
+
+  test("POST persists max_budget_usd; GET returns the same value", async (ctx) => {
+    if (!etcdReachable || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const created = await admin.createApiKey({
+      key_hash: KEY_HASH,
+      allowed_models: ["*"],
+      max_budget_usd: 500.0,
+    });
+    expect(created.id).toBeTruthy();
+
+    const got = await admin.json<{
+      id: string;
+      value: { max_budget_usd?: number };
+    }>("GET", `/admin/v1/apikeys/${created.id}`);
+    expect(got.value.max_budget_usd).toBe(500);
+  });
+
+  test("POST with negative max_budget_usd is rejected with 400", async (ctx) => {
+    if (!etcdReachable || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    let caught: unknown;
+    try {
+      await admin.createApiKey({
+        key_hash: createHash("sha256").update("sk-neg-budget").digest("hex"),
+        allowed_models: ["*"],
+        max_budget_usd: -1,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("400");
+  });
+});


### PR DESCRIPTION
## Summary

PR #182 documented a real product bug it surfaced: the ApiKey JSON
Schema in `apikey_schema()` doesn't list `max_budget_usd`, while the
Rust struct does. With `additionalProperties: false`, any admin
POST/PUT carrying `max_budget_usd` was rejected with 400 — making
the field unreachable through the standalone admin API. This PR
closes that *ingestion* gap; the field is now accepted, deserialised
into `ApiKey { max_budget_usd: Some(_), .. }`, and persisted to
etcd.

- **schema.rs** — add `max_budget_usd: { type: number, minimum: 0 }`
  to `apikey_schema()`. Matches `ApiKey.max_budget_usd: Option<f64>`
  in `crates/aisix-core/src/models/apikey.rs:37`.
- **schema.rs tests** — `apikey_with_max_budget_usd_passes` proves a
  body with `max_budget_usd: 500.0` validates; a paired
  `apikey_negative_max_budget_usd_rejected` pins `minimum: 0`.
- **e2e** — `tests/e2e/src/cases/apikey-budget-e2e.test.ts` adds a
  black-box round-trip: `POST /admin/v1/apikeys` with
  `max_budget_usd: 500.0`, then `GET /admin/v1/apikeys/{id}`,
  asserts the field round-trips. Plus a negative case that POSTing
  `-1` returns 400.
- **docs/api-admin.md** — drop the §4.4 ⚠️ "Known gap" callout that
  PR #182 added, and restore `"max_budget_usd": 500.0` in the §4.2
  example body that #182 had to remove as a workaround.

## Scope clarification — ingestion only

This PR restores **only the ingestion path**. The standalone proxy
data plane does not currently consume `ApiKey.max_budget_usd`;
budget enforcement today delegates to cp-api's `/dp/budget_check`,
so on a standalone deployment the field is persisted-but-unenforced.
This is a separate product gap, not a regression introduced here —
filed as #189 and not merge-blocking.

## Follow-ups (filed, not blocking)

- #189 — standalone proxy needs to read `ApiKey.max_budget_usd`
  locally when cp-api isn't wired (closes the enforcement half of
  the gap; this PR closes only the ingestion half).
- #190 — once enforcement lands, the schema should likely be
  `exclusiveMinimum: 0` to disallow a literal `0` cap that would
  brick the key.

Stacked on top of PR #182 (`fix/docs-admin-schema-truth`) so the
docs delta only shows the gap-closing changes; merge order is #182
first, then this.

Refs #182.

## Test plan

- [x] `cargo test -p aisix-core` — 96 passed (was 94; +2 new)
- [x] `npx tsc --noEmit` in `tests/e2e/` — clean
- [ ] CI green (e2e suite must run against a real etcd-backed app
      per the harness; the new test follows the same pattern as
      `allowed-models-e2e.test.ts`)
- [ ] Once #182 is merged, retarget base to \`main\` so this can land

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys now support per-key USD spending limits configurable at creation and update

* **Documentation**
  * Updated Admin API documentation with budget configuration details and examples

* **Tests**
  * Added end-to-end tests validating budget limit configuration and validation behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/185)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->