### PR TITLE
feat(provider): tolerate common api_base forms in OpenAI and Anthropic bridges

### DIFF
--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -81,9 +81,35 @@ fn default_client() -> Client {
         .unwrap_or_else(|_| Client::new())
 }
 
+/// Path suffixes the Anthropic bridge appends. If an operator
+/// accidentally pastes a fuller form into `api_base`, strip the suffix
+/// so request building still produces the right URL.
+const ANTHROPIC_ENDPOINT_SUFFIXES: &[&str] = &["/v1/messages", "/v1"];
+
+/// Tolerate the common variations of `api_base` an operator might
+/// paste for the Anthropic upstream. Accepted forms:
+///
+/// - `https://api.anthropic.com` (canonical)
+/// - `https://api.anthropic.com/` (trailing slash)
+/// - `https://api.anthropic.com/v1` (extra `/v1` segment — common copy-paste
+///   habit from OpenAI conventions)
+/// - `https://api.anthropic.com/v1/messages` (full upstream URL pasted)
+///
+/// All collapse to the canonical bare host. The bridge then appends
+/// `/v1/messages` at request time.
+fn normalize_api_base(base: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    for suffix in ANTHROPIC_ENDPOINT_SUFFIXES {
+        if let Some(rest) = trimmed.strip_suffix(suffix) {
+            return rest.trim_end_matches('/').to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
 fn resolve_base(ctx: &BridgeContext) -> String {
     match ctx.provider_key.api_base.as_deref() {
-        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
+        Some(b) if !b.trim().is_empty() => normalize_api_base(b.trim()),
         _ => ANTHROPIC_DEFAULT_BASE.to_string(),
     }
 }
@@ -522,5 +548,54 @@ data: {\"type\":\"message_stop\"}\n\n";
         .unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_override));
         assert_eq!(resolve_base(&ctx), "https://proxy.example.com");
+    }
+
+    fn pk_with_base(api_base: &str) -> ProviderKey {
+        let cfg = format!(r#"{{"display_name":"x","secret":"k","api_base":"{api_base}"}}"#);
+        serde_json::from_str(&cfg).unwrap()
+    }
+
+    /// All four Anthropic api_base forms a real operator might paste must
+    /// collapse to the canonical bare host. The bridge appends
+    /// `/v1/messages` itself at request time.
+    #[test]
+    fn anthropic_api_base_tolerance_bare_host_v1_and_full_messages_path() {
+        let canonical = "https://api.anthropic.com";
+
+        for form in [
+            "https://api.anthropic.com",
+            "https://api.anthropic.com/",
+            "https://api.anthropic.com/v1",
+            "https://api.anthropic.com/v1/",
+            "https://api.anthropic.com/v1/messages",
+            "https://api.anthropic.com/v1/messages/",
+            "  https://api.anthropic.com  ",
+        ] {
+            let pk = pk_with_base(form);
+            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+            assert_eq!(
+                resolve_base(&ctx),
+                canonical,
+                "form {form:?} should normalize to {canonical}",
+            );
+        }
+    }
+
+    /// Same normalization applies to a custom proxy host — operator pastes
+    /// whichever form their proxy URL takes, all converge to the bare
+    /// host the bridge can append `/v1/messages` to.
+    #[test]
+    fn anthropic_api_base_tolerance_custom_proxy_host() {
+        let canonical = "https://proxy.example.com";
+
+        for form in [
+            "https://proxy.example.com",
+            "https://proxy.example.com/v1",
+            "https://proxy.example.com/v1/messages",
+        ] {
+            let pk = pk_with_base(form);
+            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+            assert_eq!(resolve_base(&ctx), canonical);
+        }
     }
 }

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -40,6 +40,32 @@ use crate::wire::{
 /// this constant only covers degenerate config paths.
 pub const OPENAI_DEFAULT_BASE: &str = "https://api.openai.com/v1";
 
+/// Fallback host for the `deepseek`-named variant of this bridge.
+/// Mirrors `aisix_provider_deepseek::DEEPSEEK_DEFAULT_BASE` so that a
+/// `with_name("deepseek")` instance without an explicit `api_base`
+/// dispatches to DeepSeek rather than OpenAI.
+const DEEPSEEK_DEFAULT_BASE: &str = "https://api.deepseek.com";
+
+/// Fallback host for the `gemini`-named variant of this bridge.
+/// Mirrors `aisix_provider_gemini::GEMINI_DEFAULT_BASE` so that a
+/// `with_name("gemini")` instance without an explicit `api_base`
+/// dispatches to Google's OpenAI-compatible Gemini endpoint.
+const GEMINI_DEFAULT_BASE: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
+
+/// Path suffixes the bridge appends to `api_base` when building upstream
+/// URLs. If an operator accidentally pastes the full upstream URL into
+/// `api_base` (e.g. `https://api.openai.com/v1/chat/completions`),
+/// strip the suffix so request building still produces a valid URL.
+const OPENAI_ENDPOINT_SUFFIXES: &[&str] = &[
+    "/chat/completions",
+    "/completions",
+    "/embeddings",
+    "/images/generations",
+    "/audio/transcriptions",
+    "/audio/translations",
+    "/audio/speech",
+];
+
 pub struct OpenAiBridge {
     client: Client,
     name: &'static str,
@@ -63,6 +89,50 @@ impl OpenAiBridge {
         self.name = name;
         self
     }
+
+    /// Default upstream base for this bridge variant. The bridge factory
+    /// wraps with `with_name("deepseek")` / `with_name("gemini")` to
+    /// retarget; the default base follows the same retargeting so a
+    /// degenerate config (no `api_base` on the Model) still reaches the
+    /// right host.
+    fn default_base(&self) -> &'static str {
+        match self.name {
+            "deepseek" => DEEPSEEK_DEFAULT_BASE,
+            "gemini" => GEMINI_DEFAULT_BASE,
+            _ => OPENAI_DEFAULT_BASE,
+        }
+    }
+
+    /// Resolve `ProviderKey.api_base` into the canonical base URL the
+    /// request handlers append paths onto. Tolerates common operator
+    /// mistakes:
+    ///
+    /// - leading and trailing whitespace
+    /// - trailing slash
+    /// - accidental endpoint suffix (e.g. `/chat/completions` pasted
+    ///   along with the host)
+    /// - bare canonical OpenAI host without `/v1` (the bridge adds it)
+    /// - canonical DeepSeek host with an extra `/v1` segment (the
+    ///   bridge strips it — DeepSeek serves OpenAI-compatible endpoints
+    ///   at the host root)
+    ///
+    /// `/v1` synthesis and stripping happens **only for the canonical
+    /// upstream host of each provider**. Corporate proxies, alternative
+    /// deployments, and any non-default path the operator chose on
+    /// purpose pass through unchanged after suffix stripping — the
+    /// operator's intent on a non-canonical host wins.
+    ///
+    /// For the `gemini` variant and any future `with_name` variant, the
+    /// path is left as-is after suffix stripping — Gemini's `/v1beta/openai`
+    /// prefix is non-trivial and operators typically copy-paste the full
+    /// form.
+    fn resolve_base(&self, ctx: &BridgeContext) -> String {
+        let raw = match ctx.provider_key.api_base.as_deref() {
+            Some(b) if !b.trim().is_empty() => b.trim().to_string(),
+            _ => return self.default_base().to_string(),
+        };
+        normalize_api_base(&raw, self.name)
+    }
 }
 
 impl Default for OpenAiBridge {
@@ -78,11 +148,67 @@ fn default_client() -> Client {
         .unwrap_or_else(|_| Client::new())
 }
 
-fn resolve_base(ctx: &BridgeContext) -> String {
-    match ctx.provider_key.api_base.as_deref() {
-        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
-        _ => OPENAI_DEFAULT_BASE.to_string(),
+/// Strip a known endpoint suffix from `base`. Idempotent: if no known
+/// suffix matches, returns the input with only the trailing slash trimmed.
+fn strip_known_endpoint(base: &str) -> &str {
+    let trimmed = base.trim_end_matches('/');
+    for suffix in OPENAI_ENDPOINT_SUFFIXES {
+        if let Some(rest) = trimmed.strip_suffix(suffix) {
+            return rest.trim_end_matches('/');
+        }
     }
+    trimmed
+}
+
+/// Provider-aware `api_base` normalization for the OpenAI-compatible
+/// bridge.
+///
+/// Normalization is intentionally **conservative**: it only adjusts
+/// `/v1` segments for the canonical upstream host of each provider.
+/// Corporate proxies, alternative deployments, and test mocks pass
+/// through verbatim after suffix stripping — the operator's path on
+/// a non-canonical host is trusted as-is.
+///
+/// See [`OpenAiBridge::resolve_base`] for accepted forms.
+fn normalize_api_base(base: &str, provider: &str) -> String {
+    let stripped = strip_known_endpoint(base);
+    match provider {
+        "openai" => normalize_canonical_openai(stripped),
+        "deepseek" => normalize_canonical_deepseek(stripped),
+        _ => stripped.to_string(),
+    }
+}
+
+/// Canonical OpenAI hosts. Both schemes covered for ops convenience —
+/// in production only `https://` is meaningful.
+const OPENAI_CANONICAL_HOSTS: &[&str] = &["https://api.openai.com", "http://api.openai.com"];
+
+/// Add the canonical `/v1` segment if and only if the operator pasted
+/// the bare canonical OpenAI host. Anything past the host root is left
+/// as-is so non-default paths the operator chose on purpose win.
+fn normalize_canonical_openai(base: &str) -> String {
+    for host in OPENAI_CANONICAL_HOSTS {
+        if base == *host {
+            return format!("{host}/v1");
+        }
+    }
+    base.to_string()
+}
+
+/// Canonical DeepSeek hosts.
+const DEEPSEEK_CANONICAL_HOSTS: &[&str] = &["https://api.deepseek.com", "http://api.deepseek.com"];
+
+/// Strip the `/v1` segment when the operator added it on the canonical
+/// DeepSeek host (a common copy-paste habit from OpenAI conventions).
+/// DeepSeek serves OpenAI-compatible endpoints at the host root.
+fn normalize_canonical_deepseek(base: &str) -> String {
+    for host in DEEPSEEK_CANONICAL_HOSTS {
+        let with_v1 = format!("{host}/v1");
+        if base == with_v1 {
+            return host.to_string();
+        }
+    }
+    base.to_string()
 }
 
 fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
@@ -150,7 +276,7 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
-        let base = resolve_base(ctx);
+        let base = self.resolve_base(ctx);
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -191,7 +317,7 @@ impl Bridge for OpenAiBridge {
         req: &EmbeddingRequest,
         ctx: &BridgeContext,
     ) -> Result<EmbeddingResponse, BridgeError> {
-        let base = resolve_base(ctx);
+        let base = self.resolve_base(ctx);
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -231,7 +357,7 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let base = resolve_base(ctx);
+        let base = self.resolve_base(ctx);
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -277,7 +403,7 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let base = resolve_base(ctx);
+        let base = self.resolve_base(ctx);
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -323,7 +449,7 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let base = resolve_base(ctx);
+        let base = self.resolve_base(ctx);
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -641,11 +767,13 @@ data: [DONE]\n\n";
 
     #[test]
     fn resolve_base_trims_trailing_slash_and_honours_override() {
+        let bridge = OpenAiBridge::new();
+
         // No api_base set → falls back to OPENAI_DEFAULT_BASE.
         let pk_default: ProviderKey =
             serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_default));
-        assert_eq!(resolve_base(&ctx), OPENAI_DEFAULT_BASE);
+        assert_eq!(bridge.resolve_base(&ctx), OPENAI_DEFAULT_BASE);
 
         // api_base override: trailing slash stripped.
         let pk_override: ProviderKey = serde_json::from_str(
@@ -653,6 +781,109 @@ data: [DONE]\n\n";
         )
         .unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_override));
-        assert_eq!(resolve_base(&ctx), "https://proxy.example.com/v1");
+        assert_eq!(bridge.resolve_base(&ctx), "https://proxy.example.com/v1");
+    }
+
+    fn pk_with_base(api_base: &str) -> ProviderKey {
+        let cfg = format!(r#"{{"display_name":"x","secret":"k","api_base":"{api_base}"}}"#);
+        serde_json::from_str(&cfg).unwrap()
+    }
+
+    /// All three OpenAI api_base forms a real operator might paste must
+    /// resolve to the same canonical `<host>/v1`.
+    #[test]
+    fn openai_api_base_tolerance_bare_host_v1_and_full_endpoint() {
+        let bridge = OpenAiBridge::new();
+        let canonical = "https://api.openai.com/v1";
+
+        for form in [
+            "https://api.openai.com",
+            "https://api.openai.com/",
+            "https://api.openai.com/v1",
+            "https://api.openai.com/v1/",
+            "https://api.openai.com/v1/chat/completions",
+            "https://api.openai.com/v1/embeddings",
+            "  https://api.openai.com/v1  ",
+        ] {
+            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
+            assert_eq!(
+                bridge.resolve_base(&ctx),
+                canonical,
+                "form {form:?} should normalize to {canonical}",
+            );
+        }
+    }
+
+    /// DeepSeek serves OpenAI-compatible paths at the host root; pasting
+    /// `/v1` (a common copy-paste habit from OpenAI) must be tolerated.
+    #[test]
+    fn deepseek_api_base_tolerance_bare_host_and_v1_form() {
+        let bridge = OpenAiBridge::new().with_name("deepseek");
+        let canonical = "https://api.deepseek.com";
+
+        for form in [
+            "https://api.deepseek.com",
+            "https://api.deepseek.com/",
+            "https://api.deepseek.com/v1",
+            "https://api.deepseek.com/v1/",
+            "https://api.deepseek.com/chat/completions",
+        ] {
+            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
+            assert_eq!(
+                bridge.resolve_base(&ctx),
+                canonical,
+                "form {form:?} should normalize to {canonical}",
+            );
+        }
+    }
+
+    /// DeepSeek without an explicit api_base must default to the DeepSeek
+    /// host, not the OpenAI host. Regression for a long-standing default
+    /// fallback bug exposed during the api_base tolerance work.
+    #[test]
+    fn deepseek_default_base_targets_deepseek_not_openai() {
+        let bridge = OpenAiBridge::new().with_name("deepseek");
+        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(bridge.resolve_base(&ctx), "https://api.deepseek.com");
+    }
+
+    /// Gemini default must target the OpenAI-compatible `/v1beta/openai`
+    /// path rather than falling through to the OpenAI host.
+    #[test]
+    fn gemini_default_base_targets_gemini_v1beta_openai() {
+        let bridge = OpenAiBridge::new().with_name("gemini");
+        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(
+            bridge.resolve_base(&ctx),
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+        );
+    }
+
+    /// For Gemini and any future `with_name` variant, the bridge does not
+    /// synthesize a `/v1beta/openai` prefix — the path is non-trivial. It
+    /// still strips an accidentally-pasted endpoint suffix.
+    #[test]
+    fn gemini_api_base_strips_endpoint_suffix_but_does_not_synthesize_prefix() {
+        let bridge = OpenAiBridge::new().with_name("gemini");
+
+        // Canonical form passes through.
+        let canonical = "https://generativelanguage.googleapis.com/v1beta/openai";
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(canonical)));
+        assert_eq!(bridge.resolve_base(&ctx), canonical);
+
+        // Endpoint suffix is stripped.
+        let with_suffix =
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(with_suffix)));
+        assert_eq!(bridge.resolve_base(&ctx), canonical);
+
+        // Bare host is left as-is — the operator's responsibility to
+        // include the unusual prefix. (See provider-keys.md for the
+        // per-provider truth table.)
+        let bare = "https://generativelanguage.googleapis.com";
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(bare)));
+        assert_eq!(bridge.resolve_base(&ctx), bare);
     }
 }

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -67,11 +67,61 @@ pub(crate) fn require_upstream_model(model: &Model) -> Result<&str, ProxyError> 
     })
 }
 
