### PR TITLE
fix(health): minimize unauthenticated health responses

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -140,15 +140,12 @@ pub fn build_router(state: AdminState) -> Router {
 }
 
 async fn health(
-    axum::extract::State(state): axum::extract::State<AdminState>,
+    _state: axum::extract::State<AdminState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let snap = state.snapshot.load();
     (
         StatusCode::OK,
         Json(json!({
             "status": "ok",
-            "models": snap.models.len(),
-            "apikeys": snap.apikeys.len(),
         })),
     )
 }
@@ -328,7 +325,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_reports_snapshot_counts() {
+    async fn health_reports_only_minimal_status() {
         let app = build_router(build_state());
         let req = Request::builder()
             .uri("/health")
@@ -338,6 +335,9 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v["status"], "ok");
+        assert_eq!(v.as_object().map(|o| o.len()), Some(1));
+        assert!(v.get("models").is_none());
+        assert!(v.get("apikeys").is_none());
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -1,7 +1,12 @@
 //! aisix-admin — Admin API + Playground (:3001).
 //!
-//! Mounts the admin surface behind admin-key bearer auth:
+//! Public admin-listener endpoints:
 //! - `GET  /health`
+//! - `GET  /metrics`
+//! - `GET  /admin/openapi.json`
+//! - `GET  /admin/openapi-scalar`
+//!
+//! Admin-key protected routes:
 //! - `GET|POST            /admin/v1/models`
 //! - `GET|PUT|DELETE      /admin/v1/models/:id`
 //! - `GET|POST            /admin/v1/apikeys`

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -144,9 +144,7 @@ pub fn build_router(state: AdminState) -> Router {
         .with_state(state)
 }
 
-async fn health(
-    _state: axum::extract::State<AdminState>,
-) -> (StatusCode, Json<serde_json::Value>) {
+async fn health(_state: axum::extract::State<AdminState>) -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::OK,
         Json(json!({

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -341,6 +341,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn health_rejects_non_get_requests() {
+        let app = build_router(build_state());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
     async fn create_model_returns_entry_with_generated_id() {
         let app = build_router(build_state());
         let resp = run(

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -26,7 +26,7 @@ const OPENAPI_JSON: &str = r##"{
   "paths": {
     "/health": {
       "get": {
-        "summary": "process health + snapshot counts",
+        "summary": "minimal process health status",
         "security": [],
         "responses": {"200": {"description": "OK"}}
       }

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -495,7 +495,10 @@ mod tests {
         assert_eq!(schema["type"], "object");
         assert_eq!(schema["required"], serde_json::json!(["status"]));
         assert_eq!(schema["additionalProperties"], false);
-        assert_eq!(schema["properties"]["status"]["enum"], serde_json::json!(["ok"]));
+        assert_eq!(
+            schema["properties"]["status"]["enum"],
+            serde_json::json!(["ok"])
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -28,7 +28,23 @@ const OPENAPI_JSON: &str = r##"{
       "get": {
         "summary": "minimal process health status",
         "security": [],
-        "responses": {"200": {"description": "OK"}}
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["status"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "status": {"type": "string", "enum": ["ok"]}
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/metrics": {
@@ -467,6 +483,19 @@ mod tests {
                 "{path} should declare security: [] but got {security:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn openapi_health_documents_minimal_status_only() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
+        let schema = &parsed["paths"]["/health"]["get"]["responses"]["200"]["content"]
+            ["application/json"]["schema"];
+
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["required"], serde_json::json!(["status"]));
+        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(schema["properties"]["status"]["enum"], serde_json::json!(["ok"]));
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/state.rs
+++ b/crates/aisix-admin/src/state.rs
@@ -3,7 +3,7 @@
 //! Holds:
 //! - the bootstrap-config-provided `admin_keys` (auth)
 //! - the `ConfigStore` trait object (CRUD backend)
-//! - a `SnapshotHandle` for the /health endpoint (snapshot counts)
+//! - a `SnapshotHandle` for authenticated operator-health handlers
 //! - an optional `Metrics` handle — when present, `/metrics` renders
 //!   the same Prometheus exposition that the proxy's middleware writes to
 //!

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -175,16 +175,12 @@ async fn drain_body(body: axum::body::Body) {
 }
 
 async fn health(
-    axum::extract::State(state): axum::extract::State<ProxyState>,
+    _state: axum::extract::State<ProxyState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let snap = state.snapshot.load();
     (
         StatusCode::OK,
         Json(json!({
             "status": "ok",
-            "models": snap.models.len(),
-            "apikeys": snap.apikeys.len(),
-            "providers": state.hub.len(),
         })),
     )
 }
@@ -404,6 +400,25 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "invalid_api_key");
+    }
+
+    #[tokio::test]
+    async fn health_reports_only_minimal_status() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v, serde_json::json!({"status": "ok"}));
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -174,9 +174,7 @@ async fn drain_body(body: axum::body::Body) {
     .await;
 }
 
-async fn health(
-    _state: axum::extract::State<ProxyState>,
-) -> (StatusCode, Json<serde_json::Value>) {
+async fn health(_state: axum::extract::State<ProxyState>) -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::OK,
         Json(json!({

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -422,6 +422,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn health_rejects_non_get_requests() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
     async fn unknown_api_key_returns_401() {
         let hub = Arc::new(Hub::new());
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -23,7 +23,7 @@ configured in the bootstrap YAML under `admin.admin_keys` (a list).
 
 The unauthenticated endpoints are:
 
-- `/health` — liveness probe.
+- `/health` — minimal unauthenticated status probe.
 - `/metrics` — Prometheus scrape (intended to be private).
 - `/admin/openapi.json`, `/admin/openapi-scalar` — the OpenAPI spec
   and the Scalar UI.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,7 +100,7 @@ Lives in `tests/e2e/`. Each test:
    (`/aisix-e2e-<uuid>`) so concurrent runs cannot collide.
 4. Writes a YAML config to a temp dir.
 5. Spawns `target/debug/aisix --config <path>`.
-6. Waits up to 10 s for `/health` and `/admin/v1/health` to respond.
+6. Waits up to 10 s for the minimal `/health` probe and `/admin/v1/health` to respond.
 7. Drives the request scenario via the Admin and Proxy clients.
 8. Tears down: SIGTERM + 3 s grace + SIGKILL fallback, plus etcd
    prefix cleanup.

--- a/tests/e2e/src/cases/health-minimal-e2e.test.ts
+++ b/tests/e2e/src/cases/health-minimal-e2e.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { EtcdClient, spawnApp, type SpawnedApp } from "../harness/index.js";
+import { harnessRequest } from "../harness/http.js";
+
+describe("health e2e: public health stays minimal and does not rename to /livez", () => {
+  let app: SpawnedApp | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    app = await spawnApp();
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+  });
+
+  test("proxy and admin public health return only status, and /livez is absent", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const proxyHealth = await harnessRequest(`${app.proxyUrl}/health`, { method: "GET" });
+    expect(proxyHealth.statusCode).toBe(200);
+    expect(JSON.parse(await proxyHealth.body.text())).toEqual({ status: "ok" });
+
+    const adminHealth = await harnessRequest(`${app.adminUrl}/health`, { method: "GET" });
+    expect(adminHealth.statusCode).toBe(200);
+    expect(JSON.parse(await adminHealth.body.text())).toEqual({ status: "ok" });
+
+    const proxyLivez = await harnessRequest(`${app.proxyUrl}/livez`, { method: "GET" });
+    expect(proxyLivez.statusCode).toBe(404);
+    await proxyLivez.body.dump();
+
+    const adminLivez = await harnessRequest(`${app.adminUrl}/livez`, { method: "GET" });
+    expect(adminLivez.statusCode).toBe(404);
+    await adminLivez.body.dump();
+  });
+});


### PR DESCRIPTION
## Summary
- minimize unauthenticated `GET /health` responses on both the proxy and admin listeners to `{"status":"ok"}` only
- document the tightened public admin `/health` response schema in OpenAPI
- add regression coverage so `/health` stays minimal and `/livez` is not introduced in this PR

## Verification
- `cargo test -p aisix-proxy health_reports_only_minimal_status`
- `cargo test -p aisix-admin health_`
- `cargo test -p aisix-admin openapi_`
- `cargo build`
- `cd tests/e2e && npm install`
- `cd tests/e2e && npm test -- --run src/cases/health-minimal-e2e.test.ts`

## Follow-up
- `/health` -> `/livez` rename remains follow-up work in `#253` and is intentionally not included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * /health now returns a minimal JSON payload {"status":"ok"} across public endpoints and no longer exposes snapshot or count fields; non-GET requests now return 405.

* **Documentation**
  * API docs updated to describe /health as a minimal unauthenticated status probe and OpenAPI schema tightened to require the single-status response.
  * Admin/state docs clarified.

* **Tests**
  * Added unit and E2E tests verifying minimal /health responses and 405 behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/256)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->