### PR TITLE
feat: add RateLimitPolicy entity and policy-based rate limiting

### DIFF
--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -31,11 +31,11 @@ pub use error::{
 };
 pub use models::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_model,
-    validate_observability_exporter, validate_provider_key, AisixSnapshot, ApiKey, CachePolicy,
-    CooldownConfig, ExporterKind, Guardrail, GuardrailHookPoint, GuardrailKind, KeywordConfig,
-    KeywordPattern, Model, ObservabilityExporter, OnAllFilteredPolicy, Provider, ProviderKey,
-    RateLimit, Routing, RoutingStrategy, RoutingTarget, SchemaError,
-    DEFAULT_COOLDOWN_TRIGGER_STATUSES,
+    validate_observability_exporter, validate_provider_key, validate_rate_limit_policy,
+    AisixSnapshot, ApiKey, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
+    GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern, Model, ObservabilityExporter,
+    OnAllFilteredPolicy, Provider, ProviderKey, RateLimit, RateLimitPolicy, Routing,
+    RoutingStrategy, RoutingTarget, SchemaError, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -35,18 +35,10 @@ pub struct ApiKey {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub team_id: Option<String>,
 
-    /// Rate limit inherited from the owning team.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub team_rate_limit: Option<RateLimit>,
-
     /// Org member who owns this key. Used as a limiter bucket key
     /// (`member:<id>`) for member-level rate limiting.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner_id: Option<String>,
-
-    /// Rate limit inherited from the owning member.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub owner_rate_limit: Option<RateLimit>,
 
     /// etcd-key uuid; filled by the loader, never in the JSON payload.
     #[serde(skip)]
@@ -163,9 +155,7 @@ mod tests {
             allowed_models: vec![],
             rate_limit: None,
             team_id: None,
-            team_rate_limit: None,
             owner_id: None,
-            owner_rate_limit: None,
             runtime_id: String::new(),
         };
         assert!(!k.can_access("my-gpt4"));
@@ -237,24 +227,18 @@ mod tests {
               "key_hash": "{SAMPLE_HASH}",
               "allowed_models": ["gpt-4o"],
               "team_id": "team-uuid-1",
-              "team_rate_limit": {{"rpm": 600}},
-              "owner_id": "member-uuid-1",
-              "owner_rate_limit": {{"tpm": 200000}}
+              "owner_id": "member-uuid-1"
             }}"#
         ))
         .unwrap();
         assert_eq!(k.team_id.as_deref(), Some("team-uuid-1"));
-        assert_eq!(k.team_rate_limit.as_ref().unwrap().rpm, Some(600));
         assert_eq!(k.owner_id.as_deref(), Some("member-uuid-1"));
