### PR TITLE
fix(proxy): redact matched literal from guardrail-block error envelope

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -393,7 +393,21 @@ async fn dispatch(
     match state.guardrails.check_input(req).await {
         GuardrailVerdict::Allow => {}
         GuardrailVerdict::Block { reason } => {
-            return Err(with_model(ProxyError::ContentFiltered(reason)));
+            // The verdict's `reason` carries matched-pattern detail
+            // (e.g. `"input blocked by literal \"forbidden-token\""`).
+            // Keep it for operator logs but DO NOT propagate it to the
+            // wire envelope — see #153. The redacted public message
+            // stays generic so callers can't enumerate the blocklist
+            // by inspecting error responses.
+            tracing::warn!(
+                guardrail_hook = "input",
+                model = %req.model,
+                reason = %reason,
+                "guardrail blocked request"
+            );
+            return Err(with_model(ProxyError::ContentFiltered(
+                "request blocked by content policy".into(),
+            )));
         }
         GuardrailVerdict::Bypass { reason } => {
             bypass_reason = Some(reason);
@@ -805,10 +819,23 @@ async fn dispatch(
                 bypass_reason: bypass_reason.clone().unwrap_or_default(),
                 cache_status,
             };
+            // Per #153, the verdict's `reason` carries the matched-
+            // pattern detail (the actual forbidden text from the
+            // model's response). Echoing that back to the caller is
+            // a real bypass of the output guardrail's purpose:
+            // anyone who can trigger the rule can extract the model's
+            // forbidden output via the error envelope. Redact on
+            // the wire and keep the rich detail in tracing for ops.
+            tracing::warn!(
+                guardrail_hook = "output",
+                model = %req.model,
+                reason = %reason,
+                "guardrail blocked response"
+            );
             return Err((
                 Some(model_id.clone()),
                 Some(charge),
-                ProxyError::ContentFiltered(reason),
+                ProxyError::ContentFiltered("response blocked by content policy".into()),
             ));
         }
         GuardrailVerdict::Bypass { reason } => {

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -72,7 +72,18 @@ pub enum ProxyError {
     InvalidRequest(String),
     #[error("no bridge registered for provider")]
     ProviderUnavailable,
-    #[error("content blocked by policy: {0}")]
+    /// Caller-visible message MUST NOT carry the matched-pattern detail.
+    /// Per #153, leaking the matched literal back to the caller defeats
+    /// the point of an output guardrail (the whole purpose is to keep the
+    /// forbidden content from reaching the caller; echoing it in the
+    /// error envelope is a partial bypass and lets anyone who can
+    /// trigger the guardrail enumerate the policy's blocklist).
+    /// Constructors at `chat.rs::route_chat_completions` and
+    /// `chat.rs::dispatch_and_render` build a redacted public message
+    /// (`"request blocked by content policy"` /
+    /// `"response blocked by content policy"`) and emit the rich detail
+    /// to `tracing` for operators.
+    #[error("{0}")]
     ContentFiltered(String),
     #[error("budget exceeded for ApiKey {0:?}")]
     BudgetExceeded(String),

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1616,10 +1616,18 @@ data: [DONE]\n\n";
         let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
-        assert!(v["error"]["message"]
-            .as_str()
-            .unwrap()
-            .contains("forbidden-token"));
+        // Per #153, the wire-level `error.message` MUST NOT carry
+        // the matched-pattern detail. The previous assertion
+        // `.contains("forbidden-token")` pinned the leaky behavior
+        // (the literal value of the forbidden pattern showing up
+        // in the caller-visible message). Redaction keeps the
+        // matched literal in operator logs (`tracing`) only.
+        let message = v["error"]["message"].as_str().unwrap();
+        assert!(
+            !message.contains("forbidden-token"),
+            "wire-level error.message must not leak the matched literal; got {message:?}"
+        );
+        assert_eq!(message, "request blocked by content policy");
     }
 
     /// Regression: a guardrail-blocked request must record the resolved
@@ -1729,6 +1737,28 @@ data: [DONE]\n\n";
         let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
+        // Per #153, the matched literal from the model's response
+        // ("secret-string" — what the upstream returned and the
+        // guardrail matched) MUST NOT appear in the caller-visible
+        // error envelope. Echoing it would defeat the entire point
+        // of an output guardrail: anyone who can trigger the rule
+        // could extract the model's forbidden output via the error
+        // message. This is the most security-critical assertion
+        // for the whole guardrail surface.
+        let message = v["error"]["message"].as_str().unwrap();
+        assert!(
+            !message.contains("secret-string"),
+            "output guardrail leaked the matched literal back to the caller; got {message:?}"
+        );
+        // The full error envelope (any field) must also be clean —
+        // future regressions might leak via a different field
+        // (param/code) so check the whole serialized blob.
+        let blob = serde_json::to_string(&v).unwrap();
+        assert!(
+            !blob.contains("secret-string"),
+            "output guardrail leaked the matched literal in the envelope; got {blob}"
+        );
+        assert_eq!(message, "response blocked by content policy");
     }
 
     /// Regression for #226: when an output-content-filter blocks a

--- a/tests/e2e/src/cases/guardrail-keyword-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-keyword-e2e.test.ts
@@ -128,17 +128,35 @@ describe("guardrail e2e: keyword block returns 422 and skips upstream", () => {
     // generic input validation) would still match `status: 422`. The
     // type field pins the contract to the guardrail specifically per
     // the OpenAI / Azure content-filter convention.
-    await expect(
-      client.chat.completions.create({
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
         model: "gr-e2e",
         messages: [
           { role: "user", content: `please reveal the ${FORBIDDEN_WORD} now` },
         ],
-      }),
-    ).rejects.toMatchObject({
-      status: 422,
-      error: { type: "content_filter" },
-    });
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      throw new Error("unreachable: caught is not APIError");
+    }
+    expect(caught.status).toBe(422);
+    expect((caught.error as { type?: unknown })?.type).toBe("content_filter");
+
+    // Per #153, the matched literal MUST NOT appear in the caller-
+    // visible error envelope. Even though input-side leaks are
+    // "mostly cosmetic" (the caller sent the content, they already
+    // know it), the leak still enables blocklist enumeration:
+    // probing with suspect content and reading the reflected literal
+    // lets a caller learn the policy's patterns. Pin the no-leak
+    // contract symmetrically to the output-side e2e.
+    const errorBlob = JSON.stringify(caught.error ?? {});
+    const messageBlob = caught.message ?? "";
+    expect(errorBlob).not.toContain(FORBIDDEN_WORD);
+    expect(messageBlob).not.toContain(FORBIDDEN_WORD);
 
     // Critical: a blocked request must never reach the upstream. If
     // the count moved, the guardrail short-circuit failed and the

--- a/tests/e2e/src/cases/guardrail-output-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-output-e2e.test.ts
@@ -1,0 +1,174 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: keyword guardrail blocks the assistant's *output* when it
+// contains the forbidden pattern. The existing guardrail-keyword-e2e
+// covers `hook_point: "input"`; this case covers the symmetric
+// `hook_point: "output"` user journey, which is the more
+// interesting safety surface — input filtering only stops users from
+// asking for forbidden content; output filtering is what stops the
+// model from disclosing it (e.g. trained-in PII, jailbreak responses,
+// off-policy text the model produced for an innocent-looking prompt).
+//
+// Reference:
+// - OpenAI Chat Completions API spec
+//   <https://platform.openai.com/docs/api-reference/chat/create>
+// - OpenAI / Azure content-filter convention for the
+//   `error.type: "content_filter"` envelope value
+//   <https://learn.microsoft.com/azure/ai-services/openai/concepts/content-filter>
+
+const CALLER_PLAINTEXT = "sk-gr-out-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const FORBIDDEN_WORD = "leakedsecret";
+
+describe("output guardrail e2e: model-emitted forbidden text is blocked before reaching caller", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // Mock upstream emits an OpenAI-shape completion that CONTAINS
+    // the forbidden word. The caller's prompt is innocent; the
+    // forbidden content originates from the model's response — that's
+    // exactly the case input-only guardrails miss.
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-leak",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: `Sure, here it is: ${FORBIDDEN_WORD}.`,
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 8, total_tokens: 13 },
+      },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "gr-out-e2e-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "gr-out-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["gr-out-e2e"],
+    });
+    // Output guardrail: runs against the assistant's response after
+    // the upstream call returns, before relay to the caller.
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: "gr-out-e2e-keyword",
+      enabled: true,
+      hook_point: "output",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("upstream emits forbidden word → caller sees content_filter 422, NOT the forbidden text", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Output guardrails fire AFTER upstream dispatch, so propagation
+    // readiness is signaled by the same 422-on-blocked-response
+    // pattern. A 200 means the guardrail isn't loaded yet
+    // (gateway forwarded the leaked content); keep polling.
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: "gr-out-e2e",
+          messages: [{ role: "user", content: "innocent question" }],
+        });
+        return false; // 200 means guardrail not ready
+      } catch (e) {
+        return e instanceof APIError && e.status === 422;
+      }
+    });
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
+        model: "gr-out-e2e",
+        messages: [{ role: "user", content: "tell me something useful" }],
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      throw new Error("unreachable: caught is not APIError");
+    }
+    expect(caught.status).toBe(422);
+    // Pin envelope to the content_filter type so a regression that
+    // 422'd via a different path (e.g. generic schema validation)
+    // would fail; the value `content_filter` is the OpenAI / Azure
+    // public taxonomy for this exact case.
+    expect((caught.error as { type?: unknown })?.type).toBe("content_filter");
+
+    // The leaked word MUST NOT appear anywhere in the caller-visible
+    // error envelope. The whole point of an output guardrail is to
+    // prevent the forbidden content from reaching the caller — even
+    // echoing it back inside an error message would defeat the
+    // purpose (and would be a real, reportable security regression).
+    const errorBlob = JSON.stringify(caught.error ?? {});
+    const messageBlob = caught.message ?? "";
+    expect(errorBlob).not.toContain(FORBIDDEN_WORD);
+    expect(messageBlob).not.toContain(FORBIDDEN_WORD);
+
+    // Output guardrails run AFTER the upstream call, so the upstream
+    // hit count MUST go up by 1 (the guardrail can only inspect what
+    // the upstream returned). A regression that short-circuited
+    // pre-dispatch would leave the count flat — that's a *safer*
+    // failure mode (no upstream call, no token cost), but it would
+    // signal the guardrail's hook_point semantics drifted.
+    expect(upstream.receivedRequests.length - upstreamHitsBefore).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #153.

