### PR TITLE
ci: add schema drift check for resource JSON Schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,26 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  schema-drift:
+    name: schema drift (resources)
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+      - name: regenerate schemas
+        run: cargo run -p aisix-core --bin dump-schema
+      - name: assert no drift
+        run: |
+          if ! git diff --exit-code schemas/; then
+            echo "::error::Resource JSON Schemas in 'schemas/resources/' drift from the Rust types in 'crates/aisix-core/src/models/'."
+            echo "::error::Fix: run 'cargo run -p aisix-core --bin dump-schema' locally and commit the diff."
+            exit 1
+          fi
+
   rust-unit:
     name: rust unit + coverage
     runs-on: ubicloud-standard-2


### PR DESCRIPTION
> **Stacked on #308.** Base will switch to `main` once #308 merges.

## Summary

Adds a `schema-drift` job to `.github/workflows/ci.yml` that:

1. Runs `cargo run -p aisix-core --bin dump-schema`
2. Asserts `git diff --exit-code schemas/` is clean

PRs that modify a resource struct in `crates/aisix-core/src/models/` but forget to regenerate the schema files now fail CI with a fix instruction in the error message:

> ::error::Resource JSON Schemas in 'schemas/resources/' drift from the Rust types in 'crates/aisix-core/src/models/'.
> ::error::Fix: run 'cargo run -p aisix-core --bin dump-schema' locally and commit the diff.

## Why

Refs api7/ai-gateway#304 item #1. The `dump-schema` tool and the nine `schemas/resources/*.schema.json` files landed in #308. Without an enforcement mechanism the committed schemas can silently diverge from the Rust types as the resource graph evolves — especially relevant during issue #302 Phase A, which is actively mutating `ProviderKey` and `Model`. This job is that enforcement.

## Job placement

Sits as a peer to `lint` — fast, independent, no service dependencies. Runs in parallel with `lint`, `rust-unit`, and `build-bin`. Not a `needs:` target of any downstream job, so a drift failure does not block e2e or coverage signals.

## Verification

**Positive path:**
- `cargo run -p aisix-core --bin dump-schema` on HEAD succeeds
- `git diff --exit-code schemas/` is empty (no drift in tree)

**Negative path (proving the check actually catches drift):**
- Locally truncated `schemas/resources/api_key.schema.json` to `{}`
- `git diff --exit-code schemas/` returned non-zero ✓
- Reverted with `git checkout schemas/resources/api_key.schema.json`
- `git diff --exit-code schemas/` clean again ✓

**Workflow file:**
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses successfully

## Diff (20 added lines)

```yaml
  schema-drift:
    name: schema drift (resources)
    runs-on: ubicloud-standard-2
    steps:
      - uses: actions/checkout@v4
      - uses: dtolnay/rust-toolchain@stable
      - uses: arduino/setup-protoc@v3
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
      - uses: Swatinem/rust-cache@v2
      - name: regenerate schemas
        run: cargo run -p aisix-core --bin dump-schema
      - name: assert no drift
        run: |
          if ! git diff --exit-code schemas/; then
            echo "::error::Resource JSON Schemas in 'schemas/resources/' drift from the Rust types in 'crates/aisix-core/src/models/'."
            echo "::error::Fix: run 'cargo run -p aisix-core --bin dump-schema' locally and commit the diff."
            exit 1
          fi
```

## Stack

Builds on #308 (binary + initial schemas), which builds on #307 (JsonSchema derives). Merge order: #307 → #308 → this PR.

Refs api7/ai-gateway#304 (#1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generated canonical JSON Schema files for core resource types (ApiKey, CachePolicy, Guardrail, Model, ObservabilityExporter, ProviderKey, RateLimit, RateLimitPolicy, Routing), providing structured documentation of configuration shapes and constraints.

* **Chores**
  * Added automated schema validation to CI to ensure schema definitions remain synchronized with resource definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->