### PR TITLE
feat(rerank): Cohere provider support on /v1/rerank (#213 Phase 1)

### DIFF
--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -25,6 +25,10 @@ pub enum Provider {
     Anthropic,
     Gemini,
     Deepseek,
+    /// Cohere — currently exposed for `/v1/rerank` only (#213 Phase 1).
+    /// Cohere's chat / generate APIs are not OpenAI-compatible; a
+    /// future bridge implementation can extend coverage.
+    Cohere,
 }
 
 impl Provider {
@@ -34,6 +38,7 @@ impl Provider {
             Self::Anthropic => "https://api.anthropic.com",
             Self::Gemini => "https://generativelanguage.googleapis.com/v1beta/openai",
             Self::Deepseek => "https://api.deepseek.com",
+            Self::Cohere => "https://api.cohere.com",
         }
     }
 
@@ -43,6 +48,7 @@ impl Provider {
             Self::Anthropic => "anthropic",
             Self::Gemini => "gemini",
             Self::Deepseek => "deepseek",
+            Self::Cohere => "cohere",
         }
     }
 }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -109,7 +109,7 @@ fn model_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "display_name":    { "type": "string", "minLength": 1 },
-            "provider":        { "type": "string", "enum": ["openai","anthropic","gemini","deepseek"] },
+            "provider":        { "type": "string", "enum": ["openai","anthropic","gemini","deepseek","cohere"] },
             "model_name":      { "type": "string", "minLength": 1 },
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -36,6 +36,14 @@ use crate::error::ProxyError;
 use crate::state::ProxyState;
 
 /// Provider defaults indexed by provider-prefix string.
