### PR TITLE
test(e2e): G6 — widen 70/30 tolerance to ±15 to kill CI flake

### DIFF
--- a/tests/e2e/src/cases/weighted-routing-distribution-e2e.test.ts
+++ b/tests/e2e/src/cases/weighted-routing-distribution-e2e.test.ts
@@ -237,7 +237,7 @@ describe("weighted routing distribution e2e: 70/30 split lands inside [55,85] / 
     expect(aDelta + bDelta).toBe(TOTAL_REQUESTS);
 
     // Distribution assertion: heavy side ~70, light side ~30, both
-    // inside ±10. A round-robin regression (50/50) fails both gates;
+    // inside ±15. A round-robin regression (50/50) fails both gates;
     // a pin-to-one regression (100/0) fails both gates.
     expect(aDelta).toBeGreaterThanOrEqual(HEAVY_LO);
     expect(aDelta).toBeLessThanOrEqual(HEAVY_HI);

--- a/tests/e2e/src/cases/weighted-routing-distribution-e2e.test.ts
+++ b/tests/e2e/src/cases/weighted-routing-distribution-e2e.test.ts
@@ -26,17 +26,20 @@ import {
 //     statistically reasonable tolerance window around the declared
 //     ratio. A regression that ignored `weight` and round-robined
 //     instead would fail (each side would land ~50%, well outside
-//     [60, 80] / [20, 40]).
+//     [55, 85] / [15, 45]).
 //
 // Reference: OpenAI Chat Completions API spec for the shape the
 // caller sees (https://platform.openai.com/docs/api-reference/chat).
 //
-// The 100-request count and the [60, 80] / [20, 40] tolerance are
-// chosen so that even a moderately uneven scheduler (drift of a few
-// percent within a 100-sample window) still passes, while a scheduler
-// that completely ignores weight (e.g. round-robins, or pins to one
-// target) cannot. Two independent binomial windows: 70±10 and 30±10
-// comfortably covers a 99% interval at p=0.7 over n=100 (σ≈4.6).
+// The 100-request count and the [55, 85] / [15, 45] tolerance are
+// chosen so a scheduler that completely ignores weight (e.g.
+// round-robins or pins to one target) cannot pass — round-robin
+// lands at 50/50, well outside [55, 85] for the heavy side — while
+// the legitimate 70/30 path stays comfortably inside. Two
+// independent binomial windows: 70±15 over n=100 with σ≈4.58 puts
+// the gate at ~3.3σ, P(false positive) ≈ 0.1%. The previous ±10
+// gate sat at ~2.2σ (≈2.8%) and tripped roughly once per ~36 CI
+// runs — wide enough to be a steady CI flake.
 
 const CALLER_PLAINTEXT = "sk-wr-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -46,13 +49,14 @@ const CALLER_KEY_HASH = createHash("sha256")
 const TOTAL_REQUESTS = 100;
 const HEAVY_WEIGHT = 70;
 const LIGHT_WEIGHT = 30;
-// Tolerance: weight ±10 absolute on a 100-sample window.
-const HEAVY_LO = 60;
-const HEAVY_HI = 80;
-const LIGHT_LO = 20;
-const LIGHT_HI = 40;
+// Tolerance: weight ±15 absolute on a 100-sample window. See header
+// comment for the statistical-power tradeoff vs the previous ±10.
+const HEAVY_LO = 55;
+const HEAVY_HI = 85;
+const LIGHT_LO = 15;
+const LIGHT_HI = 45;
 
-describe("weighted routing distribution e2e: 70/30 split lands inside [60,80] / [20,40]", () => {
+describe("weighted routing distribution e2e: 70/30 split lands inside [55,85] / [15,45]", () => {
   let app: SpawnedApp | undefined;
   let upstreamA: OpenAiUpstream | undefined;
   let upstreamB: OpenAiUpstream | undefined;


### PR DESCRIPTION
## Summary

The G6 weighted-routing-distribution case (#183) was tripping the e2e job on unrelated PRs because its tolerance window was too tight for the sample size.

| | Old | New |
|---|---|---|
| Sample size | 100 | 100 |
| Heavy gate | [60, 80] | [55, 85] |
| Light gate | [20, 40] | [15, 45] |
| Sigma multiple | ~2.18σ | ~3.27σ |
| P(false positive per side) | ≈ 2.8% | ≈ 0.05% |
| P(combined two-sided) | ≈ 5.6% | ≈ 0.1% |

Math: \`σ = √(n·p·(1-p)) = √(100·0.7·0.3) ≈ 4.58\`. ±10 / 4.58 ≈ 2.18σ; ±15 / 4.58 ≈ 3.27σ.

## Why now

Observed in production: PR #186's e2e run hit \`expected 81 to be less than or equal to 80\` while the gateway is behaving correctly. 81 vs the [60, 80] heavy gate is exactly the kind of close-to-edge sample the old tolerance can't accommodate.

## What didn't change

The contract being pinned is unchanged: the test still distinguishes a working weighted scheduler (70/30) from:

- **round-robin** (lands at 50/50): 50 is still < 55, fails the heavy gate.
- **pin-to-one** (lands at 100/0): 100 is > 85 on heavy AND 0 < 15 on light, fails both.
- **swapped weights** (would land at 30/70): 30 is < 55 on heavy, fails.

The relaxation only sacrifices distinguishability against near-by ratios (e.g. 60/40 vs 70/30), which the original PR's audit already called out as out of scope for G6.

## Test plan

- [x] Constants moved from ±10 to ±15
- [x] Inline header math updated to reflect the new statistical-power tradeoff
- [x] describe-block label updated to match the new gate
- [x] No assertion logic changed; same shape, wider numeric window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tolerance thresholds for weighted routing distribution validation to ensure accurate test assertions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/195)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->