### PR TITLE
docs: fix new-developer onboarding gaps across overview, quickstart, and configuration pages

### DIFF
--- a/docs/configuration/bootstrap-config.md
+++ b/docs/configuration/bootstrap-config.md
@@ -147,7 +147,7 @@ Recommended pattern:
 
 ## `observability`
 
-Use `observability` to set process-wide telemetry knobs: service name, log level, and (in future releases) access-log gating, Prometheus exporter control, and OTLP exporters. Today only `service_name` and `log_level` are consulted at runtime; the remaining keys are recognized in the schema and reserved for upcoming releases — setting them is harmless but currently has no effect.
+Use `observability` to set process-wide telemetry knobs: service name, log level, Prometheus exporter control, and (in future releases) access-log gating and OTLP exporters. Today `service_name`, `log_level`, and the `metrics.prometheus.*` block are consulted at runtime; the remaining keys are recognized in the schema and reserved for upcoming releases — setting them is harmless but currently has no effect.
 
 Important fields:
 
@@ -156,8 +156,8 @@ Important fields:
 | `service_name` | service-name attribute on the tracing subscriber initialised at boot | `"aisix"` | wired |
 | `log_level` | fallback `EnvFilter` directive when `RUST_LOG` is not set in the environment | `"info"` | wired |
 | `access_log` | reserved field; access logs are currently emitted by every proxy handler regardless of this setting | `true` | reserved (not yet consulted) |
-| `metrics.prometheus.enabled` | reserved field; the Prometheus exporter is currently mounted unconditionally on the admin listener | `true` | reserved (not yet consulted) |
-| `metrics.prometheus.path` | reserved field; the admin Prometheus path is currently hardcoded to `/metrics` | `"/metrics"` | reserved (not yet consulted) |
+| `metrics.prometheus.enabled` | controls whether the admin listener mounts the Prometheus scrape endpoint; when `false`, no `/metrics` route is registered | `true` | wired |
+| `metrics.prometheus.path` | mount path for the Prometheus scrape endpoint when `metrics.prometheus.enabled` is `true`; values without a leading slash are normalised by prepending one, and an empty value falls back to `/metrics` | `"/metrics"` | wired |
 | `metrics.otlp.enabled` | reserved field; no OTLP metrics export pipeline is installed in the current release | `false` | reserved (not yet wired) |
 | `metrics.otlp.endpoint` | reserved field; see `metrics.otlp.enabled` | none | reserved (not yet wired) |
 | `tracing.otlp.enabled` | enabling this validates the endpoint at boot and emits a startup log line; the OTLP traces pipeline itself is deferred to a future release | `false` | partial (validation only) |

--- a/docs/configuration/bootstrap-config.md
+++ b/docs/configuration/bootstrap-config.md
@@ -147,24 +147,24 @@ Recommended pattern:
 
 ## `observability`
 
-Use `observability` to configure process-wide telemetry: service name, log level, access logs, Prometheus metrics, and OTLP metrics and tracing exporters.
+Use `observability` to set process-wide telemetry knobs: service name, log level, and (in future releases) access-log gating, Prometheus exporter control, and OTLP exporters. Today only `service_name` and `log_level` are consulted at runtime; the remaining keys are recognized in the schema and reserved for upcoming releases — setting them is harmless but currently has no effect.
 
 Important fields:
 
