### PR TITLE
fix(admin): drop standalone max_budget_usd contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Surfaces and capabilities currently in main:
 
 - **Managed-mode bootstrap** — cert-bundle path (no `/dp/register` round-trip): cp-api signs the mTLS leaf at mint time and ships PEMs as env vars at `docker run`. Snapshot persisted to `config_cache.json` so the proxy survives CP outages and restarts (offline resilience per PRD-09 §9.7.2).
 
-- **Per-key budgets** — `ApiKey.max_budget_usd` inline cap; managed mode delegates evaluation to cp-api `/dp/budget_check` with a 5 s LRU on the DP side.
+- **Per-key budgets** — enforced through the managed cp-api `/dp/budget_check` path with a 5 s LRU on the DP side. Standalone does not provide local budget authoring.
 
 ## Workspace
 
@@ -77,7 +77,7 @@ crates/
 
 The same binary runs both modes; the table is about **which surface owns the feature**, not about whether it works at all in one mode.
 
-> A few resources (Budget, Team, Member/Role, Audit Log, Billing) belong to the SaaS control plane and are intentionally **absent** from the standalone DP — standalone uses inline per-key alternatives (`ApiKey.max_budget_usd`, `ApiKey.rate_limit`).
+> A few resources (Budget, Team, Member/Role, Audit Log, Billing) belong to the SaaS control plane and are intentionally **absent** from the standalone DP. Standalone keeps per-key rate limiting, but budget policy remains CP-owned.
 
 | Capability | Standalone (DP only) | Managed (DP + AISIX-Cloud CP) |
 |---|---|---|
@@ -85,7 +85,7 @@ The same binary runs both modes; the table is about **which surface owns the fea
 | Multi-tenant model | None — single instance, single namespace | Org → Team → Member → Environment hierarchy |
 | ProviderKey storage | Plaintext `secret` in etcd (mTLS-only channel) | Master-key envelope-encrypted at rest, decrypted on projection |
 | API key handling | Hash on create, plaintext shown once | Hash + masked / one-time reveal in dashboard, rotation flow |
-| Budget enforcement | Per-ApiKey inline cap (`max_budget_usd`) | Per-ApiKey + per-ProviderKey + per-Environment + per-Org budgets, hard-stop / warn-only modes, alerts, audit |
+| Budget enforcement | Not locally authored in standalone; enforcement is absent without the managed CP budget-check path | Per-ApiKey + per-ProviderKey + per-Environment + per-Org budgets, hard-stop / warn-only modes, alerts, audit |
 | Audit log | None | Full org-scoped audit with diff viewer, RBAC-gated views |
 | RBAC / Roles | None — admin key is binary access | Org-scoped roles (owner / admin / developer / viewer), invitations |
 | Auth for proxy clients | Inbound `ApiKey` only | Inbound `ApiKey` only (proxy contract is identical) |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Surfaces and capabilities currently in main:
 
 - **Managed-mode bootstrap** — cert-bundle path (no `/dp/register` round-trip): cp-api signs the mTLS leaf at mint time and ships PEMs as env vars at `docker run`. Snapshot persisted to `config_cache.json` so the proxy survives CP outages and restarts (offline resilience per PRD-09 §9.7.2).
 
-- **Per-key budgets** — enforced through the managed cp-api `/dp/budget_check` path with a 5 s LRU on the DP side. Standalone does not provide local budget authoring.
+- **Per-key budgets** — enforced through the managed cp-api `/dp/budget_check` path with a 5 s LRU on the DP side. Standalone does not provide local budget resources or authoring.
 
 ## Workspace
 
@@ -77,7 +77,7 @@ crates/
 
 The same binary runs both modes; the table is about **which surface owns the feature**, not about whether it works at all in one mode.
 
-> A few resources (Budget, Team, Member/Role, Audit Log, Billing) belong to the SaaS control plane and are intentionally **absent** from the standalone DP. Standalone keeps per-key rate limiting, but budget policy remains CP-owned.
+> A few resources (Budget, Team, Member/Role, Audit Log, Billing) belong to the SaaS control plane and are intentionally **absent** from the standalone DP. Standalone keeps per-key rate limiting; budget policy remains CP-owned.
 
 | Capability | Standalone (DP only) | Managed (DP + AISIX-Cloud CP) |
 |---|---|---|
@@ -85,7 +85,7 @@ The same binary runs both modes; the table is about **which surface owns the fea
 | Multi-tenant model | None — single instance, single namespace | Org → Team → Member → Environment hierarchy |
 | ProviderKey storage | Plaintext `secret` in etcd (mTLS-only channel) | Master-key envelope-encrypted at rest, decrypted on projection |
 | API key handling | Hash on create, plaintext shown once | Hash + masked / one-time reveal in dashboard, rotation flow |
-| Budget enforcement | Not locally authored in standalone; enforcement is absent without the managed CP budget-check path | Per-ApiKey + per-ProviderKey + per-Environment + per-Org budgets, hard-stop / warn-only modes, alerts, audit |
+| Budget enforcement | No standalone budget resource or hard-stop engine | Per-ApiKey + per-ProviderKey + per-Environment + per-Org budgets, hard-stop / warn-only modes, alerts, audit |
 | Audit log | None | Full org-scoped audit with diff viewer, RBAC-gated views |
 | RBAC / Roles | None — admin key is binary access | Org-scoped roles (owner / admin / developer / viewer), invitations |
 | Auth for proxy clients | Inbound `ApiKey` only | Inbound `ApiKey` only (proxy contract is identical) |

