### PR TITLE
test(e2e): #212 OpenAI-only e2e on /v1/rerank + /v1/images/generations + #207 docstring

### DIFF
--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -46,8 +46,11 @@ fn default_base(provider_prefix: &str) -> Option<&'static str> {
     }
 }
 
-/// `true` if `seg` looks like an api-version path component
-/// (`v0`, `v1`, `v2alpha` is rejected — strictly `v\d+`).
+/// `true` if `seg` is a strict api-version path component matching
+/// `v\d+`: `v1`, `v2`, `v10` are accepted; `v2alpha`, `V1`, `v`,
+/// non-ASCII digits are rejected. Used by [`strip_redundant_version_segment`]
+/// to decide whether to dedup the leading version of `rest` against
+/// the trailing version of `api_base`.
 fn is_api_version_segment(seg: &str) -> bool {
     seg.starts_with('v') && seg.len() > 1 && seg[1..].chars().all(|c| c.is_ascii_digit())
 }

--- a/tests/e2e/src/cases/images-generations-e2e.test.ts
+++ b/tests/e2e/src/cases/images-generations-e2e.test.ts
@@ -173,4 +173,87 @@ describe("images generations e2e: /v1/images/generations verbatim forward + mode
     expect(sentBody.size).toBe(requestPayload.size);
     expect(sentBody.response_format).toBe(requestPayload.response_format);
   });
+
+  test("non-OpenAI provider returns 400 invalid_request_error, upstream untouched (#212 / docs §4.9)", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // Per docs §4.9 + #168 (closed by #211): /v1/images/generations
+    // only works with OpenAI providers; non-OpenAI Models reject at
+    // the gateway boundary with 400. Pre-#211 the gateway dispatched
+    // silently and the upstream returned 404 (Anthropic has no image
+    // API; Gemini's image generation uses a different URL + body
+    // shape; DeepSeek doesn't expose image generation). #212 covers
+    // the e2e gap on this contract.
+    const nonOaPk = await admin.createProviderKey({
+      display_name: "img-anthropic-pk",
+      secret: "sk-ant-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "img-anthropic",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: nonOaPk.id,
+    });
+    const nonOaCaller = `${CALLER_PLAINTEXT}-non-oa`;
+    await admin.createApiKey({
+      key_hash: createHash("sha256").update(nonOaCaller).digest("hex"),
+      allowed_models: ["img-anthropic"],
+    });
+
+    const headers = {
+      authorization: `Bearer ${nonOaCaller}`,
+      "content-type": "application/json",
+    };
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/v1/images/generations`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            model: "img-anthropic",
+            prompt: "ready-probe",
+          }),
+        });
+        if (r.status !== 400) {
+          await r.text();
+          return false;
+        }
+        const j = (await r.json()) as { error?: { type?: unknown } };
+        return j.error?.type === "invalid_request_error";
+      } catch {
+        return false;
+      }
+    });
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/images/generations`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "img-anthropic",
+        prompt: "A sunset over mountains",
+        n: 1,
+        size: "1024x1024",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error?: { type?: unknown; message?: unknown };
+    };
+    expect(body.error?.type).toBe("invalid_request_error");
+    // Per #168/#211: rejection message names the OpenAI-only
+    // restriction. "requires OpenAI" is the stable marker.
+    expect(typeof body.error?.message).toBe("string");
+    expect(body.error?.message as string).toMatch(/requires OpenAI/i);
+
+    // Hard contract: upstream must NEVER be hit when the gateway
+    // refuses for provider mismatch.
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+  });
 });

--- a/tests/e2e/src/cases/rerank-e2e.test.ts
+++ b/tests/e2e/src/cases/rerank-e2e.test.ts
@@ -191,4 +191,98 @@ describe("rerank e2e: /v1/rerank verbatim forward + model translation", () => {
     expect(sentBody.documents).toEqual(requestPayload.documents);
     expect(sentBody.top_n).toBe(requestPayload.top_n);
   });
