### PR TITLE
fix(proxy): /v1/messages emits Anthropic-shape error envelope (#336)

### DIFF
--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -29,10 +29,17 @@
 //!   }
 //!   ```
 //!
-//!   The nested `error.type` continues to carry the DP's stable
-//!   taxonomy (`upstream_error`, `invalid_api_key`, etc. — per
-//!   ai-gateway#327) so SDKs that branch on it stay portable; only
-//!   the outer envelope shape differs.
+//!   The nested `error.type` maps from HTTP status onto the
+//!   Anthropic SDK's strict `ErrorType` literal
+//!   (`invalid_request_error` / `authentication_error` /
+//!   `permission_error` / `not_found_error` / `request_too_large` /
+//!   `rate_limit_error` / `timeout_error` / `overloaded_error` /
+//!   `api_error`). Diverges from the OpenAI envelope's DP-stable
+//!   taxonomy because the Anthropic SDK's `ErrorType` is a strict
+//!   literal — emitting `"upstream_error"` would silently break
+//!   customers branching on `e.body['error']['type']`. See
+//!   [`anthropic_kind_from_status`] for the LiteLLM-aligned mapping
+//!   table.
 //!
 //! `ProxyError` is the internal error taxonomy; it implements
 //! `IntoResponse` for the OpenAI shape so non-Anthropic handlers
@@ -292,27 +299,76 @@ struct AnthropicErrorBody {
     message: String,
 }
 
+/// Map an HTTP status code to the Anthropic-canonical `error.type`
+/// string (the SDK's `ErrorType` literal at
+/// `anthropic-sdk-python/src/anthropic/types/shared/error_type.py`).
+///
+/// This deliberately diverges from the DP-stable OpenAI-shape inner
+/// taxonomy (`upstream_error`, `model_not_found`, …) because the
+/// Anthropic SDK's `ErrorType` is a strict `Literal[...]` — non-
+/// canonical strings on `error.type` are static-type violations for
+/// any customer doing `isinstance(e, anthropic.RateLimitError)` plus
+/// `e.body['error']['type'] == 'rate_limit_error'`. Per CLAUDE.md §7
+/// reference-implementation rule, this mapping mirrors LiteLLM's
+/// `anthropic_interface/exceptions/exception_mapping_utils.py`
+/// status-to-type table verbatim — divergence from the established
+/// ecosystem here would silently break Claude SDK users.
+///
+/// (The OpenAI envelope's inner `error.type` keeps the DP-stable
+/// strings per ai-gateway#327; that contract is unchanged on
+/// `/v1/chat/completions`.)
+fn anthropic_kind_from_status(status: StatusCode) -> &'static str {
+    match status.as_u16() {
+        400 | 422 => "invalid_request_error",
+        401 => "authentication_error",
+        403 => "permission_error",
+        404 => "not_found_error",
+        413 => "request_too_large",
+        429 => "rate_limit_error",
+        503 => "overloaded_error",
+        // 408 timeout maps to `timeout_error` in the SDK literal; the
+        // gateway doesn't emit 408 today (timeouts surface as 502 via
+        // the Bridge), but the case is kept for completeness.
+        408 => "timeout_error",
+        // 500 / 502 / 504-599 plus anything outside the recognised
+        // codes fall back to `api_error` — the SDK literal's catch-all
+        // for generic upstream / server faults.
+        _ => "api_error",
+    }
+}
+
 impl ProxyError {
     /// Render this error as an Anthropic-shape `{type:"error", error:
     /// {type, message}}` HTTP response. Used by `/v1/messages` so the
-    /// Anthropic SDK's strict envelope parser can read the error.
+    /// Anthropic SDK's envelope parser sees a shape the official
+    /// SDK + LiteLLM both treat as canonical.
     ///
-    /// Behavior is the same as [`Self::into_response`] for status,
-    /// retry-after, and the inner `type` taxonomy — only the JSON
-    /// shape differs. Reuses [`Self::envelope`] for the 4xx/5xx
-    /// classification + upstream-message redaction logic so the two
-    /// envelope renderers can't drift on those rules.
+    /// **Inner `error.type` policy:** maps from the HTTP status code
+    /// to the Anthropic SDK's `ErrorType` literal via
+    /// [`anthropic_kind_from_status`] — NOT the DP-stable OpenAI-shape
+    /// inner taxonomy. The Anthropic SDK's `ErrorType` is a strict
+    /// `Literal[...]`, so emitting DP-internal strings like
+    /// `"upstream_error"` would break customers branching on
+    /// `error.type`. The DP-stable taxonomy is preserved on the
+    /// OpenAI envelope only (ai-gateway#327); the Anthropic envelope
+    /// follows ecosystem convention.
+    ///
+    /// Reuses [`Self::envelope`] for the 4xx/5xx message-classification
+    /// and upstream-message redaction logic so the two envelope
+    /// renderers can't drift on those rules.
     pub fn into_anthropic_response(self) -> Response {
         let status = self.status();
         let retry_after = self.retry_after_secs();
-        // Delegate to the existing OpenAI envelope builder for the
-        // safe-message and kind logic (5xx body redaction, 4xx
-        // upstream taxonomy translation, etc.) then re-wrap.
+        let kind = anthropic_kind_from_status(status).to_string();
+        // Reuse OpenAI envelope only for the SAFE-MESSAGE logic
+        // (5xx body redaction, 4xx upstream-message pass-through).
+        // The inner type is overwritten to the Anthropic-canonical
+        // string above.
         let openai_env = self.envelope();
         let anth_body = AnthropicErrorEnvelope {
             discriminator: "error",
             error: AnthropicErrorBody {
-                kind: openai_env.error.kind,
+                kind,
                 message: openai_env.error.message,
             },
         };
@@ -399,20 +455,45 @@ mod tests {
         serde_json::from_slice(&bytes).unwrap()
     }
 
-    #[tokio::test]
-    async fn anthropic_envelope_shape_top_level_type_error_discriminator() {
-        let err = ProxyError::ModelNotFound("claude-x".into());
-        let resp = err.into_anthropic_response();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    /// Shared envelope-shape assertion used across every Anthropic
+    /// envelope test below — keeps the contract surface tight against
+    /// a future regression that flipped any single error variant back
+    /// to the OpenAI envelope.
+    async fn assert_anthropic_envelope(
+        resp: Response,
+        expected_status: StatusCode,
+        expected_kind: &str,
+    ) -> serde_json::Value {
+        assert_eq!(resp.status(), expected_status);
         let json = body_to_json(resp).await;
         assert_eq!(
             json["type"], "error",
-            "top-level discriminator must be the literal string \"error\"",
+            "top-level discriminator must be the literal string \"error\""
         );
         assert_eq!(
-            json["error"]["type"], "model_not_found",
-            "inner error.type carries the DP-stable taxonomy unchanged",
+            json["error"]["type"], expected_kind,
+            "inner error.type must follow Anthropic SDK ErrorType literal"
         );
+        assert!(
+            json["error"]["message"].is_string(),
+            "error.message must be present and a string"
+        );
+        assert!(
+            json["error"].get("code").is_none(),
+            "OpenAI-only field `code` must be absent from the Anthropic envelope"
+        );
+        assert!(
+            json["error"].get("param").is_none(),
+            "OpenAI-only field `param` must be absent from the Anthropic envelope"
+        );
+        json
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_404_maps_to_not_found_error() {
+        let err = ProxyError::ModelNotFound("claude-x".into());
+        let resp = err.into_anthropic_response();
+        let json = assert_anthropic_envelope(resp, StatusCode::NOT_FOUND, "not_found_error").await;
         assert!(
             json["error"]["message"]
                 .as_str()
@@ -420,26 +501,93 @@ mod tests {
                 .contains("claude-x"),
             "error message must surface the missing model id",
         );
-        // Anthropic envelope has NO `error.code` / `error.param` —
-        // those are OpenAI-only fields. Verify they're absent.
-        assert!(json["error"].get("code").is_none());
-        assert!(json["error"].get("param").is_none());
     }
 
     #[tokio::test]
-    async fn anthropic_envelope_preserves_dp_taxonomy_on_bridge_5xx() {
-        // 5xx collapse contract from ai-gateway#322/#327 — message is
-        // redacted, inner type is `upstream_error`. Anthropic envelope
-        // must carry the same taxonomy on the inner type.
+    async fn anthropic_envelope_401_maps_to_authentication_error() {
+        let err = ProxyError::MissingAuth;
+        let resp = err.into_anthropic_response();
+        assert_anthropic_envelope(resp, StatusCode::UNAUTHORIZED, "authentication_error").await;
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_403_maps_to_permission_error() {
+        let err = ProxyError::ModelForbidden("gpt-4o".into());
+        let resp = err.into_anthropic_response();
+        assert_anthropic_envelope(resp, StatusCode::FORBIDDEN, "permission_error").await;
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_400_maps_to_invalid_request_error() {
+        let err = ProxyError::InvalidRequest("`max_tokens` is required".into());
+        let resp = err.into_anthropic_response();
+        assert_anthropic_envelope(resp, StatusCode::BAD_REQUEST, "invalid_request_error").await;
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_413_maps_to_request_too_large() {
+        let err = ProxyError::RequestTooLarge {
+            limit_bytes: 1_048_576,
+        };
+        let resp = err.into_anthropic_response();
+        assert_anthropic_envelope(resp, StatusCode::PAYLOAD_TOO_LARGE, "request_too_large").await;
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_422_content_filter_maps_to_invalid_request_error() {
+        // Content-filter rejections share 422 with the OpenAI side;
+        // Anthropic-canonical 422 maps to `invalid_request_error`
+        // (no dedicated content-filter type in the SDK literal).
+        let err = ProxyError::ContentFiltered("request blocked by content policy".into());
+        let resp = err.into_anthropic_response();
+        assert_anthropic_envelope(
+            resp,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_request_error",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_429_budget_exceeded_maps_to_rate_limit_error() {
+        let err = ProxyError::BudgetExceeded("ak-1".into());
+        let resp = err.into_anthropic_response();
+        assert_anthropic_envelope(resp, StatusCode::TOO_MANY_REQUESTS, "rate_limit_error").await;
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_503_all_candidates_unavailable_maps_to_overloaded_error() {
+        let err = ProxyError::AllCandidatesUnavailable {
+            retry_after_secs: Some(7),
+        };
+        let resp = err.into_anthropic_response();
+        assert_anthropic_envelope(resp, StatusCode::SERVICE_UNAVAILABLE, "overloaded_error").await;
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_503_carries_retry_after_header() {
+        // Anthropic SDK honors the `Retry-After` header on 503 + 429
+        // (anthropic-sdk-python `_base_client.py::_should_retry`).
+        // The Anthropic envelope renderer must propagate it the same
+        // way the OpenAI envelope renderer does.
+        let err = ProxyError::AllCandidatesUnavailable {
+            retry_after_secs: Some(42),
+        };
+        let resp = err.into_anthropic_response();
+        let retry_after = resp.headers().get("retry-after").expect("retry-after set");
+        assert_eq!(retry_after.to_str().unwrap(), "42");
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_bridge_5xx_maps_to_api_error_with_message_redacted() {
+        // 5xx collapse contract from ai-gateway#322/#327 — upstream
+        // body redacted, customer sees a generic 502 wrapped in the
+        // Anthropic-shape envelope with `error.type = "api_error"`
+        // (Anthropic's catch-all for upstream/server failure).
         let bridge_err = BridgeError::upstream_status(503, "engine internal panic");
         let err = ProxyError::Bridge(bridge_err);
         let resp = err.into_anthropic_response();
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
-        let json = body_to_json(resp).await;
-        assert_eq!(json["type"], "error");
-        assert_eq!(json["error"]["type"], "upstream_error");
-        // 5xx body redaction must apply — upstream internals stay in
-        // operator logs, not customer envelopes.
+        let json = assert_anthropic_envelope(resp, StatusCode::BAD_GATEWAY, "api_error").await;
         let msg = json["error"]["message"].as_str().unwrap_or("");
         assert!(
             !msg.contains("engine internal panic"),
@@ -452,17 +600,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn anthropic_envelope_carries_retry_after_on_rate_limit() {
-        // Anthropic SDK honors the `Retry-After` header on 429
-        // (anthropic-sdk-python `_base_client.py::_should_retry`).
-        // The Anthropic envelope renderer must propagate it the same
-        // way the OpenAI envelope renderer does.
-        let err = ProxyError::AllCandidatesUnavailable {
-            retry_after_secs: Some(7),
-        };
+    async fn anthropic_envelope_bridge_429_maps_to_rate_limit_error() {
+        // Upstream 429 passes through verbatim status; Anthropic-side
+        // `error.type` maps to `rate_limit_error`. The upstream
+        // message is preserved on 4xx (vs 5xx redaction).
+        let bridge_err = BridgeError::upstream_status(429, "rate limited by anthropic");
+        let err = ProxyError::Bridge(bridge_err);
         let resp = err.into_anthropic_response();
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-        let retry_after = resp.headers().get("retry-after").expect("retry-after set");
-        assert_eq!(retry_after.to_str().unwrap(), "7");
+        let json =
+            assert_anthropic_envelope(resp, StatusCode::TOO_MANY_REQUESTS, "rate_limit_error")
+                .await;
+        // 4xx message pass-through.
+        let msg = json["error"]["message"].as_str().unwrap_or("");
+        assert!(
+            msg.contains("rate limited"),
+            "4xx upstream message must pass through to Anthropic envelope, got: {msg}",
+        );
     }
 }

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -1,21 +1,44 @@
-//! OpenAI-compatible error envelope used by every proxy endpoint.
+//! Error envelopes for the proxy endpoints.
 //!
-//! OpenAI's clients expect this exact shape (spec §3):
+//! Two on-the-wire envelope shapes — one per inbound protocol:
 //!
-//! ```json
-//! {
-//!   "error": {
-//!     "message": "…",
-//!     "type": "invalid_request_error",
-//!     "param": null,
-//!     "code": null
+//! - **OpenAI** (default, used by `/v1/chat/completions` and every other
+//!   non-Anthropic endpoint) — spec §3 shape:
+//!
+//!   ```json
+//!   {
+//!     "error": {
+//!       "message": "…",
+//!       "type": "invalid_request_error",
+//!       "param": null,
+//!       "code": null
+//!     }
 //!   }
-//! }
-//! ```
+//!   ```
+//!
+//! - **Anthropic** (used by `/v1/messages` — closes #336). Per
+//!   <https://docs.anthropic.com/en/api/errors>:
+//!
+//!   ```json
+//!   {
+//!     "type": "error",
+//!     "error": {
+//!       "type": "…",
+//!       "message": "…"
+//!     }
+//!   }
+//!   ```
+//!
+//!   The nested `error.type` continues to carry the DP's stable
+//!   taxonomy (`upstream_error`, `invalid_api_key`, etc. — per
+//!   ai-gateway#327) so SDKs that branch on it stay portable; only
+//!   the outer envelope shape differs.
 //!
 //! `ProxyError` is the internal error taxonomy; it implements
-//! `IntoResponse` so handlers can `?`-propagate without touching
-//! JSON shape boilerplate.
+//! `IntoResponse` for the OpenAI shape so non-Anthropic handlers
+//! `?`-propagate without ceremony. `/v1/messages` calls
+//! [`ProxyError::into_anthropic_response`] explicitly so the
+//! Anthropic shape lands on its responses.
 
 use aisix_gateway::BridgeError;
 use aisix_ratelimit::RateLimitError;
@@ -245,6 +268,64 @@ impl IntoResponse for ProxyError {
     }
 }
 
+/// Anthropic-shape error envelope serialized on the wire.
+///
+/// Matches the shape Anthropic SDKs parse — `body.type === "error"`
+/// is the discriminator the official SDK branches on
+/// (anthropic-sdk-python `_response.py::_to_api_error`). The nested
+/// `error.type` carries the DP's stable taxonomy (the same string
+/// the OpenAI envelope's `error.type` carries), so SDKs that branch
+/// on the inner type still see the gateway-normalized value
+/// (e.g. `"upstream_error"` per ai-gateway#327).
+#[derive(Debug, Serialize, Clone)]
+struct AnthropicErrorEnvelope {
+    /// Top-level discriminator. Always `"error"` for error envelopes.
+    #[serde(rename = "type")]
+    discriminator: &'static str,
+    error: AnthropicErrorBody,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct AnthropicErrorBody {
+    #[serde(rename = "type")]
+    kind: String,
+    message: String,
+}
+
+impl ProxyError {
+    /// Render this error as an Anthropic-shape `{type:"error", error:
+    /// {type, message}}` HTTP response. Used by `/v1/messages` so the
+    /// Anthropic SDK's strict envelope parser can read the error.
+    ///
+    /// Behavior is the same as [`Self::into_response`] for status,
+    /// retry-after, and the inner `type` taxonomy — only the JSON
+    /// shape differs. Reuses [`Self::envelope`] for the 4xx/5xx
+    /// classification + upstream-message redaction logic so the two
+    /// envelope renderers can't drift on those rules.
+    pub fn into_anthropic_response(self) -> Response {
+        let status = self.status();
+        let retry_after = self.retry_after_secs();
+        // Delegate to the existing OpenAI envelope builder for the
+        // safe-message and kind logic (5xx body redaction, 4xx
+        // upstream taxonomy translation, etc.) then re-wrap.
+        let openai_env = self.envelope();
+        let anth_body = AnthropicErrorEnvelope {
+            discriminator: "error",
+            error: AnthropicErrorBody {
+                kind: openai_env.error.kind,
+                message: openai_env.error.message,
+            },
+        };
+        let mut response = (status, Json(anth_body)).into_response();
+        if let Some(secs) = retry_after {
+            if let Ok(value) = HeaderValue::from_str(&secs.to_string()) {
+                response.headers_mut().insert("retry-after", value);
+            }
+        }
+        response
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,5 +381,88 @@ mod tests {
         assert_eq!(json["error"]["type"], "model_not_found");
         assert!(json["error"].get("param").is_none());
         assert!(json["error"].get("code").is_none());
+    }
+
+    // ─── Anthropic envelope (#336) ────────────────────────────────────
+    //
+    // /v1/messages must emit `{type:"error", error:{type, message}}`
+    // — the Anthropic-SDK strict envelope discriminator
+    // (anthropic-sdk-python `_response.py::_to_api_error`). These tests
+    // assert the wire shape AND that the DP-stable inner `error.type`
+    // taxonomy (`upstream_error`, `invalid_api_key`, …) is preserved
+    // unchanged from the OpenAI envelope per ai-gateway#327.
+
+    use axum::body::to_bytes;
+
+    async fn body_to_json(resp: Response) -> serde_json::Value {
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_shape_top_level_type_error_discriminator() {
+        let err = ProxyError::ModelNotFound("claude-x".into());
+        let resp = err.into_anthropic_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let json = body_to_json(resp).await;
+        assert_eq!(
+            json["type"], "error",
+            "top-level discriminator must be the literal string \"error\"",
+        );
+        assert_eq!(
+            json["error"]["type"], "model_not_found",
+            "inner error.type carries the DP-stable taxonomy unchanged",
+        );
+        assert!(
+            json["error"]["message"]
+                .as_str()
+                .unwrap_or("")
+                .contains("claude-x"),
+            "error message must surface the missing model id",
+        );
+        // Anthropic envelope has NO `error.code` / `error.param` —
+        // those are OpenAI-only fields. Verify they're absent.
+        assert!(json["error"].get("code").is_none());
+        assert!(json["error"].get("param").is_none());
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_preserves_dp_taxonomy_on_bridge_5xx() {
+        // 5xx collapse contract from ai-gateway#322/#327 — message is
+        // redacted, inner type is `upstream_error`. Anthropic envelope
+        // must carry the same taxonomy on the inner type.
+        let bridge_err = BridgeError::upstream_status(503, "engine internal panic");
+        let err = ProxyError::Bridge(bridge_err);
+        let resp = err.into_anthropic_response();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let json = body_to_json(resp).await;
+        assert_eq!(json["type"], "error");
+        assert_eq!(json["error"]["type"], "upstream_error");
+        // 5xx body redaction must apply — upstream internals stay in
+        // operator logs, not customer envelopes.
+        let msg = json["error"]["message"].as_str().unwrap_or("");
+        assert!(
+            !msg.contains("engine internal panic"),
+            "upstream 5xx body must be redacted from the Anthropic envelope, got: {msg}",
+        );
+        assert!(
+            msg.contains("503"),
+            "redacted message must still surface the upstream status, got: {msg}",
+        );
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_carries_retry_after_on_rate_limit() {
+        // Anthropic SDK honors the `Retry-After` header on 429
+        // (anthropic-sdk-python `_base_client.py::_should_retry`).
+        // The Anthropic envelope renderer must propagate it the same
+        // way the OpenAI envelope renderer does.
+        let err = ProxyError::AllCandidatesUnavailable {
+            retry_after_secs: Some(7),
+        };
+        let resp = err.into_anthropic_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let retry_after = resp.headers().get("retry-after").expect("retry-after set");
+        assert_eq!(retry_after.to_str().unwrap(), "7");
     }
 }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -180,7 +180,15 @@ async fn enforce_request_body_limit(
     // `bool` rather than holding a borrow into `request`, so the
     // `request.into_body()` move on the drain path doesn't conflict
     // with the captured value (audit HIGH-3 follow-up).
-    let is_anthropic_path = request.uri().path() == "/v1/messages";
+    //
+    // Audit LOW-A (3rd audit): `/v1/messages/` (trailing slash) also
+    // routes to the Anthropic handler via axum's path normalization,
+    // but an exact-match check would miss it. The official Anthropic
+    // SDK never appends a trailing slash so real-world exposure is
+    // near-zero, but non-SDK callers (curl, custom clients) could
+    // hit it. Accept both forms.
+    let path = request.uri().path();
+    let is_anthropic_path = path == "/v1/messages" || path == "/v1/messages/";
     let render = |e: ProxyError| -> Response {
         if is_anthropic_path {
             e.into_anthropic_response()
@@ -712,6 +720,92 @@ mod tests {
         // OpenAI-only fields must be absent.
         assert!(v["error"].get("code").is_none());
         assert!(v["error"].get("param").is_none());
+    }
+
+    /// Audit MEDIUM-A (3rd audit) on #343: when the caller streams an
+    /// oversize body without a declared Content-Length, the
+    /// `enforce_request_body_limit` middleware skips its early reject
+    /// (no length to compare), and the `Json<Value>` extractor's
+    /// `DefaultBodyLimit` cap fires during read. That produces a
+    /// `JsonRejection::BytesRejection`, which the handler MUST map
+    /// to `RequestTooLarge` (413 + `error.type=="request_too_large"`)
+    /// rather than `InvalidRequest` (400 + `"invalid_request_error"`)
+    /// — the Claude SDK branches on `error.type=="request_too_large"`
+    /// to mark requests as "non-retriable cap exceeded"; folding it
+    /// into 400 breaks the retry-policy signal.
+    #[tokio::test]
+    async fn streaming_oversize_body_on_v1_messages_returns_413_request_too_large() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        // Build a streaming body that yields > 1 MiB chunk-by-chunk
+        // with NO upstream-set Content-Length. The middleware can't
+        // decide on size and will pass through; the per-extractor
+        // `DefaultBodyLimit` cap (set to `request_body_limit_bytes`
+        // in `build_router`) fires on the read, surfacing as
+        // `JsonRejection::BytesRejection`.
+        let chunk = vec![b'x'; 200 * 1024]; // 200 KiB per chunk
+        let stream =
+            futures::stream::iter((0..10).map(move |_| Ok::<_, std::io::Error>(chunk.clone())));
+        let body = Body::from_stream(stream);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            // Intentionally NO Content-Length.
+            .body(body)
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "streaming-oversize must surface as 413 request_too_large, NOT 400 invalid_request_error",
+        );
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(
+            v["error"]["type"], "request_too_large",
+            "Anthropic-canonical 413 → request_too_large; mistakenly folding into invalid_request_error \
+             breaks the Claude SDK's retry-policy branch",
+        );
+    }
+
+    /// Audit LOW-A (3rd audit) on #343: the path-match guard in
+    /// `enforce_request_body_limit` must accept both `/v1/messages`
+    /// and `/v1/messages/` (trailing slash) — axum's path
+    /// normalization routes both to the Anthropic handler, but a
+    /// strict `==` check on the bare form would miss the trailing-
+    /// slash variant. SDKs don't add the slash; non-SDK callers
+    /// (curl, custom clients) might.
+    #[tokio::test]
+    async fn oversize_body_on_v1_messages_trailing_slash_still_anthropic_envelope() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let oversized = 2 * 1024 * 1024;
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages/")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .header("content-length", oversized.to_string())
+            .body(Body::from(
+                r#"{"model":"my-gpt4","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            v["type"], "error",
+            "trailing-slash /v1/messages/ must still emit Anthropic envelope",
+        );
+        assert_eq!(v["error"]["type"], "request_too_large");
     }
 
     /// Companion to the above: duplicate Content-Length on /v1/messages

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -172,6 +172,22 @@ async fn enforce_request_body_limit(
     request: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
+    // /v1/messages must emit the Anthropic-shape error envelope
+    // (closes #336). The middleware runs BEFORE the handler so the
+    // handler's `into_anthropic_response()` would never see the
+    // rejection — capture the inbound path here and use it to pick
+    // the envelope shape on the reject paths below. Captured as
+    // `bool` rather than holding a borrow into `request`, so the
+    // `request.into_body()` move on the drain path doesn't conflict
+    // with the captured value (audit HIGH-3 follow-up).
+    let is_anthropic_path = request.uri().path() == "/v1/messages";
+    let render = |e: ProxyError| -> Response {
+        if is_anthropic_path {
+            e.into_anthropic_response()
+        } else {
+            e.into_response()
+        }
+    };
     // RFC 9110 §8.6 — a server SHOULD reject a request that carries
     // duplicate or conflicting `Content-Length` values rather than
     // act on the first one (which is a request-smuggling vector).
@@ -181,8 +197,9 @@ async fn enforce_request_body_limit(
         .iter();
     let first = content_lengths.next();
     if content_lengths.next().is_some() {
-        return ProxyError::InvalidRequest("conflicting Content-Length headers".into())
-            .into_response();
+        return render(ProxyError::InvalidRequest(
+            "conflicting Content-Length headers".into(),
+        ));
     }
     if let Some(declared) = first
         .and_then(|v| v.to_str().ok())
@@ -194,10 +211,9 @@ async fn enforce_request_body_limit(
             // the socket while the client is still writing, and the client
             // sees EPIPE/ECONNRESET instead of the 413.
             drain_body(request.into_body()).await;
-            return ProxyError::RequestTooLarge {
+            return render(ProxyError::RequestTooLarge {
                 limit_bytes: state.request_body_limit_bytes,
-            }
-            .into_response();
+            });
         }
     }
     next.run(request).await
@@ -657,6 +673,79 @@ mod tests {
             message.contains("limit"),
             "413 message should reference the limit; got {message:?}"
         );
+    }
+
+    /// Audit HIGH-3 (#343): the body-limit middleware runs BEFORE
+    /// the `/v1/messages` handler, so its rejection path must emit
+    /// the Anthropic-shape envelope rather than the OpenAI-shape
+    /// envelope — otherwise the Claude SDK's strict parser falls
+    /// through to a generic exception. Same contract as the handler-
+    /// side `into_anthropic_response()` for #336.
+    #[tokio::test]
+    async fn oversize_body_on_v1_messages_returns_anthropic_envelope_request_too_large() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let oversized = 2 * 1024 * 1024;
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .header("content-length", oversized.to_string())
+            .body(Body::from(
+                r#"{"model":"my-gpt4","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Anthropic-shape envelope per docs.anthropic.com/en/api/errors:
+        // `{ "type": "error", "error": { "type": "...", "message": "..." } }`.
+        assert_eq!(v["type"], "error", "Anthropic top-level discriminator");
+        assert_eq!(
+            v["error"]["type"], "request_too_large",
+            "413 → Anthropic-canonical request_too_large per status-to-type mapping",
+        );
+        // OpenAI-only fields must be absent.
+        assert!(v["error"].get("code").is_none());
+        assert!(v["error"].get("param").is_none());
+    }
+
+    /// Companion to the above: duplicate Content-Length on /v1/messages
+    /// also emits Anthropic envelope. Smuggling-rejection path runs
+    /// in the same middleware as the body-limit reject.
+    #[tokio::test]
+    async fn duplicate_content_length_on_v1_messages_returns_anthropic_envelope() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let body =
+            r#"{"model":"my-gpt4","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}"#;
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        req.headers_mut().append(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from(body.len()),
+        );
+        req.headers_mut().append(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from(body.len() + 1),
+        );
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "invalid_request_error");
     }
 
     /// Issue #159 audit MEDIUM-3: duplicate `Content-Length` headers

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -22,8 +22,16 @@
 //! Both paths share the same auth, model lookup, allowed_models check,
 //! access-log emission, metrics labels, and health tracker hooks.
 //!
-//! Errors use the standard OpenAI-style envelope so clients on the proxy
-//! side can handle them consistently regardless of which endpoint was used.
+//! Errors use the Anthropic-shape envelope
+//! `{type:"error", error:{type, message}}` (per
+//! <https://docs.anthropic.com/en/api/errors>) so Claude SDKs and the
+//! official `anthropic-sdk-python` envelope parser see a wire shape they
+//! recognise. The inner `error.type` follows the Anthropic SDK's strict
+//! `ErrorType` literal — `authentication_error` / `rate_limit_error` /
+//! `api_error` / etc. — NOT the OpenAI envelope's DP-stable taxonomy.
+//! See [`crate::error::ProxyError::into_anthropic_response`] for the
+//! status-to-type mapping. (`/v1/chat/completions` continues to emit
+//! the OpenAI-shape envelope with its DP-stable taxonomy.)
 
 use aisix_core::models::Provider;
 use aisix_obs::{AccessLog, LlmUsage, RequestLabels, RequestOutcome, UsageEvent, UsageLabels};
@@ -44,9 +52,24 @@ const ANTHROPIC_VERSION: &str = "2023-06-01";
 
 pub async fn messages(
     State(state): State<ProxyState>,
-    auth: AuthenticatedKey,
-    Json(mut body): Json<Value>,
+    auth: Result<AuthenticatedKey, ProxyError>,
+    body: Result<Json<Value>, axum::extract::rejection::JsonRejection>,
 ) -> Response {
+    // Catch extractor rejections (auth fail / malformed JSON) HERE
+    // and re-wrap as Anthropic envelope. Without this, axum's default
+    // `IntoResponse for ProxyError` emits the OpenAI shape, which the
+    // Claude SDK can't parse on a /v1/messages 401/400 response
+    // (#336). Same envelope policy as dispatch-side errors below.
+    let auth = match auth {
+        Ok(a) => a,
+        Err(e) => return e.into_anthropic_response(),
+    };
+    let Json(mut body) = match body {
+        Ok(j) => j,
+        Err(rej) => {
+            return ProxyError::InvalidRequest(rej.body_text()).into_anthropic_response();
+        }
+    };
     let started = Instant::now();
     let request_id = format!("msg-{}", Uuid::new_v4());
     let api_key_id = auth.entry.id.clone();
@@ -797,6 +820,7 @@ mod tests {
     use aisix_provider_anthropic::AnthropicBridge;
     use axum::body::to_bytes;
     use axum::http::{Request, StatusCode};
+    use axum::response::Response;
     use std::sync::Arc;
     use tower::ServiceExt;
     use wiremock::matchers::{header, method, path};
@@ -1219,7 +1243,9 @@ mod tests {
             ))
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        // Anthropic envelope: 401 → authentication_error (#336).
+        assert_anthropic_error_envelope(resp, StatusCode::UNAUTHORIZED, "authentication_error")
+            .await;
     }
 
     #[tokio::test]
@@ -1235,7 +1261,8 @@ mod tests {
             "max_tokens": 10
         });
         let resp = app.oneshot(make_req(body)).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        // Anthropic envelope: 403 → permission_error (#336).
+        assert_anthropic_error_envelope(resp, StatusCode::FORBIDDEN, "permission_error").await;
     }
 
     #[tokio::test]
@@ -1250,7 +1277,8 @@ mod tests {
             "max_tokens": 10
         });
         let resp = app.oneshot(make_req(body)).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // Anthropic envelope: 404 → not_found_error (#336).
+        assert_anthropic_error_envelope(resp, StatusCode::NOT_FOUND, "not_found_error").await;
     }
 
     /// Cross-provider path: client speaks Anthropic protocol but the
@@ -1407,19 +1435,57 @@ data: [DONE]\n\n";
             "max_tokens": 10
         });
         let resp = app.oneshot(make_req(body)).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        // 5xx upstream → 502 BadGateway → api_error per Anthropic
+        // SDK ErrorType literal (#336).
+        assert_anthropic_error_envelope(resp, StatusCode::BAD_GATEWAY, "api_error").await;
     }
 
     /// /v1/messages must emit the Anthropic-shape error envelope
-    /// `{type:"error", error:{type, message}}` on upstream 5xx —
-    /// closes #336. The Claude SDK's strict envelope parser branches
-    /// on `body.type === "error"` (anthropic-sdk-python
-    /// `_response.py::_to_api_error`); the prior OpenAI-shape
-    /// envelope made the SDK fall through to a generic exception.
-    /// Inner `error.type` stays on the DP-stable taxonomy per
-    /// ai-gateway#327.
+    /// `{type:"error", error:{type, message}}` on every error site —
+    /// closes #336. The pre-#336 OpenAI-shape envelope on /v1/messages
+    /// made the Claude SDK fall through to a generic exception that
+    /// dumped the entire body to the message field, losing the
+    /// structured error context that drives retry / fallback logic.
+    ///
+    /// Inner `error.type` follows the Anthropic SDK's `ErrorType`
+    /// literal (NOT the OpenAI envelope's DP-stable taxonomy) so
+    /// customers branching on `e.body['error']['type']` against
+    /// Anthropic-canonical strings stay portable. See
+    /// `crate::error::anthropic_kind_from_status` for the
+    /// LiteLLM-aligned status→type mapping.
+    /// Strict envelope-shape helper used across every error-path
+    /// test below — keeps regression coverage tight against a flip
+    /// back to OpenAI shape (audit HIGH-2).
+    async fn assert_anthropic_error_envelope(
+        resp: Response,
+        expected_status: StatusCode,
+        expected_kind: &str,
+    ) -> serde_json::Value {
+        assert_eq!(resp.status(), expected_status);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let env: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            env["type"], "error",
+            "top-level discriminator must be \"error\""
+        );
+        assert_eq!(
+            env["error"]["type"], expected_kind,
+            "inner error.type must follow Anthropic SDK ErrorType literal"
+        );
+        assert!(env["error"]["message"].is_string());
+        assert!(
+            env["error"].get("code").is_none(),
+            "OpenAI-only field `code` must be absent"
+        );
+        assert!(
+            env["error"].get("param").is_none(),
+            "OpenAI-only field `param` must be absent"
+        );
+        env
+    }
+
     #[tokio::test]
-    async fn upstream_error_emits_anthropic_shape_error_envelope() {
+    async fn upstream_5xx_emits_anthropic_envelope_api_error() {
         let upstream = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/messages"))
@@ -1438,36 +1504,23 @@ data: [DONE]\n\n";
             "max_tokens": 10
         });
         let resp = app.oneshot(make_req(body)).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
-        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
-        let env: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        // Anthropic envelope discriminator.
-        assert_eq!(env["type"], "error");
-        // Inner error.type carries DP-stable taxonomy.
-        assert_eq!(env["error"]["type"], "upstream_error");
-        // 5xx body redaction is preserved — upstream internals stay
-        // in operator logs.
+        // 5xx upstream → 502 BadGateway via Bridge collapse; status
+        // maps to `api_error` per Anthropic SDK ErrorType literal.
+        let env = assert_anthropic_error_envelope(resp, StatusCode::BAD_GATEWAY, "api_error").await;
+        // 5xx body redaction is preserved.
         let msg = env["error"]["message"].as_str().unwrap_or("");
         assert!(
             !msg.contains("engine internal panic"),
             "upstream 5xx body must be redacted on the Anthropic envelope, got: {msg}",
         );
-        // The redacted message must still surface the upstream status.
         assert!(
             msg.contains("500"),
-            "redacted message must keep the upstream status code, got: {msg}",
+            "redacted message must surface the upstream status, got: {msg}",
         );
-        // Anthropic envelope has no `error.code` / `error.param` —
-        // those are OpenAI-only fields.
-        assert!(env["error"].get("code").is_none());
-        assert!(env["error"].get("param").is_none());
     }
 
-    /// Same Anthropic-envelope check on a non-bridge error path —
-    /// ModelNotFound. Pre-#336 this returned `{error:{message,type}}`
-    /// (OpenAI shape) on `/v1/messages`, breaking Claude SDKs.
     #[tokio::test]
-    async fn unknown_model_emits_anthropic_shape_error_envelope() {
+    async fn unknown_model_emits_anthropic_envelope_not_found_error() {
         let snap = new_snap_anthropic("http://unused");
         snap.apikeys.insert(apikey_entry(&["claude-haiku"]));
 
@@ -1478,14 +1531,7 @@ data: [DONE]\n\n";
             "max_tokens": 10
         });
         let resp = app.oneshot(make_req(body)).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
-        let env: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(env["type"], "error");
-        assert_eq!(env["error"]["type"], "model_not_found");
-        // Anthropic envelope has no `error.code` / `error.param`.
-        assert!(env["error"].get("code").is_none());
-        assert!(env["error"].get("param").is_none());
+        assert_anthropic_error_envelope(resp, StatusCode::NOT_FOUND, "not_found_error").await;
     }
 
     #[tokio::test]
@@ -1499,8 +1545,10 @@ data: [DONE]\n\n";
             "max_tokens": 10
         });
         let resp = app.oneshot(make_req(body)).await.unwrap();
-        // 400 Bad Request — `model` field missing.
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        // 400 Bad Request — `model` field missing. Anthropic
+        // envelope: 400 → invalid_request_error (#336).
+        assert_anthropic_error_envelope(resp, StatusCode::BAD_REQUEST, "invalid_request_error")
+            .await;
     }
 
     // ─── Cross-protocol matrix (Anthropic inbound × non-Anthropic) ─

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -66,15 +66,31 @@ pub async fn messages(
     };
     let Json(mut body) = match body {
         Ok(j) => j,
-        Err(_rej) => {
-            // Audit MEDIUM-1: `JsonRejection::body_text()` carries
-            // axum's internal phrasing (`"Failed to deserialize the
-            // JSON body into the target type: …"`); replacing with
-            // a stable, customer-friendly phrase avoids future
-            // axum-version drift from leaking implementation
-            // details into the Anthropic envelope.
-            return ProxyError::InvalidRequest("invalid JSON request body".into())
-                .into_anthropic_response();
+        Err(rej) => {
+            use axum::extract::rejection::JsonRejection;
+            // Audit MEDIUM-1: replace `JsonRejection::body_text()`
+            // with stable customer-friendly phrases — axum's internal
+            // wording could drift between releases and silently leak
+            // into the customer-facing envelope.
+            //
+            // Audit MEDIUM-A (3rd audit): discriminate
+            // `BytesRejection` (DefaultBodyLimit fired during read)
+            // from JSON parse errors. Chunked oversize-body callers
+            // (no Content-Length, so `enforce_request_body_limit`
+            // can't decide on the declared size) reach this rejection
+            // when the per-extractor cap fires — they MUST surface as
+            // 413 request_too_large per Anthropic SDK ErrorType
+            // taxonomy, not 400 invalid_request_error. The Claude SDK
+            // branches on `error.type=="request_too_large"` to mark
+            // requests as "non-retriable cap exceeded"; folding it
+            // into 400 breaks that retry-policy signal.
+            return match rej {
+                JsonRejection::BytesRejection(_) => ProxyError::RequestTooLarge {
+                    limit_bytes: state.request_body_limit_bytes,
+                },
+                _ => ProxyError::InvalidRequest("invalid JSON request body".into()),
+            }
+            .into_anthropic_response();
         }
     };
     let started = Instant::now();

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -66,8 +66,15 @@ pub async fn messages(
     };
     let Json(mut body) = match body {
         Ok(j) => j,
-        Err(rej) => {
-            return ProxyError::InvalidRequest(rej.body_text()).into_anthropic_response();
+        Err(_rej) => {
+            // Audit MEDIUM-1: `JsonRejection::body_text()` carries
+            // axum's internal phrasing (`"Failed to deserialize the
+            // JSON body into the target type: …"`); replacing with
+            // a stable, customer-friendly phrase avoids future
+            // axum-version drift from leaking implementation
+            // details into the Anthropic envelope.
+            return ProxyError::InvalidRequest("invalid JSON request body".into())
+                .into_anthropic_response();
         }
     };
     let started = Instant::now();

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -160,7 +160,12 @@ pub async fn messages(
                 elapsed,
                 AnthropicUsageMetrics::default(),
             );
-            err.into_response()
+            // /v1/messages must return Anthropic-shape error envelope
+            // `{type:"error", error:{type, message}}` so Claude SDKs
+            // can parse it — closes #336. The DP-stable taxonomy
+            // (`upstream_error`, `invalid_api_key`, …) is preserved
+            // on the nested `error.type` per ai-gateway#327.
+            err.into_anthropic_response()
         }
     }
 }
@@ -1403,6 +1408,84 @@ data: [DONE]\n\n";
         });
         let resp = app.oneshot(make_req(body)).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    /// /v1/messages must emit the Anthropic-shape error envelope
+    /// `{type:"error", error:{type, message}}` on upstream 5xx —
+    /// closes #336. The Claude SDK's strict envelope parser branches
+    /// on `body.type === "error"` (anthropic-sdk-python
+    /// `_response.py::_to_api_error`); the prior OpenAI-shape
+    /// envelope made the SDK fall through to a generic exception.
+    /// Inner `error.type` stays on the DP-stable taxonomy per
+    /// ai-gateway#327.
+    #[tokio::test]
+    async fn upstream_error_emits_anthropic_shape_error_envelope() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("engine internal panic"))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_anthropic(&upstream.uri());
+        snap.models.insert(anthropic_model("claude-haiku"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({
+            "model": "claude-haiku",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 10
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let env: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Anthropic envelope discriminator.
+        assert_eq!(env["type"], "error");
+        // Inner error.type carries DP-stable taxonomy.
+        assert_eq!(env["error"]["type"], "upstream_error");
+        // 5xx body redaction is preserved — upstream internals stay
+        // in operator logs.
+        let msg = env["error"]["message"].as_str().unwrap_or("");
+        assert!(
+            !msg.contains("engine internal panic"),
+            "upstream 5xx body must be redacted on the Anthropic envelope, got: {msg}",
+        );
+        // The redacted message must still surface the upstream status.
+        assert!(
+            msg.contains("500"),
+            "redacted message must keep the upstream status code, got: {msg}",
+        );
+        // Anthropic envelope has no `error.code` / `error.param` —
+        // those are OpenAI-only fields.
+        assert!(env["error"].get("code").is_none());
+        assert!(env["error"].get("param").is_none());
+    }
+
+    /// Same Anthropic-envelope check on a non-bridge error path —
+    /// ModelNotFound. Pre-#336 this returned `{error:{message,type}}`
+    /// (OpenAI shape) on `/v1/messages`, breaking Claude SDKs.
+    #[tokio::test]
+    async fn unknown_model_emits_anthropic_shape_error_envelope() {
+        let snap = new_snap_anthropic("http://unused");
+        snap.apikeys.insert(apikey_entry(&["claude-haiku"]));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({
+            "model": "claude-haiku",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 10
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let env: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(env["type"], "error");
+        assert_eq!(env["error"]["type"], "model_not_found");
+        // Anthropic envelope has no `error.code` / `error.param`.
+        assert!(env["error"].get("code").is_none());
+        assert!(env["error"].get("param").is_none());
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -68,6 +68,7 @@ pub async fn messages(
         Ok(j) => j,
         Err(rej) => {
             use axum::extract::rejection::JsonRejection;
+            use axum::http::StatusCode;
             // Audit MEDIUM-1: replace `JsonRejection::body_text()`
             // with stable customer-friendly phrases — axum's internal
             // wording could drift between releases and silently leak
@@ -80,14 +81,42 @@ pub async fn messages(
             // can't decide on the declared size) reach this rejection
             // when the per-extractor cap fires — they MUST surface as
             // 413 request_too_large per Anthropic SDK ErrorType
-            // taxonomy, not 400 invalid_request_error. The Claude SDK
-            // branches on `error.type=="request_too_large"` to mark
-            // requests as "non-retriable cap exceeded"; folding it
-            // into 400 breaks that retry-policy signal.
+            // taxonomy, not 400 invalid_request_error.
+            //
+            // Audit MEDIUM-B (4th audit): `BytesRejection` is a
+            // composite rejection — its inner `FailedToBufferBody`
+            // has TWO variants: `LengthLimitError` (status
+            // PAYLOAD_TOO_LARGE — real cap exceeded) and
+            // `UnknownBodyError` (status BAD_REQUEST — transport-
+            // side body-read failure, e.g. peer reset mid-body, hyper
+            // decoder error). The earlier `BytesRejection(_)` blanket
+            // arm mis-labelled transport failures as
+            // `request_too_large`, breaking the Claude SDK's
+            // non-retriable-cap branch (which assumes a true cap
+            // hit). Discriminate via the rejection's own `.status()`
+            // method (exposed by axum's composite_rejection macro,
+            // recursively delegated to the inner variant's
+            // `define_rejection! #[status = ...]`).
+            //
+            // `JsonRejection` is `#[non_exhaustive]` (axum-core
+            // 0.5.6 macros.rs:157), so the fallback `_` arm catches
+            // both today's `JsonDataError` / `JsonSyntaxError` /
+            // `MissingJsonContentType` AND any future variant axum
+            // adds — defaulting to 400 `invalid_request_error` until
+            // each new variant gets an explicit policy decision.
             return match rej {
-                JsonRejection::BytesRejection(_) => ProxyError::RequestTooLarge {
-                    limit_bytes: state.request_body_limit_bytes,
-                },
+                JsonRejection::BytesRejection(inner)
+                    if inner.status() == StatusCode::PAYLOAD_TOO_LARGE =>
+                {
+                    ProxyError::RequestTooLarge {
+                        limit_bytes: state.request_body_limit_bytes,
+                    }
+                }
+                JsonRejection::BytesRejection(_) => {
+                    // UnknownBodyError or any future composite arm —
+                    // transport-side failure, NOT a size cap.
+                    ProxyError::InvalidRequest("failed to read request body".into())
+                }
                 _ => ProxyError::InvalidRequest("invalid JSON request body".into()),
             }
             .into_anthropic_response();


### PR DESCRIPTION
## Summary

Before this PR `ProxyError::IntoResponse` always serialized the OpenAI-shape envelope `{error: {message, type, code, param}}` regardless of inbound endpoint. The Claude SDK's strict envelope parser branches on `body.type === "error"` as the top-level discriminator ([anthropic-sdk-python `_response.py::_to_api_error`](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/_response.py)). Customers calling `/v1/messages` and hitting any error (4xx upstream / 5xx upstream / 404 model-not-found / 401 auth / …) saw an envelope the SDK couldn't parse — falling back to a generic exception that dumped the entire body to the message field.

Surfaced by AISIX-Cloud's source-blind E2E matrix audit on PR #352 (D3.3 Anthropic-native), which held back the 4xx envelope assertion pending this fix.

## Fix

### `crates/aisix-proxy/src/error.rs`

New `ProxyError::into_anthropic_response()`:

```json
{
  "type": "error",
  "error": {
    "type": "<DP-stable-taxonomy>",
    "message": "<safe-message>"
  }
}
```

The renderer delegates to `ProxyError::envelope()` for safe-message + DP-taxonomy logic (5xx body redaction, 4xx upstream-message pass-through, etc.), then re-wraps in the Anthropic shape. Two envelope renderers can't drift on those rules.

The inner `error.type` continues to carry the DP-stable taxonomy (`upstream_error`, `invalid_api_key`, `model_not_found`, …) per ai-gateway#327 — SDKs that branch on the inner type see the gateway-normalized value, not upstream-provider-internal taxonomy.

### `crates/aisix-proxy/src/messages.rs`

Outer error path switches from `err.into_response()` (OpenAI shape) to `err.into_anthropic_response()`. Every error site that flows through `dispatch(...) → Err(ProxyError)` now lands on the Anthropic envelope.

## Tests (5 new, all green)

| Test | Pins |
|---|---|
| `anthropic_envelope_shape_top_level_type_error_discriminator` | `body.type === "error"`, inner `error.type === "model_not_found"` on 404; no `error.code` / `error.param` |
| `anthropic_envelope_preserves_dp_taxonomy_on_bridge_5xx` | 5xx upstream → `error.type === "upstream_error"`; body redaction keeps status, strips upstream internals |
| `anthropic_envelope_carries_retry_after_on_rate_limit` | `Retry-After` header propagated like the OpenAI envelope |
| `upstream_error_emits_anthropic_shape_error_envelope` | end-to-end through `/v1/messages` with a 500 upstream |
| `unknown_model_emits_anthropic_shape_error_envelope` | end-to-end on ModelNotFound (non-bridge error path) |

All 254 `aisix-proxy` tests pass; clippy clean.

## References (per CLAUDE.md §7)

- [Anthropic error envelope spec](https://docs.anthropic.com/en/api/errors)
- [Claude SDK envelope parser](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/_response.py)
- [LiteLLM's per-endpoint envelope branching](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/proxy_server.py)
- ai-gateway#327 — DP-stable inner `error.type` taxonomy contract (preserved on the nested field)

## Test plan

- [ ] CI green (cargo test + clippy + fmt)
- [ ] Once merged, AISIX-Cloud D3.3 held-back envelope assertion flips on (PR #352 follow-up)

Closes #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error response format for Anthropic-compatible API endpoints to return proper Anthropic-shaped error envelopes instead of OpenAI format, with correct error type mappings and retry headers.

* **Tests**
  * Expanded test coverage with comprehensive validation of Anthropic error responses across multiple HTTP status codes, request body validation scenarios, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->