### PR TITLE
docs: remove max_budget_usd references from standalone docs (managed-only field)

### DIFF
--- a/docs/configuration/api-keys.md
+++ b/docs/configuration/api-keys.md
@@ -108,9 +108,6 @@ Managed budget enforcement exists on the managed `/dp/budget_check` path.
 Current standalone boundary:
 
 - standalone self-hosted deployments default to a disabled budget client, which is allow-all
-- the standalone admin write validator currently rejects `max_budget_usd`, even though broader typed and OpenAPI surfaces reference it
-
-Do not treat `max_budget_usd` as part of the current verified standalone admin write contract.
 
 ## Troubleshooting
 

--- a/docs/configuration/budgets.md
+++ b/docs/configuration/budgets.md
@@ -52,9 +52,16 @@ This is a caller-visible denial, not just an internal accounting event.
 
 Inspect budget-check freshness and the cached-decision behavior first.
 
-### A standalone deployment does not enforce per-key budgets
+### Standalone admin write validator rejects `max_budget_usd`
 
-That is expected with the current standalone runtime boundary. Standalone deployments default to allow-all; per-key budget enforcement lives in the managed control plane via the budget-check path.
+`max_budget_usd` is a managed-mode field implemented in AISIX Cloud's control plane.
+The standalone OSS admin write validator rejects it with `400 Bad Request — unknown field`
+(via `#[serde(deny_unknown_fields)]` on `StandaloneApiKeyBody`).
+
+If you are migrating a config from AISIX Cloud to standalone deployment, drop
+`max_budget_usd` from your API key write payload. Standalone deployments currently do
+not enforce per-key budgets by default; budget enforcement is implemented in the managed
+data-plane budget controller.
 
 ## Related Pages
 

--- a/docs/configuration/budgets.md
+++ b/docs/configuration/budgets.md
@@ -52,17 +52,6 @@ This is a caller-visible denial, not just an internal accounting event.
 
 Inspect budget-check freshness and the cached-decision behavior first.
 
-### Standalone admin write validator rejects `max_budget_usd`
-
-`max_budget_usd` is a managed-mode field implemented in AISIX Cloud's control plane.
-The standalone OSS admin write validator rejects it with `400 Bad Request — unknown field`
-(via `#[serde(deny_unknown_fields)]` on `StandaloneApiKeyBody`).
-
-If you are migrating a config from AISIX Cloud to standalone deployment, drop
-`max_budget_usd` from your API key write payload. Standalone deployments currently do
-not enforce per-key budgets by default; budget enforcement is implemented in the managed
-data-plane budget controller.
-
 ## Related Pages
 
 - [API Keys](api-keys.md)

--- a/docs/configuration/budgets.md
+++ b/docs/configuration/budgets.md
@@ -6,8 +6,6 @@ sidebar_position: 37
 
 Budget enforcement in the current gateway runtime is driven by the managed budget-check path, not by a standalone in-process budget engine.
 
-Use this page to avoid over-assuming what `max_budget_usd` means in standalone deployments.
-
 ## Current Runtime Model
 
 Before dispatch, the proxy can call:
@@ -26,13 +24,6 @@ Current boundary:
 
 - managed deployments can attach a live budget client through the managed data-plane path
 - standalone self-hosted deployments default to `BudgetClient::disabled()`, which allows requests through
-
-Because of that boundary, `max_budget_usd` should not be treated as part of the current verified standalone admin write contract.
-
-Current standalone caveat:
-
-- the typed `ApiKey` model and admin OpenAPI mention `max_budget_usd`
-- the active standalone admin JSON Schema validator rejects `max_budget_usd` on write today
 
 ## Operator Guidance
 
@@ -61,11 +52,9 @@ This is a caller-visible denial, not just an internal accounting event.
 
 Inspect budget-check freshness and the cached-decision behavior first.
 
-### A standalone deployment ignores `max_budget_usd`
+### A standalone deployment does not enforce per-key budgets
 
-That is expected with the current standalone runtime boundary.
-
-If you are using the standalone admin API directly, do not send `max_budget_usd` until the write validator and runtime contract are aligned.
+That is expected with the current standalone runtime boundary. Standalone deployments default to allow-all; per-key budget enforcement lives in the managed control plane via the budget-check path.
 
 ## Related Pages
 

--- a/docs/integration/errors-and-retries.md
+++ b/docs/integration/errors-and-retries.md
@@ -40,7 +40,7 @@ The proxy emits the following gateway-generated failures. The `error.type` strin
 | `413`  | `invalid_request_error`  | Request body exceeded `proxy.request_body_limit_bytes` |
 | `422`  | `content_filter`         | Guardrail blocked the request or response content |
 | `429`  | `rate_limit_exceeded`    | Rate-limit rejection (per-key or per-model) |
