### PR TITLE
feat(core): add Adapter enum (skeleton for issue #302 Phase A)

### DIFF
--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -31,7 +31,7 @@ pub use error::{
 };
 pub use models::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_model,
-    validate_observability_exporter, validate_provider_key, validate_rate_limit_policy,
+    validate_observability_exporter, validate_provider_key, validate_rate_limit_policy, Adapter,
     AisixSnapshot, ApiKey, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
     GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern, Model, ObservabilityExporter,
     OnAllFilteredPolicy, Provider, ProviderKey, RateLimit, RateLimitPolicy, Routing,

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -34,7 +34,8 @@ pub use guardrail::{
     GuardrailKind, KeywordConfig, KeywordPattern,
 };
 pub use model::{
-    BackgroundModelCheck, CooldownConfig, Model, Provider, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
+    Adapter, BackgroundModelCheck, CooldownConfig, Model, Provider,
+    DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use observability_exporter::{ExporterKind, ObservabilityExporter, OtlpHttpConfig};
 pub use provider_key::ProviderKey;

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -62,6 +62,62 @@ impl Provider {
     }
 }
 
+/// Wire-shape adapter used to talk to an upstream. This is the closed
+/// set of upstream protocols the gateway knows how to encode against —
+/// distinct from a vendor identity (which is captured separately on
+/// `ProviderKey`).
+///
+/// Introduced as a skeleton for issue #302 Phase A. This type is purely
+/// additive in this PR: nothing in the gateway dispatches off `Adapter`
+/// yet, no entity field is changed, and `Provider` continues to drive
+/// all runtime behavior. Follow-up PRs in Phase A migrate entities and
+/// the Hub to consume `Adapter` directly.
+///
+/// Note on serde casing: `Adapter` uses `kebab-case` so the `AzureOpenai`
+/// variant serializes as `"azure-openai"`. This intentionally differs
+/// from `Provider`'s `lowercase` casing, which produced no hyphens
+/// because all current `Provider` names are single tokens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Adapter {
+    Openai,
+    Anthropic,
+    Bedrock,
+    Vertex,
+    AzureOpenai,
+}
+
+impl From<Provider> for Adapter {
+    /// Best-effort mapping from the legacy `Provider` enum onto the
+    /// `Adapter` wire-shape set, for use during the Phase A skeleton
+    /// stage. Rationale per variant:
+    ///
+    /// - `Openai` / `Anthropic`: direct equivalents.
+    /// - `Google` → `Vertex`: Gemini-family models are routed through
+    ///   the Vertex AI wire shape (the production target for Google
+    ///   upstream traffic). `Adapter` does not currently have a
+    ///   separate Google AI Studio variant.
+    /// - `Deepseek` → `Openai`: DeepSeek exposes an OpenAI-compatible
+    ///   chat completions endpoint, so the adapter shape is `openai`.
+    /// - `Cohere` → `Openai`: the gateway currently talks to Cohere's
+    ///   OpenAI-compatible endpoints (#213 Phase 1 — rerank-only),
+    ///   so the wire adapter is `openai`. A native Cohere adapter is
+    ///   not part of this skeleton.
+    /// - `Jina` → `Openai`: Jina's rerank is identity-mapped to the
+    ///   OpenAI-compat rerank shape (#213 Phase 2), so the wire
+    ///   adapter is `openai`.
+    fn from(provider: Provider) -> Self {
+        match provider {
+            Provider::Openai => Adapter::Openai,
+            Provider::Anthropic => Adapter::Anthropic,
+            Provider::Google => Adapter::Vertex,
+            Provider::Deepseek => Adapter::Openai,
+            Provider::Cohere => Adapter::Openai,
+            Provider::Jina => Adapter::Openai,
+        }
+    }
+}
+
 /// Per-token cost for budget tracking. Both values are in USD per 1,000 tokens.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -434,6 +490,84 @@ mod tests {
         let bg = m.background_model_check.unwrap();
         assert!(bg.enabled);
         assert_eq!(bg.ignore_statuses, vec![408, 429]);
