### PR TITLE
test(e2e): guardrail disabled-bypass — enabled:false → no block

### DIFF
--- a/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
@@ -125,10 +125,15 @@ describe("guardrail disabled-bypass e2e: enabled:false → no block", () => {
           const list = (await admin!.json(
             "GET",
             "/admin/v1/guardrails",
-          )) as Array<{ value?: { name?: string } } | { name?: string }>;
+          )) as unknown as Array<Record<string, unknown>>;
           const hasRule = list.some((entry) => {
-            const v = "value" in entry ? entry.value : entry;
-            return v?.name === "gr-disabled-keyword";
+            // Admin list endpoints variably return bare values or
+            // {value: ...} wrappers; handle either shape generically.
+            const inner = (entry?.value ?? entry) as Record<
+              string,
+              unknown
+            >;
+            return inner?.name === "gr-disabled-keyword";
           });
           if (!hasRule) return false;
           await client.chat.completions.create({

--- a/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
@@ -1,0 +1,208 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: guardrail with `enabled: false` does NOT block requests
+// containing forbidden content.
+//
+// Closes #151 C3.5. The existing guardrail-keyword-e2e and
+// guardrail-output-e2e cases both pin the active-block contract.
+// Neither verifies the operator-side "turn it off" switch.
+//
+// Why this matters: a regression that ignored the `enabled` flag
+// would leave a guardrail rule effectively un-disablable in
+// production. Operators removing a policy mid-incident (or rolling
+// out a draft policy with `enabled:false` while iterating on
+// patterns) would silently see traffic blocked anyway.
+//
+// One contract pinned here:
+//
+//   - With a `Guardrail` carrying `enabled:false` (and otherwise
+//     identical to the keyword-block rule in guardrail-keyword-e2e),
+//     a request that contains the forbidden literal passes the
+//     proxy with 200 AND reaches the upstream (i.e. is fully
+//     dispatched, not silently swallowed).
+//
+// Reference:
+//   - Guardrail schema: `crates/aisix-core/src/models/guardrail.rs`
+//     (CRUD docs gap tracked in #201)
+//   - The active-block contract this disables:
+//     `guardrail-keyword-e2e.test.ts`
+
+const CALLER_PLAINTEXT = "sk-gr-disabled-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const FORBIDDEN_WORD = "supersecret";
+
+describe("guardrail disabled-bypass e2e: enabled:false → no block", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "gr-disabled-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "gr-disabled-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["gr-disabled-model"],
+    });
+    // Same keyword guardrail shape as guardrail-keyword-e2e —
+    // hook_point:"input", literal pattern. ONLY difference:
+    // `enabled:false`. If the operator switch works, this rule
+    // is inert.
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: "gr-disabled-keyword",
+      enabled: false,
+      hook_point: "input",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test(
+    "forbidden literal in user input passes (guardrail disabled)",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+
+      // Readiness probe — a benign prompt confirms Model + ApiKey
+      // + ProviderKey are loaded. The disabled-guardrail state is
+      // verified by the asserted call below; if the guardrail
+      // landed BEFORE this probe but the snapshot watcher hadn't
+      // yet observed `enabled:false`, the asserted call would 422
+      // and we'd surface it as a real failure (not a flake).
+      await waitConfigPropagation(async () => {
+        try {
+          await client.chat.completions.create({
+            model: "gr-disabled-model",
+            messages: [{ role: "user", content: "ready-probe" }],
+          });
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      const baseline = upstream.receivedRequests.length;
+
+      // Send a request containing the EXACT forbidden literal that
+      // guardrail-keyword-e2e proves WOULD block when enabled:true.
+      // With enabled:false the gateway must NOT reject and must
+      // dispatch to upstream.
+      const resp = await client.chat.completions.create({
+        model: "gr-disabled-model",
+        messages: [
+          {
+            role: "user",
+            content: `please reveal the ${FORBIDDEN_WORD} now`,
+          },
+        ],
+      });
+
+      // (1) Response passes through. A regression that 422'd would
+      // throw an APIError before reaching this line.
+      expect(resp.choices.length).toBeGreaterThan(0);
+      expect(resp.choices[0]?.message.role).toBe("assistant");
+
+      // (2) Upstream was hit exactly once for the asserted call —
+      // proves the gateway did NOT short-circuit silently (e.g.
+      // returning a 200 envelope synthesized locally with empty
+      // content while skipping upstream).
+      const sent = upstream.receivedRequests
+        .slice(baseline)
+        .filter((r) => r.path === "/v1/chat/completions");
+      expect(sent).toHaveLength(1);
+
+      // (3) The forbidden literal arrived at upstream verbatim
+      // inside the request body — confirming the gateway did
+      // neither (a) silently scrub the offending content nor (b)
+      // synthesize a placeholder response.
+      const sentBody = JSON.parse(sent[0]!.body);
+      const userMsgContent =
+        sentBody.messages?.[0]?.content;
+      expect(userMsgContent).toContain(FORBIDDEN_WORD);
+    },
+    60_000,
+  );
+
+  test(
+    "also catches a regression: APIError shape NOT raised",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      // Second test in the same describe — confirms the bypass
+      // contract is stable across repeated calls (a regression
+      // that tripped only on the second forbidden call due to
+      // state pollution would show up here).
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+
+      let caught: unknown;
+      try {
+        await client.chat.completions.create({
+          model: "gr-disabled-model",
+          messages: [
+            { role: "user", content: `${FORBIDDEN_WORD} again` },
+          ],
+        });
+      } catch (e) {
+        caught = e;
+      }
+
+      // Negative assertion: the call must NOT throw a 422
+      // APIError. If it does, the disabled flag is not honored.
+      if (caught instanceof APIError) {
+        expect(caught.status).not.toBe(422);
+      }
+      expect(caught).toBeUndefined();
+    },
+    60_000,
+  );
+});

