### PR TITLE
fix(proxy): dedup duplicated /v1 prefix on passthrough URL build

### DIFF
--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -46,6 +46,40 @@ fn default_base(provider_prefix: &str) -> Option<&'static str> {
     }
 }
 
+/// `true` if `seg` looks like an api-version path component
+/// (`v0`, `v1`, `v2alpha` is rejected — strictly `v\d+`).
+fn is_api_version_segment(seg: &str) -> bool {
+    seg.starts_with('v') && seg.len() > 1 && seg[1..].chars().all(|c| c.is_ascii_digit())
+}
+
+/// Strip one leading api-version segment from `rest` when it
+/// matches the trailing version segment of `base`. Returns `rest`
+/// unchanged when no dedup applies.
+///
+/// See #164: the published examples in `docs/api-admin.md` §4.3
+/// (api_base `https://api.openai.com/v1`) and `docs/api-proxy.md`
+/// §4.10 (call `/passthrough/openai/v1/batches`) when followed
+/// verbatim produce the malformed URL `.../v1/v1/batches`.
+fn strip_redundant_version_segment<'a>(base: &str, rest: &'a str) -> &'a str {
+    let base_tail = base.rsplit('/').next().unwrap_or("");
+    if !is_api_version_segment(base_tail) {
+        return rest;
+    }
+    // Only dedup when `rest`'s leading segment EXACTLY matches
+    // `base_tail`. So `/v2` + `v1/foo` does NOT trigger (caller
+    // asked for v1 explicitly); `/v1` + `v1/foo` does (the
+    // duplicated `/v1` is the docs-example bug).
+    if let Some(remainder) = rest.strip_prefix(base_tail) {
+        if remainder.is_empty() {
+            return remainder;
+        }
+        if let Some(after_slash) = remainder.strip_prefix('/') {
+            return after_slash;
+        }
+    }
+    rest
+}
+
 /// Wildcard handler mounted at `/passthrough/:provider/*rest`.
 ///
 /// `method` is not a path parameter — axum merges all HTTP methods for wildcard
@@ -155,11 +189,27 @@ async fn dispatch(
             })?,
     };
 