-        assert_eq!(k.owner_rate_limit.as_ref().unwrap().tpm, Some(200000));
     }
 
     #[test]
     fn absent_team_owner_fields_default_to_none() {
         let k = sample();
         assert!(k.team_id.is_none());
-        assert!(k.team_rate_limit.is_none());
         assert!(k.owner_id.is_none());
-        assert!(k.owner_rate_limit.is_none());
     }
 }

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -30,13 +30,13 @@ pub struct ApiKey {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<RateLimit>,
 
-    /// Team this API key belongs to. Used as a limiter bucket key
-    /// (`team:<id>`) for team-level rate limiting.
+    /// Team this API key belongs to. Used for matching team-scope
+    /// rate limit policies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub team_id: Option<String>,
 
-    /// Org member who owns this key. Used as a limiter bucket key
-    /// (`member:<id>`) for member-level rate limiting.
+    /// Org member who owns this key. Used for matching member-scope
+    /// rate limit policies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner_id: Option<String>,
 

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -22,6 +22,7 @@ pub mod model;
 pub mod observability_exporter;
 pub mod provider_key;
 pub mod rate_limit;
+pub mod rate_limit_policy;
 pub mod routing;
 pub mod schema;
 pub mod snapshot;
@@ -38,9 +39,11 @@ pub use model::{
 pub use observability_exporter::{ExporterKind, ObservabilityExporter, OtlpHttpConfig};
 pub use provider_key::ProviderKey;
 pub use rate_limit::RateLimit;
+pub use rate_limit_policy::RateLimitPolicy;
 pub use routing::{OnAllFilteredPolicy, Routing, RoutingStrategy, RoutingTarget};
 pub use schema::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_model,
-    validate_observability_exporter, validate_provider_key, SchemaError,
+    validate_observability_exporter, validate_provider_key, validate_rate_limit_policy,
+    SchemaError,
 };
 pub use snapshot::AisixSnapshot;

--- a/crates/aisix-core/src/models/rate_limit_policy.rs
+++ b/crates/aisix-core/src/models/rate_limit_policy.rs
@@ -1,3 +1,16 @@
+//! `RateLimitPolicy` entity — standalone rate-limit rules stored in etcd
+//! under `rate_limit_policies/<uuid>`.
+//!
+//! Each policy targets a single subject via `(scope, scope_ref)`:
+//! - `api_key` — matches by API key entry ID
+//! - `model`   — matches by model entry ID
+//! - `team`    — matches by team ID on the API key
+//! - `member`  — matches by owner ID on the API key
+//!
+//! The proxy iterates all policies on each request, converts the
+//! `window`+`max_requests`/`max_tokens` into a `RateLimit`, and
+//! reserves under `policy:<scope>:<scope_ref>:<policy_id>`.
+
 use serde::{Deserialize, Serialize};
 
 use crate::resource::Resource;

--- a/crates/aisix-core/src/models/rate_limit_policy.rs
+++ b/crates/aisix-core/src/models/rate_limit_policy.rs
@@ -1,0 +1,112 @@
+use serde::{Deserialize, Serialize};
+
+use crate::resource::Resource;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RateLimitPolicy {
+    pub name: String,
+    pub scope: String,
+    pub scope_ref: String,
+    pub window: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_requests: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+impl Resource for RateLimitPolicy {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    #[allow(clippy::misnamed_getters)]
+    fn name(&self) -> &str {
+        &self.scope_ref
+    }
+
+    fn kind() -> &'static str {
+        "rate_limit_policies"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_with_all_fields() {
+        let p: RateLimitPolicy = serde_json::from_str(
+            r#"{
+              "name": "team-quota",
+              "scope": "team",
+              "scope_ref": "team-uuid-1",
+              "window": "minute",
+              "max_requests": 100,
+              "max_tokens": 50000
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(p.name, "team-quota");
+        assert_eq!(p.scope, "team");
+        assert_eq!(p.scope_ref, "team-uuid-1");
+        assert_eq!(p.window, "minute");
+        assert_eq!(p.max_requests, Some(100));
+        assert_eq!(p.max_tokens, Some(50000));
+    }
+
+    #[test]
+    fn deserialises_with_only_max_requests() {
+        let p: RateLimitPolicy = serde_json::from_str(
+            r#"{
+              "name": "key-rpm",
+              "scope": "api_key",
+              "scope_ref": "key-uuid-1",
+              "window": "minute",
+              "max_requests": 60
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(p.max_requests, Some(60));
+        assert!(p.max_tokens.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let r: Result<RateLimitPolicy, _> = serde_json::from_str(
+            r#"{
+              "name": "x",
+              "scope": "team",
+              "scope_ref": "t1",
+              "window": "minute",
+              "extra": true
+            }"#,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn resource_trait_returns_correct_kind() {
+        assert_eq!(RateLimitPolicy::kind(), "rate_limit_policies");
+    }
+
+    #[test]
+    fn resource_name_returns_scope_ref() {
+        let mut p: RateLimitPolicy = serde_json::from_str(
+            r#"{
+              "name": "test",
+              "scope": "member",
+              "scope_ref": "member-uuid-1",
+              "window": "hour",
+              "max_tokens": 1000000
+            }"#,
+        )
+        .unwrap();
+        p.runtime_id = "policy-1".into();
+        assert_eq!(p.id(), "policy-1");
+        assert_eq!(p.name(), "member-uuid-1");
+    }
+}

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -458,7 +458,11 @@ fn rate_limit_policy_schema() -> Value {
             "window":       { "type": "string", "enum": ["second", "minute", "hour"] },
             "max_requests": { "type": "integer", "minimum": 1 },
             "max_tokens":   { "type": "integer", "minimum": 1 }
-        }
+        },
+        "anyOf": [
+            { "required": ["max_requests"] },
+            { "required": ["max_tokens"] }
+        ]
     })
 }
 
@@ -927,6 +931,17 @@ mod tests {
             "scope_ref": "x",
             "window": "minute",
             "max_requests": 0
+        });
+        assert!(validate_rate_limit_policy(&v).is_err());
+    }
+
+    #[test]
+    fn rate_limit_policy_rejects_no_limits() {
+        let v = json!({
+            "name": "noop",
+            "scope": "team",
+            "scope_ref": "x",
+            "window": "minute"
         });
         assert!(validate_rate_limit_policy(&v).is_err());
     }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -28,6 +28,7 @@ pub struct Schemas {
     pub guardrail: Validator,
     pub cache_policy: Validator,
     pub observability_exporter: Validator,
+    pub rate_limit_policy: Validator,
 }
 
 pub static SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::compile()));
@@ -53,6 +54,9 @@ impl Schemas {
             observability_exporter: jsonschema::options()
                 .build(&observability_exporter_schema())
                 .expect("observability_exporter schema is well-formed"),
+            rate_limit_policy: jsonschema::options()
+                .build(&rate_limit_policy_schema())
+                .expect("rate_limit_policy schema is well-formed"),
         }
     }
 }
