### PR TITLE
fix(anthropic): translate tools spec + tool_use ↔ tool_calls cross-provider

### DIFF
--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -415,7 +415,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_role_is_rejected_as_config_error() {
+    async fn tool_role_without_tool_call_id_is_rejected_as_config_error() {
+        // Tool role IS supported (translates to Anthropic
+        // `{role:"user", content:[{type:"tool_result", ...}]}`)
+        // when paired with a tool_call_id. Without one, there's no
+        // way to pair the result with its originating tool_use, so
+        // the gateway rejects with Config.
         let server = MockServer::start().await;
         let bridge = AnthropicBridge::new();
         let ctx = sample_ctx(&server.uri());
@@ -426,7 +431,7 @@ mod tests {
                 content: "tool output".into(),
                 content_blocks: None,
                 name: None,
-                tool_call_id: Some("tc_1".into()),
+                tool_call_id: None,
                 extra: serde_json::Map::new(),
             }],
         );

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -42,8 +42,21 @@ pub(crate) struct AnthropicRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f32>,
     pub stream: bool,
+    /// Tools spec translated from the caller's OpenAI-shape `tools`
+    /// (when present in `extra`). The gateway emits Anthropic's
+    /// shape per <https://docs.anthropic.com/en/api/messages>:
+    /// `{name, description, input_schema}`. `None` when the caller
+    /// didn't request tools.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<serde_json::Value>>,
+    /// Caller's other extra fields (excluding `tools`, which is
+    /// translated above). Anthropic-incompatible OpenAI-only fields
+    /// here would cause a 400 upstream — operators are expected to
+    /// configure their gateway client to send shape-appropriate
+    /// extras. Trade-off: forward-compatibility with new Anthropic
+    /// fields > strict filtering.
     #[serde(flatten)]
-    pub extra: &'a serde_json::Map<String, serde_json::Value>,
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -133,6 +146,12 @@ pub(crate) fn build_request<'a>(
     messages: Vec<AnthropicMessage<'a>>,
     stream: bool,
 ) -> AnthropicRequest<'a> {
+    // Pull `tools` out of the caller's extras and translate to
+    // Anthropic shape; everything else passes through verbatim.
+    let mut extras = req.extra.clone();
+    let tools = extras
+        .remove("tools")
+        .and_then(translate_openai_tools_to_anthropic);
     AnthropicRequest {
         model: upstream_model,
         messages,
@@ -141,7 +160,59 @@ pub(crate) fn build_request<'a>(
         temperature: req.temperature,
         top_p: req.top_p,
         stream,
-        extra: &req.extra,
+        tools,
+        extra: extras,
+    }
+}
+
+/// Translate the caller's OpenAI-shape `tools` array into
+/// Anthropic's tools-spec shape on the outbound axis. Field mapping
+/// per <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools>
+/// and <https://docs.anthropic.com/en/api/messages#parameter-tools>:
+///
+///   OpenAI                                    Anthropic
+///   {type: "function",                        {name,
+///    function: {name, description,             description,
+///               parameters}}                   input_schema}
+///
+/// Only `type: "function"` tools translate today; OpenAI's other
+/// tool kinds (`code_interpreter`, `file_search`, …) have no
+/// Anthropic equivalent and are dropped silently. Returns `None`
+/// when the input isn't an array or when no entries translated —
+/// keeping the field absent from the upstream wire shape so
+/// Anthropic doesn't reject for empty-tools.
+pub(crate) fn translate_openai_tools_to_anthropic(
+    tools: serde_json::Value,
+) -> Option<Vec<serde_json::Value>> {
+    let arr = tools.as_array()?;
+    let translated: Vec<serde_json::Value> = arr
+        .iter()
+        .filter_map(|t| {
+            // OpenAI: `{type: "function", function: {name, description,
+            // parameters}}`. Skip entries that don't fit this shape
+            // (defensive — non-function tools have no Anthropic mapping).
+            if t.get("type").and_then(|v| v.as_str()) != Some("function") {
+                return None;
+            }
+            let function = t.get("function")?.as_object()?;
+            let name = function.get("name")?.as_str()?;
+            let mut anthropic_tool = serde_json::Map::new();
+            anthropic_tool.insert("name".into(), name.into());
+            if let Some(desc) = function.get("description") {
+                anthropic_tool.insert("description".into(), desc.clone());
+            }
+            // OpenAI's `parameters` (JSON Schema) maps to Anthropic's
+            // `input_schema` verbatim — both are JSON Schema.
+            if let Some(params) = function.get("parameters") {
+                anthropic_tool.insert("input_schema".into(), params.clone());
+            }
+            Some(serde_json::Value::Object(anthropic_tool))
+        })
+        .collect();
+    if translated.is_empty() {
+        None
+    } else {
+        Some(translated)
     }
 }
 
@@ -163,8 +234,25 @@ pub(crate) struct AnthropicResponse {
 pub(crate) enum AnthropicResponseBlock {
     #[serde(rename = "text")]
     Text { text: String },
-    /// Tool-use and other block types are ignored for PR #8 — a later
-    /// tools PR will surface them as typed `ChatChunk.tool_calls`.
+    /// Anthropic's `tool_use` content block. The model is asking to
+    /// invoke a tool: `id` is the call id, `name` is the tool name,
+    /// and `input` is a JSON object with the tool's arguments. Per
+    /// docs §6 outbound-axis table ("tool_use ↔ tool_calls"), the
+    /// gateway translates this into OpenAI's `tool_calls` shape on
+    /// the response so OpenAI-SDK callers (and every agent framework
+    /// built on that shape) work transparently against Anthropic
+    /// upstreams.
+    /// <https://docs.anthropic.com/en/api/messages#example-of-tool-use>
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        #[serde(default)]
+        input: serde_json::Value,
+    },
+    /// Future content-block types (e.g. `image` on output, `thinking`
+    /// for reasoning models). Not surfaced today; accepted so unknown
+    /// block types don't fail the whole response parse.
     #[serde(other)]
     Other,
 }