-    // Build the target URL: {base}/{rest}
-    let url = if rest.is_empty() {
+    // Build the target URL: {base}/{rest}.
+    //
+    // Per #164: when the configured `api_base` ends with an
+    // api-version segment (e.g. `/v1`) AND the passthrough rest
+    // path starts with the same segment, naive concatenation
+    // produces a doubled prefix like `/v1/v1/files`. The published
+    // examples in `docs/api-admin.md` §4.3 (api_base with `/v1`)
+    // and `docs/api-proxy.md` §4.10 (rest with `/v1/...`)
+    // together hit this case.
+    //
+    // Strip the redundant leading version segment from `rest` ONLY
+    // when it exactly matches `api_base`'s trailing version
+    // segment. Constraining the dedup to api-version-shaped
+    // segments (`v\d+`) prevents false dedups on paths like
+    // `/v1/files/v1/foo` where the trailing `v1` is a genuine
+    // path component, not a version prefix.
+    let rest_after_dedup = strip_redundant_version_segment(&base, rest);
+    let url = if rest_after_dedup.is_empty() {
         base.clone()
     } else {
-        format!("{base}/{rest}")
+        format!("{base}/{rest_after_dedup}")
     };
 
     // Preserve the query string.
@@ -304,6 +354,7 @@ fn emit_access_log(
 
 #[cfg(test)]
 mod tests {
+    use super::{is_api_version_segment, strip_redundant_version_segment};
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -314,6 +365,93 @@ mod tests {
     use tower::ServiceExt;
     use wiremock::matchers::{method as wm_method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn is_api_version_segment_recognises_canonical_v_prefix_versions() {
+        assert!(is_api_version_segment("v1"));
+        assert!(is_api_version_segment("v2"));
+        assert!(is_api_version_segment("v10"));
+        // Reject look-alikes that would be unsafe to dedup on.
+        assert!(!is_api_version_segment("v")); // bare 'v'
+        assert!(!is_api_version_segment("v1alpha")); // mixed
+        assert!(!is_api_version_segment("V1")); // case-sensitive: gateway sees lowercased URLs
+        assert!(!is_api_version_segment("messages")); // ordinary path component
+        assert!(!is_api_version_segment("")); // empty
+    }
+
+    /// Issue #164: api_base ending in /v1 plus rest starting with v1/
+    /// must dedup to a single /v1 prefix. The published examples in
+    /// docs/api-admin.md §4.3 (api_base with /v1) and docs/api-proxy.md
+    /// §4.10 (call /passthrough/openai/v1/batches) follow this exact
+    /// pattern; pre-fix the gateway concatenated to /v1/v1/batches
+    /// which the real OpenAI API would 404.
+    #[test]
+    fn strip_redundant_version_segment_dedups_canonical_docs_example() {
+        // The exact docs-example case.
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com/v1", "v1/batches"),
+            "batches"
+        );
+        // Trailing-slash on `rest` (axum sometimes preserves it).
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com/v1", "v1/files/"),
+            "files/"
+        );
+        // `rest` exactly equals the trailing version.
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com/v1", "v1"),
+            ""
+        );
+    }
+
+    #[test]
+    fn strip_redundant_version_segment_does_not_touch_non_version_tails() {
+        // No version on api_base → no dedup.
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com", "v1/files"),
+            "v1/files"
+        );
+        // Tail isn't a version segment → no dedup.
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com/api", "v1/files"),
+            "v1/files"
+        );
+    }
+
+    #[test]
+    fn strip_redundant_version_segment_only_strips_leading_match() {
+        // Trailing /v1 in `rest` is a genuine path component
+        // (not a version prefix), MUST NOT be touched.
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com/v1", "v1/files/v1/foo"),
+            "files/v1/foo"
+        );
+    }
+
+    #[test]
+    fn strip_redundant_version_segment_only_dedups_exact_version_match() {
+        // api_base /v2 + rest v1/foo → caller asked for v1
+        // explicitly; do NOT dedup (would silently rewrite the call
+        // to a different version).
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com/v2", "v1/foo"),
+            "v1/foo"
+        );
+        // api_base /v1 + rest v2/foo → caller asked for v2, do NOT
+        // dedup.
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com/v1", "v2/foo"),
+            "v2/foo"
+        );
+    }
+
+    #[test]
+    fn strip_redundant_version_segment_handles_empty_rest() {
+        assert_eq!(
+            strip_redundant_version_segment("https://api.openai.com/v1", ""),
+            ""
+        );
+    }
 
     fn cfg() -> ProxyConfig {
         ProxyConfig {

--- a/tests/e2e/src/cases/passthrough-e2e.test.ts
+++ b/tests/e2e/src/cases/passthrough-e2e.test.ts
@@ -30,10 +30,19 @@ import {
 // /passthrough — meaning every customer using batches, files, or
 // fine-tuning APIs had no regression protection on the wire.
 //
-// One user journey pinned:
+// Two user journeys pinned:
 //
-//   - Anthropic passthrough — caller hits a custom Anthropic
-//     endpoint (e.g. /v1/messages/batches). Gateway must:
+//   1. OpenAI passthrough — caller follows the published examples
+//      verbatim: `api_base: "https://api.openai.com/v1"` per
+//      `docs/api-admin.md` §4.3, and a call to
+//      `/passthrough/openai/v1/files` per `docs/api-proxy.md` §4.10.
+//      The gateway must dedup the duplicated `/v1` prefix and hit
+//      the upstream at `/v1/files` — a naive concatenation would
+//      hit `/v1/v1/files` which the real OpenAI API would 404.
+//      Pre-fix this was bug #164.
+//
+//   2. Anthropic passthrough — caller hits a custom Anthropic
+//      endpoint (e.g. /v1/messages/batches). Gateway must:
 //       * strip the /passthrough/anthropic prefix and forward
 //         path + body + method verbatim
 //       * inject Anthropic's auth shape (`x-api-key` +
@@ -41,15 +50,10 @@ import {
 //         (a regression that forwarded Bearer to Anthropic would
 //         401 in production)
 //
-// (The "OpenAI passthrough" case is held back pending a product /
-// docs reconciliation — `docs/api-admin.md` §4.3 publishes
-// `api_base: "https://api.openai.com/v1"` (with /v1), and
-// `docs/api-proxy.md` §4.10 example uses
-// `/passthrough/openai/v1/batches` (also with /v1). Together
-// these produce a double-/v1 upstream URL. See follow-up issue.)
-//
 // References:
 // - Gateway's own /passthrough contract: `docs/api-proxy.md` §4.10
+// - OpenAI Files API
+//   <https://platform.openai.com/docs/api-reference/files>
 // - Anthropic auth headers spec
 //   <https://docs.anthropic.com/en/api/getting-started>
 
@@ -58,7 +62,7 @@ const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
 
-describe("passthrough e2e: /passthrough/anthropic/*rest auth-shape switching + verbatim forward", () => {
+describe("passthrough e2e: /passthrough/{provider}/*rest verbatim forwarding with auth injection + double-/v1 dedup", () => {
   let app: SpawnedApp | undefined;
   let admin: AdminClient | undefined;
   let etcdReachable = false;
@@ -79,6 +83,135 @@ describe("passthrough e2e: /passthrough/anthropic/*rest auth-shape switching + v
   afterAll(async () => {
     await app?.exit();
     await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("OpenAI passthrough: gateway dedups doubled /v1, forwards verbatim, injects Bearer auth", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    // Mock upstream returns a distinctive body the caller will
+    // see. The body shape is intentionally NOT chat-completions —
+    // passthrough is for endpoints the gateway doesn't natively
+    // wrap (batches/files/fine-tuning), so the gateway must NOT
+    // try to parse or normalize the response.
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        // Shaped like an OpenAI Files API response per
+        // <https://platform.openai.com/docs/api-reference/files/object>.
+        id: "file-pt-openai-01",
+        object: "file",
+        bytes: 12345,
+        created_at: Math.floor(Date.now() / 1000),
+        filename: "passthrough-test.jsonl",
+        purpose: "batch",
+        status: "uploaded",
+      },
+    });
+    upstreams.push(upstream);
+
+    // Configure exactly per docs/api-admin.md §4.3 example:
+    // `api_base: "https://api.openai.com/v1"` (with /v1).
+    const pk = await admin.createProviderKey({
+      display_name: "pt-openai-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    // The Model's provider field is what the passthrough route
+    // matches on (per docs §4.10 "first Model with that prefix").
+    await admin.createModel({
+      display_name: "pt-openai-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+
+    const headers = {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    };
+
+    // Readiness gate: poll passthrough until it returns 200 with
+    // the upstream's distinctive body. A 404 means either the
+    // snapshot hasn't propagated yet OR the gateway is hitting
+    // `/v1/v1/files` upstream (#164 pre-fix behavior — the mock
+    // doesn't have a route there, so it 404s).
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/passthrough/openai/v1/files`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ purpose: "batch", filename: "ready-probe.jsonl" }),
+        });
+        if (r.status !== 200) {
+          await r.text();
+          return false;
+        }
+        const j = (await r.json()) as { object?: unknown };
+        return j.object === "file";
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+    const requestBody = JSON.stringify({
+      purpose: "batch",
+      filename: "real-call.jsonl",
+      // Distinctive marker so the body-verbatim assertion can
+      // confirm the gateway didn't strip or rewrite anything.
+      arbitrary_unknown_field: "must-pass-through-untouched",
+    });
+    // Call exactly per docs/api-proxy.md §4.10 example:
+    // `/passthrough/openai/v1/files` (with /v1).
+    const res = await fetch(`${app.proxyUrl}/passthrough/openai/v1/files`, {
+      method: "POST",
+      headers,
+      body: requestBody,
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id?: unknown; object?: unknown };
+    // Caller sees the upstream's body byte-for-byte. Passthrough
+    // explicitly disclaims body normalisation per docs §4.10
+    // ("forwards the request verbatim").
+    expect(body.id).toBe("file-pt-openai-01");
+    expect(body.object).toBe("file");
+
+    // Upstream-side: the gateway hit `/v1/files`, NOT `/v1/v1/files`.
+    // The dedup is the load-bearing #164 contract: api_base ending
+    // in `/v1` plus rest starting with `v1/` must produce a single
+    // `/v1` prefix. A regression that re-introduces the doubled
+    // prefix would land at `/v1/v1/files` and fail this filter.
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/files");
+    expect(testCalls).toHaveLength(1);
+    expect(testCalls[0]?.method).toBe("POST");
+
+    // Verify there were NO requests to the doubled-prefix path.
+    // A regression that reintroduces the bug would still emit a
+    // request — pinning that no such request exists is the strict
+    // form of the dedup contract.
+    const doubledCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/v1/files");
+    expect(doubledCalls).toHaveLength(0);
+
+    // Auth injection: per docs §4.10, the gateway injects the
+    // configured provider API key. For OpenAI that's
+    // `Authorization: Bearer <secret>`. The caller's own bearer
+    // MUST NOT reach the upstream — that would leak the proxy key
+    // into upstream provider logs.
+    expect(testCalls[0]?.headers["authorization"]).toBe("Bearer sk-mock");
+
+    // Body verbatim: every field the caller sent reaches the
+    // upstream unchanged, including unknown fields the gateway
+    // doesn't recognise. A regression that JSON-round-tripped or
+    // schema-validated the body would silently drop unknown
+    // fields like `arbitrary_unknown_field`.
+    expect(testCalls[0]?.body).toBe(requestBody);
   });
 
   test("Anthropic passthrough: gateway uses x-api-key + anthropic-version, NOT Bearer", async (ctx) => {


### PR DESCRIPTION
Closes #164.

## Problem

The gateway's two published docs prescribe configurations that, followed verbatim, produce a malformed upstream URL with a doubled `/v1` prefix:

- `docs/api-admin.md` §4.3 publishes the canonical OpenAI api_base as `{ "api_base": "https://api.openai.com/v1" }`
- `docs/api-proxy.md` §4.10 publishes the canonical passthrough call as `curl -X POST http://localhost:3000/passthrough/openai/v1/batches`

Together the gateway concatenates `api_base + "/" + rest`:
`https://api.openai.com/v1` + `/v1/batches` = **`https://api.openai.com/v1/v1/batches`** — which the real OpenAI API 404s. A user following the published examples verbatim has a non-functional passthrough setup.

## Fix

Smart dedup in `crates/aisix-proxy/src/passthrough.rs::dispatch`. When `api_base`'s trailing path segment is an api-version-shaped token (`v\d+`) AND `rest` starts with the same exact token, strip one leading version segment from `rest`. Constraining the dedup to api-version segments avoids false dedups on paths like `/v1/files/v1/foo` where the trailing `/v1` is a genuine path component.

```rust
// Build the target URL: {base}/{rest}.
let rest_after_dedup = strip_redundant_version_segment(&base, rest);
let url = if rest_after_dedup.is_empty() {
    base.clone()
} else {
    format!("{base}/{rest_after_dedup}")
};
```

Helper signature:

```rust
fn strip_redundant_version_segment<'a>(base: &str, rest: &'a str) -> &'a str
fn is_api_version_segment(seg: &str) -> bool   // strict v\d+
```

### Behavioral matrix

| api_base | rest | url (after fix) | Notes |
|----------|------|-----------------|-------|
| `https://api.openai.com/v1` | `v1/files` | `https://api.openai.com/v1/files` | docs-example case — fixed |
| `https://api.openai.com/v1` | `v1/files/v1/foo` | `https://api.openai.com/v1/files/v1/foo` | only leading `v1` stripped |
| `https://api.openai.com` | `v1/files` | `https://api.openai.com/v1/files` | bare host: no dedup needed |
| `https://api.openai.com/v2` | `v1/foo` | `https://api.openai.com/v2/v1/foo` | exact-version-match guard |
| `https://api.openai.com/v1` | `v2/foo` | `https://api.openai.com/v1/v2/foo` | exact-version-match guard |

The exact-match guard is the reason this fix is safe: a caller asking explicitly for `v1` against a `v2` api_base gets the literal path through (no silent rewrite). Only the docs-example collision (`/v1 + v1/...`) dedupes.

## Tests

**Rust unit (`crates/aisix-proxy/src/passthrough.rs`):** six new tests covering the helper functions:
- `is_api_version_segment_recognises_canonical_v_prefix_versions`
- `strip_redundant_version_segment_dedups_canonical_docs_example` — the bug-report repro
- `strip_redundant_version_segment_does_not_touch_non_version_tails`
- `strip_redundant_version_segment_only_strips_leading_match` — `/v1/files/v1/foo` preserved
- `strip_redundant_version_segment_only_dedups_exact_version_match` — caller-asked-explicitly path
- `strip_redundant_version_segment_handles_empty_rest`

**E2E (`tests/e2e/src/cases/passthrough-e2e.test.ts`):** restored the held-back OpenAI passthrough case. Configures EXACTLY per the published docs examples (`api_base: "${upstream.baseUrl}/v1"`, call to `/passthrough/openai/v1/files`) and asserts:
- `res.status === 200`, response body byte-for-byte
- upstream received the call at `/v1/files` (NOT `/v1/v1/files`)
- explicit zero-count assertion that no `/v1/v1/files` call was made (catches a regression that re-introduces the doubled prefix)
- gateway injects `Authorization: Bearer sk-mock` (caller's bearer NOT forwarded)
- request body byte-for-byte including unknown fields

## Verification

- `cargo test -p aisix-proxy --lib`: **151/151 passing**
- `cargo clippy -p aisix-proxy --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## Resolution path picked

Per the issue's resolution-paths section, this PR picks **Path A (smarter prefix dedup)**. Trade-offs:

- **A wins on user experience**: the published docs examples Just Work. No docs change needed; existing customers with api_base ending in `/v1` are not asked to reconfigure.
- **A's cited risk** (`/v1/files/v1/foo` triggering false dedup) is mitigated by only stripping the LEADING segment when it exactly matches the trailing segment of api_base. The trailing `/v1/foo` is a genuine path component and is preserved by the leading-only strip rule. Pinned by `strip_redundant_version_segment_only_strips_leading_match`.
- **A's secondary risk** (cross-version silent rewrite — caller asking for `v1` against a `v2` api_base) is closed by the exact-match guard. Pinned by `strip_redundant_version_segment_only_dedups_exact_version_match`.

Path B (docs change requiring bare-host api_base for passthrough users) was rejected because it splits the api_base convention — the same ProviderKey can't then serve both `/v1/chat/completions` (which expects api_base WITH `/v1` for the native bridges that compose `/chat/completions`) AND `/passthrough/openai/v1/...`.

## References

- Issue: #164
- `docs/api-admin.md` §4.3 (api_base example)
- `docs/api-proxy.md` §4.10 (passthrough call example)
