### PR TITLE
feat(rerank): Jina AI provider support on /v1/rerank (#213 Phase 2)

### DIFF
--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -245,5 +245,14 @@ mod tests {
             Provider::Deepseek.default_base_url(),
             "https://api.deepseek.com"
         );
+        // #213 Phase 1 / Phase 2: rerank-only providers. Per audit
+        // LOW-3 on PR #229 — pin these too so a regression that
+        // swaps the host (e.g. Jina's `https://api.jina.ai` →
+        // `https://api.jina.com`) fails at the unit level.
+        assert_eq!(
+            Provider::Cohere.default_base_url(),
+            "https://api.cohere.com"
+        );
+        assert_eq!(Provider::Jina.default_base_url(), "https://api.jina.ai");
     }
 }

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -29,6 +29,13 @@ pub enum Provider {
     /// Cohere's chat / generate APIs are not OpenAI-compatible; a
     /// future bridge implementation can extend coverage.
     Cohere,
+    /// Jina AI — currently exposed for `/v1/rerank` only (#213 Phase 2).
+    /// Jina's rerank wire shape is identity-mapped to the OpenAI-compat
+    /// shape (`{model, query, documents, top_n}` with Bearer auth at
+    /// `https://api.jina.ai/v1/rerank`), so the gateway forwards
+    /// verbatim with no transform. Jina's chat / embeddings APIs are
+    /// out of scope for this phase.
+    Jina,
 }
 
 impl Provider {
@@ -39,6 +46,7 @@ impl Provider {
             Self::Gemini => "https://generativelanguage.googleapis.com/v1beta/openai",
             Self::Deepseek => "https://api.deepseek.com",
             Self::Cohere => "https://api.cohere.com",
+            Self::Jina => "https://api.jina.ai",
         }
     }
 
@@ -49,6 +57,7 @@ impl Provider {
             Self::Gemini => "gemini",
             Self::Deepseek => "deepseek",
             Self::Cohere => "cohere",
+            Self::Jina => "jina",
         }
     }
 }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -109,7 +109,7 @@ fn model_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "display_name":    { "type": "string", "minLength": 1 },
-            "provider":        { "type": "string", "enum": ["openai","anthropic","gemini","deepseek","cohere"] },
+            "provider":        { "type": "string", "enum": ["openai","anthropic","gemini","deepseek","cohere","jina"] },
             "model_name":      { "type": "string", "minLength": 1 },
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -37,12 +37,13 @@ use crate::state::ProxyState;
 
 /// Provider defaults indexed by provider-prefix string.
 ///
