### PR TITLE
feat(provider-openai): add overrides module for RuntimeConfig request/response (Phase A skeleton)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
+ "http 1.4.0",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/aisix-provider-openai/Cargo.toml
+++ b/crates/aisix-provider-openai/Cargo.toml
@@ -21,6 +21,7 @@ tokio.workspace = true
 futures.workspace = true
 async-stream = "0.3"
 bytes.workspace = true
+http.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/crates/aisix-provider-openai/src/lib.rs
+++ b/crates/aisix-provider-openai/src/lib.rs
@@ -12,6 +12,7 @@
 #![deny(rust_2018_idioms)]
 
 mod bridge;
+pub mod overrides;
 mod wire;
 
 pub use bridge::{OpenAiBridge, OPENAI_DEFAULT_BASE};

--- a/crates/aisix-provider-openai/src/overrides.rs
+++ b/crates/aisix-provider-openai/src/overrides.rs
@@ -90,8 +90,15 @@ pub enum StreamDoneOutcome {
 ///
 /// Rewrites every present top-level key whose name matches a key in
 /// `renames` to the renames-map's value. Absent source keys are
-/// no-ops. Conflicts (the target key already exists) prefer the
-/// already-present value — the rename is *non-destructive*.
+/// no-ops.
+///
+/// **Collision semantics: source wins.** When both source and target
+/// are present in the body, the source value overwrites the target.
+/// Matches LiteLLM's convention across `databricks` / `openai_like` /
+/// `sambanova` / `dynamic_config` transformations — for the canonical
+/// `max_completion_tokens → max_tokens` case the newer (source) value
+/// is what the caller intended; an accidentally-leftover deprecated
+/// `max_tokens` value should not shadow it.
 ///
 /// Non-object bodies are no-ops by construction; the function does
 /// not panic on `null` / array / scalar inputs.
@@ -106,11 +113,8 @@ pub fn apply_param_renames(body: &mut Value, renames: &HashMap<String, String>) 
         let Some(value) = obj.remove(from) else {
             continue;
         };
-        // Non-destructive: if the target already has a value, the
-        // existing entry wins and we drop the renamed one. cp-api
-        // shouldn't ship a rename that collides with an explicit
-        // value the caller already set.
-        obj.entry(to.clone()).or_insert(value);
+        // Source wins: overwrite any pre-existing target value.
+        obj.insert(to.clone(), value);
     }
 }
 
@@ -151,6 +155,17 @@ pub fn apply_param_constraints(body: &mut Value, constraints: &Constraints) {
     }
 }
 
+/// Authentication-related headers that `apply_default_headers` will
+/// never set, even if cp-api validation slips and allows them through.
+/// Defense-in-depth: a misconfigured `default_headers` block must never
+/// override the auth header the OpenAiBridge sets itself. cp-api SHOULD
+/// reject these at write time (issue #302 §5 validation rules), but
+/// the DP enforces it again at apply time.
+///
+/// `HeaderName` is case-insensitive so the lowercase form is the
+/// canonical comparison key.
+const RESERVED_DEFAULT_HEADERS: &[&str] = &["authorization", "x-api-key", "x-goog-api-key"];
+
 /// Apply `request.default_headers` to an outbound `HeaderMap`.
 ///
 /// Headers already present on `headers` (case-insensitive, since