@@ -99,6 +103,10 @@ pub fn validate_cache_policy(value: &Value) -> Result<(), SchemaError> {
 
 pub fn validate_observability_exporter(value: &Value) -> Result<(), SchemaError> {
     validate(&SCHEMAS.observability_exporter, value)
+}
+
+pub fn validate_rate_limit_policy(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.rate_limit_policy, value)
 }
 
 fn model_schema() -> Value {
@@ -248,9 +256,7 @@ fn apikey_schema() -> Value {
             },
             "rate_limit": { "$ref": "#/$defs/rate_limit" },
             "team_id": { "type": "string", "minLength": 1 },
-            "team_rate_limit": { "$ref": "#/$defs/rate_limit" },
-            "owner_id": { "type": "string", "minLength": 1 },
-            "owner_rate_limit": { "$ref": "#/$defs/rate_limit" }
+            "owner_id": { "type": "string", "minLength": 1 }
         },
         "$defs": {
             "rate_limit": {
@@ -439,6 +445,23 @@ fn observability_exporter_schema() -> Value {
     })
 }
 
+fn rate_limit_policy_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["name", "scope", "scope_ref", "window"],
+        "additionalProperties": false,
+        "properties": {
+            "name":         { "type": "string", "minLength": 1 },
+            "scope":        { "type": "string", "enum": ["api_key", "model", "team", "member"] },
+            "scope_ref":    { "type": "string", "minLength": 1 },
+            "window":       { "type": "string", "enum": ["second", "minute", "hour"] },
+            "max_requests": { "type": "integer", "minimum": 1 },
+            "max_tokens":   { "type": "integer", "minimum": 1 }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -564,9 +587,7 @@ mod tests {
             "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
             "allowed_models":["gpt-4o"],
             "team_id": "team-uuid-1",
-            "team_rate_limit": {"rpm": 600},
-            "owner_id": "member-uuid-1",
-            "owner_rate_limit": {"tpm": 200000}
+            "owner_id": "member-uuid-1"
         });
         validate_apikey(&v).unwrap();
     }
@@ -847,5 +868,66 @@ mod tests {
         });
         // Phase 4 will add role_arn; today it's rejected.
         assert!(validate_guardrail(&v).is_err());
+    }
+
+    // ---- rate_limit_policy schema tests ----
+
+    #[test]
+    fn rate_limit_policy_happy_path() {
+        let v = json!({
+            "name": "team-quota",
+            "scope": "team",
+            "scope_ref": "team-uuid-1",
+            "window": "minute",
+            "max_requests": 100,
+            "max_tokens": 50000
+        });
+        validate_rate_limit_policy(&v).unwrap();
+    }
+
+    #[test]
+    fn rate_limit_policy_rejects_unknown_scope() {
+        let v = json!({
+            "name": "bad",
+            "scope": "org",
+            "scope_ref": "x",
+            "window": "minute"
+        });
+        assert!(validate_rate_limit_policy(&v).is_err());
+    }
+
+    #[test]
+    fn rate_limit_policy_rejects_unknown_window() {
+        let v = json!({
+            "name": "bad",
+            "scope": "team",
+            "scope_ref": "x",
+            "window": "day"
+        });
+        assert!(validate_rate_limit_policy(&v).is_err());
+    }
+
+    #[test]
+    fn rate_limit_policy_rejects_extra_field() {
+        let v = json!({
+            "name": "bad",
+            "scope": "team",
+            "scope_ref": "x",
+            "window": "minute",
+            "extra": 1
+        });
+        assert!(validate_rate_limit_policy(&v).is_err());
+    }
+
+    #[test]
+    fn rate_limit_policy_rejects_zero_max_requests() {
+        let v = json!({
+            "name": "bad",
+            "scope": "team",
+            "scope_ref": "x",
+            "window": "minute",
+            "max_requests": 0
+        });
+        assert!(validate_rate_limit_policy(&v).is_err());
     }
 }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -895,7 +895,8 @@ mod tests {
             "name": "bad",
             "scope": "org",
             "scope_ref": "x",
-            "window": "minute"
+            "window": "minute",
+            "max_requests": 10
         });
         assert!(validate_rate_limit_policy(&v).is_err());
     }
@@ -906,7 +907,8 @@ mod tests {
             "name": "bad",
             "scope": "team",
             "scope_ref": "x",
-            "window": "day"
+            "window": "day",
+            "max_requests": 10
         });
         assert!(validate_rate_limit_policy(&v).is_err());
     }
@@ -918,6 +920,7 @@ mod tests {
             "scope": "team",
             "scope_ref": "x",
             "window": "minute",
+            "max_requests": 10,
             "extra": 1
         });
         assert!(validate_rate_limit_policy(&v).is_err());

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -10,6 +10,7 @@ use super::guardrail::Guardrail;
 use super::model::Model;
 use super::observability_exporter::ObservabilityExporter;
 use super::provider_key::ProviderKey;
+use super::rate_limit_policy::RateLimitPolicy;
 use crate::snapshot::ResourceTable;
 
 /// Composite of every typed [`ResourceTable`] the gateway reads on the hot
