### PR TITLE
ci: switch docker-image workflow to ubicloud runner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Switch the docker-image workflow from `ubuntu-latest` to `ubicloud-standard-2`, matching the CI workflow.