+/// Path suffixes the proxy-side handlers (audio, responses, messages)
+/// build via [`build_v1_url`]. If an operator accidentally pasted the
+/// full upstream URL into `api_base`, strip the suffix here so the
+/// later [`build_v1_url`] call does not double-append. The list mirrors
+/// every concrete endpoint the proxy currently routes to upstream,
+/// covered in both the bare (`/responses`) and `/v1`-prefixed
+/// (`/v1/responses`) form an operator might paste.
+///
+/// Longer suffixes appear first so `/v1/audio/transcriptions` matches
+/// before `/audio/transcriptions`, etc.
+const API_BASE_ENDPOINT_SUFFIXES: &[&str] = &[
+    "/v1/audio/transcriptions",
+    "/v1/audio/translations",
+    "/v1/audio/speech",
+    "/v1/chat/completions",
+    "/v1/images/generations",
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/responses",
+    "/v1/messages",
+    "/v1/rerank",
+    "/audio/transcriptions",
+    "/audio/translations",
+    "/audio/speech",
+    "/chat/completions",
+    "/images/generations",
+    "/completions",
+    "/embeddings",
+    "/responses",
+    "/messages",
+    "/rerank",
+];
+
+/// Strip a known endpoint suffix from `base` and its trailing slash.
+/// Idempotent. Mirrors the suffix-stripping the bridge crates do on
+/// their own `resolve_base`, so handlers that bypass the bridge (audio,
+/// responses, messages) get the same tolerance.
+fn strip_endpoint_suffix(base: &str) -> &str {
+    let trimmed = base.trim_end_matches('/');
+    for suffix in API_BASE_ENDPOINT_SUFFIXES {
+        if let Some(rest) = trimmed.strip_suffix(suffix) {
+            return rest.trim_end_matches('/');
+        }
+    }
+    trimmed
+}
+
 /// The upstream base URL: `provider_key.api_base` override if set,