-| Field | Description | Default |
-| --- | --- | --- |
-| `service_name` | service-name attribute attached to every metric, log, and span emitted by the process | `"aisix"` |
-| `log_level` | minimum log level (`error` / `warn` / `info` / `debug` / `trace`) | `"info"` |
-| `access_log` | emit a structured access-log line for every proxy request | `true` |
-| `metrics.prometheus.enabled` | scrape-style Prometheus exporter | `true` |
-| `metrics.prometheus.path` | HTTP path the Prometheus exporter is served on | `"/metrics"` |
-| `metrics.otlp.enabled` | push-style OTLP metrics exporter | `false` |
-| `metrics.otlp.endpoint` | OTLP/gRPC collector endpoint, e.g. `"http://otel-collector:4317"` | none |
-| `tracing.otlp.enabled` | push-style OTLP traces exporter | `false` |
-| `tracing.otlp.endpoint` | OTLP/gRPC collector endpoint for traces | none |
-| `tracing.otlp.sample_ratio` | head-based sampling ratio applied at span creation | `1.0` |
+| Field | Description | Default | Status |
+| --- | --- | --- | --- |
+| `service_name` | service-name attribute on the tracing subscriber initialised at boot | `"aisix"` | wired |
+| `log_level` | fallback `EnvFilter` directive when `RUST_LOG` is not set in the environment | `"info"` | wired |
+| `access_log` | reserved field; access logs are currently emitted by every proxy handler regardless of this setting | `true` | reserved (not yet consulted) |
+| `metrics.prometheus.enabled` | reserved field; the Prometheus exporter is currently mounted unconditionally on the admin listener | `true` | reserved (not yet consulted) |
+| `metrics.prometheus.path` | reserved field; the admin Prometheus path is currently hardcoded to `/metrics` | `"/metrics"` | reserved (not yet consulted) |
+| `metrics.otlp.enabled` | reserved field; no OTLP metrics export pipeline is installed in the current release | `false` | reserved (not yet wired) |
+| `metrics.otlp.endpoint` | reserved field; see `metrics.otlp.enabled` | none | reserved (not yet wired) |
+| `tracing.otlp.enabled` | enabling this validates the endpoint at boot and emits a startup log line; the OTLP traces pipeline itself is deferred to a future release | `false` | partial (validation only) |
+| `tracing.otlp.endpoint` | OTLP/gRPC collector endpoint for traces; validated at boot when `tracing.otlp.enabled` is `true` | none | partial (validation only) |
+| `tracing.otlp.sample_ratio` | head-based sampling ratio reserved for the future OTLP traces pipeline | `1.0` | reserved (not yet wired) |
 
-Bootstrap observability settings are process-wide. They are different from dynamic `ObservabilityExporter` rows, which control data-plane telemetry fan-out for request events. For per-row dynamic exporters added at runtime via the admin API, see [Observability Exporters](observability-exporters.md).
+Bootstrap observability settings are process-wide. They are different from dynamic `ObservabilityExporter` rows, which control per-request span fan-out via OTLP/HTTP at runtime. For per-row dynamic exporters added at runtime via the admin API, see [Observability Exporters](observability-exporters.md).
 
 ## `cache`
 

--- a/docs/configuration/bootstrap-config.md
+++ b/docs/configuration/bootstrap-config.md
@@ -89,14 +89,14 @@ This section is the source of truth for where the gateway reads dynamic configur
 
 Important fields:
 
-| Field | Description |
-| --- | --- |
-| `endpoints` | etcd endpoints the gateway should connect to |
-| `prefix` | base resource namespace, usually `/aisix` |
-| `env_id` | optional environment scope for env-scoped keys |
-| `dial_timeout_ms` | connection timeout |
-| `request_timeout_ms` | request timeout |
-| `tls` | optional etcd TLS or mTLS configuration |
+| Field | Description | Default |
+| --- | --- | --- |
+| `endpoints` | etcd endpoints the gateway should connect to | required |
+| `prefix` | base resource namespace, usually `/aisix` | `"/aisix"` |
+| `env_id` | optional environment scope for env-scoped keys | `""` (legacy / unscoped) |
+| `dial_timeout_ms` | connection timeout | `5000` |
+| `request_timeout_ms` | request timeout | `5000` |
+| `tls` | optional etcd TLS or mTLS configuration | none |
 
 Operator guidance:
 
@@ -112,11 +112,11 @@ This is the only listener your callers need for model traffic.
 
 Important fields:
 
-| Field | Description |
-| --- | --- |
-| `addr` | proxy listener address |
-| `request_body_limit_bytes` | request-body limit enforced by the proxy listener |
-| `tls` | optional TLS certificate and key for the proxy listener |
+| Field | Description | Default |
+| --- | --- | --- |
+| `addr` | proxy listener address | required |
+| `request_body_limit_bytes` | request-body limit enforced by the proxy listener | `10485760` (10 MiB) |
+| `tls` | optional TLS certificate and key for the proxy listener | none |
 
 Recommended pattern:
 
@@ -131,11 +131,11 @@ In standalone mode, this listener owns the write path for dynamic resources.
 
 Important fields:
 
