### PR TITLE
feat(routing): add same-target retries and 429 failover

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -332,7 +332,9 @@ const OPENAPI_JSON: &str = r##"{
               }
             }
           },
-          "retry_budget": {"type": "integer", "minimum": 0}
+          "retries": {"type": "integer", "minimum": 0},
+          "max_fallbacks": {"type": "integer", "minimum": 0},
+          "retry_on_429": {"type": "boolean"}
         }
       },
       "ModelCost": {

--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -3,7 +3,8 @@
 //! When a Model carries a `routing` block, the proxy treats it as a
 //! pointer to other Models. Per-request the proxy picks one target via
 //! the configured strategy and dispatches through that target's bridge.
-//! Failures fall back to the next target up to `retry_budget` attempts.
+//! Failures may retry the current target and then fall back to later
+//! targets.
 //!
 //! Three strategies (spec §3):
 //! - `round_robin`: cycle through targets in declaration order.
@@ -61,19 +62,33 @@ pub struct Routing {
     #[serde(default)]
     pub strategy: RoutingStrategy,
     pub targets: Vec<RoutingTarget>,
-    /// Max number of distinct targets to attempt per request. Defaults
-    /// to `targets.len()` when absent. A value of 1 disables fallback.
+    /// Retry attempts on the current target before failing over.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub retry_budget: Option<u32>,
+    pub retries: Option<u32>,
+    /// Max number of later targets to attempt after the initial target
+    /// fails permanently. Defaults to all later targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_fallbacks: Option<u32>,
+    /// Whether upstream 429 participates in retries and failover.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_on_429: Option<bool>,
 }
 
 impl Routing {
-    pub fn retry_budget_or_default(&self) -> usize {
-        match self.retry_budget {
-            Some(0) => self.targets.len(),
-            Some(n) => (n as usize).min(self.targets.len()),
-            None => self.targets.len(),
+    pub fn retries_or_default(&self) -> usize {
+        self.retries.unwrap_or(0) as usize
+    }
+
+    pub fn max_fallbacks_or_default(&self) -> usize {
+        let later_targets = self.targets.len().saturating_sub(1);
+        match self.max_fallbacks {
+            Some(n) => (n as usize).min(later_targets),
+            None => later_targets,
         }
+    }
+
+    pub fn retry_on_429_or_default(&self) -> bool {
+        self.retry_on_429.unwrap_or(false)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -93,14 +108,18 @@ mod tests {
                 {"model": "primary", "weight": 90},
                 {"model": "backup",  "weight": 10}
             ],
-            "retry_budget": 2
+            "retries": 2,
+            "max_fallbacks": 1,
+            "retry_on_429": true
         }"#;
         let r: Routing = serde_json::from_str(json).unwrap();
         assert_eq!(r.strategy, RoutingStrategy::Weighted);
         assert_eq!(r.targets.len(), 2);
         assert_eq!(r.targets[0].model, "primary");
         assert_eq!(r.targets[0].weight_or_default(), 90);
-        assert_eq!(r.retry_budget_or_default(), 2);
+        assert_eq!(r.retries_or_default(), 2);
+        assert_eq!(r.max_fallbacks_or_default(), 1);
+        assert!(r.retry_on_429_or_default());
     }
 
     #[test]
@@ -108,27 +127,33 @@ mod tests {
         let r: Routing =
             serde_json::from_str(r#"{"targets":[{"model":"a"},{"model":"b"}]}"#).unwrap();
         assert_eq!(r.strategy, RoutingStrategy::Failover);
-        assert_eq!(r.retry_budget_or_default(), 2);
+        assert_eq!(r.retries_or_default(), 0);
+        assert_eq!(r.max_fallbacks_or_default(), 1);
+        assert!(!r.retry_on_429_or_default());
     }
 
     #[test]
-    fn retry_budget_zero_means_full_targets() {
+    fn max_fallbacks_zero_disables_failover() {
         let r = Routing {
             strategy: RoutingStrategy::RoundRobin,
             targets: vec![RoutingTarget::new("a"), RoutingTarget::new("b")],
-            retry_budget: Some(0),
+            retries: Some(0),
+            max_fallbacks: Some(0),
+            retry_on_429: None,
         };
-        assert_eq!(r.retry_budget_or_default(), 2);
+        assert_eq!(r.max_fallbacks_or_default(), 0);
     }
 
     #[test]
-    fn retry_budget_clamps_to_targets_len() {
+    fn max_fallbacks_clamps_to_later_targets() {
         let r = Routing {
             strategy: RoutingStrategy::Failover,
             targets: vec![RoutingTarget::new("a")],
-            retry_budget: Some(99),
+            retries: None,
+            max_fallbacks: Some(99),
+            retry_on_429: None,
         };
-        assert_eq!(r.retry_budget_or_default(), 1);
+        assert_eq!(r.max_fallbacks_or_default(), 0);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -136,7 +136,9 @@ fn model_schema() -> Value {
                             }
                         }
                     },
-                    "retry_budget": { "type": "integer", "minimum": 0 }
+                    "retries": { "type": "integer", "minimum": 0 },
+                    "max_fallbacks": { "type": "integer", "minimum": 0 },
+                    "retry_on_429": { "type": "boolean" }
                 }
             },
             "cost": {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -428,7 +428,7 @@ async fn dispatch(
     // single-provider Model we just dispatch to it directly.
     let attempt_models: Vec<aisix_core::Model> =
         if let Some(routing) = virtual_entry.value.routing.as_ref() {
-            let names = state.routing.pick_order(&req.model, routing);
+            let names = state.routing.pick_targets(&req.model, routing);
             if names.is_empty() {
                 return Err(with_model(ProxyError::InvalidRequest(
                     "routing model has no targets".into(),
@@ -735,11 +735,24 @@ async fn dispatch(
         }
     }
 
-    // Walk the attempt-list. First retryable failure → next target.
-    // Non-retryable (4xx) or exhausted budget → propagate the last error.
+    // Walk the target list. Retry the current target first, then fail over
+    // to later targets only after retries are exhausted. Non-retryable
+    // (non-429 4xx) errors stop immediately.
     let mut last_err: Option<BridgeError> = None;
     let mut chosen_provider: Option<String> = None;
     let mut upstream: Option<aisix_gateway::ChatResponse> = None;
+    let retries = virtual_entry
+        .value
+        .routing
+        .as_ref()
+        .map(|routing| routing.retries_or_default())
+        .unwrap_or(0);
+    let retry_on_429 = virtual_entry
+        .value
+        .routing
+        .as_ref()
+        .map(|routing| routing.retry_on_429_or_default())
+        .unwrap_or(false);
 
     for model in &attempt_models {
         let Some(provider) = model.provider else {
@@ -765,31 +778,42 @@ async fn dispatch(
         let pk_arc = Arc::new(pk_entry.value.clone());
         let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
 
-        match bridge.chat(req, &ctx).await {
-            Ok(resp) => {
-                state.health.record_success(&model.display_name);
-                chosen_provider = Some(format!("{provider:?}").to_lowercase());
-                upstream = Some(resp);
-                break;
-            }
-            Err(err) => {
-                tracing::warn!(
-                    target_model = %model.display_name,
-                    error = %err,
-                    retryable = is_retryable(&err),
-                    "routing target attempt failed",
-                );
-                // Only retryable (server-side) errors indicate deployment
-                // health deterioration; 4xx are caller mistakes.
-                if is_retryable(&err) {
-                    state.health.record_failure(&model.display_name);
-                }
-                if !is_retryable(&err) {
-                    last_err = Some(err);
+        for attempt_idx in 0..=retries {
+            match bridge.chat(req, &ctx).await {
+                Ok(resp) => {
+                    state.health.record_success(&model.display_name);
+                    chosen_provider = Some(format!("{provider:?}").to_lowercase());
+                    upstream = Some(resp);
                     break;
                 }
-                last_err = Some(err);
-                continue;
+                Err(err) => {
+                    let retryable = is_retryable(&err, retry_on_429);
+                    tracing::warn!(
+                        target_model = %model.display_name,
+                        target_attempt = attempt_idx + 1,
+                        error = %err,
+                        retryable,
+                        "routing target attempt failed",
+                    );
+                    if retryable {
+                        state.health.record_failure(&model.display_name);
+                    }
+                    last_err = Some(err);
+                    if !retryable {
+                        break;
+                    }
+                    if attempt_idx == retries {
+                        break;
+                    }
+                }
+            }
+        }
+        if upstream.is_some() {
+            break;
+        }
+        if let Some(err) = last_err.as_ref() {
+            if !is_retryable(err, retry_on_429) {
+                break;
             }
         }
     }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -2015,7 +2015,12 @@ data: [DONE]\n\n";
         let resp = run(app, req).await;
         let status = resp.status();
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
-        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&bytes));
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(&bytes)
+        );
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["choices"][0]["message"]["content"], "fallback worked");
     }
@@ -2080,7 +2085,12 @@ data: [DONE]\n\n";
         let resp = run(app, req).await;
         let status = resp.status();
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
-        assert_eq!(status, StatusCode::BAD_REQUEST, "{}", String::from_utf8_lossy(&bytes));
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{}",
+            String::from_utf8_lossy(&bytes)
+        );
     }
 
     #[tokio::test]
@@ -2148,7 +2158,12 @@ data: [DONE]\n\n";
         let resp = run(app, req).await;
         let status = resp.status();
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
-        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&bytes));
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(&bytes)
+        );
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["choices"][0]["message"]["content"], "after retries");
     }
@@ -2218,7 +2233,12 @@ data: [DONE]\n\n";
         let resp = run(app, req).await;
         let status = resp.status();
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
-        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&bytes));
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(&bytes)
+        );
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["choices"][0]["message"]["content"], "429 fallback worked");
     }