-/// otherwise the `Provider`'s built-in default.
+/// otherwise the `Provider`'s built-in default. Tolerates an operator
+/// pasting the full upstream URL into `api_base` by stripping any
+/// trailing endpoint suffix — see [`API_BASE_ENDPOINT_SUFFIXES`] for
+/// the full list and [`build_v1_url`] for the matching `/v1` synthesis.
 pub(crate) fn resolve_base_url(provider: Provider, provider_key: &ProviderKey) -> String {
     match provider_key.api_base.as_deref() {
-        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
+        Some(b) if !b.trim().is_empty() => strip_endpoint_suffix(b.trim()).to_string(),
         _ => provider.default_base_url().to_string(),
     }
 }
@@ -228,6 +278,133 @@ mod tests {
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let base = resolve_base_url(Provider::Anthropic, &pk);
         assert_eq!(base, Provider::Anthropic.default_base_url());
+    }
+
+    fn pk_with_base(api_base: &str) -> ProviderKey {
+        let cfg = format!(r#"{{"display_name":"x","secret":"k","api_base":"{api_base}"}}"#);
+        serde_json::from_str(&cfg).unwrap()
+    }
+
+    /// Every OpenAI-shape paste an operator might make must, when fed
+    /// to `build_v1_url(base, "/<endpoint>")`, produce the canonical
+    /// upstream URL. The intermediate `resolve_base_url` result may be
+    /// either bare-host or `<host>/v1` — `build_v1_url` accepts both —
+    /// so the assertion is on the final URL the handler dispatches to,
+    /// not on the intermediate base.
+    ///
+    /// Without suffix stripping, pasting `…/v1/audio/transcriptions`
+    /// into `api_base` produces `…/v1/audio/transcriptions/v1/audio/transcriptions`.
+    #[test]
+    fn resolve_base_url_strips_openai_endpoint_suffixes() {
+        let cases: &[(&str, &str)] = &[
+            ("https://api.openai.com/v1", "/responses"),
+            ("https://api.openai.com/v1/", "/responses"),
+            ("https://api.openai.com/v1/responses", "/responses"),
+            (
+                "https://api.openai.com/v1/audio/transcriptions",
+                "/audio/transcriptions",
+            ),
+            (
+                "https://api.openai.com/v1/audio/translations",
+                "/audio/translations",
+            ),
+            ("https://api.openai.com/v1/audio/speech", "/audio/speech"),
+            (
+                "https://api.openai.com/v1/chat/completions",
+                "/chat/completions",
+            ),
+            ("https://api.openai.com/v1/completions", "/completions"),
+            ("https://api.openai.com/v1/embeddings", "/embeddings"),
+            (
+                "https://api.openai.com/v1/images/generations",
+                "/images/generations",
+            ),
+            ("https://api.openai.com/v1/rerank", "/rerank"),
+        ];
+        for (paste, endpoint) in cases {
+            let pk = pk_with_base(paste);
+            let base = resolve_base_url(Provider::Openai, &pk);
+            let url = build_v1_url(&base, endpoint);
+            let expected = format!("https://api.openai.com/v1{endpoint}");
+            assert_eq!(
+                url, expected,
+                "paste {paste:?} + endpoint {endpoint:?} must build to {expected:?}",
+            );
+        }
+    }
+
+    /// DeepSeek serves OpenAI-compatible endpoints at the host root.
+    /// Same contract: every paste must build to the canonical URL.
+    #[test]
+    fn resolve_base_url_strips_deepseek_endpoint_suffixes() {
+        for paste in [
+            "https://api.deepseek.com",
+            "https://api.deepseek.com/",
+            "https://api.deepseek.com/chat/completions",
+            "https://api.deepseek.com/embeddings",
+        ] {
+            let pk = pk_with_base(paste);
+            let base = resolve_base_url(Provider::Deepseek, &pk);
+            let url = build_v1_url(&base, "/chat/completions");
+            assert_eq!(
+                url, "https://api.deepseek.com/v1/chat/completions",
+                "paste {paste:?} must build to the canonical chat-completions URL",
+            );
+        }
+    }
+
+    /// Anthropic: the messages handler builds `…/v1/messages`. A paste
+    /// of the full upstream URL must strip so `build_v1_url("/messages")`
+    /// does not produce `…/v1/messages/v1/messages`.
+    #[test]
+    fn resolve_base_url_strips_anthropic_messages_suffix() {
+        for paste in [
+            "https://api.anthropic.com",
+            "https://api.anthropic.com/",
+            "https://api.anthropic.com/v1",
+            "https://api.anthropic.com/v1/messages",
+            "https://api.anthropic.com/v1/messages/",
+        ] {
+            let pk = pk_with_base(paste);
+            let base = resolve_base_url(Provider::Anthropic, &pk);
+            assert_eq!(
+                build_v1_url(&base, "/messages"),
+                "https://api.anthropic.com/v1/messages",
+                "paste {paste:?} must build to the canonical messages URL",
+            );
+        }
+    }
+
+    /// Non-canonical hosts (corporate proxies, test mocks) pass through
+    /// after suffix-stripping. The operator's path on a non-default
+    /// host is trusted as-is.
+    #[test]
+    fn resolve_base_url_passes_non_canonical_hosts_through() {
+        let pk = pk_with_base("https://proxy.example.com/openai-shim");
+        assert_eq!(
+            resolve_base_url(Provider::Openai, &pk),
+            "https://proxy.example.com/openai-shim",
+        );
+
+        // Suffix stripping still applies on non-canonical hosts —
+        // operator pasting the full upstream URL is still recovered.
+        let pk = pk_with_base("https://proxy.example.com/openai-shim/v1/responses");
+        let base = resolve_base_url(Provider::Openai, &pk);
+        assert_eq!(
+            build_v1_url(&base, "/responses"),
+            "https://proxy.example.com/openai-shim/v1/responses",
+        );
+    }
+
+    /// Whitespace trim must compose with suffix stripping.
+    #[test]
+    fn resolve_base_url_trims_whitespace_and_endpoint_suffix() {
+        let pk = pk_with_base("  https://api.openai.com/v1/chat/completions/  ");
+        let base = resolve_base_url(Provider::Openai, &pk);
+        assert_eq!(
+            build_v1_url(&base, "/chat/completions"),
+            "https://api.openai.com/v1/chat/completions",
+        );
     }
 
     // ---------------------------------------------------------------

--- a/docs/configuration/provider-keys.md
+++ b/docs/configuration/provider-keys.md
@@ -45,11 +45,11 @@ curl -sS -X POST http://127.0.0.1:3001/admin/v1/provider_keys \
 
 ## `api_base` Behavior
 
-`api_base` overrides the provider's default upstream base URL. The gateway uses the value almost as-is — it only strips a trailing `/`. There is **no `/v1` normalization**. Each provider bridge appends a different suffix at request time, so the exact form `api_base` must take depends on which `provider` your model selects.
+`api_base` overrides the provider's default upstream base URL. Each provider bridge appends a different path at request time, so the canonical form `api_base` should take depends on which `provider` your model selects.
 
 Each provider has its own convention — the four current bridges do **not** share one. Use the table below; do not generalize from one row to another.
 
-| `provider` | What `api_base` should be | Bridge appends | Default if `api_base` is omitted |
+| `provider` | Canonical `api_base` form | Bridge appends | Default if `api_base` is omitted |
 |---|---|---|---|
 | `openai` | include `/v1` | `/chat/completions`, `/embeddings`, `/completions`, `/images/generations`, `/audio/*` | `https://api.openai.com/v1` |
 | `deepseek` | bare host (DeepSeek serves OpenAI-compatible paths at the host root) | `/chat/completions` | `https://api.deepseek.com` |
@@ -58,7 +58,33 @@ Each provider has its own convention — the four current bridges do **not** sha
 
 The OpenAI and Anthropic conventions match each upstream's official SDK — `openai-python` initialises `base_url = "https://api.openai.com/v1"`, while `anthropic-sdk-python` initialises `base_url = "https://api.anthropic.com"` and appends `/v1/messages` itself. DeepSeek is OpenAI-compatible but exposes `/chat/completions` directly at the host root, and Gemini's OpenAI-compatible surface lives under a fixed `/v1beta/openai` prefix that the bridge does not synthesize.
 
-Wrong forms fail at request time with an upstream `404`, not at admin-write time. For example, `api_base: "https://api.openai.com"` for an `openai` provider produces an upstream request to `https://api.openai.com/chat/completions` — the upstream returns `404` because OpenAI's API lives under `/v1`. There is no admin-side validation today that catches this. Tracking issue: [api7/ai-gateway#270](https://github.com/api7/ai-gateway/issues/270).
+### Forms the gateway tolerates
+
+The gateway accepts several common operator paste-mistakes and normalizes them to the canonical form. Tolerance is intentionally conservative — `/v1` synthesis and stripping happens **only for the canonical upstream host of each provider**. Corporate proxies and any non-default path the operator chose on purpose pass through unchanged.
+
+All providers (always tolerated):
+
+- leading and trailing whitespace
+- trailing slash
+- accidental endpoint suffix appended to the URL — e.g. pasting `https://api.openai.com/v1/chat/completions` works the same as `https://api.openai.com/v1`. The same applies to `/embeddings`, `/completions`, `/images/generations`, and `/audio/*` for OpenAI-compat bridges, and to `/v1/messages` and `/v1` for the Anthropic bridge.
+
+For `openai` on the canonical OpenAI host only:
+
+- pasting the bare host without `/v1` — `api_base: "https://api.openai.com"` is accepted and the bridge adds `/v1` at dispatch time.
+
+For `deepseek` on the canonical DeepSeek host only:
+
+- pasting an extra `/v1` segment — `api_base: "https://api.deepseek.com/v1"` is accepted and the bridge strips `/v1` at dispatch time. Common copy-paste habit from OpenAI conventions.
+
+For `anthropic` (always tolerated):
+
+- the full upstream URL `…/v1/messages` or the `/v1` prefix is stripped — `api_base: "https://api.anthropic.com/v1/messages"`, `…/v1`, and bare host all converge to the bare host at dispatch time.
+
+For `gemini` and any other variant: only suffix stripping; the bridge does not synthesize the `/v1beta/openai` prefix. Operators should paste the full canonical form.
+
+### Outside the canonical hosts
+
+For corporate proxies or alternative deployments, the operator's `api_base` is trusted verbatim (after suffix stripping and trailing-slash trim). If your proxy serves the OpenAI API at `https://my-proxy.example.com/openai-shim`, set `api_base` to exactly that — the bridge will not unilaterally add `/v1`.
 
 ## Reuse Model References
 

--- a/docs/quickstart/first-model-first-key-first-request.md
+++ b/docs/quickstart/first-model-first-key-first-request.md
@@ -46,7 +46,7 @@ curl -sS -X POST http://127.0.0.1:3001/admin/v1/provider_keys \
 ```
 
 :::caution `api_base` convention differs per provider
-Each provider has its own rule — do not generalize from this OpenAI example. `openai` expects `api_base` to include `/v1`; `deepseek` wants the bare host (`https://api.deepseek.com`); `gemini` wants the OpenAI-compat prefix (`https://generativelanguage.googleapis.com/v1beta/openai`); `anthropic` wants the bare host (the bridge appends `/v1/messages` itself). The gateway does not normalize these forms today; a wrong `api_base` fails as an upstream `404` at request time, not at admin-write time. See [Provider Keys § `api_base` Behavior](../configuration/provider-keys.md#api_base-behavior) for the full truth table.
+Each provider has its own canonical form — do not generalize from this OpenAI example. `openai` expects `api_base` to include `/v1`; `deepseek` wants the bare host (`https://api.deepseek.com`); `gemini` wants the OpenAI-compat prefix (`https://generativelanguage.googleapis.com/v1beta/openai`); `anthropic` wants the bare host (the bridge appends `/v1/messages` itself). The gateway tolerates common paste-mistakes such as trailing slashes, full endpoint URLs, and (for the canonical OpenAI/DeepSeek hosts) the missing or extra `/v1` segment. See [Provider Keys § `api_base` Behavior](../configuration/provider-keys.md#api_base-behavior) for the full truth table and the tolerated forms.
 :::
 
 The admin envelope returns a `ResourceEntry` shape:

--- a/tests/e2e/src/cases/api-base-tolerance-e2e.test.ts
+++ b/tests/e2e/src/cases/api-base-tolerance-e2e.test.ts
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: provider_key.api_base tolerates an operator pasting the full
+// upstream URL (endpoint suffix included). The bridge strips the known
+// suffix before appending its own path, so the request still lands at
+// the canonical endpoint instead of `…/chat/completions/chat/completions`.
+//
+// Two scenarios per provider category:
+//   - OpenAI-compat bridge: api_base ending in `/chat/completions` is
+//     stripped; final upstream request path is `/chat/completions`.
+//   - Anthropic bridge: api_base ending in `/v1/messages` is stripped;
+//     final upstream request path is `/v1/messages`.
+//
+// The unit suites in `crates/aisix-provider-openai` and
+// `crates/aisix-provider-anthropic` cover the canonical-host /v1
+// normalization (e.g. pasting `https://api.openai.com` without `/v1`).
+// That path can only be exercised against the real OpenAI host, so the
+// e2e here narrows to the host-agnostic suffix-stripping contract.
+//
+// References:
+//   - OpenAI Chat Completions API spec
+//     <https://platform.openai.com/docs/api-reference/chat/create>
+//   - Anthropic Messages API spec
+//     <https://docs.anthropic.com/en/api/messages>
+
+const OPENAI_CALLER_PLAINTEXT = "sk-api-base-openai-e2e";
+const OPENAI_CALLER_KEY_HASH = createHash("sha256")
+  .update(OPENAI_CALLER_PLAINTEXT)
+  .digest("hex");
+const ANTHROPIC_CALLER_PLAINTEXT = "sk-api-base-anthropic-e2e";
+const ANTHROPIC_CALLER_KEY_HASH = createHash("sha256")
+  .update(ANTHROPIC_CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("api_base tolerance e2e: endpoint suffix is stripped before dispatch", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    await admin.createApiKey({
+      key_hash: OPENAI_CALLER_KEY_HASH,
+      allowed_models: ["openai-suffix-tolerance"],
+    });
+    await admin.createApiKey({
+      key_hash: ANTHROPIC_CALLER_KEY_HASH,
+      allowed_models: ["anthropic-suffix-tolerance"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("OpenAI bridge strips a `/chat/completions` suffix from api_base", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    // The mock returns 200 on every path, so a regression that
+    // forgot to strip would still produce 200. Path assertion below
+    // pins what we actually care about: the upstream URL the bridge
+    // constructed.
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-api-base-openai",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "tolerance ok" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    upstreams.push(upstream);
+
+    // Operator pastes the full upstream URL into api_base. Without
+    // suffix stripping, the bridge would dispatch to
+    //   `${baseUrl}/chat/completions/chat/completions`
+    // and `upstream.receivedRequests[*].path` would echo that.
+    const pk = await admin.createProviderKey({
+      display_name: "openai-suffix-tolerance-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/chat/completions`,
+    });
+    await admin.createModel({
+      display_name: "openai-suffix-tolerance",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const res = await fetch(`${app?.proxyUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${OPENAI_CALLER_PLAINTEXT}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "openai-suffix-tolerance",
+            messages: [{ role: "user", content: "ready" }],
+          }),
+        });
+        await res.text();
+        return res.status === 200;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${OPENAI_CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "openai-suffix-tolerance",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    await res.text();
+
+    // The exactly-one new upstream request landed at the canonical
+    // endpoint path. A regression that doubled the suffix would record
+    // `/chat/completions/chat/completions` instead.
+    const newRequests = upstream.receivedRequests.slice(baseline);
+    expect(newRequests).toHaveLength(1);
+    expect(newRequests[0]?.path).toBe("/chat/completions");
+  });
+
+  test("Anthropic bridge strips a `/v1/messages` suffix from api_base", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_api_base_anthropic",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "anthropic tolerance ok" }],
+        model: "claude-3-5-haiku-20241022",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    upstreams.push(upstream);
+
+    // Operator pastes the full Anthropic upstream URL. Without the
+    // strip, the bridge would dispatch to
+    //   `${baseUrl}/v1/messages/v1/messages`.
+    const pk = await admin.createProviderKey({
+      display_name: "anthropic-suffix-tolerance-pk",
+      secret: "sk-ant-mock",
+      api_base: `${upstream.baseUrl}/v1/messages`,
+    });
+    await admin.createModel({
+      display_name: "anthropic-suffix-tolerance",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: pk.id,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const res = await fetch(`${app?.proxyUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${ANTHROPIC_CALLER_PLAINTEXT}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "anthropic-suffix-tolerance",
+            messages: [{ role: "user", content: "ready" }],
+          }),
+        });
+        await res.text();
+        return res.status === 200;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${ANTHROPIC_CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "anthropic-suffix-tolerance",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    await res.text();
+
+    const newRequests = upstream.receivedRequests.slice(baseline);
+    expect(newRequests).toHaveLength(1);
+    expect(newRequests[0]?.path).toBe("/v1/messages");
+  });
+});


### PR DESCRIPTION
Closes #270.

## Summary

Operators commonly paste `provider_key.api_base` in shapes the bridge's request-builder rejects with a confusing upstream 404 — pasting the bare canonical OpenAI host without `/v1`, the canonical DeepSeek host with an extra `/v1`, or the full upstream URL with the endpoint suffix appended. The previous code only stripped a trailing slash, so each of these landed at the wrong upstream URL.

This PR adds conservative, provider-aware normalization to both bridges, plus a long-standing default-fallback bug fix (DeepSeek and Gemini variants previously fell through to the OpenAI host when `api_base` was omitted).

## What this PR changes

### `aisix-provider-openai/src/bridge.rs`

- `resolve_base()` becomes a method on `&OpenAiBridge` so it can read `self.name` and route to provider-specific normalization.
- `strip_known_endpoint()` removes a trailing `/chat/completions`, `/completions`, `/embeddings`, `/images/generations`, or `/audio/*` suffix.
- `normalize_api_base()` then dispatches on `self.name`:
  - `openai`: if the input is the bare canonical OpenAI host, append `/v1`
  - `deepseek`: if the input is the canonical DeepSeek host with `/v1`, strip it
  - `gemini` and any future variant: pass through
- `default_base(&self)` routes the no-`api_base` fallback by `self.name`. A `deepseek` or `gemini` bridge without an explicit `api_base` previously fell through to the OpenAI host (long-standing bug); both now reach their intended hosts. Regression tests added.

### `aisix-provider-anthropic/src/bridge.rs`

- `resolve_base()` strips a trailing `/v1/messages` or `/v1` segment from `api_base` before returning.
- The bridge appends `/v1/messages` itself at request time, so the three common forms (bare host, host + `/v1`, host + `/v1/messages`) all converge to the same upstream URL.
- Applied universally — the appended path does not conflict with reasonable proxy structures.

## Design: conservative tolerance

Normalization is intentionally **conservative**: `/v1` synthesis and stripping for OpenAI/DeepSeek happens **only for the canonical upstream host of each provider**. Corporate proxies, alternative deployments, and test mocks pass through verbatim after suffix stripping, so the operator's intent on a non-canonical host wins.

This decision is reflected in the docs: `provider-keys.md` documents the canonical form per provider and the tolerated paste-mistakes, with an explicit "Outside the canonical hosts" section so corporate-proxy operators know their `api_base` is trusted verbatim.

The OpenAI and Anthropic conventions match each upstream's official SDK — `openai-python` initialises `base_url = "https://api.openai.com/v1"`, while `anthropic-sdk-python` initialises `base_url = "https://api.anthropic.com"` and appends `/v1/messages` itself. The bridge now matches that contract for the canonical hosts.

## Tests

- **Unit**: parametric tolerance tests per bridge — bare host, `/v1`-suffixed, full-endpoint-suffixed, trailing slash, whitespace — all collapse to the same canonical base. Plus regression tests for the DeepSeek and Gemini default-base bug.
- **E2E**: `tests/e2e/src/cases/api-base-tolerance-e2e.test.ts` exercises endpoint-suffix stripping through the full proxy + admin + bridge pipeline for both providers, asserting on the upstream-received request path (not just the response status). A regression that doubled the suffix would record `/chat/completions/chat/completions` instead of the canonical path and fail the assertion.

Results:
- `cargo test --workspace --lib` → 706 passed
- `cargo clippy --workspace --tests -- -D warnings` → clean
- `tests/e2e/src/cases/api-base-tolerance-e2e.test.ts` → 2 passed

## Docs

- `docs/configuration/provider-keys.md` — replaces "the gateway does not normalize" claim with the actual per-provider tolerance scope, including the "Outside the canonical hosts" note.
- `docs/quickstart/first-model-first-key-first-request.md` — callout updated.

## Test plan

- [x] Unit tests cover the documented tolerance forms per provider
- [x] E2E covers endpoint-suffix stripping through the real proxy
- [x] DeepSeek and Gemini default-base bug fix has explicit regression tests
- [x] Docs reflect the actual tolerance scope (not aspirational)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-aware normalization of api_base so pasted values (trailing slashes, full endpoint URLs, missing/extra /v1 forms) are tolerated and converted to canonical provider forms (OpenAI, DeepSeek, Gemini, Anthropic).

* **Bug Fixes**
  * Prevents duplicated endpoint path segments when proxying by stripping accidental endpoint suffixes from api_base overrides.

* **Documentation**
  * Clarified canonical api_base formats and which input forms the gateway tolerates per provider.

* **Tests**
  * Added unit and E2E tests covering api_base normalization and end-to-end request behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/275)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->