@@ -27,6 +28,7 @@ pub struct AisixSnapshot {
     /// Per-env observability exporters. Each enabled row receives a
     /// fan-out POST per chat completion (see `aisix-obs::OtlpHttpFanOut`).
     pub observability_exporters: ResourceTable<ObservabilityExporter>,
+    pub rate_limit_policies: ResourceTable<RateLimitPolicy>,
 }
 
 impl AisixSnapshot {
@@ -43,6 +45,7 @@ impl AisixSnapshot {
             + self.guardrails.len()
             + self.cache_policies.len()
             + self.observability_exporters.len()
+            + self.rate_limit_policies.len()
     }
 }
 

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -13,8 +13,9 @@
 
 use aisix_core::models::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_model,
-    validate_observability_exporter, validate_provider_key, ApiKey, CachePolicy, Guardrail, Model,
-    ObservabilityExporter, ProviderKey, SchemaError,
+    validate_observability_exporter, validate_provider_key, validate_rate_limit_policy, ApiKey,
+    CachePolicy, Guardrail, Model, ObservabilityExporter, ProviderKey, RateLimitPolicy,
+    SchemaError,
 };
 use aisix_core::resource::ResourceEntry;
 use aisix_core::AisixSnapshot;
@@ -217,6 +218,18 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
                     &mut stats,
                 ) {
                     snapshot.observability_exporters.insert(entry);
+                }
+            }
+            "rate_limit_policies" => {
+                if let Some(entry) = validate_and_parse::<RateLimitPolicy>(
+                    &raw.key,
+                    raw.revision,
+                    parsed,
+                    &value,
+                    validate_rate_limit_policy,
+                    &mut stats,
+                ) {
+                    snapshot.rate_limit_policies.insert(entry);
                 }
             }
             other => {
@@ -429,5 +442,30 @@ mod tests {
         // name to m-2, but both id entries are present in the table.
         assert_eq!(snap.models.len(), 2);
         assert_eq!(snap.apikeys.len(), 1);
+    }
+
+    const VALID_RATE_LIMIT_POLICY: &[u8] = br#"{
+        "name": "team-quota",
+        "scope": "team",
+        "scope_ref": "team-uuid-1",
+        "window": "minute",
+        "max_requests": 100
+    }"#;
+
+    #[test]
+    fn rate_limit_policy_loads_into_snapshot() {
+        let entries = vec![raw(
+            "/aisix/rate_limit_policies/rlp-1",
+            VALID_RATE_LIMIT_POLICY,
+            5,
+        )];
+        let (snap, stats) = build_snapshot("/aisix", &entries);
+        assert_eq!(stats.accepted, 1);
+        assert_eq!(snap.rate_limit_policies.len(), 1);
+        let entry = snap.rate_limit_policies.get_by_id("rlp-1").unwrap();
+        assert_eq!(entry.value.name, "team-quota");
+        assert_eq!(entry.value.scope, "team");
+        assert_eq!(entry.value.scope_ref, "team-uuid-1");
+        assert_eq!(entry.value.max_requests, Some(100));
     }
 }

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -357,6 +357,9 @@ impl<P: ConfigProvider> Supervisor<P> {
             for e in tiny.observability_exporters.entries() {
                 new.observability_exporters.insert(clone_entry(&e));
             }
+            for e in tiny.rate_limit_policies.entries() {
+                new.rate_limit_policies.insert(clone_entry(&e));
+            }
             new
         });
 
@@ -408,6 +411,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             "observability_exporters" => {
                 snap.observability_exporters.get_by_id(parsed.id).is_some()
             }
+            "rate_limit_policies" => snap.rate_limit_policies.get_by_id(parsed.id).is_some(),
             _ => false,
         };
         drop(snap);
@@ -441,6 +445,9 @@ impl<P: ConfigProvider> Supervisor<P> {
                 }
                 "observability_exporters" => {
                     new.observability_exporters.remove(parsed.id);
+                }
+                "rate_limit_policies" => {
+                    new.rate_limit_policies.remove(parsed.id);
                 }
                 _ => {}
             }
@@ -657,6 +664,9 @@ fn clone_snapshot(src: &AisixSnapshot) -> AisixSnapshot {
     }
     for e in src.observability_exporters.entries() {
         out.observability_exporters.insert(clone_entry(&e));
+    }
+    for e in src.rate_limit_policies.entries() {
+        out.rate_limit_policies.insert(clone_entry(&e));
     }
     out
 }

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -289,7 +289,7 @@ async fn multipart_dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let model = &model_entry.value;
     let provider = crate::dispatch::require_provider(model)?;
@@ -412,7 +412,7 @@ async fn speech_dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let model = &model_entry.value;
     let provider = crate::dispatch::require_provider(model)?;

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -287,7 +287,8 @@ async fn multipart_dispatch(
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 
-    let model_rl = crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.value);
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
 
     let model = &model_entry.value;
@@ -409,7 +410,8 @@ async fn speech_dispatch(
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 
-    let model_rl = crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.value);
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
 
     let model = &model_entry.value;

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -503,7 +503,11 @@ async fn dispatch(
     }
 
     // Multi-layer rate-limit reservation (api_key + model + team + member).