@@ -2231,8 +2251,14 @@ data: [DONE]\n\n";
         hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
-        snap.models
-            .insert(routing_entry("smart", "failover", &["nonexistent"], None, None, None));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["nonexistent"],
+            None,
+            None,
+            None,
+        ));
         snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
         // No upstream provider_key needed — the routing target itself
         // is missing so dispatch fails before any provider lookup.

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -192,6 +192,7 @@ mod tests {
     use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
     use futures::StreamExt;
+    use reqwest::Client;
     use std::sync::Arc;
     use tower::ServiceExt;
     use wiremock::matchers::{header, method, path};
@@ -203,6 +204,15 @@ mod tests {
             request_body_limit_bytes: 1_048_576,
             tls: None,
         }
+    }
+
+    fn openai_test_bridge() -> OpenAiBridge {
+        let client = Client::builder()
+            .user_agent("aisix-test/0.1")
+            .no_proxy()
+            .build()
+            .unwrap();
+        OpenAiBridge::with_client(client)
     }
 
     /// State used by the *existing* tests — cache disabled so the
@@ -353,7 +363,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -488,7 +498,7 @@ mod tests {
     #[tokio::test]
     async fn model_not_in_allowed_list_returns_403() {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         // ApiKey allows only "other-model", the caller asks for "my-gpt4".
         let snap = seed_snapshot("my-gpt4", &["other-model"], "http://unused");
         let app = build_router(build_state(snap, hub));
@@ -689,7 +699,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -814,7 +824,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -873,7 +883,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -1161,7 +1171,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1238,7 +1248,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1303,7 +1313,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1365,7 +1375,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1419,7 +1429,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
 
         let state = build_state(snap, hub);
@@ -1474,7 +1484,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1528,7 +1538,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         // Cache gate opens only when an enabled policy exists in
         // snapshot. Without this seed step the test would 200 but
@@ -1603,7 +1613,7 @@ data: [DONE]\n\n";
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         seed_cache_policy(&snap, "test-cache");
         let state = build_state_with_cache(snap, hub).with_usage_sink(UsageSink::new(tx));
@@ -1669,7 +1679,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         seed_cache_policy(&snap, "test-cache");
         let state = build_state_with_cache(snap, hub);
@@ -1730,7 +1740,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         // The api key + model are named "my-gpt4"; the policy below
         // pins applies_to to a different model name so no request in
         // this test matches.
@@ -1852,7 +1862,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         seed_cache_policy_with_applies_to(&snap, "scoped", "model:my-gpt4");
         let state = build_state_with_cache(snap, hub);
@@ -1916,7 +1926,14 @@ data: [DONE]\n\n";
 
     /// Build a virtual routing Model that points at `targets` (other
     /// Model.display_name values) using the given strategy.
-    fn routing_entry(name: &str, strategy: &str, targets: &[&str]) -> ResourceEntry<Model> {
+    fn routing_entry(
+        name: &str,
+        strategy: &str,
+        targets: &[&str],
+        retries: Option<u32>,
+        max_fallbacks: Option<u32>,
+        retry_on_429: Option<bool>,
+    ) -> ResourceEntry<Model> {
         let target_objs: Vec<serde_json::Value> = targets
             .iter()
             .map(|t| serde_json::json!({"model": t}))
@@ -1926,6 +1943,9 @@ data: [DONE]\n\n";
             "routing": {
                 "strategy": strategy,
                 "targets": target_objs,
+                "retries": retries,
+                "max_fallbacks": max_fallbacks,
+                "retry_on_429": retry_on_429,
             }
         });
         let model: Model = serde_json::from_value(cfg).unwrap();
@@ -1958,7 +1978,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -1973,6 +1993,9 @@ data: [DONE]\n\n";
             "smart",
             "failover",
             &["primary", "secondary"],
+            None,
+            None,
+            None,
         ));
         snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
 
