### PR TITLE
feat(obs): add ttft_ms (time to first token) to UsageEvent

### DIFF
--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -312,6 +312,9 @@ fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
     }
     attributes.push(attr_string("aisix.exporter_name", exporter_name));
     attributes.push(attr_string("aisix.request_id", &event.request_id));
+    if event.ttft_ms > 0 {
+        attributes.push(attr_int("aisix.ttft_ms", event.ttft_ms as i64));
+    }
 
     json!({
         "resourceSpans": [{
@@ -557,6 +560,21 @@ mod tests {
         assert!(!keys.contains(&"gen_ai.response.id"));
         assert!(!keys.contains(&"gen_ai.response.model"));
         assert!(!keys.contains(&"gen_ai.response.finish_reasons"));
+        // ttft_ms = 0 (default) → omitted
+        assert!(!keys.contains(&"aisix.ttft_ms"));
+    }
+
+    #[test]
+    fn payload_includes_ttft_when_set() {
+        let mut ev = sample_event();
+        ev.ttft_ms = 42;
+        let body = build_otlp_traces_payload(&ev, "test-exp");
+        let attrs = body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+            .as_array()
+            .unwrap();
+        let ttft_attr = attrs.iter().find(|a| a["key"] == "aisix.ttft_ms");
+        assert!(ttft_attr.is_some(), "aisix.ttft_ms should be present");
+        assert_eq!(ttft_attr.unwrap()["value"]["intValue"], "42");
     }
 
     #[test]

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -90,6 +90,13 @@ pub struct UsageEvent {
 
     pub latency_ms: u32,
 
+    /// Time to first token in milliseconds. Only meaningful on the
+    /// streaming path — measures elapsed time from request entry to
+    /// the first upstream SSE chunk. 0 on non-streaming, error, and
+    /// cache-hit paths (omitted from the wire via skip_serializing_if).
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub ttft_ms: u32,
+
     /// HTTP status code the proxy returned to the downstream caller.
     pub status_code: u16,
 
@@ -310,6 +317,7 @@ mod tests {
         assert!(!json.contains("provider_request_id"));
         assert!(!json.contains("provider_model_version"));
         assert!(!json.contains("finish_reason"));
+        assert!(!json.contains("ttft_ms"));
     }
 
     #[test]
@@ -325,6 +333,7 @@ mod tests {
             provider_request_id: "chatcmpl-abc".into(),
             provider_model_version: "gpt-4o-2024-08-06".into(),
             finish_reason: "stop".into(),
+            ttft_ms: 123,
             ..Default::default()
         };
         let json = serde_json::to_string(&ev).unwrap();
@@ -335,6 +344,7 @@ mod tests {
         assert!(json.contains(r#""provider_request_id":"chatcmpl-abc""#));
         assert!(json.contains(r#""provider_model_version":"gpt-4o-2024-08-06""#));
         assert!(json.contains(r#""finish_reason":"stop""#));
+        assert!(json.contains(r#""ttft_ms":123"#));
     }
 
     fn sample_event(id: &str) -> UsageEvent {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1430,7 +1430,12 @@ where
         while let Some(item) = upstream.next().await {
             let ev = match item {
                 Ok(chunk) => {
-                    if !first_chunk_seen {
+                    // Record TTFT on the first chunk carrying generated
+                    // output (content or tool calls). Skip role-only
+                    // chunks that OpenAI emits before actual tokens.
+                    if !first_chunk_seen
+                        && (chunk.delta.content.is_some() || chunk.delta.tool_calls.is_some())
+                    {
                         first_chunk_seen = true;
                         guard.comp().ttft_ms =
                             started.elapsed().as_millis().min(u32::MAX as u128) as u32;

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -131,6 +131,7 @@ pub async fn chat_completions(
                         cache_status: success.cache_status.as_str().to_string(),
                         cache_hit_saved_input_tokens: success.cache_hit_saved_input_tokens,
                         cache_hit_saved_output_tokens: success.cache_hit_saved_output_tokens,
+                        ttft_ms: 0,
                     },
                     success.cost_usd,
                     /* guardrail_blocked */ false,
@@ -212,6 +213,7 @@ pub async fn chat_completions(
                         cache_status: c.cache_status.as_str().to_string(),
                         cache_hit_saved_input_tokens: 0,
                         cache_hit_saved_output_tokens: 0,
+                        ttft_ms: 0,
                     },
                 ),
                 None => (0, 0, UsageExtras::default()),
@@ -567,6 +569,7 @@ async fn dispatch(
             upstream,
             now,
             stream_guardrail,
+            started,
             move |comp: StreamCompletion| {
                 // Rate-limit accounting (TPM cap) for all layers.
                 for key in &post_stream_keys {
@@ -613,6 +616,7 @@ async fn dispatch(
                         cache_status: CacheStatus::Disabled.as_str().to_string(),
                         cache_hit_saved_input_tokens: 0,
                         cache_hit_saved_output_tokens: 0,
+                        ttft_ms: comp.ttft_ms,
                     },
                     /* cost_usd */ 0.0,
                     comp.guardrail_blocked,
@@ -1164,6 +1168,7 @@ fn emit_usage_event(
         cache_status: extras.cache_status,
         cache_hit_saved_input_tokens: extras.cache_hit_saved_input_tokens,
         cache_hit_saved_output_tokens: extras.cache_hit_saved_output_tokens,
+        ttft_ms: extras.ttft_ms,
         // chat.rs is the OpenAI-shape /v1/chat/completions handler.
         // /v1/responses / /v1/embeddings / /v1/audio* / /v1/images* /
         // /v1/rerank don't emit UsageEvents today; when they do they
@@ -1212,6 +1217,7 @@ struct UsageExtras {
     /// ingest from these + its pricing catalog (see #88).
     cache_hit_saved_input_tokens: u32,
     cache_hit_saved_output_tokens: u32,
+    ttft_ms: u32,
 }
 
 fn record_error(metrics: &Metrics, err: &ProxyError, model: &str, status: u16, elapsed: Duration) {
@@ -1316,6 +1322,9 @@ struct StreamCompletion {
     /// fail-opened on a streamed response. Empty string = no bypass.
     /// First-bypass-wins matches the non-streaming convention.
     bypass_reason: String,
+    /// Time to first token in milliseconds. Set once when the first
+    /// Ok(chunk) arrives in `build_sse_stream`.
+    ttft_ms: u32,
 }
 
 /// Parameters needed to run output-guardrail evaluation at
@@ -1375,6 +1384,7 @@ fn build_sse_stream<F>(
     upstream: aisix_gateway::ChatChunkStream,
     created: i64,
     output_guardrail: Option<StreamGuardrailContext>,
+    started: Instant,
     on_complete: F,
 ) -> impl Stream<Item = Result<Event, Infallible>>
 where
@@ -1416,9 +1426,15 @@ where
         // treats `[DONE]` as clean-completion would mis-interpret
         // the truncated response as a successful one.
         let mut errored = false;
+        let mut first_chunk_seen = false;
         while let Some(item) = upstream.next().await {
             let ev = match item {
                 Ok(chunk) => {
+                    if !first_chunk_seen {
+                        first_chunk_seen = true;
+                        guard.comp().ttft_ms =
+                            started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+                    }
                     let comp = guard.comp();
                     if !chunk.id.is_empty() {
                         comp.provider_request_id = chunk.id.clone();


### PR DESCRIPTION
Add a `ttft_ms` field to `UsageEvent` to track first-token latency on the streaming path.

**What changed:**

- `UsageEvent` gains `ttft_ms: u32` — time from request entry to first upstream SSE chunk carrying `delta.content` or `delta.tool_calls` (milliseconds). Role-only chunks are skipped. Omitted from the wire when 0 (backwards-compatible with older cp-api).
- Streaming path in `build_sse_stream` records elapsed time on the first content/tool-call chunk, stored in `StreamCompletion` and propagated through `UsageExtras` → `emit_usage_event`.
- Non-streaming, error, and cache-hit paths keep `ttft_ms = 0`.
- OTLP trace export includes `aisix.ttft_ms` span attribute when > 0.

**Files:**
- `crates/aisix-obs/src/usage.rs` — new field + serialization tests
- `crates/aisix-proxy/src/chat.rs` — TTFT capture + wiring
- `crates/aisix-obs/src/otlp_http_sink.rs` — OTLP attribute + test

**Follow-up:** cp-api side (telemetryEvent struct, DB migration, dashboard) to persist and surface TTFT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time-to-first-token (TTFT) telemetry for chat completions; streaming paths now capture and include TTFT in telemetry while non-streaming emits zero.

* **Tests**
  * Extended tests to ensure TTFT is collected for streaming, serialized into telemetry when set, and omitted from payloads when zero.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/276)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->