@@ -160,11 +175,19 @@ pub fn apply_param_constraints(body: &mut Value, constraints: &Constraints) {
 /// silently skipped; the default block came from cp-api validation
 /// and any unparseable entry is a config error one layer up, not a
 /// runtime failure the dispatch should hard-fail on.
+///
+/// **Auth-header guard:** keys in [`RESERVED_DEFAULT_HEADERS`] are
+/// dropped before insertion as defense-in-depth — a misconfigured
+/// default_headers block must never inject `Authorization` or vendor
+/// API-key headers that would override the Bridge's own auth.
 pub fn apply_default_headers(headers: &mut HeaderMap, defaults: &HashMap<String, String>) {
     for (name, value) in defaults {
         let Ok(parsed_name) = name.parse::<HeaderName>() else {
             continue;
         };
+        if RESERVED_DEFAULT_HEADERS.contains(&parsed_name.as_str()) {
+            continue;
+        }
         if headers.contains_key(&parsed_name) {
             continue;
         }
@@ -406,16 +429,19 @@ mod tests {
     }
 
     #[test]
-    fn rename_with_existing_target_keeps_existing() {
-        // Caller already supplied `max_tokens`; the rename from
-        // `max_completion_tokens` must not overwrite it.
+    fn rename_source_wins_when_both_present() {
+        // Both source and target keys are present in the body. Per
+        // LiteLLM convention (source wins), the source's value should
+        // overwrite the target's pre-existing value — for the canonical
+        // max_completion_tokens → max_tokens case, the newer source
+        // value 100 wins over the deprecated target value 50.
         let mut body = json!({ "max_completion_tokens": 100, "max_tokens": 50 });
         let renames = HashMap::from([(
             "max_completion_tokens".to_string(),
             "max_tokens".to_string(),
         )]);
         apply_param_renames(&mut body, &renames);
-        assert_eq!(body, json!({ "max_tokens": 50 }));
+        assert_eq!(body, json!({ "max_tokens": 100 }));
     }
 
     #[test]
@@ -541,6 +567,43 @@ mod tests {
         apply_default_headers(&mut headers, &defaults);
         assert!(headers.get("x-foo").is_some());
         assert_eq!(headers.len(), 1);
+    }
+
+    #[test]
+    fn rejects_reserved_auth_headers() {
+        // Defense-in-depth: even if cp-api validation slipped and shipped
+        // a default_headers block containing Authorization / X-Api-Key /
+        // X-Goog-Api-Key, DP must not inject them. Case-insensitive via
+        // HeaderName canonicalization.
+        let mut headers = HeaderMap::new();
+        let defaults = HashMap::from([
+            (
+                "Authorization".to_string(),
+                "Bearer attacker-token".to_string(),
+            ),
+            ("X-Api-Key".to_string(), "attacker-key".to_string()),
+            ("X-API-KEY".to_string(), "attacker-key-2".to_string()),
+            (
+                "x-goog-api-key".to_string(),
+                "attacker-google-key".to_string(),
+            ),
+            ("x-foo".to_string(), "ok-default".to_string()),
+        ]);
+        apply_default_headers(&mut headers, &defaults);
+        assert!(
+            headers.get("authorization").is_none(),
+            "auth must be blocked"
+        );
+        assert!(
+            headers.get("x-api-key").is_none(),
+            "x-api-key must be blocked"
+        );
+        assert!(
+            headers.get("x-goog-api-key").is_none(),
+            "x-goog-api-key must be blocked"
+        );
+        assert_eq!(headers.get("x-foo").unwrap(), "ok-default");
+        assert_eq!(headers.len(), 1, "only x-foo should have been inserted");
     }
 
     // --- apply_default_body_fields --------------------------------

--- a/crates/aisix-provider-openai/src/overrides.rs
+++ b/crates/aisix-provider-openai/src/overrides.rs
@@ -1,0 +1,786 @@
+//! Per-`ProviderKey` request/response override primitives.
+//!
+//! Skeleton for [api7/AISIX-Cloud#302](https://github.com/api7/AISIX-Cloud/issues/302)
+//! Phase A. The issue's §5 RuntimeConfig adds a `request` block
+//! (`param_renames` / `param_constraints` / `default_headers` /
+//! `default_body_fields`) and a `response` block (`stream_done_marker` /
+//! `content_list_to_string` / `error_envelope` / `reasoning_field`) so
+//! cp-api can capture per-provider quirks without forking a Bridge.
+//!
+//! This module ships the primitive transforms. **Nothing in
+//! [`OpenAiBridge`](crate::OpenAiBridge) wires them in yet** — the
+//! struct types that would carry the override blocks on `ProviderKey`
+//! are not landed (#298 added `provider` / `adapter` / `telemetry_tags`
+//! only). Phase D consumes these functions from inside the Bridge
+//! when the new contract cuts over. Until then the public API is
+//! exercised by unit tests against `serde_json::Value` /
+//! `http::HeaderMap` inputs.
+//!
+//! Each function takes primitive Rust types rather than a future
+//! `RequestOverrides` / `ResponseOverrides` struct on purpose — the
+//! caller picks fields out of whatever container lands and forwards
+//! them here, so the wire schema for those blocks can iterate without
+//! touching this file.
+//!
+//! Reference implementations consulted:
+//! - LiteLLM `convert_content_list_to_str` —
+//!   <https://github.com/BerriAI/litellm/blob/main/litellm/litellm_core_utils/prompt_templates/common_utils.py>
+//! - LiteLLM `convert_content_list_to_string` flag —
+//!   <https://github.com/BerriAI/litellm/blob/main/litellm/llms/openai_like/dynamic_config.py>
+//! - DeepSeek reasoning shape (`delta.reasoning_content`) —
+//!   <https://api-docs.deepseek.com/guides/reasoning_model>
+//! - OpenAI SSE `data: [DONE]` terminator —
+//!   <https://platform.openai.com/docs/api-reference/chat/streaming>
+
+use std::collections::HashMap;
+
+use http::{
+    header::{HeaderName, HeaderValue},
+    HeaderMap,
+};
+use serde_json::{Map, Value};
+
+/// Numeric range clamps applied to chat-completion request bodies.
+///
+/// Mirrors the `param_constraints` block in issue #302 §5. Phase A
+/// scope: `temperature` only — `top_p`, `frequency_penalty`, and
+/// friends are intentionally deferred until a real upstream quirk
+/// requires them (YAGNI per CLAUDE.md §2).
+#[derive(Debug, Default, Clone)]
+pub struct Constraints {
+    /// Upper bound for `temperature`. Values above this are clamped
+    /// to this value. `None` means "no upper clamp".
+    pub temperature_max: Option<f64>,
+    /// Lower bound for `temperature`. Values below this are clamped
+    /// to this value. `None` means "no lower clamp".
+    pub temperature_min: Option<f64>,
+}
+
+/// Stream `[DONE]` terminator policy for an SSE response.
+///
+/// Mirrors `response.stream_done_marker` in issue #302 §5. The
+/// caller observes whether the upstream actually emitted
+/// `data: [DONE]` and dispatches into [`apply_stream_done_marker_policy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamDoneMarker {
+    /// Upstream must emit `data: [DONE]`. Absence is a wire-shape
+    /// violation. OpenAI proper, DeepSeek, Groq.
+    Required,
+    /// Either presence or absence is acceptable. Used when the
+    /// upstream is OpenAI-compat but does not promise the terminator.
+    Optional,
+    /// Upstream is expected to *omit* the marker. Some Azure / Vertex
+    /// flavors terminate cleanly on connection close.
+    None,
+}
+
+/// Outcome of evaluating an SSE stream against a
+/// [`StreamDoneMarker`] policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamDoneOutcome {
+    /// Stream complied with the policy.
+    Ok,
+    /// Required terminator was missing.
+    MissingDoneMarker,
+    /// Terminator was forbidden but observed.
+    UnexpectedDoneMarker,
+}
+
+/// Apply `request.param_renames` to a JSON request body.
+///
+/// Rewrites every present top-level key whose name matches a key in
+/// `renames` to the renames-map's value. Absent source keys are
+/// no-ops. Conflicts (the target key already exists) prefer the
+/// already-present value — the rename is *non-destructive*.
+///
+/// Non-object bodies are no-ops by construction; the function does
+/// not panic on `null` / array / scalar inputs.
+pub fn apply_param_renames(body: &mut Value, renames: &HashMap<String, String>) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    for (from, to) in renames {
+        if from == to {
+            continue;
+        }
+        let Some(value) = obj.remove(from) else {
+            continue;
+        };
+        // Non-destructive: if the target already has a value, the
+        // existing entry wins and we drop the renamed one. cp-api
+        // shouldn't ship a rename that collides with an explicit
+        // value the caller already set.
+        obj.entry(to.clone()).or_insert(value);
+    }
+}
+
+/// Apply `request.param_constraints` to a JSON request body.
+///
+/// Phase A handles `temperature` only — other parameter clamps are
+/// added when a real upstream needs them. If the body has no
+/// `temperature` field, or its value is not a number, the function
+/// is a no-op (the upstream itself will surface invalid types).
+pub fn apply_param_constraints(body: &mut Value, constraints: &Constraints) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    let Some(temp) = obj.get_mut("temperature") else {
+        return;
+    };
+    let Some(current) = temp.as_f64() else {
+        return;
+    };
+    let mut next = current;
+    if let Some(max) = constraints.temperature_max {
+        if next > max {
+            next = max;
+        }
+    }
+    if let Some(min) = constraints.temperature_min {
+        if next < min {
+            next = min;
+        }
+    }
+    if next != current {
+        // serde_json::Number::from_f64 returns None for NaN/Inf —
+        // those aren't valid JSON anyway, so leaving the field
+        // unchanged on the conversion failure is correct.
+        if let Some(num) = serde_json::Number::from_f64(next) {
+            *temp = Value::Number(num);
+        }
+    }
+}
+
+/// Apply `request.default_headers` to an outbound `HeaderMap`.
+///
+/// Headers already present on `headers` (case-insensitive, since
+/// [`http::HeaderName`] is case-insensitive) are left alone — the
+/// caller's explicit value always wins over a default. Names or
+/// values that fail [`HeaderName`] / [`HeaderValue`] parsing are
+/// silently skipped; the default block came from cp-api validation
+/// and any unparseable entry is a config error one layer up, not a
+/// runtime failure the dispatch should hard-fail on.
+pub fn apply_default_headers(headers: &mut HeaderMap, defaults: &HashMap<String, String>) {
+    for (name, value) in defaults {
+        let Ok(parsed_name) = name.parse::<HeaderName>() else {
+            continue;
+        };
+        if headers.contains_key(&parsed_name) {
+            continue;
+        }
+        let Ok(parsed_value) = HeaderValue::from_str(value) else {
+            continue;
+        };
+        headers.insert(parsed_name, parsed_value);
+    }
+}
+
+/// Apply `request.default_body_fields` to a JSON request body.
+///
+/// Adds each entry of `defaults` to the body when the key is absent.
+/// Existing keys are left untouched (caller wins). Non-object bodies
+/// are a no-op.
+pub fn apply_default_body_fields(body: &mut Value, defaults: &Map<String, Value>) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    for (key, value) in defaults {
+        obj.entry(key.clone()).or_insert_with(|| value.clone());
+    }
+}
+
+/// Evaluate an SSE stream's terminator against a policy.
+///
+/// `done_marker_seen` reports whether the stream actually emitted
+/// `data: [DONE]`. Returns the resulting [`StreamDoneOutcome`] so
+/// the caller decides whether to emit a synthesized terminator,
+/// surface a wire-shape error, or accept silently.
+pub fn apply_stream_done_marker_policy(
+    policy: StreamDoneMarker,
+    done_marker_seen: bool,
+) -> StreamDoneOutcome {
+    match (policy, done_marker_seen) {
+        (StreamDoneMarker::Required, true) => StreamDoneOutcome::Ok,
+        (StreamDoneMarker::Required, false) => StreamDoneOutcome::MissingDoneMarker,
+        (StreamDoneMarker::Optional, _) => StreamDoneOutcome::Ok,
+        (StreamDoneMarker::None, false) => StreamDoneOutcome::Ok,
+        (StreamDoneMarker::None, true) => StreamDoneOutcome::UnexpectedDoneMarker,
+    }
+}
+
+/// Apply `response.content_list_to_string` to a chat-completions
+/// request body.
+///
+/// Some OpenAI-compat upstreams (Mistral on Azure AI, SambaNova,
+/// Heroku) only accept `message.content` as a string. This walks
+/// every entry in the top-level `messages` array and, when an
+/// entry's `content` is an array of `{type:"text", text:"..."}`
+/// blocks, replaces it with the concatenated text of those blocks.
+///
+/// Matches LiteLLM's `convert_content_list_to_str`: text blocks are
+/// concatenated with no separator. Non-text blocks (image_url,
+/// audio, etc.) are skipped — same behavior as the reference — and
+/// if every block is non-text the field is left as-is, since
+/// flattening a vision payload to an empty string would silently
+/// drop user intent.
+pub fn apply_content_list_to_string(body: &mut Value) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    let Some(messages) = obj.get_mut("messages").and_then(|m| m.as_array_mut()) else {
+        return;
+    };
+    for message in messages {
+        let Some(message_obj) = message.as_object_mut() else {
+            continue;
+        };
+        let Some(content) = message_obj.get_mut("content") else {
+            continue;
+        };
+        let Some(blocks) = content.as_array() else {
+            continue;
+        };
+        let mut texts = String::new();
+        let mut saw_text = false;
+        for block in blocks {
+            let Some(block_obj) = block.as_object() else {
+                continue;
+            };
+            if block_obj.get("type").and_then(|t| t.as_str()) != Some("text") {
+                continue;
+            }
+            if let Some(text) = block_obj.get("text").and_then(|t| t.as_str()) {
+                texts.push_str(text);
+                saw_text = true;
+            }
+        }
+        if saw_text {
+            *content = Value::String(texts);
+        }
+    }
+}
+
+/// Lift a nested reasoning field on a streaming chunk up to the
+/// canonical `delta.reasoning_content` slot.
+///
+/// `path` is a `.`-separated address inside `chunk` (e.g.
+/// `"delta.reasoning_content"`). When the value at that path is a
+/// non-empty string and lives on a `delta` object, we copy it onto
+/// the same delta as `reasoning_content`. When the source path
+/// itself is `delta.reasoning_content` the function is a no-op
+/// (already canonical).
+///
+/// This intentionally does *not* mutate any other shape — the only
+/// guarantee is "after a successful call, the canonical
+/// `reasoning_content` slot reflects whatever the upstream put at
+/// `path`, when the upstream put a string there". Reference:
+/// LiteLLM normalizes vendor-specific reasoning fields onto
+/// `reasoning_content` in [`litellm/llms/ovhcloud/chat/transformation.py`](https://github.com/BerriAI/litellm/blob/main/litellm/llms/ovhcloud/chat/transformation.py).
+pub fn extract_reasoning_field(chunk: &mut Value, path: &str) {
+    let segments: Vec<&str> = path.split('.').filter(|s| !s.is_empty()).collect();
+    if segments.is_empty() {
+        return;
+    }
+
+    // Walk every choice's `delta` for an OpenAI-style chunk:
+    // `{ "choices": [{ "delta": { ... } }, ...] }`. The path
+    // semantics from issue #302 §5 (`"delta.reasoning_content"`)
+    // are relative to each entry's delta-bearing object, so we
+    // require the first segment to be `delta`.
+    if segments[0] != "delta" || segments.len() < 2 {
+        return;
+    }
+    let tail = &segments[1..];
+
+    let Some(choices) = chunk
+        .as_object_mut()
+        .and_then(|obj| obj.get_mut("choices"))
+        .and_then(|c| c.as_array_mut())
+    else {
+        return;
+    };
+
+    for choice in choices {
+        let Some(delta) = choice
+            .as_object_mut()
+            .and_then(|obj| obj.get_mut("delta"))
+            .and_then(|d| d.as_object_mut())
+        else {
+            continue;
+        };
+
+        // Drill down `tail` inside delta to fetch the source string.
+        let mut cursor: &Value = match delta.get(tail[0]) {
+            Some(v) => v,
+            None => continue,
+        };
+        for seg in &tail[1..] {
+            cursor = match cursor.as_object().and_then(|o| o.get(*seg)) {
+                Some(v) => v,
+                None => {
+                    cursor = &Value::Null;
+                    break;
+                }
+            };
+        }
+        let Some(source_str) = cursor.as_str() else {
+            continue;
+        };
+        if source_str.is_empty() {
+            continue;
+        }
+        // Canonical slot is `delta.reasoning_content`. If the source
+        // path *is* the canonical slot the entry already exists and
+        // the insert is a no-op of the same value — cheaper to leave
+        // it alone.
+        if tail == ["reasoning_content"] {
+            continue;
+        }
+        let owned = source_str.to_string();
+        delta.insert("reasoning_content".to_string(), Value::String(owned));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- apply_param_renames --------------------------------------
+
+    #[test]
+    fn renames_known_param() {
+        let mut body = json!({ "max_completion_tokens": 100, "temperature": 0.5 });
+        let renames = HashMap::from([(
+            "max_completion_tokens".to_string(),
+            "max_tokens".to_string(),
+        )]);
+        apply_param_renames(&mut body, &renames);
+        assert_eq!(body, json!({ "max_tokens": 100, "temperature": 0.5 }));
+    }
+
+    #[test]
+    fn rename_absent_key_is_noop() {
+        let mut body = json!({ "temperature": 0.5 });
+        let renames = HashMap::from([(
+            "max_completion_tokens".to_string(),
+            "max_tokens".to_string(),
+        )]);
+        apply_param_renames(&mut body, &renames);
+        assert_eq!(body, json!({ "temperature": 0.5 }));
+    }
+
+    #[test]
+    fn rename_preserves_value_type() {
+        // Source value type (array, object, bool, number, null) is
+        // preserved unchanged after rename.
+        let mut body = json!({ "stop": ["END"] });
+        let renames = HashMap::from([("stop".to_string(), "stop_sequences".to_string())]);
+        apply_param_renames(&mut body, &renames);
+        assert_eq!(body, json!({ "stop_sequences": ["END"] }));
+    }
+
+    #[test]
+    fn applies_multiple_renames() {
+        let mut body = json!({
+            "max_completion_tokens": 100,
+            "stop": ["X"],
+            "temperature": 0.5
+        });
+        let renames = HashMap::from([
+            (
+                "max_completion_tokens".to_string(),
+                "max_tokens".to_string(),
+            ),
+            ("stop".to_string(), "stop_sequences".to_string()),
+        ]);
+        apply_param_renames(&mut body, &renames);
+        assert_eq!(
+            body,
+            json!({
+                "max_tokens": 100,
+                "stop_sequences": ["X"],
+                "temperature": 0.5
+            })
+        );
+    }
+
+    #[test]
+    fn rename_with_existing_target_keeps_existing() {
+        // Caller already supplied `max_tokens`; the rename from
+        // `max_completion_tokens` must not overwrite it.
+        let mut body = json!({ "max_completion_tokens": 100, "max_tokens": 50 });
+        let renames = HashMap::from([(
+            "max_completion_tokens".to_string(),
+            "max_tokens".to_string(),
+        )]);
+        apply_param_renames(&mut body, &renames);
+        assert_eq!(body, json!({ "max_tokens": 50 }));
+    }
+
+    #[test]
+    fn rename_to_self_is_noop() {
+        let mut body = json!({ "model": "gpt-4o" });
+        let renames = HashMap::from([("model".to_string(), "model".to_string())]);
+        apply_param_renames(&mut body, &renames);
+        assert_eq!(body, json!({ "model": "gpt-4o" }));
+    }
+
+    #[test]
+    fn renames_on_non_object_body_is_noop() {
+        let mut body = json!(42);
+        let renames = HashMap::from([("a".to_string(), "b".to_string())]);
+        apply_param_renames(&mut body, &renames);
+        assert_eq!(body, json!(42));
+    }
+
+    // --- apply_param_constraints ----------------------------------
+
+    #[test]
+    fn temperature_above_max_is_clamped() {
+        let mut body = json!({ "temperature": 1.7 });
+        let constraints = Constraints {
+            temperature_max: Some(1.0),
+            temperature_min: None,
+        };
+        apply_param_constraints(&mut body, &constraints);
+        assert_eq!(body["temperature"].as_f64(), Some(1.0));
+    }
+
+    #[test]
+    fn temperature_within_range_is_untouched() {
+        let mut body = json!({ "temperature": 0.7 });
+        let constraints = Constraints {
+            temperature_max: Some(1.0),
+            temperature_min: Some(0.0),
+        };
+        apply_param_constraints(&mut body, &constraints);
+        assert_eq!(body["temperature"].as_f64(), Some(0.7));
+    }
+
+    #[test]
+    fn temperature_below_min_is_clamped() {
+        let mut body = json!({ "temperature": -0.2 });
+        let constraints = Constraints {
+            temperature_max: None,
+            temperature_min: Some(0.0),
+        };
+        apply_param_constraints(&mut body, &constraints);
+        assert_eq!(body["temperature"].as_f64(), Some(0.0));
+    }
+
+    #[test]
+    fn temperature_missing_is_noop() {
+        let mut body = json!({ "model": "gpt-4o" });
+        let constraints = Constraints {
+            temperature_max: Some(1.0),
+            temperature_min: None,
+        };
+        apply_param_constraints(&mut body, &constraints);
+        assert_eq!(body, json!({ "model": "gpt-4o" }));
+    }
+
+    #[test]
+    fn temperature_non_number_is_noop() {
+        // Garbage-typed temperature lets the upstream surface the
+        // type error; the clamp doesn't try to coerce.
+        let mut body = json!({ "temperature": "hot" });
+        let constraints = Constraints {
+            temperature_max: Some(1.0),
+            temperature_min: None,
+        };
+        apply_param_constraints(&mut body, &constraints);
+        assert_eq!(body, json!({ "temperature": "hot" }));
+    }
+
+    #[test]
+    fn empty_constraints_is_noop() {
+        let mut body = json!({ "temperature": 2.0 });
+        let constraints = Constraints::default();
+        apply_param_constraints(&mut body, &constraints);
+        assert_eq!(body["temperature"].as_f64(), Some(2.0));
+    }
+
+    // --- apply_default_headers ------------------------------------
+
+    #[test]
+    fn adds_missing_default_header() {
+        let mut headers = HeaderMap::new();
+        let defaults = HashMap::from([("anthropic-version".to_string(), "2023-06-01".to_string())]);
+        apply_default_headers(&mut headers, &defaults);
+        assert_eq!(headers.get("anthropic-version").unwrap(), "2023-06-01");
+    }
+
+    #[test]
+    fn does_not_overwrite_existing_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-foo", HeaderValue::from_static("caller-value"));
+        let defaults = HashMap::from([("x-foo".to_string(), "default-value".to_string())]);
+        apply_default_headers(&mut headers, &defaults);
+        assert_eq!(headers.get("x-foo").unwrap(), "caller-value");
+    }
+
+    #[test]
+    fn header_match_is_case_insensitive() {
+        // Caller-set header in mixed case must still block a default
+        // header keyed in lowercase — http::HeaderName is canonicalized.
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Foo", HeaderValue::from_static("caller-value"));
+        let defaults = HashMap::from([("x-foo".to_string(), "default-value".to_string())]);
+        apply_default_headers(&mut headers, &defaults);
+        assert_eq!(headers.get("x-foo").unwrap(), "caller-value");
+    }
+
+    #[test]
+    fn skips_unparseable_header_name() {
+        let mut headers = HeaderMap::new();
+        let defaults = HashMap::from([
+            ("not a valid name".to_string(), "v".to_string()),
+            ("x-foo".to_string(), "ok".to_string()),
+        ]);
+        apply_default_headers(&mut headers, &defaults);
+        assert!(headers.get("x-foo").is_some());
+        assert_eq!(headers.len(), 1);
+    }
+
+    // --- apply_default_body_fields --------------------------------
+
+    #[test]
+    fn adds_missing_default_field() {
+        let mut body = json!({ "model": "gpt-4o" });
+        let defaults: Map<String, Value> =
+            serde_json::from_value(json!({ "safe_prompt": true })).unwrap();
+        apply_default_body_fields(&mut body, &defaults);
+        assert_eq!(body, json!({ "model": "gpt-4o", "safe_prompt": true }));
+    }
+
+    #[test]
+    fn does_not_overwrite_existing_field() {
+        let mut body = json!({ "safe_prompt": false });
+        let defaults: Map<String, Value> =
+            serde_json::from_value(json!({ "safe_prompt": true })).unwrap();
+        apply_default_body_fields(&mut body, &defaults);
+        assert_eq!(body, json!({ "safe_prompt": false }));
+    }
+
+    #[test]
+    fn default_body_fields_non_object_is_noop() {
+        let mut body = json!([1, 2, 3]);
+        let defaults: Map<String, Value> =
+            serde_json::from_value(json!({ "safe_prompt": true })).unwrap();
+        apply_default_body_fields(&mut body, &defaults);
+        assert_eq!(body, json!([1, 2, 3]));
+    }
+
+    // --- apply_stream_done_marker_policy --------------------------
+
+    #[test]
+    fn done_required_and_seen_is_ok() {
+        assert_eq!(
+            apply_stream_done_marker_policy(StreamDoneMarker::Required, true),
+            StreamDoneOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn done_required_and_missing_is_error() {
+        assert_eq!(
+            apply_stream_done_marker_policy(StreamDoneMarker::Required, false),
+            StreamDoneOutcome::MissingDoneMarker
+        );
+    }
+
+    #[test]
+    fn done_optional_accepts_either() {
+        assert_eq!(
+            apply_stream_done_marker_policy(StreamDoneMarker::Optional, true),
+            StreamDoneOutcome::Ok
+        );
+        assert_eq!(
+            apply_stream_done_marker_policy(StreamDoneMarker::Optional, false),
+            StreamDoneOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn done_none_accepts_absence() {
+        assert_eq!(
+            apply_stream_done_marker_policy(StreamDoneMarker::None, false),
+            StreamDoneOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn done_none_flags_unexpected_marker() {
+        assert_eq!(
+            apply_stream_done_marker_policy(StreamDoneMarker::None, true),
+            StreamDoneOutcome::UnexpectedDoneMarker
+        );
+    }
+
+    // --- apply_content_list_to_string -----------------------------
+
+    #[test]
+    fn flattens_two_text_blocks() {
+        // Matches LiteLLM's convert_content_list_to_str: text fields
+        // are concatenated with no separator.
+        let mut body = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "hi" },
+                    { "type": "text", "text": "world" }
+                ]
+            }]
+        });
+        apply_content_list_to_string(&mut body);
+        assert_eq!(body["messages"][0]["content"], json!("hiworld"));
+    }
+
+    #[test]
+    fn leaves_string_content_alone() {
+        let mut body = json!({
+            "messages": [{ "role": "user", "content": "already a string" }]
+        });
+        apply_content_list_to_string(&mut body);
+        assert_eq!(body["messages"][0]["content"], json!("already a string"));
+    }
+
+    #[test]
+    fn preserves_image_only_blocks() {
+        // Vision payloads with only image_url blocks: don't silently
+        // drop them by flattening to "". Leave as-is and let the
+        // upstream surface the unsupported wire.
+        let original = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "image_url", "image_url": { "url": "https://x.example/a.png" } }
+                ]
+            }]
+        });
+        let mut body = original.clone();
+        apply_content_list_to_string(&mut body);
+        assert_eq!(body, original);
+    }
+
+    #[test]
+    fn skips_non_text_blocks_but_flattens_text_neighbours() {
+        let mut body = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "describe " },
+                    { "type": "image_url", "image_url": { "url": "https://x.example/a.png" } },
+                    { "type": "text", "text": "this" }
+                ]
+            }]
+        });
+        apply_content_list_to_string(&mut body);
+        assert_eq!(body["messages"][0]["content"], json!("describe this"));
+    }
+
+    #[test]
+    fn no_messages_field_is_noop() {
+        let mut body = json!({ "model": "gpt-4o" });
+        apply_content_list_to_string(&mut body);
+        assert_eq!(body, json!({ "model": "gpt-4o" }));
+    }
+
+    // --- extract_reasoning_field ----------------------------------
+
+    #[test]
+    fn extracts_deepseek_reasoning_to_canonical_slot() {
+        // DeepSeek emits `reasoning_content` already on delta — the
+        // canonical slot matches, so it's a structural no-op but
+        // must not corrupt the chunk.
+        let mut chunk = json!({
+            "choices": [
+                { "delta": { "reasoning_content": "thinking..." } }
+            ]
+        });
+        let snapshot = chunk.clone();
+        extract_reasoning_field(&mut chunk, "delta.reasoning_content");
+        assert_eq!(chunk, snapshot);
+    }
+
+    #[test]
+    fn lifts_nested_reasoning_to_canonical_slot() {
+        // Hypothetical upstream nests reasoning inside an extra
+        // object: lift it onto the canonical key on the same delta.
+        let mut chunk = json!({
+            "choices": [
+                {
+                    "delta": {
+                        "vendor_extras": { "thoughts": "thinking..." }
+                    }
+                }
+            ]
+        });
+        extract_reasoning_field(&mut chunk, "delta.vendor_extras.thoughts");
+        assert_eq!(
+            chunk["choices"][0]["delta"]["reasoning_content"],
+            json!("thinking...")
+        );
+        // Source field is preserved — extraction is non-destructive.
+        assert_eq!(
+            chunk["choices"][0]["delta"]["vendor_extras"]["thoughts"],
+            json!("thinking...")
+        );
+    }
+
+    #[test]
+    fn missing_source_path_is_noop() {
+        let mut chunk = json!({
+            "choices": [{ "delta": { "content": "hello" } }]
+        });
+        let snapshot = chunk.clone();
+        extract_reasoning_field(&mut chunk, "delta.reasoning_content");
+        assert_eq!(chunk, snapshot);
+    }
+
+    #[test]
+    fn empty_string_source_is_noop() {
+        // An empty reasoning_content string should not populate the
+        // canonical slot — caller treats it the same as missing.
+        let mut chunk = json!({
+            "choices": [{ "delta": { "vendor_extras": { "thoughts": "" } } }]
+        });
+        extract_reasoning_field(&mut chunk, "delta.vendor_extras.thoughts");
+        assert!(chunk["choices"][0]["delta"]
+            .get("reasoning_content")
+            .is_none());
+    }
+
+    #[test]
+    fn non_delta_root_path_is_rejected() {
+        // The contract is "lift from delta sub-path". A root that
+        // isn't `delta` is treated as a no-op rather than silently
+        // mutating an unrelated tree.
+        let mut chunk = json!({
+            "choices": [{ "delta": { "content": "hi" }, "extras": { "thoughts": "t" } }]
+        });
+        let snapshot = chunk.clone();
+        extract_reasoning_field(&mut chunk, "extras.thoughts");
+        assert_eq!(chunk, snapshot);
+    }
+
+    #[test]
+    fn handles_multiple_choices() {
+        let mut chunk = json!({
+            "choices": [
+                { "delta": { "vendor_extras": { "thoughts": "first" } } },
+                { "delta": { "vendor_extras": { "thoughts": "second" } } }
+            ]
+        });
+        extract_reasoning_field(&mut chunk, "delta.vendor_extras.thoughts");
+        assert_eq!(
+            chunk["choices"][0]["delta"]["reasoning_content"],
+            json!("first")
+        );
+        assert_eq!(
+            chunk["choices"][1]["delta"]["reasoning_content"],
+            json!("second")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Sub-PR of [api7/AISIX-Cloud#302](https://github.com/api7/AISIX-Cloud/issues/302) Phase A. Ships the **primitive request/response transforms** referenced by issue v10 §5 RuntimeConfig:

```json
"request": {
  "param_renames":      { "max_completion_tokens": "max_tokens" },
  "param_constraints":  { "temperature_max": 1.0 },
  "default_headers":    { "X-Foo": "bar" },
  "default_body_fields":{ "safe_prompt": true }
},
"response": {
  "stream_done_marker":     "required",
  "content_list_to_string": false,
  "error_envelope":         "openai",
  "reasoning_field":        "delta.reasoning_content"
}
```

**Zero behavior change.** Nothing in `OpenAiBridge::chat()` /
`chat_stream()` consumes these functions yet; the module sits in
`aisix-provider-openai::overrides` as standalone utilities. Phase D
wires them into the Bridge dispatch path when the new contract
cuts over.

## Why primitive parameter types, not `RequestOverrides` / `ResponseOverrides`

PR #298 (Phase A2, merged) landed `provider` / `adapter` /
`telemetry_tags` on `ProviderKey` but did **not** add the `request`
or `response` blocks. Those struct types don't exist in the
codebase yet. Rather than invent them here (and force a second PR
to rename when Phase A's later sub-PRs land them), each function
takes the smallest primitive that lets callers pass field values
straight through:

| Function | Parameter |
|---|---|
| `apply_param_renames` | `&HashMap<String, String>` |
| `apply_param_constraints` | `&Constraints` (module-local, temperature only) |
| `apply_default_headers` | `&HashMap<String, String>` |
| `apply_default_body_fields` | `&serde_json::Map<String, Value>` |
| `apply_stream_done_marker_policy` | `StreamDoneMarker` enum + `bool` |
| `apply_content_list_to_string` | `&mut serde_json::Value` (request body) |
| `extract_reasoning_field` | `&mut Value`, `&str` path |

When the struct types do land, the future Bridge wire-up passes
the field values straight in. The override behavior is decoupled
from the on-disk schema shape.

## What the module does NOT do

- ❌ Does not touch `OpenAiBridge::chat()` / `chat_stream()` / any
  dispatch path
- ❌ Does not modify `RuntimeConfig` types (none of the override
  struct types exist yet — see above)
- ❌ Does not touch `Hub`, `lib`, `wire`, or `bridge` files beyond
  one `pub mod overrides;` line in `lib.rs`
- ❌ Does not create a new crate

## Reference implementations consulted

- LiteLLM `convert_content_list_to_str` —
  [common_utils.py](https://github.com/BerriAI/litellm/blob/main/litellm/litellm_core_utils/prompt_templates/common_utils.py).
  Reference behavior: concatenate text fields of every `type:"text"`
  block with no separator, drop non-text blocks. Tests pin this
  contract.
- LiteLLM `convert_content_list_to_string` flag —
  [openai_like/dynamic_config.py](https://github.com/BerriAI/litellm/blob/main/litellm/llms/openai_like/dynamic_config.py).
  Confirms this is per-provider opt-in, not a default transform.
- DeepSeek `delta.reasoning_content` shape —
  [reasoning_model docs](https://api-docs.deepseek.com/guides/reasoning_model).
  Source of the `extract_reasoning_field` canonical-slot choice.
- OpenAI SSE `data: [DONE]` terminator —
  [chat/streaming](https://platform.openai.com/docs/api-reference/chat/streaming).
  Source of the `Required` policy's wire definition.

## Test plan

- [x] `cargo test -p aisix-provider-openai --lib` — 62 passed (+35 over main)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `apply_param_renames`: key-present, key-absent, value-type-preserved, multiple renames, existing-target wins, no-op self-rename, non-object body
- [x] `apply_param_constraints`: above max, within range, below min, missing field, non-number value, empty constraints
- [x] `apply_default_headers`: missing header added, existing header preserved (case-insensitive), unparseable name skipped
- [x] `apply_default_body_fields`: missing added, existing preserved, non-object no-op
- [x] `apply_stream_done_marker_policy`: required+seen, required+missing, optional (both), none (both)
- [x] `apply_content_list_to_string`: two-text-block flatten, string content untouched, image-only preserved (don't drop), text + non-text mixed, no-messages-field no-op
- [x] `extract_reasoning_field`: canonical-path no-op, nested-path lift, missing source no-op, empty-string source no-op, non-delta root rejected, multiple choices

## References

- Tracking issue: api7/AISIX-Cloud#302
- Predecessors: #297 (Adapter enum), #298 (Phase A2 ProviderKey fields), #299 (Phase A rerank refactor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request and response override utilities for improved provider compatibility, including parameter transformation, temperature constraints, header and body field defaults, and content normalization.

* **Chores**
  * Added `http` dependency to the OpenAI provider crate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->