-    let model_rl = crate::quota::ModelRateLimit::from_model(&req.model, &virtual_entry.value);
+    let model_rl = crate::quota::ModelRateLimit::from_model(
+        &req.model,
+        &virtual_entry.id,
+        &virtual_entry.value,
+    );
     let reservation =
         crate::quota::enforce_rate_limit(state, auth, model_rl).map_err(&with_model)?;
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -509,7 +509,7 @@ async fn dispatch(
         &virtual_entry.value,
     );
     let reservation =
-        crate::quota::enforce_rate_limit(state, auth, model_rl).map_err(&with_model)?;
+        crate::quota::enforce_rate_limit(state, auth, Some(&model_rl)).map_err(&with_model)?;
 
     let now = created_ts();
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -502,7 +502,7 @@ async fn dispatch(
         }
     }
 
-    // Multi-layer rate-limit reservation (api_key + model + team + member).
+    // Multi-layer rate-limit reservation (api_key inline + model inline + policies).
     let model_rl = crate::quota::ModelRateLimit::from_model(
         &req.model,
         &virtual_entry.id,

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -110,7 +110,7 @@ async fn dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let model = &model_entry.value;
     let provider = crate::dispatch::require_provider(model)?;

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -108,7 +108,8 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(model_name.to_string()));
     }
 
-    let model_rl = crate::quota::ModelRateLimit::from_model(model_name, &model_entry.value);
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
 
     let model = &model_entry.value;

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -141,7 +141,8 @@ async fn dispatch(
         .get(provider)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
-    let model_rl = crate::quota::ModelRateLimit::from_model(&body.model, &model_entry.value);
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&body.model, &model_entry.id, &model_entry.value);
     let reservation = crate::quota::enforce(state, auth, model_rl).await?;
 
     let upstream_model_id = crate::dispatch::require_upstream_model(model)?.to_string();

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -143,7 +143,7 @@ async fn dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&body.model, &model_entry.id, &model_entry.value);
-    let reservation = crate::quota::enforce(state, auth, model_rl).await?;
+    let reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let upstream_model_id = crate::dispatch::require_upstream_model(model)?.to_string();
 

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -104,7 +104,8 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(model_name.to_string()));
     }
 
