### PR TITLE
fix(routing): replace nanos-clock entropy with proper PRNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "hyper 1.9.0",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -38,6 +38,13 @@ futures-util.workspace = true
 async-trait.workspace = true
 async-stream = "0.3"
 dashmap.workspace = true
+# Per-request weighted-random target selection in `routing::weighted_pick`.
+# `thread_rng()` gives proper per-request entropy that converges to the
+# configured weights over a finite sample (fix for #197 — the prior
+# nanos-clock-mod-total entropy collapsed to a single bin under
+# rapid-fire calls because consecutive subsec_nanos values differ by
+# a constant that aliases against the modulus).
+rand = { workspace = true }
 chrono.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -17,6 +17,7 @@
 use aisix_core::{Routing, RoutingStrategy, RoutingTarget};
 use aisix_gateway::BridgeError;
 use dashmap::DashMap;
+use rand::Rng;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Whether a Bridge error is retryable across routing targets.
@@ -118,7 +119,6 @@ fn weighted_pick(targets: &[RoutingTarget]) -> usize {
     if total == 0 {
         return 0;
     }
-    use rand::Rng;
     let pick = rand::thread_rng().gen_range(0..total);
     let mut acc: u64 = 0;
     for (i, t) in targets.iter().enumerate() {
@@ -226,10 +226,10 @@ mod tests {
             ],
             Some(0),
         );
-        // Across many trials, "a" should dominate as the starting pick.
-        // We don't assert exact distribution (entropy is sub-second
-        // wall-clock); we just assert correctness of the *order* shape:
+        // We just assert correctness of the *order* shape:
         // exactly two attempts, distinct targets, both targets covered.
+        // (Aggregate distribution is pinned by the dedicated tests
+        // below.)
         let order = reg.pick_order("v", &routing);
         assert_eq!(order.len(), 2);
         assert!(order.iter().any(|t| t == "a"));
@@ -298,10 +298,10 @@ mod tests {
     /// 200/0 in e2e on a configured 70/30); a proper PRNG converges
     /// to the analytic distribution.
     ///
-    /// Tolerance: n=1000 with p=0.7 has σ=√(np(1-p))=√210≈14.5. A ±5%
-    /// window (50 absolute counts) is ~3.5σ → P(false positive)<0.1%.
-    /// The pre-fix collapse-to-one-bin failure produces 1000/0 which
-    /// is ~33σ outside the window — caught with overwhelming margin.
+    /// Tolerance: n=1000 with p=0.7 has σ=√(np(1-p))=√210≈14.49. A ±50
+    /// absolute window is ~3.45σ → P(false positive) ≈ 0.056%. The
+    /// pre-fix collapse-to-one-bin failure produces 1000/0 which is
+    /// ~33σ outside the window — caught with overwhelming margin.
     #[test]
     fn weighted_pick_70_30_split_converges_to_configured_ratio() {
         let targets = vec![
@@ -310,10 +310,69 @@ mod tests {
         ];
         let n = 1_000;
         let a_count = (0..n).filter(|_| weighted_pick(&targets) == 0).count();
-        // Expected ~700; tolerance window [650, 750] (≈±3.5σ).
+        // Expected ~700; tolerance window [650, 750] (≈±3.45σ).
         assert!(
             (650..=750).contains(&a_count),
             "70/30 weighted split must land near 700/1000; got {a_count}/{n} on heavy target",
+        );
+    }
+
+    /// 3-target coverage: a weight-blind impl that only ever picks
+    /// `targets[0]` if `pick < sum/n` (and `targets[1]` otherwise)
+    /// would pass every 2-target test in this module but fail with
+    /// 3+ targets — the third bin would starve. Pin a 50/30/20 split
+    /// and assert each bin lands within a generous tolerance window.
+    ///
+    /// n=2000 chosen so the smallest bin (20% → ~400) has σ ≈ 17.9;
+    /// ±100 window ≈ 5.6σ for that bin, larger margins for the other
+    /// two.
+    #[test]
+    fn weighted_pick_50_30_20_split_distributes_to_all_three_bins() {
+        let targets = vec![
+            RoutingTarget::new("a").with_weight(50),
+            RoutingTarget::new("b").with_weight(30),
+            RoutingTarget::new("c").with_weight(20),
+        ];
+        let n = 2_000;
+        let mut counts = [0_usize; 3];
+        for _ in 0..n {
+            counts[weighted_pick(&targets)] += 1;
+        }
+        // Expected 1000/600/400. ±100 window catches a weight-blind
+        // 2-target collapse (where the 3rd bin would be 0) AND
+        // sample noise.
+        assert!(
+            (900..=1100).contains(&counts[0]),
+            "50%-weighted bin should land near 1000/2000; got {counts:?}",
+        );
+        assert!(
+            (500..=700).contains(&counts[1]),
+            "30%-weighted bin should land near 600/2000; got {counts:?}",
+        );
+        assert!(
+            (300..=500).contains(&counts[2]),
+            "20%-weighted bin should land near 400/2000; got {counts:?}",
+        );
+    }
+
+    /// Zero-weight-in-the-middle: a weight=0 target between two
+    /// non-zero targets must NEVER be picked. The CDF predicate
+    /// `pick < acc` (strict less-than) is what enforces this — a
+    /// weight-0 segment doesn't widen `acc` so the predicate skips
+    /// past it. A regression that used `<=` would incidentally pick
+    /// the zero-weight bin on the boundary value of `pick`.
+    #[test]
+    fn weighted_pick_zero_weight_target_in_middle_is_never_picked() {
+        let targets = vec![
+            RoutingTarget::new("a").with_weight(10),
+            RoutingTarget::new("b").with_weight(0),
+            RoutingTarget::new("c").with_weight(10),
+        ];
+        let n = 2_000;
+        let b_count = (0..n).filter(|_| weighted_pick(&targets) == 1).count();
+        assert_eq!(
+            b_count, 0,
+            "weight=0 target must never be picked; got {b_count}/{n}",
         );
     }
 

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -95,16 +95,31 @@ fn attempt_order(targets: &[RoutingTarget], start_idx: usize, budget: usize) -> 
 
 /// Pick an index by weighted-random. Ignores zero weights; a fully-zero
 /// list falls back to index 0 deterministically.
+///
+/// Per #197: each call must draw an INDEPENDENT sample from the weight
+/// distribution. The prior implementation used
+/// `SystemTime::now().subsec_nanos() + Instant::now().elapsed().as_nanos()`
+/// as entropy, which has two correctness bugs that compound:
+///   1. `Instant::now().elapsed()` always returns ~0 (the Instant was
+///      just created), so the mix is effectively just subsec_nanos.
+///   2. Under rapid-fire requests (e2e fires N=100 in tight loop),
+///      consecutive subsec_nanos values differ by a near-constant
+///      step (≈1 µs of wall-clock per request). Modular reduction
+///      `entropy() % total_weight` against that step pattern aliases
+///      to a single bin — every request lands on the same target.
+///      Empirical observation: 200/0 split on a configured 70/30.
+///
+/// Use `rand::thread_rng()` instead. The thread-local PRNG is seeded
+/// from OS entropy on first use and is independent across calls; the
+/// distribution converges to the configured weights over a finite
+/// sample (per the spec the e2e pins).
 fn weighted_pick(targets: &[RoutingTarget]) -> usize {
     let total: u64 = targets.iter().map(|t| t.weight_or_default() as u64).sum();
     if total == 0 {
         return 0;
     }
-    // We don't need a strong PRNG here — just enough entropy to spread
-    // requests roughly per weights. Use the system clock's nanos as a
-    // cheap entropy source so we avoid pulling in `rand` crate just
-    // for one call site.
-    let pick = entropy() % total;
+    use rand::Rng;
+    let pick = rand::thread_rng().gen_range(0..total);
     let mut acc: u64 = 0;
     for (i, t) in targets.iter().enumerate() {
         acc += t.weight_or_default() as u64;
@@ -113,17 +128,6 @@ fn weighted_pick(targets: &[RoutingTarget]) -> usize {
         }
     }
     targets.len() - 1
-}
-
-fn entropy() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.subsec_nanos() as u64)
-        .unwrap_or(0)
-        // Mix in something monotonic so two calls in the same nanosecond
-        // diverge — `Instant` provides that without `unsafe`.
-        .wrapping_add(std::time::Instant::now().elapsed().as_nanos() as u64)
 }
 
 #[cfg(test)]
@@ -241,27 +245,14 @@ mod tests {
         assert_eq!(weighted_pick(&targets), 0);
     }
 
-    /// Soft property: across many trials, a 99/1 weight bias must
-    /// measurably favor the heavy target. The existing
-    /// `weighted_picks_from_targets_and_falls_back_in_order` only
-    /// checks order *shape* (both targets present) — it cannot tell
-    /// a weighted impl from a uniform-random one. This test pins the
-    /// *intent* of `Weighted`: weight actually steers the picks.
-    ///
-    /// Tolerance is intentionally loose: `entropy()` is sub-second
-    /// wall-clock + `Instant::now().elapsed()` (see comment in
-    /// `entropy`), so short-loop nanos can cluster. We assert "weight
-    /// 99 dominates uniform 50/50" with a ≥ 60 % lower bound, which
-    /// is robust to the weak entropy source while still failing on a
-    /// weight-blind implementation (uniform RNG → ~50 %).
-    /// Total weight = 101 is deliberate (so is the same total in the
-    /// companion `_respects_index_swap` test below). With weights
-    /// summing to a power-of-10 like 100 we empirically saw the
-    /// minority bin starve under the weak nanosecond-clock entropy
-    /// — a 5000-trial run on `[1, 99]` yielded only ~53 %, well below
-    /// the 60 % threshold. Bumping the heavy weight to 100 widens the
-    /// majority bin to ~99 % expected and gives the test enough margin
-    /// to absorb the entropy weakness without flaking.
+    /// Aggregate-distribution property: across many trials, a 100/1
+    /// weight bias must converge to ~99% on the heavy target. Pre-#197
+    /// the threshold sat at ≥ 60% to absorb the weak nanos-clock entropy
+    /// — that gate would also pass a weight-half-sensitivity regression
+    /// (~75% would slip through). With proper PRNG entropy in
+    /// `weighted_pick`, the empirical bin should land within ~1% of
+    /// the analytic 100/(100+1) = 99.0% expectation; we assert ≥ 95%
+    /// (≈4σ band for n=5000, rejects half-sensitivity AND weight-blind).
     #[test]
     fn weighted_pick_aggregate_distribution_favors_heavier_weight() {
         let targets = vec![
@@ -271,13 +262,12 @@ mod tests {
         let n = 5_000;
         let a_count = (0..n).filter(|_| weighted_pick(&targets) == 0).count();
         // Uniform 50/50 → ~2500. Weighted 100/1 → ~4950 in theory.
-        // 60 % threshold (3000) is a wide safety margin: it already
-        // rejects both a weight-blind impl (~50 %) and a "weights
-        // inverted" regression (~1 %). Tightening to 90 % would catch
-        // a half-sensitivity regression but adds CI-flake risk against
-        // weak entropy — the looser bound is the stable choice.
+        // 95% threshold (4750) rejects both a weight-blind impl
+        // (~50%) AND a half-sensitivity regression (~75% would also
+        // fail). With proper PRNG entropy this gate has ~5σ margin;
+        // CI-flake risk is negligible.
         assert!(
-            a_count * 100 / n >= 60,
+            a_count * 100 / n >= 95,
             "weight=100 target should dominate aggregate picks; got {a_count}/{n}",
         );
     }
@@ -287,8 +277,7 @@ mod tests {
     /// the heavy weight is at index 0). Swap the weights so the heavy
     /// target sits at index 1 — a weight-blind impl that always picks
     /// the first target would now fail this test, while a correct
-    /// weighted impl still favors index 1. Same total=101 reasoning
-    /// as the test above.
+    /// weighted impl still favors index 1.
     #[test]
     fn weighted_pick_aggregate_distribution_respects_index_swap() {
         let targets = vec![
@@ -298,8 +287,33 @@ mod tests {
         let n = 5_000;
         let b_count = (0..n).filter(|_| weighted_pick(&targets) == 1).count();
         assert!(
-            b_count * 100 / n >= 60,
+            b_count * 100 / n >= 95,
             "weight=100 target at index 1 should dominate aggregate picks; got {b_count}/{n}",
+        );
+    }
+
+    /// Issue #197 regression: a 70/30 weighted split must land near
+    /// 70/30 over a finite sample. The pre-fix nanos-clock entropy
+    /// collapsed to a single bin under rapid-fire calls (observed
+    /// 200/0 in e2e on a configured 70/30); a proper PRNG converges
+    /// to the analytic distribution.
+    ///
+    /// Tolerance: n=1000 with p=0.7 has σ=√(np(1-p))=√210≈14.5. A ±5%
+    /// window (50 absolute counts) is ~3.5σ → P(false positive)<0.1%.
+    /// The pre-fix collapse-to-one-bin failure produces 1000/0 which
+    /// is ~33σ outside the window — caught with overwhelming margin.
+    #[test]
+    fn weighted_pick_70_30_split_converges_to_configured_ratio() {
+        let targets = vec![
+            RoutingTarget::new("a").with_weight(70),
+            RoutingTarget::new("b").with_weight(30),
+        ];
+        let n = 1_000;
+        let a_count = (0..n).filter(|_| weighted_pick(&targets) == 0).count();
+        // Expected ~700; tolerance window [650, 750] (≈±3.5σ).
+        assert!(
+            (650..=750).contains(&a_count),
+            "70/30 weighted split must land near 700/1000; got {a_count}/{n} on heavy target",
         );
     }
 


### PR DESCRIPTION
Closes #197.

## Problem

`routing::weighted_pick` used a custom nanos-clock entropy source:

```rust
fn entropy() -> u64 {
    SystemTime::now().subsec_nanos() as u64
        .wrapping_add(Instant::now().elapsed().as_nanos() as u64)
}
let pick = entropy() % total;
```

Two compounding bugs:

1. **`Instant::now().elapsed()` always returns ~0** — the Instant was just created. The mix was effectively just `subsec_nanos()`.
2. **Under rapid-fire requests**, consecutive `subsec_nanos` values differ by a near-constant step (~1 µs per request). Modular reduction `entropy() % total_weight` against that step pattern aliases to a single bin — every request collapses to the same target.

The e2e test `weighted-routing-distribution-e2e.test.ts` fires 200 requests against a configured 70/30 split and asserted the heavy side lands in [55, 85]. On main the test sees 200/0.

Under correct weighted-random sampling, P(0 hits on the 30%-weighted target across 200 trials) = 0.7^200 ≈ **10⁻³¹** — not sampling variance, a real contract violation.

## Fix

```rust
use rand::Rng;
let pick = rand::thread_rng().gen_range(0..total);
```

`thread_rng()` is seeded from OS entropy on first use, and consecutive draws are independent. The empirical distribution converges to the configured weights over a finite sample, per the spec the e2e pins.

`rand = { workspace = true }` added to `aisix-proxy/Cargo.toml`. The workspace already declared `rand = "0.8"` for other crates, so this is a fresh consumer of an existing dependency, not a new dep.

## Tests

**Tightened existing aggregate-distribution tests** — the pre-fix ≥ 60% threshold absorbed the weak entropy; with proper PRNG it should land within ~1% of analytic. Tightened to ≥ 95% (≈4σ band for n=5000), which rejects:
- Weight-blind impl (~50%)
- Half-sensitivity regression (~75%)
- Weight-inverted (~5%)

**New direct repro** — `weighted_pick_70_30_split_converges_to_configured_ratio`:
- n=1000, expects heavy count in [650, 750] (≈±3.5σ at p=0.7).
- Pre-fix collapse produces 1000/0, ~33σ outside the window. Caught with overwhelming margin.

The held-back e2e (`weighted-routing-distribution-e2e.test.ts`) is already on main with `[55, 85]` tolerance band; should now pass cleanly.

## Verification

- `cargo test -p aisix-proxy --lib`: **158/158 passing** (incl. new convergence test)
- `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean

## References

- Issue: #197
- Reference implementation pattern in this category: per-request weighted-random sampling via independent draws from a probability distribution. The de-facto standard router implementation in this space uses `random.choices(..., weights=...)` per request and asserts empirical convergence on N=1000-trial tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved weighted random target selection mechanism in request routing for more reliable load distribution.

* **Tests**
  * Enhanced test suite with stricter validation and comprehensive statistical distribution coverage for weighted selection behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/217)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->