### PR TITLE
fix(health): rename public liveness route to /livez

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -140,15 +140,12 @@ pub fn build_router(state: AdminState) -> Router {
 }
 
 async fn health(
-    axum::extract::State(state): axum::extract::State<AdminState>,
+    _state: axum::extract::State<AdminState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let snap = state.snapshot.load();
     (
         StatusCode::OK,
         Json(json!({
             "status": "ok",
-            "models": snap.models.len(),
-            "apikeys": snap.apikeys.len(),
         })),
     )
 }
@@ -328,7 +325,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_reports_snapshot_counts() {
+    async fn health_reports_only_minimal_status() {
         let app = build_router(build_state());
         let req = Request::builder()
             .uri("/health")
@@ -338,6 +335,9 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v["status"], "ok");
+        assert_eq!(v.as_object().map(|o| o.len()), Some(1));
+        assert!(v.get("models").is_none());
+        assert!(v.get("apikeys").is_none());
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -1,7 +1,7 @@
 //! aisix-admin — Admin API + Playground (:3001).
 //!
 //! Public admin-listener endpoints:
-//! - `GET  /health`
+//! - `GET  /livez`
 //! - `GET  /metrics`
 //! - `GET  /admin/openapi.json`
 //! - `GET  /admin/openapi-scalar`
@@ -53,12 +53,11 @@ pub use state::AdminState;
 pub use store::{ConfigStore, InMemoryStore, StoreError};
 
 use axum::routing::{get, post};
-use axum::{http::StatusCode, Json, Router};
-use serde_json::json;
+use axum::{http::StatusCode, response::Response, Router};
 
 pub fn build_router(state: AdminState) -> Router {
     Router::new()
-        .route("/health", get(health))
+        .route("/livez", get(livez))
         .route("/metrics", get(metrics_handler))
         // OpenAPI scalar UI is unauthenticated like /metrics — admin
         // listener is private in production.
@@ -144,13 +143,11 @@ pub fn build_router(state: AdminState) -> Router {
         .with_state(state)
 }
 
-async fn health(_state: axum::extract::State<AdminState>) -> (StatusCode, Json<serde_json::Value>) {
-    (
-        StatusCode::OK,
-        Json(json!({
-            "status": "ok",
-        })),
-    )
+async fn livez(
+    axum::extract::State(state): axum::extract::State<AdminState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    aisix_proxy::health::livez_response(&state.livez_state, params.contains_key("verbose"))
 }
 
 /// Prometheus `/metrics` endpoint. Unauthenticated by design — the admin
@@ -328,31 +325,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_reports_only_minimal_status() {
+    async fn livez_reports_plain_ok_by_default() {
         let app = build_router(build_state());
         let req = Request::builder()
-            .uri("/health")
+            .uri("/livez")
             .body(Body::empty())
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert_eq!(v["status"], "ok");
-        assert_eq!(v.as_object().map(|o| o.len()), Some(1));
-        assert!(v.get("models").is_none());
-        assert!(v.get("apikeys").is_none());
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "ok");
     }
 
     #[tokio::test]
-    async fn health_rejects_non_get_requests() {
+    async fn livez_rejects_non_get_requests() {
         let app = build_router(build_state());
         let req = Request::builder()
             .method("POST")
-            .uri("/health")
+            .uri("/livez")
             .body(Body::empty())
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn livez_returns_500_when_shutting_down() {
+        let state = build_state();
+        state.livez_state.mark_shutting_down();
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert!(text.contains("livez check failed"));
+    }
+
+    #[tokio::test]
+    async fn health_route_is_not_found() {
+        let app = build_router(build_state());
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -1,7 +1,12 @@
 //! aisix-admin — Admin API + Playground (:3001).
 //!
-//! Mounts the admin surface behind admin-key bearer auth:
+//! Public admin-listener endpoints:
 //! - `GET  /health`
+//! - `GET  /metrics`
+//! - `GET  /admin/openapi.json`
+//! - `GET  /admin/openapi-scalar`
+//!
+//! Admin-key protected routes:
 //! - `GET|POST            /admin/v1/models`
 //! - `GET|PUT|DELETE      /admin/v1/models/:id`
 //! - `GET|POST            /admin/v1/apikeys`

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -144,9 +144,7 @@ pub fn build_router(state: AdminState) -> Router {
         .with_state(state)
 }
 
-async fn health(
-    _state: axum::extract::State<AdminState>,
-) -> (StatusCode, Json<serde_json::Value>) {
+async fn health(_state: axum::extract::State<AdminState>) -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::OK,
         Json(json!({

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -1,7 +1,7 @@
 //! aisix-admin — Admin API + Playground (:3001).
 //!
 //! Public admin-listener endpoints:
-//! - `GET  /health`
+//! - `GET  /livez`
 //! - `GET  /metrics`
 //! - `GET  /admin/openapi.json`
 //! - `GET  /admin/openapi-scalar`
@@ -53,12 +53,11 @@ pub use state::AdminState;
 pub use store::{ConfigStore, InMemoryStore, StoreError};
 
 use axum::routing::{get, post};
-use axum::{http::StatusCode, Json, Router};
-use serde_json::json;
+use axum::{http::StatusCode, response::Response, Router};
 
 pub fn build_router(state: AdminState) -> Router {
     Router::new()
-        .route("/health", get(health))
+        .route("/livez", get(livez))
         .route("/metrics", get(metrics_handler))
         // OpenAPI scalar UI is unauthenticated like /metrics — admin
         // listener is private in production.
@@ -144,13 +143,11 @@ pub fn build_router(state: AdminState) -> Router {
         .with_state(state)
 }
 
-async fn health(_state: axum::extract::State<AdminState>) -> (StatusCode, Json<serde_json::Value>) {
-    (
-        StatusCode::OK,
-        Json(json!({
-            "status": "ok",
-        })),
-    )
+async fn livez(
+    axum::extract::State(state): axum::extract::State<AdminState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    aisix_proxy::health::livez_response(&state.livez_state, params.contains_key("verbose"))
 }
 
 /// Prometheus `/metrics` endpoint. Unauthenticated by design — the admin
@@ -328,31 +325,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_reports_only_minimal_status() {
+    async fn livez_reports_plain_ok_by_default() {
         let app = build_router(build_state());
         let req = Request::builder()
-            .uri("/health")
+            .uri("/livez")
             .body(Body::empty())
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert_eq!(v["status"], "ok");
-        assert_eq!(v.as_object().map(|o| o.len()), Some(1));
-        assert!(v.get("models").is_none());
-        assert!(v.get("apikeys").is_none());
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "ok");
     }
 
     #[tokio::test]
-    async fn health_rejects_non_get_requests() {
+    async fn livez_rejects_non_get_requests() {
         let app = build_router(build_state());
         let req = Request::builder()
             .method("POST")
-            .uri("/health")
+            .uri("/livez")
             .body(Body::empty())
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn health_route_is_not_found() {
+        let app = build_router(build_state());
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -341,6 +341,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn health_rejects_non_get_requests() {
+        let app = build_router(build_state());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
     async fn create_model_returns_entry_with_generated_id() {
         let app = build_router(build_state());
         let resp = run(

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -350,6 +350,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn livez_returns_500_when_shutting_down() {
+        let state = build_state();
+        state.livez_state.mark_shutting_down();
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert!(text.contains("livez check failed"));
+    }
+
+    #[tokio::test]
     async fn health_route_is_not_found() {
         let app = build_router(build_state());
         let req = Request::builder()

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -28,14 +28,32 @@ const OPENAPI_JSON: &str = r##"{
       "get": {
         "summary": "minimal public liveness probe",
         "security": [],
+        "parameters": [
+          {
+            "name": "verbose",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "string"},
+            "description": "When present, returns a multi-line text report instead of the terse `ok` body."
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "text/plain": {
                 "schema": {
-                  "type": "string",
-                  "enum": ["ok"]
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Liveness checks failed during shutdown",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -489,7 +507,12 @@ mod tests {
             ["schema"];
 
         assert_eq!(schema["type"], "string");
-        assert_eq!(schema["enum"], serde_json::json!(["ok"]));
+        assert!(schema.get("enum").is_none());
+        assert_eq!(
+            parsed["paths"]["/livez"]["get"]["parameters"][0]["name"],
+            "verbose"
+        );
+        assert!(parsed["paths"]["/livez"]["get"]["responses"]["500"].is_object());
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -24,22 +24,36 @@ const OPENAPI_JSON: &str = r##"{
     "description": "Admin surface for the standalone aisix gateway. All `/admin/v1/*` routes require Bearer admin-key auth (configured via `admin.admin_keys`). Errors use {\"error_msg\": \"...\"}.\n\nIn managed mode (aisix.cloud tenant) the admin listener is not bound — the dashboard owns CRUD via the AISIX-Cloud control plane."
   },
   "paths": {
-    "/health": {
+    "/livez": {
       "get": {
-        "summary": "minimal process health status",
+        "summary": "minimal public liveness probe",
         "security": [],
+        "parameters": [
+          {
+            "name": "verbose",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "string"},
+            "description": "When present, returns a multi-line text report instead of the terse `ok` body."
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
-                  "type": "object",
-                  "required": ["status"],
-                  "additionalProperties": false,
-                  "properties": {
-                    "status": {"type": "string", "enum": ["ok"]}
-                  }
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Liveness checks failed during shutdown",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -415,7 +429,7 @@ mod tests {
             serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
         // Every route mounted in build_router should be documented.
         for path in [
-            "/health",
+            "/livez",
             "/metrics",
             "/admin/openapi.json",
             "/admin/openapi-scalar",
@@ -464,7 +478,7 @@ mod tests {
 
     #[tokio::test]
     async fn openapi_unauthenticated_routes_carry_empty_security() {
-        // /health, /metrics, and the openapi self-references are public
+        // /livez, /metrics, and the openapi self-references are public
         // (mirrors the `unauthenticated like /metrics` design note in
         // build_router). The spec must mark them with security: [] so
         // Scalar's "Try it" doesn't prompt for an admin key on those
@@ -472,7 +486,7 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
         for path in [
-            "/health",
+            "/livez",
             "/metrics",
             "/admin/openapi.json",
             "/admin/openapi-scalar",
@@ -486,19 +500,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn openapi_health_documents_minimal_status_only() {
+    async fn openapi_livez_documents_plain_ok() {
         let parsed: serde_json::Value =
             serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
-        let schema = &parsed["paths"]["/health"]["get"]["responses"]["200"]["content"]
-            ["application/json"]["schema"];
+        let schema = &parsed["paths"]["/livez"]["get"]["responses"]["200"]["content"]["text/plain"]
+            ["schema"];
 
-        assert_eq!(schema["type"], "object");
-        assert_eq!(schema["required"], serde_json::json!(["status"]));
-        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(schema["type"], "string");
+        assert!(schema.get("enum").is_none());
         assert_eq!(
-            schema["properties"]["status"]["enum"],
-            serde_json::json!(["ok"])
+            parsed["paths"]["/livez"]["get"]["parameters"][0]["name"],
+            "verbose"
         );
+        assert!(parsed["paths"]["/livez"]["get"]["responses"]["500"].is_object());
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -26,7 +26,7 @@ const OPENAPI_JSON: &str = r##"{
   "paths": {
     "/health": {
       "get": {
-        "summary": "process health + snapshot counts",
+        "summary": "minimal process health status",
         "security": [],
         "responses": {"200": {"description": "OK"}}
       }

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -495,7 +495,10 @@ mod tests {
         assert_eq!(schema["type"], "object");
         assert_eq!(schema["required"], serde_json::json!(["status"]));
         assert_eq!(schema["additionalProperties"], false);
-        assert_eq!(schema["properties"]["status"]["enum"], serde_json::json!(["ok"]));
+        assert_eq!(
+            schema["properties"]["status"]["enum"],
+            serde_json::json!(["ok"])
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -24,22 +24,18 @@ const OPENAPI_JSON: &str = r##"{
     "description": "Admin surface for the standalone aisix gateway. All `/admin/v1/*` routes require Bearer admin-key auth (configured via `admin.admin_keys`). Errors use {\"error_msg\": \"...\"}.\n\nIn managed mode (aisix.cloud tenant) the admin listener is not bound — the dashboard owns CRUD via the AISIX-Cloud control plane."
   },
   "paths": {
-    "/health": {
+    "/livez": {
       "get": {
-        "summary": "minimal process health status",
+        "summary": "minimal public liveness probe",
         "security": [],
         "responses": {
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
-                  "type": "object",
-                  "required": ["status"],
-                  "additionalProperties": false,
-                  "properties": {
-                    "status": {"type": "string", "enum": ["ok"]}
-                  }
+                  "type": "string",
+                  "enum": ["ok"]
                 }
               }
             }
@@ -415,7 +411,7 @@ mod tests {
             serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
         // Every route mounted in build_router should be documented.
         for path in [
-            "/health",
+            "/livez",
             "/metrics",
             "/admin/openapi.json",
             "/admin/openapi-scalar",
@@ -464,7 +460,7 @@ mod tests {
 
     #[tokio::test]
     async fn openapi_unauthenticated_routes_carry_empty_security() {
-        // /health, /metrics, and the openapi self-references are public
+        // /livez, /metrics, and the openapi self-references are public
         // (mirrors the `unauthenticated like /metrics` design note in
         // build_router). The spec must mark them with security: [] so
         // Scalar's "Try it" doesn't prompt for an admin key on those
@@ -472,7 +468,7 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
         for path in [
-            "/health",
+            "/livez",
             "/metrics",
             "/admin/openapi.json",
             "/admin/openapi-scalar",
@@ -486,19 +482,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn openapi_health_documents_minimal_status_only() {
+    async fn openapi_livez_documents_plain_ok() {
         let parsed: serde_json::Value =
             serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
-        let schema = &parsed["paths"]["/health"]["get"]["responses"]["200"]["content"]
-            ["application/json"]["schema"];
+        let schema = &parsed["paths"]["/livez"]["get"]["responses"]["200"]["content"]["text/plain"]
+            ["schema"];
 
-        assert_eq!(schema["type"], "object");
-        assert_eq!(schema["required"], serde_json::json!(["status"]));
-        assert_eq!(schema["additionalProperties"], false);
-        assert_eq!(
-            schema["properties"]["status"]["enum"],
-            serde_json::json!(["ok"])
-        );
+        assert_eq!(schema["type"], "string");
+        assert_eq!(schema["enum"], serde_json::json!(["ok"]));
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -28,7 +28,23 @@ const OPENAPI_JSON: &str = r##"{
       "get": {
         "summary": "minimal process health status",
         "security": [],
-        "responses": {"200": {"description": "OK"}}
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["status"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "status": {"type": "string", "enum": ["ok"]}
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/metrics": {
@@ -467,6 +483,19 @@ mod tests {
                 "{path} should declare security: [] but got {security:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn openapi_health_documents_minimal_status_only() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(OPENAPI_JSON).expect("OPENAPI_JSON must parse");
+        let schema = &parsed["paths"]["/health"]["get"]["responses"]["200"]["content"]
+            ["application/json"]["schema"];
+
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["required"], serde_json::json!(["status"]));
+        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(schema["properties"]["status"]["enum"], serde_json::json!(["ok"]));
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/state.rs
+++ b/crates/aisix-admin/src/state.rs
@@ -15,7 +15,7 @@ use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AdminConfig, AisixSnapshot};
 use aisix_etcd::WatchStatus;
 use aisix_obs::Metrics;
-use aisix_proxy::HealthTracker;
+use aisix_proxy::{HealthTracker, LivezState};
 use axum::Router;
 use std::sync::Arc;
 
@@ -36,6 +36,8 @@ pub struct AdminState {
     /// stream that would otherwise let the gateway serve a stale
     /// snapshot indefinitely. See issue #114.
     pub watch_status: Option<WatchStatus>,
+    /// Shared liveness state for the public `GET /livez` endpoint.
+    pub livez_state: Arc<LivezState>,
     /// Proxy router shared for the `/playground/chat/completions` endpoint.
     /// The playground handler calls `router.oneshot(req)` so the request
     /// goes through the full proxy middleware stack (auth, rate-limit, bridge)
@@ -56,6 +58,7 @@ impl AdminState {
             metrics: None,
             health_tracker: None,
             watch_status: None,
+            livez_state: Arc::new(LivezState::new()),
             proxy_router: None,
         }
     }
@@ -80,6 +83,13 @@ impl AdminState {
     /// `GET /admin/v1/health` reflects per-model upstream health.
     pub fn with_health_tracker(mut self, tracker: Arc<HealthTracker>) -> Self {
         self.health_tracker = Some(tracker);
+        self
+    }
+
+    /// Share the public liveness state with the proxy so both listeners
+    /// report the same shutdown signal.
+    pub fn with_livez_state(mut self, livez_state: Arc<LivezState>) -> Self {
+        self.livez_state = livez_state;
         self
     }
 

--- a/crates/aisix-admin/src/state.rs
+++ b/crates/aisix-admin/src/state.rs
@@ -3,7 +3,7 @@
 //! Holds:
 //! - the bootstrap-config-provided `admin_keys` (auth)
 //! - the `ConfigStore` trait object (CRUD backend)
-//! - a `SnapshotHandle` for the /health endpoint (snapshot counts)
+//! - a `SnapshotHandle` for authenticated operator-health handlers
 //! - an optional `Metrics` handle — when present, `/metrics` renders
 //!   the same Prometheus exposition that the proxy's middleware writes to
 //!

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -297,7 +297,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// stamp the cache with the etcd `load_all` revision even when the
     /// resulting entry set is empty (so the file still reflects when
     /// the DP last successfully reached the CP). Also stamps
-    /// `WatchStatus.last_apply_at` so `/health` reflects the
+    /// `WatchStatus.last_apply_at` so `/admin/v1/health` reflects the
     /// successful round-trip with etcd even on an empty config.
     fn set_revision_floor(&self, revision: i64) {
         let mut rev = self.revision.lock().unwrap();
@@ -373,7 +373,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                 *rev = entry.revision;
             }
         }
-        // /health reads this — record the apply so `last_apply_age`
+        // /admin/v1/health reads this — record the apply so `last_apply_age`
         // resets on every event we successfully process.
         self.status.record_apply(entry.revision);
         self.flush_cache();
@@ -447,7 +447,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             new
         });
         self.state.lock().unwrap().remove(key_str);
-        // Stamp /health freshness on a successful delete. We
+        // Stamp /admin/v1/health freshness on a successful delete. We
         // don't have a per-event revision on the wire delete
         // (the etcd watch revision is held at the cycle level);
         // call record_apply with the current revision so age
@@ -481,7 +481,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                 *rev = rev_val;
             }
         }
-        // /health: stamp freshness on every resync, even when the
+        // /admin/v1/health: stamp freshness on every resync, even when the
         // resulting entry set is empty (record_apply with the current
         // revision floor so the operator sees recent activity).
         let cur_rev = *self.revision.lock().unwrap();
@@ -1079,7 +1079,7 @@ mod tests {
     async fn watch_status_age_grows_when_no_events_arrive() {
         // Pin the freshness signal: after an apply, the age is small;
         // wait briefly and observe it has grown. This is what the
-        // /health handler reads to detect a wedged watch — without
+        // /admin/v1/health reads this to detect a wedged watch — without
         // this signal the proxy could serve stale config indefinitely.
         let provider = Arc::new(FakeProvider::new(vec![], 5));
         let sup = Supervisor::new(provider, "/aisix");

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -14,7 +14,78 @@
 //! under stress without waiting for a full outage.
 
 use dashmap::DashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU32, Ordering};
+
+use axum::http::header::{HeaderName, HeaderValue, CONTENT_TYPE};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+static X_CONTENT_TYPE_OPTIONS: HeaderName = HeaderName::from_static("x-content-type-options");
+static NOSNIFF: HeaderValue = HeaderValue::from_static("nosniff");
+static TEXT_PLAIN_UTF8: HeaderValue = HeaderValue::from_static("text/plain; charset=utf-8");
+
+#[derive(Debug, Default)]
+pub struct LivezState {
+    shutting_down: AtomicBool,
+}
+
+impl LivezState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn mark_shutting_down(&self) {
+        self.shutting_down.store(true, Ordering::Relaxed);
+    }
+
+    fn shutdown_check(&self) -> Result<(), &'static str> {
+        if self.shutting_down.load(Ordering::Relaxed) {
+            Err("process is shutting down")
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub fn livez_response(livez: &LivezState, verbose: bool) -> Response {
+    let mut body = String::new();
+    let mut failed = false;
+
+    body.push_str("[+]ping ok\n");
+    match livez.shutdown_check() {
+        Ok(()) => body.push_str("[+]shutdown ok\n"),
+        Err(_) => {
+            failed = true;
+            body.push_str("[-]shutdown failed: reason withheld\n");
+        }
+    }
+
+    let headers = [
+        (CONTENT_TYPE, TEXT_PLAIN_UTF8.clone()),
+        (X_CONTENT_TYPE_OPTIONS.clone(), NOSNIFF.clone()),
+    ];
+
+    if failed {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            headers,
+            format!("{body}livez check failed"),
+        )
+            .into_response();
+    }
+
+    if !verbose {
+        return (StatusCode::OK, headers, "ok").into_response();
+    }
+
+    (
+        StatusCode::OK,
+        headers,
+        format!("{body}livez check passed\n"),
+    )
+        .into_response()
+}
 
 /// Numeric health level reported by the API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
@@ -143,6 +214,7 @@ impl HealthTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::to_bytes;
 
     #[test]
     fn new_model_is_healthy() {
@@ -193,5 +265,41 @@ mod tests {
         assert!(t.all_levels().is_empty());
         t.record_success("m");
         assert_eq!(t.all_levels().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn livez_default_success_is_plain_ok() {
+        let state = LivezState::new();
+        let resp = livez_response(&state, false);
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn livez_verbose_success_lists_checks() {
+        let state = LivezState::new();
+        let resp = livez_response(&state, true);
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(text.contains("[+]ping ok"));
+        assert!(text.contains("[+]shutdown ok"));
+        assert!(text.contains("livez check passed"));
+    }
+
+    #[tokio::test]
+    async fn livez_failure_returns_500_with_reason_withheld() {
+        let state = LivezState::new();
+        state.mark_shutting_down();
+        let resp = livez_response(&state, false);
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(text.contains("[-]shutdown failed: reason withheld"));
+        assert!(text.contains("livez check failed"));
     }
 }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -175,16 +175,12 @@ async fn drain_body(body: axum::body::Body) {
 }
 
 async fn health(
-    axum::extract::State(state): axum::extract::State<ProxyState>,
+    _state: axum::extract::State<ProxyState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let snap = state.snapshot.load();
     (
         StatusCode::OK,
         Json(json!({
             "status": "ok",
-            "models": snap.models.len(),
-            "apikeys": snap.apikeys.len(),
-            "providers": state.hub.len(),
         })),
     )
 }
@@ -404,6 +400,25 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "invalid_api_key");
+    }
+
+    #[tokio::test]
+    async fn health_reports_only_minimal_status() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v, serde_json::json!({"status": "ok"}));
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1,7 +1,7 @@
 //! aisix-proxy — client-facing proxy router (`:3000`).
 //!
 //! Mounts the OpenAI-compatible surface:
-//! - `GET  /health`
+//! - `GET  /livez`
 //! - `POST /v1/chat/completions` (streaming + non-streaming)
 //!
 //! Handlers run behind the [`AuthenticatedKey`] extractor which reads
@@ -47,7 +47,7 @@ mod state;
 
 pub use auth::AuthenticatedKey;
 pub use error::{ErrorEnvelope, ProxyError};
-pub use health::HealthTracker;
+pub use health::{HealthTracker, LivezState};
 pub use state::ProxyState;
 
 use axum::extract::State;
@@ -55,15 +55,14 @@ use axum::http::Request;
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get, post};
-use axum::{http::StatusCode, Json, Router};
-use serde_json::json;
+use axum::Router;
 
-/// Build the proxy router. Mounts `/health` plus the
+/// Build the proxy router. Mounts `/livez` plus the
 /// OpenAI-compatible proxy surface.
 pub fn build_router(state: ProxyState) -> Router {
     let body_limit = state.request_body_limit_bytes;
     Router::new()
-        .route("/health", get(health))
+        .route("/livez", get(livez))
         .route("/v1/models", get(models::list_models))
         .route("/v1/chat/completions", post(chat::chat_completions))
         .route("/v1/completions", post(completions::completions))
@@ -174,13 +173,11 @@ async fn drain_body(body: axum::body::Body) {
     .await;
 }
 
-async fn health(_state: axum::extract::State<ProxyState>) -> (StatusCode, Json<serde_json::Value>) {
-    (
-        StatusCode::OK,
-        Json(json!({
-            "status": "ok",
-        })),
-    )
+async fn livez(
+    State(state): State<ProxyState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    crate::health::livez_response(&state.livez, params.contains_key("verbose"))
 }
 
 #[cfg(test)]
@@ -401,7 +398,62 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_reports_only_minimal_status() {
+    async fn livez_reports_plain_ok_by_default() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn livez_rejects_non_get_requests() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn livez_returns_500_when_shutting_down() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let state = build_state(snap, hub);
+        state.livez.mark_shutting_down();
+        let app = build_router(state);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert!(text.contains("livez check failed"));
+    }
+
+    #[tokio::test]
+    async fn health_route_is_not_found() {
         let hub = Arc::new(Hub::new());
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
         let app = build_router(build_state(snap, hub));
@@ -413,26 +465,7 @@ mod tests {
             .unwrap();
 
         let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
-        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(v, serde_json::json!({"status": "ok"}));
-    }
-
-    #[tokio::test]
-    async fn health_rejects_non_get_requests() {
-        let hub = Arc::new(Hub::new());
-        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
-        let app = build_router(build_state(snap, hub));
-
-        let req = Request::builder()
-            .method("POST")
-            .uri("/health")
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -432,6 +432,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn livez_returns_500_when_shutting_down() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let state = build_state(snap, hub);
+        state.livez.mark_shutting_down();
+        let app = build_router(state);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert!(text.contains("livez check failed"));
+    }
+
+    #[tokio::test]
     async fn health_route_is_not_found() {
         let hub = Arc::new(Hub::new());
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -174,9 +174,7 @@ async fn drain_body(body: axum::body::Body) {
     .await;
 }
 
-async fn health(
-    _state: axum::extract::State<ProxyState>,
-) -> (StatusCode, Json<serde_json::Value>) {
+async fn health(_state: axum::extract::State<ProxyState>) -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::OK,
         Json(json!({

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -422,6 +422,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn health_rejects_non_get_requests() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
     async fn unknown_api_key_returns_401() {
         let hub = Arc::new(Hub::new());
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1,7 +1,7 @@
 //! aisix-proxy — client-facing proxy router (`:3000`).
 //!
 //! Mounts the OpenAI-compatible surface:
-//! - `GET  /health`
+//! - `GET  /livez`
 //! - `POST /v1/chat/completions` (streaming + non-streaming)
 //!
 //! Handlers run behind the [`AuthenticatedKey`] extractor which reads
@@ -47,7 +47,7 @@ mod state;
 
 pub use auth::AuthenticatedKey;
 pub use error::{ErrorEnvelope, ProxyError};
-pub use health::HealthTracker;
+pub use health::{HealthTracker, LivezState};
 pub use state::ProxyState;
 
 use axum::extract::State;
@@ -55,15 +55,14 @@ use axum::http::Request;
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get, post};
-use axum::{http::StatusCode, Json, Router};
-use serde_json::json;
+use axum::Router;
 
-/// Build the proxy router. Mounts `/health` plus the
+/// Build the proxy router. Mounts `/livez` plus the
 /// OpenAI-compatible proxy surface.
 pub fn build_router(state: ProxyState) -> Router {
     let body_limit = state.request_body_limit_bytes;
     Router::new()
-        .route("/health", get(health))
+        .route("/livez", get(livez))
         .route("/v1/models", get(models::list_models))
         .route("/v1/chat/completions", post(chat::chat_completions))
         .route("/v1/completions", post(completions::completions))
@@ -174,13 +173,11 @@ async fn drain_body(body: axum::body::Body) {
     .await;
 }
 
-async fn health(_state: axum::extract::State<ProxyState>) -> (StatusCode, Json<serde_json::Value>) {
-    (
-        StatusCode::OK,
-        Json(json!({
-            "status": "ok",
-        })),
-    )
+async fn livez(
+    State(state): State<ProxyState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    crate::health::livez_response(&state.livez, params.contains_key("verbose"))
 }
 
 #[cfg(test)]
@@ -401,7 +398,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_reports_only_minimal_status() {
+    async fn livez_reports_plain_ok_by_default() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn livez_rejects_non_get_requests() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn health_route_is_not_found() {
         let hub = Arc::new(Hub::new());
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
         let app = build_router(build_state(snap, hub));
@@ -413,26 +444,7 @@ mod tests {
             .unwrap();
 
         let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
-        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(v, serde_json::json!({"status": "ok"}));
-    }
-
-    #[tokio::test]
-    async fn health_rejects_non_get_requests() {
-        let hub = Arc::new(Hub::new());
-        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
-        let app = build_router(build_state(snap, hub));
-
-        let req = Request::builder()
-            .method("POST")
-            .uri("/health")
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -24,7 +24,7 @@ use aisix_ratelimit::Limiter;
 use std::sync::Arc;
 
 use crate::budget::BudgetClient;
-use crate::health::HealthTracker;
+use crate::health::{HealthTracker, LivezState};
 use crate::routing::RoutingRegistry;
 
 #[derive(Clone)]
@@ -44,6 +44,8 @@ pub struct ProxyState {
     /// Per-model health tracker. Updated on every upstream call outcome;
     /// read by `GET /admin/v1/health`.
     pub health: Arc<HealthTracker>,
+    /// Public liveness state served on `GET /livez`.
+    pub livez: Arc<LivezState>,
     /// CP-side usage telemetry sink. Backed by an mpsc channel into the
     /// sender worker spawned in aisix-server (see `telemetry::spawn`).
     /// Defaults to a no-op sink when running outside managed mode so
@@ -70,6 +72,7 @@ impl ProxyState {
             guardrails: Arc::new(GuardrailChain::empty()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
+            livez: Arc::new(LivezState::new()),
             usage_sink: UsageSink::disabled(),
             otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
@@ -94,6 +97,7 @@ impl ProxyState {
             guardrails: Arc::new(GuardrailChain::empty()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
+            livez: Arc::new(LivezState::new()),
             usage_sink: UsageSink::disabled(),
             otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
@@ -121,6 +125,7 @@ impl ProxyState {
             guardrails: Arc::new(GuardrailChain::empty()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
+            livez: Arc::new(LivezState::new()),
             usage_sink: UsageSink::disabled(),
             otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -480,6 +480,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     ));
     // Clone shared trackers before consuming proxy_state in build_router.
     let health_tracker = proxy_state.health.clone();
+    let livez_state = proxy_state.livez.clone();
     let proxy_router = aisix_proxy::build_router(proxy_state);
 
     // Admin router + listener are only built in standalone mode.
@@ -494,6 +495,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // Share the health tracker so /admin/v1/health reflects live
             // per-model upstream failure counts.
             .with_health_tracker(health_tracker)
+            .with_livez_state(livez_state.clone())
             // Share the supervisor's freshness state so /admin/v1/health
             // exposes etcd watch staleness — without this, a wedged
             // watch lets the gateway serve stale config indefinitely
@@ -514,7 +516,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         // Drop unused shared components so the compiler can see they
         // don't escape managed mode. The health tracker exists on
         // proxy_state and keeps working regardless.
-        let _ = &health_tracker;
+        let _ = (&health_tracker, &livez_state);
         tracing::info!("managed mode enabled — admin surface not bound");
         None
     };
@@ -529,7 +531,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
 
     // Step 10: shutdown coordinator. Whichever of (signal, proxy, admin)
     // completes first triggers the rest.
-    let signal_task = tokio::spawn(wait_for_signal(cancel_tx.clone()));
+    let signal_task = tokio::spawn(wait_for_signal(cancel_tx.clone(), livez_state));
 
     let proxy_res = proxy_serve.await;
     proxy_res.map_err(|e| anyhow::anyhow!("proxy serve error: {e}"))?;
@@ -796,7 +798,10 @@ async fn shutdown_signal(mut cancel: watch::Receiver<bool>, label: &'static str)
     }
 }
 
-async fn wait_for_signal(cancel_tx: watch::Sender<bool>) {
+async fn wait_for_signal(
+    cancel_tx: watch::Sender<bool>,
+    livez_state: std::sync::Arc<aisix_proxy::LivezState>,
+) {
     let ctrl_c = async {
         let _ = tokio::signal::ctrl_c().await;
     };
@@ -819,6 +824,7 @@ async fn wait_for_signal(cancel_tx: watch::Sender<bool>) {
         _ = term => tracing::info!("received SIGTERM"),
     }
 
+    livez_state.mark_shutting_down();
     let _ = cancel_tx.send(true);
 }
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -825,6 +825,7 @@ async fn wait_for_signal(
     }
 
     livez_state.mark_shutting_down();
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     let _ = cancel_tx.send(true);
 }
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -480,6 +480,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     ));
     // Clone shared trackers before consuming proxy_state in build_router.
     let health_tracker = proxy_state.health.clone();
+    let livez_state = proxy_state.livez.clone();
     let proxy_router = aisix_proxy::build_router(proxy_state);
 
     // Admin router + listener are only built in standalone mode.
@@ -494,6 +495,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // Share the health tracker so /admin/v1/health reflects live
             // per-model upstream failure counts.
             .with_health_tracker(health_tracker)
+            .with_livez_state(livez_state.clone())
             // Share the supervisor's freshness state so /admin/v1/health
             // exposes etcd watch staleness — without this, a wedged
             // watch lets the gateway serve stale config indefinitely
@@ -514,7 +516,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         // Drop unused shared components so the compiler can see they
         // don't escape managed mode. The health tracker exists on
         // proxy_state and keeps working regardless.
-        let _ = &health_tracker;
+        let _ = (&health_tracker, &livez_state);
         tracing::info!("managed mode enabled — admin surface not bound");
         None
     };
@@ -529,7 +531,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
 
     // Step 10: shutdown coordinator. Whichever of (signal, proxy, admin)
     // completes first triggers the rest.
-    let signal_task = tokio::spawn(wait_for_signal(cancel_tx.clone()));
+    let signal_task = tokio::spawn(wait_for_signal(cancel_tx.clone(), livez_state));
 
     let proxy_res = proxy_serve.await;
     proxy_res.map_err(|e| anyhow::anyhow!("proxy serve error: {e}"))?;
@@ -796,7 +798,10 @@ async fn shutdown_signal(mut cancel: watch::Receiver<bool>, label: &'static str)
     }
 }
 
-async fn wait_for_signal(cancel_tx: watch::Sender<bool>) {
+async fn wait_for_signal(
+    cancel_tx: watch::Sender<bool>,
+    livez_state: std::sync::Arc<aisix_proxy::LivezState>,
+) {
     let ctrl_c = async {
         let _ = tokio::signal::ctrl_c().await;
     };
@@ -819,6 +824,8 @@ async fn wait_for_signal(cancel_tx: watch::Sender<bool>) {
         _ = term => tracing::info!("received SIGTERM"),
     }
 
+    livez_state.mark_shutting_down();
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     let _ = cancel_tx.send(true);
 }
 

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -23,7 +23,7 @@ configured in the bootstrap YAML under `admin.admin_keys` (a list).
 
 The unauthenticated endpoints are:
 
-- `/health` — liveness probe.
+- `/health` — minimal unauthenticated status probe.
 - `/metrics` — Prometheus scrape (intended to be private).
 - `/admin/openapi.json`, `/admin/openapi-scalar` — the OpenAPI spec
   and the Scalar UI.

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -28,6 +28,9 @@ The unauthenticated endpoints are:
 - `/admin/openapi.json`, `/admin/openapi-scalar` — the OpenAPI spec
   and the Scalar UI.
 
+`/health` is no longer mounted as the public liveness route. Update
+probes and automation to use `/livez`.
+
 ## 2. Error envelope
 
 Admin errors use a deliberately simpler envelope than the proxy:

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -23,7 +23,7 @@ configured in the bootstrap YAML under `admin.admin_keys` (a list).
 
 The unauthenticated endpoints are:
 
-- `/health` — minimal unauthenticated status probe.
+- `/livez` — minimal unauthenticated liveness probe.
 - `/metrics` — Prometheus scrape (intended to be private).
 - `/admin/openapi.json`, `/admin/openapi-scalar` — the OpenAPI spec
   and the Scalar UI.

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -28,9 +28,6 @@ The unauthenticated endpoints are:
 - `/admin/openapi.json`, `/admin/openapi-scalar` — the OpenAPI spec
   and the Scalar UI.
 
-`/health` is no longer mounted as the public liveness route. Update
-probes and automation to use `/livez`.
-
 ## 2. Error envelope
 
 Admin errors use a deliberately simpler envelope than the proxy:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,9 +105,6 @@ Lives in `tests/e2e/`. Each test:
 8. Tears down: SIGTERM + 3 s grace + SIGKILL fallback, plus etcd
    prefix cleanup.
 
-If you have older local scripts that still poll `/health`, update them
-to `/livez` before running the harness.
-
 ### 4.1 Layout
 
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,7 +100,7 @@ Lives in `tests/e2e/`. Each test:
    (`/aisix-e2e-<uuid>`) so concurrent runs cannot collide.
 4. Writes a YAML config to a temp dir.
 5. Spawns `target/debug/aisix --config <path>`.
-6. Waits up to 10 s for `/health` and `/admin/v1/health` to respond.
+6. Waits up to 10 s for the minimal `/health` probe and `/admin/v1/health` to respond.
 7. Drives the request scenario via the Admin and Proxy clients.
 8. Tears down: SIGTERM + 3 s grace + SIGKILL fallback, plus etcd
    prefix cleanup.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,6 +105,9 @@ Lives in `tests/e2e/`. Each test:
 8. Tears down: SIGTERM + 3 s grace + SIGKILL fallback, plus etcd
    prefix cleanup.
 
+If you have older local scripts that still poll `/health`, update them
+to `/livez` before running the harness.
+
 ### 4.1 Layout
 
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,7 +100,7 @@ Lives in `tests/e2e/`. Each test:
    (`/aisix-e2e-<uuid>`) so concurrent runs cannot collide.
 4. Writes a YAML config to a temp dir.
 5. Spawns `target/debug/aisix --config <path>`.
-6. Waits up to 10 s for the minimal `/health` probe and `/admin/v1/health` to respond.
+6. Waits up to 10 s for the minimal `/livez` probe and `/admin/v1/health` to respond.
 7. Drives the request scenario via the Admin and Proxy clients.
 8. Tears down: SIGTERM + 3 s grace + SIGKILL fallback, plus etcd
    prefix cleanup.

--- a/tests/e2e/src/cases/health-minimal-e2e.test.ts
+++ b/tests/e2e/src/cases/health-minimal-e2e.test.ts
@@ -38,4 +38,34 @@ describe("livez e2e: public liveness route is /livez and /health is gone", () =>
     expect(adminHealth.statusCode).toBe(404);
     await adminHealth.body.dump();
   });
+
+  test("proxy /livez turns unhealthy after SIGTERM before exit", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    app.signal("SIGTERM");
+
+    const deadline = Date.now() + 3000;
+    let observedUnhealthy = false;
+    while (Date.now() < deadline) {
+      try {
+        const res = await harnessRequest(`${app.proxyUrl}/livez`, { method: "GET" });
+        if (res.statusCode !== 200) {
+          observedUnhealthy = true;
+          await res.body.dump();
+          break;
+        }
+        await res.body.dump();
+      } catch {
+        observedUnhealthy = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    expect(observedUnhealthy).toBe(true);
+    app = undefined;
+  });
 });

--- a/tests/e2e/src/cases/health-minimal-e2e.test.ts
+++ b/tests/e2e/src/cases/health-minimal-e2e.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { EtcdClient, spawnApp, type SpawnedApp } from "../harness/index.js";
 import { harnessRequest } from "../harness/http.js";
 
-describe("health e2e: public health stays minimal and does not rename to /livez", () => {
+describe("livez e2e: public liveness route is /livez and /health is gone", () => {
   let app: SpawnedApp | undefined;
   let etcdReachable = false;
 
@@ -16,26 +16,26 @@ describe("health e2e: public health stays minimal and does not rename to /livez"
     await app?.exit();
   });
 
-  test("proxy and admin public health return only status, and /livez is absent", async (ctx) => {
+  test("proxy and admin public /livez return plain ok, and /health is absent", async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();
       return;
     }
 
-    const proxyHealth = await harnessRequest(`${app.proxyUrl}/health`, { method: "GET" });
-    expect(proxyHealth.statusCode).toBe(200);
-    expect(JSON.parse(await proxyHealth.body.text())).toEqual({ status: "ok" });
-
-    const adminHealth = await harnessRequest(`${app.adminUrl}/health`, { method: "GET" });
-    expect(adminHealth.statusCode).toBe(200);
-    expect(JSON.parse(await adminHealth.body.text())).toEqual({ status: "ok" });
-
     const proxyLivez = await harnessRequest(`${app.proxyUrl}/livez`, { method: "GET" });
-    expect(proxyLivez.statusCode).toBe(404);
-    await proxyLivez.body.dump();
+    expect(proxyLivez.statusCode).toBe(200);
+    expect(await proxyLivez.body.text()).toBe("ok");
 
     const adminLivez = await harnessRequest(`${app.adminUrl}/livez`, { method: "GET" });
-    expect(adminLivez.statusCode).toBe(404);
-    await adminLivez.body.dump();
+    expect(adminLivez.statusCode).toBe(200);
+    expect(await adminLivez.body.text()).toBe("ok");
+
+    const proxyHealth = await harnessRequest(`${app.proxyUrl}/health`, { method: "GET" });
+    expect(proxyHealth.statusCode).toBe(404);
+    await proxyHealth.body.dump();
+
+    const adminHealth = await harnessRequest(`${app.adminUrl}/health`, { method: "GET" });
+    expect(adminHealth.statusCode).toBe(404);
+    await adminHealth.body.dump();
   });
 });

--- a/tests/e2e/src/cases/health-minimal-e2e.test.ts
+++ b/tests/e2e/src/cases/health-minimal-e2e.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { EtcdClient, spawnApp, type SpawnedApp } from "../harness/index.js";
 import { harnessRequest } from "../harness/http.js";
 
-describe("health e2e: public health stays minimal and does not rename to /livez", () => {
+describe("livez e2e: public liveness route is /livez and /health is gone", () => {
   let app: SpawnedApp | undefined;
   let etcdReachable = false;
 
@@ -16,26 +16,56 @@ describe("health e2e: public health stays minimal and does not rename to /livez"
     await app?.exit();
   });
 
-  test("proxy and admin public health return only status, and /livez is absent", async (ctx) => {
+  test("proxy and admin public /livez return plain ok, and /health is absent", async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();
       return;
     }
 
-    const proxyHealth = await harnessRequest(`${app.proxyUrl}/health`, { method: "GET" });
-    expect(proxyHealth.statusCode).toBe(200);
-    expect(JSON.parse(await proxyHealth.body.text())).toEqual({ status: "ok" });
-
-    const adminHealth = await harnessRequest(`${app.adminUrl}/health`, { method: "GET" });
-    expect(adminHealth.statusCode).toBe(200);
-    expect(JSON.parse(await adminHealth.body.text())).toEqual({ status: "ok" });
-
     const proxyLivez = await harnessRequest(`${app.proxyUrl}/livez`, { method: "GET" });
-    expect(proxyLivez.statusCode).toBe(404);
-    await proxyLivez.body.dump();
+    expect(proxyLivez.statusCode).toBe(200);
+    expect(await proxyLivez.body.text()).toBe("ok");
 
     const adminLivez = await harnessRequest(`${app.adminUrl}/livez`, { method: "GET" });
-    expect(adminLivez.statusCode).toBe(404);
-    await adminLivez.body.dump();
+    expect(adminLivez.statusCode).toBe(200);
+    expect(await adminLivez.body.text()).toBe("ok");
+
+    const proxyHealth = await harnessRequest(`${app.proxyUrl}/health`, { method: "GET" });
+    expect(proxyHealth.statusCode).toBe(404);
+    await proxyHealth.body.dump();
+
+    const adminHealth = await harnessRequest(`${app.adminUrl}/health`, { method: "GET" });
+    expect(adminHealth.statusCode).toBe(404);
+    await adminHealth.body.dump();
+  });
+
+  test("proxy /livez turns unhealthy after SIGTERM before exit", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    app.signal("SIGTERM");
+
+    const deadline = Date.now() + 3000;
+    let observedUnhealthy = false;
+    while (Date.now() < deadline) {
+      try {
+        const res = await harnessRequest(`${app.proxyUrl}/livez`, { method: "GET" });
+        if (res.statusCode !== 200) {
+          observedUnhealthy = true;
+          await res.body.dump();
+          break;
+        }
+        await res.body.dump();
+      } catch {
+        observedUnhealthy = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    expect(observedUnhealthy).toBe(true);
+    app = undefined;
   });
 });

--- a/tests/e2e/src/cases/health-minimal-e2e.test.ts
+++ b/tests/e2e/src/cases/health-minimal-e2e.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { EtcdClient, spawnApp, type SpawnedApp } from "../harness/index.js";
+import { harnessRequest } from "../harness/http.js";
+
+describe("health e2e: public health stays minimal and does not rename to /livez", () => {
+  let app: SpawnedApp | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    app = await spawnApp();
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+  });
+
+  test("proxy and admin public health return only status, and /livez is absent", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const proxyHealth = await harnessRequest(`${app.proxyUrl}/health`, { method: "GET" });
+    expect(proxyHealth.statusCode).toBe(200);
+    expect(JSON.parse(await proxyHealth.body.text())).toEqual({ status: "ok" });
+
+    const adminHealth = await harnessRequest(`${app.adminUrl}/health`, { method: "GET" });
+    expect(adminHealth.statusCode).toBe(200);
+    expect(JSON.parse(await adminHealth.body.text())).toEqual({ status: "ok" });
+
+    const proxyLivez = await harnessRequest(`${app.proxyUrl}/livez`, { method: "GET" });
+    expect(proxyLivez.statusCode).toBe(404);
+    await proxyLivez.body.dump();
+
+    const adminLivez = await harnessRequest(`${app.adminUrl}/livez`, { method: "GET" });
+    expect(adminLivez.statusCode).toBe(404);
+    await adminLivez.body.dump();
+  });
+});

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -23,6 +23,7 @@ export interface SpawnedApp {
   adminUrl: string;
   adminKey: string;
   etcdPrefix: string;
+  signal(signal: NodeJS.Signals): void;
   exit(): Promise<void>;
 }
 
@@ -128,6 +129,9 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
     adminUrl,
     adminKey,
     etcdPrefix,
+    signal(signal: NodeJS.Signals) {
+      if (child.exitCode === null) child.kill(signal);
+    },
     async exit() {
       await terminate(child);
       await cleanup(etcd, etcdPrefix, dir);

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -23,6 +23,7 @@ export interface SpawnedApp {
   adminUrl: string;
   adminKey: string;
   etcdPrefix: string;
+  signal(signal: NodeJS.Signals): void;
   exit(): Promise<void>;
 }
 
@@ -34,8 +35,9 @@ const SHUTDOWN_GRACE_MS = 3_000;
 /**
  * Per-test handle to a spawned `aisix` binary. Each call writes a fresh
  * config YAML into a tmp dir, picks two free ports, picks a unique etcd
- * prefix, and waits up to 10s for `/health` on both ports to respond
- * 200. `exit()` issues SIGTERM and waits up to 3s, escalating to SIGKILL.
+ * prefix, and waits up to 10s for `/livez` on the proxy and `/admin/v1/health`
+ * on the admin listener to respond 200. `exit()` issues SIGTERM and waits up to
+ * 3s, escalating to SIGKILL.
  */
 export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   const etcd = new EtcdClient();
@@ -109,7 +111,7 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
 
   try {
     await Promise.all([
-      waitForReady(`${proxyUrl}/health`, READY_TIMEOUT_MS),
+      waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
       waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey),
     ]);
   } catch (err) {
@@ -127,6 +129,9 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
     adminUrl,
     adminKey,
     etcdPrefix,
+    signal(signal: NodeJS.Signals) {
+      if (child.exitCode === null) child.kill(signal);
+    },
     async exit() {
       await terminate(child);
       await cleanup(etcd, etcdPrefix, dir);

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -34,7 +34,8 @@ const SHUTDOWN_GRACE_MS = 3_000;
 /**
  * Per-test handle to a spawned `aisix` binary. Each call writes a fresh
  * config YAML into a tmp dir, picks two free ports, picks a unique etcd
- * prefix, and waits up to 10s for `/health` on both ports to respond
+ * prefix, and waits up to 10s for `/livez` on the proxy and `/admin/v1/health`
+ * on the admin listener to respond
  * 200. `exit()` issues SIGTERM and waits up to 3s, escalating to SIGKILL.
  */
 export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp> {
@@ -109,7 +110,7 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
 
   try {
     await Promise.all([
-      waitForReady(`${proxyUrl}/health`, READY_TIMEOUT_MS),
+      waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
       waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey),
     ]);
   } catch (err) {


### PR DESCRIPTION
## Summary
- rename the unauthenticated public liveness route from `/health` to `/livez` on both proxy and standalone admin listeners
- keep `/admin/v1/health` unchanged for authenticated operator health, and update OpenAPI, docs, and e2e coverage to match
- wire the shared livez state into shutdown so the liveness response can fail during graceful termination

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated liveness endpoint at /livez (plain-text "ok" by default) with optional verbose output and shutdown detection; liveness state is shared across components.

* **Bug Fixes**
  * Removed the previous public /health route (now returns 404).

* **Documentation**
  * Updated API and testing docs to reference /livez for probes.

* **Tests**
  * Added/updated unit and E2E tests for /livez; test harness can forward signals to the spawned app.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/257)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->