### PR TITLE
test(e2e): G2 streaming tool_calls — fragments assemble to valid JSON

### DIFF
--- a/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
+++ b/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
@@ -139,6 +139,12 @@ describe("streaming tool_calls e2e: arguments fragments concatenate to a valid J
       }
     });
 
+    // Baseline-isolate the readiness probe so the upstream wire-shape
+    // assertion below measures only the actual test call. Without
+    // this, the probe (which also goes through the streaming path)
+    // would inflate the request count.
+    const upstreamBaseline = upstream.receivedRequests.length;
+
     const stream = await client.chat.completions.create({
       model: "stream-tools-model",
       messages: [
@@ -200,10 +206,14 @@ describe("streaming tool_calls e2e: arguments fragments concatenate to a valid J
     expect(firstWithTool?.idDelta).toBe(TOOL_CALL_ID);
     expect(firstWithTool?.nameDelta).toBe(TOOL_NAME);
 
-    const subsequentWithTool = captured
-      .slice(captured.indexOf(firstWithTool!) + 1)
-      .filter((c) => c.argsDelta !== undefined);
-    for (const c of subsequentWithTool) {
+    // Sweep every chunk after the first tool_call delta — including
+    // empty-delta chunks like the terminal finish chunk — to catch a
+    // regression that re-emits id/name on a chunk that has no
+    // arguments fragment (which an args-filtered sweep would miss).
+    const afterFirst = captured.slice(
+      captured.indexOf(firstWithTool!) + 1,
+    );
+    for (const c of afterFirst) {
       expect(c.idDelta).toBeUndefined();
       expect(c.nameDelta).toBeUndefined();
     }
@@ -230,5 +240,29 @@ describe("streaming tool_calls e2e: arguments fragments concatenate to a valid J
     // tool_calls fragments arrive after finish_reason. Catches a
     // regression that flushed a stray fragment after the terminator.
     expect(captured[captured.length - 1]?.finish).toBe("tool_calls");
+
+    // (5) Upstream wire-shape assertion. The gateway must have sent
+    // exactly one request to the mock upstream, on the chat
+    // completions path, with the tools array intact, stream:true,
+    // and the ProviderKey's secret as the bearer token. A regression
+    // that stripped the tools array, dropped stream:true, or rewrote
+    // the auth header would still pass the response-shape gates
+    // above (because the mock replays canned events regardless) —
+    // this check is what closes that blind spot.
+    const sent = upstream.receivedRequests.slice(upstreamBaseline);
+    const completions = sent.filter(
+      (r) => r.path === "/v1/chat/completions",
+    );
+    expect(completions).toHaveLength(1);
+    const sentReq = completions[0]!;
+    expect(sentReq.method).toBe("POST");
+    expect(sentReq.headers.authorization).toBe("Bearer sk-mock");
+    const sentBody = JSON.parse(sentReq.body);
+    expect(sentBody.stream).toBe(true);
+    expect(sentBody.model).toBe("gpt-4o-mini");
+    expect(Array.isArray(sentBody.tools)).toBe(true);
+    expect(sentBody.tools).toHaveLength(1);
+    expect(sentBody.tools[0]?.type).toBe("function");
+    expect(sentBody.tools[0]?.function?.name).toBe(TOOL_NAME);
   }, 60_000);
 });

--- a/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
+++ b/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
@@ -53,18 +53,30 @@ const TOOL_NAME = "get_weather";
 // Arguments fragments — concatenation must equal CANONICAL_ARGS.
 // Split mid-key, mid-value, and mid-quote to exercise non-aligned
 // boundaries the assembler cannot trivially short-circuit on.
+//
+// These fragments contain literal `"` characters that are part of
+// the inner JSON the model is invoking. When the upstream serializes
+// each fragment as the value of `function.arguments` (a JSON string
+// field), those quotes need JSON-escaping in the wire payload — we
+// use JSON.stringify(fragment) below which adds the surrounding
+// quotes AND escapes any inner `"` and `\` to produce a valid
+// JSON-encoded string literal.
 const ARGS_FRAGMENTS = ['{"', "loc", 'ation":"Bei', 'jing"}'];
 const CANONICAL_ARGS = ARGS_FRAGMENTS.join("");
 const CANONICAL_PARSED = { location: "Beijing" };
 
+// Shorthand for embedding a string fragment as a JSON-encoded value
+// inside a template literal (handles inner quote/backslash escaping).
+const j = (s: string) => JSON.stringify(s);
+
 const SSE_EVENTS = [
   // Role delta + first tool_call fragment (carries id, type, name,
   // first slice of arguments).
-  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"${TOOL_CALL_ID}","type":"function","function":{"name":"${TOOL_NAME}","arguments":"${ARGS_FRAGMENTS[0]}"}}]},"finish_reason":null}]}`,
+  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":${j(TOOL_CALL_ID)},"type":"function","function":{"name":${j(TOOL_NAME)},"arguments":${j(ARGS_FRAGMENTS[0]!)}}}]},"finish_reason":null}]}`,
   // Subsequent fragments carry only arguments under index 0.
