### PR TITLE
chore(core): derive JsonSchema on resource types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "once_cell",
  "regex",
  "rstest",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3775,6 +3776,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -3795,6 +3808,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -3866,6 +3891,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/aisix-core/Cargo.toml
+++ b/crates/aisix-core/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 config.workspace = true
 humantime-serde.workspace = true
 jsonschema.workspace = true
+schemars.workspace = true
 once_cell.workspace = true
 regex.workspace = true
 # ApiKey::hash_bearer (prd-09a §9A.7B.4) is the canonical SHA-256 the

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use super::rate_limit::RateLimit;
 use crate::resource::Resource;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ApiKey {
     /// SHA-256 hex of the plaintext bearer. Secondary-indexed for

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -18,7 +18,9 @@ use crate::resource::Resource;
 /// Cache backend choice. `Memory` is enforced by the DP today;
 /// `Redis` is the kine-level wire-shape stub for the upcoming
 /// shared-cluster backend (DP enforcement pending).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum CacheBackend {
     #[default]
@@ -35,7 +37,7 @@ pub enum CacheBackend {
 /// new fields ahead of a DP rollout without a hard reject. New
 /// optional fields land at `#[serde(default)]` here on the next DP
 /// release.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct CachePolicy {
     /// Operator-facing name; surfaces in metric labels + cache headers.
     pub name: String,

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -32,7 +32,9 @@ use serde::{Deserialize, Serialize};
 use crate::resource::Resource;
 
 /// What part of the request lifecycle a guardrail inspects.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum GuardrailHookPoint {
     /// Run on the request payload before bridge dispatch.
@@ -49,7 +51,7 @@ pub enum GuardrailHookPoint {
 /// `Regex` to a compiled `regex::Regex`. Invalid regex at parse
 /// time is loader-rejected (the DP refuses to apply a guardrail it
 /// can't compile, so a typo doesn't silently disarm the policy).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", content = "value", rename_all = "lowercase")]
 pub enum KeywordPattern {
     Literal(String),
@@ -57,7 +59,7 @@ pub enum KeywordPattern {
 }
 
 /// Config block for `kind: "keyword"`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct KeywordConfig {
     /// Blocklist patterns. Empty list is legal but pointless — the
@@ -73,7 +75,7 @@ pub struct KeywordConfig {
 /// envelope-encrypted secret at projection time (same trust
 /// boundary as `provider_keys` — see PRD-09c §6.3). The DP only
 /// ever holds plaintext in memory; it does not need a master key.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum BedrockAWSCredentials {
     Static {
@@ -89,7 +91,7 @@ pub enum BedrockAWSCredentials {
 /// waits unconditionally; `timed` aborts at `timeout_ms` and
 /// applies the row-level `fail_open` flag. Range matches cp-api's
 /// validator (100..5000ms) — see PRD-09c §6.6.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum BedrockLatencyMode {
     Serial,
@@ -99,7 +101,7 @@ pub enum BedrockLatencyMode {
 /// Config block for `kind: "bedrock"`. Phase 1 stores the shape +
 /// passes it through `aisix-guardrails::build` which logs
 /// `bedrock not yet implemented` and skips the row.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BedrockConfig {
     /// AWS-console-issued guardrail identifier (12 chars today).
@@ -116,7 +118,7 @@ pub struct BedrockConfig {
 
 /// Provider discriminator. The kind drives which `*_config` block is
 /// expected; serde's `tag = "kind"` keeps us honest at parse time.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum GuardrailKind {
     /// In-process literal/regex blocklist. Always available.
@@ -137,7 +139,7 @@ pub enum GuardrailKind {
 /// inner enum needs. Strict typo-rejection happens earlier in the
 /// JSON Schema (`schema::validate_guardrail`) which the loader
 /// runs before deserialise on every watch event.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct Guardrail {
     /// Operator-facing name; surfaces in metric labels + error reasons.
     pub name: String,

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -18,7 +18,7 @@ use super::routing::Routing;
 use crate::resource::Resource;
 
 /// Supported upstream providers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Provider {
     Openai,
@@ -77,7 +77,7 @@ impl Provider {
 /// variant serializes as `"azure-openai"`. This intentionally differs
 /// from `Provider`'s `lowercase` casing, which produced no hyphens
 /// because all current `Provider` names are single tokens.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum Adapter {
     Openai,
@@ -130,7 +130,7 @@ impl From<Provider> for Adapter {
 }
 
 /// Per-token cost for budget tracking. Both values are in USD per 1,000 tokens.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ModelCost {
     /// Input (prompt) token cost in USD per 1,000 tokens.
@@ -148,7 +148,7 @@ impl ModelCost {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BackgroundModelCheck {
     pub enabled: bool,
@@ -175,7 +175,7 @@ pub struct BackgroundModelCheck {
 ///
 /// All fields are optional; defaults preserve a safe behavior for any
 /// direct model that doesn't ship a `cooldown` block.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CooldownConfig {
     /// Whether cooldown is active for this model. Default: true.
@@ -253,7 +253,7 @@ impl CooldownConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Model {
     /// Operator-facing unique label. Surfaces on `/v1/models`,

--- a/crates/aisix-core/src/models/observability_exporter.rs
+++ b/crates/aisix-core/src/models/observability_exporter.rs
@@ -41,13 +41,13 @@ use crate::resource::Resource;
 /// `tag = "kind"` puts the variant tag inline with the inner struct's
 /// fields — same shape as `GuardrailKind` so the kine wire stays
 /// consistent across resource types.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ExporterKind {
     OtlpHttp(OtlpHttpConfig),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct OtlpHttpConfig {
     /// Full URL of the OTLP/HTTP traces endpoint. Must already include
@@ -70,7 +70,7 @@ pub struct OtlpHttpConfig {
 /// field. Strict typo rejection happens at the JSON Schema layer
 /// (`schema::validate_observability_exporter`) which the etcd loader
 /// runs before the serde deserialize.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct ObservabilityExporter {
     /// Operator-facing label, surfaced in /logs and the dashboard list.
     /// Not used for routing — the etcd-key uuid is the identity.

--- a/crates/aisix-core/src/models/provider_key.rs
+++ b/crates/aisix-core/src/models/provider_key.rs
@@ -26,7 +26,7 @@ use crate::resource::Resource;
 // `default_body_fields`), neither of which can implement `Eq` due to
 // NaN / Number-equality semantics. Tests compare via `assert_eq!`
 // which only needs `PartialEq`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ProviderKey {
     /// Operator-facing label, unique within the gateway. Surfaces in
@@ -101,7 +101,7 @@ pub struct ProviderKey {
 /// means an omitted block or omitted individual key both yield the
 /// zero-value `TelemetryTags`, preserving backward compatibility
 /// with existing `ProviderKey` payloads.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct TelemetryTags {
     /// `"catalog"` for first-party curated providers, `"byo"` for
@@ -145,7 +145,7 @@ pub struct TelemetryTags {
 ///
 /// `f64` in [`ParamConstraints`] is the reason the parent
 /// [`ProviderKey`] derives `PartialEq` rather than `Eq`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct RequestOverrides {
     /// `apply_param_renames` input. Top-level body keys named on the
@@ -179,7 +179,7 @@ pub struct RequestOverrides {
 ///
 /// `f64` not `Eq`: NaN comparisons make a derived `Eq` unsound.
 /// [`PartialEq`] is enough for the round-trip test.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ParamConstraints {
     /// Upper bound for `temperature`. Values above this are clamped
@@ -208,7 +208,7 @@ pub struct ParamConstraints {
 /// `error_envelope` is on-disk only — issue #302 §5 keeps it as a
 /// `"openai" | "passthrough"` string so cp-api can iterate without
 /// a Rust-side enum migration. Phase D pins the closed set.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ResponseOverrides {
     /// Stream `[DONE]` terminator expectation. `None` means "no
@@ -246,7 +246,7 @@ pub struct ResponseOverrides {
 /// The runtime apply function lives in `aisix-provider-openai`
 /// (`apply_stream_done_marker_policy`) and consumes this enum
 /// directly via re-export from `aisix-core`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum StreamDoneMarker {
     /// Upstream must emit `data: [DONE]`. Absence is a wire-shape

--- a/crates/aisix-core/src/models/rate_limit.rs
+++ b/crates/aisix-core/src/models/rate_limit.rs
@@ -8,7 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RateLimit {
     /// Tokens per minute (60s window).

--- a/crates/aisix-core/src/models/rate_limit_policy.rs
+++ b/crates/aisix-core/src/models/rate_limit_policy.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::resource::Resource;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RateLimitPolicy {
     pub name: String,

--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -15,7 +15,9 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum RoutingStrategy {
     RoundRobin,
@@ -28,7 +30,7 @@ pub enum RoutingStrategy {
 
 /// One destination in a routing config. `model` references another
 /// `Model.name` in the snapshot.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct RoutingTarget {
     pub model: String,
@@ -64,7 +66,9 @@ impl RoutingTarget {
 /// amplifies cascading outages. Operators that prefer the legacy
 /// behavior (try every candidate regardless of known state) can opt
 /// into `OriginalOrder` per routing model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum OnAllFilteredPolicy {
     /// Return 503 with a fixed Retry-After hint (currently 30 seconds —
@@ -86,7 +90,7 @@ pub enum OnAllFilteredPolicy {
     OriginalOrder,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Routing {
     #[serde(default)]


### PR DESCRIPTION
## Summary

Adds `schemars::JsonSchema` derive to every public resource struct and enum under `crates/aisix-core/src/models/`, and wires `schemars.workspace = true` into `aisix-core`'s dependencies.

The workspace had `schemars = "0.8"` pinned in `Cargo.toml` but no crate consumed it. This PR fills that gap.

## Resources touched (32 types across 9 files)

| File | Types |
|---|---|
| `apikey.rs` | `ApiKey` |
| `cache_policy.rs` | `CacheBackend`, `CachePolicy` |
| `guardrail.rs` | `GuardrailHookPoint`, `KeywordPattern`, `KeywordConfig`, `BedrockAWSCredentials`, `BedrockLatencyMode`, `BedrockConfig`, `GuardrailKind`, `Guardrail` |
| `model.rs` | `Provider`, `Adapter`, `ModelCost`, `BackgroundModelCheck`, `CooldownConfig`, `Model` |
| `observability_exporter.rs` | `ExporterKind`, `OtlpHttpConfig`, `ObservabilityExporter` |
| `provider_key.rs` | `ProviderKey`, `TelemetryTags`, `RequestOverrides`, `ParamConstraints`, `ResponseOverrides`, `StreamDoneMarker` |
| `rate_limit.rs` | `RateLimit` |
| `rate_limit_policy.rs` | `RateLimitPolicy` |

> `AppliesTo` (in `cache_policy.rs`) intentionally has no `Serialize` / `Deserialize` / `JsonSchema` — it's a runtime-parsed typed view of `CachePolicy::applies_to: String`. The other three on-disk-irrelevant types (`AisixSnapshot`, `Schemas`, `SchemaError`) are also correctly excluded.
| `routing.rs` | `RoutingStrategy`, `RoutingTarget`, `OnAllFilteredPolicy`, `Routing` |

## Why

Refs api7/ai-gateway#304 item #1 (canonical JSON Schema as config source of truth). This PR is the foundational derive pass — **no schema files are emitted yet**. The next PR adds a `dump-schema` binary that walks these derives and writes `schemas/resources/*.schema.json` files for downstream consumers (AISIX-Cloud cp-api, dashboard form rendering, docs).

Doing this in isolation lets the compiler validate serde↔schemars compatibility across all 32 types **before** any tooling depends on the output shape.

## Scope

Zero behavior change. `JsonSchema` is a pure compile-time additional trait impl. It does not affect:

- serde serialize / deserialize paths
- request dispatch (`Hub`, `Bridge`)
- etcd watch / loader
- snapshot rotation (`ArcSwap`)
- runtime configuration

All existing serde annotations (`deny_unknown_fields`, `rename_all`, `default`, `skip_serializing_if`, `skip`) are honored verbatim by `schemars` 0.8.

## Verification

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p aisix-core --lib` — 168 passed, 0 failed

## Follow-ups (separate PRs)

- Add `dump-schema` binary + commit initial `schemas/resources/*.schema.json` files
- Add CI drift check (regenerate schemas in CI, fail if `git diff` is non-empty)
- Refactor `crates/aisix-admin/src/openapi.rs` to `$ref` the generated schema files (drops the current inline schema duplication)

Refs api7/ai-gateway#304 (#1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON Schema metadata support to core API models and configuration types, enabling automatic schema generation for improved API documentation and enhanced integration with development tools and code generators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
