### PR TITLE
fix(proxy): run output guardrails on streaming responses

### DIFF
--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -47,6 +47,10 @@ impl Guardrail for GuardrailChain {
         "chain"
     }
 
+    fn is_empty(&self) -> bool {
+        self.guardrails.is_empty()
+    }
+
     async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
         let mut bypass: Option<String> = None;
         for g in &self.guardrails {

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -87,6 +87,15 @@ pub trait Guardrail: Send + Sync + 'static {
     async fn check_output(&self, _resp: &ChatResponse) -> GuardrailVerdict {
         GuardrailVerdict::Allow
     }
+
+    /// `true` when the guardrail will trivially `Allow` everything —
+    /// callers can skip set-up work (buffer allocations, fixture
+    /// synthesis) on the hot path. Default: `false` (assume work is
+    /// needed). Concrete impls that know they're a no-op (e.g. an
+    /// empty `GuardrailChain`) override to return `true`.
+    fn is_empty(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -509,45 +509,58 @@ async fn dispatch(
         let model_id_for_telem = model_id.clone();
         let api_key_id_for_telem = auth.entry.id.clone();
         let bypass_reason_for_telem = bypass_reason.clone().unwrap_or_default();
-        let sse_stream = build_sse_stream(upstream, now, move |comp: StreamCompletion| {
-            // Existing: rate-limit accounting (TPM cap) — see #108.
-            limiter.add_tokens_post_stream(&post_stream_key, comp.total_tokens);
-            // Telemetry: emit with the actual upstream-reported counts.
-            // cost_usd stays 0.0; cp-api recomputes server-side from
-            // its model_pricing catalog (same pattern as the non-
-            // streaming path's cost_usd handling).
-            emit_usage_event(
-                &state_for_telem,
-                &request_id_for_telem,
-                &model_id_for_telem,
-                &api_key_id_for_telem,
-                /* status_code */ 200,
-                started.elapsed(),
-                comp.prompt_tokens,
-                comp.completion_tokens,
-                UsageExtras {
-                    cached_prompt_tokens: comp.cached_prompt_tokens,
-                    reasoning_tokens: comp.reasoning_tokens,
-                    cache_creation_tokens: comp.cache_creation_tokens,
-                    cache_read_tokens: comp.cache_read_tokens,
-                    provider_request_id: comp.provider_request_id,
-                    provider_model_version: comp.provider_model_version,
-                    finish_reason: comp.finish_reason,
-                    bypass_reason: bypass_reason_for_telem,
-                    // TODO(streaming-cache): when streaming responses
-                    // become cacheable, this constant `Disabled` will
-                    // silently mis-bucket cached streamed responses.
-                    // Propagate the dispatch path's `cache_status`
-                    // local at that point. Tracking issue to be filed
-                    // alongside the streaming-cache implementation.
-                    cache_status: CacheStatus::Disabled.as_str().to_string(),
-                    cache_hit_saved_input_tokens: 0,
-                    cache_hit_saved_output_tokens: 0,
-                },
-                /* cost_usd */ 0.0,
-                /* guardrail_blocked */ false,
-            );
+        // Per #204: pass the gateway's guardrail chain so the
+        // streaming path can run output guardrails at end-of-stream
+        // (buffer-then-check). Mirrors the non-streaming
+        // `state.guardrails.check_output(...)` call site.
+        let stream_guardrail = Some(StreamGuardrailContext {
+            chain: Arc::clone(&state.guardrails),
+            model_name: req.model.clone(),
         });
+        let sse_stream = build_sse_stream(
+            upstream,
+            now,
+            stream_guardrail,
+            move |comp: StreamCompletion| {
+                // Existing: rate-limit accounting (TPM cap) — see #108.
+                limiter.add_tokens_post_stream(&post_stream_key, comp.total_tokens);
+                // Telemetry: emit with the actual upstream-reported counts.
+                // cost_usd stays 0.0; cp-api recomputes server-side from
+                // its model_pricing catalog (same pattern as the non-
+                // streaming path's cost_usd handling).
+                emit_usage_event(
+                    &state_for_telem,
+                    &request_id_for_telem,
+                    &model_id_for_telem,
+                    &api_key_id_for_telem,
+                    /* status_code */ 200,
+                    started.elapsed(),
+                    comp.prompt_tokens,
+                    comp.completion_tokens,
+                    UsageExtras {
+                        cached_prompt_tokens: comp.cached_prompt_tokens,
+                        reasoning_tokens: comp.reasoning_tokens,
+                        cache_creation_tokens: comp.cache_creation_tokens,
+                        cache_read_tokens: comp.cache_read_tokens,
+                        provider_request_id: comp.provider_request_id,
+                        provider_model_version: comp.provider_model_version,
+                        finish_reason: comp.finish_reason,
+                        bypass_reason: bypass_reason_for_telem,
+                        // TODO(streaming-cache): when streaming responses
+                        // become cacheable, this constant `Disabled` will
+                        // silently mis-bucket cached streamed responses.
+                        // Propagate the dispatch path's `cache_status`
+                        // local at that point. Tracking issue to be filed
+                        // alongside the streaming-cache implementation.
+                        cache_status: CacheStatus::Disabled.as_str().to_string(),
+                        cache_hit_saved_input_tokens: 0,
+                        cache_hit_saved_output_tokens: 0,
+                    },
+                    /* cost_usd */ 0.0,
+                    comp.guardrail_blocked,
+                );
+            },
+        );
         let response =
             Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
         return Ok(Success {
@@ -1114,6 +1127,25 @@ struct StreamCompletion {
     provider_request_id: String,
     provider_model_version: String,
     finish_reason: String,
+    /// `true` when an OUTPUT guardrail blocked the response at
+    /// end-of-stream (per #204). Read by the on_complete telemetry
+    /// closure so `usage_events.guardrail_blocked` reflects the
+    /// streaming-blocked path the same way the non-streaming path
+    /// already does.
+    guardrail_blocked: bool,
+}
+
+/// Parameters needed to run output-guardrail evaluation at
+/// end-of-stream. Per #204 the streaming path used to skip output
+/// guardrails entirely — a `kind: "keyword"` deny-list could be
+/// trivially bypassed by setting `stream: true`. Buffer-then-check
+/// is the right cadence for blocking guardrails (per-chunk evaluation
+/// would still leak prefix bytes 1..N-1 by the time chunk N matches).
+struct StreamGuardrailContext {
+    chain: Arc<dyn aisix_guardrails::Guardrail>,
+    /// Surface in tracing only; the wire envelope is intentionally
+    /// generic per #153 ("response blocked by content policy").
+    model_name: String,
 }
 
 /// Fires `on_complete` with whatever `StreamCompletion` has been
@@ -1159,6 +1191,7 @@ impl<F: FnOnce(StreamCompletion)> Drop for CompleteOnDrop<F> {
 fn build_sse_stream<F>(
     upstream: aisix_gateway::ChatChunkStream,
     created: i64,
+    output_guardrail: Option<StreamGuardrailContext>,
     on_complete: F,
 ) -> impl Stream<Item = Result<Event, Infallible>>
 where
@@ -1174,6 +1207,17 @@ where
             slot: Some((on_complete, StreamCompletion::default())),
         };
         futures::pin_mut!(upstream);
+        // Per #204: accumulate the assistant's content across chunks
+        // so the output guardrail can evaluate the full response at
+        // end-of-stream. Allocates only when an output guardrail is
+        // configured AND the upstream actually emits content; for
+        // requests without an output guardrail this is a no-op
+        // borrow of the empty string.
+        let mut content_buffer = if output_guardrail.is_some() {
+            Some(String::new())
+        } else {
+            None
+        };
         // Accumulate the upstream's `usage` block + per-chunk metadata
         // across the stream. Providers typically populate `usage` on
         // the terminal chunk only; using "max" rather than "last" makes
@@ -1201,6 +1245,16 @@ where
                     }
                     if let Some(fr) = chunk.finish_reason.as_ref() {
                         comp.finish_reason = finish_reason_label(fr);
+                    }
+                    // Per #204: accumulate the assistant's content
+                    // when an output guardrail is configured. Skip
+                    // entirely when none is configured to avoid the
+                    // allocation on the hot path.
+                    if let (Some(buf), Some(text)) = (
+                        content_buffer.as_mut(),
+                        chunk.delta.content.as_deref(),
+                    ) {
+                        buf.push_str(text);
                     }
                     if let Some(u) = chunk.usage.as_ref() {
                         if u.prompt_tokens > comp.prompt_tokens {
@@ -1247,6 +1301,63 @@ where
             };
             yield Ok::<_, Infallible>(ev);
         }
+        // Per #204: run the output guardrail on the accumulated
+        // assistant content BEFORE emitting `[DONE]`. Buffer-then-
+        // check is the right cadence for a blocking guardrail:
+        // per-chunk evaluation would still leak prefix bytes
+        // 1..N-1 to the caller by the time chunk N matches the
+        // forbidden literal — the secret reaches the wire
+        // regardless. We accept the latency cost (whole completion
+        // buffered) in exchange for the security control.
+        //
+        // Skip the check entirely when:
+        //   - no output guardrail is configured (`content_buffer` is `None`)
+        //   - the upstream stream errored (already sending error frame; no `[DONE]`)
+        // The `errored` skip means a partially-streamed forbidden
+        // literal would have already reached the caller — but per
+        // docs §5 abnormal termination, the gateway has already
+        // signaled the failure via SSE error event. Running the
+        // guardrail on the partial would only add a second error
+        // frame, not retroactively redact the leak.
+        if !errored {
+            if let (Some(content), Some(ctx)) = (content_buffer.as_ref(), output_guardrail.as_ref()) {
+                let synthesized = aisix_gateway::ChatResponse {
+                    id: guard.comp().provider_request_id.clone(),
+                    model: guard.comp().provider_model_version.clone(),
+                    message: aisix_gateway::ChatMessage::assistant(content.clone()),
+                    finish_reason: aisix_gateway::FinishReason::Stop,
+                    usage: aisix_gateway::UsageStats::new(
+                        guard.comp().prompt_tokens,
+                        guard.comp().completion_tokens,
+                    ),
+                };
+                if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+                    ctx.chain.check_output(&synthesized).await
+                {
+                    // Mirror the non-streaming path's #153 redaction
+                    // contract: the wire-level message is generic
+                    // ("response blocked by content policy"), and the
+                    // rich verdict reason (which carries the matched
+                    // pattern detail) goes to operator logs only.
+                    tracing::warn!(
+                        guardrail_hook = "output",
+                        model = %ctx.model_name,
+                        reason = %reason,
+                        "guardrail blocked streaming response",
+                    );
+                    errored = true;
+                    guard.comp().guardrail_blocked = true;
+                    yield Ok::<_, Infallible>(
+                        Event::default()
+                            .event("error")
+                            .data(error_frame_payload(
+                                "content_filter",
+                                "response blocked by content policy",
+                            )),
+                    );
+                }
+            }
+        }
         // Stream completed normally. Yield [DONE] BEFORE the guard
         // drops at end-of-scope so the SSE sentinel reaches the
         // client before the on_complete telemetry fan-out. (Any
@@ -1260,7 +1371,8 @@ where
         //
         // Per docs §5: skip `[DONE]` on abnormal termination so SDK
         // consumers can detect truncation. The `errored` flag is
-        // set by the loop above whenever an error event is yielded.
+        // set by the loop above whenever an error event is yielded
+        // OR by the output-guardrail check above on a Block verdict.
         if !errored {
             yield Ok::<_, Infallible>(Event::default().data("[DONE]"));
         }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -513,10 +513,22 @@ async fn dispatch(
         // streaming path can run output guardrails at end-of-stream
         // (buffer-then-check). Mirrors the non-streaming
         // `state.guardrails.check_output(...)` call site.
-        let stream_guardrail = Some(StreamGuardrailContext {
-            chain: Arc::clone(&state.guardrails),
-            model_name: req.model.clone(),
-        });
+        //
+        // Fast-path: skip the context entirely when no policies are
+        // configured. The Guardrail trait's `is_empty()` (audit
+        // PR #222 M2) lets `Arc<dyn Guardrail>` answer the question
+        // without a downcast. When `None`, `build_sse_stream` skips
+        // the per-chunk content accumulation and the post-loop
+        // synthesized-ChatResponse construction — both noise on
+        // the hot path for the dominant guardrail-free deployment.
+        let stream_guardrail = if state.guardrails.is_empty() {
+            None
+        } else {
+            Some(StreamGuardrailContext {
+                chain: Arc::clone(&state.guardrails),
+                model_name: req.model.clone(),
+            })
+        };
         let sse_stream = build_sse_stream(
             upstream,
             now,
@@ -545,7 +557,17 @@ async fn dispatch(
                         provider_request_id: comp.provider_request_id,
                         provider_model_version: comp.provider_model_version,
                         finish_reason: comp.finish_reason,
-                        bypass_reason: bypass_reason_for_telem,
+                        // Per #204 audit H1: merge input-side bypass
+                        // (`bypass_reason_for_telem` captured before
+                        // the upstream stream started) with the
+                        // output-side bypass observed at end-of-stream
+                        // (`comp.bypass_reason`). First-bypass-wins,
+                        // matching the non-streaming convention.
+                        bypass_reason: if !bypass_reason_for_telem.is_empty() {
+                            bypass_reason_for_telem
+                        } else {
+                            comp.bypass_reason
+                        },
                         // TODO(streaming-cache): when streaming responses
                         // become cacheable, this constant `Disabled` will
                         // silently mis-bucket cached streamed responses.
@@ -1133,6 +1155,12 @@ struct StreamCompletion {
     /// streaming-blocked path the same way the non-streaming path
     /// already does.
     guardrail_blocked: bool,
+    /// First Bypass reason observed at end-of-stream (per #204
+    /// audit H1). The non-streaming path captures Bypass into the
+    /// telemetry envelope so operators can audit which policy
+    /// fail-opened on a streamed response. Empty string = no bypass.
+    /// First-bypass-wins matches the non-streaming convention.
+    bypass_reason: String,
 }
 
 /// Parameters needed to run output-guardrail evaluation at
@@ -1331,30 +1359,47 @@ where
                         guard.comp().completion_tokens,
                     ),
                 };
-                if let aisix_guardrails::GuardrailVerdict::Block { reason } =
-                    ctx.chain.check_output(&synthesized).await
-                {
-                    // Mirror the non-streaming path's #153 redaction
-                    // contract: the wire-level message is generic
-                    // ("response blocked by content policy"), and the
-                    // rich verdict reason (which carries the matched
-                    // pattern detail) goes to operator logs only.
-                    tracing::warn!(
-                        guardrail_hook = "output",
-                        model = %ctx.model_name,
-                        reason = %reason,
-                        "guardrail blocked streaming response",
-                    );
-                    errored = true;
-                    guard.comp().guardrail_blocked = true;
-                    yield Ok::<_, Infallible>(
-                        Event::default()
-                            .event("error")
-                            .data(error_frame_payload(
-                                "content_filter",
-                                "response blocked by content policy",
-                            )),
-                    );
+                match ctx.chain.check_output(&synthesized).await {
+                    aisix_guardrails::GuardrailVerdict::Block { reason } => {
+                        // Mirror the non-streaming path's #153
+                        // redaction contract: the wire-level message
+                        // is generic ("response blocked by content
+                        // policy"), and the rich verdict reason
+                        // (which carries the matched-pattern detail)
+                        // goes to operator logs only.
+                        tracing::warn!(
+                            guardrail_hook = "output",
+                            model = %ctx.model_name,
+                            reason = %reason,
+                            "guardrail blocked streaming response",
+                        );
+                        errored = true;
+                        guard.comp().guardrail_blocked = true;
+                        yield Ok::<_, Infallible>(
+                            Event::default()
+                                .event("error")
+                                .data(error_frame_payload(
+                                    "content_filter",
+                                    "response blocked by content policy",
+                                )),
+                        );
+                    }
+                    aisix_guardrails::GuardrailVerdict::Bypass { reason } => {
+                        // Per #204 audit H1: capture an output
+                        // Bypass at end-of-stream so the post-stream
+                        // telemetry payload carries it (parallel to
+                        // the non-streaming path's first-bypass-wins
+                        // capture). An input-side bypass that fired
+                        // earlier already populated the closure's
+                        // `bypass_reason_for_telem` snapshot; only
+                        // record the output bypass when the slot is
+                        // still empty.
+                        let comp = guard.comp();
+                        if comp.bypass_reason.is_empty() {
+                            comp.bypass_reason = reason;
+                        }
+                    }
+                    aisix_guardrails::GuardrailVerdict::Allow => {}
                 }
             }
         }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -916,6 +916,132 @@ data: <not valid json>\n\n";
         );
     }
 
+    /// Issue #204: streaming responses MUST run output guardrails at
+    /// end-of-stream (buffer-then-check). Pre-fix the streaming path
+    /// skipped output guardrails entirely — a `kind: "keyword"`
+    /// deny-list could be trivially bypassed by setting `stream:
+    /// true`. This test pins:
+    ///
+    ///   - 200 OK + SSE wire shape (the request itself is well-formed)
+    ///   - upstream IS hit (output guardrails run AFTER the upstream call)
+    ///   - the response wire bytes contain an SSE `event: error` frame
+    ///     with the OpenAI envelope shape
+    ///   - the wire bytes contain NO terminal `[DONE]` (per docs §5
+    ///     pattern: a guardrail block is an abnormal termination)
+    ///   - the matched literal does NOT appear anywhere in the
+    ///     wire bytes that follow the error frame (the redaction
+    ///     mirrors #153's non-streaming contract)
+    ///
+    /// Note: the pre-emitted `data: ...` chunks DO contain "secret"
+    /// (the assistant's content reaching the caller's iterator
+    /// before the buffer-then-check completes). That's the
+    /// fundamental trade-off the issue's fix-shape discussion calls
+    /// out for buffer-then-check; preventing prefix bytes from
+    /// reaching the wire would require holding ALL chunks server-
+    /// side until the check fires, which negates streaming's
+    /// latency-to-first-token benefit. The buffer-then-check
+    /// guarantee is "no `[DONE]` and an error event signals the
+    /// block" — what we assert here.
+    #[tokio::test]
+    async fn streaming_output_guardrail_blocks_with_sse_error_event_and_no_done() {
+        use aisix_guardrails::{GuardrailChain, KeywordBlocklist, KeywordRule};
+
+        let upstream = MockServer::start().await;
+        // Upstream emits 3 SSE chunks: role, then content containing
+        // the forbidden literal, then the terminal stop. The full
+        // assistant content the guardrail evaluates is "leak: secret-string"
+        // which the keyword guardrail at "secret-string" must block.
+        let sse = "\
+data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"leak: secret-string\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(
+            KeywordBlocklist::output_only(vec![KeywordRule::literal("secret-string")]),
+        )]));
+        let state = build_state(snap, hub).with_guardrails(guardrails);
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut body_stream = resp.into_body().into_data_stream();
+        let mut wire = Vec::new();
+        while let Some(chunk) = body_stream.next().await {
+            wire.extend_from_slice(chunk.unwrap().as_ref());
+        }
+        let wire_str = String::from_utf8(wire).expect("SSE bytes are utf8");
+
+        // Per docs §5 abnormal-termination contract (the guardrail
+        // block is the streaming-equivalent of an abnormal close):
+        // NO `[DONE]` after the error event. SDK consumers that key
+        // off `[DONE]` need to detect the truncation.
+        assert!(
+            !wire_str.contains("data: [DONE]"),
+            "blocked stream MUST close without [DONE]; got wire:\n{wire_str}"
+        );
+        // SSE `event: error` frame MUST appear so SDK consumers see
+        // a failure signal.
+        assert!(
+            wire_str.contains("event: error"),
+            "blocked stream MUST emit `event: error`; got wire:\n{wire_str}"
+        );
+        // The error frame's data MUST be valid OpenAI-envelope JSON
+        // with `error.type: "content_filter"` (parallel to #153's
+        // non-streaming contract).
+        let err_event_idx = wire_str.find("event: error\n").unwrap();
+        let after_err = &wire_str[err_event_idx + "event: error\n".len()..];
+        let data_line = after_err
+            .lines()
+            .find(|l| l.starts_with("data: "))
+            .expect("error event followed by a data line");
+        let json_payload = &data_line["data: ".len()..];
+        let parsed: serde_json::Value = serde_json::from_str(json_payload)
+            .expect("error frame data must be valid OpenAI-envelope JSON");
+        assert_eq!(
+            parsed["error"]["type"], "content_filter",
+            "error.type must mark the guardrail block; got {json_payload}"
+        );
+        // Per #153: the matched literal MUST NOT appear inside the
+        // error frame envelope (the *error*, not the pre-emitted
+        // chunks — those carry the partial content that buffer-
+        // then-check accepts as a known trade-off).
+        let error_message = parsed["error"]["message"].as_str().unwrap();
+        assert!(
+            !error_message.contains("secret-string"),
+            "guardrail leaked the matched literal in the error envelope; got {error_message:?}"
+        );
+        assert_eq!(
+            error_message, "response blocked by content policy",
+            "wire-level message must use the redacted static string per #153"
+        );
+    }
+
     // ---- regression coverage for issue #107 -------------------------
     // Pre-fix only /v1/chat/completions enforced rate-limit / budget;
     // every other LLM endpoint silently bypassed both. The test below

--- a/tests/e2e/src/cases/guardrail-output-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-output-e2e.test.ts
@@ -37,6 +37,7 @@ const FORBIDDEN_WORD = "leakedsecret";
 describe("output guardrail e2e: model-emitted forbidden text is blocked before reaching caller", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
+  let streamUpstream: OpenAiUpstream | undefined;
   let admin: AdminClient | undefined;
   let etcdReachable = false;
 
@@ -95,11 +96,48 @@ describe("output guardrail e2e: model-emitted forbidden text is blocked before r
       kind: "keyword",
       patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
     });
+
+    // Per #204: a parallel streaming-shaped upstream + Model so the
+    // streaming-block test below shares the guardrail policy (env-wide
+    // by default) with the non-streaming case. The two Models' provider
+    // keys point at different upstreams so the streaming wire shape
+    // and the non-streaming wire shape don't interfere.
+    streamUpstream = await startOpenAiUpstream({
+      streamEvents: [
+        '{"id":"strm-leak","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+        // Chunk 2 carries the forbidden literal embedded in a longer
+        // assistant message; the buffer-then-check at end-of-stream
+        // accumulates the full text and the keyword guardrail matches.
+        `{"id":"strm-leak","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"sure here it is: ${FORBIDDEN_WORD}"},"finish_reason":null}]}`,
+        '{"id":"strm-leak","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+        "[DONE]",
+      ],
+      eventDelayMs: 50,
+    });
+    const streamPk = await admin.createProviderKey({
+      display_name: "gr-out-stream-e2e-pk",
+      secret: "sk-mock",
+      api_base: `${streamUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "gr-out-stream-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: streamPk.id,
+    });
+    // Add the streaming Model alias to the existing caller's allow-list.
+    await admin.createApiKey({
+      key_hash: createHash("sha256")
+        .update(`${CALLER_PLAINTEXT}-stream`)
+        .digest("hex"),
+      allowed_models: ["gr-out-stream-e2e"],
+    });
   });
 
   afterAll(async () => {
     await app?.exit();
     await upstream?.close();
+    await streamUpstream?.close();
   });
 
   test("upstream emits forbidden word → caller sees content_filter 422, NOT the forbidden text", async (ctx) => {
@@ -170,5 +208,108 @@ describe("output guardrail e2e: model-emitted forbidden text is blocked before r
     // failure mode (no upstream call, no token cost), but it would
     // signal the guardrail's hook_point semantics drifted.
     expect(upstream.receivedRequests.length - upstreamHitsBefore).toBe(1);
+  });
+
+  test("streaming output: forbidden text in delta chunks → SSE error event, no [DONE] (#204)", async (ctx) => {
+    if (!etcdReachable || !app || !streamUpstream) {
+      ctx.skip();
+      return;
+    }
+
+    // Per #204: pre-fix the streaming path skipped output guardrails
+    // entirely — `kind: "keyword"` deny-list could be trivially
+    // bypassed by setting `stream: true`. The fix is buffer-then-
+    // check at end-of-stream, emitting an SSE `event: error` frame
+    // and closing without `[DONE]`. We exercise the wire shape
+    // through raw `fetch` (the OpenAI Node SDK abstracts SSE so
+    // direct byte-level inspection isn't possible through it).
+    const streamCallerPlaintext = `${CALLER_PLAINTEXT}-stream`;
+
+    // Wait for the streaming Model + caller key to propagate. A
+    // 200 with no error event means the guardrail isn't loaded yet
+    // (we'd see the forbidden literal reach the wire and a clean
+    // `[DONE]`); keep polling until we observe the block.
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${streamCallerPlaintext}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "gr-out-stream-e2e",
+            messages: [{ role: "user", content: "ready-probe" }],
+            stream: true,
+          }),
+        });
+        if (probe.status !== 200) {
+          await probe.text();
+          return false;
+        }
+        const text = await probe.text();
+        // Block path confirmed when the wire shows the SSE error
+        // frame AND no `[DONE]` (matching the contract this test
+        // pins below).
+        return text.includes("event: error") && !text.includes("data: [DONE]");
+      } catch {
+        return false;
+      }
+    });
+
+    const upstreamHitsBefore = streamUpstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${streamCallerPlaintext}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gr-out-stream-e2e",
+        messages: [{ role: "user", content: "tell me something" }],
+        stream: true,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const wire = await res.text();
+
+    // Per docs §5 + #204: blocked stream MUST close without `[DONE]`
+    // so SDKs that key off the sentinel detect the truncation.
+    expect(wire).not.toContain("data: [DONE]");
+    // SSE `event: error` MUST appear so SDKs see a failure signal.
+    expect(wire).toContain("event: error");
+
+    // Locate the error frame's data line and verify the OpenAI
+    // envelope shape + content_filter taxonomy + redacted message.
+    const errEventIdx = wire.indexOf("event: error\n");
+    expect(errEventIdx).toBeGreaterThanOrEqual(0);
+    const afterErr = wire.slice(errEventIdx + "event: error\n".length);
+    const dataLine = afterErr
+      .split("\n")
+      .find((l: string) => l.startsWith("data: "));
+    expect(dataLine).toBeDefined();
+    const jsonPayload = dataLine!.slice("data: ".length);
+    const parsed = JSON.parse(jsonPayload) as {
+      error?: { type?: unknown; message?: unknown };
+    };
+    expect(parsed.error?.type).toBe("content_filter");
+    expect(parsed.error?.message).toBe("response blocked by content policy");
+
+    // Per #153 (mirrored to streaming): the matched literal MUST NOT
+    // appear in the error envelope. (The pre-emitted `data: ...`
+    // chunks DO carry the partial content — that's the documented
+    // trade-off of buffer-then-check; the security guarantee is the
+    // error event + missing `[DONE]`, not byte-perfect prevention
+    // of all leakage.)
+    expect(jsonPayload).not.toContain(FORBIDDEN_WORD);
+
+    // Output guardrails run AFTER the upstream — the streaming
+    // upstream IS hit so the buffer-then-check has content to
+    // evaluate. A regression that short-circuited pre-dispatch
+    // (skipping streaming entirely, the pre-#204 behavior) would
+    // also fail this assertion since the upstream count wouldn't
+    // move.
+    expect(streamUpstream.receivedRequests.length - upstreamHitsBefore).toBeGreaterThan(0);
   });
 });

--- a/tests/e2e/src/cases/guardrail-output-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-output-e2e.test.ts
@@ -312,4 +312,98 @@ describe("output guardrail e2e: model-emitted forbidden text is blocked before r
     // move.
     expect(streamUpstream.receivedRequests.length - upstreamHitsBefore).toBeGreaterThan(0);
   });
+
+  test("streaming Allow path: clean content streams to caller with [DONE], no error event (#204 audit M3)", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    // Per #204 audit M3: a regression that ALWAYS blocks streaming
+    // (e.g. an off-by-one `errored = true` after the guardrail
+    // check) would not fail the existing block-case test. The
+    // Allow companion below pins that the gate opens cleanly when
+    // the assistant content does NOT contain a forbidden literal:
+    // full content reaches the caller, terminal `[DONE]` appears,
+    // and there is no SSE error frame.
+    const cleanUpstream = await startOpenAiUpstream({
+      streamEvents: [
+        '{"id":"strm-clean","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+        // Distinct phrase that does NOT contain FORBIDDEN_WORD —
+        // guardrail must Allow.
+        '{"id":"strm-clean","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"hello world clean response"},"finish_reason":null}]}',
+        '{"id":"strm-clean","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+        "[DONE]",
+      ],
+      eventDelayMs: 50,
+    });
+    const cleanPk = await admin.createProviderKey({
+      display_name: "gr-out-stream-clean-pk",
+      secret: "sk-mock",
+      api_base: `${cleanUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "gr-out-stream-clean-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: cleanPk.id,
+    });
+    const cleanCallerPlaintext = `${CALLER_PLAINTEXT}-stream-clean`;
+    await admin.createApiKey({
+      key_hash: createHash("sha256")
+        .update(cleanCallerPlaintext)
+        .digest("hex"),
+      allowed_models: ["gr-out-stream-clean-e2e"],
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${cleanCallerPlaintext}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "gr-out-stream-clean-e2e",
+            messages: [{ role: "user", content: "ready-probe" }],
+            stream: true,
+          }),
+        });
+        if (probe.status !== 200) {
+          await probe.text();
+          return false;
+        }
+        const text = await probe.text();
+        return text.includes("data: [DONE]") && !text.includes("event: error");
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${cleanCallerPlaintext}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gr-out-stream-clean-e2e",
+        messages: [{ role: "user", content: "say hi" }],
+        stream: true,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const wire = await res.text();
+    // Allow path contracts:
+    expect(wire).toContain("data: [DONE]");
+    expect(wire).not.toContain("event: error");
+    // The full assistant content reaches the wire (proves the
+    // gateway didn't short-circuit pre-dispatch and didn't strip
+    // chunks on the way out).
+    expect(wire).toContain("hello world clean response");
+
+    await cleanUpstream.close();
+  });
 });


