### PR TITLE
fix(schema): add team/owner rate-limit fields to apikey JSON schema

### DIFF
--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -197,7 +197,11 @@ fn apikey_schema() -> Value {
                 "type": "array",
                 "items": { "type": "string" }
             },
-            "rate_limit": { "$ref": "#/$defs/rate_limit" }
+            "rate_limit": { "$ref": "#/$defs/rate_limit" },
+            "team_id": { "type": "string" },
+            "team_rate_limit": { "$ref": "#/$defs/rate_limit" },
+            "owner_id": { "type": "string" },
+            "owner_rate_limit": { "$ref": "#/$defs/rate_limit" }
         },
         "$defs": {
             "rate_limit": {
@@ -506,11 +510,24 @@ mod tests {
     }
 
     #[test]
+    fn apikey_with_team_and_owner_fields_passes() {
+        let v = json!({
+            "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
+            "allowed_models":["gpt-4o"],
+            "team_id": "team-uuid-1",
+            "team_rate_limit": {"rpm": 600},
+            "owner_id": "member-uuid-1",
+            "owner_rate_limit": {"tpm": 200000}
+        });
+        validate_apikey(&v).unwrap();
+    }
+
+    #[test]
     fn apikey_unknown_field_rejected() {
         let v = json!({
             "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
             "allowed_models":["a"],
-            "max_budget_usd": 500.0
+            "bogus_field": true
         });
         assert!(validate_apikey(&v).is_err());
     }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -198,9 +198,9 @@ fn apikey_schema() -> Value {
                 "items": { "type": "string" }
             },
             "rate_limit": { "$ref": "#/$defs/rate_limit" },
-            "team_id": { "type": "string" },
+            "team_id": { "type": "string", "minLength": 1 },
             "team_rate_limit": { "$ref": "#/$defs/rate_limit" },
-            "owner_id": { "type": "string" },
+            "owner_id": { "type": "string", "minLength": 1 },
             "owner_rate_limit": { "$ref": "#/$defs/rate_limit" }
         },
         "$defs": {


### PR DESCRIPTION
PR #267 added `team_id`, `team_rate_limit`, `owner_id`, and `owner_rate_limit` to the `ApiKey` Rust struct but missed updating the JSON schema validator in `schema.rs`. Since the apikey schema uses `additionalProperties: false`, any payload with these fields gets rejected at validation time before serde deserialization.

This adds the four fields to the apikey JSON schema and updates the unknown-field test to use a truly unknown field name (`bogus_field`) instead of `max_budget_usd` (dropped in #259).

Blocks api7/AISIX-Cloud#271 (CP e2e fails because the dev image rejects `owner_id`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key schema now accepts optional team and owner identifiers plus optional team and owner rate limit settings.

* **Tests**
  * Validation tests updated to cover API keys with the new team/owner fields and to ensure unknown fields are rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/269)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->