-| `429`  | `billing_error` (with `code: "budget_exceeded"`) | Budget rejection from the ApiKey's `max_budget_usd` |
+| `429`  | `billing_error` (with `code: "budget_exceeded"`) | Budget rejection from the managed budget controller |
 | `503`  | `provider_unavailable`   | No provider bridge is registered for the resolved provider |
 | `503`  | `all_candidates_unavailable` | Every routing candidate was excluded by runtime status (cooldown or background-unhealthy) and the routing model is configured with `on_all_filtered: fail`. The response carries `Retry-After: 30`. See [Routing And Failover § All-Targets-Filtered Policy](../configuration/routing-and-failover.md#all-targets-filtered-policy) |
 

--- a/docs/overview/core-concepts.md
+++ b/docs/overview/core-concepts.md
@@ -53,8 +53,6 @@ An API key also carries:
 
 `team_id` and `owner_id` are bucket identifiers consumed by `team`-scoped and `member`-scoped [`RateLimitPolicy`](#rate-limit-policy) rows. They are not access controls on their own.
 
-Managed budget paths may also reference per-key budget state, but `max_budget_usd` is not part of the current verified standalone admin write contract.
-
 An empty `allowed_models` list denies access to every model. A wildcard entry `"*"` allows access to every model in scope.
 
 ## Rate Limit Policy

--- a/docs/overview/feature-matrix.md
+++ b/docs/overview/feature-matrix.md
@@ -25,7 +25,7 @@ Use it as a navigation aid, not as a replacement for detailed feature pages.
 | Provider-specific passthrough | Available | Use `/passthrough/:provider/*rest` for unsupported or provider-native routes. |
 | Standalone admin API | Available | Current admin surface includes models, API keys, provider keys, guardrails, cache policies, observability exporters, health, metrics, OpenAPI, and playground. |
 | API key allowlist authz | Available | Uses hashed caller keys and model allowlists. |
-| Per-key budgets | Limited | Live enforcement is currently centered on managed-mode `/dp/budget_check`. Standalone self-hosted mode defaults to allow-all, and the standalone admin write validator does not currently accept `max_budget_usd`. |
+| Per-key budgets | Limited | standalone deployments do not enforce per-key budgets; managed deployments enforce via the budget controller. |
 | Rate limits and concurrency limits | Available | Three layers are AND-combined per request: `ApiKey.rate_limit`, `Model.rate_limit`, and scope-matched `RateLimitPolicy` rows (`api_key` / `model` / `team` / `member`). |
 | Routing models and failover | Available | Current model schema supports routing strategies and retry budget behavior. |
 | Keyword guardrails | Available | Current runtime enforcement is on `POST /v1/chat/completions`; non-chat endpoints do not run the guardrail chain today. |

--- a/docs/overview/feature-matrix.md
+++ b/docs/overview/feature-matrix.md
@@ -25,7 +25,7 @@ Use it as a navigation aid, not as a replacement for detailed feature pages.
 | Provider-specific passthrough | Available | Use `/passthrough/:provider/*rest` for unsupported or provider-native routes. |
 | Standalone admin API | Available | Current admin surface includes models, API keys, provider keys, guardrails, cache policies, observability exporters, health, metrics, OpenAPI, and playground. |
 | API key allowlist authz | Available | Uses hashed caller keys and model allowlists. |
-| Per-key budgets | Limited | standalone deployments do not enforce per-key budgets; managed deployments enforce via the budget controller. |
+| Per-key budgets | Limited | Standalone deployments do not enforce per-key budgets; managed deployments enforce via the budget controller. |
 | Rate limits and concurrency limits | Available | Three layers are AND-combined per request: `ApiKey.rate_limit`, `Model.rate_limit`, and scope-matched `RateLimitPolicy` rows (`api_key` / `model` / `team` / `member`). |
 | Routing models and failover | Available | Current model schema supports routing strategies and retry budget behavior. |
 | Keyword guardrails | Available | Current runtime enforcement is on `POST /v1/chat/completions`; non-chat endpoints do not run the guardrail chain today. |

--- a/docs/reference/resource-schemas.md
+++ b/docs/reference/resource-schemas.md
@@ -42,7 +42,6 @@ Not every field or shape present in the schema should be interpreted as equally 
 
 Examples:
 
-- the typed `ApiKey` model and admin OpenAPI mention `max_budget_usd`, but the current standalone admin write validator rejects it and standalone hard-stop budget behavior is not the current documented default
 - `Model.rate_limit` and `ApiKey.rate_limit` are both enforced today, alongside scope-matched `RateLimitPolicy` rows. See [Rate Limits](../configuration/rate-limits.md) for the layer order and the AND-combination semantics.
 - `Model.background_model_check` exists in schema, but it only applies to direct models and its runtime effect is surfaced through `/admin/v1/models/status`
 - `Guardrail.kind = bedrock` exists in schema, but current generally reliable runtime behavior is strongest on `keyword`


### PR DESCRIPTION
## Summary

Remove all 12 customer-facing references to `max_budget_usd` from the docs. The field name does not exist as an OSS standalone `ApiKey` schema field (PR #259 removed it; `StandaloneApiKeyBody` rejects unknown fields). Pass-1.5 verification (see Revision notes) confirmed it also does not exist on AISIX-Cloud's admin API surface — Cloud uses `limit_cents` int64 internally. Final state: `grep -rn 'max_budget_usd' docs/` returns 0 hits. See **Revision notes** below for the multi-pivot history.

## Changes

| File | Change |
| --- | --- |
| `docs/integration/errors-and-retries.md` | 429 row rationale: `Budget rejection from the ApiKey's max_budget_usd` → `Budget rejection from the managed budget controller` |
| `docs/reference/resource-schemas.md` | Remove the `Runtime Versus Schema Boundary` example bullet about the typed model / OpenAPI / write validator inconsistency |
| `docs/configuration/api-keys.md` | Drop the `Budget Boundary` bullet about the write validator rejecting the field + the trailing "Do not treat ... as part of the verified standalone admin write contract" advisory |
| `docs/configuration/budgets.md` | Remove the intro line; drop the `Managed Versus Standalone` "Because of that boundary..." sentence and the typed/OpenAPI + write validator bullets; remove the `A standalone deployment ignores max_budget_usd` troubleshooting subsection (no replacement). Final state: no `max_budget_usd` mentions on this page. See Revision notes for pivot history. |
| `docs/overview/core-concepts.md` | Remove the trailing sentence "Managed budget paths may also reference per-key budget state, but max_budget_usd is not part of the current verified standalone admin write contract" |
| `docs/overview/feature-matrix.md` | "Per-key budgets" row rationale: replace mention of the rejected field with "standalone deployments do not enforce per-key budgets; managed deployments enforce via the budget controller" |

Net diff: 6 files, +4 / -21, no `.rs` / schema / config / test files touched.

## Test plan

- [x] `grep -rn 'max_budget_usd' docs/ --include='*.md'` after the edits returns 0 hits — confirms the field name does not appear anywhere in OSS docs.
- [x] `grep -rn 'max_budget_usd' crates/aisix-core/src/models/apikey.rs` returns zero matches — confirms the field is genuinely absent from the OSS schema (this PR documents that absence; no code change required).
- [x] `cargo fmt --check` — PASS (exit 0).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — PASS (exit 0, no warnings, `Finished dev profile [unoptimized + debuginfo] target(s) in 41.91s`).
- [x] `cargo test --workspace` — PASS (exit 0, all crate test suites green; no failures, 2 ignored).
- [x] E2E: `grep -rln <each affected page> tests/e2e/` returns empty for all 6 pages — no e2e fixture references them, `pnpm test` not applicable.

## References

- Closes #295
- #259 — `fix(admin): drop standalone max_budget_usd contract` (the field removal that this docs cleanup is a follow-up to)
- #255 — *Remove max_budget_usd from standalone AISIX admin contract without breaking SaaS CP budget control* (the originating decision)
- #249 — `docs: rebuild customer-facing docs across overview, config, cloud, ops, reference, and tutorials` (the rebuild that re-introduced the now-stale references)



## Revision notes

- **Revision 1 → 2 (`2ed56fb` → `1822515`)**: original R3 approach removed all 12 max_budget_usd references and rewrote budgets.md abstractly. Per operator review, restored one canonical Troubleshooting subsection on `docs/configuration/budgets.md` naming the field in the rejection context. Rationale: preserves discoverability for the 400-rejection error users hit when migrating Cloud-style configs to standalone. Other 5 files's R3 removals remain.
- **Revision 3 → 4 (`a8cb07e` → `7aa99ce`)**: Pass-1.5 verification surfaced that `max_budget_usd` doesn't exist as a field name on AISIX-Cloud's admin API surface either (Cloud uses `limit_cents` int64; verified no `max_budget_usd` in Go source, OpenAPI, or YAML/JSON specs). The canonical Troubleshooting subsection added in revision 2 (`1822515`) asserted "managed-mode field implemented in AISIX Cloud's control plane" — that assertion is empirically false. Operator pivoted from Option δ → pure R1 (full removal). The Troubleshooting subsection deleted entirely.
- Final state: `grep -rn 'max_budget_usd' docs/` returns 0 hits. The field name does not appear anywhere in OSS docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that standalone deployments do not enforce per-key budgets by default (budget client disabled/allow-all) and removed prior contradictory validation notes.
  * Added guidance to drop per-key budget fields from standalone admin write payloads.
  * Updated errors to include HTTP 429 billing_error for budget-exceeded responses.
  * Clarified model access control: empty list denies; wildcard "*" allows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