@@ -1990,8 +2013,9 @@ data: [DONE]\n\n";
             .unwrap();
 
         let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        let status = resp.status();
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&bytes));
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["choices"][0]["message"]["content"], "fallback worked");
     }
@@ -2019,7 +2043,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -2034,6 +2058,9 @@ data: [DONE]\n\n";
             "smart",
             "failover",
             &["primary", "secondary"],
+            None,
+            None,
+            None,
         ));
         snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
 
@@ -2051,7 +2078,149 @@ data: [DONE]\n\n";
             .unwrap();
 
         let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{}", String::from_utf8_lossy(&bytes));
+    }
+
+    #[tokio::test]
+    async fn routing_retries_current_target_before_failover() {
+        let flaky_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("try again"))
+            .expect(2)
+            .mount(&flaky_upstream)
+            .await;
+
+        let good_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-good",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "after retries"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1)
+            .mount(&good_upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-flaky", &flaky_upstream.uri()));
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-good", &good_upstream.uri()));
+        snap.models
+            .insert(model_entry_with_id("m-flaky", "primary", "pk-flaky"));
+        snap.models
+            .insert(model_entry_with_id("m-good", "secondary", "pk-good"));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary", "secondary"],
+            Some(1),
+            Some(1),
+            None,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let app = build_router(build_state(snap, hub));
+        let body = serde_json::json!({
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&bytes));
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["choices"][0]["message"]["content"], "after retries");
+    }
+
+    #[tokio::test]
+    async fn routing_can_retry_and_failover_on_429_when_enabled() {
+        let ratelimited_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("slow down"))
+            .expect(2)
+            .mount(&ratelimited_upstream)
+            .await;
+
+        let good_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-good",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "429 fallback worked"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1)
+            .mount(&good_upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-429", &ratelimited_upstream.uri()));
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-good", &good_upstream.uri()));
+        snap.models
+            .insert(model_entry_with_id("m-429", "primary", "pk-429"));
+        snap.models
+            .insert(model_entry_with_id("m-good", "secondary", "pk-good"));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary", "secondary"],
+            Some(1),
+            Some(1),
+            Some(true),
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let app = build_router(build_state(snap, hub));
+        let body = serde_json::json!({
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&bytes));
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["choices"][0]["message"]["content"], "429 fallback worked");
     }
 
     #[tokio::test]
@@ -2059,11 +2228,11 @@ data: [DONE]\n\n";
         // Routing references a Model that isn't in the snapshot — this
         // is a misconfiguration and should surface as a clean 400.
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.models
-            .insert(routing_entry("smart", "failover", &["nonexistent"]));
+            .insert(routing_entry("smart", "failover", &["nonexistent"], None, None, None));
         snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
         // No upstream provider_key needed — the routing target itself
         // is missing so dispatch fails before any provider lookup.