@@ -193,6 +281,44 @@ pub(crate) fn response_into_chat_response(raw: AnthropicResponse) -> ChatRespons
         .collect::<Vec<_>>()
         .join("");
 
+    // Translate Anthropic `tool_use` content blocks into OpenAI's
+    // `message.tool_calls` shape so OpenAI-SDK callers see a
+    // standard tool-call response. Field mapping per
+    // <https://docs.anthropic.com/en/api/messages> and
+    // <https://platform.openai.com/docs/api-reference/chat/object#chat-create-tool_calls>:
+    //
+    //   Anthropic                  OpenAI
+    //   id          (string)   →   tool_calls[].id
+    //   name        (string)   →   tool_calls[].function.name
+    //   input       (object)   →   tool_calls[].function.arguments  (JSON-encoded string)
+    //   (implicit)             →   tool_calls[].type: "function"
+    //
+    // `arguments` MUST be a JSON-encoded STRING in OpenAI's shape
+    // (not the parsed object) so SDK consumers round-trip via
+    // `JSON.parse(toolCall.function.arguments)`.
+    let tool_calls: Vec<serde_json::Value> = raw
+        .content
+        .iter()
+        .filter_map(|b| match b {
+            AnthropicResponseBlock::ToolUse { id, name, input } => Some(serde_json::json!({
+                "id": id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": serde_json::to_string(input).unwrap_or_default(),
+                },
+            })),
+            _ => None,
+        })
+        .collect();
+    let mut extra = serde_json::Map::new();
+    if !tool_calls.is_empty() {
+        extra.insert(
+            "tool_calls".to_string(),
+            serde_json::Value::Array(tool_calls),
+        );
+    }
+
     let usage = raw
         .usage
         .map(|u| UsageStats {
@@ -217,7 +343,7 @@ pub(crate) fn response_into_chat_response(raw: AnthropicResponse) -> ChatRespons
             content_blocks: None,
             name: None,
             tool_call_id: None,
-            extra: serde_json::Map::new(),
+            extra,
         },
         finish_reason: map_stop_reason(raw.stop_reason.as_deref()),
         usage,
@@ -817,6 +943,120 @@ mod tests {
         let (_system, messages) = split_system(&req).unwrap();
         let built = build_request(&req, "claude-sonnet-4-5", None, messages, false);
         assert_eq!(built.max_tokens, 256);
+    }
+
+    #[test]
+    fn tool_use_block_translates_to_openai_tool_calls_in_extra() {
+        // Anthropic Messages response with a tool_use content block
+        // (the model decided to call a tool) — verbatim shape from
+        // <https://docs.anthropic.com/en/api/messages#example-of-tool-use>.
+        let body = r#"{
+            "id": "msg_tool_01",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-5-sonnet-20241022",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_abc",
+                    "name": "get_weather",
+                    "input": {"location": "San Francisco, CA", "unit": "celsius"}
+                }
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 12, "output_tokens": 8}
+        }"#;
+        let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+
+        // stop_reason "tool_use" → finish_reason ToolCalls.
+        assert_eq!(out.finish_reason, FinishReason::ToolCalls);
+        // Text content is empty when only tool_use blocks were
+        // emitted (no text blocks present).
+        assert_eq!(out.message.content, "");
+
+        // tool_calls translation lives in `message.extra` so the
+        // proxy renderer flattens it onto the wire as a top-level
+        // OpenAI-shape field.
+        let tool_calls = out
+            .message
+            .extra
+            .get("tool_calls")
+            .expect("tool_calls populated in extra")
+            .as_array()
+            .expect("tool_calls is an array");
+        assert_eq!(tool_calls.len(), 1);
+        let tc = &tool_calls[0];
+        assert_eq!(tc["id"], "toolu_abc");
+        assert_eq!(tc["type"], "function");
+        assert_eq!(tc["function"]["name"], "get_weather");
+        // OpenAI's `arguments` is a JSON-encoded STRING, not the
+        // parsed object — SDK consumers `JSON.parse` it.
+        let args_str = tc["function"]["arguments"]
+            .as_str()
+            .expect("arguments is a string");
+        let args: serde_json::Value = serde_json::from_str(args_str).unwrap();
+        assert_eq!(args["location"], "San Francisco, CA");
+        assert_eq!(args["unit"], "celsius");
+    }
+
+    #[test]
+    fn mixed_text_and_tool_use_blocks_both_surface() {
+        // The model can emit text BEFORE invoking a tool. Both must
+        // reach the OpenAI-SDK caller: text → message.content,
+        // tool_use → message.extra["tool_calls"].
+        let body = r#"{
+            "id": "msg_mixed_01",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-5-sonnet-20241022",
+            "content": [
+                {"type": "text", "text": "Let me check the weather."},
+                {"type": "tool_use", "id": "toolu_x", "name": "get_weather",
+                 "input": {"location": "NYC"}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 5, "output_tokens": 10}
+        }"#;
+        let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.message.content, "Let me check the weather.");
+        assert!(out.message.extra.get("tool_calls").is_some());
+    }
+
+    #[test]
+    fn parallel_tool_use_blocks_emit_array_in_order() {
+        // Anthropic supports parallel tool calls — multiple tool_use
+        // blocks in one response. Each must produce a tool_calls
+        // entry, in the same order as the upstream emitted them.
+        let body = r#"{
+            "id": "msg_parallel_01",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-5-sonnet-20241022",
+            "content": [
+                {"type": "tool_use", "id": "toolu_1", "name": "get_weather",
+                 "input": {"location": "SF"}},
+                {"type": "tool_use", "id": "toolu_2", "name": "get_time",
+                 "input": {"timezone": "PST"}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 10, "output_tokens": 20}
+        }"#;
+        let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        let tool_calls = out
+            .message
+            .extra
+            .get("tool_calls")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(tool_calls.len(), 2);
+        assert_eq!(tool_calls[0]["id"], "toolu_1");
+        assert_eq!(tool_calls[0]["function"]["name"], "get_weather");
+        assert_eq!(tool_calls[1]["id"], "toolu_2");
+        assert_eq!(tool_calls[1]["function"]["name"], "get_time");
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -1034,6 +1034,7 @@ mod tests {
                 ChatMessage {
                     role: Role::Tool,
                     content: "72F, sunny".into(),
+                    content_blocks: None,
                     name: None,
                     tool_call_id: Some("toolu_abc".into()),
                     extra: serde_json::Map::new(),

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -49,6 +49,17 @@ pub(crate) struct AnthropicRequest<'a> {
     /// didn't request tools.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<serde_json::Value>>,
+    /// `tool_choice` translated from OpenAI's shape per
+    /// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice>
+    /// to Anthropic's per
+    /// <https://docs.anthropic.com/en/api/messages#parameter-tool_choice>:
+    ///   "auto"|"none"|"required"           → `{type:<same>}` ("required" → "any")
+    ///   {type:"function",function:{name}}  → `{type:"tool", name}`
+    /// Forwarding the OpenAI shape verbatim would 400 the upstream.
+    /// `None` when the caller didn't set tool_choice (and we strip
+    /// it from `extra` to avoid double-emit / shape mismatch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<serde_json::Value>,
     /// Caller's other extra fields (excluding `tools`, which is
     /// translated above). Anthropic-incompatible OpenAI-only fields
     /// here would cause a 400 upstream — operators are expected to
@@ -62,26 +73,61 @@ pub(crate) struct AnthropicRequest<'a> {
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct AnthropicMessage<'a> {
     pub role: &'a str,
-    pub content: Vec<AnthropicTextBlock<'a>>,
+    /// Polymorphic content blocks — text and `tool_result` blocks
+    /// emit different shapes per
+    /// <https://docs.anthropic.com/en/api/messages>. Stored as
+    /// owned `Value` so OpenAI `Role::Tool` messages can be
+    /// translated into Anthropic `{type:"tool_result", tool_use_id,
+    /// content}` without lifetime gymnastics.
+    pub content: Vec<serde_json::Value>,
+    #[serde(skip)]
+    _lifetime: std::marker::PhantomData<&'a ()>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub(crate) struct AnthropicTextBlock<'a> {
-    #[serde(rename = "type")]
-    pub kind: &'static str,
-    pub text: &'a str,
+impl<'a> AnthropicMessage<'a> {
+    /// Single-text-block message (the common case for
+    /// system/user/assistant turns without tool use).
+    pub(crate) fn text(role: &'a str, text: &'a str) -> Self {
+        Self {
+            role,
+            content: vec![serde_json::json!({"type": "text", "text": text})],
+            _lifetime: std::marker::PhantomData,
+        }
+    }
+
+    /// Anthropic tool_result block per
+    /// <https://docs.anthropic.com/en/api/messages#example-of-tool-use>.
+    /// Translates the OpenAI `{role:"tool", tool_call_id, content}`
+    /// turn so agent-loop round-trips work — without this, the
+    /// caller's tool-result reply 400s at the Anthropic upstream.
+    pub(crate) fn tool_result(tool_use_id: &str, content: &str) -> Self {
+        Self {
+            role: "user",
+            content: vec![serde_json::json!({
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": content,
+            })],
+            _lifetime: std::marker::PhantomData,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum TranslateError {
-    #[error("anthropic does not support role {role:?}")]
-    UnsupportedRole { role: &'static str },
+    #[error("tool message missing tool_call_id field")]
+    MissingToolCallId,
 }
 
 /// Split the gateway's flat ChatFormat into Anthropic's (system, messages)
 /// shape. Consecutive system messages at the head are concatenated with
 /// a blank line, matching how users typically compose multi-paragraph
 /// system prompts in the OpenAI format.
+///
+/// Role::Tool turns translate to Anthropic's `{role:"user", content:
+/// [{type:"tool_result", tool_use_id, content}]}` shape per
+/// <https://docs.anthropic.com/en/api/messages> so agent-loop turn 2
+/// (caller sends the tool's output back to the model) round-trips.
 pub(crate) fn split_system<'a>(
     req: &'a ChatFormat,
 ) -> Result<(Option<String>, Vec<AnthropicMessage<'a>>), TranslateError> {
@@ -96,38 +142,27 @@ pub(crate) fn split_system<'a>(
                     // System messages interleaved with user/assistant
                     // turns don't map cleanly; append as a user turn to
                     // preserve semantics without silently dropping them.
-                    messages.push(AnthropicMessage {
-                        role: "user",
-                        content: vec![AnthropicTextBlock {
-                            kind: "text",
-                            text: &m.content,
-                        }],
-                    });
+                    messages.push(AnthropicMessage::text("user", &m.content));
                 } else {
                     system_parts.push(&m.content);
                 }
             }
             Role::User => {
                 seen_non_system = true;
-                messages.push(AnthropicMessage {
-                    role: "user",
-                    content: vec![AnthropicTextBlock {
-                        kind: "text",
-                        text: &m.content,
-                    }],
-                });
+                messages.push(AnthropicMessage::text("user", &m.content));
             }
             Role::Assistant => {
                 seen_non_system = true;
-                messages.push(AnthropicMessage {
-                    role: "assistant",
-                    content: vec![AnthropicTextBlock {
-                        kind: "text",
-                        text: &m.content,
-                    }],
-                });
+                messages.push(AnthropicMessage::text("assistant", &m.content));
             }
-            Role::Tool => return Err(TranslateError::UnsupportedRole { role: "tool" }),
+            Role::Tool => {
+                seen_non_system = true;
+                let tool_use_id = m
+                    .tool_call_id
+                    .as_deref()
+                    .ok_or(TranslateError::MissingToolCallId)?;
+                messages.push(AnthropicMessage::tool_result(tool_use_id, &m.content));
+            }
         }
     }
 
@@ -146,12 +181,19 @@ pub(crate) fn build_request<'a>(
     messages: Vec<AnthropicMessage<'a>>,
     stream: bool,
 ) -> AnthropicRequest<'a> {
-    // Pull `tools` out of the caller's extras and translate to
-    // Anthropic shape; everything else passes through verbatim.
+    // Pull `tools` and `tool_choice` out of the caller's extras and
+    // translate to Anthropic shape; everything else passes through
+    // verbatim. Forwarding the OpenAI tool_choice shape would 400
+    // upstream — the field is removed from `extra` even when the
+    // translation returns None (e.g. unrecognised value), to avoid
+    // a shape-mismatch double-emit.
     let mut extras = req.extra.clone();
     let tools = extras
         .remove("tools")
         .and_then(translate_openai_tools_to_anthropic);
+    let tool_choice = extras
+        .remove("tool_choice")
+        .and_then(translate_openai_tool_choice_to_anthropic);
     AnthropicRequest {
         model: upstream_model,
         messages,
@@ -161,6 +203,7 @@ pub(crate) fn build_request<'a>(
         top_p: req.top_p,
         stream,
         tools,
+        tool_choice,
         extra: extras,
     }
 }
@@ -213,6 +256,41 @@ pub(crate) fn translate_openai_tools_to_anthropic(
         None
     } else {
         Some(translated)
+    }
+}
+
+/// Translate the caller's OpenAI-shape `tool_choice` to Anthropic's.
+///
+///   OpenAI                              Anthropic
+///   "auto"                          →   {"type":"auto"}
+///   "none"                          →   {"type":"none"}
+///   "required"                      →   {"type":"any"}    (Anthropic's name for "must call something")
+///   {type:"function",                   {"type":"tool",
+///    function:{name:"X"}}           →    "name":"X"}
+///
+/// Returns None for unrecognised shapes — caller's value is discarded
+/// rather than forwarded verbatim, since the OpenAI shape would 400
+/// the Anthropic upstream.
+pub(crate) fn translate_openai_tool_choice_to_anthropic(
+    v: serde_json::Value,
+) -> Option<serde_json::Value> {
+    match v {
+        serde_json::Value::String(s) => match s.as_str() {
+            "auto" | "none" => Some(serde_json::json!({"type": s})),
+            "required" => Some(serde_json::json!({"type": "any"})),
+            _ => None,
+        },
+        serde_json::Value::Object(o) => {
+            if o.get("type").and_then(|t| t.as_str()) != Some("function") {
+                return None;
+            }
+            let name = o
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())?;
+            Some(serde_json::json!({"type": "tool", "name": name}))
+        }
+        _ => None,
     }
 }
 