-    let model_rl = crate::quota::ModelRateLimit::from_model(model_name, &model_entry.value);
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
 
     let model = &model_entry.value;

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -106,7 +106,7 @@ async fn dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let model = &model_entry.value;
 

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -161,7 +161,7 @@ async fn dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let model = &model_entry.value;
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -159,7 +159,8 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 
-    let model_rl = crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.value);
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
 
     let model = &model_entry.value;

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -27,9 +27,10 @@ pub(crate) struct ModelRateLimit {
 }
 
 impl ModelRateLimit {
-    /// Build from a resolved model entry. Always returns `Some` so that
-    /// model-scope policies can match even when the model has no inline
-    /// rate limit.
+    /// Build from a resolved model entry. Always returns a
+    /// `ModelRateLimit` carrying the model identity (name + entry ID)
+    /// needed for model-scope policy matching. The inline rate limit
+    /// is `None` when the model has no configured limit.
     pub fn from_model(model_name: &str, model_entry_id: &str, model: &aisix_core::Model) -> Self {
         let limits = model
             .rate_limit
@@ -124,8 +125,9 @@ fn reserve_layers<'a>(
 }
 
 /// Apply budget + multi-layer rate-limit checks for one request.
-/// `model_rl` is the resolved Model's rate_limit (if any). Pass `None`
-/// for endpoints that don't resolve a model (e.g. passthrough).
+/// `model_rl` carries the resolved model identity for policy matching
+/// and optional inline limits. Pass `None` only for endpoints that
+/// don't resolve a model (e.g. passthrough).
 pub(crate) async fn enforce<'a>(
     state: &'a ProxyState,
     auth: &AuthenticatedKey,

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -2,15 +2,16 @@
 //!
 //! Applies budget + multi-layer rate limiting:
 //! 1. Budget pre-check (cp-api cached decision)
-//! 2. API-key rate limit (`auth.entry.id`)
-//! 3. Model rate limit (`model:<name>`) — when the resolved Model has one
-//! 4. Team rate limit (`team:<id>`) — when the ApiKey carries team info
-//! 5. Member rate limit (`member:<id>`) — when the ApiKey carries owner info
+//! 2. API-key inline rate limit (`auth.entry.id`)
+//! 3. Model inline rate limit (`model:<name>`) — when the resolved Model has one
+//! 4. Policy-based rate limits — looked up from the snapshot's
+//!    `rate_limit_policies` table, matched by scope (api_key/model/team/member)
 //!
 //! All layers use AND logic — every layer must pass or the request gets
 //! 429. The returned [`MultiReservation`] commits token usage to all
 //! layers and releases all concurrency permits on drop.
 
+use aisix_core::models::RateLimitPolicy;
 use aisix_core::RateLimit;
 use aisix_ratelimit::MultiReservation;
 
@@ -21,6 +22,7 @@ use crate::state::ProxyState;
 /// Optional model rate-limit info resolved by the caller before enforce.
 pub(crate) struct ModelRateLimit {
     pub name: String,
+    pub entry_id: String,
     pub limits: RateLimit,
 }
 
@@ -28,27 +30,52 @@ impl ModelRateLimit {
     /// Build from a resolved model entry. Returns `None` when the model
     /// has no rate limit configured or has an unrestricted one (all fields
     /// are `None`).
-    pub fn from_model(model_name: &str, model: &aisix_core::Model) -> Option<Self> {
+    pub fn from_model(
+        model_name: &str,
+        model_entry_id: &str,
+        model: &aisix_core::Model,
+    ) -> Option<Self> {
         model
             .rate_limit
             .as_ref()
             .filter(|rl| !rl.is_unrestricted())
             .map(|rl| Self {
                 name: model_name.to_owned(),
+                entry_id: model_entry_id.to_owned(),
                 limits: rl.clone(),
             })
     }
 }
 
-/// Reserve across all applicable rate-limit layers (api_key, model, team, member).
+fn policy_to_rate_limit(policy: &RateLimitPolicy) -> RateLimit {
+    let mut rl = RateLimit::default();
+    match policy.window.as_str() {
+        "second" => {
+            rl.rpm = policy.max_requests.map(|r| r * 60);
+            rl.tpm = policy.max_tokens.map(|t| t * 60);
+        }
+        "minute" => {
+            rl.rpm = policy.max_requests;
+            rl.tpm = policy.max_tokens;
+        }
+        "hour" => {
+            rl.rpd = policy.max_requests.map(|r| r * 24);
+            rl.tpd = policy.max_tokens.map(|t| t * 24);
+        }
+        _ => {}
+    }
+    rl
+}
+
+/// Reserve across all applicable rate-limit layers (api_key, model, policies).
 fn reserve_layers<'a>(
     state: &'a ProxyState,
     auth: &AuthenticatedKey,
     model_rl: Option<ModelRateLimit>,
 ) -> Result<MultiReservation<'a, aisix_ratelimit::SystemClock>, ProxyError> {
-    let mut reservations = Vec::with_capacity(4);
+    let mut reservations = Vec::with_capacity(8);
 
-    // Layer 1: API key rate limit.
+    // Layer 1: API key inline rate limit.
     let key_limits = auth.key().rate_limit.clone().unwrap_or_default();
     if !key_limits.is_unrestricted() {
         let r = state
@@ -58,8 +85,8 @@ fn reserve_layers<'a>(
         reservations.push(r);
     }
 
-    // Layer 2: Model rate limit.
-    if let Some(mrl) = model_rl {
+    // Layer 2: Model inline rate limit.
+    if let Some(ref mrl) = model_rl {
         if !mrl.limits.is_unrestricted() {
             let key = format!("model:{}", mrl.name);
             let r = state
@@ -70,28 +97,32 @@ fn reserve_layers<'a>(
         }
     }
 
-    // Layer 3: Team rate limit.
-    if let (Some(tid), Some(trl)) = (&auth.key().team_id, &auth.key().team_rate_limit) {
-        if !tid.is_empty() && !trl.is_unrestricted() {
-            let key = format!("team:{tid}");
-            let r = state
-                .limiter
-                .pre_commit(&key, trl)
-                .map_err(ProxyError::from)?;
-            reservations.push(r);
+    // Layer 3+: Rate limit policies from snapshot.
+    let snap = state.snapshot.load();
+    for entry in snap.rate_limit_policies.entries() {
+        let policy = &entry.value;
+        let applies = match policy.scope.as_str() {
+            "api_key" => policy.scope_ref == auth.entry.id,
+            "model" => model_rl
+                .as_ref()
+                .is_some_and(|m| policy.scope_ref == m.entry_id),
+            "team" => auth.key().team_id.as_deref() == Some(policy.scope_ref.as_str()),
+            "member" => auth.key().owner_id.as_deref() == Some(policy.scope_ref.as_str()),
+            _ => false,
+        };
+        if !applies {
+            continue;
         }
-    }
-
-    // Layer 4: Member/owner rate limit.
-    if let (Some(oid), Some(orl)) = (&auth.key().owner_id, &auth.key().owner_rate_limit) {
-        if !oid.is_empty() && !orl.is_unrestricted() {
-            let key = format!("member:{oid}");
-            let r = state
-                .limiter
-                .pre_commit(&key, orl)
-                .map_err(ProxyError::from)?;
-            reservations.push(r);
+        let rl = policy_to_rate_limit(policy);
+        if rl.is_unrestricted() {
+            continue;
         }
+        let bucket_key = format!("policy:{}", entry.id);
+        let r = state
+            .limiter
+            .pre_commit(&bucket_key, &rl)
+            .map_err(ProxyError::from)?;
+        reservations.push(r);
     }
 
     Ok(MultiReservation::new(reservations))
@@ -123,4 +154,58 @@ pub(crate) fn enforce_rate_limit<'a>(
     model_rl: Option<ModelRateLimit>,
 ) -> Result<MultiReservation<'a, aisix_ratelimit::SystemClock>, ProxyError> {
     reserve_layers(state, auth, model_rl)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_policy(window: &str, max_req: Option<u64>, max_tok: Option<u64>) -> RateLimitPolicy {
+        serde_json::from_value(serde_json::json!({
+            "name": "test",
+            "scope": "team",
+            "scope_ref": "ref",
+            "window": window,
+            "max_requests": max_req,
+            "max_tokens": max_tok,
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn minute_maps_to_rpm_tpm() {
+        let rl = policy_to_rate_limit(&make_policy("minute", Some(100), Some(50000)));
+        assert_eq!(rl.rpm, Some(100));
+        assert_eq!(rl.tpm, Some(50000));
+        assert!(rl.rpd.is_none());
+        assert!(rl.tpd.is_none());
+    }
+
+    #[test]
+    fn second_scales_to_per_minute() {
+        let rl = policy_to_rate_limit(&make_policy("second", Some(10), Some(1000)));
+        assert_eq!(rl.rpm, Some(600));
+        assert_eq!(rl.tpm, Some(60000));
+    }
+
+    #[test]
+    fn hour_scales_to_per_day() {
+        let rl = policy_to_rate_limit(&make_policy("hour", Some(1000), Some(500000)));
+        assert_eq!(rl.rpd, Some(24000));
+        assert_eq!(rl.tpd, Some(12000000));
+        assert!(rl.rpm.is_none());
+    }
+
+    #[test]
+    fn unknown_window_produces_unrestricted() {
+        let rl = policy_to_rate_limit(&make_policy("week", Some(100), Some(100)));
+        assert!(rl.is_unrestricted());
+    }
+
+    #[test]
+    fn partial_fields_only_set_relevant_dimension() {
+        let rl = policy_to_rate_limit(&make_policy("minute", Some(60), None));
+        assert_eq!(rl.rpm, Some(60));
+        assert!(rl.tpm.is_none());
+    }
 }

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -112,7 +112,7 @@ fn reserve_layers<'a>(
         if rl.is_unrestricted() {
             continue;
         }
-        let bucket_key = format!("policy:{}", entry.id);
+        let bucket_key = format!("policy:{}:{}:{}", policy.scope, policy.scope_ref, entry.id);
         let r = state
             .limiter
             .pre_commit(&bucket_key, &rl)

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -23,27 +23,24 @@ use crate::state::ProxyState;
 pub(crate) struct ModelRateLimit {
     pub name: String,
     pub entry_id: String,
-    pub limits: RateLimit,
+    pub limits: Option<RateLimit>,
 }
 
 impl ModelRateLimit {
-    /// Build from a resolved model entry. Returns `None` when the model
-    /// has no rate limit configured or has an unrestricted one (all fields
-    /// are `None`).
-    pub fn from_model(
-        model_name: &str,
-        model_entry_id: &str,
-        model: &aisix_core::Model,
-    ) -> Option<Self> {
-        model
+    /// Build from a resolved model entry. Always returns `Some` so that
+    /// model-scope policies can match even when the model has no inline
+    /// rate limit.
+    pub fn from_model(model_name: &str, model_entry_id: &str, model: &aisix_core::Model) -> Self {
+        let limits = model
             .rate_limit
             .as_ref()
             .filter(|rl| !rl.is_unrestricted())
-            .map(|rl| Self {
-                name: model_name.to_owned(),
-                entry_id: model_entry_id.to_owned(),
-                limits: rl.clone(),
-            })
+            .cloned();
+        Self {
+            name: model_name.to_owned(),
+            entry_id: model_entry_id.to_owned(),
+            limits,
+        }
     }
 }
 
@@ -51,16 +48,16 @@ fn policy_to_rate_limit(policy: &RateLimitPolicy) -> RateLimit {
     let mut rl = RateLimit::default();
     match policy.window.as_str() {
         "second" => {
-            rl.rpm = policy.max_requests.map(|r| r * 60);
-            rl.tpm = policy.max_tokens.map(|t| t * 60);
+            rl.rpm = policy.max_requests.map(|r| r.saturating_mul(60));
+            rl.tpm = policy.max_tokens.map(|t| t.saturating_mul(60));
         }
         "minute" => {
             rl.rpm = policy.max_requests;
             rl.tpm = policy.max_tokens;
         }
         "hour" => {
-            rl.rpd = policy.max_requests.map(|r| r * 24);
-            rl.tpd = policy.max_tokens.map(|t| t * 24);
+            rl.rpd = policy.max_requests.map(|r| r.saturating_mul(24));
+            rl.tpd = policy.max_tokens.map(|t| t.saturating_mul(24));
         }
         _ => {}
     }
@@ -71,7 +68,7 @@ fn policy_to_rate_limit(policy: &RateLimitPolicy) -> RateLimit {
 fn reserve_layers<'a>(
     state: &'a ProxyState,
     auth: &AuthenticatedKey,
-    model_rl: Option<ModelRateLimit>,
+    model_rl: Option<&ModelRateLimit>,
 ) -> Result<MultiReservation<'a, aisix_ratelimit::SystemClock>, ProxyError> {
     let mut reservations = Vec::with_capacity(8);
 
@@ -86,12 +83,12 @@ fn reserve_layers<'a>(
     }
 
     // Layer 2: Model inline rate limit.
-    if let Some(ref mrl) = model_rl {
-        if !mrl.limits.is_unrestricted() {
+    if let Some(mrl) = model_rl {
+        if let Some(ref limits) = mrl.limits {
             let key = format!("model:{}", mrl.name);
             let r = state
                 .limiter
-                .pre_commit(&key, &mrl.limits)
+                .pre_commit(&key, limits)
                 .map_err(ProxyError::from)?;
             reservations.push(r);
         }
@@ -103,9 +100,7 @@ fn reserve_layers<'a>(
         let policy = &entry.value;
         let applies = match policy.scope.as_str() {
             "api_key" => policy.scope_ref == auth.entry.id,
-            "model" => model_rl
-                .as_ref()
-                .is_some_and(|m| policy.scope_ref == m.entry_id),
+            "model" => model_rl.is_some_and(|m| policy.scope_ref == m.entry_id),
             "team" => auth.key().team_id.as_deref() == Some(policy.scope_ref.as_str()),
             "member" => auth.key().owner_id.as_deref() == Some(policy.scope_ref.as_str()),
             _ => false,
@@ -134,7 +129,7 @@ fn reserve_layers<'a>(
 pub(crate) async fn enforce<'a>(
     state: &'a ProxyState,
     auth: &AuthenticatedKey,
-    model_rl: Option<ModelRateLimit>,
+    model_rl: Option<&ModelRateLimit>,
 ) -> Result<MultiReservation<'a, aisix_ratelimit::SystemClock>, ProxyError> {
     let decision = state.budgets.check(&auth.entry.id).await;
     if !decision.allowed {
@@ -151,7 +146,7 @@ pub(crate) async fn enforce<'a>(
 pub(crate) fn enforce_rate_limit<'a>(
     state: &'a ProxyState,
     auth: &AuthenticatedKey,
-    model_rl: Option<ModelRateLimit>,
+    model_rl: Option<&ModelRateLimit>,
 ) -> Result<MultiReservation<'a, aisix_ratelimit::SystemClock>, ProxyError> {
     reserve_layers(state, auth, model_rl)
 }

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -106,7 +106,7 @@ async fn dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let model = &model_entry.value;
 

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -104,7 +104,8 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 
-    let model_rl = crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.value);
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
 
     let model = &model_entry.value;

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -110,7 +110,7 @@ async fn dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let model = &model_entry.value;
 

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -108,7 +108,8 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 
-    let model_rl = crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.value);
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, model_rl).await?;
 
     let model = &model_entry.value;


### PR DESCRIPTION
Replaces inline team/member rate limits on ApiKey with standalone rate limit policy entities loaded from etcd.

**Changes:**

- Remove `team_rate_limit` and `owner_rate_limit` fields from `ApiKey` (keep `team_id`/`owner_id` as bucket keys)
- Add `RateLimitPolicy` entity (`rate_limit_policies` kind) with scope-based matching: `api_key`, `model`, `team`, `member`
- Add JSON Schema validation (requires at least one of `max_requests`/`max_tokens`), snapshot table, and etcd loader arm
- Refactor `quota.rs`: layers 3/4 (inline team/member limits) replaced with policy lookup from snapshot
- `ModelRateLimit::from_model` now always returns a value so model-scope policies work even without inline model limits
- Window mapping uses saturating arithmetic: `second`→rpm/tpm(×60), `minute`→rpm/tpm, `hour`→rpd/tpd(×24)

**Test coverage:**

- RateLimitPolicy serde + Resource trait tests
- Schema validation tests (happy path, bad scope/window, extra fields, zero values, no-limits rejection)
- Loader integration test for `rate_limit_policies` entries
- `policy_to_rate_limit` unit tests for all window types
- Updated existing ApiKey tests to remove dropped fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limit policies for reusable, scope-based quota rules.

* **Improvements**
  * Policy-driven, multi-layer rate-limit reservations for finer-grained enforcement.
  * Model-level rate limiting now uses model resource identity for accurate tracking.
  * Loading/snapshot pipeline and proxy enforcement paths updated to honor policies.

* **Bug Fixes / API**
  * API key JSON shape simplified: removed per-team/per-owner inline rate-limit fields.

* **Tests**
  * Added schema and unit tests for policies and validations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/280)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->