@@ -2104,7 +2273,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -2172,7 +2341,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
 
         let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(KeywordBlocklist::new(
@@ -2234,7 +2403,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(KeywordBlocklist::new(
             vec![KeywordRule::literal("forbidden-token")],
@@ -2293,7 +2462,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
 
         let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(
@@ -2620,7 +2789,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
 
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let state = build_state(snap, hub).with_budget_client(Arc::new(BudgetClient::new(

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -12,7 +12,7 @@
 //!   so callers spread evenly across targets.
 //! - **weighted**: pick a starting target with probability proportional
 //!   to `weight`, then walk forward on failure (weights only affect the
-//!   *first* attempt — once we're falling back, order is positional).
+//!   *first* target choice — once we're falling back, order is positional).
 
 use aisix_core::{Routing, RoutingStrategy, RoutingTarget};
 use aisix_gateway::BridgeError;
@@ -20,13 +20,18 @@ use dashmap::DashMap;
 use rand::Rng;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Whether a Bridge error is retryable across routing targets.
-/// 4xx is the caller's mistake — retrying to a different target won't
-/// help and may amplify damage. Everything else (5xx, timeout, transport,
-/// decode, config, stream abort) gets the fallback path.
-pub fn is_retryable(err: &BridgeError) -> bool {
+/// Whether a Bridge error is retryable at all, optionally treating 429
+/// as retryable. Non-429 4xx is the caller's mistake — retrying won't
+/// help and may amplify damage. Everything else (5xx, timeout,
+/// transport, decode, config, stream abort) gets the retry/failover path.
+pub fn is_retryable(err: &BridgeError, retry_on_429: bool) -> bool {
     match err {
-        BridgeError::UpstreamStatus { status, .. } => !(400..500).contains(status),
+        BridgeError::UpstreamStatus { status, .. } => {
+            if *status == 429 {
+                return retry_on_429;
+            }
+            !(400..500).contains(status)
+        }
         BridgeError::Timeout { .. }
         | BridgeError::Transport(_)
         | BridgeError::UpstreamDecode(_)
@@ -46,17 +51,16 @@ impl RoutingRegistry {
         Self::default()
     }
 
-    /// Pick the attempt order for one request. The first element is the
-    /// initial target; subsequent elements are the fallback chain (in
-    /// declaration order, wrapping if needed). Length is bounded by
-    /// `routing.retry_budget_or_default()`.
-    pub fn pick_order(&self, virtual_name: &str, routing: &Routing) -> Vec<String> {
-        let budget = routing.retry_budget_or_default();
-        if budget == 0 || routing.targets.is_empty() {
+    /// Pick the target order for one request. The first element is the
+    /// initial target; subsequent elements are later fallback targets (in
+    /// declaration order, wrapping if needed). Length is bounded by the
+    /// initial target plus `routing.max_fallbacks_or_default()`.
+    pub fn pick_targets(&self, virtual_name: &str, routing: &Routing) -> Vec<String> {
+        if routing.targets.is_empty() {
             return Vec::new();
         }
         let start = self.starting_index(virtual_name, routing);
-        attempt_order(&routing.targets, start, budget)
+        attempt_order(&routing.targets, start, routing.max_fallbacks_or_default() + 1)
     }
 
     fn starting_index(&self, virtual_name: &str, routing: &Routing) -> usize {
@@ -82,12 +86,12 @@ impl std::fmt::Debug for RoutingRegistry {
     }
 }
 
-/// Build the attempt-order vector starting at `start_idx`, walking forward
-/// (wrap-around) for `budget` distinct entries.
-fn attempt_order(targets: &[RoutingTarget], start_idx: usize, budget: usize) -> Vec<String> {
+/// Build the target-order vector starting at `start_idx`, walking forward
+/// (wrap-around) for `limit` distinct entries.
+fn attempt_order(targets: &[RoutingTarget], start_idx: usize, limit: usize) -> Vec<String> {
     let n = targets.len();
-    let mut order = Vec::with_capacity(budget);
-    for i in 0..budget {
+    let mut order = Vec::with_capacity(limit);
+    for i in 0..limit {
         let t = &targets[(start_idx + i) % n];
         order.push(t.model.clone());
     }
@@ -135,11 +139,17 @@ mod tests {
     use super::*;
     use aisix_core::{Routing, RoutingStrategy, RoutingTarget};
 
-    fn r(strategy: RoutingStrategy, targets: Vec<RoutingTarget>, budget: Option<u32>) -> Routing {
+    fn r(
+        strategy: RoutingStrategy,
+        targets: Vec<RoutingTarget>,
+        max_fallbacks: Option<u32>,
+    ) -> Routing {
         Routing {
             strategy,
             targets,
-            retry_budget: budget,
+            retries: None,
+            max_fallbacks,
+            retry_on_429: None,
         }
     }
 
@@ -156,7 +166,7 @@ mod tests {
             None,
         );
         for _ in 0..5 {
-            let order = reg.pick_order("v", &routing);
+            let order = reg.pick_targets("v", &routing);
             assert_eq!(order, vec!["primary", "secondary", "tertiary"]);
         }
     }
@@ -175,7 +185,7 @@ mod tests {
         );
         let mut firsts = Vec::new();
         for _ in 0..6 {
-            let order = reg.pick_order("v", &routing);
+            let order = reg.pick_targets("v", &routing);
             firsts.push(order[0].clone());
         }
         // Two full cycles of a→b→c.
@@ -191,10 +201,10 @@ mod tests {
             Some(1),
         );
         // Two distinct virtual models advance independently.
-        assert_eq!(reg.pick_order("v1", &routing)[0], "a");
-        assert_eq!(reg.pick_order("v2", &routing)[0], "a");
-        assert_eq!(reg.pick_order("v1", &routing)[0], "b");
-        assert_eq!(reg.pick_order("v2", &routing)[0], "b");
+        assert_eq!(reg.pick_targets("v1", &routing)[0], "a");
+        assert_eq!(reg.pick_targets("v2", &routing)[0], "a");
+        assert_eq!(reg.pick_targets("v1", &routing)[0], "b");
+        assert_eq!(reg.pick_targets("v2", &routing)[0], "b");
     }
 
     #[test]
@@ -207,12 +217,12 @@ mod tests {
                 RoutingTarget::new("b"),
                 RoutingTarget::new("c"),
             ],
-            Some(0), // 0 → use full target count (3 attempts)
+            Some(2),
         );
         // First call starts at a → a, b, c
-        assert_eq!(reg.pick_order("v", &routing), vec!["a", "b", "c"]);
+        assert_eq!(reg.pick_targets("v", &routing), vec!["a", "b", "c"]);
         // Second call starts at b → b, c, a
-        assert_eq!(reg.pick_order("v", &routing), vec!["b", "c", "a"]);
+        assert_eq!(reg.pick_targets("v", &routing), vec!["b", "c", "a"]);
     }
 
     #[test]
@@ -224,13 +234,13 @@ mod tests {
                 RoutingTarget::new("a").with_weight(99),
                 RoutingTarget::new("b").with_weight(1),
             ],
-            Some(0),
+            Some(1),
         );
         // We just assert correctness of the *order* shape:
         // exactly two attempts, distinct targets, both targets covered.
         // (Aggregate distribution is pinned by the dedicated tests
         // below.)
-        let order = reg.pick_order("v", &routing);
+        let order = reg.pick_targets("v", &routing);
         assert_eq!(order.len(), 2);
         assert!(order.iter().any(|t| t == "a"));
         assert!(order.iter().any(|t| t == "b"));
@@ -377,14 +387,14 @@ mod tests {
     }
 
     #[test]
-    fn budget_one_disables_fallback() {
+    fn max_fallbacks_zero_disables_failover() {
         let reg = RoutingRegistry::new();
         let routing = r(
             RoutingStrategy::Failover,
             vec![RoutingTarget::new("a"), RoutingTarget::new("b")],
-            Some(1),
+            Some(0),
         );
-        let order = reg.pick_order("v", &routing);
+        let order = reg.pick_targets("v", &routing);
         assert_eq!(order, vec!["a"]);
     }
 
@@ -392,7 +402,7 @@ mod tests {
     fn empty_targets_yields_empty_order() {
         let reg = RoutingRegistry::new();
         let routing = r(RoutingStrategy::Failover, vec![], None);
-        assert!(reg.pick_order("v", &routing).is_empty());
+        assert!(reg.pick_targets("v", &routing).is_empty());
     }
 
     #[test]
@@ -400,19 +410,23 @@ mod tests {
         assert!(!is_retryable(&BridgeError::UpstreamStatus {
             status: 400,
             message: "bad request".into(),
-        }));
+        }, false));
         assert!(!is_retryable(&BridgeError::UpstreamStatus {
             status: 429,
             message: "rate limited".into(),
-        }));
+        }, false));
+        assert!(is_retryable(&BridgeError::UpstreamStatus {
+            status: 429,
+            message: "rate limited".into(),
+        }, true));
         assert!(is_retryable(&BridgeError::UpstreamStatus {
             status: 502,
             message: "bad gateway".into(),
-        }));
-        assert!(is_retryable(&BridgeError::Timeout { elapsed_ms: 1 }));
-        assert!(is_retryable(&BridgeError::Transport("conn".into())));
-        assert!(is_retryable(&BridgeError::UpstreamDecode("x".into())));
-        assert!(is_retryable(&BridgeError::Config("bad key".into())));
-        assert!(is_retryable(&BridgeError::StreamAborted));
+        }, false));
+        assert!(is_retryable(&BridgeError::Timeout { elapsed_ms: 1 }, false));
+        assert!(is_retryable(&BridgeError::Transport("conn".into()), false));
+        assert!(is_retryable(&BridgeError::UpstreamDecode("x".into()), false));
+        assert!(is_retryable(&BridgeError::Config("bad key".into()), false));
+        assert!(is_retryable(&BridgeError::StreamAborted, false));
     }
 }

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -60,7 +60,11 @@ impl RoutingRegistry {
             return Vec::new();
         }
         let start = self.starting_index(virtual_name, routing);
-        attempt_order(&routing.targets, start, routing.max_fallbacks_or_default() + 1)
+        attempt_order(
+            &routing.targets,
+            start,
+            routing.max_fallbacks_or_default() + 1,
+        )
     }
 
     fn starting_index(&self, virtual_name: &str, routing: &Routing) -> usize {
@@ -407,25 +411,40 @@ mod tests {
 
     #[test]
     fn is_retryable_distinguishes_4xx_from_other_failures() {
-        assert!(!is_retryable(&BridgeError::UpstreamStatus {
-            status: 400,
-            message: "bad request".into(),
-        }, false));
-        assert!(!is_retryable(&BridgeError::UpstreamStatus {
-            status: 429,
-            message: "rate limited".into(),
-        }, false));
-        assert!(is_retryable(&BridgeError::UpstreamStatus {
-            status: 429,
-            message: "rate limited".into(),
-        }, true));
-        assert!(is_retryable(&BridgeError::UpstreamStatus {
-            status: 502,
-            message: "bad gateway".into(),
-        }, false));
+        assert!(!is_retryable(
+            &BridgeError::UpstreamStatus {
+                status: 400,
+                message: "bad request".into(),
+            },
+            false
+        ));
+        assert!(!is_retryable(
+            &BridgeError::UpstreamStatus {
+                status: 429,
+                message: "rate limited".into(),
+            },
+            false
+        ));
+        assert!(is_retryable(
+            &BridgeError::UpstreamStatus {
+                status: 429,
+                message: "rate limited".into(),
+            },
+            true
+        ));
+        assert!(is_retryable(
+            &BridgeError::UpstreamStatus {
+                status: 502,
+                message: "bad gateway".into(),
+            },
+            false
+        ));
         assert!(is_retryable(&BridgeError::Timeout { elapsed_ms: 1 }, false));
         assert!(is_retryable(&BridgeError::Transport("conn".into()), false));
-        assert!(is_retryable(&BridgeError::UpstreamDecode("x".into()), false));
+        assert!(is_retryable(
+            &BridgeError::UpstreamDecode("x".into()),
+            false
+        ));
         assert!(is_retryable(&BridgeError::Config("bad key".into()), false));
         assert!(is_retryable(&BridgeError::StreamAborted, false));
     }

--- a/tests/e2e/src/cases/routing-strategies-e2e.test.ts
+++ b/tests/e2e/src/cases/routing-strategies-e2e.test.ts
@@ -1,0 +1,417 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const CALLER_PLAINTEXT = "sk-routing-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("routing strategies and retry behavior e2e", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  async function createOpenAiModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin client not initialized");
+    const providerKey = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: providerKey.id,
+    });
+  }
+
+  async function waitUntilModelResponds(
+    model: string,
+    content: string,
+  ): Promise<void> {
+    await waitConfigPropagation(async () => {
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app?.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+      try {
+        const probe = await client.chat.completions.create({
+          model,
+          messages: [{ role: "user", content: `ready-${model}` }],
+        });
+        return probe.choices[0]?.message.content === content;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  test("failover retries the current target before moving to the next target", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const primary = await startOpenAiUpstream({
+      status: 502,
+      errorBody: { error: { message: "retry primary down", type: "server_error" } },
+    });
+    const secondary = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-routing-retry-fallback",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "after retries" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    upstreams.push(primary, secondary);
+
+    await createOpenAiModel("routing-retry-primary", primary);
+    await createOpenAiModel("routing-retry-secondary", secondary);
+    await waitUntilModelResponds("routing-retry-secondary", "after retries");
+    await admin.createModel({
+      display_name: "routing-retry-virtual",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "routing-retry-primary" },
+          { model: "routing-retry-secondary" },
+        ],
+        retries: 1,
+        max_fallbacks: 1,
+      },
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "routing-retry-virtual",
+          messages: [{ role: "user", content: "ready-routing-retry" }],
+        });
+        return probe.choices[0]?.message.content === "after retries";
+      } catch {
+        return false;
+      }
+    });
+
+    const primaryBaseline = primary.receivedRequests.length;
+    const secondaryBaseline = secondary.receivedRequests.length;
+
+    const completion = await client.chat.completions.create({
+      model: "routing-retry-virtual",
+      messages: [{ role: "user", content: "retry then fallback" }],
+    });
+
+    expect(completion.choices[0]?.message.content).toBe("after retries");
+    expect(primary.receivedRequests.length - primaryBaseline).toBe(2);
+    expect(secondary.receivedRequests.length - secondaryBaseline).toBe(1);
+  });
+
+  test("retry_on_429 lets 429 participate in retry and failover", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const primary = await startOpenAiUpstream({
+      status: 429,
+      errorBody: { error: { message: "too many requests", type: "rate_limit_error" } },
+    });
+    const secondary = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-routing-429-fallback",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "429 fallback worked" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    upstreams.push(primary, secondary);
+
+    await createOpenAiModel("routing-429-primary", primary);
+    await createOpenAiModel("routing-429-secondary", secondary);
+    await waitUntilModelResponds("routing-429-secondary", "429 fallback worked");
+    await admin.createModel({
+      display_name: "routing-429-virtual",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "routing-429-primary" },
+          { model: "routing-429-secondary" },
+        ],
+        retries: 1,
+        max_fallbacks: 1,
+        retry_on_429: true,
+      },
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "routing-429-virtual",
+          messages: [{ role: "user", content: "ready-routing-429" }],
+        });
+        return probe.choices[0]?.message.content === "429 fallback worked";
+      } catch {
+        return false;
+      }
+    });
+
+    const primaryBaseline = primary.receivedRequests.length;
+    const secondaryBaseline = secondary.receivedRequests.length;
+
+    const completion = await client.chat.completions.create({
+      model: "routing-429-virtual",
+      messages: [{ role: "user", content: "429 should retry and fail over" }],
+    });
+
+    expect(completion.choices[0]?.message.content).toBe("429 fallback worked");
+    expect(primary.receivedRequests.length - primaryBaseline).toBe(2);
+    expect(secondary.receivedRequests.length - secondaryBaseline).toBe(1);
+  });
+
+  test("round_robin rotates the starting target between requests", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const first = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-routing-rr-a",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "rr-a" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    const second = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-routing-rr-b",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "rr-b" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    upstreams.push(first, second);
+
+    await createOpenAiModel("routing-rr-a", first);
+    await createOpenAiModel("routing-rr-b", second);
+    await waitUntilModelResponds("routing-rr-a", "rr-a");
+    await waitUntilModelResponds("routing-rr-b", "rr-b");
+    await admin.createModel({
+      display_name: "routing-rr-virtual",
+      routing: {
+        strategy: "round_robin",
+        targets: [{ model: "routing-rr-a" }, { model: "routing-rr-b" }],
+        max_fallbacks: 0,
+      },
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "routing-rr-virtual",
+          messages: [{ role: "user", content: "ready-routing-rr" }],
+        });
+        return ["rr-a", "rr-b"].includes(probe.choices[0]?.message.content ?? "");
+      } catch {
+        return false;
+      }
+    });
+
+    const firstBaseline = first.receivedRequests.length;
+    const secondBaseline = second.receivedRequests.length;
+    const contents: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const completion = await client.chat.completions.create({
+        model: "routing-rr-virtual",
+        messages: [{ role: "user", content: `round-robin-${i}` }],
+      });
+      contents.push(completion.choices[0]?.message.content ?? "");
+    }
+
+    expect(new Set(contents)).toEqual(new Set(["rr-a", "rr-b"]));
+    expect(contents[0]).not.toBe(contents[1]);
+    expect(contents[1]).not.toBe(contents[2]);
+    expect(contents[2]).not.toBe(contents[3]);
+    expect(first.receivedRequests.length - firstBaseline).toBe(2);
+    expect(second.receivedRequests.length - secondBaseline).toBe(2);
+  });
+
+  test("weighted picks the positive-weight target first and falls forward from there", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const zeroWeightBefore = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-routing-weighted-before",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "should-not-run" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    const weightedPrimary = await startOpenAiUpstream({
+      status: 503,
+      errorBody: { error: { message: "weighted primary down", type: "server_error" } },
+    });
+    const forwardFallback = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-routing-weighted-fallback",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "weighted fallback worked" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    upstreams.push(zeroWeightBefore, weightedPrimary, forwardFallback);
+
+    await createOpenAiModel("routing-weighted-before", zeroWeightBefore);
+    await createOpenAiModel("routing-weighted-primary", weightedPrimary);
+    await createOpenAiModel("routing-weighted-fallback", forwardFallback);
+    await waitUntilModelResponds("routing-weighted-before", "should-not-run");
+    await waitUntilModelResponds("routing-weighted-fallback", "weighted fallback worked");
+    await admin.createModel({
+      display_name: "routing-weighted-virtual",
+      routing: {
+        strategy: "weighted",
+        targets: [
+          { model: "routing-weighted-before", weight: 0 },
+          { model: "routing-weighted-primary", weight: 1 },
+          { model: "routing-weighted-fallback", weight: 0 },
+        ],
+        max_fallbacks: 1,
+      },
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "routing-weighted-virtual",
+          messages: [{ role: "user", content: "ready-routing-weighted" }],
+        });
+        return probe.choices[0]?.message.content === "weighted fallback worked";
+      } catch {
+        return false;
+      }
+    });
+
+    const beforeBaseline = zeroWeightBefore.receivedRequests.length;
+    const primaryBaseline = weightedPrimary.receivedRequests.length;
+    const fallbackBaseline = forwardFallback.receivedRequests.length;
+
+    const completion = await client.chat.completions.create({
+      model: "routing-weighted-virtual",
+      messages: [{ role: "user", content: "weighted routing request" }],
+    });
+
+    expect(completion.choices[0]?.message.content).toBe("weighted fallback worked");
+    expect(zeroWeightBefore.receivedRequests.length - beforeBaseline).toBe(0);
+    expect(weightedPrimary.receivedRequests.length - primaryBaseline).toBe(1);
+    expect(forwardFallback.receivedRequests.length - fallbackBaseline).toBe(1);
+  });
+});