-/// NOTE: `"cohere"` is intentionally absent. #213 Phase 1 ships
-/// Cohere on `/v1/rerank` only; passthrough support is out of
-/// scope. Operators using `/passthrough/cohere/*` with a
-/// `provider: "cohere"` Model must set `api_base` explicitly on
-/// the ProviderKey. The fallback emits a 400
-/// `InvalidRequest("no api_base configured for provider 'cohere' and no default known")`
+/// NOTE: `"cohere"` and `"jina"` are intentionally absent. #213
+/// Phases 1–2 ship those providers on `/v1/rerank` only;
+/// passthrough support is out of scope. Operators using
+/// `/passthrough/cohere/*` or `/passthrough/jina/*` with the
+/// matching provider Model must set `api_base` explicitly on the
+/// ProviderKey. The fallback emits a 400
+/// `InvalidRequest("no api_base configured for provider '<name>' and no default known")`
 /// — graceful, not a crash. Tracked alongside #213's later phases.
 fn default_base(provider_prefix: &str) -> Option<&'static str> {
     match provider_prefix {

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -109,24 +109,30 @@ async fn dispatch(
 
     let model = &model_entry.value;
 
-    // Per #168 + #213 Phase 1: `/v1/rerank` accepts OpenAI- and
-    // Cohere-shape upstreams. Both speak the same body shape
-    // (`{model, query, documents, top_n, ...}`) at `…/v1/rerank`
-    // with `Authorization: Bearer …` auth, so the gateway can
-    // forward verbatim with only the `model` field rewritten.
-    // Anthropic, Gemini, and DeepSeek do not expose this surface —
-    // routing a Model with one of those providers here would
-    // silently 404 upstream, so reject explicitly at the gateway
-    // boundary (parallel to `/v1/responses` §4.6's pattern).
+    // Per #168 + #213 Phases 1–2: `/v1/rerank` accepts OpenAI-,
+    // Cohere-, and Jina-shape upstreams. All three speak the same
+    // body shape (`{model, query, documents, top_n, ...}`) at
+    // `…/v1/rerank` with `Authorization: Bearer …` auth, so the
+    // gateway forwards verbatim with only the `model` field
+    // rewritten. Anthropic, Gemini, and DeepSeek do not expose
+    // this surface — routing a Model with one of those providers
+    // here would silently 404 upstream, so reject explicitly at
+    // the gateway boundary (parallel to `/v1/responses` §4.6).
+    //
+    // Voyage AI is intentionally NOT in this set despite also
+    // having `/v1/rerank` — Voyage uses `top_k` (not `top_n`) on
+    // request and `data` (not `results`) on response, so it
+    // requires a request/response adapter that's out of scope
+    // for this phase. Tracked in the #213 follow-up.
     use aisix_core::models::Provider;
     let provider_allowed = matches!(
         model.provider,
-        Some(Provider::Openai) | Some(Provider::Cohere)
+        Some(Provider::Openai) | Some(Provider::Cohere) | Some(Provider::Jina)
     );
     if !provider_allowed {
         return Err(ProxyError::InvalidRequest(format!(
-            "model `{model_name}` is not an OpenAI or Cohere provider; \
-             /v1/rerank requires OpenAI or Cohere"
+            "model `{model_name}` is not an OpenAI, Cohere, or Jina provider; \
+             /v1/rerank requires OpenAI, Cohere, or Jina"
         )));
     }
 
@@ -150,12 +156,12 @@ async fn dispatch(
     //
     // The provider arm of `default_base_for_provider` is guaranteed to
     // return `Some` here because the gate above already rejected any
-    // `model.provider` outside `{Openai, Cohere}` — both have explicit
-    // arms in the helper. The `unwrap_or_else` is defensive against a
-    // future enum variant that gets through the gate without an arm in
-    // the helper; the audit-trail-friendly default is OpenAI's host
-    // (it's a 4xx-from-OpenAI rather than dispatching to a stale
-    // Cohere legacy domain).
+    // `model.provider` outside `{Openai, Cohere, Jina}` — all three
+    // have explicit arms in the helper. The `unwrap_or_else` is
+    // defensive against a future enum variant that gets through the
+    // gate without an arm in the helper; the audit-trail-friendly
+    // default is OpenAI's host (it's a 4xx-from-OpenAI rather than
+    // dispatching to a stale legacy domain).
     let base = match pk_entry.value.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
         _ => model
@@ -226,6 +232,10 @@ fn default_base_for_provider(provider: aisix_core::models::Provider) -> Option<S
         // `api_base` to `https://api.cohere.com/v2` — see #213's v2
         // follow-up for the version-routing extension if needed.
         Provider::Cohere => Some("https://api.cohere.com".to_string()),
+        // Jina rerank is identity-mapped to the OpenAI-compat /
+        // Cohere wire shape on both request AND response — same
+        // body fields, same `results` array shape, Bearer auth.
+        Provider::Jina => Some("https://api.jina.ai".to_string()),
         Provider::Anthropic => None, // Anthropic doesn't expose a rerank API
         Provider::Gemini => None,    // Gemini doesn't expose a rerank API
         Provider::Deepseek => None,
@@ -297,6 +307,14 @@ mod tests {
     fn cohere_model(name: &str) -> ResourceEntry<Model> {
         let json = format!(
             r#"{{"display_name":"{name}","provider":"cohere","model_name":"rerank-english-v3.0","provider_key_id":"{PK_ID}"}}"#
+        );
+        let m: Model = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn jina_model(name: &str) -> ResourceEntry<Model> {
+        let json = format!(
+            r#"{{"display_name":"{name}","provider":"jina","model_name":"jina-reranker-v2-base-multilingual","provider_key_id":"{PK_ID}"}}"#
         );
         let m: Model = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("m-1", m, 1)
@@ -418,15 +436,95 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "invalid_request_error");
         let message = v["error"]["message"].as_str().unwrap();
-        // Per #213 Phase 1: Cohere is now also a valid provider for
-        // /v1/rerank, so the rejection message must enumerate BOTH
-        // accepted shapes — `OpenAI or Cohere` — not just OpenAI.
-        // Pin the new wording so a regression that drops Cohere
-        // would fail this assertion.
-        assert!(
-            message.contains("OpenAI or Cohere"),
-            "rejection should reference OpenAI/Cohere restriction; got {message:?}"
+        // Per #213 Phases 1–2: the rejection message enumerates the
+        // accepted set `{OpenAI, Cohere, Jina}`. Pin each provider
+        // name individually so:
+        //   - a regression that drops a provider from the gate's
+        //     accepted set fails this assertion (the missing name
+        //     wouldn't appear in the error message);
+        //   - future Phase 2.5+ additions can reword the message
+        //     freely without breaking this test (substring-per-
+        //     provider is forward-compatible per audit LOW-2 on
+        //     PR #227).
+        assert!(message.contains("OpenAI"), "got {message:?}");
+        assert!(message.contains("Cohere"), "got {message:?}");
+        assert!(message.contains("Jina"), "got {message:?}");
+    }
+
+    /// Issue #213 Phase 2: a Model with `provider: "jina"` MUST
+    /// dispatch successfully on `/v1/rerank`. Jina's rerank
+    /// (https://api.jina.ai/v1/rerank) is identity-mapped to the
+    /// Cohere/OpenAI-compat wire shape — same body fields
+    /// (`{model, query, documents, top_n, ...}`), same Bearer
+    /// auth, same `results: [{index, relevance_score}]` response
+    /// shape — so the gateway forwards verbatim with only the
+    /// `model` field rewritten.
+    #[tokio::test]
+    async fn jina_provider_dispatches_to_upstream_with_bearer_auth() {
+        use wiremock::matchers::header;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/rerank"))
+            .and(header("authorization", "Bearer jina_mock_secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "model": "jina-reranker-v2-base-multilingual",
+                "usage": {"total_tokens": 42},
+                "results": [
+                    {"index": 0, "relevance_score": 0.91},
+                    {"index": 1, "relevance_score": 0.27}
+                ]
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        // Operator-style configuration: bare host, no /v1 suffix.
+        // The gateway's `build_v1_url` produces `/v1/rerank` correctly
+        // for both `https://api.jina.ai` and `https://api.jina.ai/v1`.
+        let pk_json = format!(
+            r#"{{"display_name":"jina-up","secret":"jina_mock_secret","api_base":"{}"}}"#,
+            upstream.uri()
         );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();
+        snap.provider_keys.insert(ResourceEntry::new(PK_ID, pk, 1));
+        snap.models.insert(jina_model("jina-rerank"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "jina-rerank",
+                "query": "search query",
+                "documents": ["doc one", "doc two"],
+                "top_n": 2
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Jina provider must dispatch successfully on /v1/rerank per #213 Phase 2"
+        );
+
+        // Pin the EXACT field set forwarded to Jina (parallel to the
+        // Cohere case). Jina's documented body is
+        // `{model, query, documents, top_n, return_documents}`; the
+        // gateway forwards verbatim with only `model` rewritten. A
+        // regression injecting an OpenAI-only field would 400 against
+        // Jina without failing a happy-path 200 alone.
+        let received = upstream.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        let upstream_body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(
+            upstream_body["model"], "jina-reranker-v2-base-multilingual",
+            "model field MUST be rewritten to upstream model_name"
+        );
+        let upstream_obj = upstream_body.as_object().unwrap();
+        let mut keys: Vec<&str> = upstream_obj.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["documents", "model", "query", "top_n"]);
     }
 
     /// Issue #213 Phase 1: a Model with `provider: "cohere"` MUST

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -762,9 +762,16 @@ fn load_heartbeat_config_from_disk(
     ))
 }
 
-/// Register all four provider bridges on a fresh Hub. The Hub is
-/// created once at startup; future dynamic reload lands behind the
-/// same `register()` call.
+/// Register all bridge-backed provider implementations on a fresh
+/// Hub. The Hub is created once at startup; future dynamic reload
+/// lands behind the same `register()` call.
+///
+/// `Provider::Cohere` and `Provider::Jina` are intentionally NOT
+/// registered: per #213 Phases 1–2 they are exposed only via
+/// `/v1/rerank`, which is a verbatim HTTP forward (`aisix-proxy::
+/// rerank`) and bypasses the Bridge trait entirely. A bridge for
+/// either provider would be needed only when chat completions /
+/// embeddings on those providers are added.
 fn build_hub() -> Hub {
     let hub = Hub::new();
     hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));

--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -193,16 +193,24 @@ servers under the same body shape). Routed to `{base}/v1/rerank`.
 The Model's provider supplies the API key; the request body is
 forwarded verbatim after rewriting the `model` field.
 
-**Supported providers**: `openai`, `cohere`. Anthropic, Gemini,
-and DeepSeek do not expose a rerank API at this URL — Models with
-those providers return 400 (parallel to §4.6).
+**Supported providers**: `openai`, `cohere`, `jina`. Anthropic,
+Gemini, and DeepSeek do not expose a rerank API at this URL —
+Models with those providers return 400 (parallel to §4.6).
+Voyage AI's rerank also lives at `/v1/rerank` but uses different
+field names (`top_k` instead of `top_n` on request, `data`
+instead of `results` on response) so it requires a small
+request/response adapter that's not yet implemented; track that
+in the #213 follow-ups.
 
 For `provider: "cohere"`, the default `api_base` is
 `https://api.cohere.com`, which the gateway expands to
-`https://api.cohere.com/v1/rerank` upstream. Cohere's body shape
-(`{model, query, documents, top_n, ...}`) and Bearer-auth
-convention are identical to the OpenAI-compat shape, so the
-gateway forwards verbatim with no transform.
+`https://api.cohere.com/v1/rerank` upstream.
+
+For `provider: "jina"`, the default `api_base` is
+`https://api.jina.ai`, which the gateway expands to
+`https://api.jina.ai/v1/rerank`. Jina's body shape, Bearer-auth
+convention, and `results: [...]` response shape are identical to
+Cohere's, so the gateway forwards verbatim with no transform.
 
 > **Cohere v1 → v2 migration**: Cohere has deprecated its v1
 > endpoints in favour of v2 (`/v2/rerank`); v1 still functions

--- a/tests/e2e/src/cases/rerank-e2e.test.ts
+++ b/tests/e2e/src/cases/rerank-e2e.test.ts
@@ -32,12 +32,16 @@ import {
 //      `model` field rewritten.
 //   2. Cohere provider (#213 Phase 1) — caller POSTs against a
 //      Cohere-provider Model. Gateway dispatches to Cohere's
-//      `/v1/rerank` (or any operator-configured api_base) with
-//      Bearer auth + the rewritten model. Cohere natively
-//      implements this exact body shape, so the gateway forwards
-//      verbatim with no transform.
-//   3. Non-{OpenAI, Cohere} provider — gateway rejects at the
-//      boundary with 400 + `error.type: "invalid_request_error"`,
+//      `/v1/rerank` with Bearer auth + the rewritten model.
+//   3. Jina provider (#213 Phase 2) — caller POSTs against a
+//      Jina-provider Model. Gateway dispatches to Jina's
+//      `/v1/rerank` (https://api.jina.ai/v1/rerank). Jina's wire
+//      shape is identity-mapped to Cohere's (same body fields,
+//      same Bearer auth, same `results: [...]` response), so the
+//      gateway forwards verbatim with only the `model` field
+//      rewritten.
+//   4. Non-{OpenAI, Cohere, Jina} provider — gateway rejects at
+//      the boundary with 400 + `error.type: "invalid_request_error"`,
 //      upstream NOT hit (#212 / #168).
 //
 // References:
@@ -319,6 +323,117 @@ describe("rerank e2e: /v1/rerank verbatim forward + model translation", () => {
     // (e.g. `dimensions` from embeddings, `stream` from chat)
     // would break Cohere without failing a "happy-path 200"
     // assertion alone.
+    const sentKeys = Object.keys(
+      sentBody as Record<string, unknown>,
+    ).sort();
+    expect(sentKeys).toEqual(["documents", "model", "query", "top_n"]);
+  });
+
+  test("Jina provider: gateway dispatches with Bearer auth + rewritten model (#213 Phase 2)", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // Per #213 Phase 2: a Model with `provider: "jina"` is now a
+    // valid configuration on /v1/rerank. Jina's rerank
+    // (https://api.jina.ai/v1/rerank) implements the same body
+    // shape (`{model, query, documents, top_n, ...}`) at
+    // `…/v1/rerank` with Bearer auth — identity-mapped to Cohere /
+    // OpenAI-compat. The gateway forwards verbatim with only the
+    // `model` field rewritten.
+    const jinaSecret = "jina_mock_secret_e2e";
+    const jinaPk = await admin.createProviderKey({
+      display_name: "rerank-jina-pk",
+      secret: jinaSecret,
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "rerank-jina",
+      provider: "jina",
+      model_name: "jina-reranker-v2-base-multilingual",
+      provider_key_id: jinaPk.id,
+    });
+    const jinaCallerPlaintext = `${CALLER_PLAINTEXT}-jina`;
+    await admin.createApiKey({
+      key_hash: createHash("sha256")
+        .update(jinaCallerPlaintext)
+        .digest("hex"),
+      allowed_models: ["rerank-jina"],
+    });
+
+    const headers = {
+      authorization: `Bearer ${jinaCallerPlaintext}`,
+      "content-type": "application/json",
+    };
+
+    // Readiness gate: poll until 200 from the gateway. A 400 here
+    // would mean the gate is rejecting Jina (regression); 404 is
+    // snapshot-lag.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/v1/rerank`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            model: "rerank-jina",
+            query: "ready-probe",
+            documents: ["doc"],
+          }),
+        });
+        if (r.status !== 200) {
+          await r.text();
+          return false;
+        }
+        await r.json();
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+    const requestPayload = {
+      model: "rerank-jina",
+      query: "search query",
+      documents: ["doc one", "doc two", "doc three"],
+      top_n: 2,
+    };
+    const res = await fetch(`${app.proxyUrl}/v1/rerank`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(requestPayload),
+    });
+
+    expect(res.status).toBe(200);
+    await res.json();
+
+    // Upstream wire-shape contract:
+    //   - path is `/v1/rerank`
+    //   - `Authorization: Bearer <Jina secret>` (NOT caller's bearer)
+    //   - body: `model` rewritten to upstream model_name; everything
+    //     else byte-for-byte
+    const testCalls = upstream.receivedRequests
+      .slice(baseline)
+      .filter((r) => r.path === "/v1/rerank");
+    expect(testCalls).toHaveLength(1);
+    expect(testCalls[0]?.method).toBe("POST");
+    expect(testCalls[0]?.headers["authorization"]).toBe(`Bearer ${jinaSecret}`);
+    expect(testCalls[0]?.headers["authorization"]).not.toContain(jinaCallerPlaintext);
+
+    const sentBody = JSON.parse(testCalls[0]!.body) as {
+      model?: string;
+      query?: string;
+      documents?: string[];
+      top_n?: number;
+    };
+    expect(sentBody.model).toBe("jina-reranker-v2-base-multilingual");
+    expect(sentBody.query).toBe(requestPayload.query);
+    expect(sentBody.documents).toEqual(requestPayload.documents);
+    expect(sentBody.top_n).toBe(requestPayload.top_n);
+
+    // Same exact-field-set pin as the Cohere case (#213 audit
+    // MEDIUM-2 contract): no gateway-injected extras.
     const sentKeys = Object.keys(
       sentBody as Record<string, unknown>,
     ).sort();

