### PR TITLE
docs(api-admin): clarify budget enforcement is SaaS-only

### DIFF
--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -175,13 +175,49 @@ curl -X POST http://localhost:3001/admin/v1/provider_keys \
 
 ### 4.4 Budgets
 
-Per-ApiKey USD spend caps live inline on the ApiKey resource
-(`max_budget_usd` field) — there is no separate `/admin/v1/budgets`
-collection. The proxy reads the budget at request start (pre-check)
-and adds the cost at end of request.
+Per-ApiKey USD spend caps are expressed via `max_budget_usd` on the
+ApiKey resource — there is no separate `/admin/v1/budgets`
+collection. **Enforcement is a SaaS-tier feature**: the data-plane
+proxy never reads `max_budget_usd` from the etcd snapshot. The
+field is populated by the SaaS control plane for parity with its
+own `api_keys` table and is informational on the DP side.
 
-Team-level budgets are a SaaS-tier feature; standalone deployments
-do per-key budgeting only.
+#### SaaS / Managed mode
+
+Two flows run in parallel between the DP and cp-api:
+
+- **Pre-check (pull)** — every request triggers
+  `BudgetClient::check` (`crates/aisix-proxy/src/budget.rs`), which
+  calls cp-api over mTLS at `GET /dp/budget_check?api_key_id=<uuid>`
+  with a 5 s LRU cache per api_key. `allow=false` becomes a 429
+  `BudgetExceeded` before upstream dispatch.
+- **Usage push** — each completion enqueues a `UsageEvent`; a
+  worker (`crates/aisix-server/src/telemetry.rs`) batches up to
+  100 events or flushes every 5 s and POSTs them to
+  `/dp/telemetry`. cp-api consumes this stream to update the
+  authoritative spend, which feeds subsequent budget-check calls.
+
+Worst-case propagation between an over-cap completion and a
+follow-up 429 is therefore ≈ 10 s (5 s telemetry flush + 5 s
+budget-check cache). When cp-api is unreachable, the last good
+decision sticks for up to `AISIX_DP_BUDGET_STALE_MAX_SECONDS`
+(default 600 s); past that the proxy applies the `fail_mode`
+(`open` / `closed` / `sticky`) the most recent successful response
+carried.
+
+Because spend lives on cp-api, multiple DP instances behind the
+same cp-api stay consistent without DP-side coordination.
+
+#### Standalone mode
+
+Budget enforcement is **not implemented**. The admin API still
+accepts `max_budget_usd` on POST/PUT (the field passes through
+schema validation and persists to etcd) so the wire shape stays
+compatible with managed mode, but no part of the proxy reads it.
+Operators who need per-key spend caps must run in managed mode.
+
+Team-level budgets are SaaS-tier (cp-api owns cross-key
+aggregation) and have no standalone counterpart.
 
 ### 4.5 Health — `GET /admin/v1/health`
 

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -138,6 +138,9 @@ curl -X POST http://localhost:3001/admin/v1/apikeys \
   }'
 ```
 
+> `max_budget_usd` is enforced only in SaaS / managed mode. See
+> §4.4 for the standalone caveat and the SaaS propagation model.
+
 The `/rotate` endpoint replaces the stored hash and returns the new
 plaintext directly, so the operator does not need to compute the
 hash themselves on rotation:
@@ -191,11 +194,16 @@ Two flows run in parallel between the DP and cp-api:
   calls cp-api over mTLS at `GET /dp/budget_check?api_key_id=<uuid>`
   with a 5 s LRU cache per api_key. `allow=false` becomes a 429
   `BudgetExceeded` before upstream dispatch.
-- **Usage push** — each completion enqueues a `UsageEvent`; a
-  worker (`crates/aisix-server/src/telemetry.rs`) batches up to
-  100 events or flushes every 5 s and POSTs them to
-  `/dp/telemetry`. cp-api consumes this stream to update the
-  authoritative spend, which feeds subsequent budget-check calls.
+- **Usage push** — each `/v1/chat/completions` and `/v1/messages`
+  request enqueues a `UsageEvent`; a worker
+  (`crates/aisix-server/src/telemetry.rs`) batches up to 100
+  events or flushes every 5 s and POSTs them to `/dp/telemetry`.
+  cp-api consumes this stream to update the authoritative spend,
+  which feeds subsequent budget-check calls. **`/v1/responses`,
+  `/v1/embeddings`, `/v1/audio*`, `/v1/images*`, and `/v1/rerank`
+  do not emit usage events today** (see the comment in
+  `crates/aisix-proxy/src/chat.rs`), so spend on those endpoints
+  is not yet reflected in cp-api's ledger — tracked as #226.
 
 Worst-case propagation between an over-cap completion and a
 follow-up 429 is therefore ≈ 10 s (5 s telemetry flush + 5 s


### PR DESCRIPTION
## Summary

The §4.4 \`Budgets\` prose previously said "the proxy reads the
budget at request start and adds the cost at end of request" —
true in neither mode:

- **Standalone**: the proxy never reads \`max_budget_usd\` from the
  etcd snapshot at all (\`grep -rn 'max_budget' crates/aisix-proxy/\`
  → 0 non-test matches).
- **SaaS / Managed**: the DP doesn't compute cost or accumulate
  spend; cp-api owns both. The DP only **calls** cp-api
  (\`/dp/budget_check\`) and **pushes** usage to it
  (\`/dp/telemetry\`) — and only for chat-completion and Anthropic
  messages traffic.

Architectural review confirmed budget is a SaaS-tier feature: cp-api
is the single source of truth, multiple DP instances stay
consistent without DP-side coordination, and the DP avoids
duplicating cp-api's pricing/accumulation logic.

This PR rewrites §4.4 to describe what actually happens in each
mode, with concrete file paths, cache TTLs, batch sizes, and
worst-case propagation latency. No code changes.

## Changes

- §4.4 §"SaaS / Managed mode": describe the pull
  (\`/dp/budget_check\`, 5 s LRU cache) + push (\`/dp/telemetry\`,
  5 s / 100-event batches) flows; pin worst-case ≈ 10 s
  propagation; document the cp-api-unreachable fall-back ladder
  (\`AISIX_DP_BUDGET_STALE_MAX_SECONDS\` → \`fail_mode\`).
- §4.4 "Usage push" bullet — pin the two endpoints that emit
  UsageEvents today (\`/v1/chat/completions\`, \`/v1/messages\`)
  and explicitly list the five that don't; cross-reference #226.
- §4.4 §"Standalone mode": state plainly that enforcement is not
  implemented; explain why the admin schema still accepts the
  field (SaaS CP writes ApiKey rows including this field directly
  into etcd, so the wire shape must stay compatible).
- §4.2 — one-line caveat under the apikey example so a reader
  landing on §4.2 alone sees max_budget_usd is SaaS-only and is
  pointed at §4.4.

## Audit history

PR went through one round of independent audit (general-purpose
agent, no shared context). Findings:

- **MEDIUM** — "each completion enqueues a UsageEvent"
  overgeneralized; only chat completions + Anthropic messages
  emit. **Fixed in d1b4379** by pinning the two emitting
  endpoints and explicitly listing the five that don't.
- **LOW** — §4.2 example sets \`max_budget_usd: 500.0\` with no
  caveat. **Fixed in d1b4379** by adding a cross-reference note.
- **LOW** — "stay consistent" → "stay eventually consistent
  within the 5 s cache window". Folded into the prose during the
  fix.

Audit also surfaced a real product gap (not introduced by this
PR): non-chat endpoints don't push usage to cp-api, so SaaS
budgets undercount spend on embeddings/audio/images/responses/
rerank traffic. Filed as **#226** (HIGH for SaaS budget
correctness and billing accuracy) and linked from §4.4.

## Closes

- #189 — wontfix, by design. The DP intentionally doesn't track
  spend locally (avoids cross-DP coordination, avoids duplicating
  cp-api's pricing logic).
- #190 — depends on #189. Tightening the schema's lower bound has
  no practical effect while the field is unenforced DP-side.

## Test plan

- [x] No code changes — \`cargo test\` not affected.
- [ ] CI green (markdown-only change; lint should pass trivially).
- [ ] Reviewer reads the new §4.4 against \`crates/aisix-proxy/src/budget.rs\`,
  \`crates/aisix-server/src/telemetry.rs\`, and \`crates/aisix-proxy/src/chat.rs:977-980\`
  to confirm cache TTL, batch size, fail-mode, and emitting-endpoints
  match the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Admin API docs for budget management, clarifying per-API-key USD budget caps and that enforcement applies only in SaaS/managed mode.
  * Described enforcement workflow in SaaS/managed deployments: pre-checks, batched usage reporting, propagation timing, and stale/ fail-mode behavior during connectivity issues.
  * Noted Standalone mode accepts budget fields for compatibility but does not enforce them.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/225)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->