### PR TITLE
docs: replace stale GET /health references with /livez and /admin/v1/health

### DIFF
--- a/docs/configuration/admin-api.md
+++ b/docs/configuration/admin-api.md
@@ -28,7 +28,7 @@ Admin authentication is static and bootstrap-based for the authenticated operato
 
 The following routes are currently public on the admin listener:
 
-- `GET /health`
+- `GET /livez`
 - `GET /metrics`
 - `GET /admin/openapi.json`
 - `GET /admin/openapi-scalar`
@@ -51,7 +51,7 @@ Do not mix them.
 
 The current admin router exposes:
 
-- `GET /health`
+- `GET /livez`
 - `GET /metrics`
 - `GET /admin/openapi.json`
 - `GET /admin/openapi-scalar`
@@ -97,9 +97,9 @@ Current status behavior includes:
 - `409` for conflicts such as duplicate names
 - `500` for store failures
 
-Public routes such as `/health`, `/metrics`, and the OpenAPI endpoints do not require admin auth.
+Public routes such as `/livez`, `/metrics`, and the OpenAPI endpoints do not require admin auth.
 
-Use `GET /health` for simple admin-listener reachability. Use `GET /admin/v1/health` when you need authenticated per-model operator health.
+Use `GET /livez` for simple admin-listener reachability. Use `GET /admin/v1/health` when you need authenticated per-model operator health.
 
 For automation, plan to branch on admin status codes and `error_msg`, not on the proxy-side OpenAI-compatible error envelope.
 

--- a/docs/configuration/bootstrap-config.md
+++ b/docs/configuration/bootstrap-config.md
@@ -207,13 +207,13 @@ This is a deployment concern, not a per-guardrail-row field.
 After updating the bootstrap config, start the gateway and verify:
 
 ```bash title="Verify proxy bootstrap"
-curl -s http://127.0.0.1:3000/health
+curl -s http://127.0.0.1:3000/livez
 ```
 
 For standalone mode, also verify:
 
 ```bash title="Verify admin bootstrap"
-curl -s http://127.0.0.1:3001/health
+curl -s http://127.0.0.1:3001/livez
 ```
 
 ## Troubleshooting

--- a/docs/operations/network-and-security.md
+++ b/docs/operations/network-and-security.md
@@ -20,7 +20,7 @@ Recommended boundary:
 
 Do not assume admin auth alone is enough protection. Current admin design intentionally leaves some routes unauthenticated on that private listener.
 
-Current admin design intentionally leaves `/health`, `/metrics`, and OpenAPI endpoints unauthenticated on that private listener, so network placement matters.
+Current admin design intentionally leaves `/livez`, `/metrics`, and OpenAPI endpoints unauthenticated on that private listener, so network placement matters.
 
 ## Secrets And Credentials
 

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -85,8 +85,8 @@ Before routing real traffic, verify:
 
 After deployment, confirm:
 
-1. `GET /health` returns `200`
-2. admin-listener `GET /health` returns `200` in standalone mode
+1. `GET /livez` returns `200`
+2. admin-listener `GET /livez` returns `200` in standalone mode
 3. `GET /admin/v1/health` returns `200` in standalone mode
 4. `GET /v1/models` returns the expected caller-visible aliases for a test key
 5. one real request succeeds on each endpoint family you actually use

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -91,8 +91,8 @@ Meaning:
 
 When you are not sure where to start:
 
-1. check `GET /health`
-2. check admin-listener `GET /health`, then `GET /admin/v1/health` in standalone mode
+1. check `GET /livez`
+2. check admin-listener `GET /livez`, then `GET /admin/v1/health` in standalone mode
 3. identify whether the symptom is startup, propagation, upstream, or policy related
 4. inspect the most specific signal next: logs, metrics, headers, or admin health freshness
 

--- a/docs/operations/upgrades-and-compatibility.md
+++ b/docs/operations/upgrades-and-compatibility.md
@@ -24,6 +24,8 @@ Before and after an upgrade, verify:
 4. `GET /v1/models`
 5. one real request on each critical endpoint your clients use
 
+Note: the unauthenticated liveness route was renamed from `GET /health` to `GET /livez`. If your existing health-check tooling targets `/health`, it will return `404` after upgrading; update it to point at `/livez`. The authenticated `GET /admin/v1/health` endpoint is unchanged.
+
 If you use several endpoint families in production, test each one you depend on rather than assuming chat-completions success proves all compatibility.
 
 ## Areas To Treat Carefully

--- a/docs/operations/upgrades-and-compatibility.md
+++ b/docs/operations/upgrades-and-compatibility.md
@@ -24,8 +24,6 @@ Before and after an upgrade, verify:
 4. `GET /v1/models`
 5. one real request on each critical endpoint your clients use
 
-Note: the unauthenticated liveness route was renamed from `GET /health` to `GET /livez`. If your existing health-check tooling targets `/health`, it will return `404` after upgrading; update it to point at `/livez`. The authenticated `GET /admin/v1/health` endpoint is unchanged.
-
 If you use several endpoint families in production, test each one you depend on rather than assuming chat-completions success proves all compatibility.
 
 ## Areas To Treat Carefully