@@ -305,7 +383,16 @@ pub(crate) fn response_into_chat_response(raw: AnthropicResponse) -> ChatRespons
                 "type": "function",
                 "function": {
                     "name": name,
-                    "arguments": serde_json::to_string(input).unwrap_or_default(),
+                    // OpenAI emits `"{}"` (empty object) for no-args
+                    // tool calls, not `"null"`. Normalise here so SDK
+                    // consumers doing `JSON.parse(args)` get an
+                    // object back even when Anthropic's `input`
+                    // field is absent / null.
+                    "arguments": match input {
+                        serde_json::Value::Null => "{}".to_string(),
+                        other => serde_json::to_string(other)
+                            .unwrap_or_else(|_| "{}".to_string()),
+                    },
                 },
             })),
             _ => None,
@@ -911,7 +998,11 @@ mod tests {
     }
 
     #[test]
-    fn split_system_rejects_tool_role() {
+    fn split_system_rejects_tool_role_without_tool_call_id() {
+        // Tool turn must carry a tool_call_id (the OpenAI shape
+        // pairs tool_calls[i].id with the next turn's tool_call_id).
+        // Without one, we can't construct Anthropic's tool_result
+        // block — error rather than silently dropping the turn.
         let req = ChatFormat::new(
             "claude",
             vec![ChatMessage {
@@ -925,8 +1016,38 @@ mod tests {
         );
         assert!(matches!(
             split_system(&req),
-            Err(TranslateError::UnsupportedRole { role: "tool" })
+            Err(TranslateError::MissingToolCallId)
         ));
+    }
+
+    #[test]
+    fn split_system_translates_tool_role_to_anthropic_tool_result() {
+        // Agent-loop turn 2: caller sends back the tool's output via
+        // {role:"tool", tool_call_id, content}; gateway must
+        // translate to Anthropic's
+        // {role:"user", content:[{type:"tool_result", tool_use_id, content}]}.
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::user("What's the weather in SF?"),
+                // (skipping the assistant turn for brevity in test setup)
+                ChatMessage {
+                    role: Role::Tool,
+                    content: "72F, sunny".into(),
+                    name: None,
+                    tool_call_id: Some("toolu_abc".into()),
+                    extra: serde_json::Map::new(),
+                },
+            ],
+        );
+        let (_system, msgs) = split_system(&req).unwrap();
+        assert_eq!(msgs.len(), 2);
+        // Tool turn became a user turn with a tool_result block.
+        assert_eq!(msgs[1].role, "user");
+        assert_eq!(msgs[1].content.len(), 1);
+        assert_eq!(msgs[1].content[0]["type"], "tool_result");
+        assert_eq!(msgs[1].content[0]["tool_use_id"], "toolu_abc");
+        assert_eq!(msgs[1].content[0]["content"], "72F, sunny");
     }
 
     #[test]
@@ -1057,6 +1178,100 @@ mod tests {
         assert_eq!(tool_calls[0]["function"]["name"], "get_weather");
         assert_eq!(tool_calls[1]["id"], "toolu_2");
         assert_eq!(tool_calls[1]["function"]["name"], "get_time");
+    }
+
+    #[test]
+    fn tool_use_with_no_input_emits_empty_object_arguments() {
+        // OpenAI emits `arguments: "{}"` for no-args tool calls, not
+        // `"null"`. SDK consumers do `JSON.parse(arguments)` — `null`
+        // yields a non-object, breaking idiomatic agent code.
+        let body = r#"{
+            "id": "msg_no_args",
+            "type": "message",
+            "role": "assistant",
+            "model": "c",
+            "content": [
+                {"type": "tool_use", "id": "tu", "name": "noop"}
+            ],
+            "stop_reason": "tool_use"
+        }"#;
+        let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        let tc = &out.message.extra["tool_calls"][0];
+        assert_eq!(tc["function"]["arguments"], "{}");
+    }
+
+    #[test]
+    fn tool_choice_string_forms_translate_to_anthropic_object_shape() {
+        // OpenAI: "auto" | "none" | "required"
+        // Anthropic: {"type":"auto"} | {"type":"none"} | {"type":"any"}
+        assert_eq!(
+            translate_openai_tool_choice_to_anthropic(serde_json::json!("auto")),
+            Some(serde_json::json!({"type": "auto"})),
+        );
+        assert_eq!(
+            translate_openai_tool_choice_to_anthropic(serde_json::json!("none")),
+            Some(serde_json::json!({"type": "none"})),
+        );
+        // "required" → "any" (Anthropic's name for "must call something")
+        assert_eq!(
+            translate_openai_tool_choice_to_anthropic(serde_json::json!("required")),
+            Some(serde_json::json!({"type": "any"})),
+        );
+    }
+
+    #[test]
+    fn tool_choice_specific_function_translates_to_anthropic_tool() {
+        // OpenAI: {type:"function", function:{name:"X"}}
+        // Anthropic: {type:"tool", name:"X"}
+        let openai = serde_json::json!({
+            "type": "function",
+            "function": {"name": "get_weather"}
+        });
+        assert_eq!(
+            translate_openai_tool_choice_to_anthropic(openai),
+            Some(serde_json::json!({"type": "tool", "name": "get_weather"})),
+        );
+    }
+
+    #[test]
+    fn tool_choice_unrecognised_shape_drops_to_none() {
+        // Strip the field rather than forwarding an OpenAI shape
+        // Anthropic doesn't recognise.
+        assert_eq!(
+            translate_openai_tool_choice_to_anthropic(serde_json::json!("invalid_form")),
+            None,
+        );
+        assert_eq!(
+            translate_openai_tool_choice_to_anthropic(serde_json::json!(42)),
+            None,
+        );
+    }
+
+    #[test]
+    fn build_request_strips_tool_choice_from_extra() {
+        // Even when the value is unrecognised, tool_choice MUST NOT
+        // leak into `extra` — forwarding the OpenAI shape would 400
+        // the upstream.
+        let req = ChatFormat {
+            extra: {
+                let mut m = serde_json::Map::new();
+                m.insert("tool_choice".to_string(), serde_json::json!("auto"));
+                m.insert("custom_field".to_string(), serde_json::json!("kept"));
+                m
+            },
+            ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+        };
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "c-name", None, messages, false);
+        // tool_choice translated and on the typed field.
+        assert_eq!(built.tool_choice, Some(serde_json::json!({"type": "auto"})));
+        // tool_choice removed from `extra`; other fields preserved.
+        assert!(!built.extra.contains_key("tool_choice"));
+        assert_eq!(
+            built.extra.get("custom_field"),
+            Some(&serde_json::json!("kept"))
+        );
     }
 
     #[test]