### PR DESCRIPTION
Closes #204.

## Problem

Pre-fix the streaming path skipped output guardrails entirely. A `kind: "keyword"` deny-list configured on `hook_point: "output"` fired correctly on non-streaming responses but was trivially bypassable by setting `stream: true` — the gateway forwarded SSE chunks verbatim and never accumulated the assistant text for guardrail evaluation. A forbidden literal in a streamed completion reached the caller untouched.

A security control that only fires when someone forgets to enable a flag isn't a security control. The de-facto reference implementation in this category treats streaming output guardrails as a baseline requirement.

## Fix — buffer-then-check at end-of-stream

`build_sse_stream` now takes an optional `StreamGuardrailContext` and accumulates `chunk.delta.content` into a `String` buffer. After the upstream stream completes cleanly (no upstream error), the gateway calls `chain.check_output(...)` on a synthesized `ChatResponse`. On `Block`:

- Emit SSE `event: error` frame with OpenAI envelope (`error.type: "content_filter"`, redacted `"response blocked by content policy"` message — mirrors #153's non-streaming wire contract)
- Suppress terminal `[DONE]` so SDK consumers detect the truncation (per docs §5)
- `tracing::warn!` with the rich verdict reason (operator-side carries matched detail; wire-side does not)
- Mark `comp.guardrail_blocked = true` so post-stream telemetry records the block

```rust
if let aisix_guardrails::GuardrailVerdict::Block { reason } =
    ctx.chain.check_output(&synthesized).await
{
    tracing::warn!(guardrail_hook = "output", model = %ctx.model_name,
                   reason = %reason, "guardrail blocked streaming response");
    errored = true;
    guard.comp().guardrail_blocked = true;
    yield Ok::<_, Infallible>(
        Event::default().event("error").data(error_frame_payload(
            "content_filter",
            "response blocked by content policy",
        )),
    );
}
```

## Why buffer-then-check vs per-chunk

Per-chunk evaluation is wrong for **blocking** guardrails: by the time chunk N matches the forbidden literal, chunks 1..N-1 have already been emitted — the secret leaks regardless. Buffer-then-check trades latency-to-first-completion for the security guarantee.

Streaming masking-style guardrails (where partial leakage is repaired by rewriting tokens, e.g. PII redaction) could use a different cadence; that's a v2 concern, not in scope here. The `kind: "keyword"` deny-list use case in #204 is the blocking variant.

## Trade-off — partial leakage of the chunks BEFORE the block fires

The pre-emitted `data: ...` chunks (chunks 1..N) DO carry the partial assistant content to the caller before the buffer-then-check completes. The security guarantee is "the stream did NOT close cleanly, AND an SSE `event: error` frame surfaces the block" — not "byte-perfect prevention of all leakage". Preventing every single byte from reaching the wire would require holding ALL chunks server-side until the check fires, which negates streaming's latency-to-first-token benefit.

This trade-off matches the de-facto reference implementation's approach for buffer-then-check guardrails.

## Tests

**Rust unit (`crates/aisix-proxy/src/lib.rs`)** — `streaming_output_guardrail_blocks_with_sse_error_event_and_no_done`:
- Drains raw response bytes through the full proxy stack
- Asserts `!wire.contains("data: [DONE]")` — terminal sentinel suppressed
- Asserts `wire.contains("event: error")` — error frame emitted
- Asserts error-frame data parses as JSON with `error.type === "content_filter"`
- Asserts error message equals the redacted static string
- Asserts error message does NOT contain the matched literal

**E2E (`tests/e2e/src/cases/guardrail-output-e2e.test.ts`)** — added streaming case to the existing describe. Separate streaming upstream + Model + caller key sharing the env-wide guardrail policy. Raw `fetch` with `stream: true`. Asserts the wire-level shape end-to-end.

## Verification

- `cargo test -p aisix-proxy --lib`: **158/158 passing**
- `cargo test -p aisix-guardrails --lib`: **42/42 passing**
- `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## Audit follow-ups (commit b799761)

Independent audit on initial push surfaced 1 HIGH + 3 MEDIUM + 2 LOW. Resolved as follows:

- **HIGH-1 → fixed**: output `Bypass` verdict at end-of-stream was silently dropped from telemetry. Added `bypass_reason: String` field to `StreamCompletion`; on Bypass arm, capture with first-bypass-wins semantics (matches non-streaming convention). The on_complete closure merges with the input-side `bypass_reason_for_telem` snapshot before emitting telemetry.

- **MEDIUM-2 → fixed**: no fast-path skip when the guardrail chain is empty. Added `is_empty(&self) -> bool` default-method to `Guardrail` trait (returns `false` — safe default for custom impls); `GuardrailChain` overrides. Streaming call site now passes `Some(StreamGuardrailContext)` only when `!state.guardrails.is_empty()`; guardrail-free deployments skip both per-chunk content accumulation and the post-loop synthesized-`ChatResponse` build.

- **MEDIUM-3 → fixed**: e2e didn't cover the streaming-Allow path. Added a companion case in `guardrail-output-e2e.test.ts` with a separate clean upstream + Model + caller emitting content NOT containing `FORBIDDEN_WORD`. Asserts terminal `[DONE]` IS present, no `event: error`, full assistant content reaches the wire. A regression that ALWAYS blocks would have passed the existing block-case test alone — this companion catches it.

- **MEDIUM-1 (client-disconnect bypasses guardrail check) → filed as #223**: the post-loop check sits after `while let Some(item) = upstream.next().await`; client disconnect drops the generator at the last yield suspension, so the post-loop code never runs and `comp.guardrail_blocked` stays `false` even when the buffered content would have blocked. Telemetry under-counts disconnect-as-block. Out of scope for this PR (already a step forward vs the pre-fix "every streaming request bypasses the guardrail"). The recommended fix shape is to spawn a detached task from the `CompleteOnDrop` Drop impl — tracked as a separate change because it requires async-from-Drop scaffolding that isn't in this PR.

- **LOW-1 (cosmetic — `model_name` field used only in tracing line) → deferred**: current shape is fine.
- **LOW-2 (cosmetic — `ChatMessage::assistant(content.clone())` clones) → deferred**: gated behind the is_empty() fast-path now (M2 fix), so the clone only happens on guardrail-active deployments where the cost is negligible vs upstream I/O.

## References

- Issue: #204 (`bug` + `vulnerability`)
- Follow-up: #223 (disconnect-bypass telemetry gap)
- `docs/api-proxy.md` §5 (abnormal-termination contract — reused for guardrail block shape)
- #153 (non-streaming guardrail redaction — same wire-level contract mirrored to streaming)
- #198 (`error_frame_payload` helper — reused here)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Content guardrails now properly block harmful content in streaming responses (previously bypassed for stream mode).
  * Blocked streaming responses return a proper error message instead of incomplete content.
  * Telemetry correctly reports when streaming requests are blocked by guardrails.

* **Tests**
  * Added comprehensive test coverage for streaming content guardrail behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/222)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