--- a/tests/e2e/src/cases/routing-strategies-e2e.test.ts
+++ b/tests/e2e/src/cases/routing-strategies-e2e.test.ts
@@ -129,7 +129,17 @@ describe("routing strategies and retry behavior e2e", () => {
       maxRetries: 0,
     });
 
-    await waitConfigPropagation();
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "routing-retry-virtual",
+          messages: [{ role: "user", content: "ready-routing-retry" }],
+        });
+        return probe.choices[0]?.message.content === "after retries";
+      } catch {
+        return false;
+      }
+    });
 
     const primaryBaseline = primary.receivedRequests.length;
     const secondaryBaseline = secondary.receivedRequests.length;
@@ -195,7 +205,17 @@ describe("routing strategies and retry behavior e2e", () => {
       maxRetries: 0,
     });
 
-    await waitConfigPropagation();
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "routing-429-virtual",
+          messages: [{ role: "user", content: "ready-routing-429" }],
+        });
+        return probe.choices[0]?.message.content === "429 fallback worked";
+      } catch {
+        return false;
+      }
+    });
 
     const primaryBaseline = primary.receivedRequests.length;
     const secondaryBaseline = secondary.receivedRequests.length;

--- a/tests/e2e/src/cases/routing-strategies-e2e.test.ts
+++ b/tests/e2e/src/cases/routing-strategies-e2e.test.ts
@@ -129,17 +129,7 @@ describe("routing strategies and retry behavior e2e", () => {
       maxRetries: 0,
     });
 