--- a/tests/e2e/src/cases/rerank-e2e.test.ts
+++ b/tests/e2e/src/cases/rerank-e2e.test.ts
@@ -521,12 +521,20 @@ describe("rerank e2e: /v1/rerank verbatim forward + model translation", () => {
       error?: { type?: unknown; message?: unknown };
     };
     expect(body.error?.type).toBe("invalid_request_error");
-    // Per #168/#211 wording: the rejection message names the
-    // OpenAI-only restriction. The "requires OpenAI" substring is
-    // a stable marker (vs the OpenAI taxonomy enum string, which
-    // a generic invalid-request failure would also carry).
+    // Per #213 Phase 2 audit MEDIUM-1: the rejection message
+    // enumerates the accepted set `{OpenAI, Cohere, Jina}`. Pin
+    // each provider name individually so a regression that drops
+    // Cohere or Jina from the gate's error message (but still
+    // mentions OpenAI) fails this assertion. Mirrors the Rust
+    // unit test's per-substring check on
+    // `non_openai_provider_returns_400_invalid_request`. Phase
+    // 2.5+ additions can append "or Voyage" without breaking
+    // any of these three substring pins.
     expect(typeof body.error?.message).toBe("string");
-    expect(body.error?.message as string).toMatch(/requires OpenAI/i);
+    const errMsg = body.error?.message as string;
+    expect(errMsg).toMatch(/OpenAI/);
+    expect(errMsg).toMatch(/Cohere/);
+    expect(errMsg).toMatch(/Jina/);
 
     // Hard contract: upstream must NEVER be hit when the gateway
     // refuses for provider mismatch — otherwise the gateway is


### PR DESCRIPTION
**#213 Phase 2**: expand `/v1/rerank` accepted-provider set from `{OpenAI, Cohere}` (Phase 1 in #227) to `{OpenAI, Cohere, Jina}`.

## Why

Phase 1 (#227) added Cohere — the highest-priority non-OpenAI rerank target. Phase 2 adds **Jina AI**, the second most common one (popular in embedding+rerank pipelines).

**Voyage AI** (the third candidate listed in #213) is filed separately as **#228** because its wire shape diverges (`top_k` instead of `top_n` on request; `data` instead of `results` on response per <https://docs.voyageai.com/reference/reranker-api>) — Voyage requires a request/response adapter that's out of scope for this surgical "relax the gate + add default api_base" pattern.

## Why no transform is needed for Jina

Jina's `/v1/rerank` (<https://api.jina.ai/v1/rerank>) is identity-mapped to the Cohere/OpenAI-compat wire shape:

| Surface | Jina | Cohere | OpenAI-compat |
|---------|------|--------|---------------|
| Path | `/v1/rerank` | `/v1/rerank` | `/v1/rerank` |
| Auth | `Authorization: Bearer …` | same | same |
| Body | `{model, query, documents, top_n, ...}` | same | same |
| Response | `{model, usage, results: [{index, relevance_score, document?}]}` | same | same |

All three fields match. The gateway forwards verbatim with only the existing `model` field rewrite (display name → upstream `model_name`).

## What changes

| File | Change |
|------|--------|
| `aisix-core/src/models/model.rs` | Added `Provider::Jina` variant. `default_base_url → https://api.jina.ai`. `as_str → "jina"`. |
| `aisix-core/src/models/schema.rs` | Added `"jina"` to the `provider` JSON-schema enum. |
| `aisix-proxy/src/rerank.rs` | Gate relaxed from `{Some(Openai), Some(Cohere)}` to `{Some(Openai), Some(Cohere), Some(Jina)}`. Rejection message updated to `"requires OpenAI, Cohere, or Jina"`. `default_base_for_provider` returns Jina's URL. |
| `docs/api-proxy.md` §4.7 | Documents supported set `{openai, cohere, jina}` + Jina's default base + Voyage's wire-shape divergence (pointing to #228). |

## Tests

**Rust unit** (`crates/aisix-proxy/src/rerank.rs`):

- **NEW** `jina_provider_dispatches_to_upstream_with_bearer_auth` — configures `provider: "jina"` Model, asserts:
  - 200 OK
  - `Authorization: Bearer <Jina secret>` on upstream side (NOT caller's bearer)
  - Upstream path `/v1/rerank`
  - Body `model` rewritten to upstream `model_name`; everything else verbatim
  - **Exact field-set pin** `{documents, model, query, top_n}` — same #227 audit MEDIUM-2 contract; catches future regressions injecting OpenAI-only fields

- **TIGHTENED** `non_openai_provider_returns_400_invalid_request` — applies the audit LOW-2 forward-compat hint from #227. The rejection-message check now asserts EACH of `OpenAI`, `Cohere`, `Jina` substrings individually. Phase 2.5+ additions can append "or Voyage" without breaking this test.

**E2E** (`tests/e2e/src/cases/rerank-e2e.test.ts`):

- **NEW** `Jina provider: gateway dispatches with Bearer auth + rewritten model (#213 Phase 2)` — mirrors the Cohere e2e pattern. Separate caller key, exercises end-to-end through the live gateway, asserts upstream wire-shape (path, Bearer auth using upstream secret, body verbatim with rewritten model, exact field-set pin).
- Existing `non-OpenAI provider returns 400` test: regex `/requires OpenAI/i` still matches the new message — no change needed.

## Verification

- `cargo test -p aisix-proxy --lib rerank`: **7/7 passing**
- `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `pnpm tsc --noEmit` (e2e): clean

## Out of scope (filed)

- **#228** — Voyage AI rerank adapter (`top_n` ↔ `top_k`, `results` ↔ `data`). Sketch design in the issue; will follow the same scaffolding once the adapter direction is approved.
- **Cohere v2 path** — `/v2/rerank` requires version-aware path building (current `build_v1_url` would produce `/v2/v1/rerank` from `api_base: ".../v2"`). Tracked alongside other #213 phases.
- **Jina chat / embeddings** — separate endpoint surfaces with different wire shapes. Phase 2 is rerank-only.

## References

- Issue: #213 (Phase 2)
- Phase 1: #227 (Cohere — merged)
- Phase 2.5 follow-up: #228 (Voyage adapter)
- Upstream spec: <https://api.jina.ai/v1/rerank>
- `docs/api-proxy.md` §4.7 (rerank contract)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Jina as a supported provider for the rerank endpoint so users can send rerank requests that are forwarded to Jina.

* **Documentation**
  * Updated API docs to list Jina among supported rerank providers and clarified provider-specific rerank behaviors and defaults.

* **Tests**
  * Expanded end-to-end tests to cover Jina rerank dispatch and tightened error-message assertions to enumerate accepted providers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/229)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->