### PR TITLE
ci: rename main branch image tag from :main to :dev

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,7 +4,7 @@ name: docker-image
 #
 # Tag strategy. Every push always carries a :sha-<shortsha> tag for
 # traceability; the other tags layer on top based on the trigger:
-#   - push to main              → :main + :sha-<shortsha>
+#   - push to main              → :dev + :sha-<shortsha>
 #   - push tag vX.Y.Z           → :X.Y.Z + :X.Y + :X + :latest
 #                                 + :sha-<shortsha>
 #   - pull request              → build-only (no push), sanity check
@@ -66,7 +66,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=ref,event=pr
             type=sha,prefix=sha-,format=short
             type=semver,pattern={{version}}

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The same binary runs both modes; the table is about **which surface owns the fea
 | etcd-side authz | N/A | env-prefix enforcement (etcdauth interceptor): each DP cert is scoped to `/aisix/<env>/`, can't read another tenant's keyspace |
 | Playground | `POST /playground/chat/completions` (admin API) | Per-env playground in dashboard, audited |
 
-The DP container image (`ghcr.io/api7/ai-gateway:main`) is the same in both modes. The `managed.enabled` flag in config selects the bootstrap path.
+The DP container image (`ghcr.io/api7/ai-gateway:dev`) is the same in both modes. The `managed.enabled` flag in config selects the bootstrap path.
 
 ## Roadmap
 

--- a/docs/managed-mode.md
+++ b/docs/managed-mode.md
@@ -43,7 +43,7 @@ docker run --rm \
   -e AISIX_MANAGED__CP_ETCD_ENDPOINT=dp-manager.aisix.cloud:7943 \
   -v aisix-mtls:/var/lib/aisix \
   -p 3000:3000 \
-  ghcr.io/api7/ai-gateway:main
+  ghcr.io/api7/ai-gateway:dev
 ```
 
 For systemd or k8s Secret mounts where multi-line PEMs in env vars
@@ -89,7 +89,7 @@ docker run --rm \
   -e AISIX_MANAGED__CP_BASE_URL=https://api.us.aisix.cloud \
   -v aisix-mtls:/var/lib/aisix \
   -p 3000:3000 \
-  ghcr.io/api7/ai-gateway:main
+  ghcr.io/api7/ai-gateway:dev
 ```
 
 What each flag does:


### PR DESCRIPTION
Rename the main branch image tag from `:main` to `:dev` to make the intent clearer — this tag tracks the latest commit on main, not a stable release.

Changes:
- Update `docker-image.yml` tag strategy: `type=ref,event=branch` → `type=raw,value=dev` (only on push to main)
- Update docs references in README.md and docs/managed-mode.md

Tag-based releases (`vX.Y.Z`) are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker image tag references from `:main` to `:dev` in setup guides and bootstrapping documentation.

* **Chores**
  * Updated CI/CD workflow to produce `:dev` image tag for main branch deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/235)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->