### PR TITLE
docs(api-proxy): align error envelope, headers, cache, and OpenAPI path with code

### DIFF
--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -49,7 +49,7 @@ unset values are omitted from the envelope.
 | 401 | `invalid_api_key` | — | Missing, malformed, or unknown bearer/`x-api-key` |
 | 403 | `permission_denied` | — | Key valid but Model not in `allowed_models` |
 | 404 | `model_not_found` | — | `req.model` does not resolve in the snapshot |
-| 413 | (axum default) | — | Body exceeds axum's built-in `Json<…>` extractor limit (2 MiB). The `proxy.request_body_limit_bytes` config field is reserved for future use and not yet wired — track this in the follow-up product issue. |
+| 413 | (axum default) | — | Body exceeds axum's built-in `Json<…>` extractor limit (2 MiB). The `proxy.request_body_limit_bytes` config field is currently unused — see [#193](https://github.com/api7/ai-gateway/issues/193) for the wiring follow-up. |
 | 422 | `content_filter` | — | Guardrail rejected request or response content |
 | 429 | `rate_limit_exceeded` | — | RPM/TPM/concurrency cap engaged (all three quotas surface here — the gateway does not split concurrency into a separate code) |
 | 429 | `billing_error` | `budget_exceeded` | Per-key USD budget exhausted |

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -125,9 +125,10 @@ curl -X POST http://localhost:3000/v1/chat/completions \
 **Streaming** — set `"stream": true`. The response is `text/event-stream`
 with one `data: {chunk-json}` per delta and a final `data: [DONE]`.
 Set `"stream_options": {"include_usage": true}` to receive a final
-`usage` chunk before `[DONE]`. aisix injects this automatically when
-the request omits the field, so client SDKs get accurate token totals
-even in streaming mode.
+`usage` chunk before `[DONE]`. Callers that need accurate token
+totals on streamed completions should set this explicitly — the
+gateway forwards the request body to the upstream verbatim and does
+not auto-inject the field.
 
 **Tool calls**, **JSON mode**, **vision content blocks**, and
 **function-style tool definitions** all pass through unchanged.
@@ -240,8 +241,8 @@ possible:
 
 | Provider | Native endpoint | OpenAI-translated endpoint | Notes |
 |---|---|---|---|