--- a/crates/aisix-admin/src/apikeys_handlers.rs
+++ b/crates/aisix-admin/src/apikeys_handlers.rs
@@ -14,6 +14,7 @@ use aisix_core::resource::ResourceEntry;
 use aisix_core::ApiKey;
 use axum::extract::{Path, State};
 use axum::Json;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -23,32 +24,81 @@ use crate::state::AdminState;
 
 const STARTING_REVISION: i64 = 1;
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StandaloneApiKeyBody {
+    key_hash: String,
+    allowed_models: Vec<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rate_limit: Option<aisix_core::models::RateLimit>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PublicApiKey {
+    pub key_hash: String,
+    pub allowed_models: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<aisix_core::models::RateLimit>,
+}
+
+impl From<ApiKey> for PublicApiKey {
+    fn from(value: ApiKey) -> Self {
+        Self {
+            key_hash: value.key_hash,
+            allowed_models: value.allowed_models,
+            rate_limit: value.rate_limit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PublicApiKeyEntry {
+    pub id: String,
+    pub value: PublicApiKey,
+    pub revision: i64,
+}
+
+impl From<ResourceEntry<ApiKey>> for PublicApiKeyEntry {
+    fn from(value: ResourceEntry<ApiKey>) -> Self {
+        Self {
+            id: value.id,
+            value: PublicApiKey::from(value.value),
+            revision: value.revision,
+        }
+    }
+}
+
+fn public_entry(entry: ResourceEntry<ApiKey>) -> PublicApiKeyEntry {
+    entry.into()
+}
+
 pub async fn list_apikeys(
     _auth: AdminAuth,
     State(state): State<AdminState>,
-) -> Result<Json<Vec<ResourceEntry<ApiKey>>>, AdminError> {
+) -> Result<Json<Vec<PublicApiKeyEntry>>, AdminError> {
     let entries = state.store.list_apikeys().await?;
-    Ok(Json(entries))
+    Ok(Json(entries.into_iter().map(public_entry).collect()))
 }
 
 pub async fn get_apikey(
     _auth: AdminAuth,
     Path(id): Path<String>,
     State(state): State<AdminState>,
-) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
+) -> Result<Json<PublicApiKeyEntry>, AdminError> {
     let entry = state
         .store
         .get_apikey(&id)
         .await?
         .ok_or(AdminError::NotFound)?;
-    Ok(Json(entry))
+    Ok(Json(public_entry(entry)))
 }
 
 pub async fn create_apikey(
     _auth: AdminAuth,
     State(state): State<AdminState>,
     Json(raw): Json<Value>,
-) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
+) -> Result<Json<PublicApiKeyEntry>, AdminError> {
     let apikey = decode_apikey(&raw)?;
     let all = state.store.list_apikeys().await?;
     assert_unique_key(&all, &apikey.key_hash, None)?;
@@ -56,7 +106,7 @@ pub async fn create_apikey(
     let id = Uuid::new_v4().to_string();
     let entry = ResourceEntry::new(&id, apikey, STARTING_REVISION);
     state.store.put_apikey(entry.clone()).await?;
-    Ok(Json(entry))
+    Ok(Json(public_entry(entry)))
 }
 
 pub async fn update_apikey(
@@ -64,7 +114,7 @@ pub async fn update_apikey(
     Path(id): Path<String>,
     State(state): State<AdminState>,
     Json(raw): Json<Value>,
-) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
+) -> Result<Json<PublicApiKeyEntry>, AdminError> {
     let existing = state
         .store
         .get_apikey(&id)
@@ -77,7 +127,7 @@ pub async fn update_apikey(
 
     let entry = ResourceEntry::new(&id, apikey, existing.revision + 1);
     state.store.put_apikey(entry.clone()).await?;
-    Ok(Json(entry))
+    Ok(Json(public_entry(entry)))
 }
 
 pub async fn delete_apikey(
@@ -124,14 +174,18 @@ pub async fn rotate_apikey(
     let entry = ResourceEntry::new(&id, updated, existing.revision + 1);
     state.store.put_apikey(entry.clone()).await?;
     Ok(Json(serde_json::json!({
-        "entry":     entry,
+        "entry":     public_entry(entry),
         "plaintext": new_plaintext,
     })))
 }
 
 fn decode_apikey(raw: &Value) -> Result<ApiKey, AdminError> {
-    validate_apikey(raw)?;
-    serde_json::from_value(raw.clone())
+    let body: StandaloneApiKeyBody = serde_json::from_value(raw.clone())
+        .map_err(|e| AdminError::BadRequest(format!("malformed ApiKey payload: {e}")))?;
+    let value = serde_json::to_value(&body)
+        .map_err(|e| AdminError::BadRequest(format!("malformed ApiKey payload: {e}")))?;
+    validate_apikey(&value)?;
+    serde_json::from_value(value)
         .map_err(|e| AdminError::BadRequest(format!("malformed ApiKey payload: {e}")))
 }
 

--- a/crates/aisix-admin/src/apikeys_handlers.rs
+++ b/crates/aisix-admin/src/apikeys_handlers.rs
@@ -14,6 +14,7 @@ use aisix_core::resource::ResourceEntry;
 use aisix_core::ApiKey;
 use axum::extract::{Path, State};
 use axum::Json;
+use serde::Serialize;
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -23,32 +24,81 @@ use crate::state::AdminState;
 
 const STARTING_REVISION: i64 = 1;
 
+#[derive(Debug, Clone, Serialize)]
+pub struct PublicApiKey {
+    pub key_hash: String,
+    pub allowed_models: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<aisix_core::models::RateLimit>,
+}
+
+impl From<ApiKey> for PublicApiKey {
+    fn from(value: ApiKey) -> Self {
+        Self {
+            key_hash: value.key_hash,
+            allowed_models: value.allowed_models,
+            rate_limit: value.rate_limit,
+        }
+    }
+}
+
+impl From<&ApiKey> for PublicApiKey {
+    fn from(value: &ApiKey) -> Self {
+        Self {
+            key_hash: value.key_hash.clone(),
+            allowed_models: value.allowed_models.clone(),
+            rate_limit: value.rate_limit.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PublicApiKeyEntry {
+    pub id: String,
+    pub value: PublicApiKey,
+    pub revision: i64,
+}
+
+impl From<ResourceEntry<ApiKey>> for PublicApiKeyEntry {
+    fn from(value: ResourceEntry<ApiKey>) -> Self {
+        Self {
+            id: value.id,
+            value: PublicApiKey::from(value.value),
+            revision: value.revision,
+        }
+    }
+}
+
+fn public_entry(entry: ResourceEntry<ApiKey>) -> PublicApiKeyEntry {
+    entry.into()
+}
+
 pub async fn list_apikeys(
     _auth: AdminAuth,
     State(state): State<AdminState>,
-) -> Result<Json<Vec<ResourceEntry<ApiKey>>>, AdminError> {
+) -> Result<Json<Vec<PublicApiKeyEntry>>, AdminError> {
     let entries = state.store.list_apikeys().await?;
-    Ok(Json(entries))
+    Ok(Json(entries.into_iter().map(public_entry).collect()))
 }
 
 pub async fn get_apikey(
     _auth: AdminAuth,
     Path(id): Path<String>,
     State(state): State<AdminState>,
-) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
+) -> Result<Json<PublicApiKeyEntry>, AdminError> {
     let entry = state
         .store
         .get_apikey(&id)
         .await?
         .ok_or(AdminError::NotFound)?;
-    Ok(Json(entry))
+    Ok(Json(public_entry(entry)))
 }
 
 pub async fn create_apikey(
     _auth: AdminAuth,
     State(state): State<AdminState>,
     Json(raw): Json<Value>,
-) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
+) -> Result<Json<PublicApiKeyEntry>, AdminError> {
     let apikey = decode_apikey(&raw)?;
     let all = state.store.list_apikeys().await?;
     assert_unique_key(&all, &apikey.key_hash, None)?;
@@ -56,7 +106,7 @@ pub async fn create_apikey(
     let id = Uuid::new_v4().to_string();
     let entry = ResourceEntry::new(&id, apikey, STARTING_REVISION);
     state.store.put_apikey(entry.clone()).await?;
-    Ok(Json(entry))
+    Ok(Json(public_entry(entry)))
 }
 
 pub async fn update_apikey(
@@ -64,7 +114,7 @@ pub async fn update_apikey(
     Path(id): Path<String>,
     State(state): State<AdminState>,
     Json(raw): Json<Value>,
-) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
+) -> Result<Json<PublicApiKeyEntry>, AdminError> {
     let existing = state
         .store
         .get_apikey(&id)
@@ -77,7 +127,7 @@ pub async fn update_apikey(
 
     let entry = ResourceEntry::new(&id, apikey, existing.revision + 1);
     state.store.put_apikey(entry.clone()).await?;
-    Ok(Json(entry))
+    Ok(Json(public_entry(entry)))
 }
 
 pub async fn delete_apikey(
@@ -124,12 +174,17 @@ pub async fn rotate_apikey(
     let entry = ResourceEntry::new(&id, updated, existing.revision + 1);
     state.store.put_apikey(entry.clone()).await?;
     Ok(Json(serde_json::json!({
-        "entry":     entry,
+        "entry":     public_entry(entry),
         "plaintext": new_plaintext,
     })))
 }
 
 fn decode_apikey(raw: &Value) -> Result<ApiKey, AdminError> {
+    if raw.get("max_budget_usd").is_some() {
+        return Err(AdminError::BadRequest(
+            "max_budget_usd is managed by the control plane and is not part of the standalone admin API contract".to_string(),
+        ));
+    }
     validate_apikey(raw)?;
     serde_json::from_value(raw.clone())
         .map_err(|e| AdminError::BadRequest(format!("malformed ApiKey payload: {e}")))

--- a/crates/aisix-admin/src/apikeys_handlers.rs
+++ b/crates/aisix-admin/src/apikeys_handlers.rs
@@ -14,7 +14,6 @@ use aisix_core::resource::ResourceEntry;
 use aisix_core::ApiKey;
 use axum::extract::{Path, State};
 use axum::Json;
-use serde::Serialize;
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -24,81 +23,32 @@ use crate::state::AdminState;
 
 const STARTING_REVISION: i64 = 1;
 
-#[derive(Debug, Clone, Serialize)]
-pub struct PublicApiKey {
-    pub key_hash: String,
-    pub allowed_models: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rate_limit: Option<aisix_core::models::RateLimit>,
-}
-
-impl From<ApiKey> for PublicApiKey {
-    fn from(value: ApiKey) -> Self {
-        Self {
-            key_hash: value.key_hash,
-            allowed_models: value.allowed_models,
-            rate_limit: value.rate_limit,
-        }
-    }
-}
-
-impl From<&ApiKey> for PublicApiKey {
-    fn from(value: &ApiKey) -> Self {
-        Self {
-            key_hash: value.key_hash.clone(),
-            allowed_models: value.allowed_models.clone(),
-            rate_limit: value.rate_limit.clone(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct PublicApiKeyEntry {
-    pub id: String,
-    pub value: PublicApiKey,
-    pub revision: i64,
-}
-
-impl From<ResourceEntry<ApiKey>> for PublicApiKeyEntry {
-    fn from(value: ResourceEntry<ApiKey>) -> Self {
-        Self {
-            id: value.id,
-            value: PublicApiKey::from(value.value),
-            revision: value.revision,
-        }
-    }
-}
-
-fn public_entry(entry: ResourceEntry<ApiKey>) -> PublicApiKeyEntry {
-    entry.into()
-}
-
 pub async fn list_apikeys(
     _auth: AdminAuth,
     State(state): State<AdminState>,
-) -> Result<Json<Vec<PublicApiKeyEntry>>, AdminError> {
+) -> Result<Json<Vec<ResourceEntry<ApiKey>>>, AdminError> {
     let entries = state.store.list_apikeys().await?;
-    Ok(Json(entries.into_iter().map(public_entry).collect()))
+    Ok(Json(entries))
 }
 
 pub async fn get_apikey(
     _auth: AdminAuth,
     Path(id): Path<String>,
     State(state): State<AdminState>,
-) -> Result<Json<PublicApiKeyEntry>, AdminError> {
+) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
     let entry = state
         .store
         .get_apikey(&id)
         .await?
         .ok_or(AdminError::NotFound)?;
-    Ok(Json(public_entry(entry)))
+    Ok(Json(entry))
 }
 
 pub async fn create_apikey(
     _auth: AdminAuth,
     State(state): State<AdminState>,
     Json(raw): Json<Value>,
-) -> Result<Json<PublicApiKeyEntry>, AdminError> {
+) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
     let apikey = decode_apikey(&raw)?;
     let all = state.store.list_apikeys().await?;
     assert_unique_key(&all, &apikey.key_hash, None)?;
@@ -106,7 +56,7 @@ pub async fn create_apikey(
     let id = Uuid::new_v4().to_string();
     let entry = ResourceEntry::new(&id, apikey, STARTING_REVISION);
     state.store.put_apikey(entry.clone()).await?;
-    Ok(Json(public_entry(entry)))
+    Ok(Json(entry))
 }
 
 pub async fn update_apikey(
@@ -114,7 +64,7 @@ pub async fn update_apikey(
     Path(id): Path<String>,
     State(state): State<AdminState>,
     Json(raw): Json<Value>,
-) -> Result<Json<PublicApiKeyEntry>, AdminError> {
+) -> Result<Json<ResourceEntry<ApiKey>>, AdminError> {
     let existing = state
         .store
         .get_apikey(&id)
@@ -127,7 +77,7 @@ pub async fn update_apikey(
 
     let entry = ResourceEntry::new(&id, apikey, existing.revision + 1);
     state.store.put_apikey(entry.clone()).await?;
-    Ok(Json(public_entry(entry)))
+    Ok(Json(entry))
 }
 
 pub async fn delete_apikey(
@@ -174,17 +124,12 @@ pub async fn rotate_apikey(
     let entry = ResourceEntry::new(&id, updated, existing.revision + 1);
     state.store.put_apikey(entry.clone()).await?;
     Ok(Json(serde_json::json!({
-        "entry":     public_entry(entry),
+        "entry":     entry,
         "plaintext": new_plaintext,
     })))
 }
 
 fn decode_apikey(raw: &Value) -> Result<ApiKey, AdminError> {
-    if raw.get("max_budget_usd").is_some() {
-        return Err(AdminError::BadRequest(
-            "max_budget_usd is managed by the control plane and is not part of the standalone admin API contract".to_string(),
-        ));
-    }
     validate_apikey(raw)?;
     serde_json::from_value(raw.clone())
         .map_err(|e| AdminError::BadRequest(format!("malformed ApiKey payload: {e}")))

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -401,7 +401,7 @@ mod tests {
         assert!(v["error_msg"]
             .as_str()
             .unwrap()
-            .contains("schema validation"));
+            .contains("unknown field"));
     }
 
     #[tokio::test]
@@ -739,7 +739,7 @@ mod tests {
         assert!(v["error_msg"]
             .as_str()
             .unwrap()
-            .contains("schema validation"));
+            .contains("unknown field"));
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -658,7 +658,6 @@ mod tests {
             .map(|v| v.as_str().unwrap())
             .collect();
         assert_eq!(allowed, ["my-model"]);
-        assert!(entry["value"].get("max_budget_usd").is_none());
     }
 
     #[tokio::test]
@@ -708,7 +707,6 @@ mod tests {
         let resp = run(app, auth_req("GET", "/admin/v1/apikeys", None)).await;
         let listed = body_json(resp).await;
         assert_eq!(listed.as_array().unwrap().len(), 1);
-        assert!(listed[0]["value"].get("max_budget_usd").is_none());
 
         // Delete.
         let app = build_router(state);
@@ -721,7 +719,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_apikey_rejects_max_budget_usd() {
+    async fn create_apikey_rejects_unknown_field() {
         let app = build_router(build_state());
         let resp = run(
             app,
@@ -741,15 +739,16 @@ mod tests {
         assert!(v["error_msg"]
             .as_str()
             .unwrap()
-            .contains("max_budget_usd is managed by the control plane"));
+            .contains("schema validation"));
     }
 
     #[tokio::test]
-    async fn openapi_public_apikey_schema_excludes_max_budget_usd() {
+    async fn openapi_apikey_schema_excludes_max_budget_usd() {
         let resp = openapi::openapi_json().await;
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
-        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("OPENAPI_JSON must parse");
-        let props = &parsed["components"]["schemas"]["PublicApiKey"]["properties"];
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("OPENAPI_JSON must parse");
+        let props = &parsed["components"]["schemas"]["ApiKey"]["properties"];
         assert!(props["key_hash"].is_object());
         assert!(props["allowed_models"].is_object());
         assert!(props["rate_limit"].is_object());

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -401,7 +401,7 @@ mod tests {
         assert!(v["error_msg"]
             .as_str()
             .unwrap()
-            .contains("unknown field"));
+            .contains("schema validation"));
     }
 
     #[tokio::test]
@@ -736,10 +736,7 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let v = body_json(resp).await;
-        assert!(v["error_msg"]
-            .as_str()
-            .unwrap()
-            .contains("unknown field"));
+        assert!(v["error_msg"].as_str().unwrap().contains("unknown field"));
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -658,6 +658,7 @@ mod tests {
             .map(|v| v.as_str().unwrap())
             .collect();
         assert_eq!(allowed, ["my-model"]);
+        assert!(entry["value"].get("max_budget_usd").is_none());
     }
 
     #[tokio::test]
@@ -705,7 +706,9 @@ mod tests {
         // List sees exactly one.
         let app = build_router(state.clone());
         let resp = run(app, auth_req("GET", "/admin/v1/apikeys", None)).await;
-        assert_eq!(body_json(resp).await.as_array().unwrap().len(), 1);
+        let listed = body_json(resp).await;
+        assert_eq!(listed.as_array().unwrap().len(), 1);
+        assert!(listed[0]["value"].get("max_budget_usd").is_none());
 
         // Delete.
         let app = build_router(state);
@@ -715,6 +718,42 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn create_apikey_rejects_max_budget_usd() {
+        let app = build_router(build_state());
+        let resp = run(
+            app,
+            auth_req(
+                "POST",
+                "/admin/v1/apikeys",
+                Some(json!({
+                    "key_hash": aisix_core::ApiKey::hash_bearer("sk-budget"),
+                    "allowed_models": ["*"],
+                    "max_budget_usd": 500.0
+                })),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v = body_json(resp).await;
+        assert!(v["error_msg"]
+            .as_str()
+            .unwrap()
+            .contains("max_budget_usd is managed by the control plane"));
+    }
+
+    #[tokio::test]
+    async fn openapi_public_apikey_schema_excludes_max_budget_usd() {
+        let resp = openapi::openapi_json().await;
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("OPENAPI_JSON must parse");
+        let props = &parsed["components"]["schemas"]["PublicApiKey"]["properties"];
+        assert!(props["key_hash"].is_object());
+        assert!(props["allowed_models"].is_object());
+        assert!(props["rate_limit"].is_object());
+        assert!(props.get("max_budget_usd").is_none());
     }
 
     // ──────────────────── Guardrails CRUD ────────────────────

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -90,7 +90,7 @@ const OPENAPI_JSON: &str = r##"{
       "post": {
         "summary": "create api key",
         "description": "Body carries `key_hash` (SHA-256 of plaintext). The plaintext is generated client-side; the gateway never sees it.",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PublicApiKey"}}}},
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiKey"}}}},
         "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "409": {"description": "duplicate key_hash"}}
       }
     },
@@ -99,7 +99,7 @@ const OPENAPI_JSON: &str = r##"{
       "get":    { "summary": "get api key",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
       "put":    {
         "summary": "update api key",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PublicApiKey"}}}},
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiKey"}}}},
         "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "404": {"description": "not found"}, "409": {"description": "duplicate key_hash"}}
       },
       "delete": { "summary": "delete api key", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
@@ -114,7 +114,7 @@ const OPENAPI_JSON: &str = r##"{
             "type": "object",
             "required": ["entry", "plaintext"],
             "properties": {
-              "entry":     {"$ref": "#/components/schemas/PublicApiKeyEntry"},
+              "entry":     {"$ref": "#/components/schemas/ApiKeyEntry"},
               "plaintext": {"type": "string", "example": "sk-abcd1234ef567890"}
             }
           }}}},
@@ -248,7 +248,7 @@ const OPENAPI_JSON: &str = r##"{
           "revision": {"type": "integer"}
         }
       },
-      "PublicApiKey": {
+      "ApiKey": {
         "type": "object",
         "required": ["key_hash", "allowed_models"],
         "properties": {
@@ -257,12 +257,12 @@ const OPENAPI_JSON: &str = r##"{
           "rate_limit":     {"$ref": "#/components/schemas/RateLimit"}
         }
       },
-      "PublicApiKeyEntry": {
+      "ApiKeyEntry": {
         "type": "object",
         "required": ["id", "value", "revision"],
         "properties": {
           "id":       {"type": "string"},
-          "value":    {"$ref": "#/components/schemas/PublicApiKey"},
+          "value":    {"$ref": "#/components/schemas/ApiKey"},
           "revision": {"type": "integer"}
         }
       },
@@ -427,8 +427,8 @@ mod tests {
         for schema in [
             "Model",
             "ModelEntry",
-            "PublicApiKey",
-            "PublicApiKeyEntry",
+            "ApiKey",
+            "ApiKeyEntry",
             "ProviderKey",
             "Guardrail",
             "CachePolicy",

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -90,7 +90,7 @@ const OPENAPI_JSON: &str = r##"{
       "post": {
         "summary": "create api key",
         "description": "Body carries `key_hash` (SHA-256 of plaintext). The plaintext is generated client-side; the gateway never sees it.",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiKey"}}}},
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PublicApiKey"}}}},
         "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "409": {"description": "duplicate key_hash"}}
       }
     },
@@ -99,7 +99,7 @@ const OPENAPI_JSON: &str = r##"{
       "get":    { "summary": "get api key",    "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} },
       "put":    {
         "summary": "update api key",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiKey"}}}},
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PublicApiKey"}}}},
         "responses": {"200": {"description": "OK"}, "400": {"description": "schema validation failed"}, "404": {"description": "not found"}, "409": {"description": "duplicate key_hash"}}
       },
       "delete": { "summary": "delete api key", "responses": {"200": {"description": "OK"}, "404": {"description": "not found"}} }
@@ -114,7 +114,7 @@ const OPENAPI_JSON: &str = r##"{
             "type": "object",
             "required": ["entry", "plaintext"],
             "properties": {
-              "entry":     {"$ref": "#/components/schemas/ApiKeyEntry"},
+              "entry":     {"$ref": "#/components/schemas/PublicApiKeyEntry"},
               "plaintext": {"type": "string", "example": "sk-abcd1234ef567890"}
             }
           }}}},
@@ -248,22 +248,21 @@ const OPENAPI_JSON: &str = r##"{
           "revision": {"type": "integer"}
         }
       },
-      "ApiKey": {
+      "PublicApiKey": {
         "type": "object",
         "required": ["key_hash", "allowed_models"],
         "properties": {
           "key_hash":       {"type": "string", "description": "SHA-256 hex of the plaintext bearer. Lowercase.", "example": "91ed2dbc407561556f3e7be98ba0bd2a57986d6a868c482d867d19c6d40d201c"},
           "allowed_models": {"type": "array", "items": {"type": "string"}, "description": "Allowed Model display_names. `[\"*\"]` for all; `[]` denies everything."},
-          "rate_limit":     {"$ref": "#/components/schemas/RateLimit"},
-          "max_budget_usd": {"type": "number", "minimum": 0, "description": "Per-month USD spend cap. Absent = unlimited."}
+          "rate_limit":     {"$ref": "#/components/schemas/RateLimit"}
         }
       },
-      "ApiKeyEntry": {
+      "PublicApiKeyEntry": {
         "type": "object",
         "required": ["id", "value", "revision"],
         "properties": {
           "id":       {"type": "string"},
-          "value":    {"$ref": "#/components/schemas/ApiKey"},
+          "value":    {"$ref": "#/components/schemas/PublicApiKey"},
           "revision": {"type": "integer"}
         }
       },
@@ -428,8 +427,8 @@ mod tests {
         for schema in [
             "Model",
             "ModelEntry",
-            "ApiKey",
-            "ApiKeyEntry",
+            "PublicApiKey",
+            "PublicApiKeyEntry",
             "ProviderKey",
             "Guardrail",
             "CachePolicy",

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -30,12 +30,6 @@ pub struct ApiKey {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<RateLimit>,
 
-    /// Maximum USD spend per calendar month. When the accumulated spend
-    /// for this key reaches or exceeds this cap the proxy returns 429.
-    /// Absent = no budget enforcement.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_budget_usd: Option<f64>,
-
     /// etcd-key uuid; filled by the loader, never in the JSON payload.
     #[serde(skip)]
     pub(crate) runtime_id: String,
@@ -150,7 +144,6 @@ mod tests {
             key_hash: "abc".into(),
             allowed_models: vec![],
             rate_limit: None,
-            max_budget_usd: None,
             runtime_id: String::new(),
         };
         assert!(!k.can_access("my-gpt4"));

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -12,8 +12,7 @@
 //!
 //! Team is intentionally absent: it's a SaaS-tier concept owned by
 //! the AISIX-Cloud control plane, not by the standalone gateway.
-//! Standalone deployments do per-key budgeting via
-//! `ApiKey::max_budget_usd` and per-key rate-limiting via
+//! Standalone deployments do per-key rate-limiting via
 //! `ApiKey::rate_limit`.
 
 pub mod apikey;

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -195,8 +195,7 @@ fn apikey_schema() -> Value {
                 "type": "array",
                 "items": { "type": "string" }
             },
-            "rate_limit": { "$ref": "#/$defs/rate_limit" },
-            "max_budget_usd": { "type": "number", "minimum": 0 }
+            "rate_limit": { "$ref": "#/$defs/rate_limit" }
         },
         "$defs": {
             "rate_limit": {
@@ -505,21 +504,11 @@ mod tests {
     }
 
     #[test]
-    fn apikey_with_max_budget_usd_passes() {
-        let v = json!({
-            "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
-            "allowed_models":["a","b"],
-            "max_budget_usd": 500.0
-        });
-        validate_apikey(&v).unwrap();
-    }
-
-    #[test]
-    fn apikey_negative_max_budget_usd_rejected() {
+    fn apikey_unknown_field_rejected() {
         let v = json!({
             "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
             "allowed_models":["a"],
-            "max_budget_usd": -1.0
+            "max_budget_usd": 500.0
         });
         assert!(validate_apikey(&v).is_err());
     }

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -137,8 +137,7 @@ curl -X POST http://localhost:3001/admin/v1/apikeys \
   }'
 ```
 
-> `max_budget_usd` is not part of the standalone admin API contract.
-> Budget policy is owned by the managed control plane.
+> `max_budget_usd` is not part of the AISIX AI Gateway ApiKey schema.
 
 The `/rotate` endpoint replaces the stored hash and returns the new
 plaintext directly, so the operator does not need to compute the
@@ -179,8 +178,7 @@ curl -X POST http://localhost:3001/admin/v1/provider_keys \
 
 Per-key USD budget enforcement is a managed control-plane feature.
 There is no standalone `/admin/v1/budgets` collection, and the
-standalone admin API does not accept `max_budget_usd` on ApiKey
-writes.
+gateway ApiKey schema does not include `max_budget_usd`.
 
 #### SaaS / Managed mode
 
@@ -217,9 +215,7 @@ same cp-api stay consistent without DP-side coordination.
 
 Budget enforcement is **not implemented**.
 
-The standalone admin API rejects `max_budget_usd` on POST/PUT so
-operators do not mistake a stored field for an active enforcement
-path. Operators who need per-key spend caps must run in managed mode.
+Operators who need per-key spend caps must run in managed mode.
 
 Team-level budgets are SaaS-tier (cp-api owns cross-key
 aggregation) and have no standalone counterpart.

--- a/docs/api-admin.md
+++ b/docs/api-admin.md
@@ -133,13 +133,12 @@ curl -X POST http://localhost:3001/admin/v1/apikeys \
   -d '{
     "key_hash": "'"$KEY_HASH"'",
     "allowed_models": ["my-gpt4"],
-    "rate_limit": {"rpm": 60, "concurrency": 10},
-    "max_budget_usd": 500.0
+    "rate_limit": {"rpm": 60, "concurrency": 10}
   }'
 ```
 
-> `max_budget_usd` is enforced only in SaaS / managed mode. See
-> §4.4 for the standalone caveat and the SaaS propagation model.
+> `max_budget_usd` is not part of the standalone admin API contract.
+> Budget policy is owned by the managed control plane.
 
 The `/rotate` endpoint replaces the stored hash and returns the new
 plaintext directly, so the operator does not need to compute the
@@ -178,12 +177,10 @@ curl -X POST http://localhost:3001/admin/v1/provider_keys \
 
 ### 4.4 Budgets
 
-Per-ApiKey USD spend caps are expressed via `max_budget_usd` on the
-ApiKey resource — there is no separate `/admin/v1/budgets`
-collection. **Enforcement is a SaaS-tier feature**: the data-plane
-proxy never reads `max_budget_usd` from the etcd snapshot. The
-field is populated by the SaaS control plane for parity with its
-own `api_keys` table and is informational on the DP side.
+Per-key USD budget enforcement is a managed control-plane feature.
+There is no standalone `/admin/v1/budgets` collection, and the
+standalone admin API does not accept `max_budget_usd` on ApiKey
+writes.
 
 #### SaaS / Managed mode
 
@@ -218,11 +215,11 @@ same cp-api stay consistent without DP-side coordination.
 
 #### Standalone mode
 
-Budget enforcement is **not implemented**. The admin API still
-accepts `max_budget_usd` on POST/PUT (the field passes through
-schema validation and persists to etcd) so the wire shape stays
-compatible with managed mode, but no part of the proxy reads it.
-Operators who need per-key spend caps must run in managed mode.
+Budget enforcement is **not implemented**.
+
+The standalone admin API rejects `max_budget_usd` on POST/PUT so
+operators do not mistake a stored field for an active enforcement
+path. Operators who need per-key spend caps must run in managed mode.
 
 Team-level budgets are SaaS-tier (cp-api owns cross-key
 aggregation) and have no standalone counterpart.

--- a/tests/e2e/src/cases/apikey-budget-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-budget-e2e.test.ts
@@ -7,14 +7,13 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: standalone admin API must reject max_budget_usd writes.
-// Budget policy belongs to the managed control-plane path, so the
-// standalone admin public contract must not accept local budget authoring.
+// E2E: the standalone admin ApiKey contract must reject unknown fields.
+// `max_budget_usd` is one concrete case pinned here.
 
 const PLAINTEXT = "sk-budget-e2e";
 const KEY_HASH = createHash("sha256").update(PLAINTEXT).digest("hex");
 
-describe("apikey max_budget_usd e2e: standalone admin rejects budget field", () => {
+describe("apikey max_budget_usd e2e: standalone admin rejects removed field", () => {
   let app: SpawnedApp | undefined;
   let admin: AdminClient | undefined;
   let etcdReachable = false;
@@ -31,7 +30,7 @@ describe("apikey max_budget_usd e2e: standalone admin rejects budget field", () 
     await app?.exit();
   });
 
-  test("POST rejects max_budget_usd with 400", async (ctx) => {
+  test("POST rejects removed max_budget_usd field with 400", async (ctx) => {
     if (!etcdReachable || !admin) {
       ctx.skip();
       return;

--- a/tests/e2e/src/cases/apikey-budget-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-budget-e2e.test.ts
@@ -48,5 +48,7 @@ describe("apikey max_budget_usd e2e: standalone admin rejects removed field", ()
     }
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toContain("400");
+    expect((caught as Error).message).toContain("max_budget_usd");
+    expect((caught as Error).message).toContain("managed by the control plane");
   });
 });

--- a/tests/e2e/src/cases/apikey-budget-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-budget-e2e.test.ts
@@ -49,6 +49,6 @@ describe("apikey max_budget_usd e2e: standalone admin rejects removed field", ()
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toContain("400");
     expect((caught as Error).message).toContain("max_budget_usd");
-    expect((caught as Error).message).toContain("managed by the control plane");
+    expect((caught as Error).message).toContain("unknown field");
   });
 });

--- a/tests/e2e/src/cases/apikey-budget-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-budget-e2e.test.ts
@@ -7,22 +7,14 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: max_budget_usd round-trips through the admin API. Closes the
-// gap that PR #182 surfaced — the JSON schema previously rejected
-// max_budget_usd, making the field unreachable from a standalone
-// admin POST. This test pins the documented §4.2 contract: a body
-// carrying max_budget_usd is accepted, persisted, and returned by
-// GET unchanged. A regression that re-tightens the schema (or
-// re-adds additionalProperties: false without re-listing the field)
-// fails here loudly.
-//
-// Reference: docs/api-admin.md §4.2 (the example body now includes
-// "max_budget_usd": 500.0).
+// E2E: standalone admin API must reject max_budget_usd writes.
+// Budget policy belongs to the managed control-plane path, so the
+// standalone admin public contract must not accept local budget authoring.
 
 const PLAINTEXT = "sk-budget-e2e";
 const KEY_HASH = createHash("sha256").update(PLAINTEXT).digest("hex");
 
-describe("apikey max_budget_usd e2e: admin POST + GET round-trip", () => {
+describe("apikey max_budget_usd e2e: standalone admin rejects budget field", () => {
   let app: SpawnedApp | undefined;
   let admin: AdminClient | undefined;
   let etcdReachable = false;
@@ -39,27 +31,7 @@ describe("apikey max_budget_usd e2e: admin POST + GET round-trip", () => {
     await app?.exit();
   });
 
-  test("POST persists max_budget_usd; GET returns the same value", async (ctx) => {
-    if (!etcdReachable || !admin) {
-      ctx.skip();
-      return;
-    }
-
-    const created = await admin.createApiKey({
-      key_hash: KEY_HASH,
-      allowed_models: ["*"],
-      max_budget_usd: 500.0,
-    });
-    expect(created.id).toBeTruthy();
-
-    const got = await admin.json<{
-      id: string;
-      value: { max_budget_usd?: number };
-    }>("GET", `/admin/v1/apikeys/${created.id}`);
-    expect(got.value.max_budget_usd).toBe(500);
-  });
-
-  test("POST with negative max_budget_usd is rejected with 400", async (ctx) => {
+  test("POST rejects max_budget_usd with 400", async (ctx) => {
     if (!etcdReachable || !admin) {
       ctx.skip();
       return;
@@ -68,9 +40,9 @@ describe("apikey max_budget_usd e2e: admin POST + GET round-trip", () => {
     let caught: unknown;
     try {
       await admin.createApiKey({
-        key_hash: createHash("sha256").update("sk-neg-budget").digest("hex"),
+        key_hash: KEY_HASH,
         allowed_models: ["*"],
-        max_budget_usd: -1,
+        max_budget_usd: 500.0,
       });
     } catch (e) {
       caught = e;


### PR DESCRIPTION
## Summary
- reject `max_budget_usd` on standalone admin ApiKey writes and stop exposing it from the standalone admin read contract
- keep the internal `ApiKey` shape intact so managed/control-plane budget paths are not coupled to this standalone admin surface cleanup
- update the standalone admin OpenAPI, docs, and e2e coverage to pin the CP-owned budget boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standalone deployments now reject per-key USD budget fields; requests including that field return 400.
  * Admin API responses no longer expose the removed budget field and return API key data in a public-facing representation.

* **Documentation**
  * Clarified that per-key budget enforcement is control-plane (managed) only and removed standalone budget claims from the feature matrix.

* **Tests**
  * E2E and unit tests updated to assert the removed field is rejected and absent from the OpenAPI/schema.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/259)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->