### PR TITLE
fix(proxy): emit clean 413 instead of ECONNRESET on oversize request body

### DIFF
--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -87,6 +87,14 @@ pub enum ProxyError {
     ContentFiltered(String),
     #[error("budget exceeded for ApiKey {0:?}")]
     BudgetExceeded(String),
+    /// Per RFC 9110 §15.5.14, a request body that exceeds a server-
+    /// imposed limit gets a `413 Content Too Large`. The caller-visible
+    /// `message` is intentionally bare of the actual incoming size
+    /// (the limit is the only stable detail the caller needs). Set by
+    /// the body-limit middleware in `lib.rs::enforce_request_body_limit`
+    /// when the inbound `Content-Length` exceeds the configured cap.
+    #[error("request body exceeds {limit_bytes}-byte limit")]
+    RequestTooLarge { limit_bytes: usize },
     #[error(transparent)]
     RateLimit(#[from] RateLimitError),
     #[error(transparent)]
@@ -103,6 +111,7 @@ impl ProxyError {
             ProxyError::ProviderUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             ProxyError::ContentFiltered(_) => StatusCode::UNPROCESSABLE_ENTITY,
             ProxyError::BudgetExceeded(_) => StatusCode::TOO_MANY_REQUESTS,
+            ProxyError::RequestTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
             ProxyError::RateLimit(_) => StatusCode::TOO_MANY_REQUESTS,
             ProxyError::Bridge(b) => {
                 StatusCode::from_u16(b.http_status()).unwrap_or(StatusCode::BAD_GATEWAY)
@@ -116,6 +125,7 @@ impl ProxyError {
             ProxyError::ModelForbidden(_) => "permission_denied",
             ProxyError::ModelNotFound(_) => "model_not_found",
             ProxyError::InvalidRequest(_) => "invalid_request_error",
+            ProxyError::RequestTooLarge { .. } => "invalid_request_error",
             ProxyError::ProviderUnavailable => "provider_unavailable",
             ProxyError::ContentFiltered(_) => "content_filter",
             ProxyError::BudgetExceeded(_) => "billing_error",

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -50,6 +50,10 @@ pub use error::{ErrorEnvelope, ProxyError};
 pub use health::HealthTracker;
 pub use state::ProxyState;
 
+use axum::extract::State;
+use axum::http::Request;
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get, post};
 use axum::{http::StatusCode, Json, Router};
 use serde_json::json;
@@ -74,7 +78,48 @@ pub fn build_router(state: ProxyState) -> Router {
             "/passthrough/:provider/*rest",
             any(passthrough::passthrough),
         )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            enforce_request_body_limit,
+        ))
         .with_state(state)
+}
+
+/// Per RFC 9110 §15.5.14, a request body that exceeds the gateway's
+/// configured `request_body_limit_bytes` must surface as a clean
+/// `413 Content Too Large` response — NOT an `ECONNRESET` from a
+/// mid-write socket close. This middleware inspects the inbound
+/// `Content-Length` header before any handler runs and short-circuits
+/// with the OpenAI-shape error envelope when the declared size
+/// exceeds the cap.
+///
+/// Bodies sent with chunked transfer encoding (no Content-Length)
+/// fall through to handler-level body extraction, which still
+/// enforces the limit but with the slower fail mode (the read errors
+/// once the cap is hit). Catching the Content-Length-known case here
+/// is the load-bearing user-visible win: the OpenAI Node SDK and
+/// `fetch` both set Content-Length for non-streamed POSTs, and
+/// without this middleware they see ECONNRESET (indistinguishable
+/// from a network failure or a gateway crash) instead of 413.
+async fn enforce_request_body_limit(
+    State(state): State<ProxyState>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    if let Some(declared) = request
+        .headers()
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<usize>().ok())
+    {
+        if declared > state.request_body_limit_bytes {
+            return ProxyError::RequestTooLarge {
+                limit_bytes: state.request_body_limit_bytes,
+            }
+            .into_response();
+        }
+    }
+    next.run(request).await
 }
 
 async fn health(
@@ -374,6 +419,93 @@ mod tests {
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Issue #159: a request body whose declared `Content-Length`
+    /// exceeds the configured cap must surface as `413 Content Too
+    /// Large` per RFC 9110 §15.5.14, NOT as `ECONNRESET` from a
+    /// mid-write socket close. Regression: the handler-level body
+    /// extractor's overflow path was racing the client write,
+    /// surfacing as a network failure indistinguishable from a
+    /// gateway crash. The new middleware short-circuits on the
+    /// declared size before any handler runs.
+    #[tokio::test]
+    async fn oversize_body_returns_413_envelope_with_content_length_check() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        // Declare a Content-Length well over the test cfg's 1 MiB cap
+        // but ship a tiny actual body — the middleware MUST reject
+        // based on the declared size alone, before reading the body.
+        // (A real caller's `JSON.stringify` would set Content-Length
+        // matching the body size; the assertion is "we trust the
+        // declared header for the early reject".)
+        let oversized = 2 * 1024 * 1024; // 2 MiB > 1 MiB cap
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .header("content-length", oversized.to_string())
+            .body(Body::from(
+                r#"{"model":"my-gpt4","messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // OpenAI-shape envelope per docs/api-proxy.md §3:
+        // `{ "error": { "message": ..., "type": "..." } }`
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        let message = v["error"]["message"].as_str().unwrap();
+        assert!(
+            message.contains("limit"),
+            "413 message should reference the limit; got {message:?}"
+        );
+    }
+
+    /// Issue #159 companion: a body within the cap must NOT be
+    /// rejected — the middleware short-circuits ONLY when the
+    /// Content-Length exceeds the cap, leaving normal traffic
+    /// untouched. Without this guard, a regression that always-
+    /// rejected (e.g. comparing the wrong field) would be invisible
+    /// since most existing tests don't set Content-Length.
+    #[tokio::test]
+    async fn within_limit_body_is_not_rejected_by_middleware() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-ok",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let app = build_router(build_state(snap, hub));
+
+        let body = r#"{"model":"my-gpt4","messages":[{"role":"user","content":"hi"}]}"#;
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .header("content-length", body.len().to_string())
+            .body(Body::from(body))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -61,6 +61,7 @@ use serde_json::json;
 /// Build the proxy router. Mounts `/health` plus the
 /// OpenAI-compatible proxy surface.
 pub fn build_router(state: ProxyState) -> Router {
+    let body_limit = state.request_body_limit_bytes;
     Router::new()
         .route("/health", get(health))
         .route("/v1/models", get(models::list_models))
@@ -78,6 +79,16 @@ pub fn build_router(state: ProxyState) -> Router {
             "/passthrough/:provider/*rest",
             any(passthrough::passthrough),
         )
+        // Wire the configured cap into axum's request-body extractor
+        // chain (`Json<T>` defers to `Bytes` which honors this layer).
+        // Without this, axum 0.7's `DefaultBodyLimit` falls back to
+        // its built-in 2 MiB default, which silently rejects bodies
+        // in the 2 MiB-to-cap band with a stock `BytesRejection`
+        // response (NOT the OpenAI envelope). The middleware below
+        // catches the Content-Length-known case ahead of the
+        // extractor; this layer catches chunked / size-mismatched
+        // bodies once their actual byte count exceeds the cap.
+        .layer(axum::extract::DefaultBodyLimit::max(body_limit))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             enforce_request_body_limit,
@@ -106,9 +117,19 @@ async fn enforce_request_body_limit(
     request: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    if let Some(declared) = request
+    // RFC 9110 §8.6 — a server SHOULD reject a request that carries
+    // duplicate or conflicting `Content-Length` values rather than
+    // act on the first one (which is a request-smuggling vector).
+    let mut content_lengths = request
         .headers()
-        .get(axum::http::header::CONTENT_LENGTH)
+        .get_all(axum::http::header::CONTENT_LENGTH)
+        .iter();
+    let first = content_lengths.next();
+    if content_lengths.next().is_some() {
+        return ProxyError::InvalidRequest("conflicting Content-Length headers".into())
+            .into_response();
+    }
+    if let Some(declared) = first
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<usize>().ok())
     {
@@ -463,6 +484,50 @@ mod tests {
         assert!(
             message.contains("limit"),
             "413 message should reference the limit; got {message:?}"
+        );
+    }
+
+    /// Issue #159 audit MEDIUM-3: duplicate `Content-Length` headers
+    /// are a classic request-smuggling vector — a server that acts on
+    /// the first value while a downstream peer acts on the second can
+    /// be tricked into framing the body wrongly. Per RFC 9110 §8.6 a
+    /// server SHOULD reject the request rather than disambiguate.
+    #[tokio::test]
+    async fn duplicate_content_length_headers_return_400_invalid_request() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let body = r#"{"model":"my-gpt4","messages":[{"role":"user","content":"hi"}]}"#;
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        // Inject TWO Content-Length headers (simulating a smuggling
+        // attempt). axum's HeaderMap supports `append` for duplicate
+        // names; the middleware must reject rather than read the
+        // first value.
+        req.headers_mut().append(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from(body.len()),
+        );
+        req.headers_mut().append(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from(body.len() + 1),
+        );
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        let message = v["error"]["message"].as_str().unwrap();
+        assert!(
+            message.contains("Content-Length"),
+            "smuggling-rejection message should mention Content-Length; got {message:?}"
         );
     }
 

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -171,9 +171,22 @@ async fn dispatch(
 
     let method = req.method().clone();
     let incoming_headers = req.headers().clone();
-    let body_bytes: Bytes = axum::body::to_bytes(req.into_body(), 10 * 1024 * 1024)
+    // Use the configured cap (not a hard-coded 10 MiB) so an
+    // operator who raises `request_body_limit_bytes` for, e.g.,
+    // audio passthrough actually gets the larger limit here too.
+    // Map an oversize-body read failure to the typed
+    // `RequestTooLarge` envelope so callers see a proper 413 rather
+    // than a misleading 400 "failed to read body". The
+    // `enforce_request_body_limit` middleware short-circuits the
+    // Content-Length-known case ahead of this; this map handles the
+    // chunked / no-Content-Length / Content-Length-lying case once
+    // the actual byte count exceeds the cap.
+    let body_limit = state.request_body_limit_bytes;
+    let body_bytes: Bytes = axum::body::to_bytes(req.into_body(), body_limit)
         .await
-        .map_err(|e| ProxyError::InvalidRequest(format!("failed to read body: {e}")))?;
+        .map_err(|_| ProxyError::RequestTooLarge {
+            limit_bytes: body_limit,
+        })?;
 
     let client = crate::http_client::client();
     let mut builder = client.request(method.clone(), &url);

--- a/tests/e2e/src/cases/body-edges-e2e.test.ts
+++ b/tests/e2e/src/cases/body-edges-e2e.test.ts
@@ -202,14 +202,15 @@ describe("body edges e2e: multi-turn, oversize body, empty messages", () => {
     // OpenAI envelope shape: `{ "error": { "message": ..., "type": ... } }`.
     // A regression that returned a non-OpenAI shape (e.g. axum's
     // default `"Failed to buffer the request body: ..."`) would
-    // fail the type/message assertions below.
+    // fail the type/message assertions below. Pin `error.type` to
+    // the exact OpenAI taxonomy value so a regression that emitted
+    // any other non-empty string would fail.
     const body = (await res.json()) as {
       error?: { type?: unknown; message?: unknown };
     };
-    expect(typeof body.error?.type).toBe("string");
-    expect((body.error?.type as string).length).toBeGreaterThan(0);
+    expect(body.error?.type).toBe("invalid_request_error");
     expect(typeof body.error?.message).toBe("string");
-    expect((body.error?.message as string).length).toBeGreaterThan(0);
+    expect(body.error?.message as string).toMatch(/limit/i);
 
     // Hard contract: an over-limit request must never reach the
     // upstream — the gateway's own body-size cap is meant to

--- a/tests/e2e/src/cases/body-edges-e2e.test.ts
+++ b/tests/e2e/src/cases/body-edges-e2e.test.ts
@@ -11,7 +11,7 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: request body edge cases. Two user journeys that prior
+// E2E: request body edge cases. Three user journeys that prior
 // coverage skipped — every existing chat-completions test sends a
 // single one-message array, so the gateway's behavior on real-world
 // shapes was unverified:
@@ -22,27 +22,31 @@ import {
 //      reordered messages would silently lose context for every
 //      conversational caller.
 //
-//   2. Empty `messages: []` — OpenAI Chat Completions spec requires
+//   2. Body exceeds the configured size limit — caller must see
+//      RFC 9110 §15.5.14 `413 Content Too Large`, NOT a 500 or
+//      `ECONNRESET` from a mid-write socket close (which is
+//      indistinguishable from a network failure or a gateway
+//      crash). The gateway's `request_body_limit_bytes` is set to
+//      10 MiB by the harness (matching production default).
+//
+//   3. Empty `messages: []` — OpenAI Chat Completions spec requires
 //      a non-empty messages array. Gateway must reject with a
 //      4xx error envelope, NOT 500 / panic / hang.
-//
-// (The "body exceeds size limit → 413" case is tracked as a
-// separate test pending a product fix; the gateway currently
-// resets the connection rather than emitting 413. See follow-up
-// issue.)
 //
 // References:
 // - OpenAI Chat Completions API spec
 //   <https://platform.openai.com/docs/api-reference/chat/create>
 // - OpenAI error envelope spec
 //   <https://platform.openai.com/docs/guides/error-codes/api-errors>
+// - RFC 9110 §15.5.14 "413 Content Too Large"
+//   <https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.14>
 
 const CALLER_PLAINTEXT = "sk-body-edges-caller";
 const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
 
-describe("body edges e2e: multi-turn, empty messages", () => {
+describe("body edges e2e: multi-turn, oversize body, empty messages", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
   let admin: AdminClient | undefined;
@@ -158,6 +162,60 @@ describe("body edges e2e: multi-turn, empty messages", () => {
       expect(sentBody.messages?.[i]?.role).toBe(history[i]!.role);
       expect(sentBody.messages?.[i]?.content).toBe(history[i]!.content);
     }
+  });
+
+  test("oversize body (> 10 MiB): caller sees 413, upstream untouched", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // The harness configures `request_body_limit_bytes: 10485760`
+    // (10 MiB). Construct a body just over the limit by stuffing a
+    // 10.5 MiB filler into a single user message. `JSON.stringify`
+    // sets a Content-Length header on the fetch request, which the
+    // gateway's middleware uses to short-circuit before reading
+    // any body bytes.
+    const filler = "x".repeat(10 * 1024 * 1024 + 512 * 1024);
+    const oversizedBody = JSON.stringify({
+      model: "body-edges",
+      messages: [{ role: "user", content: filler }],
+    });
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: oversizedBody,
+    });
+
+    // RFC 9110 §15.5.14: `413 Content Too Large` is the standard
+    // status for a request body that exceeds a server-imposed
+    // limit. A 5xx here would mislead callers into retrying (the
+    // request will never succeed at this size); ECONNRESET (the
+    // pre-fix behavior) is indistinguishable from a network
+    // failure or a gateway crash.
+    expect(res.status).toBe(413);
+    // OpenAI envelope shape: `{ "error": { "message": ..., "type": ... } }`.
+    // A regression that returned a non-OpenAI shape (e.g. axum's
+    // default `"Failed to buffer the request body: ..."`) would
+    // fail the type/message assertions below.
+    const body = (await res.json()) as {
+      error?: { type?: unknown; message?: unknown };
+    };
+    expect(typeof body.error?.type).toBe("string");
+    expect((body.error?.type as string).length).toBeGreaterThan(0);
+    expect(typeof body.error?.message).toBe("string");
+    expect((body.error?.message as string).length).toBeGreaterThan(0);
+
+    // Hard contract: an over-limit request must never reach the
+    // upstream — the gateway's own body-size cap is meant to
+    // protect the upstream from oversized payloads, not pre-route
+    // them.
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
   });
 
   test("empty messages array: 4xx with OpenAI-shape error envelope, upstream untouched", async (ctx) => {


### PR DESCRIPTION
Closes #159.

## Problem

When a caller's request body exceeds the gateway's configured `request_body_limit_bytes` (default 10 MiB), the gateway closes the TCP socket mid-write rather than emitting RFC 9110 §15.5.14 `413 Content Too Large`. The caller's HTTP client surfaces this as `ECONNRESET`:

```
fetch failed: write ECONNRESET
```

ECONNRESET is indistinguishable from a network failure or a gateway crash:

- A clean `413` tells the caller the request is invalid because of size — they shouldn't retry without changing the payload.
- ECONNRESET is ambiguous: callers commonly retry on connection failures (assuming transient network issues), making the gateway look like it's hanging or flaky.
- Operator debugging: distinguishing "client sent oversized body" from "upstream timed out" from "gateway crashed" becomes much harder when all three look the same on the wire.

## Fix

Add an axum middleware (`enforce_request_body_limit` in `crates/aisix-proxy/src/lib.rs`) that inspects the inbound `Content-Length` header before any handler runs. When the declared size exceeds `state.request_body_limit_bytes`, short-circuit with the new `ProxyError::RequestTooLarge { limit_bytes }` variant which maps to a clean 413 with OpenAI-shape envelope:

```json
{
  "error": {
    "message": "request body exceeds 10485760-byte limit",
    "type": "invalid_request_error"
  }
}
```

```rust
async fn enforce_request_body_limit(
    State(state): State<ProxyState>,
    request: Request<Body>,
    next: Next,
) -> Response {
    if let Some(declared) = request.headers()
        .get(CONTENT_LENGTH)
        .and_then(|v| v.to_str().ok())
        .and_then(|s| s.parse::<usize>().ok())
    {
        if declared > state.request_body_limit_bytes {
            return ProxyError::RequestTooLarge {
                limit_bytes: state.request_body_limit_bytes,
            }.into_response();
        }
    }
    next.run(request).await
}
```

Wired into `build_router` via `middleware::from_fn_with_state(state.clone(), enforce_request_body_limit)`. Applied uniformly to every body-accepting route.

## Why Content-Length-only is the right scope

- The OpenAI Node SDK and `fetch` both set `Content-Length` on non-streamed POSTs. That covers the pre-fix ECONNRESET path the issue reports.
- Bodies sent with chunked transfer encoding (no Content-Length) fall through to handler-level body extraction. axum's `Json<T>` extractor will return a typed rejection on overflow there.
- Adding stream-level limit handling is a separate scope — see "Out of scope" below.

## Tests

**Rust unit (`crates/aisix-proxy/src/lib.rs`):**

- `oversize_body_returns_413_envelope_with_content_length_check` — declares an oversize Content-Length, ships a tiny actual body, asserts 413 + OpenAI-shape envelope. The middleware must reject based on declared size BEFORE reading the body.
- `within_limit_body_is_not_rejected_by_middleware` — normal traffic isn't rejected; without this a regression comparing the wrong field would be invisible.

**E2E (`tests/e2e/src/cases/body-edges-e2e.test.ts`):** restored the held-back oversize-body case. Sends a 10.5 MiB body via raw `fetch` and asserts:

- `res.status === 413`
- OpenAI envelope shape (typed non-empty `error.type` / `error.message`)
- `upstream.receivedRequests.length` flat (over-limit requests must NEVER reach the upstream — the cap is meant to protect the upstream)

## Verification

- `cargo test -p aisix-proxy --lib`: **145/145 passing** (post-audit fixes)
- `cargo clippy -p aisix-proxy --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## Audit follow-ups (commit 06e3fce)

Independent audit on the initial push (commit 6108434) surfaced four findings; all addressed:

- **HIGH-1 → fixed**: axum 0.7's `Json<T>` extractor defers to `Bytes` which honors the per-route `DefaultBodyLimit` extension. Without the layer wired, the default fell back to axum's built-in 2 MiB, silently rejecting bodies in the 2 MiB-to-cap band with a stock `BytesRejection` response (NOT the OpenAI envelope). Wired `axum::extract::DefaultBodyLimit::max(body_limit)` on the router so the cap is enforced uniformly across the Content-Length-known path (middleware), the chunked path (extractor), and the Content-Length-mismatched path (extractor).

- **HIGH-2 → fixed**: `/passthrough/*` previously hard-coded a 10 MiB cap on `axum::body::to_bytes`, ignoring `state.request_body_limit_bytes` entirely. Operators raising the cap (e.g. for audio passthrough) still got 10 MiB rejection here, with a misleading 400 `InvalidRequest("failed to read body: …")` envelope instead of the typed 413 `RequestTooLarge`. Use the configured cap and map the read failure to the typed envelope. This also closes the chunked-without-Content-Length bypass on the passthrough route.

- **MEDIUM-2 → fixed**: e2e previously asserted `error.type` was a non-empty string, which a regression emitting any other token would have passed. Pin to the exact OpenAI taxonomy value (`"invalid_request_error"`) and assert the message matches `/limit/i`.

- **MEDIUM-3 → fixed**: per RFC 9110 §8.6, duplicate `Content-Length` headers are a request-smuggling vector (a server acting on the first value while a downstream peer acts on the second can be tricked into framing the body wrongly). Reject with 400 `InvalidRequest("conflicting Content-Length headers")` rather than silently use the first. Added unit test `duplicate_content_length_headers_return_400_invalid_request`.

## Out of scope

- **Limit per route**: today's middleware + extractor layer apply one cap (`state.request_body_limit_bytes`) to every route. The `audio` endpoints have a 10 MiB local override in their tests but not in production config — out of scope for this PR.
- **MEDIUM-1 (chunked path with non-OpenAI envelope on the JSON extractor failure)**: with `DefaultBodyLimit::max(cap)` wired (HIGH-1 fix above), bodies that exceed the cap on the chunked / Content-Length-mismatch path do get rejected at the extractor — but axum's stock `BytesRejection` response shape is not the OpenAI envelope. The middleware's Content-Length check covers the common SDK / fetch path; the chunked path's stock-rejection shape is a separate cleanup, similar in shape to #199 (system-wide error envelope normalization). For passthrough the typed `RequestTooLarge` envelope IS surfaced (HIGH-2 fix). Worth a follow-up issue if/when the chunked path becomes a real customer concern.

- **LOW-1 (negative / non-decimal `Content-Length` parses fail silently to "no header")**: noted; explicit reject is safer than silent skip but the failure mode here is "request proceeds normally" which produces a 4xx via the body extractor anyway. Not load-bearing; future hardening pass material.

- **LOW-2 (caller-visible message leaks raw byte count)**: the new `error.message` includes the configured cap value (`"request body exceeds 10485760-byte limit"`). OpenAI / Anthropic disclose limits in their error messages too, so this is industry-accepted; intentional for caller debugability.

## References

- Issue: #159
- RFC 9110 §15.5.14 `413 Content Too Large`: <https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.14>
- OpenAI error envelope: <https://platform.openai.com/docs/guides/error-codes/api-errors>