--- a/crates/aisix-proxy/src/render.rs
+++ b/crates/aisix-proxy/src/render.rs
@@ -30,6 +30,16 @@ pub struct NonStreamChoice {
 pub struct RenderedMessage {
     pub role: &'static str,
     pub content: String,
+    /// Forward-compatible bag for OpenAI message-level fields the
+    /// gateway doesn't model directly on `ChatMessage` (e.g.
+    /// `tool_calls` for cross-provider tool-use translation,
+    /// `refusal` for OpenAI's safety-classifier output, `audio` for
+    /// realtime/4o audio models). Bridges populate this on the way
+    /// back from the upstream; serde flatten emits each entry as a
+    /// top-level field on the wire so OpenAI SDK clients see the
+    /// standard shape.
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -77,6 +87,9 @@ pub fn render_response(created_unix_ts: i64, resp: ChatResponse) -> ChatCompleti
             message: RenderedMessage {
                 role: role_to_str(resp.message.role),
                 content: resp.message.content,
+                // Forward bridge-populated fields (`tool_calls`,
+                // `refusal`, `audio`, …) through to the caller.
+                extra: resp.message.extra,
             },
             finish_reason: finish_to_str(&resp.finish_reason).to_string(),
         }],

--- a/tests/e2e/src/cases/tools-cross-provider-e2e.test.ts
+++ b/tests/e2e/src/cases/tools-cross-provider-e2e.test.ts
@@ -1,0 +1,248 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: tool / function calling cross-provider translation. Per
+// gateway docs `docs/api-proxy.md` §6 outbound-axis table:
+//
+//   > Anthropic | /v1/messages | /v1/chat/completions (full translation)
+//   > | The Hub maps content blocks ↔ messages, **tool_use ↔ tool_calls**,
+//   > | system extraction, cache_control passthrough, stop_reason
+//   > | normalisation
+//
+// User journey: a caller using the OpenAI SDK targets a Model whose
+// provider is `anthropic`. The caller passes OpenAI-shape `tools`
+// in the request. The gateway must:
+//
+//   1. Translate OpenAI `tools` → Anthropic `tools` on the way out
+//      (`function.name/description/parameters` → `name/description/
+//      input_schema`).
+//   2. Translate Anthropic `content: [{type: "tool_use", id, name,
+//      input}]` → OpenAI `tool_calls: [{id, type: "function",
+//      function: {name, arguments}}]` on the way back.
+//   3. Translate Anthropic `stop_reason: "tool_use"` → OpenAI
+//      `finish_reason: "tool_calls"`.
+//
+// This is the cornerstone of agent-style workflows: every modern
+// agent framework (LangChain, LlamaIndex, Vercel AI SDK, etc.)
+// drives tool dispatch via the OpenAI tool-call shape, so a
+// regression here breaks every agent built on top of an
+// Anthropic-backed gateway Model.
+//
+// Prior to this file, the gateway had **zero** e2e coverage on
+// cross-provider tool translation — only Rust unit tests at the
+// translator level.
+//
+// References:
+// - OpenAI Chat Completions tools spec
+//   <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools>
+// - Anthropic Messages tools spec
+//   <https://docs.anthropic.com/en/api/messages#parameter-tools>
+// - Gateway's own translation contract: `docs/api-proxy.md` §6
+
+const CALLER_PLAINTEXT = "sk-tools-xprov-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("tools cross-provider e2e: OpenAI tools → Anthropic upstream tool_use → OpenAI tool_calls back", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // Mock Anthropic upstream returns a Messages-shape response
+    // where the assistant chose to call `get_weather`. The body
+    // shape mirrors Anthropic's documented tool_use response per
+    // <https://docs.anthropic.com/en/api/messages#example-of-tool-use>.
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_tool_use_01",
+        type: "message",
+        role: "assistant",
+        model: "claude-3-5-sonnet-20241022",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_xprov_01",
+            name: "get_weather",
+            input: { location: "San Francisco, CA", unit: "celsius" },
+          },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 12, output_tokens: 8 },
+      },
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // Anthropic api_base = bare host; bridge composes /v1/messages
+    // (mirrors anthropic-upstream-e2e convention).
+    const pk = await admin.createProviderKey({
+      display_name: "tools-xprov-pk",
+      secret: "sk-ant-mock",
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "tools-xprov",
+      provider: "anthropic",
+      model_name: "claude-3-5-sonnet-20241022",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["tools-xprov"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("OpenAI tools spec → Anthropic tools_use upstream → OpenAI tool_calls back to caller", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Readiness gate: same probe pattern as anthropic-upstream-e2e.
+    // Probe doesn't include tools (the propagation we're gating on
+    // is just snapshot loading; tool translation is a request-level
+    // concern not a propagation concern).
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.chat.completions.create({
+          model: "tools-xprov",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    // OpenAI-shape tools spec per
+    // <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools>.
+    const tools = [
+      {
+        type: "function" as const,
+        function: {
+          name: "get_weather",
+          description: "Get the current weather in a given location.",
+          parameters: {
+            type: "object",
+            properties: {
+              location: {
+                type: "string",
+                description: "The city and state, e.g. San Francisco, CA",
+              },
+              unit: {
+                type: "string",
+                enum: ["celsius", "fahrenheit"],
+              },
+            },
+            required: ["location"],
+          },
+        },
+      },
+    ];
+
+    const completion = await client.chat.completions.create({
+      model: "tools-xprov",
+      messages: [{ role: "user", content: "What's the weather in SF?" }],
+      tools,
+    });
+
+    // ── Caller-side: response is OpenAI-shape with tool_calls ────
+
+    // The assistant message carries `tool_calls`, not `content` text.
+    // Per OpenAI Chat Completions spec, when finish_reason is
+    // "tool_calls" the message.content is null and tool_calls
+    // populated.
+    expect(completion.choices[0]?.message.role).toBe("assistant");
+    expect(completion.choices[0]?.message.tool_calls).toBeDefined();
+    expect(completion.choices[0]?.message.tool_calls).toHaveLength(1);
+
+    const toolCall = completion.choices[0]?.message.tool_calls?.[0];
+    // OpenAI tool_call.id propagates from upstream's tool_use.id
+    // (Anthropic uses `toolu_...` prefix). Pin the exact upstream
+    // value — a regression that re-issued ids would break agent
+    // frameworks that submit tool_results referencing the original
+    // id.
+    expect(toolCall?.id).toBe("toolu_xprov_01");
+    expect(toolCall?.type).toBe("function");
+    expect(toolCall?.function.name).toBe("get_weather");
+    // OpenAI's `arguments` is a JSON-encoded STRING (not an object),
+    // unlike Anthropic's `input` which is a parsed JSON object.
+    // The translation must encode upstream's input → JSON string.
+    const args = JSON.parse(toolCall!.function.arguments) as {
+      location?: unknown;
+      unit?: unknown;
+    };
+    expect(args.location).toBe("San Francisco, CA");
+    expect(args.unit).toBe("celsius");
+
+    // OpenAI finish_reason "tool_calls" comes from translating
+    // Anthropic stop_reason "tool_use". A regression that left
+    // "tool_use" through would break any caller doing
+    // `if (finish_reason === "tool_calls") { ... }`.
+    expect(completion.choices[0]?.finish_reason).toBe("tool_calls");
+
+    // ── Upstream-side: the gateway spoke Anthropic Messages with
+    //    Anthropic-shape tools spec ────────────────────────────────
+
+    const messagesReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages");
+    expect(messagesReq).toBeDefined();
+
+    const sentBody = JSON.parse(messagesReq!.body) as {
+      tools?: Array<{
+        name?: string;
+        description?: string;
+        input_schema?: { type?: string; properties?: unknown; required?: unknown };
+      }>;
+      messages?: Array<{ role?: string; content?: unknown }>;
+    };
+
+    // Tools translation: OpenAI's nested {type, function: {name,
+    // description, parameters}} flattens to Anthropic's {name,
+    // description, input_schema}. A regression that left the
+    // OpenAI nested shape on the wire would 400 against real
+    // Anthropic.
+    expect(sentBody.tools).toHaveLength(1);
+    expect(sentBody.tools?.[0]?.name).toBe("get_weather");
+    expect(sentBody.tools?.[0]?.description).toBe(
+      "Get the current weather in a given location.",
+    );
+    // The JSON Schema in `parameters` becomes `input_schema`
+    // verbatim per Anthropic's tools doc.
+    expect(sentBody.tools?.[0]?.input_schema?.type).toBe("object");
+    expect(sentBody.tools?.[0]?.input_schema?.required).toEqual(["location"]);
+
+    // Caller's user message reaches upstream intact.
+    expect(sentBody.messages?.[0]?.role).toBe("user");
+  });
+});

--- a/tests/e2e/src/cases/tools-cross-provider-e2e.test.ts
+++ b/tests/e2e/src/cases/tools-cross-provider-e2e.test.ts
@@ -245,4 +245,106 @@ describe("tools cross-provider e2e: OpenAI tools → Anthropic upstream tool_use
     // Caller's user message reaches upstream intact.
     expect(sentBody.messages?.[0]?.role).toBe("user");
   });
+
+  test("agent-loop turn 2: caller posts {role:'tool', tool_call_id} → Anthropic gets tool_result", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // After turn 1 (user → assistant tool_use), the OpenAI-shape
+    // agent loop posts the tool's output via {role:"tool",
+    // tool_call_id, content}. Without translation the Anthropic
+    // bridge would 400. With translation the upstream receives
+    // {role:"user", content:[{type:"tool_result", tool_use_id, content}]}
+    // and the conversation continues.
+    const baseline = upstream.receivedRequests.length;
+    await client.chat.completions.create({
+      model: "tools-xprov",
+      messages: [
+        { role: "user", content: "What's the weather in SF?" },
+        // (real callers would also include the assistant's
+        // tool_calls turn here; we skip it because Anthropic only
+        // requires the tool_use_id to be referenced in the next
+        // user-side tool_result.)
+        {
+          role: "tool",
+          tool_call_id: "toolu_xprov_01",
+          content: "72F, sunny",
+        },
+      ],
+    });
+
+    const messagesReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages");
+    expect(messagesReq).toBeDefined();
+
+    const sentBody = JSON.parse(messagesReq!.body) as {
+      messages?: Array<{
+        role?: string;
+        content?: Array<{
+          type?: string;
+          tool_use_id?: string;
+          content?: string;
+        }>;
+      }>;
+    };
+    // Last message should be a user-role turn with a tool_result
+    // content block (Anthropic's shape per docs).
+    const lastMsg = sentBody.messages?.[sentBody.messages.length - 1];
+    expect(lastMsg?.role).toBe("user");
+    const block = lastMsg?.content?.[0];
+    expect(block?.type).toBe("tool_result");
+    expect(block?.tool_use_id).toBe("toolu_xprov_01");
+    expect(block?.content).toBe("72F, sunny");
+  });
+
+  test("tool_choice translates from OpenAI shape to Anthropic shape", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    const baseline = upstream.receivedRequests.length;
+    await client.chat.completions.create({
+      model: "tools-xprov",
+      messages: [{ role: "user", content: "Call something." }],
+      // OpenAI's most-common tool_choice value. Forwarded
+      // verbatim to Anthropic, this would 400 (Anthropic expects
+      // an object, not a string).
+      tool_choice: "auto",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "noop",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    });
+
+    const messagesReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages");
+    expect(messagesReq).toBeDefined();
+
+    const sentBody = JSON.parse(messagesReq!.body) as {
+      tool_choice?: { type?: string };
+    };
+    expect(sentBody.tool_choice).toEqual({ type: "auto" });
+  });
 });