-    await waitConfigPropagation(async () => {
-      try {
-        const probe = await client.chat.completions.create({
-          model: "routing-retry-virtual",
-          messages: [{ role: "user", content: "ready-routing-retry" }],
-        });
-        return probe.choices[0]?.message.content === "after retries";
-      } catch {
-        return false;
-      }
-    });
+    await waitConfigPropagation();
 
     const primaryBaseline = primary.receivedRequests.length;
     const secondaryBaseline = secondary.receivedRequests.length;
@@ -205,17 +195,7 @@ describe("routing strategies and retry behavior e2e", () => {
       maxRetries: 0,
     });
 
-    await waitConfigPropagation(async () => {
-      try {
-        const probe = await client.chat.completions.create({
-          model: "routing-429-virtual",
-          messages: [{ role: "user", content: "ready-routing-429" }],
-        });
-        return probe.choices[0]?.message.content === "429 fallback worked";
-      } catch {
-        return false;
-      }
-    });
+    await waitConfigPropagation();
 
     const primaryBaseline = primary.receivedRequests.length;
     const secondaryBaseline = secondary.receivedRequests.length;

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -86,6 +86,14 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
     if (v !== undefined && !k.startsWith("AISIX_")) childEnv[k] = v;
   }
   childEnv.RUST_LOG = process.env.RUST_LOG ?? "warn";
