### PR TITLE
feat(gateway): add two-tier Hub dispatch (Phase A skeleton)

### DIFF
--- a/crates/aisix-gateway/src/hub.rs
+++ b/crates/aisix-gateway/src/hub.rs
@@ -8,8 +8,29 @@
 //! There is no fallback logic here — that is the proxy layer's job and
 //! lands in its own PR. The Hub exists purely to resolve Provider →
 //! Bridge cheaply and consistently.
+//!
+//! # Two-tier dispatch skeleton (issue #302 Phase A)
+//!
+//! In addition to the existing `Provider`-keyed registry, the Hub now
+//! also carries two forward-looking maps keyed by [`ProviderKey`]
+//! fields introduced in Phase A:
+//!
+//! - `family_bridges` — keyed on `Adapter` (wire shape: `openai`,
+//!   `anthropic`, `bedrock`, `vertex`, `azure-openai`). The default
+//!   bridge for any provider that matches that wire shape.
+//! - `specialized_bridges` — keyed on `ProviderKey.provider` (vendor
+//!   string, e.g. `"deepseek"`, `"jina"`). Used when a specific vendor
+//!   needs handling that diverges from its wire-shape default.
+//!
+//! [`Hub::dispatch_two_tier`] looks up specialized first, then falls
+//! back to the family bridge. It is **not consumed by any caller** in
+//! this PR — `build_hub()` does not register family/specialized
+//! bridges and the proxy path continues to dispatch through the
+//! existing `Provider`-keyed `get()`. The new methods exist so future
+//! Phase A / Phase D sub-PRs can wire dispatch through them without
+//! re-touching this file.
 
-use aisix_core::models::Provider;
+use aisix_core::models::{Adapter, Provider, ProviderKey};
 use dashmap::DashMap;
 use std::sync::Arc;
 
@@ -23,6 +44,16 @@ use crate::bridge::Bridge;
 #[derive(Default)]
 pub struct Hub {
     bridges: DashMap<Provider, Arc<dyn Bridge>>,
+    /// Wire-shape default bridges. Keyed on [`Adapter`]. Phase A
+    /// skeleton — empty until follow-up PRs register the per-family
+    /// default bridge. See module docs.
+    family_bridges: DashMap<Adapter, Arc<dyn Bridge>>,
+    /// Vendor-specific override bridges. Keyed on
+    /// `ProviderKey.provider` (vendor string). Phase A skeleton —
+    /// empty until follow-up PRs register specialized handlers for
+    /// vendors that diverge from their wire-shape default. See module
+    /// docs.
+    specialized_bridges: DashMap<String, Arc<dyn Bridge>>,
 }
 
 impl Hub {
@@ -52,12 +83,50 @@ impl Hub {
     pub fn is_empty(&self) -> bool {
         self.bridges.is_empty()
     }
+
+    /// Register the family-tier (wire-shape default) bridge for an
+    /// [`Adapter`]. Phase A skeleton — see module docs.
+    ///
+    /// Overwrites any previous entry for the same adapter, matching
+    /// the live-reconfigure semantics of [`Hub::register`].
+    pub fn register_family(&self, adapter: Adapter, bridge: Arc<dyn Bridge>) {
+        self.family_bridges.insert(adapter, bridge);
+    }
+
+    /// Register a specialized (vendor-specific) bridge keyed on the
+    /// `ProviderKey.provider` vendor string. Phase A skeleton — see
+    /// module docs.
+    ///
+    /// Overwrites any previous entry for the same vendor key.
+    pub fn register_specialized(&self, provider: impl Into<String>, bridge: Arc<dyn Bridge>) {
+        self.specialized_bridges.insert(provider.into(), bridge);
+    }
+
+    /// Two-tier dispatch: specialized vendor bridge first, then the
+    /// adapter-family default. Returns `None` if neither is registered
+    /// — the caller decides how to report a missing bridge so this
+    /// layer stays panic-free. Phase A skeleton — see module docs.
+    pub fn dispatch_two_tier(&self, pk: &ProviderKey) -> Option<Arc<dyn Bridge>> {
+        if let Some(b) = self.specialized_bridges.get(&pk.provider) {
+            return Some(b.clone());
+        }
+        let adapter = pk.adapter?;
+        self.family_bridges.get(&adapter).map(|r| r.clone())
+    }
 }
 
 impl std::fmt::Debug for Hub {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let families: Vec<Adapter> = self.family_bridges.iter().map(|r| *r.key()).collect();
+        let specialized: Vec<String> = self
+            .specialized_bridges
+            .iter()
+            .map(|r| r.key().clone())
+            .collect();
         f.debug_struct("Hub")
             .field("providers", &self.providers())
+            .field("families", &families)
+            .field("specialized", &specialized)
             .finish()
     }
 }