--- a/docs/operations/upgrades-and-compatibility.md
+++ b/docs/operations/upgrades-and-compatibility.md
@@ -18,8 +18,8 @@ Treat upgrades as behavior changes to be verified, not just binary replacements.
 
 Before and after an upgrade, verify:
 
-1. `GET /health`
-2. admin-listener `GET /health`
+1. `GET /livez`
+2. admin-listener `GET /livez`
 3. `GET /admin/v1/health`
 4. `GET /v1/models`
 5. one real request on each critical endpoint your clients use

--- a/docs/reference/admin-api-reference.md
+++ b/docs/reference/admin-api-reference.md
@@ -6,7 +6,7 @@ sidebar_position: 61
 
 ## Public Admin-Listener Routes
 
-- `GET /health`
+- `GET /livez`
 - `GET /metrics`
 - `GET /admin/openapi.json`
 - `GET /admin/openapi-scalar`


### PR DESCRIPTION
## Summary

- Replace stale `GET /health` references in customer-facing docs with `/livez` (unauthenticated liveness) or `GET /admin/v1/health` (authenticated operator-facing health) per context.
- Follow-up to #257 (`fix(health): rename public liveness route to /livez`) which renamed the route in code; the docs rebuild in #249 introduced the now-stale text.
- 14 line-level edits across 7 files. No Rust code, configs, or tests are touched.

## Changes

| File | Lines | Edit |
| --- | --- | --- |
| `docs/configuration/admin-api.md` | 31, 54 | `- `GET /health`` → `- `GET /livez`` (public-routes list entries) |
| `docs/configuration/admin-api.md` | 100 | `Public routes such as /health, /metrics, …` → `Public routes such as /livez, /metrics, …` |
| `docs/configuration/admin-api.md` | 102 | `Use GET /health for simple admin-listener reachability.` → `Use GET /livez for simple admin-listener reachability.` (the trailing `/admin/v1/health` reference is unchanged) |
| `docs/configuration/bootstrap-config.md` | 210, 216 | `curl -s http://127.0.0.1:300{0,1}/health` → `… /livez` (proxy and admin verification examples) |
| `docs/reference/admin-api-reference.md` | 9 | `- `GET /health`` → `- `GET /livez`` (Public Admin-Listener Routes entry) |
| `docs/operations/production-deployment.md` | 88, 89 | `GET /health returns 200` (proxy + admin) → `GET /livez returns 200` |
| `docs/operations/network-and-security.md` | 23 | `intentionally leaves /health, /metrics, …` → `intentionally leaves /livez, /metrics, …` |
| `docs/operations/upgrades-and-compatibility.md` | 21, 22 | `GET /health` (proxy + admin) → `GET /livez` |
| `docs/operations/troubleshooting.md` | 94, 95 | `check GET /health` / `check admin-listener GET /health` → `… /livez`; the trailing `then GET /admin/v1/health in standalone mode` on line 95 is unchanged |

`/admin/v1/health` references throughout these files remain unchanged — those point to the authenticated operator endpoint that PR #257 did not rename.

## Test plan

Docs-only diff — no `.rs` files, no schemas, no configs, no test fixtures touched. Local `cargo` pre-flight (`fmt --check` / `clippy --workspace --all-targets -- -D warnings` / `test --workspace`) was skipped because the toolchain isn't installed on the authoring environment; repo CI runs all three on every PR and is the canonical gate. E2E fixtures don't reference any of the 7 affected pages, so `pnpm test` under `tests/e2e/` is not applicable.

Local verification that was run:

- [x] `grep -rn --include='*.md' -P '(?<!v1)/health(?![a-z0-9_-])' docs/` after the edits returns zero matches — confirms no stale standalone `/health` references remain in `docs/`.
- [x] `grep -rn --include='*.md' '/admin/v1/health' docs/` returns the same set of lines before and after the edits — confirms the authenticated endpoint references were preserved.
- [x] `grep -rln --include='*.{ts,js,json}' <each-page>.md tests/e2e/` returns empty for all 7 affected pages — no e2e assertion can regress from this diff.

## References

- Issue #293 — *docs: replace GET /health references with /livez and /admin/v1/health across configuration, reference, and operations docs* (this PR closes it)
- Issue #253 — *Rename hardened /health endpoint to /livez* (the original decision to rename)
- PR #257 — `fix(health): rename public liveness route to /livez` (the rename itself; branch `fix/issue-253-rename-health-to-livez`)
- PR #249 — `docs: rebuild customer-facing docs across overview, config, cloud, ops, reference, and tutorials` (the rebuild that introduced the stale text)

Closes #293.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Switched documented liveness checks from /health to /livez across operational guides and API docs.
  * Clarified unauthenticated liveness (/livez) versus authenticated per-model health (/admin/v1/health).
  * Updated verification examples, deployment checklists, troubleshooting steps, and upgrade guidance to use /livez.
  * Added reminder to update tooling and monitoring to avoid 404s after upgrading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->