+  childEnv.HTTP_PROXY = "";
+  childEnv.HTTPS_PROXY = "";
+  childEnv.ALL_PROXY = "";
+  childEnv.http_proxy = "";
+  childEnv.https_proxy = "";
+  childEnv.all_proxy = "";
+  childEnv.NO_PROXY = "127.0.0.1,localhost";
+  childEnv.no_proxy = "127.0.0.1,localhost";
 
   const child = spawn(BIN_PATH, ["--config", cfgPath], {
     stdio: ["ignore", "pipe", "pipe"],

--- a/tests/e2e/src/harness/upstream-openai.ts
+++ b/tests/e2e/src/harness/upstream-openai.ts
@@ -16,6 +16,18 @@ export interface OpenAiUpstreamOptions {
   errorBody?: unknown;
   /** Drop the connection after writing this many SSE events. */
   disconnectAfterEvents?: number;
+  /** Per-request response script; used in order before static opts. */
+  scriptedResponses?: OpenAiUpstreamStep[];
+}
+
+export interface OpenAiUpstreamStep {
+  nonStreamBody?: unknown;
+  streamEvents?: string[];
+  responseDelayMs?: number;
+  eventDelayMs?: number;
+  status?: number;
+  errorBody?: unknown;
+  disconnectAfterEvents?: number;
 }
 
 export interface OpenAiUpstream {
@@ -42,11 +54,13 @@ export async function startOpenAiUpstream(
   opts: OpenAiUpstreamOptions = {},
 ): Promise<OpenAiUpstream> {
   const received: ReceivedRequest[] = [];
+  let requestIndex = 0;
 
   const server: Server = createServer((req, res) => {
     let raw = "";
     req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
     req.on("end", async () => {
+      const step = opts.scriptedResponses?.[requestIndex++] ?? opts;
       received.push({
         method: req.method ?? "GET",
         path: req.url ?? "/",
@@ -56,32 +70,32 @@ export async function startOpenAiUpstream(
         body: raw,
       });
 
-      if (opts.responseDelayMs) await sleep(opts.responseDelayMs);
+      if (step.responseDelayMs) await sleep(step.responseDelayMs);
 
-      const status = opts.status ?? 200;
+      const status = step.status ?? 200;
       if (status >= 400) {
         res.statusCode = status;
         res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify(opts.errorBody ?? { error: { message: "mock error" } }));
+        res.end(JSON.stringify(step.errorBody ?? { error: { message: "mock error" } }));
         return;
       }
 
-      const isStream = !!opts.streamEvents;
+      const isStream = !!step.streamEvents;
       if (isStream) {
         res.statusCode = 200;
         res.setHeader("content-type", "text/event-stream");
         res.setHeader("cache-control", "no-cache");
-        const events = opts.streamEvents ?? [];
+        const events = step.streamEvents ?? [];
         for (let i = 0; i < events.length; i++) {
           if (
-            opts.disconnectAfterEvents !== undefined &&
-            i >= opts.disconnectAfterEvents
+            step.disconnectAfterEvents !== undefined &&
+            i >= step.disconnectAfterEvents
           ) {
             res.destroy();
             return;
           }
           res.write(`data: ${events[i]}\n\n`);
-          if (opts.eventDelayMs) await sleep(opts.eventDelayMs);
+          if (step.eventDelayMs) await sleep(step.eventDelayMs);
         }
         res.end();
         return;
@@ -91,7 +105,7 @@ export async function startOpenAiUpstream(
       res.setHeader("content-type", "application/json");
       res.end(
         JSON.stringify(
-          opts.nonStreamBody ?? {
+          step.nonStreamBody ?? {
             id: "mock-1",
             object: "chat.completion",
             created: Math.floor(Date.now() / 1000),


### PR DESCRIPTION
## Summary
- replace `retry_budget` with `retries`, `max_fallbacks`, and `retry_on_429` in the routing schema and proxy behavior
- retry the current target before failover, including optional 429 participation, across failover, round-robin, and weighted strategies
- add runtime and e2e coverage for same-target retries, 429 failover, strategy behavior, and proxy-safe local test harness execution

## Breaking Change
- `retry_budget` compatibility is intentionally not preserved on read or write
- this is acceptable for now because there are no real users or production etcd payloads to migrate yet
- follow-up control-plane work in `AISIX-Cloud#260` will use only the new routing fields

## Testing
- cargo test -p aisix-proxy routing -- --nocapture
- npm test -- routing-strategies-e2e.test.ts fallback-e2e.test.ts fallback-edges-e2e.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granular routing controls: per-target retries, configurable max fallbacks, and optional retry-on-429 behavior.

* **Refactor**
  * Routing and retry logic updated to honor the new controls and defaulting semantics; target selection API simplified.

* **Tests**
  * Added E2E suite validating routing strategies, retries, failover and retry-on-429; unit tests updated.

* **Chores**
  * Test harness improved for deterministic runs (proxy isolation, scripted upstream responses).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/263)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->