-  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${ARGS_FRAGMENTS[1]}"}}]},"finish_reason":null}]}`,
-  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${ARGS_FRAGMENTS[2]}"}}]},"finish_reason":null}]}`,
-  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${ARGS_FRAGMENTS[3]}"}}]},"finish_reason":null}]}`,
+  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":${j(ARGS_FRAGMENTS[1]!)}}}]},"finish_reason":null}]}`,
+  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":${j(ARGS_FRAGMENTS[2]!)}}}]},"finish_reason":null}]}`,
+  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":${j(ARGS_FRAGMENTS[3]!)}}}]},"finish_reason":null}]}`,
   // Terminal chunk: empty delta, finish_reason = tool_calls.
   '{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
   "[DONE]",

--- a/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
+++ b/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
@@ -80,7 +80,31 @@ describe("streaming tool_calls e2e: arguments fragments concatenate to a valid J
     etcdReachable = await new EtcdClient().ping();
     if (!etcdReachable) return;
 
-    upstream = await startOpenAiUpstream({ streamEvents: SSE_EVENTS });
+    // Configure both stream and non-stream responses on the same mock:
+    // the readiness probe goes through the non-stream path (fast,
+    // deterministic), and the actual test call asks for stream:true
+    // so it consumes the streamEvents above.
+    upstream = await startOpenAiUpstream({
+      streamEvents: SSE_EVENTS,
+      nonStreamBody: {
+        id: "chatcmpl-stream-tools-probe",
+        object: "chat.completion",
+        created: 0,
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "probe ok" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+      },
+    });
 
     app = await spawnApp();
     admin = new AdminClient(app.adminUrl, app.adminKey);
@@ -119,21 +143,22 @@ describe("streaming tool_calls e2e: arguments fragments concatenate to a valid J
       maxRetries: 0,
     });
 
