### PR TITLE
fix(embeddings): preserve single-string input shape on upstream wire

### DIFF
--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -369,14 +369,28 @@ pub struct EmbeddingObject {
 /// The `input` is either a single string or a list of strings. We
 /// represent both as `Vec<String>` — single-string inputs are wrapped in
 /// a one-element vec by the proxy handler before passing to a Bridge.
+/// Per #162 / `docs/api-proxy.md` §4.4 ("both pass through"), the
+/// original wire shape is preserved through `input_was_single` so the
+/// bridge can serialise back to a single string when that's what the
+/// caller sent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingRequest {
     /// The public-facing model name (resolved to an upstream model by the
     /// proxy before the Bridge sees it).
     pub model: String,
     /// Texts to embed. A single-string input is normalised to
-    /// `vec![text]` by the proxy handler.
+    /// `vec![text]` by the proxy handler; bridges consult
+    /// `input_was_single` to decide the upstream wire shape.
     pub input: Vec<String>,
+    /// `true` iff the caller originally sent `input` as a single
+    /// string (not an array). Bridges that forward to upstreams
+    /// supporting both shapes (OpenAI does) MUST preserve this on
+    /// the wire, per docs §4.4 "both pass through". Defaults to
+    /// `false` when missing on round-trip deserialisation so older
+    /// callers / round-tripped requests that always wrote arrays
+    /// don't change behaviour silently.
+    #[serde(default)]
+    pub input_was_single: bool,
     /// Optional encoding hint forwarded verbatim (`float` / `base64`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encoding_format: Option<String>,

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -292,11 +292,29 @@ pub(crate) fn stream_chunk_into_chat_chunk(mut raw: OpenAiStreamChunk) -> ChatCh
 
 // ─── Embeddings wire types ────────────────────────────────────────────────────
 
+/// `input` field shape on the OpenAI `/v1/embeddings` request. Per
+/// OpenAI's spec (<https://platform.openai.com/docs/api-reference/embeddings/create>)
+/// the field accepts either a single string or an array — the gateway
+/// preserves whichever the caller sent, per `docs/api-proxy.md` §4.4
+/// "both pass through" and #162.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub(crate) enum OpenAiEmbedInput<'a> {
+    /// Single-string form. Used when the caller's request body had
+    /// `input: "..."` (string), preserving the wire shape on the
+    /// upstream side.
+    Single(&'a str),
+    /// Array form. Used when the caller's request body had
+    /// `input: ["...", ...]` (array) OR when the `input_was_single`
+    /// signal is missing (round-tripped requests).
+    Multi(&'a [String]),
+}
+
 /// Request body forwarded to OpenAI `/v1/embeddings`.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct OpenAiEmbedRequest<'a> {
     pub model: &'a str,
-    pub input: &'a [String],
+    pub input: OpenAiEmbedInput<'a>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding_format: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -332,9 +350,25 @@ pub(crate) fn embed_request_body<'a>(
     req: &'a EmbeddingRequest,
     upstream_model: &'a str,
 ) -> OpenAiEmbedRequest<'a> {
+    // Per #162: the upstream wire shape mirrors what the caller sent
+    // when feasible. Single-string callers get `input: "text"`;
+    // array-form callers get `input: ["text", ...]`. The
+    // `input_was_single` flag from EmbeddingRequest is the load-
+    // bearing signal — without it, callers reading docs §4.4 ("both
+    // pass through") got always-array on the upstream wire,
+    // contradicting the published contract.
+    //
+    // Defensive fallback: if `input_was_single` is true but the vec
+    // is empty or has more than one element, drop back to array
+    // form (the single-string shape is undefined for those cases).
+    let input = if req.input_was_single && req.input.len() == 1 {
+        OpenAiEmbedInput::Single(&req.input[0])
+    } else {
+        OpenAiEmbedInput::Multi(&req.input)
+    };
     OpenAiEmbedRequest {
         model: upstream_model,
-        input: &req.input,
+        input,
         encoding_format: req.encoding_format.as_deref(),
         dimensions: req.dimensions,
     }

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -151,9 +151,18 @@ async fn dispatch(
 
     let upstream_model_id = crate::dispatch::require_upstream_model(model)?.to_string();
 
+    // Preserve the caller's original `input` shape per #162 /
+    // `docs/api-proxy.md` §4.4 "both pass through". The bridge will
+    // use this flag to serialise the upstream wire body as either a
+    // single string or an array — without it, the gateway always
+    // forwarded `["text"]` even when the caller sent `"text"`,
+    // which contradicts the docs and confuses operator-side packet
+    // captures during billing reconciliation / debugging.
+    let input_was_single = matches!(body.input, InputField::Single(_));
     let req = EmbeddingRequest {
         model: upstream_model_id,
         input: body.input.into_vec(),
+        input_was_single,
         encoding_format: body.encoding_format,
         dimensions: body.dimensions,
     };
@@ -355,6 +364,88 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// Issue #162 regression: when the caller's `input` is a single
+    /// string, the upstream wire body MUST be a single string (NOT a
+    /// one-element array). Per `docs/api-proxy.md` §4.4, both shapes
+    /// pass through; pre-fix the gateway always sent `["text"]` to
+    /// the upstream regardless of the caller's shape.
+    #[tokio::test]
+    async fn single_string_input_preserves_string_shape_on_upstream_wire() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({"model": "my-embed", "input": "hello"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Drain the upstream's recorded request body and inspect the
+        // `input` field on the upstream wire. A regression that
+        // re-introduced the always-array normalisation would write
+        // `["hello"]` here.
+        let received = upstream.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1, "exactly one upstream call expected");
+        let upstream_body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("upstream body is valid JSON");
+        assert!(
+            upstream_body["input"].is_string(),
+            "single-string caller input must reach upstream as a string, not an array; got {:?}",
+            upstream_body["input"]
+        );
+        assert_eq!(upstream_body["input"], "hello");
+    }
+
+    /// Counterpart to the above: when the caller's `input` is an
+    /// array (even single-element), the upstream wire body is also
+    /// an array. Without this companion test, a regression that
+    /// over-corrected to "always single-string when len==1" would
+    /// silently rewrite the caller's explicit array.
+    #[tokio::test]
+    async fn array_input_preserves_array_shape_on_upstream_wire() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let app = build_app(snap);
+        // Caller uses array form even though there's only one
+        // element. Gateway must NOT silently rewrite to a string.
+        let body = serde_json::json!({"model": "my-embed", "input": ["only-one"]});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let received = upstream.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        let upstream_body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("upstream body is valid JSON");
+        assert!(
+            upstream_body["input"].is_array(),
+            "array-form caller input must reach upstream as an array, not coerced to a string; got {:?}",
+            upstream_body["input"]
+        );
+        let arr = upstream_body["input"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0], "only-one");
     }
 
     #[tokio::test]

--- a/tests/e2e/src/cases/embeddings-e2e.test.ts
+++ b/tests/e2e/src/cases/embeddings-e2e.test.ts
@@ -17,18 +17,21 @@ import {
 // endpoint thousands of times per request batch. Prior to this
 // file, the gateway had **zero** e2e coverage on /v1/embeddings.
 //
-// One user journey pinned:
+// Two user journeys pinned:
 //
-//   - Array input — `client.embeddings.create({input: [s1, s2, s3]})`
-//     returns N embeddings in the SAME order as the input array.
-//     A regression that re-ordered, deduplicated, or truncated the
-//     array would break every batched embedding caller.
+//   1. Array input — `client.embeddings.create({input: [s1, s2, s3]})`
+//      returns N embeddings in the SAME order as the input array.
+//      A regression that re-ordered, deduplicated, or truncated the
+//      array would break every batched embedding caller.
 //
-// (The "single-string input" case is held back pending a product
-// fix — the gateway currently normalises single-string `input` into
-// a single-element array on the upstream wire, contradicting the
-// gateway's own published contract in `docs/api-proxy.md` §4.4
-// ("both pass through"). See follow-up issue.)
+//   2. Single-string input — `client.embeddings.create({input: "hi"})`
+//      reaches the upstream as `input: "hi"` (string) per docs §4.4
+//      "both pass through" — NOT silently coerced to `["hi"]`. The
+//      pre-#162-fix gateway always normalised to an array on the
+//      upstream wire, contradicting the published contract. The
+//      caller-side response shape is identical for both forms; the
+//      contract violation is operator-visible via packet captures
+//      / billing reconciliation.
 //
 // The case pins the upstream-side wire shape: the gateway hits
 // `/v1/embeddings` (not `/v1/chat/completions`), the body is
@@ -178,5 +181,78 @@ describe("embeddings e2e: /v1/embeddings dispatch + response passthrough", () =>
     };
     expect(sentBody.model).toBe("text-embedding-3-small");
     expect(sentBody.input).toEqual(inputs);
+  });
+
+  test("single-string input reaches upstream as a string (#162: docs §4.4 'both pass through')", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        object: "list",
+        data: [{ object: "embedding", index: 0, embedding: VEC_HELLO }],
+        model: "text-embedding-3-small",
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      },
+    });
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "emb-single-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "emb-single",
+      provider: "openai",
+      model_name: "text-embedding-3-small",
+      provider_key_id: pk.id,
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.embeddings.create({
+          model: "emb-single",
+          input: "ready-probe",
+        });
+        return r.object === "list" && Array.isArray(r.data) && r.data.length > 0;
+      } catch {
+        return false;
+      }
+    });
+
+    // Caller-side assertion: response shape is identical regardless
+    // of input form (the OpenAI SDK uses the same Embeddings
+    // resource). Pre-fix this passed cleanly; the bug was upstream-
+    // side wire shape only, invisible to the caller via the SDK.
+    const baseline = upstream.receivedRequests.length;
+    const response = await client.embeddings.create({
+      model: "emb-single",
+      input: "hello",
+    });
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0]?.object).toBe("embedding");
+
+    // Upstream-side assertion: the gateway forwarded `input: "hello"`
+    // as a STRING, not `["hello"]` as an array. Per docs §4.4 the
+    // gateway promises "both pass through" — the caller's wire
+    // shape is preserved on the upstream side. A regression that
+    // re-introduces the always-array normalisation would fail the
+    // `typeof === "string"` assertion here.
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/embeddings");
+    expect(testCalls).toHaveLength(1);
+    const sentBody = JSON.parse(testCalls[0]!.body) as { input?: unknown };
+    expect(typeof sentBody.input).toBe("string");
+    expect(sentBody.input).toBe("hello");
   });
 });


