### PR TITLE
test(cache): pin disabled-cache-policy contract + drop stale 'disabled' header reference

### DIFF
--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -279,6 +279,19 @@ mod tests {
             .insert(ResourceEntry::new(format!("cp-id-{name}"), policy, 1));
     }
 
+    /// Disabled-policy seeder for #154 regression coverage. Posts a
+    /// `CachePolicy{enabled: false, applies_to: "all"}` so the
+    /// cache-gate predicate at chat.rs (`entry.value.enabled && ...`)
+    /// must skip it.
+    fn seed_cache_policy_disabled(snap: &AisixSnapshot, name: &str) {
+        let cfg = format!(
+            r#"{{"name": "{name}", "backend": "memory", "applies_to": "all", "enabled": false}}"#,
+        );
+        let policy: aisix_core::models::CachePolicy = serde_json::from_str(&cfg).unwrap();
+        snap.cache_policies
+            .insert(ResourceEntry::new(format!("cp-id-{name}"), policy, 1));
+    }
+
     fn seed_snapshot_with_limits(
         model: &str,
         allowed: &[&str],
@@ -1530,6 +1543,69 @@ data: [DONE]\n\n";
             assert!(
                 resp.headers().get("x-aisix-cache").is_none(),
                 "policy-gate-closed responses must not carry x-aisix-cache",
+            );
+        }
+    }
+
+    /// Issue #154 regression: a CachePolicy with `enabled: false`
+    /// must NOT cache. The disabled policy must be filtered out by
+    /// the find-first-enabled predicate at the chat.rs cache gate;
+    /// every identical request must reach the upstream and the
+    /// response must NOT carry an `x-aisix-cache` header (per the
+    /// "policy-gate-closed = no header" contract pinned by the
+    /// `applies_to_filters_out_unmatched_model` test above).
+    #[tokio::test]
+    async fn disabled_cache_policy_does_not_cache_and_emits_no_header() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-uncached",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "always-fresh"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(3) // each call must reach the upstream
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        // The disabled policy applies_to="all" (would match every
+        // request), but `enabled: false` MUST cause the find-first-
+        // enabled predicate to skip it.
+        seed_cache_policy_disabled(&snap, "off-policy");
+        let state = build_state_with_cache(snap, hub);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        // All three calls: 200, no `x-aisix-cache` header (policy
+        // is disabled). wiremock's `.expect(3)` fails the test if
+        // any call short-circuited via cache (= the disable flag
+        // wasn't honored).
+        for _ in 0..3 {
+            let resp = run(build_router(state.clone()), make_req()).await;
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert!(
+                resp.headers().get("x-aisix-cache").is_none(),
+                "disabled cache_policy must not emit x-aisix-cache header"
             );
         }
     }