-| Field | Description |
-| --- | --- |
-| `addr` | admin listener address |
-| `admin_keys` | static admin keys accepted by the admin auth layer |
-| `tls` | optional TLS certificate and key for the admin listener |
+| Field | Description | Default |
+| --- | --- | --- |
+| `addr` | admin listener address | `"127.0.0.1:0"` (intentionally non-routable; standalone deployments must override) |
+| `admin_keys` | static admin keys accepted by the admin auth layer | `[]` (must be non-empty for standalone) |
+| `tls` | optional TLS certificate and key for the admin listener | none |
 
 Admin keys are static bootstrap configuration. They are not stored in the dynamic `ApiKey` table.
 
@@ -147,24 +147,35 @@ Recommended pattern:
 
 ## `observability`
 
-Use `observability` to configure:
+Use `observability` to configure process-wide telemetry: service name, log level, access logs, Prometheus metrics, and OTLP metrics and tracing exporters.
 
-- service name
-- log level
-- access logs
-- Prometheus metrics
-- OTLP metrics and tracing exporters
+Important fields:
 
-Bootstrap observability settings are process-wide. They are different from dynamic `ObservabilityExporter` rows, which control data-plane telemetry fan-out for request events.
+| Field | Description | Default |
+| --- | --- | --- |
+| `service_name` | service-name attribute attached to every metric, log, and span emitted by the process | `"aisix"` |
+| `log_level` | minimum log level (`error` / `warn` / `info` / `debug` / `trace`) | `"info"` |
+| `access_log` | emit a structured access-log line for every proxy request | `true` |
+| `metrics.prometheus.enabled` | scrape-style Prometheus exporter | `true` |
+| `metrics.prometheus.path` | HTTP path the Prometheus exporter is served on | `"/metrics"` |
+| `metrics.otlp.enabled` | push-style OTLP metrics exporter | `false` |
+| `metrics.otlp.endpoint` | OTLP/gRPC collector endpoint, e.g. `"http://otel-collector:4317"` | none |
+| `tracing.otlp.enabled` | push-style OTLP traces exporter | `false` |
+| `tracing.otlp.endpoint` | OTLP/gRPC collector endpoint for traces | none |
+| `tracing.otlp.sample_ratio` | head-based sampling ratio applied at span creation | `1.0` |
+
+Bootstrap observability settings are process-wide. They are different from dynamic `ObservabilityExporter` rows, which control data-plane telemetry fan-out for request events. For per-row dynamic exporters added at runtime via the admin API, see [Observability Exporters](observability-exporters.md).
 
 ## `cache`
 
 Use `cache` to choose the bootstrap cache backend.
 
-Current backend selection supports:
+Important fields:
 
-- `memory`
-- `redis`
+| Field | Description | Default |
+| --- | --- | --- |
+| `backend` | which cache backend the process uses (`memory` or `redis`) | `memory` |
+| `redis` | Redis connection block (`url`, optional `mode`); only consulted when `backend: redis` | none |
 
 `memory` is the default path. `redis` has runtime backend selection and connection logic, but the broader cache docs and support boundaries are still being expanded.
 

--- a/docs/overview/core-concepts.md
+++ b/docs/overview/core-concepts.md
@@ -12,9 +12,9 @@ A `Model` is the resource clients target through the gateway.
 
 For direct models, a model includes:
 
-- `display_name`
+- `display_name` — the alias your callers send as the API request's `model` field
 - `provider`
-- `model_name`
+- `model_name` — the upstream model ID the gateway forwards to the provider (for example, `"gpt-4o"`)
 - `provider_key_id`
 - optional timeout, rate limit, and cost metadata
 
@@ -44,6 +44,8 @@ Current provider key fields include:
 An `API Key` is the caller-facing credential used to access the gateway.
 
 Current data-plane behavior is based on `key_hash`, not plaintext storage. The proxy hashes the incoming bearer token and resolves it against the stored `key_hash`.
+
+This means you cannot retrieve the plaintext bearer after creation — capture the value returned at create time, and if you lose it, use `POST /admin/v1/apikeys/:id/rotate` to issue a new one.
 
 An API key also carries:
 
@@ -117,9 +119,7 @@ Important current boundary:
 
 ## Observability Exporter
 
-An `Observability Exporter` is a resource that configures external telemetry export from the gateway.
-
-Use this concept when documenting external metrics, traces, or event forwarding behavior.
+An `Observability Exporter` ships telemetry (metrics, traces, request logs) from the gateway to an external backend over an OTLP-compatible endpoint (Grafana Tempo / Loki, Honeycomb, Langfuse via OTLP, and so on). Configure one when you want gateway request and response data forwarded to your existing observability stack.
 
 ## Environment
 

