### PR TITLE
fix(etcd,snapshot): fix two bugs causing guardrail E2E flakiness

### DIFF
--- a/crates/aisix-core/src/snapshot.rs
+++ b/crates/aisix-core/src/snapshot.rs
@@ -18,6 +18,7 @@
 use crate::resource::{Resource, ResourceEntry};
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 /// Per-kind table with primary id-index and secondary name-index.
@@ -120,12 +121,14 @@ impl<T: Resource> ResourceTable<T> {
 #[derive(Debug)]
 pub struct SnapshotHandle<S> {
     inner: Arc<ArcSwap<S>>,
+    version: Arc<AtomicU64>,
 }
 
 impl<S> Clone for SnapshotHandle<S> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
+            version: Arc::clone(&self.version),
         }
     }
 }
@@ -134,6 +137,7 @@ impl<S> SnapshotHandle<S> {
     pub fn new(initial: S) -> Self {
         Self {
             inner: Arc::new(ArcSwap::from_pointee(initial)),
+            version: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -142,10 +146,19 @@ impl<S> SnapshotHandle<S> {
         self.inner.load_full()
     }
 
+    /// Monotonic version counter. Incremented on every `store` / `rcu`.
+    /// Consumers can compare this to detect snapshot changes without
+    /// relying on `Arc` pointer identity (which suffers from the ABA
+    /// problem when the allocator reuses addresses).
+    pub fn version(&self) -> u64 {
+        self.version.load(Ordering::Acquire)
+    }
+
     /// Atomic store. Called by the etcd watch supervisor after building a
     /// fresh snapshot.
     pub fn store(&self, new: S) {
         self.inner.store(Arc::new(new));
+        self.version.fetch_add(1, Ordering::Release);
     }
 
     /// Read-copy-update. Runs `f(current)` to produce a new snapshot,
@@ -165,6 +178,7 @@ impl<S> SnapshotHandle<S> {
         F: FnMut(&S) -> S,
     {
         self.inner.rcu(|current| f(current.as_ref()));
+        self.version.fetch_add(1, Ordering::Release);
     }
 }
 
@@ -248,8 +262,21 @@ mod tests {
     fn snapshot_handle_atomic_swap() {
         let handle: SnapshotHandle<u64> = SnapshotHandle::new(0);
         assert_eq!(*handle.load(), 0);
+        assert_eq!(handle.version(), 0);
         handle.store(42);
         assert_eq!(*handle.load(), 42);
+        assert_eq!(handle.version(), 1);
+    }
+
+    #[test]
+    fn version_increments_on_rcu() {
+        let handle: SnapshotHandle<u64> = SnapshotHandle::new(0);
+        assert_eq!(handle.version(), 0);
+        handle.rcu(|v| v + 1);
+        assert_eq!(handle.version(), 1);
+        handle.rcu(|v| v + 1);
+        assert_eq!(handle.version(), 2);
+        assert_eq!(*handle.load(), 2);
     }
 
     #[test]

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -12,6 +12,7 @@ use etcd_client::{
     Client, ConnectOptions, Error as EtcdError, EventType, GetOptions, WatchOptions,
 };
 use futures::{Stream, StreamExt};
+use std::collections::VecDeque;
 use std::error::Error as StdError;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -178,32 +179,50 @@ impl ConfigProvider for EtcdConfigProvider {
         Ok(Box::new(EtcdWatchStream {
             inner: stream,
             _watcher: watcher,
+            buf: VecDeque::new(),
         }))
     }
 }
 
 /// Adapter from `etcd-client`'s WatchStream to our typed [`WatchEvent`].
 ///
-/// Each `WatchResponse` carries a batch of events; we flatten them.
-/// Errors from etcd are inspected for compaction and mapped to
-/// [`ProviderError::Compacted`] so the supervisor can resync.
+/// Each `WatchResponse` carries a batch of events; we flatten them
+/// into individual `WatchEvent` items. A `VecDeque` buffer drains
+/// multi-event responses across successive `poll_next` calls so that
+/// no events are silently dropped.
 pub struct EtcdWatchStream {
     inner: etcd_client::WatchStream,
     // Must outlive `inner` — dropping the Watcher closes the client→server
     // half of the gRPC stream, causing the server to tear down the watch.
     _watcher: etcd_client::Watcher,
+    buf: VecDeque<WatchEvent>,
+}
+
+fn convert_event(ev: &etcd_client::Event) -> Option<WatchEvent> {
+    match ev.event_type() {
+        EventType::Put => ev.kv().map(|kv| {
+            WatchEvent::Put(RawEntry {
+                key: String::from_utf8_lossy(kv.key()).into_owned(),
+                value: kv.value().to_vec(),
+                revision: kv.mod_revision(),
+            })
+        }),
+        EventType::Delete => ev.kv().map(|kv| WatchEvent::Delete {
+            key: String::from_utf8_lossy(kv.key()).into_owned(),
+            revision: kv.mod_revision(),
+        }),
+    }
 }
 
 impl Stream for EtcdWatchStream {
     type Item = Result<WatchEvent, ProviderError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // We use a simple one-event-at-a-time strategy: on every poll
-        // we ask the underlying stream for the next WatchResponse, then
-        // emit its events back-to-back by storing leftovers… but to keep
-        // this crate small the first event of the batch is emitted and
-        // the rest arrive on subsequent responses, since etcd in practice
-        // batches per key and our prefix produces one-entry batches.
+        // Drain buffered events from a previous multi-event response first.
+        if let Some(item) = self.buf.pop_front() {
+            return Poll::Ready(Some(Ok(item)));
+        }
+
         match self.inner.poll_next_unpin(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) => Poll::Ready(None),
@@ -221,29 +240,17 @@ impl Stream for EtcdWatchStream {
                 if resp.compact_revision() > 0 {
                     return Poll::Ready(Some(Err(ProviderError::Compacted)));
                 }
-                // Emit the first event. If a single response has multiple
-                // events, they will be received on subsequent polls by
-                // etcd's own batching — good enough for small clusters
-                // and correct under heavy load (we never drop events,
-                // we only smear them over wakeups).
-                if let Some(ev) = resp.events().first() {
-                    let item = match ev.event_type() {
-                        EventType::Put => ev.kv().map(|kv| {
-                            WatchEvent::Put(RawEntry {
-                                key: String::from_utf8_lossy(kv.key()).into_owned(),
-                                value: kv.value().to_vec(),
-                                revision: kv.mod_revision(),
-                            })
-                        }),
-                        EventType::Delete => ev.kv().map(|kv| WatchEvent::Delete {
-                            key: String::from_utf8_lossy(kv.key()).into_owned(),
-                            revision: kv.mod_revision(),
-                        }),
-                    };
-                    if let Some(item) = item {
-                        return Poll::Ready(Some(Ok(item)));
+
+                for ev in resp.events() {
+                    if let Some(item) = convert_event(ev) {
+                        self.buf.push_back(item);
                     }
                 }
+
+                if let Some(item) = self.buf.pop_front() {
+                    return Poll::Ready(Some(Ok(item)));
+                }
+
                 // Empty response (e.g. header-only): tell the runtime
                 // to poll us again rather than stalling.
                 cx.waker().wake_by_ref();

--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -82,3 +82,65 @@ async fn watch_stream_delivers_events_after_put() {
         .await
         .expect("cleanup delete");
 }
+
+/// Regression test: when multiple keys are written in rapid succession, etcd
+/// may batch them into a single WatchResponse. Before the fix, only the first
+/// event was emitted and the rest were silently dropped.
+#[tokio::test]
+async fn watch_stream_delivers_all_events_from_batched_response() {
+    let url = match etcd_url() {
+        Some(u) => u,
+        None => {
+            eprintln!("ETCD_TEST_URL not set — skipping");
+            return;
+        }
+    };
+
+    let prefix = unique_prefix();
+    let endpoints = vec![url.clone()];
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None)
+        .await
+        .expect("connect");
+
+    let (_entries, revision) = provider.load_all().await.expect("load_all");
+    let mut stream = provider.watch(revision + 1).await.expect("watch");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut writer = Client::connect([url.as_str()], None)
+        .await
+        .expect("writer connect");
+
+    // Write 4 keys in rapid succession to encourage etcd batching.
+    let keys: Vec<String> = (0..4).map(|i| format!("{prefix}/batch/{i}")).collect();
+    for key in &keys {
+        writer
+            .put(key.as_bytes(), b"v".as_ref(), None)
+            .await
+            .expect("put");
+    }
+
+    // All 4 events must arrive.
+    let mut received = Vec::new();
+    for _ in 0..4 {
+        let ev = timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("timed out waiting for batched event")
+            .expect("stream ended early");
+        match ev.expect("watch error") {
+            aisix_etcd::WatchEvent::Put(entry) => received.push(entry.key),
+            other => panic!("expected Put, got {other:?}"),
+        }
+    }
+    received.sort();
+    let mut expected = keys.clone();
+    expected.sort();
+    assert_eq!(received, expected, "all batched events must be delivered");
+
+    // Cleanup
+    for key in &keys {
+        writer
+            .delete(key.as_bytes(), None)
+            .await
+            .expect("cleanup delete");
+    }
+}

--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -83,9 +83,9 @@ async fn watch_stream_delivers_events_after_put() {
         .expect("cleanup delete");
 }
 
-/// Regression test: when multiple keys are written in rapid succession, etcd
-/// may batch them into a single WatchResponse. Before the fix, only the first
-/// event was emitted and the rest were silently dropped.
+/// Regression test: an etcd transaction writes multiple keys atomically in a
+/// single revision, producing a single WatchResponse with multiple events.
+/// Before the fix, only the first event was emitted and the rest were dropped.
 #[tokio::test]
 async fn watch_stream_delivers_all_events_from_batched_response() {
     let url = match etcd_url() {
@@ -110,14 +110,15 @@ async fn watch_stream_delivers_all_events_from_batched_response() {
         .await
         .expect("writer connect");
 
-    // Write 4 keys in rapid succession to encourage etcd batching.
+    // Write 4 keys in a single transaction so etcd emits one multi-event
+    // WatchResponse. This is the exact scenario the buffer fix addresses.
     let keys: Vec<String> = (0..4).map(|i| format!("{prefix}/batch/{i}")).collect();
-    for key in &keys {
-        writer
-            .put(key.as_bytes(), b"v".as_ref(), None)
-            .await
-            .expect("put");
-    }
+    let txn = etcd_client::Txn::new().and_then(
+        keys.iter()
+            .map(|k| etcd_client::TxnOp::put(k.as_bytes(), b"v", None))
+            .collect::<Vec<_>>(),
+    );
+    writer.txn(txn).await.expect("txn");
 
     // All 4 events must arrive.
     let mut received = Vec::new();

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -178,12 +178,15 @@ impl LiveGuardrailChain {
         snapshot: SnapshotHandle<AisixSnapshot>,
         bedrock_endpoint_url: Option<String>,
     ) -> Arc<Self> {
+        // Read version before load so that a concurrent store() between
+        // the two reads causes current() to see a version bump and rebuild,
+        // rather than caching stale data under the new version.
+        let last_version = snapshot.version();
         let snap = snapshot.load();
         let chain = Arc::new(build_chain_from_snapshot(
             &snap.guardrails,
             bedrock_endpoint_url.as_deref(),
         ));
-        let last_version = snapshot.version();
         Arc::new(Self {
             snapshot,
             bedrock_endpoint_url,

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -169,13 +169,7 @@ pub struct LiveGuardrailChain {
 }
 
 struct Cache {
-    /// Pointer-identity of the snapshot the chain was built from,
-    /// stored as `usize` for `Send + Sync` (this crate forbids
-    /// `unsafe`). `Arc::as_ptr` is stable for the snapshot's
-    /// lifetime; comparing the integer to a fresh load tells us
-    /// cheaply whether the supervisor stored a new snapshot since
-    /// we last rebuilt. We never deref the address.
-    last_snapshot_addr: usize,
+    last_version: u64,
     chain: Arc<GuardrailChain>,
 }
 
@@ -184,40 +178,35 @@ impl LiveGuardrailChain {
         snapshot: SnapshotHandle<AisixSnapshot>,
         bedrock_endpoint_url: Option<String>,
     ) -> Arc<Self> {
-        // Eager-build at construct time so the very first chat
-        // doesn't pay the rebuild cost. The pointer recorded here
-        // is the snapshot at construct time — a subsequent store
-        // from the supervisor flips the cache miss bit on next
-        // check.
         let snap = snapshot.load();
         let chain = Arc::new(build_chain_from_snapshot(
             &snap.guardrails,
             bedrock_endpoint_url.as_deref(),
         ));
-        let last_snapshot_addr = Arc::as_ptr(&snap) as usize;
+        let last_version = snapshot.version();
         Arc::new(Self {
             snapshot,
             bedrock_endpoint_url,
             cache: Mutex::new(Cache {
-                last_snapshot_addr,
+                last_version,
                 chain,
             }),
         })
     }
 
     fn current(&self) -> Arc<GuardrailChain> {
-        let snap = self.snapshot.load();
-        let cur_ptr = Arc::as_ptr(&snap) as usize;
+        let cur_version = self.snapshot.version();
         let mut cache = self
             .cache
             .lock()
             .expect("LiveGuardrailChain mutex poisoned");
-        if cache.last_snapshot_addr != cur_ptr {
+        if cache.last_version != cur_version {
+            let snap = self.snapshot.load();
             cache.chain = Arc::new(build_chain_from_snapshot(
                 &snap.guardrails,
                 self.bedrock_endpoint_url.as_deref(),
             ));
-            cache.last_snapshot_addr = cur_ptr;
+            cache.last_version = cur_version;
         }
         Arc::clone(&cache.chain)
     }


### PR DESCRIPTION
Two independent bugs caused guardrail E2E tests to fail non-deterministically:

## Bug 1: Watch stream dropping batched events

`EtcdWatchStream::poll_next()` only emitted the first event from each `WatchResponse`. When etcd batched multiple events into a single response (common under concurrent writes), the remaining events were silently dropped.

Fix: Added a `VecDeque` buffer that collects all events from each `WatchResponse` and drains them across successive `poll_next` calls.

## Bug 2: ABA problem in guardrail chain cache (the real root cause)

`LiveGuardrailChain` used `Arc::as_ptr()` comparison to detect snapshot changes. When the allocator reuses a freed `Arc` address for a new allocation (very common with rapid allocate-free cycles during RCU updates), the pointer matches the cached address and the chain incorrectly returns a stale empty guardrail chain.

This produced the binary pass/fail pattern: if the new snapshot Arc happened to land at the same address as the initial empty snapshot, the guardrail chain was never rebuilt and stayed empty forever.

Fix: Added a monotonic version counter to `SnapshotHandle` that increments on every `store()`/`rcu()` call. `LiveGuardrailChain` compares this counter instead of Arc pointers.

## Validation

- Guardrail tests pass 20/20 consecutive runs (was failing ~20-40% before)
- Full E2E suite passes 5/5 consecutive runs
- All 664 workspace unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot handles now expose a monotonic version counter via a public accessor.

* **Bug Fixes**
  * Watch stream now reliably delivers every event from a single response batch, preventing silent drops when multiple updates arrive together.
  * Guardrail rebuilds now detect snapshot changes by version to ensure timely cache invalidation.

* **Tests**
  * Added an integration regression test verifying all events from batched watch responses are observed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/258)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->