### PR TITLE
fix(proxy): restrict /v1/rerank + /v1/images/generations to OpenAI providers

### DIFF
--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -108,6 +108,25 @@ async fn dispatch(
     let _reservation = crate::quota::enforce(state, auth).await?;
 
     let model = &model_entry.value;
+
+    // Per #168: only OpenAI's API has the documented
+    // `/v1/images/generations` route + body shape. Anthropic has no
+    // image-generation API at all; Gemini's image generation lives
+    // at a different URL (`/v1beta/models/...:generateContent`) with
+    // a different body shape; DeepSeek doesn't expose image
+    // generation. Routing a non-OpenAI Model here would silently
+    // dispatch to an upstream that 404s — a confusing failure for
+    // callers who follow `docs/api-proxy.md` §4.9 configuration
+    // verbatim. Reject explicitly with 400 (parallel to
+    // /v1/responses §4.6) so the configuration error is visible
+    // at the gateway boundary.
+    if model.provider != Some(aisix_core::models::Provider::Openai) {
+        return Err(ProxyError::InvalidRequest(format!(
+            "model `{model_name}` is not an OpenAI provider; \
+             /v1/images/generations requires OpenAI"
+        )));
+    }
+
     let provider = crate::dispatch::require_provider(model)?;
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
@@ -196,6 +215,19 @@ mod tests {
         ResourceEntry::new("m-1", m, 1)
     }
 
+    fn anthropic_model_entry(name: &str) -> ResourceEntry<Model> {
+        let json = format!(
+            r#"{{
+                "display_name": "{name}",
+                "provider": "anthropic",
+                "model_name": "claude-3-5-haiku-20241022",
+                "provider_key_id": "{PK_ID}"
+            }}"#
+        );
+        let m: Model = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("m-1", m, 1)
+    }
+
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let json =
             format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
@@ -240,6 +272,37 @@ mod tests {
             "created": 1_700_000_000i64,
             "data": [{"url": "https://example.com/image.png"}]
         })