### PR DESCRIPTION
Closes #162.

## Problem

Per `docs/api-proxy.md` §4.4:

> Forwards to the configured Model's `/v1/embeddings` endpoint. `input` may be a single string or an array; **both pass through**.

In practice the gateway always normalised single-string `input` into a single-element array on the upstream wire. So a caller sending `input: "hello"` got `input: ["hello"]` forwarded to OpenAI — a documented contract violation.

The bug is invisible to the caller via the OpenAI SDK (response shape is identical), but it surfaces operator-side:

- Packet captures during billing reconciliation show different bodies on gateway-side vs upstream-side
- Customer audits comparing the two sides flag the rewrite
- Future stricter upstreams that count tokens differently for the two forms (not guaranteed; OpenAI is consistent today) would charge customers different amounts

## Fix

Preserve the caller's `input` shape from request parse through bridge serialisation:

1. **`aisix-gateway::EmbeddingRequest`** — added `input_was_single: bool` (serde `default = false` on round-trip).
2. **`aisix-proxy::embeddings::dispatch`** — sets the flag based on the parsed `InputField::{Single, Multi}` discriminant BEFORE collapsing to `Vec<String>`:

   ```rust
   let input_was_single = matches!(body.input, InputField::Single(_));
   ```

3. **`aisix-provider-openai::wire`** — replaced `OpenAiEmbedRequest::input: &[String]` with a serde-untagged enum `OpenAiEmbedInput::{Single, Multi}`. Constructor picks `Single` only when `input_was_single && input.len() == 1`; anything else falls back to `Multi` (defensive against degenerate inputs).