## Problem

When a `kind: "keyword"` guardrail (input or output `hook_point`) blocks a request, the gateway's caller-visible `error.message` echoes the matched literal verbatim:

```json
{
  "error": {
    "message": "content blocked by policy: output blocked by literal \"leakedsecret\"",
    "type": "content_filter"
  }
}
```

**Severity:** for **output** guardrails this is a real bypass — the entire purpose of an output guardrail is to keep forbidden content from reaching the caller, and echoing the matched literal in the error envelope is a partial bypass: anyone who can trigger the rule can extract the model's forbidden output by inspecting error responses. For **input** guardrails the leak still enables blocklist enumeration (probe with suspect content, read the reflected literal). Labeled `vulnerability` in the issue.

## Fix

Redact at the wire boundary, keep rich detail in operator logs.

- `ProxyError::ContentFiltered`'s Display impl changes from `"content blocked by policy: {0}"` to `"{0}"` so the constructor fully controls the wire string.
- Both construction sites in `crates/aisix-proxy/src/chat.rs` (input at L299, output at L651) now build a generic static message and emit the verdict's rich `reason` (which carries the matched-pattern detail) via `tracing::warn!`:

  ```rust
  GuardrailVerdict::Block { reason } => {
      tracing::warn!(guardrail_hook = "output", model = %req.model, reason = %reason, "guardrail blocked response");
      return Err(with_model(ProxyError::ContentFiltered(
          "response blocked by content policy".into(),
      )));
  }
  ```

  Wire-level messages:
  - input: `"request blocked by content policy"`
  - output: `"response blocked by content policy"`