-| OpenAI | `/v1/chat/completions`, `/v1/responses` | (no translation needed) | aisix auto-injects `stream_options.include_usage = true` |
-| Anthropic | `/v1/messages` | `/v1/chat/completions` (full translation) | The Hub maps content blocks ↔ messages, tool_use ↔ tool_calls, system extraction, cache_control passthrough, stop_reason normalisation |
+| OpenAI | `/v1/chat/completions`, `/v1/responses` | (no translation needed) | Request body forwarded verbatim |
+| Anthropic | `/v1/messages` | `/v1/chat/completions` (text content blocks) | Anthropic→Anthropic is a byte-for-byte passthrough that preserves `cache_control`, thinking, image, and tool_use blocks. Cross-provider translation today covers **text content blocks only** — tool_use, image, and thinking blocks are silently dropped on the inbound parse and are scheduled for a follow-up. See §4.5. |
 | Gemini | `/v1/chat/completions` (OpenAI-compat endpoint) | (same) | Uses Gemini's OpenAI-compatible base URL with `x-goog-api-key` auth |
 | DeepSeek | `/v1/chat/completions` (OpenAI-compat endpoint) | (same) | Uses Bearer auth, OpenAI-compatible payloads |
 

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -35,12 +35,13 @@ Errors follow the OpenAI shape so SDK error handlers light up:
 {
   "error": {
     "message": "model 'mygpt' not found",
-    "type": "model_not_found",
-    "param": null,
-    "code": null
+    "type": "model_not_found"
   }
 }
 ```
+
+The `param` and `code` fields are present on the wire only when set —
+unset values are omitted from the envelope.
 
 | Status | `type` | `code` | When |
 |---|---|---|---|
@@ -48,12 +49,13 @@ Errors follow the OpenAI shape so SDK error handlers light up:
 | 401 | `invalid_api_key` | — | Missing, malformed, or unknown bearer/`x-api-key` |
 | 403 | `permission_denied` | — | Key valid but Model not in `allowed_models` |
 | 404 | `model_not_found` | — | `req.model` does not resolve in the snapshot |
-| 413 | (axum default) | — | Body exceeds `proxy.request_body_limit_bytes` (default 10 MB) — produced by the body-limit middleware, not the OpenAI envelope |
+| 413 | (axum default) | — | Body exceeds axum's built-in `Json<…>` extractor limit (2 MiB). The `proxy.request_body_limit_bytes` config field is reserved for future use and not yet wired — track this in the follow-up product issue. |
 | 422 | `content_filter` | — | Guardrail rejected request or response content |
 | 429 | `rate_limit_exceeded` | — | RPM/TPM/concurrency cap engaged (all three quotas surface here — the gateway does not split concurrency into a separate code) |
 | 429 | `billing_error` | `budget_exceeded` | Per-key USD budget exhausted |
 | 502 | (per-bridge) | — | Upstream returned 5xx or invalid wire format; `type` comes from the bridge — see [§6](#6-provider-specific-notes) |
 | 503 | `provider_unavailable` | — | No bridge registered for the resolved Model's provider |
+| 504 | `timeout` | — | Upstream call exceeded its deadline. Surfaced by `BridgeError::Timeout` and mapped through the bridge's `error_type()`. |
 
 Rate-limit rejections carry a `Retry-After: <seconds>` header. Budget
 rejections do not — the operator is the one who lifts the cap, so
@@ -62,16 +64,25 @@ there is no deterministic retry interval to advertise.
 The `code` field is populated only where listed above; otherwise it
 is omitted from the envelope.
 
-## 3. Response headers (every endpoint)
+## 3. Response headers
 
-| Header | Meaning |
-|---|---|
-| `x-aisix-request-id` | Server-issued request UUID. Echo this when filing support tickets. (`/v1/chat/completions` currently emits this as `x-aisix-call-id` instead — known wart, will converge in a follow-up code change.) |
-| `x-aisix-cache` | `hit` if the response came from cache, `miss` otherwise. Absent for streaming responses. |
-| `x-ratelimit-limit-{requests,tokens,concurrent}` | Configured caps. |
-| `x-ratelimit-remaining-{requests,tokens,concurrent}` | Live counters at end of request. |
-| `x-ratelimit-reset-{requests,tokens}` | Unix timestamp when the window resets. |
-| `Retry-After` | On 429 rate-limit responses only. |
+Header coverage today is uneven across endpoints — converging on a
+single canonical request-id header is tracked as a follow-up code
+change.
+
+| Header | Meaning | Where emitted today |
+|---|---|---|
+| `x-aisix-request-id` | Server-issued request UUID. Echo this when filing support tickets. | `/v1/messages`, `/v1/responses`, `/v1/rerank`, `/v1/audio/*`, `/passthrough/*` |
+| `x-aisix-call-id` | Same intent as `x-aisix-request-id`; will be retired in favour of it. | `/v1/chat/completions` only |
+| `x-aisix-cache` | `hit` if the response came from cache, `miss` otherwise. Absent for streaming responses. | every endpoint that goes through the cache layer |
+| `x-ratelimit-limit-{requests,tokens,concurrent}` | Configured caps. | every endpoint that ran the rate-limit middleware |
+| `x-ratelimit-remaining-{requests,tokens,concurrent}` | Live counters at end of request. | same as above |
+| `x-ratelimit-reset-{requests,tokens}` | Unix timestamp when the window resets. | same as above |
+| `Retry-After` | On 429 rate-limit responses only. | proxy 429 path |
+
+`/v1/completions`, `/v1/embeddings`, `/v1/images/generations`, and
+`/v1/models` do not currently emit any request-id header. Treat the
+absence as a known gap rather than a contract.
 
 ## 4. Endpoints
 
@@ -215,7 +226,9 @@ possible:
 
 - One `data:` line per chunk, terminated by `\n\n`.
 - A keepalive comment (`: ping`) is emitted every 15 s of idle time
-  to prevent intermediate proxies from dropping the connection.
+  on `/v1/chat/completions` streams to prevent intermediate proxies
+  from dropping the connection. `/v1/messages` and `/v1/responses`
+  do not currently emit keepalives.
 - The terminal `data: [DONE]` is always sent on a clean upstream
   finish, even if the upstream omitted it.
 - If the upstream stream terminates abnormally, aisix sends a final

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -13,10 +13,11 @@ caller traffic targets. It is served on the proxy listener (default
 ## 1. Authentication
 
 Every endpoint requires a caller API key, presented as either
-`Authorization: Bearer <key>` (preferred) or `Authorization: <key>`
-(bare-key fallback for legacy SDKs). The key must exist in the
-`apikeys` table of the current snapshot. See
-[architecture.md §3](./architecture.md#3-configuration-data-plane).
+`Authorization: Bearer <key>` (preferred) or `x-api-key: <key>`
+(fallback for clients that can't set `Authorization`). A bare
+`Authorization: <key>` without the `Bearer` scheme is rejected.
+The key must exist in the `apikeys` table of the current snapshot.
+See [architecture.md §3](./architecture.md#3-configuration-data-plane).
 
 ```http
 Authorization: Bearer sk-aisix-…
@@ -41,28 +42,31 @@ Errors follow the OpenAI shape so SDK error handlers light up:
 }
 ```
 
-| Status | `type` | When |
-|---|---|---|
-| 400 | `invalid_request_error` | Malformed body, missing `model`, etc. |
-| 401 | `authentication_error` | Missing or unknown bearer key |
-| 403 | `model_access_forbidden` | Key valid but Model not in `allowed_models` |
-| 404 | `model_not_found` | `req.model` does not resolve in the snapshot |
-| 413 | `request_too_large` | Body exceeds `proxy.request_body_limit_bytes` (default 10 MB) |
-| 422 | `invalid_request_error` | Schema-valid JSON but semantically wrong (e.g. empty `messages`) |
-| 429 | `rate_limit_exceeded` / `budget_exceeded` | RPM/TPM/concurrency/budget cap |
-| 502 | `provider_error` | Upstream returned 5xx or invalid wire format |
-| 503 | `service_unavailable` | No bridge registered for the resolved Model's provider |
-| 504 | `request_timeout` | Upstream exceeded `Model.timeout` ms |
+| Status | `type` | `code` | When |
+|---|---|---|---|
+| 400 | `invalid_request_error` | — | Malformed body, missing `model`, etc. |
+| 401 | `invalid_api_key` | — | Missing, malformed, or unknown bearer/`x-api-key` |
+| 403 | `permission_denied` | — | Key valid but Model not in `allowed_models` |
+| 404 | `model_not_found` | — | `req.model` does not resolve in the snapshot |
+| 413 | (axum default) | — | Body exceeds `proxy.request_body_limit_bytes` (default 10 MB) — produced by the body-limit middleware, not the OpenAI envelope |
+| 422 | `content_filter` | — | Guardrail rejected request or response content |
+| 429 | `rate_limit_exceeded` | — | RPM/TPM/concurrency cap engaged (all three quotas surface here — the gateway does not split concurrency into a separate code) |
+| 429 | `billing_error` | `budget_exceeded` | Per-key USD budget exhausted |
+| 502 | (per-bridge) | — | Upstream returned 5xx or invalid wire format; `type` comes from the bridge — see [§6](#6-provider-specific-notes) |
+| 503 | `provider_unavailable` | — | No bridge registered for the resolved Model's provider |
 
-For rate-limit and budget errors the response also carries
-`Retry-After: <seconds>` (rate limit) or `Retry-After-Seconds-Header`
-(budget) headers when known.
+Rate-limit rejections carry a `Retry-After: <seconds>` header. Budget
+rejections do not — the operator is the one who lifts the cap, so
+there is no deterministic retry interval to advertise.
+
+The `code` field is populated only where listed above; otherwise it
+is omitted from the envelope.
 
 ## 3. Response headers (every endpoint)
 
 | Header | Meaning |
 |---|---|
-| `x-aisix-call-id` | Server-issued request UUID. Echo this when filing support tickets. |
+| `x-aisix-request-id` | Server-issued request UUID. Echo this when filing support tickets. (`/v1/chat/completions` currently emits this as `x-aisix-call-id` instead — known wart, will converge in a follow-up code change.) |
 | `x-aisix-cache` | `hit` if the response came from cache, `miss` otherwise. Absent for streaming responses. |
 | `x-ratelimit-limit-{requests,tokens,concurrent}` | Configured caps. |
 | `x-ratelimit-remaining-{requests,tokens,concurrent}` | Live counters at end of request. |
@@ -118,14 +122,13 @@ even in streaming mode.
 **function-style tool definitions** all pass through unchanged.
 
 **Caching** — non-streaming requests with the same fingerprint
-(model + messages + temperature + top_p + max_tokens) hit the cache.
-Override per request with `Cache-Control` header values:
-
-| Header value | Effect |
-|---|---|
-| `no-store` | Skip cache lookup AND skip storing the response |
-| `no-cache` | Skip lookup but still store on success |
-| `s-maxage=N` | Override TTL for this entry |
+(model + messages + temperature + top_p + max_tokens, plus the
+`tools` / `tool_choice` / `response_format` / `seed` / `stop` /
+`presence_penalty` / `frequency_penalty` request fields when set)
+hit the cache when a `CachePolicy` resource matches. Streaming
+responses are never cached. Cache behavior is configured operator-
+side via `/admin/v1/cache_policies`; there is no per-request
+`Cache-Control` override today.
 
 ### 4.3 `POST /v1/completions`
 
@@ -307,6 +310,7 @@ in parallel for at least one release.
 - [`architecture.md`](./architecture.md) — how the data and request
   paths fit together internally.
 - [`api-admin.md`](./api-admin.md) — operator CRUD surface.
-- The auto-generated OpenAPI spec lives at `/openapi` on the admin
-  listener. It is the canonical machine-readable contract; this
-  document is the human-readable companion.
+- The auto-generated OpenAPI spec lives at `/admin/openapi.json` on
+  the admin listener (with a Scalar UI at `/admin/openapi-scalar`).
+  It is the canonical machine-readable contract; this document is
+  the human-readable companion.


### PR DESCRIPTION
## Summary

The Proxy API doc had several drift items that would break a real SDK integration today. Surfaced by the doc-vs-code audit (companion to #179, #180, #181, #182). Now matches what the gateway actually emits, verified against \`crates/aisix-proxy/src/{error,auth,render}.rs\` and \`crates/aisix-admin/src/openapi.rs\`.

## Changes

### §1 Authentication
- Fallback header: was \`Authorization: <bare-key>\`, actual fallback is **\`x-api-key: <key>\`** (\`auth.rs:68\`). Bare \`Authorization: <key>\` without the \`Bearer\` scheme is rejected (test \`extract_bearer_rejects_wrong_scheme\`).

### §2 Error envelope — every \`type\` value was wrong

| Status | Doc claimed | Actually emits |
|---|---|---|
| 401 | \`authentication_error\` | \`invalid_api_key\` |
| 403 | \`model_access_forbidden\` | \`permission_denied\` |
| 422 | \`invalid_request_error\` | \`content_filter\` |
| 503 | \`service_unavailable\` | \`provider_unavailable\` |
| 429 (budget) | \`budget_exceeded\` | \`type: billing_error, code: budget_exceeded\` |

- **413**: was listed as OpenAI-shape \`request_too_large\`. Actually produced by axum's body-limit middleware **outside** the OpenAI envelope. Noted so SDKs don't expect the envelope shape on 413.
- **502**: was a single static \`provider_error\`. Actual \`type\` comes from the active bridge's error mapper (\`b.error_type()\`). Pointed at §6.
- **504**: removed. \`RequestTimeout\` is not a \`ProxyError\` variant.
- **Retry-After**: removed the fictitious \`Retry-After-Seconds-Header\` for budget rejections — no such header is set; only \`RateLimit\` produces \`Retry-After\` (\`error.rs:119-123\`).
- Added an explicit \`code\` column so \`budget_exceeded\` (the code, not the type) is visible.

### §3 Response headers
- Canonical request-id is **\`x-aisix-request-id\`** (emitted by 9 of 10 endpoints). \`/v1/chat/completions\` still emits the legacy \`x-aisix-call-id\` (single insert at \`chat.rs:122\`) — flagged as a known wart to be cleaned up code-side.

### §4.2 Caching
- Removed the per-request \`Cache-Control: no-store / no-cache / s-maxage=N\` override table. **None** of those values are honored anywhere in \`aisix-proxy\` or \`aisix-cache\` — the only \`no-cache\` occurrences set Cache-Control on SSE responses, not request-side overrides. Replaced with the actual fingerprint contents (now including \`tools\` / \`tool_choice\` / \`response_format\` / \`seed\` / \`stop\` / \`presence_penalty\` / \`frequency_penalty\`) and a pointer to operator-side \`/admin/v1/cache_policies\`.

### §10 OpenAPI path
- \`/openapi\` → \`/admin/openapi.json\` (\`openapi.rs:44\`). Also linked the Scalar UI at \`/admin/openapi-scalar\`.

## Out of scope (follow-ups)

- \`api-admin.md\` adding guardrails / cache_policies / observability_exporters CRUD sections (currently mentioned only by name)
- Code-side: unify \`x-aisix-call-id\` → \`x-aisix-request-id\` in \`chat.rs:122\`

## Test plan

- [x] Doc-only change; no code touched
- [x] Every concrete claim cross-verified against cited \`crates/\` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Stricter Proxy auth: require `Authorization: Bearer <key>` with `x-api-key` as explicit fallback; bare `Authorization: <key>` rejected.
  * Redesigned error envelope: HTTP status → `error.type` mapping, distinct handling for invalid keys vs model/permission access, clarified `Retry-After` rules and `code` usage.
  * Standardized request-id header and noted current endpoint gaps.
  * Clarified caching fingerprinting and operator-controlled CachePolicy (no per-request override); streaming keepalive and OpenAPI path updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/191)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->