+    }
+
+    /// Issue #168 regression: only OpenAI's API has the documented
+    /// `/v1/images/generations` route + body shape. A non-OpenAI
+    /// Model configured here must be rejected at the gateway
+    /// boundary with 400 (parallel to /v1/responses §4.6) rather
+    /// than dispatched to an upstream that would 404 (or worse,
+    /// hit a different Gemini route shape).
+    #[tokio::test]
+    async fn non_openai_provider_returns_400_invalid_request() {
+        let snap = new_snap("https://api.anthropic.com");
+        snap.models.insert(anthropic_model_entry("anthropic-image"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({
+            "model": "anthropic-image",
+            "prompt": "A sunset over mountains"
+        });
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        let message = v["error"]["message"].as_str().unwrap();
+        assert!(
+            message.contains("requires OpenAI"),
+            "rejection should reference OpenAI restriction; got {message:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -108,6 +108,22 @@ async fn dispatch(
     let _reservation = crate::quota::enforce(state, auth).await?;
 
     let model = &model_entry.value;
+
+    // Per #168: only OpenAI's API exposes the documented `/v1/rerank`
+    // route + body shape. Anthropic has no rerank API; Gemini's
+    // OpenAI-compat surface does not implement `/v1/rerank`;
+    // DeepSeek's does not either. Routing a non-OpenAI Model here
+    // would silently dispatch to an upstream that 404s — a confusing
+    // failure for callers who follow `docs/api-proxy.md` §4.7
+    // configuration verbatim. Reject explicitly with 400 (parallel
+    // to /v1/responses §4.6) so the configuration error is visible
+    // at the gateway boundary rather than masked by an upstream 404.
+    if model.provider != Some(aisix_core::models::Provider::Openai) {
+        return Err(ProxyError::InvalidRequest(format!(
+            "model `{model_name}` is not an OpenAI provider; /v1/rerank requires OpenAI"
+        )));
+    }
+
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
     let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
@@ -252,6 +268,14 @@ mod tests {
         ResourceEntry::new("m-1", m, 1)
     }
 
+    fn anthropic_model(name: &str) -> ResourceEntry<Model> {
+        let json = format!(
+            r#"{{"display_name":"{name}","provider":"anthropic","model_name":"claude-3-5-haiku-20241022","provider_key_id":"{PK_ID}"}}"#
+        );
+        let m: Model = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("m-1", m, 1)
+    }
+
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let json =
             format!(r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}"}}"#);
@@ -341,6 +365,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Issue #168 regression: only OpenAI's API exposes the
+    /// documented `/v1/rerank` route + body shape. A non-OpenAI
+    /// Model configured here must be rejected at the gateway
+    /// boundary with 400 (parallel to /v1/responses §4.6) rather
+    /// than dispatched to an upstream that would 404.
+    #[tokio::test]
+    async fn non_openai_provider_returns_400_invalid_request() {
+        let snap = new_snap("https://api.anthropic.com");
+        snap.models.insert(anthropic_model("anthropic-rerank"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "anthropic-rerank",
+                "query": "search",
+                "documents": ["doc1"]
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        let message = v["error"]["message"].as_str().unwrap();
+        assert!(
+            message.contains("requires OpenAI"),
+            "rejection should reference OpenAI restriction; got {message:?}"
+        );
     }
 
     #[tokio::test]

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -188,9 +188,13 @@ return 400.
 
 ### 4.7 `POST /v1/rerank`
 
-Cohere-style rerank. Routed to `{base}/v1/rerank`. The Model's
+OpenAI-style rerank. Routed to `{base}/v1/rerank`. The Model's
 provider supplies the API key; the request body is forwarded
-verbatim after rewriting the `model` field.
+verbatim after rewriting the `model` field. **OpenAI Models only —
+non-OpenAI providers return 400** (parallel to §4.6). Anthropic has
+no rerank API; Gemini's and DeepSeek's OpenAI-compat surfaces do
+not implement `/v1/rerank`, so routing to those would silently
+dispatch to an upstream that 404s.
 
 ### 4.8 `POST /v1/audio/transcriptions` / `translations` / `speech`
 
@@ -200,6 +204,10 @@ binary audio stream; the others return JSON with text + segments.
 ### 4.9 `POST /v1/images/generations`
 
 OpenAI Images API. Forwarded with the `model` field rewritten.
+**OpenAI Models only — non-OpenAI providers return 400** (parallel
+to §4.6). Anthropic has no image-generation API; Gemini's image
+generation lives at a different URL with a different body shape;
+DeepSeek doesn't expose image generation.
 
 ### 4.10 `ANY /passthrough/{provider}/*rest`
 


### PR DESCRIPTION
Closes #168.

## Problem

`docs/api-proxy.md` §4.7 (`/v1/rerank`) and §4.9 (`/v1/images/generations`) made no provider-restriction promise — implying any of `{openai, anthropic, gemini, deepseek}` would work. In practice:

- **Anthropic** has neither `/v1/rerank` nor `/v1/images/generations`.
- **Gemini's** OpenAI-compat surface does NOT implement `/v1/rerank`. Gemini's image generation lives at a different URL (`/v1beta/models/...:generateContent`) with a different body shape.
- **DeepSeek** has neither route.

A user following the docs and configuring `provider: "anthropic"` (or gemini, or deepseek) for a rerank or image-generation Model would have the gateway dispatch to an upstream that returns 404. The cause requires capturing upstream traffic to debug.

`/v1/responses` §4.6 already publishes an explicit restriction (`"OpenAI Models only — non-OpenAI providers return 400"`) and rejects at the gateway boundary. This PR adopts the same pattern for §4.7 and §4.9.

## Fix

Both `crates/aisix-proxy/src/rerank.rs::dispatch` and `crates/aisix-proxy/src/images.rs::dispatch` now check the Model's provider:

```rust
if model.provider != Some(aisix_core::models::Provider::Openai) {
    return Err(ProxyError::InvalidRequest(format!(
        "model `{model_name}` is not an OpenAI provider; \
         /v1/rerank requires OpenAI"
    )));
}
```

The 400 fires at the gateway boundary, so the configuration error is visible immediately on the response envelope rather than masked behind an upstream 404.

## Docs

`docs/api-proxy.md` §4.7 + §4.9 now publish the restriction explicitly (parallel to §4.6):

- §4.7: "**OpenAI Models only — non-OpenAI providers return 400**" (also corrected from "Cohere-style rerank" to "OpenAI-style rerank" — the gateway forwards to OpenAI's `/v1/rerank` route, so the wire shape is OpenAI's, not Cohere's).
- §4.9: same wording.

## Tests

Two new Rust unit tests (parallel to /v1/responses' existing restriction tests):

- `rerank::tests::non_openai_provider_returns_400_invalid_request`: configures Anthropic Model on /v1/rerank, asserts 400 + `error.type === "invalid_request_error"` + message contains "requires OpenAI".
- `images::tests::non_openai_provider_returns_400_invalid_request`: same but for /v1/images/generations.

Helpers `anthropic_model` / `anthropic_model_entry` added to both test modules.

## Verification

- `cargo test -p aisix-proxy --lib`: **154/154 passing** (incl. 2 new restriction tests)
- `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean

## Resolution path picked

Per the issue's resolution-paths section, this PR picks **Path B** (tighten gateway). Trade-offs:

- **Path B aligns with the existing precedent** (§4.6) of explicit gateway-side rejection for OpenAI-only routes. Operators get a consistent failure shape.
- **Path C** (document partial-support nuance) was rejected — it shifts the failure from "gateway 400" to "upstream 404", which is worse UX for callers. The cause becomes invisible at the gateway boundary.
- **Path A** (tighten docs without code change) was rejected — same reason. The docs describe what the gateway does, not what it should do; without a code change the gateway still happily dispatches to the wrong upstream.

## Audit follow-up (filed as #212)

Independent audit on this push surfaced one MEDIUM finding plus two LOW notes. Resolution:

- **MEDIUM-1 (e2e coverage of the gateway-side restriction) → filed as #212**: PR adds Rust unit tests but no e2e cases. The /v1/responses §4.6 precedent has the same gap (Rust unit only, no e2e), so this PR maintains parity. Filed #212 to add e2e coverage symmetrically across `/v1/rerank`, `/v1/images/generations`, AND `/v1/responses` (closing the precedent gap too) — black-box tests that POST a non-OpenAI Model to each route and assert 400 + `error.type === "invalid_request_error"` + message contains "requires OpenAI" + upstream untouched.

- **LOW-1 (provider check fires after `quota::enforce`) → noted, no change**: the check-after-reservation pattern matches the /v1/responses §4.6 precedent (`responses.rs:113` enforce, `:118` check). The `Reservation` is `Drop`-released on early-return without burning persistent RPM/TPM, so a rejected request consumes one rate-limit slot for the duration of the check (microseconds). Acceptable. A separate cleanup PR could move the check ahead of `quota::enforce` for all three endpoints uniformly; not urgent.

- **LOW-2 (minor punctuation differences in error messages) → noted, no change**: rerank uses single-line `"...; /v1/rerank requires OpenAI"`; images uses `"...; \n /v1/images/generations requires OpenAI"`. Both contain the asserted substring `"requires OpenAI"` so the unit-test assertions match. Tone is consistent with `responses.rs:120`. Cosmetic.

## References

- Issue: #168
- Follow-up: #212 (e2e coverage)
- `docs/api-proxy.md` §4.6 (existing OpenAI-only restriction precedent — `/v1/responses`)
- OpenAI Embeddings + Images APIs (the wire shape this fix preserves)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image generation and rerank endpoints now properly reject non-OpenAI models with clear 400 error responses, preventing failed upstream requests.

* **Documentation**
  * Updated API documentation to clarify OpenAI-only support for image generation and rerank endpoints.

* **Tests**
  * Added regression tests for unsupported model provider validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/211)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