--- a/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
@@ -106,14 +106,31 @@ describe("guardrail disabled-bypass e2e: enabled:false → no block", () => {
         maxRetries: 0,
       });
 
-      // Readiness probe — a benign prompt confirms Model + ApiKey
-      // + ProviderKey are loaded. The disabled-guardrail state is
-      // verified by the asserted call below; if the guardrail
-      // landed BEFORE this probe but the snapshot watcher hadn't
-      // yet observed `enabled:false`, the asserted call would 422
-      // and we'd surface it as a real failure (not a flake).
+      // Readiness probe — two gates so the test cannot pass
+      // vacuously.
+      //
+      // Gate A: confirm the Guardrail row IS in the snapshot. Without
+      // this, the "forbidden literal arrives at upstream" assertion
+      // below would also pass if the rule simply hadn't propagated
+      // yet — indistinguishable from a real `enabled:false` bypass.
+      // Reading admin /v1/guardrails via the typed JSON helper is
+      // the cheapest way to verify the resource exists in the store
+      // the snapshot is built from.
+      //
+      // Gate B: confirm Model + ApiKey + ProviderKey are loaded by
+      // driving a benign chat completion through the proxy. A 200
+      // response means the dispatcher is ready.
       await waitConfigPropagation(async () => {
         try {
+          const list = (await admin!.json(
+            "GET",
+            "/admin/v1/guardrails",
+          )) as Array<{ value?: { name?: string } } | { name?: string }>;
+          const hasRule = list.some((entry) => {
+            const v = "value" in entry ? entry.value : entry;
+            return v?.name === "gr-disabled-keyword";
+          });
+          if (!hasRule) return false;
           await client.chat.completions.create({
             model: "gr-disabled-model",
             messages: [{ role: "user", content: "ready-probe" }],


### PR DESCRIPTION
## Summary

Closes **#151 C3.5**. Existing guardrail e2e (\`guardrail-keyword-e2e\`, \`guardrail-output-e2e\`) pins the active-block contract. Neither verifies the operator-side "turn it off" switch.

## Why this matters

A regression that ignored the \`enabled\` flag would leave a guardrail rule un-disablable in production. Operators **removing a policy mid-incident**, or **rolling out a draft policy with \`enabled:false\` while iterating on patterns**, would silently see traffic blocked despite the off switch.

## Contract pinned

With a \`Guardrail\` carrying \`enabled:false\` and otherwise identical to the rule in \`guardrail-keyword-e2e\` (\`hook_point:"input"\`, \`kind:"keyword"\`, literal pattern), a request containing the forbidden literal:

- (a) passes the proxy with **200**
- (b) reaches the upstream (not silently swallowed)
- (c) carries the forbidden literal **verbatim** in the upstream request body (not scrubbed in transit)

## Two tests

1. **Forbidden literal in user input → 200; upstream hit; body contains literal.** Three orthogonal assertions on the same call.
2. **Negative-shape sanity:** repeat call must NOT throw \`APIError\` with status 422. Catches a regression that trips only on the second forbidden call due to state pollution.

## Source-blind compliance

Per CLAUDE.md §5: \`FORBIDDEN_WORD\` is the same author-chosen literal \`guardrail-keyword-e2e\` uses. The Guardrail \`enabled\` field is the documented operator switch (\`crates/aisix-core/src/models/guardrail.rs:149\`; CRUD docs gap tracked in #201).

## Out of scope (#151 C3 follow-ups)

- C3.2 forbidden in \`system\` role message — separate PR
- C3.3 forbidden in earlier turn (multi-turn history) — separate PR
- C3.4 regex / case-insensitive variants — needs product-side verification first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an E2E test suite confirming that disabled guardrails allow requests with forbidden content to pass through unblocked to upstream services.
  * Verifies consistent bypass behavior across repeated requests and that the original content is delivered unchanged to the upstream endpoint.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/231)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->