+
+  test("non-OpenAI provider returns 400 invalid_request_error, upstream untouched (#212 / docs §4.7)", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // Per docs §4.7 + #168 (closed by #211): /v1/rerank only works
+    // with OpenAI providers; non-OpenAI Models reject at the gateway
+    // boundary with 400. Pre-#211 the gateway dispatched silently
+    // and the upstream returned 404 (Anthropic / DeepSeek have no
+    // rerank API; Gemini's OpenAI-compat surface doesn't expose
+    // /v1/rerank). #212 covers the e2e gap on this contract.
+    const nonOaPk = await admin.createProviderKey({
+      display_name: "rerank-anthropic-pk",
+      secret: "sk-ant-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "rerank-anthropic",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: nonOaPk.id,
+    });
+    const nonOaCaller = `${CALLER_PLAINTEXT}-non-oa`;
+    await admin.createApiKey({
+      key_hash: createHash("sha256").update(nonOaCaller).digest("hex"),
+      allowed_models: ["rerank-anthropic"],
+    });
+
+    const headers = {
+      authorization: `Bearer ${nonOaCaller}`,
+      "content-type": "application/json",
+    };
+
+    // Readiness gate: poll until the gateway returns the documented
+    // 400 with `error.type: "invalid_request_error"` per docs §2
+    // status→type table. A 404 here would be the snapshot-lag
+    // "model_not_found" case (which is mapped to 404, NOT 400);
+    // probing on 400 + invalid_request_error gates on the model
+    // resolving AND the gateway refusing per §4.7.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/v1/rerank`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            model: "rerank-anthropic",
+            query: "ready-probe",
+            documents: ["doc"],
+          }),
+        });
+        if (r.status !== 400) {
+          await r.text();
+          return false;
+        }
+        const j = (await r.json()) as { error?: { type?: unknown } };
+        return j.error?.type === "invalid_request_error";
+      } catch {
+        return false;
+      }
+    });
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/rerank`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "rerank-anthropic",
+        query: "search",
+        documents: ["doc1", "doc2"],
+      }),
+    });
+
+    // Per docs §4.7: non-OpenAI providers return 400. 5xx would mean
+    // the gateway crashed; 404 would mean snapshot-lag (caught by
+    // the readiness gate above).
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error?: { type?: unknown; message?: unknown };
+    };
+    expect(body.error?.type).toBe("invalid_request_error");
+    // Per #168/#211 wording: the rejection message names the
+    // OpenAI-only restriction. The "requires OpenAI" substring is
+    // a stable marker (vs the OpenAI taxonomy enum string, which
+    // a generic invalid-request failure would also carry).
+    expect(typeof body.error?.message).toBe("string");
+    expect(body.error?.message as string).toMatch(/requires OpenAI/i);
+
+    // Hard contract: upstream must NEVER be hit when the gateway
+    // refuses for provider mismatch — otherwise the gateway is
+    // billing the caller's quota on a request it claims to reject.
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+  });
 });


### PR DESCRIPTION
Closes #212. Closes #207 (L1 docstring fix; M2 e2e deferred — see below).

## #212 — e2e coverage of the OpenAI-only restriction

PR #211 (closed #168) added a gateway-side 400 rejection on `/v1/rerank`, `/v1/images/generations`, and `/v1/responses` when a non-OpenAI Model is configured. Rust unit tests pinned the rejection at the function level but the user-visible contract had no e2e until now.

Added e2e cases:

- **`tests/e2e/src/cases/rerank-e2e.test.ts`**: `non-OpenAI provider returns 400 invalid_request_error, upstream untouched (#212 / docs §4.7)`. Configures an Anthropic Model on /v1/rerank, asserts:
  - 400 status with `error.type: "invalid_request_error"` per docs §2 status→type table
  - `error.message` matches `/requires OpenAI/i` — the #168/#211 rejection-message marker (stable substring; broader than asserting the entire OpenAI-error-taxonomy enum, narrower than just `error.type`)
  - upstream NOT hit (proves gateway-side refusal, not dispatch-then-upstream-404)

- **`tests/e2e/src/cases/images-generations-e2e.test.ts`**: same shape for /v1/images/generations.

- **`/v1/responses`**: already covered by `tests/e2e/src/cases/responses-endpoint-e2e.test.ts`'s parameterized non-OpenAI matrix (anthropic / gemini / deepseek) — closes the precedent gap mentioned in #212 with no additional change needed here.

With the rerank + images additions, #212 is closed across all three endpoints.

## #207 — passthrough docstring grammar (L1)

`crates/aisix-proxy/src/passthrough.rs::is_api_version_segment` had a docstring that parsed as "v0, v1, v2alpha is rejected" (wrong — v0 and v1 are accepted). Rewrote to:

```rust
/// `true` if `seg` is a strict api-version path component matching
/// `v\d+`: `v1`, `v2`, `v10` are accepted; `v2alpha`, `V1`, `v`,
/// non-ASCII digits are rejected. Used by [`strip_redundant_version_segment`]
/// to decide whether to dedup the leading version of `rest` against
/// the trailing version of `api_base`.
fn is_api_version_segment(seg: &str) -> bool {
```

## #207 — M2 deferral

The companion M2 finding from #207 — black-box e2e covering the trailing-`/v1`-as-real-segment property (`rest = v1/files/v1/foo` against `api_base = .../v1` should reach upstream at `/v1/files/v1/foo`, NOT `/v1/foo`) — is **deferred**:

- The property is already pinned by the Rust unit `strip_redundant_version_segment_only_strips_leading_match` (passthrough.rs).
- The reference implementation in this category does not have any version-prefix dedup at all (it concatenates naively + relies on operator convention) — so api7/ai-gateway's dedup is strict-superset defensive behavior, not a regression risk that needs e2e reinforcement.
- A black-box e2e for the trailing-/v1 case would require harness-level support for arbitrary-path mock upstreams (today's `startOpenAiUpstream` mock matches specific paths). The cost-to-benefit doesn't justify a harness extension for a LOW-priority reinforcement.

If the dedup helper grows additional behaviors later (e.g. handling `/v2`-vs-`/v1`-mismatch differently, or supporting non-version segments), the e2e gap should be revisited.

## Verification

- `cargo test -p aisix-proxy --lib passthrough`: **11/11 passing** (existing dedup unit tests still pin the helper's contract)
- `cargo clippy -p aisix-proxy --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## References

- #207 (passthrough dedup follow-ups — L1 fixed, M2 deferred)
- #212 (e2e coverage of OpenAI-only restriction — closed across all three endpoints)
- #168 / #211 (the underlying OpenAI-only restriction)
- `docs/api-proxy.md` §4.7 (rerank), §4.9 (images), §4.6 (responses)
