### PR TITLE
fix(proxy): record real token counts on streamed + output-blocked chats

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -58,7 +58,7 @@ pub async fn chat_completions(
     let api_key_id = auth.entry.id.clone();
     let model_name = req.model.clone();
 
-    let outcome = dispatch(&state, &auth, &req, &request_id).await;
+    let outcome = dispatch(&state, &auth, &req, &request_id, started).await;
 
     match outcome {
         Ok(mut success) => {
@@ -85,31 +85,39 @@ pub async fn chat_completions(
                 success.total_tokens,
                 &request_id,
             );
-            emit_usage_event(
-                &state,
-                &request_id,
-                &success.model_id,
-                &api_key_id,
-                status,
-                elapsed,
-                success.prompt_tokens.unwrap_or(0) as u32,
-                success.completion_tokens.unwrap_or(0) as u32,
-                UsageExtras {
-                    cached_prompt_tokens: success.cached_prompt_tokens,
-                    reasoning_tokens: success.reasoning_tokens,
-                    cache_creation_tokens: success.cache_creation_tokens,
-                    cache_read_tokens: success.cache_read_tokens,
-                    provider_request_id: success.provider_request_id.clone(),
-                    provider_model_version: success.provider_model_version.clone(),
-                    finish_reason: success.finish_reason.clone(),
-                    bypass_reason: success.bypass_reason.clone().unwrap_or_default(),
-                    cache_status: success.cache_status.as_str().to_string(),
-                    cache_hit_saved_input_tokens: success.cache_hit_saved_input_tokens,
-                    cache_hit_saved_output_tokens: success.cache_hit_saved_output_tokens,
-                },
-                success.cost_usd,
-                /* guardrail_blocked */ false,
-            );
+            // The streaming path wires telemetry into the SSE stream's
+            // on_complete callback (it has to wait for the terminal
+            // chunk to read the upstream's `usage` block). Calling
+            // `emit_usage_event` here for streaming would double-emit
+            // — once with all-zero tokens at handler return, then
+            // again with the real values at stream end.
+            if !success.telemetry_handled_by_stream {
+                emit_usage_event(
+                    &state,
+                    &request_id,
+                    &success.model_id,
+                    &api_key_id,
+                    status,
+                    elapsed,
+                    success.prompt_tokens.unwrap_or(0) as u32,
+                    success.completion_tokens.unwrap_or(0) as u32,
+                    UsageExtras {
+                        cached_prompt_tokens: success.cached_prompt_tokens,
+                        reasoning_tokens: success.reasoning_tokens,
+                        cache_creation_tokens: success.cache_creation_tokens,
+                        cache_read_tokens: success.cache_read_tokens,
+                        provider_request_id: success.provider_request_id.clone(),
+                        provider_model_version: success.provider_model_version.clone(),
+                        finish_reason: success.finish_reason.clone(),
+                        bypass_reason: success.bypass_reason.clone().unwrap_or_default(),
+                        cache_status: success.cache_status.as_str().to_string(),
+                        cache_hit_saved_input_tokens: success.cache_hit_saved_input_tokens,
+                        cache_hit_saved_output_tokens: success.cache_hit_saved_output_tokens,
+                    },
+                    success.cost_usd,
+                    /* guardrail_blocked */ false,
+                );
+            }
             // Inject x-ratelimit-* headers so OpenAI SDK clients see the
             // current window state. We peek *after* the commit so
             // remaining-requests reflects the post-dispatch tally.
@@ -123,10 +131,23 @@ pub async fn chat_completions(
             }
             success.response
         }
-        Err((resolved_model_id, err)) => {
+        Err((resolved_model_id, charge, err)) => {
             let status = err.status().as_u16();
             let elapsed = started.elapsed();
             record_error(&state.metrics, &err, &model_name, status, elapsed);
+            // Access log: surface the upstream-billed counts when the
+            // error fired AFTER the upstream call (output-content-filter
+            // block). Pre-upstream errors (input filter, budget,
+            // model-not-found) carry no charge — log None there so the
+            // line reflects "request never reached the model".
+            let (al_prompt, al_completion, al_total) = match charge.as_ref() {
+                Some(c) => (
+                    Some(u64::from(c.prompt_tokens)),
+                    Some(u64::from(c.completion_tokens)),
+                    Some(u64::from(c.prompt_tokens) + u64::from(c.completion_tokens)),
+                ),
+                None => (None, None, None),
+            };
             emit_access_log(
                 method,
                 path,
@@ -135,9 +156,9 @@ pub async fn chat_completions(
                 None,
                 Some(&model_name),
                 Some(&api_key_id),
-                None,
-                None,
-                None,
+                al_prompt,
+                al_completion,
+                al_total,
                 &request_id,
             );
             // Telemetry for the failure path. `resolved_model_id` is
@@ -150,6 +171,33 @@ pub async fn chat_completions(
             // with the dedicated `guardrail_blocked` flag so the
             // dashboard can surface it on the Blocked tab.
             let guardrail_blocked = matches!(err, ProxyError::ContentFiltered(_));
+            // For output-content-filter blocks the upstream WAS called
+            // and the provider already billed for `prompt_tokens` +
+            // `completion_tokens`. The captured `charge` carries those
+            // counts forward so the customer's `usage_events` row
+            // reflects the bill. For all other error paths charge is
+            // None and tokens stay at 0 — those errors never reached
+            // the upstream.
+            let (prompt_tokens, completion_tokens, extras) = match charge {
+                Some(c) => (
+                    c.prompt_tokens,
+                    c.completion_tokens,
+                    UsageExtras {
+                        cached_prompt_tokens: c.cached_prompt_tokens,
+                        reasoning_tokens: c.reasoning_tokens,
+                        cache_creation_tokens: c.cache_creation_tokens,
+                        cache_read_tokens: c.cache_read_tokens,
+                        provider_request_id: c.provider_request_id,
+                        provider_model_version: c.provider_model_version,
+                        finish_reason: c.finish_reason,
+                        bypass_reason: String::new(),
+                        cache_status: String::new(),
+                        cache_hit_saved_input_tokens: 0,
+                        cache_hit_saved_output_tokens: 0,
+                    },
+                ),
+                None => (0, 0, UsageExtras::default()),
+            };
             emit_usage_event(
                 &state,
                 &request_id,
@@ -157,12 +205,9 @@ pub async fn chat_completions(
                 &api_key_id,
                 status,
                 elapsed,
-                /* prompt_tokens */ 0,
-                /* completion_tokens */ 0,
-                // Error path never reached the upstream — no provider
-                // id / model version / finish_reason to record, all
-                // zero / empty.
-                UsageExtras::default(),
+                prompt_tokens,
+                completion_tokens,
+                extras,
                 /* cost_usd */ 0.0,
                 guardrail_blocked,
             );
@@ -216,6 +261,13 @@ struct Success {
     /// the dashboard's /logs column. See `aisix-core::CachePolicy`
     /// (Stage 2) and `aisix-cache::Cache` for the source of truth.
     cache_status: CacheStatus,
+    /// True when telemetry emission is wired into the SSE stream's
+    /// on_complete callback (streaming path). The top-level handler
+    /// must NOT call `emit_usage_event` again — that would emit one
+    /// event with all-zero tokens at handler return on top of the real
+    /// one from stream completion. Always false for non-streaming
+    /// paths (handler emits inline with `success.prompt_tokens` etc.).
+    telemetry_handled_by_stream: bool,
     /// On a cache HIT, the prompt + completion tokens of the cached
     /// response — the work the upstream would have repeated had the
     /// cache not served the request. Both 0 on miss / disabled. cp-api
@@ -261,14 +313,39 @@ impl CacheStatus {
 /// surfaces this id on the failure-path telemetry event so the
 /// dashboard's `/logs` page can show the model that was targeted by a
 /// guardrail-blocked / budget-exceeded / bridge-failed request.
+/// Upstream-billed token counts attached to dispatch errors that fired
+/// AFTER the upstream call already responded. Today this is populated
+/// only on the output-content-filter block path: the gateway received a
+/// full upstream response (which the provider has already charged for),
+/// then the output guardrail decided to block delivery to the client.
+/// The customer is still on the hook for those tokens, so the charge
+/// flows up to the handler so its `usage_events` row reflects the bill.
+///
+/// `None` on every other error path — input-filter blocks, budget
+/// failures, rate-limit rejections, model-not-found, etc. all happen
+/// BEFORE any upstream call and the customer pays nothing.
+struct UpstreamCharge {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    cached_prompt_tokens: u32,
+    reasoning_tokens: u32,
+    cache_creation_tokens: u32,
+    cache_read_tokens: u32,
+    provider_request_id: String,
+    provider_model_version: String,
+    finish_reason: String,
+}
+
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
     req: &ChatFormat,
     request_id: &str,
-) -> Result<Success, (Option<String>, ProxyError)> {
+    started: Instant,
+) -> Result<Success, (Option<String>, Option<UpstreamCharge>, ProxyError)> {
     if req.messages.is_empty() {
         return Err((
+            None,
             None,
             ProxyError::InvalidRequest("messages array must not be empty".into()),
         ));
@@ -278,13 +355,17 @@ async fn dispatch(
     let virtual_entry = snapshot
         .models
         .get_by_name(&req.model)
-        .ok_or_else(|| (None, ProxyError::ModelNotFound(req.model.clone())))?;
+        .ok_or_else(|| (None, None, ProxyError::ModelNotFound(req.model.clone())))?;
     let model_id = virtual_entry.id.clone();
 
     // Every error from here on attaches the resolved model_id so the
     // failure-path telemetry event in `chat_completions` can surface
     // which model the request targeted.
-    let with_model = |e: ProxyError| (Some(model_id.clone()), e);
+    // Pre-upstream errors carry `None` for the charge — by definition
+    // they fire before any provider billing happens. The output-filter
+    // path below is the only site that builds a `Some(UpstreamCharge)`
+    // (manually, not via this helper).
+    let with_model = |e: ProxyError| (Some(model_id.clone()), None, e);
 
     if !auth.key().can_access(&req.model) {
         return Err(with_model(ProxyError::ModelForbidden(req.model.clone())));
@@ -388,10 +469,51 @@ async fn dispatch(
         // Pre-fix this path called commit_tokens(0) and never came
         // back, leaving TPM caps blind for all streaming traffic.
         drop(reservation);
+        // Capture everything the stream-completion callback needs so
+        // it can fire `emit_usage_event` once the terminal SSE chunk
+        // has yielded its `usage` block. Telemetry emission has to
+        // wait until end-of-stream because OpenAI / Anthropic only
+        // populate `usage` on the last chunk; emitting at handler
+        // return (the non-streaming path's spot) would record zeros.
         let limiter = Arc::clone(&state.limiter);
         let post_stream_key = rl_key.clone();
-        let sse_stream = build_sse_stream(upstream, now, move |total_tokens| {
-            limiter.add_tokens_post_stream(&post_stream_key, total_tokens);
+        let state_for_telem = state.clone();
+        let request_id_for_telem = request_id.to_string();
+        let model_id_for_telem = model_id.clone();
+        let api_key_id_for_telem = auth.entry.id.clone();
+        let bypass_reason_for_telem = bypass_reason.clone().unwrap_or_default();
+        let sse_stream = build_sse_stream(upstream, now, move |comp: StreamCompletion| {
+            // Existing: rate-limit accounting (TPM cap) — see #108.
+            limiter.add_tokens_post_stream(&post_stream_key, comp.total_tokens);
+            // Telemetry: emit with the actual upstream-reported counts.
+            // cost_usd stays 0.0; cp-api recomputes server-side from
+            // its model_pricing catalog (same pattern as the non-
+            // streaming path's cost_usd handling).
+            emit_usage_event(
+                &state_for_telem,
+                &request_id_for_telem,
+                &model_id_for_telem,
+                &api_key_id_for_telem,
+                /* status_code */ 200,
+                started.elapsed(),
+                comp.prompt_tokens,
+                comp.completion_tokens,
+                UsageExtras {
+                    cached_prompt_tokens: comp.cached_prompt_tokens,
+                    reasoning_tokens: comp.reasoning_tokens,
+                    cache_creation_tokens: comp.cache_creation_tokens,
+                    cache_read_tokens: comp.cache_read_tokens,
+                    provider_request_id: comp.provider_request_id,
+                    provider_model_version: comp.provider_model_version,
+                    finish_reason: comp.finish_reason,
+                    bypass_reason: bypass_reason_for_telem,
+                    cache_status: CacheStatus::Disabled.as_str().to_string(),
+                    cache_hit_saved_input_tokens: 0,
+                    cache_hit_saved_output_tokens: 0,
+                },
+                /* cost_usd */ 0.0,
+                /* guardrail_blocked */ false,
+            );
         });
         let response =
             Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
@@ -399,15 +521,14 @@ async fn dispatch(
             response: response.into_response(),
             provider: format!("{provider:?}").to_lowercase(),
             model_id: model_id.clone(),
+            // Token totals are populated on the SSE stream's terminal
+            // chunk and forwarded into telemetry from on_complete; the
+            // top-level handler skips its own `emit_usage_event` for
+            // streaming via `telemetry_handled_by_stream` below.
             prompt_tokens: None,
             completion_tokens: None,
             total_tokens: None,
-            // Streaming path doesn't compute cost yet (no token totals
-            // until the stream completes upstream). Phase 2 wires
-            // mid-stream accumulation; for now telemetry records 0.
             cost_usd: 0.0,
-            // Cache / reasoning counters require parsing the terminal
-            // SSE chunk's usage block; not wired yet — Phase 2.
             cached_prompt_tokens: 0,
             reasoning_tokens: 0,
             cache_creation_tokens: 0,
@@ -417,11 +538,12 @@ async fn dispatch(
             finish_reason: String::new(),
             bypass_reason: bypass_reason.clone(),
             // Streaming responses aren't cached at this layer — see
-            // crates/aisix-cache/src/lib.rs and Phase 2 above. Always
-            // surface as `disabled` on the streaming path.
+            // crates/aisix-cache/src/lib.rs. Always surface as
+            // `disabled` on the streaming path.
             cache_status: CacheStatus::Disabled,
             cache_hit_saved_input_tokens: 0,
             cache_hit_saved_output_tokens: 0,
+            telemetry_handled_by_stream: true,
         });
     }
 
@@ -535,6 +657,7 @@ async fn dispatch(
                     // without joining on the status enum.
                     cache_hit_saved_input_tokens: prompt.try_into().unwrap_or(u32::MAX),
                     cache_hit_saved_output_tokens: completion.try_into().unwrap_or(u32::MAX),
+                    telemetry_handled_by_stream: false,
                 });
             }
             Ok(None) => {}
@@ -637,7 +760,28 @@ async fn dispatch(
     match state.guardrails.check_output(&upstream).await {
         GuardrailVerdict::Allow => {}
         GuardrailVerdict::Block { reason } => {
-            return Err(with_model(ProxyError::ContentFiltered(reason)));
+            // Output filter fires AFTER the upstream call, so the
+            // provider has already billed for these tokens. Surface
+            // the captured upstream `UsageStats` to the handler so
+            // `usage_events` reflects the bill — silently zeroing
+            // them would let the customer's dashboard underreport
+            // tokens they paid the provider for.
+            let charge = UpstreamCharge {
+                prompt_tokens: upstream.usage.prompt_tokens,
+                completion_tokens: upstream.usage.completion_tokens,
+                cached_prompt_tokens,
+                reasoning_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                provider_request_id: provider_request_id.clone(),
+                provider_model_version: provider_model_version.clone(),
+                finish_reason: finish_reason.clone(),
+            };
+            return Err((
+                Some(model_id.clone()),
+                Some(charge),
+                ProxyError::ContentFiltered(reason),
+            ));
         }
         GuardrailVerdict::Bypass { reason } => {
             // First bypass wins — input bypass already populated
@@ -698,6 +842,7 @@ async fn dispatch(
         // the request *did* hit the upstream, no work was saved.
         cache_hit_saved_input_tokens: 0,
         cache_hit_saved_output_tokens: 0,
+        telemetry_handled_by_stream: false,
     })
 }
 
@@ -889,28 +1034,84 @@ fn created_ts() -> i64 {
 /// — the same loop exit). Errors mid-stream still terminate the loop
 /// normally, so partial-response cases commit whatever tokens were
 /// observed.
+/// What `build_sse_stream` extracts from the upstream stream and hands
+/// to `on_complete` once the terminal chunk arrives. Sourced from the
+/// `usage` block on whichever chunk carried it (typically the last one
+/// before `[DONE]`) plus the most-recently-seen `chunk.id` /
+/// `chunk.model` / `chunk.finish_reason`. Each numeric field defaults
+/// to 0 (and string field to "") when the upstream never emits a
+/// `usage` block — for example, an OpenAI streaming request without
+/// `stream_options.include_usage=true`. Callers are responsible for
+/// treating 0 as "no signal" the same way the non-streaming path
+/// treats `prompt_tokens.unwrap_or(0)`.
+#[derive(Default)]
+struct StreamCompletion {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    /// `u64` because the rate-limit accounting consumer (TPM cap)
+    /// uses u64; cp-api's wire-shape `prompt_tokens` is u32 but
+    /// cumulative-tokens accounting can overflow u32 over a long key.
+    total_tokens: u64,
+    cached_prompt_tokens: u32,
+    reasoning_tokens: u32,
+    cache_creation_tokens: u32,
+    cache_read_tokens: u32,
+    provider_request_id: String,
+    provider_model_version: String,
+    finish_reason: String,
+}
+
 fn build_sse_stream<F>(
     upstream: aisix_gateway::ChatChunkStream,
     created: i64,
     on_complete: F,
 ) -> impl Stream<Item = Result<Event, Infallible>>
 where
-    F: FnOnce(u64) + Send + 'static,
+    F: FnOnce(StreamCompletion) + Send + 'static,
 {
     async_stream::stream! {
         futures::pin_mut!(upstream);
-        // Track the largest `total_tokens` we've seen on any chunk's
-        // usage block. Providers typically populate this on the
-        // terminal chunk only; using "max" rather than "last" makes
+        // Accumulate the upstream's `usage` block + per-chunk metadata
+        // across the stream. Providers typically populate `usage` on
+        // the terminal chunk only; using "max" rather than "last" makes
         // the bookkeeping robust to a provider that double-emits.
-        let mut total_tokens: u64 = 0;
+        // `chunk.id` / `chunk.model` / `chunk.finish_reason` use
+        // last-seen-wins because those are stable per stream.
+        let mut comp = StreamCompletion::default();
         while let Some(item) = upstream.next().await {
             let ev = match item {
                 Ok(chunk) => {
+                    if !chunk.id.is_empty() {
+                        comp.provider_request_id = chunk.id.clone();
+                    }
+                    if !chunk.model.is_empty() {
+                        comp.provider_model_version = chunk.model.clone();
+                    }
+                    if let Some(fr) = chunk.finish_reason.as_ref() {
+                        comp.finish_reason = finish_reason_label(fr);
+                    }
                     if let Some(u) = chunk.usage.as_ref() {
+                        if u.prompt_tokens > comp.prompt_tokens {
+                            comp.prompt_tokens = u.prompt_tokens;
+                        }
+                        if u.completion_tokens > comp.completion_tokens {
+                            comp.completion_tokens = u.completion_tokens;
+                        }
                         let t = u.total_tokens as u64;
-                        if t > total_tokens {
-                            total_tokens = t;
+                        if t > comp.total_tokens {
+                            comp.total_tokens = t;
+                        }
+                        if u.cached_prompt_tokens > comp.cached_prompt_tokens {
+                            comp.cached_prompt_tokens = u.cached_prompt_tokens;
+                        }
+                        if u.reasoning_tokens > comp.reasoning_tokens {
+                            comp.reasoning_tokens = u.reasoning_tokens;
+                        }
+                        if u.cache_creation_tokens > comp.cache_creation_tokens {
+                            comp.cache_creation_tokens = u.cache_creation_tokens;
+                        }
+                        if u.cache_read_tokens > comp.cache_read_tokens {
+                            comp.cache_read_tokens = u.cache_read_tokens;
                         }
                     }
                     let rendered = render_chunk(created, chunk);
@@ -927,10 +1128,12 @@ where
             };
             yield Ok::<_, Infallible>(ev);
         }
-        // Stream done — account for the upstream's reported tokens.
-        // For providers that don't emit usage in the stream this stays
-        // 0; on_complete is responsible for treating 0 as "no signal".
-        on_complete(total_tokens);
+        // Stream done — fire on_complete with whatever we accumulated.
+        // For providers that don't emit `usage` in the stream the
+        // numeric fields stay 0; on_complete callers must treat 0 as
+        // "no signal" (cp-api does — its pricing catalog falls back
+        // to the standard rate when these are absent).
+        on_complete(comp);
         yield Ok::<_, Infallible>(Event::default().data("[DONE]"));
     }
 }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -190,8 +190,8 @@ pub async fn chat_completions(
                         provider_request_id: c.provider_request_id,
                         provider_model_version: c.provider_model_version,
                         finish_reason: c.finish_reason,
-                        bypass_reason: String::new(),
-                        cache_status: String::new(),
+                        bypass_reason: c.bypass_reason,
+                        cache_status: c.cache_status.as_str().to_string(),
                         cache_hit_saved_input_tokens: 0,
                         cache_hit_saved_output_tokens: 0,
                     },
@@ -334,6 +334,19 @@ struct UpstreamCharge {
     provider_request_id: String,
     provider_model_version: String,
     finish_reason: String,
+    /// First bypass reason observed on this request (input or output
+    /// guardrail returned `Bypass` because a remote-API guardrail was
+    /// unreachable + `fail_open=true`). Empty string = no bypass.
+    /// Carried so the output-block telemetry surfaces "this blocked
+    /// request had a degraded input check" — without this, an operator
+    /// auditing a guardrail bypass would only see the bypass on
+    /// successfully-served requests, never on output-blocked ones.
+    bypass_reason: String,
+    /// Cache outcome decided BEFORE the output guardrail ran. The
+    /// dashboard's cache-status filter counts misses vs disabled vs
+    /// hits — without forwarding it on the output-block path the
+    /// blocked-but-billed request is mis-bucketed as "no cache decision".
+    cache_status: CacheStatus,
 }
 
 async fn dispatch(
@@ -507,6 +520,12 @@ async fn dispatch(
                     provider_model_version: comp.provider_model_version,
                     finish_reason: comp.finish_reason,
                     bypass_reason: bypass_reason_for_telem,
+                    // TODO(streaming-cache): when streaming responses
+                    // become cacheable, this constant `Disabled` will
+                    // silently mis-bucket cached streamed responses.
+                    // Propagate the dispatch path's `cache_status`
+                    // local at that point. Tracking issue to be filed
+                    // alongside the streaming-cache implementation.
                     cache_status: CacheStatus::Disabled.as_str().to_string(),
                     cache_hit_saved_input_tokens: 0,
                     cache_hit_saved_output_tokens: 0,
@@ -766,6 +785,13 @@ async fn dispatch(
             // `usage_events` reflects the bill — silently zeroing
             // them would let the customer's dashboard underreport
             // tokens they paid the provider for.
+            //
+            // `bypass_reason` and `cache_status` are also forwarded
+            // so an output-blocked request stays comparable to a
+            // succeeded-but-billed one in the dashboard's bypass /
+            // cache-status filters. Without these, an operator
+            // auditing input-bypass would never see them on
+            // output-blocked requests.
             let charge = UpstreamCharge {
                 prompt_tokens: upstream.usage.prompt_tokens,
                 completion_tokens: upstream.usage.completion_tokens,
@@ -776,6 +802,8 @@ async fn dispatch(
                 provider_request_id: provider_request_id.clone(),
                 provider_model_version: provider_model_version.clone(),
                 finish_reason: finish_reason.clone(),
+                bypass_reason: bypass_reason.clone().unwrap_or_default(),
+                cache_status,
             };
             return Err((
                 Some(model_id.clone()),
@@ -1061,6 +1089,46 @@ struct StreamCompletion {
     finish_reason: String,
 }
 
+/// Fires `on_complete` with whatever `StreamCompletion` has been
+/// accumulated when the guard is dropped. The async_stream body holds
+/// this guard for the whole stream lifetime so on_complete fires
+/// reliably on BOTH normal completion AND mid-stream cancellation.
+///
+/// Why this is necessary: code AFTER a `yield` in `async_stream::stream!{}`
+/// only runs when the consumer pulls. If axum drops the response
+/// future (client disconnect, request timeout, etc.), the generator
+/// is dropped at its last suspension point and post-yield code never
+/// runs. Pre-Drop-guard, that meant a streaming chat with a client
+/// disconnect emitted ZERO telemetry events — the customer was billed
+/// upstream, the gateway recorded nothing. Drop runs on cancellation,
+/// so the captured `StreamCompletion` (potentially zeros if the
+/// disconnect beat the upstream's `usage` chunk) is always shipped.
+struct CompleteOnDrop<F: FnOnce(StreamCompletion)> {
+    /// `Option<(closure, accumulator)>` — Drop calls the closure
+    /// exactly once via `.take()`, so manual disarm before the
+    /// natural drop is also safe (we don't currently use that, but
+    /// it leaves the door open).
+    slot: Option<(F, StreamCompletion)>,
+}
+
+impl<F: FnOnce(StreamCompletion)> CompleteOnDrop<F> {
+    fn comp(&mut self) -> &mut StreamCompletion {
+        &mut self
+            .slot
+            .as_mut()
+            .expect("CompleteOnDrop guard accessed after take")
+            .1
+    }
+}
+
+impl<F: FnOnce(StreamCompletion)> Drop for CompleteOnDrop<F> {
+    fn drop(&mut self) {
+        if let Some((f, c)) = self.slot.take() {
+            f(c);
+        }
+    }
+}
+
 fn build_sse_stream<F>(
     upstream: aisix_gateway::ChatChunkStream,
     created: i64,
@@ -1070,6 +1138,14 @@ where
     F: FnOnce(StreamCompletion) + Send + 'static,
 {
     async_stream::stream! {
+        // Hold on_complete + the running StreamCompletion accumulator
+        // inside a Drop guard so on_complete fires even on client-
+        // disconnect cancellation. See `CompleteOnDrop` above for the
+        // why; tl;dr without this, async_stream! body code after a
+        // yield only runs on consumer pulls.
+        let mut guard = CompleteOnDrop {
+            slot: Some((on_complete, StreamCompletion::default())),
+        };
         futures::pin_mut!(upstream);
         // Accumulate the upstream's `usage` block + per-chunk metadata
         // across the stream. Providers typically populate `usage` on
@@ -1077,10 +1153,10 @@ where
         // the bookkeeping robust to a provider that double-emits.
         // `chunk.id` / `chunk.model` / `chunk.finish_reason` use
         // last-seen-wins because those are stable per stream.
-        let mut comp = StreamCompletion::default();
         while let Some(item) = upstream.next().await {
             let ev = match item {
                 Ok(chunk) => {
+                    let comp = guard.comp();
                     if !chunk.id.is_empty() {
                         comp.provider_request_id = chunk.id.clone();
                     }
@@ -1128,12 +1204,20 @@ where
             };
             yield Ok::<_, Infallible>(ev);
         }
-        // Stream done — fire on_complete with whatever we accumulated.
+        // Stream completed normally. Yield [DONE] BEFORE the guard
+        // drops at end-of-scope so the SSE sentinel reaches the
+        // client before the on_complete telemetry fan-out. (Any
+        // ordering relationship between the two is non-causal — both
+        // are independent side effects on this thread — but matching
+        // the prior "on_complete then [DONE]" intent feels right.)
         // For providers that don't emit `usage` in the stream the
-        // numeric fields stay 0; on_complete callers must treat 0 as
-        // "no signal" (cp-api does — its pricing catalog falls back
-        // to the standard rate when these are absent).
-        on_complete(comp);
+        // accumulator's numeric fields stay 0; on_complete callers
+        // must treat 0 as "no signal" (cp-api does — its pricing
+        // catalog falls back to the standard rate when absent).
         yield Ok::<_, Infallible>(Event::default().data("[DONE]"));
+        // `guard` drops here. On client disconnect, the generator
+        // drops at the suspension point inside the loop; Drop fires
+        // there with whatever StreamCompletion has been captured up
+        // to that point.
     }
 }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1731,6 +1731,162 @@ data: [DONE]\n\n";
         assert_eq!(v["error"]["type"], "content_filter");
     }
 
+    /// Regression for #226: when an output-content-filter blocks a
+    /// response that the upstream already produced, the telemetry event
+    /// MUST carry the upstream-billed `prompt_tokens` /
+    /// `completion_tokens` instead of zeroing them. Pre-fix the error
+    /// path uniformly emitted zeros for every error variant — the
+    /// "request never reached the upstream" assumption baked into the
+    /// failure-path comment was wrong for the output-block case where
+    /// the upstream HAS run and the provider has already charged.
+    #[tokio::test]
+    async fn output_guardrail_block_records_upstream_usage_in_telemetry() {
+        use aisix_guardrails::{GuardrailChain, KeywordBlocklist, KeywordRule};
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-blocked-1",
+                "model": "gpt-4o-2024-08-06",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "leak the secret-string"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(
+            KeywordBlocklist::output_only(vec![KeywordRule::literal("secret-string")]),
+        )]));
+        let state = build_state(snap, hub)
+            .with_guardrails(guardrails)
+            .with_usage_sink(UsageSink::new(tx));
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "anything"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("usage event was never emitted")
+            .expect("sender dropped without sending");
+        // The customer paid the provider for these tokens — telemetry
+        // must reflect that, not silently drop them to 0.
+        assert_eq!(
+            event.prompt_tokens, 11,
+            "output-block must preserve the upstream's prompt_tokens"
+        );
+        assert_eq!(
+            event.completion_tokens, 7,
+            "output-block must preserve the upstream's completion_tokens"
+        );
+        assert!(event.guardrail_blocked);
+        assert_eq!(event.status_code, 422);
+        assert_eq!(event.provider_request_id, "cmpl-blocked-1");
+        assert_eq!(event.provider_model_version, "gpt-4o-2024-08-06");
+        assert_eq!(event.finish_reason, "stop");
+    }
+
+    /// Regression for #225: streaming chat must read the terminal SSE
+    /// chunk's `usage` block and forward those counts into the
+    /// telemetry event. Pre-fix the streaming path captured only
+    /// `total_tokens` (for rate-limit accounting) and dropped
+    /// `prompt_tokens` / `completion_tokens` — telemetry recorded zero
+    /// for every streamed request even though the DP had the real
+    /// counts in hand.
+    #[tokio::test]
+    async fn streaming_chat_telemetry_records_usage_from_terminal_chunk() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        // OpenAI's stream_options.include_usage=true shape: the final
+        // delta chunk before [DONE] carries a `usage` block.
+        let sse = "\
+data: {\"id\":\"cmpl-stream-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-stream-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-stream-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":13,\"completion_tokens\":4,\"total_tokens\":17}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true,
+            "stream_options": {"include_usage": true}
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Drain the SSE body so build_sse_stream's on_complete fires.
+        // Telemetry emission is wired to that callback; the channel
+        // stays empty until the full stream has been consumed.
+        let mut body_stream = resp.into_body().into_data_stream();
+        while let Some(chunk) = body_stream.next().await {
+            let _ = chunk.unwrap();
+        }
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("usage event was never emitted")
+            .expect("sender dropped without sending");
+        assert_eq!(
+            event.prompt_tokens, 13,
+            "streaming telemetry must capture prompt_tokens from the terminal chunk's usage block"
+        );
+        assert_eq!(
+            event.completion_tokens, 4,
+            "streaming telemetry must capture completion_tokens from the terminal chunk"
+        );
+        assert_eq!(event.status_code, 200);
+        assert!(!event.guardrail_blocked);
+        assert_eq!(event.provider_request_id, "cmpl-stream-1");
+        assert_eq!(event.provider_model_version, "gpt-4o-2024-08-06");
+        assert_eq!(event.finish_reason, "stop");
+    }
+
     #[tokio::test]
     async fn budget_exceeded_returns_429() {
         use crate::budget::BudgetClient;

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1806,6 +1806,87 @@ data: [DONE]\n\n";
         assert_eq!(event.provider_request_id, "cmpl-blocked-1");
         assert_eq!(event.provider_model_version, "gpt-4o-2024-08-06");
         assert_eq!(event.finish_reason, "stop");
+        // cache_status reflects the per-policy gate the request went
+        // through; "disabled" here because the test seeds no
+        // cache_policy. A regression that drops cache_status on the
+        // output-block path would surface as empty-string here.
+        assert_eq!(event.cache_status, "disabled");
+    }
+
+    /// Regression for ai-gateway#196 audit HIGH-1: streaming chat
+    /// telemetry must fire even when the client disconnects mid-
+    /// stream. Pre-fix, on_complete lived in a `yield`-following
+    /// branch of the async_stream! body that only ran when the
+    /// consumer pulled — a dropped consumer (axum aborting the
+    /// response future) skipped it entirely, so the customer's
+    /// upstream call billed but the gateway recorded zero events.
+    /// Post-fix, on_complete fires from a Drop guard so cancellation
+    /// still produces a usage_event (with whatever counts were
+    /// captured up to disconnect, typically 0 if disconnect beat
+    /// the upstream's `usage` chunk).
+    #[tokio::test]
+    async fn streaming_chat_telemetry_fires_on_client_disconnect() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        // Use a slow drip so we can disconnect before [DONE] arrives.
+        let sse = "\
+data: {\"id\":\"cmpl-cancel-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-cancel-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-cancel-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Read ONE chunk then drop the response body — simulates a
+        // client that hung up before the upstream's terminal chunk.
+        // The Drop guard inside build_sse_stream must still fire
+        // on_complete for this disconnected request.
+        let mut body_stream = resp.into_body().into_data_stream();
+        let _first = body_stream.next().await;
+        drop(body_stream);
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("usage event was never emitted (Drop guard regression)")
+            .expect("sender dropped without sending");
+        // The exact token counts depend on how many chunks reached
+        // the guard before disconnect — could be 0 (disconnect beat
+        // the upstream emission entirely) or more. The contract is
+        // simply that an event fires; counts are best-effort. Pin
+        // the structural fields to confirm we didn't grab some
+        // unrelated event.
+        assert_eq!(event.status_code, 200);
+        assert!(!event.guardrail_blocked);
     }
 
     /// Regression for #225: streaming chat must read the terminal SSE


### PR DESCRIPTION
Fixes two related telemetry-token bugs in \`/v1/chat/completions\` (OpenAI-shape). Both surfaced by failing e2e tests in api7/AISIX-Cloud (held back behind \`t.Skip\` until this PR lands).

**Scope is intentionally OpenAI chat-completions only.** The Anthropic-native \`/v1/messages\` streaming path has the parallel gap and is filed separately at api7/AISIX-Cloud#245 — its wire shape (\`message_start\` / \`message_delta\` / \`message_stop\`) is materially different from OpenAI's and warrants its own parser + fix.

## Bug 1 — streamed chats record prompt_tokens=0 / completion_tokens=0 on /dp/telemetry

**api7/AISIX-Cloud#225**.

The DP reads the upstream's terminal SSE chunk's \`usage\` block to drive rate-limit accounting (TPM cap, #108), but only kept \`total_tokens\` — the per-direction counters were dropped. Telemetry was emitted at handler return (before the stream had actually completed) with \`success.prompt_tokens = None\`, so the wire payload zeroed out.

Fix: extend \`build_sse_stream\` to capture the full \`UsageStats\` plus \`chunk.id\` / \`chunk.model\` / \`finish_reason\` from the terminal chunk into a \`StreamCompletion\` struct, and defer telemetry emission to the \`on_complete\` callback so it fires AFTER the stream has yielded its usage block. Adds \`Success.telemetry_handled_by_stream\` so the top-level handler skips its own \`emit_usage_event\` in this case (no double-emission).

The on_complete callback fires from a **Drop guard** (\`CompleteOnDrop\`), not from post-yield code in the \`async_stream!\` body. This matters: code after a \`yield\` only runs when the consumer pulls — a dropped consumer (axum aborting the response future, client TCP disconnect, request timeout) never resumes. Pre-Drop-guard, that meant streaming + client-disconnect = zero telemetry events even though the upstream had been billed. Drop fires reliably on cancellation, so the captured \`StreamCompletion\` (potentially zeros if disconnect beat the upstream's \`usage\` chunk) is always shipped.

## Bug 2 — output-content-filter blocks report prompt_tokens=0 even though upstream already billed

**api7/AISIX-Cloud#226**.

When an output-content-filter (post-upstream guardrail) rejects a successful upstream response, the customer is still on the hook for the tokens the provider charged. Pre-fix, the dispatch error path uniformly assumed "request never reached the upstream" and zeroed every counter — true for input-block / budget / model-not-found, wrong for the output-block case.

Fix: extend dispatch's error tuple from \`(Option<String>, ProxyError)\` to \`(Option<String>, Option<UpstreamCharge>, ProxyError)\`. The output-block site builds an \`UpstreamCharge\` from the captured upstream \`UsageStats\` and passes it up. The handler's error path uses the charge to populate \`emit_usage_event\` with the real counts (\`prompt_tokens\`, \`completion_tokens\`, cache + reasoning counters, \`provider_request_id\`, \`provider_model_version\`, \`finish_reason\`, plus the input-guardrail \`bypass_reason\` and the dispatch-time \`cache_status\` so dashboard filters bucket blocked-but-billed requests correctly). \`emit_access_log\` gets the same treatment so the on-host log matches the wire telemetry. All other error paths carry \`None\` and continue zeroing — they genuinely never billed.

## Tests

Three new unit tests in \`crates/aisix-proxy/src/lib.rs\` that pin the contracts via the public chat endpoint with a capturing \`UsageSink\`:

- \`streaming_chat_telemetry_records_usage_from_terminal_chunk\` — SSE stream with a \`usage\` block on the terminal chunk; asserts the emitted \`UsageEvent\` carries upstream-reported prompt/completion tokens (13/4), provider id (\"cmpl-stream-1\"), model version (\"gpt-4o-2024-08-06\"), and finish_reason (\"stop\").
- \`streaming_chat_telemetry_fires_on_client_disconnect\` — reads one SSE chunk then drops the response body, asserts a usage event still fires within 2s. Pin against the audit's HIGH-1 finding (Drop-guard regression).
- \`output_guardrail_block_records_upstream_usage_in_telemetry\` — upstream returns 200 with \`usage\`, output keyword guardrail blocks the response; asserts the emitted \`UsageEvent\` carries the upstream's billed tokens (11 prompt / 7 completion, NOT zeros), \`guardrail_blocked=true\`, \`status_code=422\`, and \`cache_status=\"disabled\"\` (regression catches dropping cache_status on the output-block path).

All would deterministically fail against pre-fix behavior — the regression net for these two bugs.

## Test results

\`\`\`text
$ cargo test -p aisix-proxy
test result: ok. 141 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy --workspace -- -D warnings
Finished in 23.74s — clean

$ cargo fmt -- --check
Clean
\`\`\`

## Audit (CLAUDE.md §7)

Independent audit returned 2 HIGH + 3 MEDIUM. Address summary:

- **HIGH-1** (client-disconnect drops telemetry) — fixed via \`CompleteOnDrop\` Drop guard. Regression test added.
- **HIGH-2** (Anthropic Messages streaming has same bug) — out-of-scope for this PR by design; filed as api7/AISIX-Cloud#245.
- **MEDIUM-1** (output-block drops bypass_reason) — \`UpstreamCharge\` now carries it.
- **MEDIUM-2** (output-block hardcodes cache_status to "") — \`UpstreamCharge\` now carries it.
- **MEDIUM-3** (streaming-cache footgun on \`cache_status: Disabled\` constant) — TODO comment added at the call site.
- 3 LOW findings noted as non-blocking.

## Test plan

- [x] cargo build / test / clippy / fmt clean
- [x] New unit tests deterministically reproduce all three regression classes (#225 streamed-usage, #226 output-block-billing, audit-HIGH-1 client-disconnect) and pass with the fix
- [x] Independent audit per CLAUDE.md §7; HIGH + MEDIUM addressed (or scoped + filed)
- [ ] Once merged + a fresh DP image lands in api7/AISIX-Cloud's stack, the held \`t.Skip\` lines on \`e2e/cases/streaming_billing_test.go\` and \`e2e/cases/guardrail_billing_test.go\` get removed (tracked in api7/AISIX-Cloud#244)