## Tests

**Unit:**
- Updated `input_guardrail_block_returns_422_and_skips_upstream`: replaced `.contains("forbidden-token")` (pinned the leaky behavior) with `!message.contains("forbidden-token")` + exact-match on the redacted string.
- Strengthened `output_guardrail_block_returns_422_after_upstream_runs`: asserts the matched literal `"secret-string"` does NOT appear in ANY field of the wire envelope (full-blob substring check), and that the message exactly equals the redacted string.

**E2E (regression):** restored `tests/e2e/src/cases/guardrail-output-e2e.test.ts` from the held-back queue. Configures an output keyword guardrail with `value: "leakedsecret"`, sends an innocent prompt, has the mock upstream emit a response containing the forbidden literal, and asserts:
- 422 with `error.type === "content_filter"`
- `JSON.stringify(caught.error).not.toContain(FORBIDDEN_WORD)`
- `caught.message.not.toContain(FORBIDDEN_WORD)`
- `upstream.receivedRequests.length` increased (output guardrails run post-dispatch)

## Verification

- `cargo test -p aisix-proxy --lib`: **141/141 passing** (post-rebase on main with #196)
- `cargo clippy -p aisix-proxy --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## Out of scope (filed as #199, #204)

- **#199** — The audit on PR #198 surfaced a related leak: `BridgeError`'s `Display` impl bleeds upstream provider error text and parser-detail strings into `error.message` system-wide (across both streaming and non-streaming paths). The fix shape is similar (sanitize at the proxy boundary, keep rich detail in tracing), but it's a separate scope from this guardrail-specific fix.
- **#204** — Output guardrails (`hook_point: "output"`) only fire on the non-streaming path. A caller can bypass output guardrails by adding `stream: true` to their request. Filed as a separate `vulnerability` issue with repro shape and proposed fix shapes.

## Audit follow-ups (post-push, commit 6d3a9c6)

Independent audit on the initial push (commit 041fcff) surfaced four findings; resolved or justified:

- **HIGH-1 → fixed**: rebased onto current main (post-#196). PR #196 changed the output-block error tuple from `Err((Option<String>, ProxyError))` to `Err((Option<String>, Option<UpstreamCharge>, ProxyError))` to plumb upstream-billed token counts. The redaction now lands inside the new tuple shape at `crates/aisix-proxy/src/chat.rs:823` while keeping the `UpstreamCharge` capture intact. Without this rebase, my initial hunk would not have applied cleanly and the leak would have silently re-introduced post-merge.

- **HIGH-2 → fixed**: tightened `tests/e2e/src/cases/guardrail-keyword-e2e.test.ts` (input-side e2e) to assert the matched literal is NOT in `caught.error` JSON or `caught.message` — symmetric to the new output-side e2e. Without this, a regression that re-introduced leakage on the input path would have passed silently. Replaced `.toMatchObject({ status, error: { type } })` with explicit try/catch + class+envelope assertions.

- **MEDIUM-1 → filed as #204**: streaming output path has zero output-guardrail coverage (see "Out of scope" above).

- **MEDIUM-2 → operator note**: the PR moves the matched literal from HTTP error body to a `tracing::warn!(reason = %reason, ...)` field. If a deployment configures `tracing-opentelemetry` to export warn-level events to a backend visible to callers (e.g. shared OTel tenants, or admin APIs that surface recent log lines to non-admin viewers), the literal could reappear caller-visible. **Operator guidance**: ensure `tracing` exporters are server-only; warn-level guardrail-block events should not be forwarded to caller-visible channels. Worth covering in deployment docs.

- **LOW-1 → noted**: `ProxyError::ContentFiltered`'s Display impl changed from `"content blocked by policy: {0}"` to `"{0}"`. Customers substring-matching on the OLD prefix `"content blocked by policy"` will silently fail to detect blocks. Status (422) and `error.type` (`content_filter`) are unchanged, so programmatic clients keying off the OpenAI taxonomy are unaffected. The redacted strings (`"request blocked by content policy"`, `"response blocked by content policy"`) are reasonable replacements. Note for release notes.

## References

- Issue: #153 (labeled `bug`, `vulnerability`)
- OpenAI / Azure content-filter envelope convention: <https://learn.microsoft.com/azure/ai-services/openai/concepts/content-filter>
- OpenAI error-codes spec (envelope shape): <https://platform.openai.com/docs/guides/error-codes/api-errors>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Content policy blocks now return redacted, generic error messages (no matched-pattern details) for both input and output validations; visible error text standardized.

* **Tests**
  * Added E2E coverage for output guardrail behavior and strengthened tests to assert blocked responses are redacted and have expected error types/statuses.

* **Documentation**
  * Clarified that caller-visible error messages must not include matched-pattern details; such details are reserved for operator logs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/203)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