--- a/tests/e2e/src/cases/cache-policy-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-policy-e2e.test.ts
@@ -14,10 +14,14 @@ import {
 // E2E: prompt-response cache policy, identical-request short-circuit.
 // With a `CachePolicy{applies_to: "all", enabled: true}` in scope, two
 // identical chat completions must result in the upstream being hit only
-// once — the second response is served from cache. The gateway also
-// emits a public `x-aisix-cache: hit|miss|disabled` response header
-// (depended on by cp-api and the dashboard's /logs view) which the
-// caller must observe.
+// once — the second response is served from cache. The gateway emits
+// a public `x-aisix-cache: hit|miss` response header (per
+// `docs/api-proxy.md` §3 — `hit` if served from cache, `miss`
+// otherwise; absent for streaming responses and absent when no
+// enabled cache_policy applies to the request). The header is
+// observed by cp-api and the dashboard's /logs view via the
+// telemetry path; both the header and the persisted
+// `usage_events.cache_status` field expose the cache outcome.
 //
 // Reference: OpenAI Chat Completions API spec
 // (https://platform.openai.com/docs/api-reference/chat/create) for
@@ -123,11 +127,15 @@ describe("cache policy e2e: identical request hits cache", () => {
     expect(second.choices[0]?.message.role).toBe("assistant");
 
     // Caller-observable cache signaling — the gateway emits an
-    // `x-aisix-cache: hit|miss|disabled` header that cp-api and the
-    // dashboard's /logs view depend on. The OpenAI SDK swallows
-    // response headers, so drop down to fetch directly to verify.
-    // Use a fresh prompt so this header check doesn't reuse the cache
-    // entry built up by the SDK calls above.
+    // `x-aisix-cache: hit|miss` header (`miss` on first call when
+    // an enabled policy applies, `hit` on identical follow-up).
+    // The header is absent when no enabled cache_policy matches
+    // the request — that "no header" outcome is pinned in the Rust
+    // unit `disabled_cache_policy_does_not_cache_and_emits_no_header`.
+    // The OpenAI SDK swallows response headers, so drop down to
+    // fetch directly to verify. Use a fresh prompt so this header
+    // check doesn't reuse the cache entry built up by the SDK calls
+    // above.
     const headerCheckHeaders = {
       authorization: `Bearer ${CALLER_PLAINTEXT}`,
       "content-type": "application/json",


### PR DESCRIPTION
Refs #154 (does not close — see below).

## TL;DR

The bug reported in #154 (CachePolicy `enabled: false` still caches; header reports `miss` instead of `disabled`) **does not reproduce** against current main. This PR adds a regression test that walks the exact issue scenario and confirms the gateway honors the disable flag, plus a comment cleanup on the existing e2e test that referenced a header value (`disabled`) the gateway has never published.

## Why the bug doesn't reproduce

Tracing through current code in `crates/aisix-proxy/src/chat.rs`:

1. **The cache-gate predicate filters on `enabled`** — `find()` over `snapshot.cache_policies.entries()` matches the first `entry.value.enabled && parsed_applies_to().matches(...)`. A disabled policy gets filtered out uniformly regardless of `applies_to`.
2. **Disabled path emits no header** — `cache_status` is set to `CacheStatus::Disabled` when no enabled policy matches; the response-header insertion at the end of dispatch only runs on `CacheStatus::Miss`. So the disabled-policy outcome on the wire is "no header at all", not `miss`.
3. **Existing tests already pin this** — `applies_to_filters_out_unmatched_model` asserts `"policy-gate-closed responses must not carry x-aisix-cache"`. That's the same outcome the new test pins for the `enabled: false` path.

## Why "x-aisix-cache: disabled" was never the contract

The issue's expected behavior was `x-aisix-cache: disabled` on responses where the policy is disabled. Looking at the actual contracts:

- `docs/api-proxy.md` §3 publishes the header values as `hit | miss` only, with the explicit note "Absent for streaming responses". No `disabled`.
- The `CacheStatus::Disabled` enum value DOES exist internally — it lands on `usage_events.cache_status` in the cp-api telemetry stream, alongside `hit` and `miss`. But that's the **telemetry** surface, not the response **header** surface.
- The pre-existing `cache-policy-e2e.test.ts` only asserts on the `hit` and `miss` values (no `disabled` assertion). The "disabled" mention in its comments was decorative / aspirational, not a pinned contract.

## What this PR does

**`crates/aisix-proxy/src/lib.rs` — new regression test:**

```rust
async fn disabled_cache_policy_does_not_cache_and_emits_no_header() {
    // ... seeds CachePolicy{enabled: false, applies_to: "all"} ...
    // wiremock.expect(3) — every call MUST reach upstream (no cache hit)
    for _ in 0..3 {
        let resp = run(build_router(state.clone()), make_req()).await;
        assert_eq!(resp.status(), StatusCode::OK);
        assert!(
            resp.headers().get("x-aisix-cache").is_none(),
            "disabled cache_policy must not emit x-aisix-cache header"
        );
    }
}
```

This is defense-in-depth — pre-existing tests cover `applies_to` mismatches but not the `enabled: false` path explicitly.

**`tests/e2e/src/cases/cache-policy-e2e.test.ts` — comment cleanup:**

Two references to `x-aisix-cache: hit|miss|disabled` updated to `hit|miss`, with a note that `disabled` is the internal telemetry value (lands on `usage_events.cache_status`), not a header value.

## Verification

- `cargo test -p aisix-proxy --lib`: **152/152 passing** (incl. new test)
- `cargo clippy -p aisix-proxy --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## Note on closing #154

This PR does NOT close #154 — the issue claims a behavior (`x-aisix-cache: miss` on a disabled policy) that doesn't reproduce, and the fix shape it requested (`x-aisix-cache: disabled` header value) was never the published contract. Recommendation:

- If the issue's reporter has a concrete repro that still produces `miss` on current main, they can re-open with steps and the regression test in this PR will catch it.
- Otherwise, close as obsolete — the regression test guards the documented behavior going forward.

I'll let the maintainer make the close call.

## References

- Issue: #154
- `docs/api-proxy.md` §3 (header table)
- Internal telemetry: `crates/aisix-proxy/src/chat.rs::CacheStatus`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test coverage for disabled cache policies to ensure requests bypass caching correctly.
  * Updated test documentation clarifying that the `x-aisix-cache` response header is omitted when no enabled cache policy applies or during streaming responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/208)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->