```rust
#[serde(untagged)]
pub(crate) enum OpenAiEmbedInput<'a> {
    Single(&'a str),
    Multi(&'a [String]),
}
```

## Tests

**Rust unit (`crates/aisix-proxy/src/embeddings.rs`)** — two new tests that drain `upstream.received_requests()` and inspect the upstream wire body's `input` field:

| Test | Caller sends | Asserts upstream receives |
|------|--------------|---------------------------|
| `single_string_input_preserves_string_shape_on_upstream_wire` | `{"input": "hello"}` | `input: "hello"` (string, not `["hello"]`) |
| `array_input_preserves_array_shape_on_upstream_wire` | `{"input": ["only-one"]}` | `input: ["only-one"]` (array, not coerced to `"only-one"`) |

The companion array-side test catches a regression that over-corrects to "always single-string when len==1".

**E2E (`tests/e2e/src/cases/embeddings-e2e.test.ts`)** — restored the held-back single-string-input case. Configures Embeddings model, caller hits gateway with `input: "hello"`, asserts:

- Caller-side: 200 + `data.length === 1`
- Upstream-side: `typeof sentBody.input === "string"` + `sentBody.input === "hello"`

## Verification

- `cargo test -p aisix-proxy --lib`: **154/154 passing** (incl. 2 new shape tests)
- `cargo test -p aisix-provider-openai --lib`: **17/17 passing**
- `cargo test -p aisix-gateway --lib`: **42/42 passing**
- `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## References

- Issue: #162
- `docs/api-proxy.md` §4.4 (embeddings contract: "both pass through")
- OpenAI Embeddings API spec: <https://platform.openai.com/docs/api-reference/embeddings/create>
