### PR TITLE
docs: clarify managed DP bootstrap config

### DIFF
--- a/docs/cloud/gateway-certificates-and-managed-dp.md
+++ b/docs/cloud/gateway-certificates-and-managed-dp.md
@@ -44,6 +44,38 @@ When diagnosing managed bootstrap, think certificate bundle, trust roots, and mT
 
 Do not start with bearer-token assumptions unless your deployment intentionally uses a legacy or self-managed path.
 
+## Runtime Configuration Notes
+
+`AISIX_MANAGED__CP_BASE_URL` must point at the control-plane
+data-plane-manager endpoint that serves `/dp/heartbeat`,
+`/dp/telemetry`, `/dp/rotate-cert`, and `/dp/budget_check`.
+
+For example:
+
+- `https://dpm.example.com:7944` for an externally reachable DPM
+- `https://dpm:7944` when the DP joins the AISIX Cloud Compose network
+
+Do not use the browser-facing dashboard/cp-api origin such as
+`http://api:8080`; that service does not own the `/dp/*` heartbeat
+surface.
+
+The DP accepts either inline PEM values:
+
+- `AISIX_MANAGED__CP_CERT_PEM`
+- `AISIX_MANAGED__CP_KEY_PEM`
+- `AISIX_MANAGED__CP_CA_PEM`
+
+or file paths:
+
+- `AISIX_MANAGED__CP_CERT_FILE`
+- `AISIX_MANAGED__CP_KEY_FILE`
+- `AISIX_MANAGED__CP_CA_FILE`
+
+If file paths are used from a container, make sure the process user can
+read those files and can write the runtime state directory
+`/var/lib/aisix`. The state directory contains the persisted mTLS
+bundle and sidecar files such as the DP identity used on restart.
+
 ## Troubleshooting
 
 ### The data plane never appears healthy in Cloud

--- a/docs/quickstart/aisix-cloud-managed-dp.md
+++ b/docs/quickstart/aisix-cloud-managed-dp.md
@@ -54,6 +54,30 @@ In managed mode, the data plane is started with environment variables for:
 - `AISIX_MANAGED__CP_KEY_PEM`
 - `AISIX_MANAGED__CP_CA_PEM`
 
+`AISIX_MANAGED__CP_BASE_URL` is the data-plane manager `/dp/*` mTLS
+surface, for example `https://dpm.example.com:7944` or
+`https://dpm:7944` inside the AISIX Cloud Compose network. Do not point
+it at the browser dashboard or cp-api origin such as
+`http://api:8080`; heartbeat is always built as
+`<CP_BASE_URL>/dp/heartbeat`.
+
+For deployments that should not inline PEM material into environment
+variables, use the file-based equivalents instead:
+
+- `AISIX_MANAGED__CP_CERT_FILE`
+- `AISIX_MANAGED__CP_KEY_FILE`
+- `AISIX_MANAGED__CP_CA_FILE`
+
+The inline and file variants are mutually exclusive for each cert/key/CA
+pair.
+
+The data plane persists the issued mTLS bundle, `dp_id`, and runtime
+state under `/var/lib/aisix` by default. If the container runs as a
+non-default user and reads bind-mounted PEM files, make `/var/lib/aisix`
+writable by that same user, for example by mounting a host-owned state
+directory there. Mounting only the `mtls` subdirectory is not enough
+because the process also writes sidecar files next to it.
+
 The managed data plane then uses the same single binary, but follows the managed bootstrap path instead of binding the standalone admin surface.
 
 In other words:
@@ -94,6 +118,11 @@ Start with:
 - `AISIX_MANAGED__CP_BASE_URL`
 - `AISIX_MANAGED__CP_ETCD_ENDPOINT`
 - trust chain in `AISIX_MANAGED__CP_CA_PEM`
+- writable state directory for `/var/lib/aisix`
+
+If logs show `/dp/heartbeat` returning 404, `CP_BASE_URL` usually points
+at the wrong service. It should point at the DPM mTLS endpoint, not the
+cp-api/dashboard origin.
 
 ### The data plane starts but does not receive configuration
 


### PR DESCRIPTION
## 问题说明

这次 NUC managed DP 启动过程中暴露出几个文档/认知问题：

1. `AISIX_MANAGED__CP_BASE_URL` 容易被误解为 cp-api/dashboard URL，例如 `http://api:8080`。实际 DP heartbeat 会拼成 `<CP_BASE_URL>/dp/heartbeat`，所以它必须指向 DPM `/dp/*` mTLS surface。
2. 文档只列了 inline PEM 环境变量，缺少 `CP_CERT_FILE` / `CP_KEY_FILE` / `CP_CA_FILE` 这条更适合文件挂载和 secret 管理的路径。
3. 容器以非默认用户读取 bind-mounted PEM 文件时，还需要可写的 `/var/lib/aisix` state root；只挂载 `/var/lib/aisix/mtls` 不够，因为 DP 还会写 `dp_id` 等 sidecar/state 文件。

## 复现步骤

1. 使用 dashboard 生成的 cert/key/CA bundle 启动 managed DP。
2. 将 `AISIX_MANAGED__CP_BASE_URL` 设置为 cp-api 地址（例如 `http://api:8080`）。
3. DP 能启动 listener，但 heartbeat 打到 `http://api:8080/dp/heartbeat` 并返回 404。
4. 若改用 file-mounted PEM 且以 host UID 运行容器，DP 可以读取 cert，但如果 `/var/lib/aisix` 不可写，会在写 `mtls` bundle 或 `dp_id/env_id` sidecar 时失败。

## 修正内容

- 在 Cloud managed DP quickstart 中明确 `CP_BASE_URL` 必须是 DPM `/dp/*` mTLS endpoint，例如 `https://dpm:7944`。
- 补充 `AISIX_MANAGED__CP_CERT_FILE` / `CP_KEY_FILE` / `CP_CA_FILE` 文件路径变量。
- 补充 `/var/lib/aisix` state root 的写权限要求。
- 在 gateway certificates 文档里同步这些 runtime config notes。

## 验证

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced managed data-plane configuration documentation with detailed setup guidance for certificate-based flows.
  * Added clarification on required endpoint configuration and file-based certificate options.
  * Documented persistence requirements and state directory management.
  * Expanded troubleshooting section with diagnostic guidance for common configuration issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->