@@ -168,5 +237,148 @@ mod tests {
         let resp = bridge.chat(&req, &ctx).await.unwrap();
         assert_eq!(resp.message.content, "stubbed");
         assert_eq!(resp.finish_reason, FinishReason::Stop);
+    }
+
+    // ---- two-tier dispatch (issue #302 Phase A skeleton) ----
+
+    /// Build a `ProviderKey` carrying just the vendor + adapter fields
+    /// the two-tier dispatcher reads. JSON deserialization matches the
+    /// existing test style and exercises the on-disk schema we expect
+    /// future PRs to populate.
+    fn pk(provider: &str, adapter: Option<&str>) -> aisix_core::ProviderKey {
+        let adapter_field = match adapter {
+            Some(a) => format!(r#","adapter":"{a}""#),
+            None => String::new(),
+        };
+        let json = format!(
+            r#"{{"display_name":"pk","secret":"k","provider":"{provider}"{adapter_field}}}"#
+        );
+        serde_json::from_str::<aisix_core::ProviderKey>(&json).unwrap()
+    }
+
+    #[test]
+    fn register_family_and_dispatch_via_adapter() {
+        let hub = Hub::new();
+        hub.register_family(
+            Adapter::Openai,
+            Arc::new(StubBridge {
+                name: "family-openai",
+            }),
+        );
+        let b = hub
+            .dispatch_two_tier(&pk("deepseek", Some("openai")))
+            .unwrap();
+        assert_eq!(b.name(), "family-openai");
+    }
+
+    #[test]
+    fn register_specialized_and_dispatch_overrides_family() {
+        let hub = Hub::new();
+        hub.register_family(
+            Adapter::Openai,
+            Arc::new(StubBridge {
+                name: "family-openai",
+            }),
+        );
+        hub.register_specialized(
+            "deepseek",
+            Arc::new(StubBridge {
+                name: "specialized-deepseek",
+            }),
+        );
+        let b = hub
+            .dispatch_two_tier(&pk("deepseek", Some("openai")))
+            .unwrap();
+        assert_eq!(b.name(), "specialized-deepseek");
+    }
+
+    #[test]
+    fn dispatch_two_tier_returns_none_when_neither_registered() {
+        let hub = Hub::new();
+        assert!(hub
+            .dispatch_two_tier(&pk("unknown", Some("openai")))
+            .is_none());
+    }
+
+    #[test]
+    fn dispatch_two_tier_returns_none_when_adapter_missing_and_no_specialized() {
+        let hub = Hub::new();
+        hub.register_family(
+            Adapter::Openai,
+            Arc::new(StubBridge {
+                name: "family-openai",
+            }),
+        );
+        // Old payloads / un-migrated keys land here: provider doesn't
+        // match a specialized entry, and adapter is None so the family
+        // tier has nothing to key on.
+        assert!(hub.dispatch_two_tier(&pk("legacy", None)).is_none());
+    }
+
+    #[test]
+    fn dispatch_two_tier_specialized_hits_even_when_adapter_missing() {
+        let hub = Hub::new();
+        hub.register_specialized(
+            "jina",
+            Arc::new(StubBridge {
+                name: "specialized-jina",
+            }),
+        );
+        // No adapter on the key, but the vendor string matches a
+        // specialized registration — first tier still wins.
+        let b = hub.dispatch_two_tier(&pk("jina", None)).unwrap();
+        assert_eq!(b.name(), "specialized-jina");
+    }
+
+    #[test]
+    fn register_family_overwrites_previous_entry() {
+        let hub = Hub::new();
+        hub.register_family(Adapter::Openai, Arc::new(StubBridge { name: "v1" }));
+        hub.register_family(Adapter::Openai, Arc::new(StubBridge { name: "v2" }));
+        let b = hub
+            .dispatch_two_tier(&pk("anyvendor", Some("openai")))
+            .unwrap();
+        assert_eq!(b.name(), "v2");
+    }
+
+    #[test]
+    fn register_specialized_overwrites_previous_entry() {
+        let hub = Hub::new();
+        hub.register_specialized("deepseek", Arc::new(StubBridge { name: "v1" }));
+        hub.register_specialized("deepseek", Arc::new(StubBridge { name: "v2" }));
+        let b = hub
+            .dispatch_two_tier(&pk("deepseek", Some("openai")))
+            .unwrap();
+        assert_eq!(b.name(), "v2");
+    }
+
+    #[test]
+    fn legacy_provider_registry_is_unaffected_by_two_tier_maps() {
+        // Registering only on the new tiers must not satisfy a lookup
+        // through the legacy `Provider`-keyed API, and vice versa.
+        // Co-existence is the explicit contract of this skeleton PR.
+        let hub = Hub::new();
+        hub.register_family(Adapter::Openai, Arc::new(StubBridge { name: "family" }));
+        hub.register_specialized(
+            "deepseek",
+            Arc::new(StubBridge {
+                name: "specialized",
+            }),
+        );
+        assert!(hub.get(Provider::Openai).is_none());
+        assert!(hub.is_empty());
+
+        hub.register(Provider::Openai, Arc::new(StubBridge { name: "legacy" }));
+        // Legacy bump touches only the Provider-keyed map.
+        assert_eq!(hub.get(Provider::Openai).unwrap().name(), "legacy");
+        assert_eq!(hub.len(), 1);
+        // Two-tier maps still resolve their own registrations
+        // independently.
+        assert_eq!(
+            hub.dispatch_two_tier(&pk("deepseek", Some("openai")))
+                .unwrap()
+                .name(),
+            "specialized"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Skeleton sub-PR for issue #302 Phase A. Adds the two forward-looking tier maps to `Hub` (`crates/aisix-gateway/src/hub.rs`) so future Phase A / Phase D sub-PRs can wire bridges through them without re-touching this file.

- `family_bridges: DashMap<Adapter, Arc<dyn Bridge>>` — wire-shape default bridges, keyed on the `Adapter` enum (added in #297).
- `specialized_bridges: DashMap<String, Arc<dyn Bridge>>` — vendor overrides, keyed on `ProviderKey.provider` (added in #298).
- `register_family` / `register_specialized` accessors.
- `dispatch_two_tier(&ProviderKey) -> Option<Arc<dyn Bridge>>` — specialized lookup first, then adapter-family fallback. Returns `Option` so the caller picks the missing-bridge error semantics; this layer stays panic-free.

## Zero behavior change

- Existing `bridges: DashMap<Provider, _>` and `register` / `get(Provider)` are untouched. `aisix-proxy`, rerank (#299), and `build_hub()` keep using them.
- `build_hub()` is intentionally **not modified** — the new maps stay empty until follow-up PRs register the per-family / per-vendor bridges as part of the Phase D cutover.
- No proxy or rerank path consumes the new methods yet (verified by `cargo test -p aisix-proxy --lib`: 218 passed).

## Context

Phase A skeleton trail so far:

- #297 — `Adapter` enum (5-value closed enum).
- #298 — `ProviderKey` gained `provider: String`, `adapter: Option<Adapter>`, `display_name`, `telemetry_tags` (all `#[serde(default)]`, backward-compatible).
- #299 — rerank.rs switched to `Provider::as_str()`.
- **This PR** — Hub gains the two-tier dispatch surface, still un-consumed.

Per issue #302 §3, follow-up PRs (Phase D cutover) will:

1. Populate `ProviderKey.provider` / `.adapter` in entity payloads and the bridge factory wiring.
2. Register family + specialized bridges in `build_hub()`.
3. Flip the proxy dispatch path from `Hub::get(Provider)` to `Hub::dispatch_two_tier(&ProviderKey)`.

## Test plan

- [x] `cargo test -p aisix-gateway` — 54 passed (8 new tests cover: family hit, specialized override, double-miss, adapter-None paths, overwrite semantics, legacy `Provider`-keyed registry co-existence).
- [x] `cargo test -p aisix-proxy --lib` — 218 passed (downstream `Hub.get(Provider)` consumer unaffected).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

Closes none. Linked to: #302.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a multi-tier dispatch system supporting adapter and vendor-specific bridge registrations with automatic fallback resolution
  * Enhanced request resolution with improved configuration management across different provider types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->