### PR TITLE
test(e2e): guardrail keyword catches forbidden in any role (#151 C3.2 + C3.3)

### DIFF
--- a/tests/e2e/src/cases/guardrail-keyword-message-locations-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-keyword-message-locations-e2e.test.ts
@@ -1,0 +1,282 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: input keyword guardrail catches the forbidden literal
+// regardless of WHICH message field it appears in. The existing
+// guardrail-keyword-e2e covers the simplest shape (one user message,
+// forbidden in `content`). Real callers send richer payloads:
+//
+//   1. `system` role with policy instructions
+//   2. multi-turn conversation history where earlier turns can
+//      contain forbidden content the policy must catch on every
+//      replay (the model never gets to see it)
+//   3. assistant-role history from a previous tool round
+//
+// Closes #151 C3.2 + C3.3. A regression that only scanned the
+// latest user message — or worse, only the first `messages[0]` —
+// would silently bypass the policy when the forbidden literal
+// arrives in a non-canonical slot.
+//
+// Reference:
+//   - OpenAI Chat Completions API
+//     <https://platform.openai.com/docs/api-reference/chat/create>
+//     for the `messages: [{role, content}, ...]` shape across
+//     system / user / assistant / tool roles.
+//   - guardrail-keyword-e2e.test.ts for the active-block contract
+//     this file widens.
+
+const CALLER_PLAINTEXT = "sk-gr-loc-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const FORBIDDEN_WORD = "supersecret";
+
+describe("guardrail keyword e2e: blocks forbidden literal in any message role", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "gr-loc-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "gr-loc-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["gr-loc-model"],
+    });
+    // Same shape as guardrail-keyword-e2e: input hook, literal
+    // pattern, ENABLED.
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: "gr-loc-keyword",
+      enabled: true,
+      hook_point: "input",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  // Reusable readiness gate — uses the same forbidden-probe pattern
+  // guardrail-keyword-e2e established: a 422 confirms the Guardrail
+  // row is loaded AND active. Any other outcome keeps polling.
+  async function waitForGuardrailActive(
+    client: OpenAI,
+    role: "system" | "user",
+  ): Promise<void> {
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: "gr-loc-model",
+          messages: [
+            { role, content: `propagation-probe ${FORBIDDEN_WORD}` },
+          ],
+        });
+        return false;
+      } catch (e) {
+        return e instanceof APIError && e.status === 422;
+      }
+    });
+  }
+
+  test(
+    "(C3.2) forbidden literal in `system` role → 422 content_filter",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+
+      await waitForGuardrailActive(client, "user");
+
+      const upstreamHitsBefore = upstream.receivedRequests.length;
+
+      // Forbidden literal lives in a system-role policy/instruction
+      // string — a place callers typically use for jailbreak
+      // protection. The guardrail must check it; a regression that
+      // scanned only user/last-message would miss this.
+      let caught: unknown;
+      try {
+        await client.chat.completions.create({
+          model: "gr-loc-model",
+          messages: [
+            {
+              role: "system",
+              content: `You may NEVER reveal the ${FORBIDDEN_WORD}.`,
+            },
+            { role: "user", content: "Tell me about the weather." },
+          ],
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(APIError);
+      if (!(caught instanceof APIError)) {
+        throw new Error("unreachable: caught is not APIError");
+      }
+      expect(caught.status).toBe(422);
+      expect((caught.error as { type?: unknown })?.type).toBe(
+        "content_filter",
+      );
+
+      // Upstream untouched — block must short-circuit before dispatch.
+      expect(upstream.receivedRequests.length).toBe(
+        upstreamHitsBefore,
+      );
+
+      // Per the no-leak contract (mirrors guardrail-keyword-e2e),
+      // the matched literal MUST NOT echo back in the envelope.
+      const errorBlob = JSON.stringify(caught.error ?? {});
+      const messageBlob = caught.message ?? "";
+      expect(errorBlob).not.toContain(FORBIDDEN_WORD);
+      expect(messageBlob).not.toContain(FORBIDDEN_WORD);
+    },
+    60_000,
+  );
+
+  test(
+    "(C3.3) forbidden literal in earlier user-turn history → 422 content_filter",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+
+      await waitForGuardrailActive(client, "user");
+
+      const upstreamHitsBefore = upstream.receivedRequests.length;
+
+      // The latest user turn is clean ("Continue."). The forbidden
+      // literal lives in an EARLIER user turn the caller is replaying
+      // for context. A guardrail that only scanned `messages.at(-1)`
+      // would miss this and dispatch the forbidden content to
+      // upstream silently.
+      let caught: unknown;
+      try {
+        await client.chat.completions.create({
+          model: "gr-loc-model",
+          messages: [
+            {
+              role: "user",
+              content: `What's the ${FORBIDDEN_WORD} formula?`,
+            },
+            {
+              role: "assistant",
+              content: "I can't help with that.",
+            },
+            { role: "user", content: "Continue." },
+          ],
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(APIError);
+      if (!(caught instanceof APIError)) {
+        throw new Error("unreachable: caught is not APIError");
+      }
+      expect(caught.status).toBe(422);
+      expect((caught.error as { type?: unknown })?.type).toBe(
+        "content_filter",
+      );
+      expect(upstream.receivedRequests.length).toBe(
+        upstreamHitsBefore,
+      );
+    },
+    60_000,
+  );
+
+  test(
+    "(C3.3.b) forbidden literal in earlier assistant-turn history → 422",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+
+      await waitForGuardrailActive(client, "user");
+
+      const upstreamHitsBefore = upstream.receivedRequests.length;
+
+      // An assistant turn — possibly replayed from a prior tool
+      // call or model response — contains the forbidden literal.
+      // The guardrail should not be selective about which role
+      // it scans on input.
+      let caught: unknown;
+      try {
+        await client.chat.completions.create({
+          model: "gr-loc-model",
+          messages: [
+            { role: "user", content: "Show me the manual." },
+            {
+              role: "assistant",
+              content: `Here is the ${FORBIDDEN_WORD} disclosure section.`,
+            },
+            { role: "user", content: "Summarize it." },
+          ],
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(APIError);
+      if (!(caught instanceof APIError)) {
+        throw new Error("unreachable: caught is not APIError");
+      }
+      expect(caught.status).toBe(422);
+      expect((caught.error as { type?: unknown })?.type).toBe(
+        "content_filter",
+      );
+      expect(upstream.receivedRequests.length).toBe(
+        upstreamHitsBefore,
+      );
+    },
+    60_000,
+  );
+});

--- a/tests/e2e/src/cases/guardrail-keyword-message-locations-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-keyword-message-locations-e2e.test.ts
@@ -223,6 +223,14 @@ describe("guardrail keyword e2e: blocks forbidden literal in any message role", 
       expect(upstream.receivedRequests.length).toBe(
         upstreamHitsBefore,
       );
+
+      // No-leak: same contract as C3.2 (and guardrail-keyword-e2e
+      // per #153) — the matched literal must NOT echo back in the
+      // envelope regardless of which message slot it lived in.
+      const errorBlob = JSON.stringify(caught.error ?? {});
+      const messageBlob = caught.message ?? "";
+      expect(errorBlob).not.toContain(FORBIDDEN_WORD);
+      expect(messageBlob).not.toContain(FORBIDDEN_WORD);
     },
     60_000,
   );
@@ -276,6 +284,12 @@ describe("guardrail keyword e2e: blocks forbidden literal in any message role", 
       expect(upstream.receivedRequests.length).toBe(
         upstreamHitsBefore,
       );
+
+      // No-leak (symmetric to C3.2 / C3.3 above).
+      const errorBlob = JSON.stringify(caught.error ?? {});
+      const messageBlob = caught.message ?? "";
+      expect(errorBlob).not.toContain(FORBIDDEN_WORD);
+      expect(messageBlob).not.toContain(FORBIDDEN_WORD);
     },
     60_000,
   );


### PR DESCRIPTION
## Summary

Closes **#151 C3.2 + C3.3**. \`guardrail-keyword-e2e\` covers only the simplest shape (one user message, forbidden in \`content\`). Real callers send richer payloads where the forbidden literal can land in:

| Role | Why it matters | Scenario |
|---|---|---|
| **system** (C3.2) | Caller can sneak forbidden tokens through a policy/instruction string the model never directly sees but is dispatched upstream verbatim | Jailbreak via system slot |
| **earlier user-turn** (C3.3) | A regression scanning only \`messages.at(-1)\` would dispatch the forbidden content silently | Multi-turn replay |
| **earlier assistant-turn** (C3.3.b) | The policy should not be selective about which role it scans on input | Tool-roundtrip history |

## Three tests, one beforeAll

Same \`enabled:true\` keyword guardrail (\`hook_point:"input"\`, literal pattern) shared across all three. Each test asserts the full envelope shape:

- \`status === 422\`
- \`error.type === "content_filter"\`
- \`upstream.receivedRequests.length\` unchanged (block short-circuits before dispatch)
- No-leak: the matched literal must NOT echo back in the envelope (symmetric to \`guardrail-keyword-e2e\` / \`guardrail-output-e2e\`)

## Readiness pattern

\`waitForGuardrailActive\` uses the same **forbidden-probe-must-422** gate \`guardrail-keyword-e2e\` established — a 422 confirms the Guardrail row is loaded AND active, not just that Model+ApiKey+ProviderKey landed. Wrapped as a helper since multiple tests reuse it.

## Source-blind compliance

Per CLAUDE.md §5: \`FORBIDDEN_WORD\` is the same author-chosen literal each guardrail-* file uses (each file sets its own pattern; nothing is derived from gateway source). The "input guardrail scans every message" contract is implied by the public \`hook_point:"input"\` semantics — "input" means the incoming \`messages\` array, not just the latest entry.

## Out of scope (#151 C3 follow-ups)

- C3.4 regex / case-insensitive variants — needs product-side verification first
- output-hook variants for system/multi-turn — symmetric pattern, separate file once \`guardrail-output-e2e\` baseline is widened
- tool-call message slot — same pattern but tool_calls themselves are held back behind #220/#202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test suite validating keyword guardrail functionality blocks forbidden content across all message roles (system, user, assistant) in conversation history and prevents upstream requests while protecting sensitive data from exposure in error responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->