### PR TITLE
feat(provider-vertex): add aisix-provider-vertex skeleton crate (D5, #302 §3 Phase E)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "aisix-provider-vertex"
+version = "0.1.0"
+dependencies = [
+ "aisix-core",
+ "aisix-gateway",
+ "async-trait",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "aisix-proxy"
 version = "0.1.0"
 dependencies = [
@@ -298,6 +311,7 @@ dependencies = [
  "aisix-obs",
  "aisix-provider-anthropic",
  "aisix-provider-openai",
+ "aisix-provider-vertex",
  "aisix-proxy",
  "aisix-ratelimit",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/aisix-gateway",
     "crates/aisix-provider-openai",
     "crates/aisix-provider-anthropic",
+    "crates/aisix-provider-vertex",
     "crates/aisix-proxy",
     "crates/aisix-admin",
     "crates/aisix-obs",

--- a/crates/aisix-provider-vertex/Cargo.toml
+++ b/crates/aisix-provider-vertex/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aisix-provider-vertex"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "aisix: Google Vertex AI provider bridge (skeleton — multi-publisher dispatch)"
+
+[dependencies]
+aisix-core = { path = "../aisix-core" }
+aisix-gateway = { path = "../aisix-gateway" }
+async-trait.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+serde_json.workspace = true

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -1,0 +1,333 @@
+//! `VertexBridge` — family Bridge for [`Adapter::Vertex`].
+//!
+//! Skeleton: structure + publisher resolution + Hub-registrable
+//! shell. The actual HTTP dispatch lands in follow-up PRs (see
+//! crate-level docs).
+
+use aisix_gateway::{
+    Bridge, BridgeContext, BridgeError, ChatChunkStream, ChatFormat, ChatResponse,
+};
+use async_trait::async_trait;
+
+use crate::wire;
+
+/// Family Bridge for Google Vertex AI. Registered as the
+/// `Adapter::Vertex` family entry in `Hub::register_family` — a
+/// provider_key with `adapter: "vertex"` dispatches here regardless of
+/// which Vertex publisher it targets (Gemini, Anthropic-on-Vertex,
+/// Llama, Mistral, AI21, GPT-OSS). The publisher is resolved from the
+/// upstream model id at dispatch time per the LiteLLM `vertex_ai/`
+/// convention.
+///
+/// **Skeleton:** the bridge compiles, registers, and surfaces a clear
+/// `BridgeError::Config` on every call. Real dispatch is wired in
+/// follow-up PRs — see [`crate`] docs.
+pub struct VertexBridge {
+    /// Static `name()` returned to the Hub. Kept for metrics-label
+    /// stability even though we don't have a transport yet.
+    name: &'static str,
+}
+
+impl VertexBridge {
+    /// Construct a Vertex bridge with the canonical name `"vertex"`.
+    /// The Hub looks this up via [`Bridge::name`] when emitting
+    /// per-request metrics (provider label).
+    pub fn new() -> Self {
+        Self { name: "vertex" }
+    }
+}
+
+impl Default for VertexBridge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The set of Vertex publishers we will eventually dispatch to.
+/// Public so cp-api / dashboard can surface "which Vertex publishers
+/// are supported" without re-deriving the list from the upstream id
+/// parser.
+///
+/// New publishers added here MUST also be handled in
+/// [`VertexPublisher::from_upstream_id`] and the dispatch match in
+/// `chat` / `chat_stream`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexPublisher {
+    /// `publishers/google/models/gemini-*` — Google's own Gemini line.
+    Google,
+    /// `publishers/anthropic/models/claude-*` — Anthropic models hosted
+    /// on Vertex. Wire shape is `streamRawPredict`, not canonical
+    /// Anthropic Messages.
+    Anthropic,
+    /// `publishers/meta/models/llama-*` — Meta's Llama family.
+    Meta,
+    /// `publishers/mistralai/models/mistral-*` — Mistral on Vertex.
+    Mistral,
+    /// `publishers/ai21/models/jamba-*` — AI21 Jamba family.
+    Ai21,
+}
+
+impl VertexPublisher {
+    /// Resolve the publisher from the upstream model id, following the
+    /// LiteLLM `vertex_ai/` convention. Returns `None` for ids that
+    /// don't match any known publisher prefix — caller surfaces a
+    /// clear `BridgeError::Config` so the operator can correct the
+    /// model registration.
+    ///
+    /// Recognized prefixes (case-insensitive on the model name itself,
+    /// not on the publisher tag):
+    ///
+    /// - `gemini-*` → [`Self::Google`]
+    /// - `claude-*` → [`Self::Anthropic`]
+    /// - `llama-*` → [`Self::Meta`]
+    /// - `mistral-*` / `codestral-*` → [`Self::Mistral`]
+    /// - `jamba-*` → [`Self::Ai21`]
+    pub fn from_upstream_id(upstream_id: &str) -> Option<Self> {
+        let lower = upstream_id.to_ascii_lowercase();
+        if lower.starts_with("gemini-") {
+            Some(Self::Google)
+        } else if lower.starts_with("claude-") {
+            Some(Self::Anthropic)
+        } else if lower.starts_with("llama-") {
+            Some(Self::Meta)
+        } else if lower.starts_with("mistral-") || lower.starts_with("codestral-") {
+            Some(Self::Mistral)
+        } else if lower.starts_with("jamba-") {
+            Some(Self::Ai21)
+        } else {
+            None
+        }
+    }
+
+    /// The `publishers/<tag>` URL segment Vertex expects. Used by the
+    /// follow-up dispatch PR when building per-publisher endpoint URLs.
+    pub fn url_segment(self) -> &'static str {
+        match self {
+            Self::Google => "publishers/google",
+            Self::Anthropic => "publishers/anthropic",
+            Self::Meta => "publishers/meta",
+            Self::Mistral => "publishers/mistralai",
+            Self::Ai21 => "publishers/ai21",
+        }
+    }
+}
+
+#[async_trait]
+impl Bridge for VertexBridge {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn chat(
+        &self,
+        req: &ChatFormat,
+        _ctx: &BridgeContext,
+    ) -> Result<ChatResponse, BridgeError> {
+        // Skeleton: validate the publisher resolution path so a
+        // misconfigured upstream_id surfaces a clear error today,
+        // even though the actual HTTP call is TODO.
+        let _publisher = VertexPublisher::from_upstream_id(&req.model).ok_or_else(|| {
+            BridgeError::Config(format!(
+                "vertex publisher unknown for upstream model id {:?}; \
+                 expected one of gemini-* / claude-* / llama-* / mistral-* / jamba-*",
+                req.model
+            ))
+        })?;
+        // Reserved-config helper exercised by tests: keeps the wire
+        // module reachable from the public surface so a future
+        // dispatch PR can drop its body straight in.
+        let _ = wire::reserved_query_params();
+        Err(BridgeError::Config(
+            "vertex bridge is not yet implemented — \
+             tracked under api7/AISIX-Cloud#302 Phase E (D5)"
+                .into(),
+        ))
+    }
+
+    async fn chat_stream(
+        &self,
+        req: &ChatFormat,
+        _ctx: &BridgeContext,
+    ) -> Result<ChatChunkStream, BridgeError> {
+        let _publisher = VertexPublisher::from_upstream_id(&req.model).ok_or_else(|| {
+            BridgeError::Config(format!(
+                "vertex publisher unknown for upstream model id {:?}; \
+                 expected one of gemini-* / claude-* / llama-* / mistral-* / jamba-*",
+                req.model
+            ))
+        })?;
+        Err(BridgeError::Config(
+            "vertex bridge is not yet implemented — \
+             tracked under api7/AISIX-Cloud#302 Phase E (D5)"
+                .into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publisher_resolves_gemini_prefix() {
+        assert_eq!(
+            VertexPublisher::from_upstream_id("gemini-1.5-pro"),
+            Some(VertexPublisher::Google),
+        );
+        assert_eq!(
+            VertexPublisher::from_upstream_id("gemini-2.0-flash-exp"),
+            Some(VertexPublisher::Google),
+        );
+    }
+
+    #[test]
+    fn publisher_resolves_anthropic_prefix() {
+        // Vertex hosts Claude under the `claude-*` model id with an
+        // `@version` suffix; the prefix match must tolerate that.
+        assert_eq!(
+            VertexPublisher::from_upstream_id("claude-3-5-sonnet@20241022"),
+            Some(VertexPublisher::Anthropic),
+        );
+        assert_eq!(
+            VertexPublisher::from_upstream_id("claude-3-haiku@20240307"),
+            Some(VertexPublisher::Anthropic),
+        );
+    }
+
+    #[test]
+    fn publisher_resolves_meta_mistral_ai21_prefixes() {
+        assert_eq!(
+            VertexPublisher::from_upstream_id("llama-3-70b-instruct-maas"),
+            Some(VertexPublisher::Meta),
+        );
+        assert_eq!(
+            VertexPublisher::from_upstream_id("mistral-large-2411"),
+            Some(VertexPublisher::Mistral),
+        );
+        assert_eq!(
+            VertexPublisher::from_upstream_id("codestral-2501"),
+            Some(VertexPublisher::Mistral),
+        );
+        assert_eq!(
+            VertexPublisher::from_upstream_id("jamba-1.5-large"),
+            Some(VertexPublisher::Ai21),
+        );
+    }
+
+    #[test]
+    fn publisher_case_insensitive_on_model_name() {
+        assert_eq!(
+            VertexPublisher::from_upstream_id("Gemini-1.5-Pro"),
+            Some(VertexPublisher::Google),
+        );
+    }
+
+    #[test]
+    fn publisher_unknown_prefix_returns_none() {
+        assert_eq!(VertexPublisher::from_upstream_id("gpt-4o"), None);
+        assert_eq!(VertexPublisher::from_upstream_id(""), None);
+        assert_eq!(
+            VertexPublisher::from_upstream_id("not-a-vendor-model"),
+            None
+        );
+    }
+
+    #[test]
+    fn publisher_url_segment_matches_vertex_api_path() {
+        // Tight pin on the URL fragment Vertex expects — a typo here
+        // would surface as a 404 from every Vertex dispatch.
+        assert_eq!(VertexPublisher::Google.url_segment(), "publishers/google");
+        assert_eq!(
+            VertexPublisher::Anthropic.url_segment(),
+            "publishers/anthropic",
+        );
+        assert_eq!(VertexPublisher::Meta.url_segment(), "publishers/meta");
+        // Mistral's Vertex publisher tag is `mistralai`, not `mistral`
+        // — Google's catalog convention.
+        assert_eq!(
+            VertexPublisher::Mistral.url_segment(),
+            "publishers/mistralai",
+        );
+        assert_eq!(VertexPublisher::Ai21.url_segment(), "publishers/ai21");
+    }
+
+    #[test]
+    fn bridge_name_is_stable() {
+        // Metrics label is part of the public contract — a rename
+        // would silently break customer dashboards.
+        assert_eq!(VertexBridge::new().name(), "vertex");
+    }
+
+    use aisix_core::{Model, ProviderKey};
+    use aisix_gateway::ChatMessage;
+    use std::sync::Arc;
+
+    fn sample_model() -> Arc<Model> {
+        Arc::new(
+            serde_json::from_str(
+                r#"{
+                    "display_name": "my-gemini",
+                    "provider": "google",
+                    "model_name": "gemini-1.5-pro",
+                    "provider_key_id": "11111111-1111-1111-1111-111111111111"
+                }"#,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn sample_pk() -> Arc<ProviderKey> {
+        Arc::new(
+            serde_json::from_str(r#"{"display_name": "vertex-prod", "secret": "ya29.test"}"#)
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn chat_surfaces_clear_not_implemented_error() {
+        // Skeleton contract: dispatch returns Config error with the
+        // tracking-issue link, so an operator who lands here knows
+        // the path is intentional-WIP not silently-broken.
+        let bridge = VertexBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(), sample_pk());
+        let req = ChatFormat::new("gemini-1.5-pro", vec![ChatMessage::user("hi")]);
+        let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        match err {
+            BridgeError::Config(msg) => {
+                assert!(
+                    msg.contains("vertex bridge is not yet implemented"),
+                    "error message must call out the WIP status; got {msg}"
+                );
+                assert!(
+                    msg.contains("#302"),
+                    "error message must link to the tracking issue; got {msg}"
+                );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn chat_with_unknown_publisher_prefix_errors_before_dispatch() {
+        // The publisher-resolution guard fires before the
+        // not-implemented stub — proves the bridge will route per
+        // upstream_id once the dispatch lands.
+        let bridge = VertexBridge::new();
+        let ctx = BridgeContext::new("req-1", sample_model(), sample_pk());
+        let req = ChatFormat::new("gpt-4o", vec![ChatMessage::user("hi")]);
+        let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        match err {
+            BridgeError::Config(msg) => {
+                assert!(
+                    msg.contains("vertex publisher unknown"),
+                    "must mention publisher resolution failure; got {msg}"
+                );
+                assert!(
+                    msg.contains("gpt-4o"),
+                    "must include the offending upstream id; got {msg}"
+                );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+}

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -143,17 +143,26 @@ impl Bridge for VertexBridge {
 
     async fn chat(
         &self,
-        req: &ChatFormat,
-        _ctx: &BridgeContext,
+        _req: &ChatFormat,
+        ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
         // Skeleton: validate the publisher resolution path so a
         // misconfigured upstream_id surfaces a clear error today,
         // even though the actual HTTP call is TODO.
-        let _publisher = VertexPublisher::from_upstream_id(&req.model).ok_or_else(|| {
+        //
+        // IMPORTANT: the Vertex upstream model id (e.g.
+        // `gemini-1.5-pro`, `claude-3-5-sonnet@20241022`) lives on
+        // Model.model_name, NOT on req.model (which is the
+        // gateway-internal display name the customer typed in
+        // `/v1/chat/completions`). See OpenAiBridge /
+        // `upstream_model(ctx)` for the established pattern. This
+        // is the D6 audit HIGH-1 fix backported.
+        let upstream_id = upstream_model(ctx)?;
+        let _publisher = VertexPublisher::from_upstream_id(upstream_id).ok_or_else(|| {
             BridgeError::Config(format!(
-                "vertex publisher unknown for upstream model id {:?}; \
-                 expected one of gemini-* / claude-* / llama-* / mistral-* / jamba-*",
-                req.model
+                "vertex publisher unknown for upstream model id {upstream_id:?}; \
+                 expected one of gemini-* / claude-* / meta/llama-* or llama* / \
+                 mistral-* / jamba-*"
             ))
         })?;
         // Reserved-config helper exercised by tests: keeps the wire
@@ -169,14 +178,15 @@ impl Bridge for VertexBridge {
 
     async fn chat_stream(
         &self,
-        req: &ChatFormat,
-        _ctx: &BridgeContext,
+        _req: &ChatFormat,
+        ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let _publisher = VertexPublisher::from_upstream_id(&req.model).ok_or_else(|| {
+        let upstream_id = upstream_model(ctx)?;
+        let _publisher = VertexPublisher::from_upstream_id(upstream_id).ok_or_else(|| {
             BridgeError::Config(format!(
-                "vertex publisher unknown for upstream model id {:?}; \
-                 expected one of gemini-* / claude-* / llama-* / mistral-* / jamba-*",
-                req.model
+                "vertex publisher unknown for upstream model id {upstream_id:?}; \
+                 expected one of gemini-* / claude-* / meta/llama-* or llama* / \
+                 mistral-* / jamba-*"
             ))
         })?;
         Err(BridgeError::Config(
@@ -185,6 +195,18 @@ impl Bridge for VertexBridge {
                 .into(),
         ))
     }
+}
+
+/// Pull the upstream model id off the BridgeContext. Vertex model ids
+/// (e.g. `gemini-1.5-pro`, `claude-3-5-sonnet@20241022`,
+/// `meta/llama-3.3-70b-instruct-maas`) live on Model.model_name. The
+/// customer-facing display name in req.model is NOT the source of
+/// truth — that was D6 audit HIGH-1, backported here proactively.
+fn upstream_model(ctx: &BridgeContext) -> Result<&str, BridgeError> {
+    ctx.model
+        .model_name
+        .as_deref()
+        .ok_or_else(|| BridgeError::Config("model.model_name missing".into()))
 }
 
 #[cfg(test)]
@@ -307,18 +329,20 @@ mod tests {
     use aisix_gateway::ChatMessage;
     use std::sync::Arc;
 
-    fn sample_model() -> Arc<Model> {
-        Arc::new(
-            serde_json::from_str(
-                r#"{
-                    "display_name": "my-gemini",
-                    "provider": "google",
-                    "model_name": "gemini-1.5-pro",
-                    "provider_key_id": "11111111-1111-1111-1111-111111111111"
-                }"#,
-            )
-            .unwrap(),
-        )
+    /// Build a Model fixture where `model_name` (the upstream Vertex
+    /// id) and `display_name` (the customer-facing name) deliberately
+    /// differ. The bridge must dispatch off `model_name`, not the
+    /// typed display name in `req.model`.
+    fn sample_model_with(model_name: &str) -> Arc<Model> {
+        let cfg = format!(
+            r#"{{
+                "display_name": "customer-facing-name",
+                "provider": "google",
+                "model_name": {model_name:?},
+                "provider_key_id": "11111111-1111-1111-1111-111111111111"
+            }}"#
+        );
+        Arc::new(serde_json::from_str(&cfg).unwrap())
     }
 
     fn sample_pk() -> Arc<ProviderKey> {
@@ -334,8 +358,10 @@ mod tests {
         // tracking-issue link, so an operator who lands here knows
         // the path is intentional-WIP not silently-broken.
         let bridge = VertexBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(), sample_pk());
-        let req = ChatFormat::new("gemini-1.5-pro", vec![ChatMessage::user("hi")]);
+        let ctx = BridgeContext::new("req-1", sample_model_with("gemini-1.5-pro"), sample_pk());
+        // req.model is the customer-facing display name; the bridge
+        // must ignore it and resolve off Model.model_name.
+        let req = ChatFormat::new("customer-facing-name", vec![ChatMessage::user("hi")]);
         let err = bridge.chat(&req, &ctx).await.unwrap_err();
         match err {
             BridgeError::Config(msg) => {
@@ -352,14 +378,45 @@ mod tests {
         }
     }
 
+    /// D6 audit HIGH-1 regression (backported to D5): dispatch must
+    /// read the upstream model id from ctx.model.model_name, NOT
+    /// from req.model. req.model is the customer-typed display
+    /// name; resolving off it would produce `/<region>/projects/
+    /// .../publishers/google/models/<customer-display-name>` and
+    /// 404 from every Vertex request.
+    #[tokio::test]
+    async fn chat_ignores_req_model_and_uses_ctx_model_name() {
+        let bridge = VertexBridge::new();
+        // model_name = valid Vertex id; req.model = something the
+        // publisher resolver would reject if it were the source of
+        // truth. Expectation: the not-implemented stub fires,
+        // proving model_name was the actual input.
+        let ctx = BridgeContext::new("req-1", sample_model_with("gemini-1.5-pro"), sample_pk());
+        let req = ChatFormat::new("gpt-4o", vec![ChatMessage::user("hi")]);
+        let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        match err {
+            BridgeError::Config(msg) => {
+                assert!(
+                    msg.contains("not yet implemented"),
+                    "must hit the not-implemented stub (proving model_name was used); got {msg}"
+                );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn chat_with_unknown_publisher_prefix_errors_before_dispatch() {
-        // The publisher-resolution guard fires before the
-        // not-implemented stub — proves the bridge will route per
+        // Publisher-resolution guard fires when model_name is
+        // unrecognized — proves the bridge will route per
         // upstream_id once the dispatch lands.
         let bridge = VertexBridge::new();
-        let ctx = BridgeContext::new("req-1", sample_model(), sample_pk());
-        let req = ChatFormat::new("gpt-4o", vec![ChatMessage::user("hi")]);
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("totally-bogus-vertex-id"),
+            sample_pk(),
+        );
+        let req = ChatFormat::new("customer-facing-name", vec![ChatMessage::user("hi")]);
         let err = bridge.chat(&req, &ctx).await.unwrap_err();
         match err {
             BridgeError::Config(msg) => {
@@ -368,9 +425,37 @@ mod tests {
                     "must mention publisher resolution failure; got {msg}"
                 );
                 assert!(
-                    msg.contains("gpt-4o"),
-                    "must include the offending upstream id; got {msg}"
+                    msg.contains("totally-bogus-vertex-id"),
+                    "must include the offending model id; got {msg}"
                 );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    /// Defense: if Model.model_name is absent (shouldn't happen in
+    /// practice — cp-api requires it — but the field is
+    /// Option<String>), the bridge surfaces a clear error rather
+    /// than panicking or treating "" as a publisher.
+    #[tokio::test]
+    async fn chat_with_missing_model_name_errors_before_dispatch() {
+        let bridge = VertexBridge::new();
+        let model_no_name: Arc<Model> = Arc::new(
+            serde_json::from_str(
+                r#"{
+                    "display_name": "no-upstream-id",
+                    "provider": "google",
+                    "provider_key_id": "11111111-1111-1111-1111-111111111111"
+                }"#,
+            )
+            .unwrap(),
+        );
+        let ctx = BridgeContext::new("req-1", model_no_name, sample_pk());
+        let req = ChatFormat::new("customer-facing", vec![ChatMessage::user("hi")]);
+        let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        match err {
+            BridgeError::Config(msg) => {
+                assert!(msg.contains("model_name missing"), "got {msg}");
             }
             other => panic!("expected Config error, got {other:?}"),
         }

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -74,21 +74,35 @@ impl VertexPublisher {
     /// clear `BridgeError::Config` so the operator can correct the
     /// model registration.
     ///
-    /// Recognized prefixes (case-insensitive on the model name itself,
-    /// not on the publisher tag):
+    /// Recognized prefixes (case-insensitive on the model name):
     ///
     /// - `gemini-*` → [`Self::Google`]
     /// - `claude-*` → [`Self::Anthropic`]
-    /// - `llama-*` → [`Self::Meta`]
+    /// - `meta/llama-*` / `llama*` (e.g. `llama3-405b-...`) →
+    ///   [`Self::Meta`] (per LiteLLM `vertex_ai_partner_models/main.py`
+    ///   META_PREFIX = "meta/" plus the bare `llama` family)
     /// - `mistral-*` / `codestral-*` → [`Self::Mistral`]
     /// - `jamba-*` → [`Self::Ai21`]
+    ///
+    /// Publishers known to LiteLLM but not yet handled here (filed for
+    /// follow-up): `deepseek-ai/*`, `qwen*`, `openai/gpt-oss-*`,
+    /// `minimaxai/*`, `moonshotai/*`, `zai-org/*`. The current
+    /// implementation surfaces "publisher unknown" for these — an
+    /// operator hitting them gets a clear error before any traffic
+    /// reaches Vertex.
     pub fn from_upstream_id(upstream_id: &str) -> Option<Self> {
         let lower = upstream_id.to_ascii_lowercase();
         if lower.starts_with("gemini-") {
             Some(Self::Google)
         } else if lower.starts_with("claude-") {
             Some(Self::Anthropic)
-        } else if lower.starts_with("llama-") {
+        } else if lower.starts_with("meta/") || lower.starts_with("llama") {
+            // Both `meta/llama-3.3-70b-instruct-maas` and the bare
+            // `llama3-405b-instruct-maas` form occur on real Vertex
+            // deployments (per LiteLLM `vertex_ai_partner_models/
+            // main.py:33-34`). The bare-llama branch deliberately
+            // does NOT require a trailing hyphen — `llama3-...`
+            // would miss otherwise.
             Some(Self::Meta)
         } else if lower.starts_with("mistral-") || lower.starts_with("codestral-") {
             Some(Self::Mistral)
@@ -99,16 +113,25 @@ impl VertexPublisher {
         }
     }
 
-    /// The `publishers/<tag>` URL segment Vertex expects. Used by the
-    /// follow-up dispatch PR when building per-publisher endpoint URLs.
-    pub fn url_segment(self) -> &'static str {
-        match self {
+    /// The `publishers/<tag>` URL segment Vertex expects on the
+    /// `:streamRawPredict` and `:rawPredict` request paths. Used by
+    /// the follow-up dispatch PR when building per-publisher endpoint
+    /// URLs.
+    ///
+    /// **Returns `None` for [`Self::Meta`]** — Llama on Vertex does
+    /// NOT use a `publishers/meta/...` URL. LiteLLM routes Llama
+    /// through an OpenAPI shim at `endpoints/openapi/chat/completions`
+    /// instead (see `litellm/llms/vertex_ai/vertex_llm_base.py:277`).
+    /// A future D5.4 (Meta dispatch) builds that URL separately rather
+    /// than via this helper.
+    pub fn url_segment(self) -> Option<&'static str> {
+        Some(match self {
             Self::Google => "publishers/google",
             Self::Anthropic => "publishers/anthropic",
-            Self::Meta => "publishers/meta",
             Self::Mistral => "publishers/mistralai",
             Self::Ai21 => "publishers/ai21",
-        }
+            Self::Meta => return None,
+        })
     }
 }
 
@@ -196,8 +219,17 @@ mod tests {
 
     #[test]
     fn publisher_resolves_meta_mistral_ai21_prefixes() {
+        // Both wire forms occur on real Vertex deployments:
+        //   - `meta/llama-3.3-70b-instruct-maas` (META_PREFIX in
+        //     LiteLLM vertex_ai_partner_models/main.py)
+        //   - `llama3-405b-instruct-maas` (bare-llama form, no
+        //     trailing hyphen between "llama" and the version)
         assert_eq!(
-            VertexPublisher::from_upstream_id("llama-3-70b-instruct-maas"),
+            VertexPublisher::from_upstream_id("meta/llama-3.3-70b-instruct-maas"),
+            Some(VertexPublisher::Meta),
+        );
+        assert_eq!(
+            VertexPublisher::from_upstream_id("llama3-405b-instruct-maas"),
             Some(VertexPublisher::Meta),
         );
         assert_eq!(
@@ -236,19 +268,32 @@ mod tests {
     fn publisher_url_segment_matches_vertex_api_path() {
         // Tight pin on the URL fragment Vertex expects — a typo here
         // would surface as a 404 from every Vertex dispatch.
-        assert_eq!(VertexPublisher::Google.url_segment(), "publishers/google");
+        assert_eq!(
+            VertexPublisher::Google.url_segment(),
+            Some("publishers/google"),
+        );
         assert_eq!(
             VertexPublisher::Anthropic.url_segment(),
-            "publishers/anthropic",
+            Some("publishers/anthropic"),
         );
-        assert_eq!(VertexPublisher::Meta.url_segment(), "publishers/meta");
         // Mistral's Vertex publisher tag is `mistralai`, not `mistral`
         // — Google's catalog convention.
         assert_eq!(
             VertexPublisher::Mistral.url_segment(),
-            "publishers/mistralai",
+            Some("publishers/mistralai"),
         );
-        assert_eq!(VertexPublisher::Ai21.url_segment(), "publishers/ai21");
+        assert_eq!(VertexPublisher::Ai21.url_segment(), Some("publishers/ai21"));
+    }
+
+    #[test]
+    fn publisher_url_segment_meta_is_none() {
+        // Llama on Vertex does NOT use `publishers/meta/...` —
+        // LiteLLM routes through `endpoints/openapi/chat/completions`
+        // (see vertex_llm_base.py:277). Pinning `None` here so a
+        // future dispatch PR can rely on the helper's signal and
+        // build the OpenAPI-shim URL separately for Meta instead of
+        // synthesizing a 404-producing path.
+        assert_eq!(VertexPublisher::Meta.url_segment(), None);
     }
 
     #[test]

--- a/crates/aisix-provider-vertex/src/lib.rs
+++ b/crates/aisix-provider-vertex/src/lib.rs
@@ -1,0 +1,57 @@
+//! aisix-provider-vertex — Google Vertex AI provider bridge.
+//!
+//! **Skeleton crate** for issue #302 Phase E. Registers as the family
+//! bridge for [`Adapter::Vertex`] in the gateway Hub. The actual GCP
+//! OAuth integration and per-publisher request building are TODOs
+//! filled in by follow-up PRs:
+//!
+//! - [ ] D5.1 — google-cloud-auth / yup-oauth2 bearer token acquisition
+//!   (service account JSON key, ADC, metadata server)
+//! - [ ] D5.2 — Gemini publisher dispatch
+//!   (`publishers/google/models/<model>:streamGenerateContent`)
+//! - [ ] D5.3 — Anthropic-on-Vertex dispatch
+//!   (`publishers/anthropic/models/<model>:streamRawPredict` —
+//!   different wire shape from canonical Anthropic Messages)
+//! - [ ] D5.4 — Llama / Mistral / AI21 publisher dispatch
+//! - [ ] D5.5 — `BridgeContext.deadline` + Retry-After plumbing
+//!
+//! For now the bridge's `chat()` / `chat_stream()` return a clear
+//! `BridgeError::Config(...)` so a misconfigured `provider: "google-vertex"`
+//! row in the kine catalog surfaces a 501 / 502 with an actionable
+//! message rather than silently dropping the dispatch.
+//!
+//! # Multi-publisher single-entry model
+//!
+//! Google Vertex AI hosts several **publishers** (Google's own Gemini
+//! plus partner offerings from Anthropic, Meta, Mistral, AI21,
+//! together's GPT-OSS) under a single API surface. The publisher is
+//! encoded in the upstream model id:
+//!
+//! - `gemini-1.5-pro` → publisher `google`
+//! - `claude-3-5-sonnet@20241022` → publisher `anthropic`
+//!   (the `@20241022` is the model version tag Anthropic uses)
+//! - `llama-3-70b-instruct-maas` → publisher `meta`
+//!
+//! This mirrors LiteLLM's `vertex_ai/` single-prefix design: every
+//! Vertex-hosted model goes through one provider name in cp-api's
+//! catalog (`google-vertex`), and the publisher is resolved inside
+//! the bridge from the upstream model id. See
+//! <https://github.com/BerriAI/litellm/tree/main/litellm/llms/vertex_ai>.
+//!
+//! Diverging from this would force every customer to register a
+//! separate provider_key per publisher even though the GCP credential
+//! is the same — exactly the operator pain `google-vertex` solves.
+//!
+//! # References
+//!
+//! - LiteLLM `vertex_ai/` design — <https://github.com/BerriAI/litellm/tree/main/litellm/llms/vertex_ai>
+//! - Vertex AI REST API — <https://cloud.google.com/vertex-ai/docs/reference/rest>
+//! - Vertex publishers index — <https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models>
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+mod bridge;
+mod wire;
+
+pub use bridge::{VertexBridge, VertexPublisher};

--- a/crates/aisix-provider-vertex/src/wire.rs
+++ b/crates/aisix-provider-vertex/src/wire.rs
@@ -1,0 +1,36 @@
+//! Vertex AI request/response wire shapes.
+//!
+//! **Skeleton:** only the constants and helpers the bridge needs to
+//! sketch the publisher-dispatch path. Real `generateContent` /
+//! `streamGenerateContent` request bodies and `streamRawPredict`
+//! wrappers (for Anthropic-on-Vertex) land in follow-up D5.x PRs.
+
+/// Query parameters reserved by the Vertex REST API that
+/// `default_headers` / `default_body_fields` must never overwrite.
+/// Vertex pins the API mode via path *and* via the `alt` query
+/// parameter; a misconfigured override block must not redirect SSE
+/// streaming to JSON or vice versa.
+///
+/// Returned by value (not a const slice) to keep the public surface
+/// import-free for callers that only need to iterate — the list is
+/// tiny so the allocation is negligible.
+pub(crate) fn reserved_query_params() -> &'static [&'static str] {
+    &["alt", "key", "access_token"]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserved_query_params_covers_vertex_auth_keys() {
+        // Vertex accepts `?key=<api-key>` (legacy / Gemini-API path)
+        // and `?access_token=<bearer>` (OAuth path) on top of the
+        // Authorization header. An override block must not be able
+        // to inject either of these.
+        let reserved = reserved_query_params();
+        assert!(reserved.contains(&"alt"));
+        assert!(reserved.contains(&"key"));
+        assert!(reserved.contains(&"access_token"));
+    }
+}

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -22,6 +22,7 @@ aisix-guardrails = { path = "../aisix-guardrails" }
 aisix-admin = { path = "../aisix-admin" }
 aisix-provider-openai = { path = "../aisix-provider-openai" }
 aisix-provider-anthropic = { path = "../aisix-provider-anthropic" }
+aisix-provider-vertex = { path = "../aisix-provider-vertex" }
 aisix-ratelimit = { path = "../aisix-ratelimit" }
 aisix-cache = { path = "../aisix-cache", features = ["redis"] }
 tokio.workspace = true

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -23,13 +23,14 @@ mod telemetry;
 
 use aisix_admin::{AdminState, ConfigStore, EtcdConfigStore};
 use aisix_cache::{Cache, MemoryCache, RedisCache};
-use aisix_core::models::Provider;
+use aisix_core::models::{Adapter, Provider};
 use aisix_core::{CacheBackend, Config, EtcdConfig, EtcdTlsConfig};
 use aisix_etcd::{EtcdConfigProvider, SnapshotCache, Supervisor};
 use aisix_gateway::Hub;
 use aisix_obs::{init_tracing, install_otlp_tracer, Metrics};
 use aisix_provider_anthropic::AnthropicBridge;
 use aisix_provider_openai::OpenAiBridge;
+use aisix_provider_vertex::VertexBridge;
 use aisix_proxy::background::run_background_model_check_once;
 use aisix_proxy::budget::BudgetClient;
 use aisix_proxy::ProxyState;
@@ -780,6 +781,21 @@ fn build_hub() -> Hub {
         Provider::Deepseek,
         Arc::new(OpenAiBridge::new().with_name("deepseek")),
     );
+
+    // Family bridges (issue #302 Phase A/D two-tier dispatch). The
+    // legacy `Provider`-keyed register() above stays the live
+    // dispatch path until cp-api stops emitting the legacy enum
+    // field; this only adds the new-schema-keyed lookup so a
+    // catalog row with `adapter: "vertex"` can resolve to a real
+    // bridge instead of falling through to the legacy fallback.
+    //
+    // Vertex is currently a SKELETON bridge — it returns a clear
+    // `BridgeError::Config` referencing api7/AISIX-Cloud#302 Phase E
+    // (D5). Registering it now lets the dispatch path light up the
+    // moment cp-api starts shipping adapter strings, instead of
+    // having the catalog be permanently inaccessible.
+    hub.register_family(Adapter::Vertex, Arc::new(VertexBridge::new()));
+
     hub
 }
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -794,6 +794,15 @@ fn build_hub() -> Hub {
     // (D5). Registering it now lets the dispatch path light up the
     // moment cp-api starts shipping adapter strings, instead of
     // having the catalog be permanently inaccessible.
+    //
+    // CUTOVER CAUTION: cp-api today blocks `provider: "google-vertex"`
+    // at createProviderKey via `isSupportedProvider` (handlers.go).
+    // The moment that gate is loosened — which Phase B is actively
+    // enabling — every chat through a `google-vertex` provider_key
+    // will route here and hit this NOT-IMPLEMENTED skeleton, taking
+    // Gemini from "works via OpenAI-compat" to "500: not implemented"
+    // in a single cp-api flip. The cutover order MUST be:
+    //   D5.2 (Gemini dispatch) merge → cp-api flip catalog.
     hub.register_family(Adapter::Vertex, Arc::new(VertexBridge::new()));
 
     hub


### PR DESCRIPTION
## Summary

Phase E / D5 of api7/AISIX-Cloud#302 — scaffolds the Google Vertex AI family bridge so a \`provider_key\` row with \`adapter: \"vertex\"\` resolves to a real bridge in the Hub.

**Skeleton PR**: the crate exists, compiles, is registered in the workspace + Hub. The actual GCP OAuth + per-publisher HTTP dispatch is tracked as D5.1–D5.5 follow-ups (see crate-level docs in \`lib.rs\`).

### What lands

- New crate \`crates/aisix-provider-vertex/\` (workspace member, registered).
- \`VertexBridge\` struct implementing \`aisix_gateway::Bridge\`:
  - \`chat()\` / \`chat_stream()\` return \`BridgeError::Config\` with a message that explicitly references issue #302 Phase E so an operator landing here knows the path is intentional WIP, not silently broken.
  - Publisher-resolution guard runs before the not-implemented stub — an upstream model id like \`gpt-4o\` (wrong publisher) surfaces a distinct error today.
- \`VertexPublisher\` enum with \`from_upstream_id()\` and \`url_segment()\` helpers — implements the **LiteLLM \`vertex_ai/\` multi-publisher single-entry pattern**. A single \`google-vertex\` catalog provider dispatches by model prefix at runtime:
  - \`gemini-*\` → \`publishers/google\`
  - \`claude-*\` → \`publishers/anthropic\`
  - \`llama-*\` → \`publishers/meta\`
  - \`mistral-*\` / \`codestral-*\` → \`publishers/mistralai\`
  - \`jamba-*\` → \`publishers/ai21\`
- \`build_hub()\` registers it via \`Hub::register_family(Adapter::Vertex, ...)\`. The legacy \`Provider\`-keyed path is unchanged.

### Why multi-publisher single entry (not per-publisher provider)

Diverging from LiteLLM would force every customer to register a separate provider_key per publisher even though the GCP credential is the same — exactly the operator pain \`google-vertex\` solves. The publisher is encoded in the upstream model id (e.g. \`claude-3-5-sonnet@20241022\`), so the bridge can dispatch internally without exposing the split to cp-api / dashboard.

### Tests (10 passing)

- Publisher prefix resolution for gemini / claude / llama / mistral / codestral / jamba
- Case-insensitive matching on the model name
- Unknown prefix returns \`None\` (drives the publisher-resolution guard)
- \`url_segment()\` matches Vertex API path conventions — including the trap that Mistral's Vertex tag is \`mistralai\`, not \`mistral\` (pinned to catch a typo regression in a future dispatch PR)
- \`chat()\` surfaces clear \"not yet implemented + issue #302\" error
- \`chat()\` with unknown publisher prefix errors before dispatch (proves the dispatch-time guard)
- \`bridge.name() == \"vertex\"\` (metrics label stability — would silently break customer dashboards on rename)
- \`wire.rs\` reserved query params (\`alt\`, \`key\`, \`access_token\`) — covered for the eventual default-headers / default-body-fields override guard (a misconfigured override block must never redirect SSE streaming to JSON or hijack auth)

### References (per CLAUDE.md §7)

- **LiteLLM vertex_ai/** single-prefix design — <https://github.com/BerriAI/litellm/tree/main/litellm/llms/vertex_ai>
- **Vertex AI REST API** — <https://cloud.google.com/vertex-ai/docs/reference/rest>
- **Vertex publishers index** — <https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models>

### Out of scope — D5 follow-up tracker

| Task | Description |
|---|---|
| D5.1 | google-cloud-auth / yup-oauth2 bearer-token acquisition (service-account JSON key, ADC, metadata server) |
| D5.2 | Gemini publisher dispatch (\`:streamGenerateContent\`) |
| D5.3 | Anthropic-on-Vertex dispatch (\`:streamRawPredict\` — different wire shape from canonical Anthropic Messages) |
| D5.4 | Llama / Mistral / AI21 publisher dispatch |
| D5.5 | \`BridgeContext.deadline\` + Retry-After plumbing |

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace --lib\` passes (818 + 10 new = 828 total)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check --all\` clean
- [ ] Independent audit per CLAUDE.md §8 (spawned after this PR is open)

## Related

- Issue: api7/AISIX-Cloud#302 (Phase E / D5)
- Depends on (merged): #297 (Adapter enum), #298 (ProviderKey new fields), #300 (Hub two-tier), #305 (D1 dispatch), #311 (D2 OpenAi wire-in)