### PR TITLE
fix(server): add newline separator when concatenating PEM blocks

### DIFF
--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -266,8 +266,13 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
     // reqwest::Identity::from_pem expects a single PEM blob containing
     // BOTH the private key and the cert chain. Concatenate in that
     // order — rustls is order-tolerant but it's the convention.
-    let mut identity_pem = Vec::with_capacity(cert_pem.len() + key_pem.len());
+    // Ensure a newline separates the two blocks; PEM files from env
+    // vars (dashboard deploy scripts) may lack a trailing newline.
+    let mut identity_pem = Vec::with_capacity(cert_pem.len() + key_pem.len() + 1);
     identity_pem.extend_from_slice(&key_pem);
+    if !key_pem.ends_with(b"\n") {
+        identity_pem.push(b'\n');
+    }
     identity_pem.extend_from_slice(&cert_pem);
     let identity = reqwest::Identity::from_pem(&identity_pem)
         .context("build mTLS Identity from client cert + key")?;
@@ -504,5 +509,49 @@ mod tests {
             err.to_string().contains("ca.crt"),
             "unexpected error: {err}"
         );
+    }
+
+    /// Regression: PEM files from dashboard deploy scripts may lack a
+    /// trailing newline. Without the separator fix, key + cert merge
+    /// into `-----END EC PRIVATE KEY----------BEGIN CERTIFICATE-----`
+    /// and reqwest's PEM parser rejects the blob.
+    #[test]
+    fn build_client_works_without_trailing_newlines() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let ca_kp = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.distinguished_name = {
+            let mut dn = DistinguishedName::new();
+            dn.push(rcgen::DnType::CommonName, "aisix-test-ca");
+            dn
+        };
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_kp).unwrap();
+
+        let leaf_kp = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut leaf_params = CertificateParams::new(vec!["dp-test".to_string()]).unwrap();
+        leaf_params.distinguished_name = {
+            let mut dn = DistinguishedName::new();
+            dn.push(rcgen::DnType::CommonName, "dp-test");
+            dn
+        };
+        let leaf_cert = leaf_params.signed_by(&leaf_kp, &ca_cert, &ca_kp).unwrap();
+
+        let ca_path = dir.path().join("ca.crt");
+        let cert_path = dir.path().join("client.crt");
+        let key_path = dir.path().join("client.key");
+        // Strip trailing newlines to mimic dashboard-generated PEMs.
+        std::fs::write(&ca_path, ca_cert.pem().trim_end()).unwrap();
+        std::fs::write(&cert_path, leaf_cert.pem().trim_end()).unwrap();
+        std::fs::write(&key_path, leaf_kp.serialize_pem().trim_end()).unwrap();
+
+        let mtls = MtlsBundle {
+            ca_cert_path: ca_path,
+            client_cert_path: cert_path,
+            client_key_path: key_path,
+            extra_ca_pem: None,
+        };
+        build_client(&mtls).expect("build_client must tolerate PEM without trailing newline");
     }
 }

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -378,4 +378,44 @@ mod tests {
         let mtls = write_test_bundle(dir.path());
         let _ = build_client(&mtls).expect("real bundle should build");
     }
+
+    /// Mirror heartbeat regression: PEM without trailing newline.
+    #[test]
+    fn build_client_works_without_trailing_newlines() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let ca_kp = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.distinguished_name = {
+            let mut dn = DistinguishedName::new();
+            dn.push(rcgen::DnType::CommonName, "aisix-test-ca");
+            dn
+        };
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_kp).unwrap();
+
+        let leaf_kp = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut leaf_params = CertificateParams::new(vec!["dp-test".to_string()]).unwrap();
+        leaf_params.distinguished_name = {
+            let mut dn = DistinguishedName::new();
+            dn.push(rcgen::DnType::CommonName, "dp-test");
+            dn
+        };
+        let leaf_cert = leaf_params.signed_by(&leaf_kp, &ca_cert, &ca_kp).unwrap();
+
+        let ca_path = dir.path().join("ca.crt");
+        let cert_path = dir.path().join("client.crt");
+        let key_path = dir.path().join("client.key");
+        std::fs::write(&ca_path, ca_cert.pem().trim_end()).unwrap();
+        std::fs::write(&cert_path, leaf_cert.pem().trim_end()).unwrap();
+        std::fs::write(&key_path, leaf_kp.serialize_pem().trim_end()).unwrap();
+
+        let mtls = MtlsBundle {
+            ca_cert_path: ca_path,
+            client_cert_path: cert_path,
+            client_key_path: key_path,
+            extra_ca_pem: None,
+        };
+        build_client(&mtls).expect("build_client must tolerate PEM without trailing newline");
+    }
 }

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -228,8 +228,12 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
     let key_pem = std::fs::read(&mtls.client_key_path)
         .with_context(|| format!("read {}", mtls.client_key_path.display()))?;
 
-    let mut identity_pem = Vec::with_capacity(cert_pem.len() + key_pem.len());
+    // Ensure a newline separates the two PEM blocks (see heartbeat.rs).
+    let mut identity_pem = Vec::with_capacity(cert_pem.len() + key_pem.len() + 1);
     identity_pem.extend_from_slice(&key_pem);
+    if !key_pem.ends_with(b"\n") {
+        identity_pem.push(b'\n');
+    }
     identity_pem.extend_from_slice(&cert_pem);
     let identity = reqwest::Identity::from_pem(&identity_pem)
         .context("build mTLS Identity from client cert + key")?;


### PR DESCRIPTION
Related to #265 (discovered during the same investigation, but this is a separate bug).

When PEM files from dashboard deploy scripts lack a trailing newline, the heartbeat/telemetry `build_client` concatenates key + cert into a blob like:

```
-----END EC PRIVATE KEY----------BEGIN CERTIFICATE-----
```

`reqwest::Identity::from_pem` cannot parse this and silently disables heartbeat, telemetry, and budget_check. The DP appears to start (proxy listens, etcd connects) but never reports back to the control plane.

The fix adds a `\n` separator between the two PEM blocks when concatenating. Both `heartbeat.rs` and `telemetry.rs` are patched with the fix and regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mTLS client certificate handling to ensure proper separation between private key and certificate blocks, preventing malformed PEMs when keys lack trailing newlines.

* **Tests**
  * Added a regression test verifying mTLS client creation succeeds with certificate/key files written without trailing newlines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/266)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->