+    }
+
+    #[test]
+    fn adapter_from_provider_covers_every_variant() {
+        // Every Provider variant must map to a defined Adapter. This
+        // test exists to fail the build if a new Provider is added
+        // without an explicit From arm — the match in `From<Provider>`
+        // is exhaustive so the real safety net is the compiler, but
+        // pinning the chosen Adapter per variant guards against a
+        // future edit silently changing the mapping.
+        assert_eq!(Adapter::from(Provider::Openai), Adapter::Openai);
+        assert_eq!(Adapter::from(Provider::Anthropic), Adapter::Anthropic);
+        assert_eq!(Adapter::from(Provider::Google), Adapter::Vertex);
+        assert_eq!(Adapter::from(Provider::Deepseek), Adapter::Openai);
+        assert_eq!(Adapter::from(Provider::Cohere), Adapter::Openai);
+        assert_eq!(Adapter::from(Provider::Jina), Adapter::Openai);
+    }
+
+    #[test]
+    fn adapter_serializes_to_kebab_case_wire_strings() {
+        // Pin each Adapter's wire form. AzureOpenai → "azure-openai"
+        // is the load-bearing case for the kebab-case choice; the
+        // others are pinned to lock the contract so a future
+        // rename_all change is surfaced as a test failure.
+        assert_eq!(
+            serde_json::to_string(&Adapter::Openai).unwrap(),
+            "\"openai\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Adapter::Anthropic).unwrap(),
+            "\"anthropic\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Adapter::Bedrock).unwrap(),
+            "\"bedrock\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Adapter::Vertex).unwrap(),
+            "\"vertex\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Adapter::AzureOpenai).unwrap(),
+            "\"azure-openai\""
+        );
+    }
+
+    #[test]
+    fn adapter_deserializes_from_kebab_case_wire_strings() {
+        assert_eq!(
+            serde_json::from_str::<Adapter>("\"openai\"").unwrap(),
+            Adapter::Openai
+        );
+        assert_eq!(
+            serde_json::from_str::<Adapter>("\"anthropic\"").unwrap(),
+            Adapter::Anthropic
+        );
+        assert_eq!(
+            serde_json::from_str::<Adapter>("\"bedrock\"").unwrap(),
+            Adapter::Bedrock
+        );
+        assert_eq!(
+            serde_json::from_str::<Adapter>("\"vertex\"").unwrap(),
+            Adapter::Vertex
+        );
+        assert_eq!(
+            serde_json::from_str::<Adapter>("\"azure-openai\"").unwrap(),
+            Adapter::AzureOpenai
+        );
+    }
+
+    #[test]
+    fn adapter_rejects_unknown_variant_strings() {
+        // Closed enum — any string outside the kebab-case wire set
+        // must fail to deserialize so callers can't silently smuggle
+        // in a typo or a legacy provider name.
+        assert!(serde_json::from_str::<Adapter>("\"gemini\"").is_err());
+        assert!(serde_json::from_str::<Adapter>("\"azureopenai\"").is_err());
+        assert!(serde_json::from_str::<Adapter>("\"azure_openai\"").is_err());
     }
 
     #[test]

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -88,15 +88,26 @@ pub enum Adapter {
 }
 
 impl From<Provider> for Adapter {
-    /// Best-effort mapping from the legacy `Provider` enum onto the
-    /// `Adapter` wire-shape set, for use during the Phase A skeleton
-    /// stage. Rationale per variant:
+    /// Mapping from the current `Provider` enum onto the `Adapter`
+    /// wire-shape set, for use during the issue #302 Phase A skeleton
+    /// stage. This mapping is **not** wired into dispatch in this PR;
+    /// it exists as a forward-looking reference that follow-up Phase A
+    /// PRs will consume when migrating entities, the Hub, and Bridges
+    /// onto `Adapter`.
+    ///
+    /// Rationale per variant:
     ///
     /// - `Openai` / `Anthropic`: direct equivalents.
-    /// - `Google` → `Vertex`: Gemini-family models are routed through
-    ///   the Vertex AI wire shape (the production target for Google
-    ///   upstream traffic). `Adapter` does not currently have a
-    ///   separate Google AI Studio variant.
+    /// - `Google` → `Vertex`: forward-looking choice for the Phase A
+    ///   migration target. **Note:** this intentionally diverges from
+    ///   the current runtime behavior — `Provider::Google` today calls
+    ///   the Gemini Generative Language API via its OpenAI-compatible
+    ///   endpoint (`/v1beta/openai`), which is an `openai`-shaped
+    ///   wire. Any downstream PR that flips dispatch onto `Adapter`
+    ///   MUST either also migrate the Google bridge to native Vertex
+    ///   AI request encoding, or revisit this arm before merging — a
+    ///   silent flip would change the wire shape sent to Google
+    ///   upstreams. See issue #302 Phase A for the migration plan.
     /// - `Deepseek` → `Openai`: DeepSeek exposes an OpenAI-compatible
     ///   chat completions endpoint, so the adapter shape is `openai`.
     /// - `Cohere` → `Openai`: the gateway currently talks to Cohere's


### PR DESCRIPTION
## Summary

First sub-PR of [api7/AISIX-Cloud#302](https://github.com/api7/AISIX-Cloud/issues/302) Phase A (DP-side Provider→Adapter refactor).

Adds a new closed `Adapter` enum on `aisix-core` alongside the existing `Provider` enum, plus a `From<Provider> for Adapter` mapping.

**This PR is intentionally zero-behavior-change** — it only introduces new types. Nothing in the gateway dispatches off `Adapter` yet, no entity field references it, and `Provider` continues to drive 100% of runtime behavior. Follow-up sub-PRs in Phase A migrate entities, schema, the Hub, and Bridges to consume `Adapter` directly.

## What this PR does

1. Adds `Adapter` enum in `crates/aisix-core/src/models/model.rs`:
   - Variants: `Openai`, `Anthropic`, `Bedrock`, `Vertex`, `AzureOpenai`
   - Same derive set as `Provider` (`Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize`)
   - `#[serde(rename_all = "kebab-case")]` so `AzureOpenai` serializes as `"azure-openai"`
2. Adds `From<Provider> for Adapter` mapping:
   - `Openai` → `Openai`
   - `Anthropic` → `Anthropic`
   - `Google` → `Vertex` (Vertex AI wire shape; the current `Provider::Google` was renamed from `Gemini` in #279)
   - `Deepseek` → `Openai` (OpenAI-compatible chat completions)
   - `Cohere` → `Openai` (gateway uses Cohere OpenAI-compat endpoints; #213 Phase 1, rerank-only)
   - `Jina` → `Openai` (rerank identity-mapped to OpenAI-compat shape; #213 Phase 2)
3. Re-exports `Adapter` from `aisix_core::models` and the crate root, mirroring `Provider`.

## What this PR does NOT do

- ❌ Does not remove or modify `Provider`
- ❌ Does not change `ProviderKey` struct
- ❌ Does not change `schema.rs` / JSON Schema
- ❌ Does not change Hub, Bridges, or any dispatch path
- ❌ Does not change any fixture or wire payload

## Serde casing note

The Adapter uses `kebab-case` while `Provider` uses `lowercase`. This is intentional: `Provider`'s values are all single tokens (no hyphens or underscores to disambiguate), but Adapter needs `azure-openai` to remain readable on the wire. Both are pinned by tests so future edits are surfaced loudly.

## Test plan

- [x] `cargo test -p aisix-core` — 136 passed, 0 failed (includes 4 new Adapter tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] All 6 `Provider` variants covered by `From<Provider>` mapping test
- [x] All 5 `Adapter` variants pinned by serialize/deserialize round-trip tests
- [x] Unknown variant strings (e.g. `"gemini"`, `"azureopenai"`, `"azure_openai"`) rejected by deserialize

## References

- Tracking issue: api7/AISIX-Cloud#302
- Provider rename precedent (Gemini → Google): #279
- Cohere/Jina rerank-only scope: #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Adapter API allowing upstream protocol representation and automatic conversion from existing providers.

* **Tests**
  * Added comprehensive unit tests covering Adapter serialization/deserialization and provider-to-Adapter mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->