-    // Snapshot propagation — drive the streaming path itself so the
-    // probe asserts on the same code path the test uses. A non-
-    // streaming probe could pass while the streaming dispatcher
-    // is still missing the Model.
+    // Snapshot propagation — non-streaming probe. Readiness in this
+    // suite means Model + ProviderKey + ApiKey are all visible to
+    // the dispatcher; both paths share that lookup. A stream-mode
+    // probe against the canned tool_call SSE was racing the 10s
+    // waitConfigPropagation budget on slow runners (consuming +
+    // breaking SSE iteration is slower than a single non-stream
+    // round-trip). The test call below still drives the real
+    // streaming dispatcher, which is what the contract assertions
+    // need.
     await waitConfigPropagation(async () => {
       try {
         const probe = await client.chat.completions.create({
           model: "stream-tools-model",
           messages: [{ role: "user", content: "ready-probe" }],
-          stream: true,
         });
-        for await (const _chunk of probe) {
-          break;
-        }
-        return true;
+        return probe.choices.length > 0;
       } catch {
         return false;
       }

--- a/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
+++ b/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
@@ -80,31 +80,7 @@ describe("streaming tool_calls e2e: arguments fragments concatenate to a valid J
     etcdReachable = await new EtcdClient().ping();
     if (!etcdReachable) return;
 
-    // Configure both stream and non-stream responses on the same mock:
-    // the readiness probe goes through the non-stream path (fast,
-    // deterministic), and the actual test call asks for stream:true
-    // so it consumes the streamEvents above.
-    upstream = await startOpenAiUpstream({
-      streamEvents: SSE_EVENTS,
-      nonStreamBody: {
-        id: "chatcmpl-stream-tools-probe",
-        object: "chat.completion",
-        created: 0,
-        model: "gpt-4o-mini",
-        choices: [
-          {
-            index: 0,
-            message: { role: "assistant", content: "probe ok" },
-            finish_reason: "stop",
-          },
-        ],
-        usage: {
-          prompt_tokens: 1,
-          completion_tokens: 1,
-          total_tokens: 2,
-        },
-      },
-    });
+    upstream = await startOpenAiUpstream({ streamEvents: SSE_EVENTS });
 
     app = await spawnApp();
     admin = new AdminClient(app.adminUrl, app.adminKey);
@@ -143,22 +119,18 @@ describe("streaming tool_calls e2e: arguments fragments concatenate to a valid J
       maxRetries: 0,
     });
 
-    // Snapshot propagation — non-streaming probe. Readiness in this
-    // suite means Model + ProviderKey + ApiKey are all visible to
-    // the dispatcher; both paths share that lookup. A stream-mode
-    // probe against the canned tool_call SSE was racing the 10s
-    // waitConfigPropagation budget on slow runners (consuming +
-    // breaking SSE iteration is slower than a single non-stream
-    // round-trip). The test call below still drives the real
-    // streaming dispatcher, which is what the contract assertions
-    // need.
+    // Snapshot propagation — read-only probe via GET /v1/models. This
+    // verifies the ApiKey + the Model are both visible in the
+    // snapshot the proxy reads from, without invoking the dispatcher
+    // (so the mock upstream's behavior on streaming vs non-streaming
+    // does not enter the readiness check). A streaming probe against
+    // the canned tool_call SSE was racing the 10s
+    // waitConfigPropagation budget on slow CI runners. The test call
+    // below still drives the real streaming dispatcher.
     await waitConfigPropagation(async () => {
       try {
-        const probe = await client.chat.completions.create({
-          model: "stream-tools-model",
-          messages: [{ role: "user", content: "ready-probe" }],
-        });
-        return probe.choices.length > 0;
+        const list = await client.models.list();
+        return list.data.some((m) => m.id === "stream-tools-model");
       } catch {
         return false;
       }

--- a/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
+++ b/tests/e2e/src/cases/streaming-tool-calls-e2e.test.ts
@@ -1,0 +1,234 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: streaming + tool_calls delta assembly. Per OpenAI's chat
+// completions wire shape
+// (https://platform.openai.com/docs/api-reference/chat/streaming),
+// when the model invokes a tool the upstream streams the
+// `tool_calls[*].function.arguments` field across multiple SSE
+// chunks — the first chunk carries the tool_call `id`, `type`,
+// and `function.name` plus an arguments fragment; subsequent chunks
+// carry only an `arguments` fragment under the same `index`. The
+// caller is expected to concatenate the fragments back into a
+// valid JSON document.
+//
+// One contract pinned here:
+//
+//   - The gateway preserves the OpenAI tool_calls delta wire shape
+//     end-to-end. Concretely, the chunks the caller observes can be
+//     assembled into:
+//       * a single tool_call with stable `id` and `function.name`
+//         (carried only on the first delta);
+//       * an `arguments` string equal to the byte-concatenation of
+//         every per-chunk `arguments` fragment;
+//       * a final chunk whose `finish_reason === "tool_calls"`.
+//
+// A regression that lost or reordered fragments would either fail
+// JSON parsing or surface as an arguments string different from
+// the canonical concatenation. A regression that swallowed the
+// trailing `finish_reason` chunk would fail the last-chunk assertion.
+//
+// Reference: OpenAI streaming spec linked above + the OpenAI Node
+// SDK's `chat.completions.create({stream: true})` chunk type.
+
+const CALLER_PLAINTEXT = "sk-stream-tools-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// Canonical tool_call identity carried only on the first delta.
+const TOOL_CALL_ID = "call_stream_tool_e2e_1";
+const TOOL_NAME = "get_weather";
+
+// Arguments fragments — concatenation must equal CANONICAL_ARGS.
+// Split mid-key, mid-value, and mid-quote to exercise non-aligned
+// boundaries the assembler cannot trivially short-circuit on.
+const ARGS_FRAGMENTS = ['{"', "loc", 'ation":"Bei', 'jing"}'];
+const CANONICAL_ARGS = ARGS_FRAGMENTS.join("");
+const CANONICAL_PARSED = { location: "Beijing" };
+
+const SSE_EVENTS = [
+  // Role delta + first tool_call fragment (carries id, type, name,
+  // first slice of arguments).
+  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"${TOOL_CALL_ID}","type":"function","function":{"name":"${TOOL_NAME}","arguments":"${ARGS_FRAGMENTS[0]}"}}]},"finish_reason":null}]}`,
+  // Subsequent fragments carry only arguments under index 0.
+  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${ARGS_FRAGMENTS[1]}"}}]},"finish_reason":null}]}`,
+  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${ARGS_FRAGMENTS[2]}"}}]},"finish_reason":null}]}`,
+  `{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"${ARGS_FRAGMENTS[3]}"}}]},"finish_reason":null}]}`,
+  // Terminal chunk: empty delta, finish_reason = tool_calls.
+  '{"id":"chatcmpl-stream-1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+  "[DONE]",
+];
+
+describe("streaming tool_calls e2e: arguments fragments concatenate to a valid JSON tool call", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({ streamEvents: SSE_EVENTS });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "stream-tools-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "stream-tools-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["stream-tools-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("OpenAI SDK stream — fragments concatenate, id stable, finish on last chunk", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Snapshot propagation — drive the streaming path itself so the
+    // probe asserts on the same code path the test uses. A non-
+    // streaming probe could pass while the streaming dispatcher
+    // is still missing the Model.
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "stream-tools-model",
+          messages: [{ role: "user", content: "ready-probe" }],
+          stream: true,
+        });
+        for await (const _chunk of probe) {
+          break;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const stream = await client.chat.completions.create({
+      model: "stream-tools-model",
+      messages: [
+        { role: "user", content: "What's the weather in Beijing?" },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: TOOL_NAME,
+            description: "Get the current weather for a location",
+            parameters: {
+              type: "object",
+              properties: {
+                location: { type: "string" },
+              },
+              required: ["location"],
+            },
+          },
+        },
+      ],
+      stream: true,
+    });
+
+    // Capture every per-chunk view of choices[0]. Capturing in arrival
+    // order, not summed, so a regression that reordered chunks (e.g.
+    // emitted finish_reason mid-stream) is visible.
+    type CapturedChunk = {
+      idDelta: string | undefined;
+      nameDelta: string | undefined;
+      argsDelta: string | undefined;
+      finish: string | null;
+    };
+    const captured: CapturedChunk[] = [];
+    for await (const chunk of stream) {
+      const choice = chunk.choices[0];
+      const tc = choice?.delta?.tool_calls?.[0];
+      captured.push({
+        idDelta: tc?.id,
+        nameDelta: tc?.function?.name,
+        argsDelta: tc?.function?.arguments,
+        finish: choice?.finish_reason ?? null,
+      });
+    }
+
+    // (1) The first chunk that carries any tool_calls delta must
+    // also carry the stable id and function name. Subsequent chunks
+    // must NOT redeclare them — they only carry argument fragments
+    // under the same index. A regression that re-emitted id/name on
+    // every chunk would still produce a valid concatenated args but
+    // would break consumers that rely on "id is set exactly once".
+    const firstWithTool = captured.find(
+      (c) =>
+        c.idDelta !== undefined ||
+        c.nameDelta !== undefined ||
+        c.argsDelta !== undefined,
+    );
+    expect(firstWithTool).toBeDefined();
+    expect(firstWithTool?.idDelta).toBe(TOOL_CALL_ID);
+    expect(firstWithTool?.nameDelta).toBe(TOOL_NAME);
+
+    const subsequentWithTool = captured
+      .slice(captured.indexOf(firstWithTool!) + 1)
+      .filter((c) => c.argsDelta !== undefined);
+    for (const c of subsequentWithTool) {
+      expect(c.idDelta).toBeUndefined();
+      expect(c.nameDelta).toBeUndefined();
+    }
+
+    // (2) Concatenating every per-chunk arguments fragment must equal
+    // the upstream's byte-by-byte concatenation, AND must parse to
+    // the canonical object. A regression that dropped a fragment
+    // (e.g. flushed an empty SSE event) would fail JSON.parse here.
+    const assembled = captured
+      .map((c) => c.argsDelta ?? "")
+      .join("");
+    expect(assembled).toBe(CANONICAL_ARGS);
+    expect(JSON.parse(assembled)).toEqual(CANONICAL_PARSED);
+
+    // (3) finish_reason arrives exactly once, on a chunk whose delta
+    // is empty (no tool_calls fragment), and the value is
+    // "tool_calls" — matching the upstream's terminal SSE event.
+    const finishChunks = captured.filter((c) => c.finish !== null);
+    expect(finishChunks).toHaveLength(1);
+    expect(finishChunks[0]?.finish).toBe("tool_calls");
+    expect(finishChunks[0]?.argsDelta).toBeUndefined();
+
+    // (4) The terminal finish chunk is the last one captured; no
+    // tool_calls fragments arrive after finish_reason. Catches a
+    // regression that flushed a stray fragment after the terminator.
+    expect(captured[captured.length - 1]?.finish).toBe("tool_calls");
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Closes the **G2** gap from [issue #127](https://github.com/api7/ai-gateway/issues/127) — currently \`[ ]\` Missing per the [2026-05-10 audit comment](https://github.com/api7/ai-gateway/issues/127#issuecomment-4412955037). Audit observed: zero \`tool_calls\` / \`function\` references across all 22 existing e2e files.

Pins one externally-observable contract: when the upstream streams a tool invocation per [OpenAI's wire shape](https://platform.openai.com/docs/api-reference/chat/streaming) — first chunk carries the tool_call \`id\`, \`type\`, \`function.name\` plus an \`arguments\` fragment; subsequent chunks carry only \`arguments\` fragments under the same \`index\`; terminal chunk carries \`finish_reason = "tool_calls"\` — the gateway preserves that shape end-to-end.

## Assertions

The caller must be able to assemble a single tool_call with:

1. **Stable id + function.name** — declared exactly once on the first tool_call delta. Subsequent fragments under the same index must NOT redeclare them. Catches a regression that re-emits id/name on every chunk (still produces valid concatenated args but breaks consumers that rely on id-set-once).
2. **Byte-exact arguments concatenation** — every per-chunk \`arguments\` fragment joins to the upstream's exact string and parses to the canonical object \`{"location":"Beijing"}\`. Catches a regression that drops or reorders fragments.
3. **Single \`finish_reason\`** — arrives exactly once on a chunk with empty delta, value \`"tool_calls"\`. Catches a regression that swallowed the terminal SSE event or duplicated it.
4. **Terminal-chunk-is-last** — no \`tool_calls\` fragments after the finish chunk. Catches a regression that flushed a stray fragment after the terminator.

## Mock-upstream design

Arguments \`{"location":"Beijing"}\` is split as \`'{"' / 'loc' / 'ation":"Bei' / 'jing"}'\` so fragment boundaries fall **mid-key, mid-value, and mid-quote**. A trivial assembler that only checks for natural boundaries (e.g. only re-joins on closing brace) would fail JSON parsing.

## Source-blind contract design

Per CLAUDE.md §5, every expected value derives from upstream-emitted bytes + JSON parsing semantics — not from reading the gateway's SSE handler:

- The 5 expected chunks come from the 5 SSE events I emit.
- The \`finish_reason\` value \`"tool_calls"\` is the value I write into the terminal SSE event.
- The canonical \`{"location":"Beijing"}\` is the byte-concatenation of the fragments I split.

## Out of scope

- G1 streaming-usage-accumulation, G3 circuit-breaker, G8 vision — separate follow-up PRs.

## Test plan

- [x] Mirrors the structure of \`cross-provider-matrix-e2e.test.ts\` streaming branch (the existing canonical streaming test pattern).
- [x] Uses only existing harness primitives (\`startOpenAiUpstream({streamEvents})\`, \`AdminClient\`, OpenAI SDK).
- [ ] Run locally against etcd + binary; the file will skip silently in environments without etcd, matching the rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end streaming test that verifies correct sequencing and assembly of fragmented tool-call arguments across streaming chunks and that the terminal finish reason is emitted exactly once.
  * Confirms the gateway issues a single streamed upstream request with the expected model, tools, and authorization during the streaming interaction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/186)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->