### PR TITLE
test(e2e): bump waitConfigPropagation timeout from 10s to 30s

### DIFF
--- a/tests/e2e/src/harness/admin.ts
+++ b/tests/e2e/src/harness/admin.ts
@@ -70,18 +70,11 @@ export class AdminClient {
  *
  * `condition` lets the caller provide a positive readiness probe; if
  * omitted, the helper falls back to the historical fixed-time wait.
- * The poll interval is 50ms.
  *
- * The default deadline is **30s** (raised from 10s). Vitest runs
- * up to `maxForks: 4` test files in parallel, each spawning an
- * `aisix` instance against a single shared etcd. Under that
- * concurrency the etcd watch dispatch can lag, especially for
- * tests that rely on the LAST resource in a write batch (e.g. a
- * Guardrail rule following Model + ApiKey + ProviderKey writes,
- * see `guardrail-keyword-e2e.test.ts`). The poll interval is
- * 50ms so in practice the function returns in 1-2s; the generous
- * ceiling only fires on genuinely stuck snapshots and avoids
- * CI rerun-flakes on slow GitHub Actions runners.
+ * Polls every 50ms, so in practice returns in 1-2s. The default
+ * deadline is **30s** (raised from 10s) to tolerate slow CI runners
+ * where multiple aisix instances share a single etcd and guardrail
+ * resources (written last) take longer to propagate.
  */
 export async function waitConfigPropagation(
   condition?: () => Promise<boolean>,
@@ -96,5 +89,5 @@ export async function waitConfigPropagation(
     if (await condition()) return;
     await new Promise((r) => setTimeout(r, 50));
   }
-  throw new Error(`waitConfigPropagation: condition not met within ${timeoutMs / 1000}s`);
+  throw new Error(`waitConfigPropagation: condition not met within ${timeoutMs}ms`);
 }

--- a/tests/e2e/src/harness/admin.ts
+++ b/tests/e2e/src/harness/admin.ts
@@ -72,28 +72,29 @@ export class AdminClient {
  * omitted, the helper falls back to the historical fixed-time wait.
  * The poll interval is 50ms.
  *
- * The deadline is **10s** (raised from 5s after #157). Vitest runs
+ * The default deadline is **30s** (raised from 10s). Vitest runs
  * up to `maxForks: 4` test files in parallel, each spawning an
  * `aisix` instance against a single shared etcd. Under that
  * concurrency the etcd watch dispatch can lag, especially for
  * tests that rely on the LAST resource in a write batch (e.g. a
  * Guardrail rule following Model + ApiKey + ProviderKey writes,
- * see `guardrail-keyword-e2e.test.ts`). 5s was sized for a
- * ~9-test suite; the suite is now 20+ files. 10s preserves the
- * "fail loudly on a genuinely stuck snapshot" property without
- * burning CI cycles on rerun-flakes.
+ * see `guardrail-keyword-e2e.test.ts`). The poll interval is
+ * 50ms so in practice the function returns in 1-2s; the generous
+ * ceiling only fires on genuinely stuck snapshots and avoids
+ * CI rerun-flakes on slow GitHub Actions runners.
  */
 export async function waitConfigPropagation(
   condition?: () => Promise<boolean>,
+  timeoutMs = 30_000,
 ): Promise<void> {
   if (!condition) {
     await new Promise((r) => setTimeout(r, 500));
     return;
   }
-  const deadline = Date.now() + 10_000;
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await condition()) return;
     await new Promise((r) => setTimeout(r, 50));
   }
-  throw new Error("waitConfigPropagation: condition not met within 10s");
+  throw new Error(`waitConfigPropagation: condition not met within ${timeoutMs / 1000}s`);
 }


### PR DESCRIPTION
The poll-based `waitConfigPropagation` uses 50ms intervals, so it returns in 1-2s normally. The 30s ceiling (up from 10s) prevents flaky timeouts on slow CI runners when multiple aisix instances share a single etcd — guardrail resources are written last and can take longer to propagate under contention.

Also makes the timeout configurable via a `timeoutMs` parameter for callers that want a tighter deadline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased the default wait timeout in the test harness from 10s to 30s and made the timeout configurable. This reduces CI flakiness during parallel test execution and improves test reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/251)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->