### PR TITLE
fix(etcd): keep Watcher alive to prevent watch stream EOF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       # Picked up by crates/aisix-admin/tests/etcd_integration.rs.
       # Same skip-if-unset pattern as the Redis case above.
       ADMIN_TEST_ETCD_URL: http://127.0.0.1:2379
+      # Picked up by crates/aisix-etcd/tests/watch_integration.rs.
+      ETCD_TEST_URL: http://127.0.0.1:2379
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -170,12 +170,15 @@ impl ConfigProvider for EtcdConfigProvider {
         let opts = WatchOptions::new()
             .with_prefix()
             .with_start_revision(start_revision);
-        let (_watcher, stream) = client
+        let (watcher, stream) = client
             .watch(self.prefix.as_bytes(), Some(opts))
             .await
             .map_err(|e| ProviderError::Watch(format_error_chain(&e)))?;
 
-        Ok(Box::new(EtcdWatchStream { inner: stream }))
+        Ok(Box::new(EtcdWatchStream {
+            inner: stream,
+            _watcher: watcher,
+        }))
     }
 }
 
@@ -186,6 +189,9 @@ impl ConfigProvider for EtcdConfigProvider {
 /// [`ProviderError::Compacted`] so the supervisor can resync.
 pub struct EtcdWatchStream {
     inner: etcd_client::WatchStream,
+    // Must outlive `inner` — dropping the Watcher closes the client→server
+    // half of the gRPC stream, causing the server to tear down the watch.
+    _watcher: etcd_client::Watcher,
 }
 
 impl Stream for EtcdWatchStream {

--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -1,0 +1,88 @@
+//! Integration test: watch stream stays alive and delivers events.
+//!
+//! Requires a real etcd — gated by `ETCD_TEST_URL`.  CI sets this via
+//! the etcd service container; local runs without the var are no-ops.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use aisix_etcd::provider::ConfigProvider;
+use aisix_etcd::EtcdConfigProvider;
+use etcd_client::Client;
+use futures::StreamExt;
+use tokio::time::timeout;
+
+fn etcd_url() -> Option<String> {
+    std::env::var("ETCD_TEST_URL").ok()
+}
+
+fn unique_prefix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    format!("/aisix-etcd-it/{nanos:x}")
+}
+
+/// The core regression test for issue #237: after `watch()` returns,
+/// the stream must stay open and deliver events.  Before the fix the
+/// `Watcher` was dropped immediately, closing the gRPC client→server
+/// half and causing an instant EOF.
+#[tokio::test]
+async fn watch_stream_delivers_events_after_put() {
+    let url = match etcd_url() {
+        Some(u) => u,
+        None => {
+            eprintln!("ETCD_TEST_URL not set — skipping");
+            return;
+        }
+    };
+
+    let prefix = unique_prefix();
+    let endpoints = vec![url.clone()];
+    let provider = EtcdConfigProvider::connect(
+        &endpoints,
+        prefix.clone(),
+        None,
+    )
+    .await
+    .expect("connect");
+
+    let (_entries, revision) = provider.load_all().await.expect("load_all");
+
+    let mut stream = provider.watch(revision + 1).await.expect("watch");
+
+    // Give the runtime a moment — with the old bug the gRPC stream
+    // would close asynchronously once the Watcher was dropped.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Write a key via a separate client so the watch should see it.
+    let mut writer = Client::connect([url.as_str()], None)
+        .await
+        .expect("writer connect");
+    let test_key = format!("{prefix}/models/watch-test");
+    let test_value = br#"{"display_name":"t","provider":"openai","model_name":"gpt-4o","provider_key_id":"11111111-1111-1111-1111-111111111111"}"#;
+    writer
+        .put(test_key.as_bytes(), test_value.as_ref(), None)
+        .await
+        .expect("put");
+
+    // The stream must deliver the event within a reasonable window.
+    let event = timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("timed out — watch stream likely dead (watcher dropped?)")
+        .expect("stream ended unexpectedly");
+
+    match event.expect("watch error") {
+        aisix_etcd::WatchEvent::Put(entry) => {
+            assert_eq!(entry.key, test_key);
+            assert_eq!(entry.value, test_value);
+        }
+        other => panic!("expected Put, got {other:?}"),
+    }
+
+    // Cleanup
+    writer
+        .delete(test_key.as_bytes(), None)
+        .await
+        .expect("cleanup delete");
+}

--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -39,13 +39,9 @@ async fn watch_stream_delivers_events_after_put() {
 
     let prefix = unique_prefix();
     let endpoints = vec![url.clone()];
-    let provider = EtcdConfigProvider::connect(
-        &endpoints,
-        prefix.clone(),
-        None,
-    )
-    .await
-    .expect("connect");
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None)
+        .await
+        .expect("connect");
 
     let (_entries, revision) = provider.load_all().await.expect("load_all");
 


### PR DESCRIPTION
The `watch()` method in `etcd_provider.rs` was dropping the `etcd_client::Watcher` immediately after opening the stream. The `Watcher` holds the `Sender<WatchRequest>` — the client→server half of the gRPC bidirectional stream. Dropping it closes that half, which causes kine's `Watch()` server to get EOF on `Recv()` and tear down the entire stream. The DP then sees EOF on the response stream and retries with backoff, but config updates created after DP boot are never delivered.

The fix stores the `Watcher` in the `EtcdWatchStream` struct so it lives as long as the stream.

Added an integration test (`watch_integration.rs`) that connects to a real etcd, opens a watch, puts a key, and asserts the event arrives — validating the stream stays alive after `watch()` returns.

Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed etcd watch stream termination issue.

* **Tests**
  * Added integration test for etcd watch functionality.

* **Chores**
  * Updated CI workflow to support etcd testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/238)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->