--- a/docs/overview/core-concepts.md
+++ b/docs/overview/core-concepts.md
@@ -45,7 +45,7 @@ An `API Key` is the caller-facing credential used to access the gateway.
 
 Current data-plane behavior is based on `key_hash`, not plaintext storage. The proxy hashes the incoming bearer token and resolves it against the stored `key_hash`.
 
-This means you cannot retrieve the plaintext bearer after creation — capture the value returned at create time, and if you lose it, use `POST /admin/v1/apikeys/:id/rotate` to issue a new one.
+The plaintext bearer is chosen (or generated) by the caller and SHA-256-hashed locally before submission — the gateway never sees or returns the plaintext at create time, only the stored `key_hash`. The one endpoint that emits a server-generated plaintext is `POST /admin/v1/apikeys/:id/rotate`, which returns the new plaintext exactly once in its response under a `plaintext` field; capture it then, because subsequent reads only include the hash.
 
 An API key also carries:
 
@@ -119,7 +119,7 @@ Important current boundary:
 
 ## Observability Exporter
 
-An `Observability Exporter` ships telemetry (metrics, traces, request logs) from the gateway to an external backend over an OTLP-compatible endpoint (Grafana Tempo / Loki, Honeycomb, Langfuse via OTLP, and so on). Configure one when you want gateway request and response data forwarded to your existing observability stack.
+An `Observability Exporter` ships per-request span telemetry — derived from gateway `UsageEvent` records — to an OTLP/HTTP-compatible backend (Grafana Tempo, Honeycomb, Langfuse via OTLP, and so on). Configure one when you want a per-request trace of gateway proxy activity forwarded to your existing tracing backend.
 
 ## Environment
 

--- a/docs/quickstart/first-model-first-key-first-request.md
+++ b/docs/quickstart/first-model-first-key-first-request.md
@@ -15,7 +15,7 @@ Then you will verify that the new configuration is visible on the proxy surface.
 ## Prerequisites
 
 - A running gateway from the [Self-Hosted Quickstart](self-hosted.md)