+///
+/// NOTE: `"cohere"` is intentionally absent. #213 Phase 1 ships
+/// Cohere on `/v1/rerank` only; passthrough support is out of
+/// scope. Operators using `/passthrough/cohere/*` with a
+/// `provider: "cohere"` Model must set `api_base` explicitly on
+/// the ProviderKey. The fallback emits a 400
+/// `InvalidRequest("no api_base configured for provider 'cohere' and no default known")`
+/// — graceful, not a crash. Tracked alongside #213's later phases.
 fn default_base(provider_prefix: &str) -> Option<&'static str> {
     match provider_prefix {
         "openai" => Some("https://api.openai.com"),

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -109,18 +109,24 @@ async fn dispatch(
 
     let model = &model_entry.value;
 
-    // Per #168: only OpenAI's API exposes the documented `/v1/rerank`
-    // route + body shape. Anthropic has no rerank API; Gemini's
-    // OpenAI-compat surface does not implement `/v1/rerank`;
-    // DeepSeek's does not either. Routing a non-OpenAI Model here
-    // would silently dispatch to an upstream that 404s — a confusing
-    // failure for callers who follow `docs/api-proxy.md` §4.7
-    // configuration verbatim. Reject explicitly with 400 (parallel
-    // to /v1/responses §4.6) so the configuration error is visible
-    // at the gateway boundary rather than masked by an upstream 404.
-    if model.provider != Some(aisix_core::models::Provider::Openai) {
+    // Per #168 + #213 Phase 1: `/v1/rerank` accepts OpenAI- and
+    // Cohere-shape upstreams. Both speak the same body shape
+    // (`{model, query, documents, top_n, ...}`) at `…/v1/rerank`
+    // with `Authorization: Bearer …` auth, so the gateway can
+    // forward verbatim with only the `model` field rewritten.
+    // Anthropic, Gemini, and DeepSeek do not expose this surface —
+    // routing a Model with one of those providers here would
+    // silently 404 upstream, so reject explicitly at the gateway
+    // boundary (parallel to `/v1/responses` §4.6's pattern).
+    use aisix_core::models::Provider;
+    let provider_allowed = matches!(
+        model.provider,
+        Some(Provider::Openai) | Some(Provider::Cohere)
+    );
+    if !provider_allowed {
         return Err(ProxyError::InvalidRequest(format!(
-            "model `{model_name}` is not an OpenAI provider; /v1/rerank requires OpenAI"
+            "model `{model_name}` is not an OpenAI or Cohere provider; \
+             /v1/rerank requires OpenAI or Cohere"
         )));
     }
 
@@ -208,6 +214,12 @@ fn default_base_for_provider(provider: aisix_core::models::Provider) -> Option<S
     use aisix_core::models::Provider;
     match provider {
         Provider::Openai => Some("https://api.openai.com".to_string()),
+        // Cohere v1 path (deprecated by Cohere but still functional)
+        // is what the gateway's `build_v1_url` produces from this
+        // base. Operators who want the Cohere v2 path can override
+        // `api_base` to `https://api.cohere.com/v2` — see #213's v2
+        // follow-up for the version-routing extension if needed.
+        Provider::Cohere => Some("https://api.cohere.com".to_string()),
         Provider::Anthropic => None, // Anthropic doesn't expose a rerank API
         Provider::Gemini => None,    // Gemini doesn't expose a rerank API
         Provider::Deepseek => None,
@@ -271,6 +283,14 @@ mod tests {
     fn anthropic_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{"display_name":"{name}","provider":"anthropic","model_name":"claude-3-5-haiku-20241022","provider_key_id":"{PK_ID}"}}"#
+        );
+        let m: Model = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn cohere_model(name: &str) -> ResourceEntry<Model> {
+        let json = format!(
+            r#"{{"display_name":"{name}","provider":"cohere","model_name":"rerank-english-v3.0","provider_key_id":"{PK_ID}"}}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
@@ -392,10 +412,93 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "invalid_request_error");
         let message = v["error"]["message"].as_str().unwrap();
+        // Per #213 Phase 1: Cohere is now also a valid provider for
+        // /v1/rerank, so the rejection message must enumerate BOTH
+        // accepted shapes — `OpenAI or Cohere` — not just OpenAI.
+        // Pin the new wording so a regression that drops Cohere
+        // would fail this assertion.
         assert!(
-            message.contains("requires OpenAI"),
-            "rejection should reference OpenAI restriction; got {message:?}"
+            message.contains("OpenAI or Cohere"),
+            "rejection should reference OpenAI/Cohere restriction; got {message:?}"
         );
+    }
+
+    /// Issue #213 Phase 1: a Model with `provider: "cohere"` MUST
+    /// dispatch successfully on `/v1/rerank` (Cohere natively
+    /// implements the same body shape OpenAI-compat servers use).
+    /// Pre-#213 the gate only accepted OpenAI; this test pins the
+    /// expansion at the unit level.
+    #[tokio::test]
+    async fn cohere_provider_dispatches_to_upstream_with_bearer_auth() {
+        use wiremock::matchers::header;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/rerank"))
+            .and(header("authorization", "Bearer sk-cohere-mock"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "rerank-resp-cohere-01",
+                "results": [
+                    {"index": 1, "relevance_score": 0.95},
+                    {"index": 0, "relevance_score": 0.42},
+                ],
+                "meta": {
+                    "api_version": {"version": "1"},
+                    "billed_units": {"search_units": 1}
+                }
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        // Cohere's API base form: bare host, no /v1 suffix. The
+        // gateway's `build_v1_url` appends /v1/rerank correctly for
+        // both `https://api.cohere.com` and `https://api.cohere.com/v1`.
+        let pk_json = format!(
+            r#"{{"display_name":"cohere-up","secret":"sk-cohere-mock","api_base":"{}"}}"#,
+            upstream.uri()
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();
+        snap.provider_keys.insert(ResourceEntry::new(PK_ID, pk, 1));
+        snap.models.insert(cohere_model("cohere-rerank"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "cohere-rerank",
+                "query": "search query",
+                "documents": ["doc one", "doc two"],
+                "top_n": 2
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Cohere provider must dispatch successfully on /v1/rerank per #213 Phase 1"
+        );
+
+        // Verify the upstream-side body: model rewritten to the
+        // `model_name` from the Cohere Model entry; everything else
+        // verbatim. wiremock's `matchers::header` already pinned the
+        // Bearer auth on the upstream request matcher.
+        let received = upstream.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1, "exactly one upstream call expected");
+        let upstream_body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("upstream body is valid JSON");
+        assert_eq!(
+            upstream_body["model"], "rerank-english-v3.0",
+            "model field MUST be rewritten to upstream model_name; got {}",
+            upstream_body["model"]
+        );
+        assert_eq!(upstream_body["query"], "search query");
+        assert_eq!(
+            upstream_body["documents"],
+            serde_json::json!(["doc one", "doc two"])
+        );
+        assert_eq!(upstream_body["top_n"], 2);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -144,18 +144,24 @@ async fn dispatch(
     }
 
     // Build upstream URL. build_v1_url tolerates either base form —
-    // `https://api.cohere.ai` (Cohere convention, no /v1) and
-    // `https://api.openai.com/v1` (OpenAI-SDK convention, with /v1)
-    // both end up at `…/v1/rerank` instead of `…/v1/v1/rerank`.
+    // `https://api.cohere.com` (bare host) and `https://api.openai.com/v1`
+    // (OpenAI-SDK convention, with /v1) both end up at `…/v1/rerank`
+    // instead of `…/v1/v1/rerank`.
+    //
+    // The provider arm of `default_base_for_provider` is guaranteed to
+    // return `Some` here because the gate above already rejected any
+    // `model.provider` outside `{Openai, Cohere}` — both have explicit
+    // arms in the helper. The `unwrap_or_else` is defensive against a
+    // future enum variant that gets through the gate without an arm in
+    // the helper; the audit-trail-friendly default is OpenAI's host
+    // (it's a 4xx-from-OpenAI rather than dispatching to a stale
+    // Cohere legacy domain).
     let base = match pk_entry.value.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
-        _ => {
-            // Derive a sensible default base from the provider.
-            model
-                .provider
-                .and_then(default_base_for_provider)
-                .unwrap_or_else(|| "https://api.cohere.ai".to_string())
-        }
+        _ => model
+            .provider
+            .and_then(default_base_for_provider)
+            .unwrap_or_else(|| "https://api.openai.com".to_string()),
     };
     let url = crate::dispatch::build_v1_url(&base, "/rerank");
 
@@ -499,6 +505,26 @@ mod tests {
             serde_json::json!(["doc one", "doc two"])
         );
         assert_eq!(upstream_body["top_n"], 2);
+
+        // Per #213 audit MEDIUM-2: pin the EXACT field set sent to
+        // Cohere. Cohere's `/v1/rerank` documents `{model, query,
+        // documents, top_n, return_documents, max_chunks_per_doc}`
+        // (https://docs.cohere.com/reference/rerank). The gateway
+        // forwards verbatim — but a future regression that injects
+        // an OpenAI-only field (e.g. `dimensions` from embeddings,
+        // or `stream` from chat) would break Cohere upstream
+        // without failing a "happy path 200" test. Pinning the
+        // exact key set catches that.
+        let upstream_obj = upstream_body
+            .as_object()
+            .expect("upstream body is a JSON object");
+        let mut keys: Vec<&str> = upstream_obj.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["documents", "model", "query", "top_n"],
+            "upstream body must contain ONLY the fields the caller sent (no gateway-injected extras)"
+        );
     }
 
     #[tokio::test]

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -188,13 +188,21 @@ return 400.
 
 ### 4.7 `POST /v1/rerank`
 
-OpenAI-style rerank. Routed to `{base}/v1/rerank`. The Model's
-provider supplies the API key; the request body is forwarded
-verbatim after rewriting the `model` field. **OpenAI Models only —
-non-OpenAI providers return 400** (parallel to §4.6). Anthropic has
-no rerank API; Gemini's and DeepSeek's OpenAI-compat surfaces do
-not implement `/v1/rerank`, so routing to those would silently
-dispatch to an upstream that 404s.
+Cohere-style rerank (also implemented by some OpenAI-compat
+servers under the same body shape). Routed to `{base}/v1/rerank`.
+The Model's provider supplies the API key; the request body is
+forwarded verbatim after rewriting the `model` field.
+
+**Supported providers**: `openai`, `cohere`. Anthropic, Gemini,
+and DeepSeek do not expose a rerank API at this URL — Models with
+those providers return 400 (parallel to §4.6).
+
+For `provider: "cohere"`, the default `api_base` is
+`https://api.cohere.com`, which the gateway expands to
+`https://api.cohere.com/v1/rerank` upstream. Cohere's body shape
+(`{model, query, documents, top_n, ...}`) and Bearer-auth
+convention are identical to the OpenAI-compat shape, so the
+gateway forwards verbatim with no transform.
 
 ### 4.8 `POST /v1/audio/transcriptions` / `translations` / `speech`
 

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -204,6 +204,17 @@ For `provider: "cohere"`, the default `api_base` is
 convention are identical to the OpenAI-compat shape, so the
 gateway forwards verbatim with no transform.
 
+> **Cohere v1 → v2 migration**: Cohere has deprecated its v1
+> endpoints in favour of v2 (`/v2/rerank`); v1 still functions
+> today but operators should plan for the migration. Operators
+> wanting v2 should track the gateway's version-routing
+> follow-up (set under #213's later phases) — direct override
+> via `api_base: "https://api.cohere.com/v2"` does not work
+> with the gateway's current `build_v1_url` helper because it
+> would produce `…/v2/v1/rerank`. Cohere's v2 body shape also
+> differs (e.g. `documents` no longer accepts the object form),
+> so a future v2 path will need a small request-body adapter.
+
 ### 4.8 `POST /v1/audio/transcriptions` / `translations` / `speech`
 
 Multipart file upload + JSON pass-through. `audio/speech` returns a

--- a/tests/e2e/src/cases/rerank-e2e.test.ts
+++ b/tests/e2e/src/cases/rerank-e2e.test.ts
@@ -24,12 +24,21 @@ import {
 // Without e2e coverage, regressions on this path would silently
 // corrupt RAG quality.
 //
-// One user journey pinned:
+// User journeys pinned:
 //
-//   - Caller POSTs Cohere-shape rerank request to /v1/rerank.
-//     Gateway forwards verbatim to upstream's /v1/rerank with only
-//     the `model` field rewritten to the upstream model_name.
-//     Caller receives upstream's response back unchanged.
+//   1. OpenAI provider — caller POSTs Cohere-shape rerank request
+//      to /v1/rerank against an OpenAI-provider Model. Gateway
+//      forwards verbatim to upstream's /v1/rerank with only the
+//      `model` field rewritten.
+//   2. Cohere provider (#213 Phase 1) — caller POSTs against a
+//      Cohere-provider Model. Gateway dispatches to Cohere's
+//      `/v1/rerank` (or any operator-configured api_base) with
+//      Bearer auth + the rewritten model. Cohere natively
+//      implements this exact body shape, so the gateway forwards
+//      verbatim with no transform.
+//   3. Non-{OpenAI, Cohere} provider — gateway rejects at the
+//      boundary with 400 + `error.type: "invalid_request_error"`,
+//      upstream NOT hit (#212 / #168).
 //
 // References:
 // - Gateway's own /v1/rerank contract: `docs/api-proxy.md` §4.7
@@ -180,6 +189,115 @@ describe("rerank e2e: /v1/rerank verbatim forward + model translation", () => {
     // rewriting the `model` field. Verify:
     //   - `model` rewritten to upstream model_name
     //   - everything else byte-for-byte (query, documents, top_n)
+    const sentBody = JSON.parse(testCalls[0]!.body) as {
+      model?: string;
+      query?: string;
+      documents?: string[];
+      top_n?: number;
+    };
+    expect(sentBody.model).toBe("rerank-english-v3.0");
+    expect(sentBody.query).toBe(requestPayload.query);
+    expect(sentBody.documents).toEqual(requestPayload.documents);
+    expect(sentBody.top_n).toBe(requestPayload.top_n);
+  });
+
+  test("Cohere provider: gateway dispatches with Bearer auth + rewritten model (#213 Phase 1)", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // Per #213 Phase 1: a Model with `provider: "cohere"` is now a
+    // valid configuration on /v1/rerank (parallel to OpenAI). Cohere
+    // natively implements the same body shape (`{model, query,
+    // documents, top_n}`) at `…/v1/rerank` with `Authorization:
+    // Bearer <key>` auth, so the gateway forwards verbatim with the
+    // `model` field rewritten — no transform required.
+    const cohereSecret = "sk-cohere-mock-e2e";
+    const coherePk = await admin.createProviderKey({
+      display_name: "rerank-cohere-pk",
+      secret: cohereSecret,
+      // Operator can also set this to `https://api.cohere.com`; the
+      // gateway's `build_v1_url` produces `…/v1/rerank` from either
+      // form.
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "rerank-cohere",
+      provider: "cohere",
+      model_name: "rerank-english-v3.0",
+      provider_key_id: coherePk.id,
+    });
+    const cohereCallerPlaintext = `${CALLER_PLAINTEXT}-cohere`;
+    await admin.createApiKey({
+      key_hash: createHash("sha256")
+        .update(cohereCallerPlaintext)
+        .digest("hex"),
+      allowed_models: ["rerank-cohere"],
+    });
+
+    const headers = {
+      authorization: `Bearer ${cohereCallerPlaintext}`,
+      "content-type": "application/json",
+    };
+
+    // Readiness gate: poll /v1/rerank with the Cohere Model until
+    // the gateway returns 200 (Cohere is now allowed). A 400 here
+    // would mean the gate is still rejecting Cohere (regression);
+    // a 404 would be snapshot-lag.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/v1/rerank`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            model: "rerank-cohere",
+            query: "ready-probe",
+            documents: ["doc"],
+          }),
+        });
+        if (r.status !== 200) {
+          await r.text();
+          return false;
+        }
+        await r.json();
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+    const requestPayload = {
+      model: "rerank-cohere",
+      query: "search query",
+      documents: ["doc one", "doc two", "doc three"],
+      top_n: 2,
+    };
+    const res = await fetch(`${app.proxyUrl}/v1/rerank`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(requestPayload),
+    });
+
+    expect(res.status).toBe(200);
+    await res.json();
+
+    // Upstream wire-shape contract:
+    //   - path is `/v1/rerank`
+    //   - `Authorization: Bearer <Cohere secret>` (NOT the caller's
+    //     plaintext bearer — that would leak the gateway's caller
+    //     credential to the upstream provider)
+    //   - body: `model` rewritten to upstream model_name; everything
+    //     else byte-for-byte
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/rerank");
+    expect(testCalls).toHaveLength(1);
+    expect(testCalls[0]?.method).toBe("POST");
+    expect(testCalls[0]?.headers["authorization"]).toBe(`Bearer ${cohereSecret}`);
+    expect(testCalls[0]?.headers["authorization"]).not.toContain(cohereCallerPlaintext);
+
     const sentBody = JSON.parse(testCalls[0]!.body) as {
       model?: string;
       query?: string;

--- a/tests/e2e/src/cases/rerank-e2e.test.ts
+++ b/tests/e2e/src/cases/rerank-e2e.test.ts
@@ -308,6 +308,21 @@ describe("rerank e2e: /v1/rerank verbatim forward + model translation", () => {
     expect(sentBody.query).toBe(requestPayload.query);
     expect(sentBody.documents).toEqual(requestPayload.documents);
     expect(sentBody.top_n).toBe(requestPayload.top_n);
+
+    // Per #213 audit MEDIUM-2: pin the EXACT field set sent to
+    // Cohere. Cohere's `/v1/rerank` documents
+    // `{model, query, documents, top_n, return_documents, ...}`
+    // — https://docs.cohere.com/reference/rerank. The gateway
+    // forwards verbatim, so the upstream body MUST contain ONLY
+    // the keys the caller sent — no gateway-injected extras.
+    // A future regression that injects an OpenAI-only field
+    // (e.g. `dimensions` from embeddings, `stream` from chat)
+    // would break Cohere without failing a "happy-path 200"
+    // assertion alone.
+    const sentKeys = Object.keys(
+      sentBody as Record<string, unknown>,
+    ).sort();
+    expect(sentKeys).toEqual(["documents", "model", "query", "top_n"]);
   });
 
   test("non-OpenAI provider returns 400 invalid_request_error, upstream untouched (#212 / docs §4.7)", async (ctx) => {


### PR DESCRIPTION
**#213 Phase 1**: expand `/v1/rerank` accepted-provider set from `{OpenAI}` to `{OpenAI, Cohere}`.

## Why

PR #211 (closed #168) restricted `/v1/rerank` to OpenAI providers only as a fail-fast against silent upstream 404s on misconfigured Models. The follow-up triage on #213 flagged this restriction as strictly more conservative than the de-facto reference implementation in this category — Cohere is the canonical non-OpenAI rerank target (most modern RAG pipelines route their rerank step there).

This PR is **Phase 1** of #213: adds Cohere. Phase 2 (Voyage / Jina) and the broader phases (`/v1/images/generations`, `/v1/responses` provider expansion) are out of scope.

## Why no transform crate is needed

Cohere's native `/v1/rerank` (https://docs.cohere.com/reference/rerank) implements the same wire shape the gateway forwards verbatim today:

```
POST {base}/v1/rerank
Authorization: Bearer <api_key>
Content-Type: application/json
{"model": "...", "query": "...", "documents": [...], "top_n": N}
```

Auth header, path, and body shape all match. The only gateway-side translation is the existing `model` field rewrite (display name → upstream model_name), which the rerank handler already does for OpenAI.

So Phase 1 is **"relax the provider check + add a default api_base"**, not "build a new bridge crate." A dedicated `aisix-provider-cohere` bridge will be needed if/when Cohere chat or embeddings get support — Cohere's chat API does diverge from OpenAI's — but that's separate scope.

## What changes

| File | Change |
|------|--------|
| `aisix-core/src/models/model.rs` | Added `Provider::Cohere` variant. `default_base_url` → `https://api.cohere.com`. `as_str` → `"cohere"`. |
| `aisix-core/src/models/schema.rs` | Added `"cohere"` to the `provider` enum. Admin validation accepts `provider: "cohere"`. |
| `aisix-proxy/src/rerank.rs` | Gate relaxed from `Some(Openai)` to `{Some(Openai), Some(Cohere)}`. Rejection message updated to `"requires OpenAI or Cohere"`. `default_base_for_provider` returns Cohere's URL. |
| `docs/api-proxy.md` §4.7 | Documents supported set `{openai, cohere}` + Cohere's default base. |

## Tests

**Rust unit** (`crates/aisix-proxy/src/rerank.rs`):

- **NEW** `cohere_provider_dispatches_to_upstream_with_bearer_auth` — configures `provider: "cohere"` Model, asserts:
  - 200 OK
  - `Authorization: Bearer <Cohere secret>` on the upstream side (NOT caller's bearer — that would leak the gateway-side caller credential)
  - Upstream path `/v1/rerank`
  - Body `model` rewritten to upstream `model_name`; `query` / `documents` / `top_n` verbatim
- **TIGHTENED** `non_openai_provider_returns_400_invalid_request` — message-substring check now pins `"OpenAI or Cohere"` so a regression dropping Cohere from the gate fails this test.

**E2E** (`tests/e2e/src/cases/rerank-e2e.test.ts`):

- **NEW** `Cohere provider: gateway dispatches with Bearer auth + rewritten model (#213 Phase 1)` — configures a Cohere Model with a separate caller, exercises end-to-end through the live gateway, asserts upstream wire-shape (path, Bearer auth using upstream secret, body verbatim with rewritten model).
- Existing `non-OpenAI provider returns 400` test: `/requires OpenAI/i` regex still matches the new `"requires OpenAI or Cohere"` message — no change needed.

## Verification

- `cargo test --workspace --lib`: all passing (rerank: 6/6 incl. new Cohere test)
- `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## Out of scope (future phases)

- **Cohere v2 endpoint** (`/v2/rerank`): the v1 path is deprecated by Cohere but functional. Operators wanting v2 can override `api_base` to `https://api.cohere.com/v2` once a version-routing extension lands. Not blocking for Phase 1.
- **Cohere on `/passthrough/*`**: `passthrough.rs::default_base` doesn't yet recognize `cohere`. An operator using passthrough with a Cohere Model would need to set `api_base` explicitly. Adding this is a one-line change but technically out of Phase 1's scope.
- **Cohere chat / embeddings**: requires a real bridge implementation. Phase 1 is rerank-only.
- **Phase 2** (Voyage, Jina): same shape as Phase 1 but different secret + base URL. Easy to slot in once Phase 1 lands.

## References

- Issue: #213 (multi-provider expansion follow-up — this PR is Phase 1)
- Upstream spec: <https://docs.cohere.com/reference/rerank>
- `docs/api-proxy.md` §4.7 (rerank contract)
- #168 / #211 (the original OpenAI-only restriction this PR partially relaxes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cohere as a supported model provider
  * /v1/rerank now accepts Cohere models and forwards them to upstream rerank endpoints

* **Documentation**
  * Updated API docs for /v1/rerank with Cohere routing and migration notes
  * Clarified passthrough behavior for Cohere when no api_base is configured

* **Tests**
  * Added E2E tests validating Cohere rerank forwarding and auth behavior

* **Bug Fixes**
  * Validation/error messaging updated to list accepted providers (OpenAI or Cohere)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/227)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->