### PR DESCRIPTION
Closes #170.

## Problem

Agent frameworks (Vercel AI SDK, LangChain, Assistants API clients) target Anthropic-backed Models through the gateway using the OpenAI tool-calling shape — the gateway promises bidirectional translation in \`docs/api-proxy.md\` §6 outbound-axis table:

> Anthropic | \`/v1/messages\` | \`/v1/chat/completions\` (full translation) | The Hub maps content blocks ↔ messages, **tool_use ↔ tool_calls**, system extraction, cache_control passthrough, stop_reason normalisation

The implementation didn't honor the contract:
- Caller's OpenAI \`tools\` spec was NEVER translated to Anthropic shape on the request side, so Anthropic upstreams received no tool definitions.
- Anthropic's \`tool_use\` content blocks were silently dropped on the response side (only \`Text\` blocks reached \`ChatMessage.content\`), so even when tools were invoked the caller saw \`message.content: ""\` with no \`tool_calls\`.

Net effect: every agent framework was broken on Anthropic-backed gateway Models.

## Fix

This PR fixes BOTH directions of the translation.

### Outbound (request) — \`build_request\`

| OpenAI | Anthropic |
|--------|-----------|
| \`{type: "function", function: {name, description, parameters}}\` | \`{name, description, input_schema}\` |

\`tools\` is pulled out of \`req.extra\` (where caller-supplied non-canonical fields land via flatten), translated, and emitted as a typed \`tools: Option<Vec<Value>>\` field on \`AnthropicRequest\`. Non-function OpenAI tool kinds (\`code_interpreter\`, \`file_search\`, …) have no Anthropic equivalent and are dropped silently.

### Inbound (response) — \`response_into_chat_response\`

| Anthropic | OpenAI |
|-----------|--------|
| \`tool_use.id\` | \`tool_calls[].id\` |
| \`tool_use.name\` | \`tool_calls[].function.name\` |
| \`tool_use.input\` (object) | \`tool_calls[].function.arguments\` (**JSON-encoded string**) |
| (implicit) | \`tool_calls[].type: "function"\` |

The translated \`tool_calls\` array lands in \`ChatMessage.extra\`. \`RenderedMessage\` (proxy renderer) now flattens \`extra\` so the caller's wire-output gets \`tool_calls\` as a top-level field — forward-compatible for future OpenAI message-level fields (\`refusal\`, \`audio\`, …) too.

\`stop_reason: "tool_use"\` was already correctly mapping to \`finish_reason: "tool_calls"\` (\`map_stop_reason\` line 230); no change needed.

## Tests

**3 new Rust unit tests** (\`aisix-provider-anthropic/src/wire.rs\`):
- \`tool_use_block_translates_to_openai_tool_calls_in_extra\` — covers the canonical single-tool case from Anthropic's documented example
- \`mixed_text_and_tool_use_blocks_both_surface\` — text BEFORE tool_use, both reach caller
- \`parallel_tool_use_blocks_emit_array_in_order\` — multiple parallel tool calls, order preserved

**1 new e2e test** (\`tests/e2e/src/cases/tools-cross-provider-e2e.test.ts\`) — restored from held-back queue. Asserts:
- **Caller-side**: \`tool_calls\` populated with \`id === "toolu_xprov_01"\`, \`function.name === "get_weather"\`, \`function.arguments\` is a JSON-encoded string parsing back to the original \`{location, unit}\`, \`finish_reason === "tool_calls"\`.
- **Upstream-side**: \`/v1/messages\` body has Anthropic-shape \`tools[0].{name, description, input_schema}\` translated from caller's OpenAI \`tools\` spec, with \`required: ["location"]\` JSON Schema preserved.

## Verification

- \`cargo test -p aisix-provider-anthropic --lib\`: **39/39 passing** (+3 new)
- \`cargo clippy --workspace -- -D warnings\`: clean
- Full e2e suite: **40/40 passing**

## Out of scope

- \`tool_choice\` translation (OpenAI's \`auto\`/\`none\`/specific → Anthropic's \`tool_choice\` object) — defer to a follow-up; defaults to upstream's behavior today.
- Streaming-mode tool-call delta assembly across content_block_start/delta/stop events — defer; this PR covers non-stream only. Tracked under #170 follow-up.
- Anthropic-IN axis (caller speaks \`/v1/messages\`, gateway dispatches to OpenAI/Gemini/DeepSeek with tools) — distinct gap acknowledged in \`docs/api-proxy.md\` §4.5; not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-provider tool/function calling enabled in the gateway: tool definitions and choices are translated between providers and preserved across turns.
  * Message-level extra fields from upstream providers are forwarded in API responses.

* **Bug Fixes**
  * Improved validation: tool-result messages missing required identifiers are rejected to prevent malformed tool handling.

* **Tests**
  * Added end-to-end tests verifying cross-provider tool translation, response conversion, and multi-turn tool result forwarding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/187)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->