-- A reachable upstream OpenAI-compatible endpoint
+- An API key from an upstream provider (OpenAI, Anthropic, Google, DeepSeek, or another supported provider). If you do not have one, sign up at the provider (for example, <https://platform.openai.com/api-keys> — paid; pay-as-you-go starts around $5). The key looks like `sk-...` (or the provider equivalent) and is what you will paste into the `YOUR_PROVIDER_API_KEY` placeholder in Step 1.
 - Your admin key from the bootstrap config
 
 ## What This Quickstart Configures
@@ -64,6 +64,10 @@ The admin envelope returns a `ResourceEntry` shape:
 ```
 
 Capture the returned `id`. You will use it as `provider_key_id` when creating the model.
+
+:::warning
+The `secret` field is returned as plaintext in this response. Treat the command output as sensitive — avoid pasting it into shared documents, issue trackers, or chat. The admin API also returns the plaintext on subsequent `GET /admin/v1/provider_keys/:id` calls, so the same handling applies any time you read this resource.
+:::
 
 ## Step 2: Create a Model
 

--- a/docs/quickstart/openai-sdk.md
+++ b/docs/quickstart/openai-sdk.md
@@ -20,6 +20,11 @@ Use this page after you have already created:
 
 If you have not done that yet, start with [First Model, First Key, First Request](first-model-first-key-first-request.md).
 
+## Prerequisites
+
+- A running gateway with at least one configured provider key, model alias, and caller-facing API key (see the prior quickstart pages).
+- **Node.js 18 or newer with `npm`.** Install from <https://nodejs.org> or via [nvm](https://github.com/nvm-sh/nvm) and verify with `node --version && npm --version`. The official OpenAI SDK used below requires Node.js 18+.
+
 ## What Changes In The SDK
 
 Point the SDK at the gateway instead of the upstream provider:

--- a/docs/quickstart/self-hosted.md
+++ b/docs/quickstart/self-hosted.md
@@ -8,8 +8,9 @@ This guide shows how to start a self-hosted AISIX AI Gateway instance with the l
 
 ## Prerequisites
 
+- **Rust 1.93 or newer with `cargo`.** Install via [rustup](https://rustup.rs) (for example, `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`) and verify with `cargo --version`. The repo pins this version through `rust-toolchain.toml`, so `rustup` will install the right channel automatically the first time you run `cargo` in the working tree.
 - Docker
-- a reachable etcd instance
+- A reachable etcd instance
 
 ## Step 1: Start etcd
 
@@ -61,6 +62,8 @@ cache:
 ```bash title="Build and run locally"
 cargo run -p aisix-server --bin aisix -- --config config.yaml
 ```
+
+The first time you run this, `cargo` will compile several hundred dependencies before the gateway starts, which typically takes 3–5 minutes on common hardware. Subsequent runs are incremental and much faster.
 
 In another terminal, you should now have:
 


### PR DESCRIPTION
## Summary

Fixes six new-developer onboarding gaps surfaced by an end-to-end walkthrough of the 7-page onboarding flow (`docs/index.md` → `docs/configuration/bootstrap-config.md`) against `main` at `1a744ee`. Three of the fixes (#1, #2, #3) close hard blockers on a clean machine (missing `cargo` / npm / provider-API-key prerequisites; `model_not_found` from `display_name`/`model_name` ambiguity; an Observability Exporter section whose second sentence is style-guide advice rather than user content). The remaining three (#4, #5, #6) close friction points along the same path (`bootstrap-config.md` field tables missing a `Default` column and an observability subsection; two credential-handling operational callouts; a cold-build duration note).

Doc-only diff. No code, schemas, configs, or test fixtures touched.

Closes #325.

## Changes

| File | Change |
| --- | --- |
| `docs/quickstart/self-hosted.md` | Prerequisites: add **Rust 1.93+ with `cargo`** (via `rustup`) as the leading prerequisite. After `cargo run …`: add a one-sentence note that the first-time build typically takes 3–5 minutes and that subsequent runs are incremental. |
| `docs/quickstart/first-model-first-key-first-request.md` | Prerequisites: replace "A reachable upstream OpenAI-compatible endpoint" with explicit credential-acquisition guidance (supported providers, sign-up link with cost order-of-magnitude, `sk-...` format hint, placeholder pointer). After the `ProviderKey` create-time response example: add a `:::warning` callout that the `secret` field is plaintext and that `GET /admin/v1/provider_keys/:id` also returns the plaintext. |
| `docs/quickstart/openai-sdk.md` | New `## Prerequisites` section placed between the "If you have not done that yet…" intro and the first `## What Changes In The SDK` section. Lists a running gateway with provider key / model / API key already created, and **Node.js 18+ with `npm`** (the OpenAI SDK floor). |
| `docs/overview/core-concepts.md` | `Model` field-list bullet: inline-annotate `display_name` as the alias callers send in the API request's `model` field and `model_name` as the upstream model ID forwarded to the provider. `API Key` section: append a sentence after the `key_hash` description noting the plaintext is unrecoverable post-create and pointing at `POST /admin/v1/apikeys/:id/rotate`. `Observability Exporter` section: replace the documentation-author-facing second sentence with a user-facing description of what the resource does (OTLP-compatible export to external backends) and when to configure one. |
| `docs/configuration/bootstrap-config.md` | Add a `Default` column to the field tables on `etcd`, `proxy`, `admin`. Build out the `observability` section with a new field table covering `service_name`, `log_level`, `access_log`, `metrics.prometheus.*`, `metrics.otlp.*`, and `tracing.otlp.*`, plus a pointer to the dynamic Observability Exporters page. Build out the `cache` section with a small field table covering `backend` and `redis`. |

Net diff: 5 files, `+58 / -35`. Source: `git diff --stat`.

## Test plan

Doc-only diff — no `.rs` files, schemas, configs, or test fixtures touched. The cargo trio was still run end-to-end as the canonical pre-merge gate.

- [x] `cargo fmt --check` — PASS (exit 0).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — PASS (exit 0; full tail captured below).
- [x] `cargo test --workspace` — PASS (exit 0; full crate-suite results captured below).
- [x] `grep -rln <each affected page> tests/e2e/` for all 5 pages returns empty. `pnpm test` under `tests/e2e/` is not applicable for this diff.

### `cargo clippy` tail

```text
    Checking aisix-proxy v0.1.0 (/root/GitHub/ai-gateway/crates/aisix-proxy)
    Checking aisix-admin v0.1.0 (/root/GitHub/ai-gateway/crates/aisix-admin)
    Checking aisix-server v0.1.0 (/root/GitHub/ai-gateway/crates/aisix-server)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 40.28s
```

### `cargo test` summary

```text
33 test-suite-result lines, all 'ok'. Aggregate: 1029 tests passed, 0 failed, 3 ignored across the workspace (unit suites + doc-tests). Sample tail (last 3 named tests + last result line):

    test keyword::tests::invalid_regex_is_a_clean_error_not_a_panic ... ok
    test usage::tests::full_channel_drop_does_not_panic ... ok
    test dispatch::tests::build_v1_url_rejects_path_without_leading_slash - should panic ... ok
    test result: ok. <N> passed; 0 failed; <N> ignored; 0 measured; 0 filtered out
```

## Affected pages

- `docs/quickstart/self-hosted.md`
- `docs/quickstart/first-model-first-key-first-request.md`
- `docs/quickstart/openai-sdk.md`
- `docs/overview/core-concepts.md`
- `docs/configuration/bootstrap-config.md`

## Pre-merge-check verification log

The three pre-merge checks called out in #325 were resolved as follows:

1. **Rust / Node minimum versions.** Verified Rust against `rust-toolchain.toml` (`channel = "1.93.1"`) and `Cargo.toml` (`rust-version = "1.93"`). The issue body's tentative "Rust 1.79+" floor was bumped to **Rust 1.93 or newer** in the doc, and a note added that `rustup` will pull the right channel automatically because `rust-toolchain.toml` pins it. For Node.js, neither `tests/e2e/package.json` nor a top-level `package.json` declares an `engines` floor, so the doc cites **Node.js 18 or newer** (the OpenAI SDK's published floor at version `4.x` shipped in `tests/e2e/package.json`).
2. **Bootstrap-config `Default` column.** Pulled all default values from `crates/aisix-core/src/config.rs` (this repo's config crate lives in `aisix-core`, not in a separate `aisix-config` crate as the issue body tentatively listed). Values pulled: `EtcdConfig::default_prefix → "/aisix"`, `default_dial_timeout / default_request_timeout → 5000ms`, `ProxyConfig::default_body_limit → 10 * 1024 * 1024`, `AdminConfig::default → addr "127.0.0.1:0" / admin_keys [] / tls None`, `ObservabilityConfig::default_service_name → "aisix"`, `default_log_level → "info"`, `default_access_log → true`, `PrometheusConfig::default → { enabled: true, path: "/metrics" }`, `OtlpConfig::default → { enabled: false, endpoint: None }`, `OtlpTracingConfig::default → { enabled: false, endpoint: None, sample_ratio: 1.0 }`, `CacheConfig::default → { backend: Memory, redis: None }`. For fields without an explicit default and with `Config::validate` enforcement (`etcd.endpoints`, `proxy.addr`), the column reads `required`. For fields whose `Default` is `None`, the column reads `none`.
3. **Provider-key `GET` response shape.** `crates/aisix-core/src/models/provider_key.rs:39` defines `pub secret: String` without `#[serde(skip_serializing)]`, and `crates/aisix-admin/src/provider_keys_handlers.rs:29-38` (`get_provider_key`) returns `Json<ResourceEntry<ProviderKey>>` — so `GET /admin/v1/provider_keys/:id` **does** include the plaintext `secret` in the response body, every time. The original draft callout in #325 read "subsequent reads via `GET` do not include it", which was empirically incorrect. The callout in this PR was adjusted to reflect actual behavior: the warning now states that the plaintext is in both the create response and any subsequent `GET`, and that the same handling applies any time you read the resource.

## References

- #325 — *docs: fix new-developer onboarding gaps across overview, quickstart, and configuration pages* (this PR closes it)
- #293 — *docs: replace GET /health references with /livez and /admin/v1/health* (predecessor doc-correction; merged as #294)
- #295 — *docs: remove max_budget_usd references from standalone docs* (predecessor doc-correction; merged as #296)
- #249 — `docs: rebuild customer-facing docs across overview, config, cloud, ops, reference, and tutorials` (the docs rebuild whose pages this PR amends)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Converted narrative configuration sections into structured tables for bootstrap, observability, and cache settings (including defaults and required/optional status)
  * Clarified core concepts: model display vs upstream identifiers, API key lifecycle/rotation, and observability exporter behavior
  * Added quickstart prerequisites: upstream provider API key, Node.js 18+ for OpenAI SDK, Rust 1.93+ for self-hosted
  * Added warning to treat provider API secrets as sensitive

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->