### PR TITLE
feat(core, server): long-tail OpenAI-adapter Provider variants + Hub registrations (#60 P2-A)

### DIFF
--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -61,7 +61,7 @@ pub enum Provider {
     Groq,
     /// Mistral AI — OpenAI-compat at `https://api.mistral.ai/v1`.
     Mistral,
-    /// Together.ai — OpenAI-compat at `https://api.together.xyz/v1`.
+    /// Together.ai — OpenAI-compat at `https://api.together.ai/v1`.
     Togetherai,
     /// Fireworks AI — OpenAI-compat at `https://api.fireworks.ai/inference/v1`.
     /// Wire id is the hyphenated `fireworks-ai` (matches the
@@ -71,8 +71,13 @@ pub enum Provider {
     /// Perplexity — OpenAI-compat at `https://api.perplexity.ai`
     /// (chat lives at the host root).
     Perplexity,
-    /// xAI Grok — OpenAI-compat at `https://api.x.ai/v1`.
-    Xai,
+    // xAI Grok was scoped out of this PR after audit: `xai` is not in
+    // AISIX-Cloud's `internal/cpapi/adapter_map/adapter_map.yaml`
+    // Featured table (PR #335 swapped xai → google for rank 8), so
+    // adding `Provider::Xai` here without a catalog entry would leave
+    // a DP variant cp-api can't write to. Tracked as a separate
+    // follow-up: add xai to adapter_map.yaml first, then a one-line
+    // Provider::Xai DP-side commit will follow.
     /// Moonshot AI (Kimi) — OpenAI-compat at `https://api.moonshot.cn/v1`.
     Moonshotai,
     /// Alibaba Cloud DashScope — OpenAI-compat at
@@ -106,10 +111,9 @@ impl Provider {
             // url is the vendor's documented OpenAI-compat endpoint.
             Self::Groq => "https://api.groq.com/openai/v1",
             Self::Mistral => "https://api.mistral.ai/v1",
-            Self::Togetherai => "https://api.together.xyz/v1",
+            Self::Togetherai => "https://api.together.ai/v1",
             Self::FireworksAi => "https://api.fireworks.ai/inference/v1",
             Self::Perplexity => "https://api.perplexity.ai",
-            Self::Xai => "https://api.x.ai/v1",
             Self::Moonshotai => "https://api.moonshot.cn/v1",
             Self::Alibaba => "https://dashscope.aliyuncs.com/compatible-mode/v1",
             Self::Zhipuai => "https://open.bigmodel.cn/api/paas/v4",
@@ -135,7 +139,6 @@ impl Provider {
             Self::Togetherai => "togetherai",
             Self::FireworksAi => "fireworks-ai",
             Self::Perplexity => "perplexity",
-            Self::Xai => "xai",
             Self::Moonshotai => "moonshotai",
             Self::Alibaba => "alibaba",
             Self::Zhipuai => "zhipuai",
@@ -216,7 +219,6 @@ impl From<Provider> for Adapter {
             | Provider::Togetherai
             | Provider::FireworksAi
             | Provider::Perplexity
-            | Provider::Xai
             | Provider::Moonshotai
             | Provider::Alibaba
             | Provider::Zhipuai
@@ -706,5 +708,46 @@ mod tests {
             "https://api.cohere.com"
         );
         assert_eq!(Provider::Jina.default_base_url(), "https://api.jina.ai");
+    }
+
+    /// Every `Provider` variant must have a non-empty `default_base_url`,
+    /// `as_str`, and an `Adapter::from` arm. A regression that added a
+    /// new variant but forgot to update one of the three would compile
+    /// fine but silently break dispatch downstream — this iterator-based
+    /// test makes the regression class explicit (audit MEDIUM-2 on
+    /// PR #345).
+    #[test]
+    fn every_provider_variant_has_default_base_url_as_str_and_adapter() {
+        let variants = [
+            Provider::Openai,
+            Provider::Anthropic,
+            Provider::Google,
+            Provider::Deepseek,
+            Provider::Cohere,
+            Provider::Jina,
+            // Long-tail OpenAI-adapter providers (#60 P2-A).
+            Provider::Groq,
+            Provider::Mistral,
+            Provider::Togetherai,
+            Provider::FireworksAi,
+            Provider::Perplexity,
+            Provider::Moonshotai,
+            Provider::Alibaba,
+            Provider::Zhipuai,
+            Provider::Baseten,
+            Provider::Huggingface,
+            Provider::Cerebras,
+        ];
+        for v in variants {
+            let url = v.default_base_url();
+            assert!(
+                url.starts_with("https://"),
+                "{v:?}: default_base_url must be an https URL, got {url:?}",
+            );
+            let id = v.as_str();
+            assert!(!id.is_empty(), "{v:?}: as_str must be non-empty");
+            // Adapter::from must compile and return some variant.
+            let _: Adapter = Adapter::from(v);
+        }
     }
 }

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -44,6 +44,53 @@ pub enum Provider {
     /// verbatim with no transform. Jina's chat / embeddings APIs are
     /// out of scope for this phase.
     Jina,
+    // ─── OpenAI-adapter long-tail providers (#60 P2-A) ────────────────
+    //
+    // The 11 variants below all expose an OpenAI-compatible chat
+    // completions surface and route through `OpenAiBridge::with_name`
+    // — the same dispatch path Deepseek / Google already use. Default
+    // base URLs are sourced from each vendor's official OpenAI-compat
+    // documentation; operators can override via `ProviderKey.api_base`.
+    //
+    // serde casing is `lowercase` (inherited from the parent enum) so
+    // each variant's wire id is its single-token lowercase form. The
+    // `fireworks-ai` variant carries an explicit `#[serde(rename)]`
+    // because its catalog id (per models.dev) is hyphenated and would
+    // not survive the default lowercase rule.
+    /// Groq — OpenAI-compat at `https://api.groq.com/openai/v1`.
+    Groq,
+    /// Mistral AI — OpenAI-compat at `https://api.mistral.ai/v1`.
+    Mistral,
+    /// Together.ai — OpenAI-compat at `https://api.together.xyz/v1`.
+    Togetherai,
+    /// Fireworks AI — OpenAI-compat at `https://api.fireworks.ai/inference/v1`.
+    /// Wire id is the hyphenated `fireworks-ai` (matches the
+    /// models.dev catalog id used by cp-api's adapter_map).
+    #[serde(rename = "fireworks-ai")]
+    FireworksAi,
+    /// Perplexity — OpenAI-compat at `https://api.perplexity.ai`
+    /// (chat lives at the host root).
+    Perplexity,
+    /// xAI Grok — OpenAI-compat at `https://api.x.ai/v1`.
+    Xai,
+    /// Moonshot AI (Kimi) — OpenAI-compat at `https://api.moonshot.cn/v1`.
+    Moonshotai,
+    /// Alibaba Cloud DashScope — OpenAI-compat at
+    /// `https://dashscope.aliyuncs.com/compatible-mode/v1`.
+    Alibaba,
+    /// Zhipu AI (智谱) — OpenAI-compat at
+    /// `https://open.bigmodel.cn/api/paas/v4`.
+    Zhipuai,
+    /// Baseten — OpenAI-compat at `https://inference.baseten.co/v1`.
+    /// Per <https://docs.baseten.co/development/model-apis/openai-clients>,
+    /// model APIs are exposed at this host root.
+    Baseten,
+    /// Hugging Face — OpenAI-compat router at
+    /// `https://router.huggingface.co/v1` per
+    /// <https://huggingface.co/docs/inference-providers/en/index#openai-compatible-api>.
+    Huggingface,
+    /// Cerebras Inference — OpenAI-compat at `https://api.cerebras.ai/v1`.
+    Cerebras,
 }
 
 impl Provider {
@@ -55,6 +102,20 @@ impl Provider {
             Self::Deepseek => "https://api.deepseek.com",
             Self::Cohere => "https://api.cohere.com",
             Self::Jina => "https://api.jina.ai",
+            // Long-tail OpenAI-adapter providers (#60 P2-A) — each
+            // url is the vendor's documented OpenAI-compat endpoint.
+            Self::Groq => "https://api.groq.com/openai/v1",
+            Self::Mistral => "https://api.mistral.ai/v1",
+            Self::Togetherai => "https://api.together.xyz/v1",
+            Self::FireworksAi => "https://api.fireworks.ai/inference/v1",
+            Self::Perplexity => "https://api.perplexity.ai",
+            Self::Xai => "https://api.x.ai/v1",
+            Self::Moonshotai => "https://api.moonshot.cn/v1",
+            Self::Alibaba => "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            Self::Zhipuai => "https://open.bigmodel.cn/api/paas/v4",
+            Self::Baseten => "https://inference.baseten.co/v1",
+            Self::Huggingface => "https://router.huggingface.co/v1",
+            Self::Cerebras => "https://api.cerebras.ai/v1",
         }
     }
 
@@ -66,6 +127,21 @@ impl Provider {
             Self::Deepseek => "deepseek",
             Self::Cohere => "cohere",
             Self::Jina => "jina",
+            // Long-tail OpenAI-adapter providers (#60 P2-A). The
+            // wire id matches the catalog id used by cp-api's
+            // adapter_map / models.dev.
+            Self::Groq => "groq",
+            Self::Mistral => "mistral",
+            Self::Togetherai => "togetherai",
+            Self::FireworksAi => "fireworks-ai",
+            Self::Perplexity => "perplexity",
+            Self::Xai => "xai",
+            Self::Moonshotai => "moonshotai",
+            Self::Alibaba => "alibaba",
+            Self::Zhipuai => "zhipuai",
+            Self::Baseten => "baseten",
+            Self::Huggingface => "huggingface",
+            Self::Cerebras => "cerebras",
         }
     }
 }
@@ -133,6 +209,20 @@ impl From<Provider> for Adapter {
             Provider::Deepseek => Adapter::Openai,
             Provider::Cohere => Adapter::Openai,
             Provider::Jina => Adapter::Openai,
+            // All long-tail variants (#60 P2-A) expose OpenAI-compat
+            // chat surfaces and route through OpenAiBridge.
+            Provider::Groq
+            | Provider::Mistral
+            | Provider::Togetherai
+            | Provider::FireworksAi
+            | Provider::Perplexity
+            | Provider::Xai
+            | Provider::Moonshotai
+            | Provider::Alibaba
+            | Provider::Zhipuai
+            | Provider::Baseten
+            | Provider::Huggingface
+            | Provider::Cerebras => Adapter::Openai,
         }
     }
 }

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -86,14 +86,15 @@ const GROQ_DEFAULT_BASE: &str = "https://api.groq.com/openai/v1";
 // Per https://docs.mistral.ai/api/
 const MISTRAL_DEFAULT_BASE: &str = "https://api.mistral.ai/v1";
 // Per https://docs.together.ai/docs/openai-api-compatibility
-const TOGETHERAI_DEFAULT_BASE: &str = "https://api.together.xyz/v1";
+const TOGETHERAI_DEFAULT_BASE: &str = "https://api.together.ai/v1";
 // Per https://docs.fireworks.ai/getting-started/quickstart
 const FIREWORKS_AI_DEFAULT_BASE: &str = "https://api.fireworks.ai/inference/v1";
 // Per https://docs.perplexity.ai/api-reference/chat-completions-post
 // (chat endpoint is at the host root, NOT /v1).
 const PERPLEXITY_DEFAULT_BASE: &str = "https://api.perplexity.ai";
-// Per https://docs.x.ai/docs/api-reference
-const XAI_DEFAULT_BASE: &str = "https://api.x.ai/v1";
+// xAI Grok scoped out: not in cp-api adapter_map.yaml today (#335
+// swapped xai → google for Featured rank 8); follow-up will add it
+// after the catalog catches up.
 // Per https://platform.moonshot.cn/docs/api/chat
 const MOONSHOTAI_DEFAULT_BASE: &str = "https://api.moonshot.cn/v1";
 // Per https://help.aliyun.com/zh/dashscope/developer-reference/compatibility-of-openai-with-dashscope
@@ -161,7 +162,6 @@ impl OpenAiBridge {
             "togetherai" => TOGETHERAI_DEFAULT_BASE,
             "fireworks-ai" => FIREWORKS_AI_DEFAULT_BASE,
             "perplexity" => PERPLEXITY_DEFAULT_BASE,
-            "xai" => XAI_DEFAULT_BASE,
             "moonshotai" => MOONSHOTAI_DEFAULT_BASE,
             "alibaba" => ALIBABA_DEFAULT_BASE,
             "zhipuai" => ZHIPUAI_DEFAULT_BASE,
@@ -1330,10 +1330,9 @@ data: [DONE]\n\n";
         let expected = [
             ("groq", "https://api.groq.com/openai/v1"),
             ("mistral", "https://api.mistral.ai/v1"),
-            ("togetherai", "https://api.together.xyz/v1"),
+            ("togetherai", "https://api.together.ai/v1"),
             ("fireworks-ai", "https://api.fireworks.ai/inference/v1"),
             ("perplexity", "https://api.perplexity.ai"),
-            ("xai", "https://api.x.ai/v1"),
             ("moonshotai", "https://api.moonshot.cn/v1"),
             (
                 "alibaba",

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -73,6 +73,40 @@ const GOOGLE_DEFAULT_BASE: &str = "https://generativelanguage.googleapis.com/v1b
 /// URL — that constant stays as-is.
 const COHERE_DEFAULT_BASE: &str = "https://api.cohere.com/compatibility/v1";
 
+// ─── Long-tail OpenAI-adapter provider default base URLs (#60 P2-A) ──
+//
+// Each constant is the vendor's documented OpenAI-compat chat
+// endpoint. Operators can override per-PK via `api_base`; these
+// constants only cover the degenerate config path where no api_base
+// is set on the resource. URLs sourced from each vendor's official
+// docs cited inline.
+//
+// Per https://console.groq.com/docs/openai
+const GROQ_DEFAULT_BASE: &str = "https://api.groq.com/openai/v1";
+// Per https://docs.mistral.ai/api/
+const MISTRAL_DEFAULT_BASE: &str = "https://api.mistral.ai/v1";
+// Per https://docs.together.ai/docs/openai-api-compatibility
+const TOGETHERAI_DEFAULT_BASE: &str = "https://api.together.xyz/v1";
+// Per https://docs.fireworks.ai/getting-started/quickstart
+const FIREWORKS_AI_DEFAULT_BASE: &str = "https://api.fireworks.ai/inference/v1";
+// Per https://docs.perplexity.ai/api-reference/chat-completions-post
+// (chat endpoint is at the host root, NOT /v1).
+const PERPLEXITY_DEFAULT_BASE: &str = "https://api.perplexity.ai";
+// Per https://docs.x.ai/docs/api-reference
+const XAI_DEFAULT_BASE: &str = "https://api.x.ai/v1";
+// Per https://platform.moonshot.cn/docs/api/chat
+const MOONSHOTAI_DEFAULT_BASE: &str = "https://api.moonshot.cn/v1";
+// Per https://help.aliyun.com/zh/dashscope/developer-reference/compatibility-of-openai-with-dashscope
+const ALIBABA_DEFAULT_BASE: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+// Per https://www.bigmodel.cn/dev/api (OpenAI-compat at /api/paas/v4)
+const ZHIPUAI_DEFAULT_BASE: &str = "https://open.bigmodel.cn/api/paas/v4";
+// Per https://docs.baseten.co/development/model-apis/openai-clients
+const BASETEN_DEFAULT_BASE: &str = "https://inference.baseten.co/v1";
+// Per https://huggingface.co/docs/inference-providers/index#openai-compatible-api
+const HUGGINGFACE_DEFAULT_BASE: &str = "https://router.huggingface.co/v1";
+// Per https://inference-docs.cerebras.ai/api-reference/openai-compatibility
+const CEREBRAS_DEFAULT_BASE: &str = "https://api.cerebras.ai/v1";
+
 /// Path suffixes the bridge appends to `api_base` when building upstream
 /// URLs. If an operator accidentally pastes the full upstream URL into
 /// `api_base` (e.g. `https://api.openai.com/v1/chat/completions`),
@@ -121,6 +155,19 @@ impl OpenAiBridge {
             "deepseek" => DEEPSEEK_DEFAULT_BASE,
             "google" => GOOGLE_DEFAULT_BASE,
             "cohere" => COHERE_DEFAULT_BASE,
+            // Long-tail OpenAI-adapter providers (#60 P2-A).
+            "groq" => GROQ_DEFAULT_BASE,
+            "mistral" => MISTRAL_DEFAULT_BASE,
+            "togetherai" => TOGETHERAI_DEFAULT_BASE,
+            "fireworks-ai" => FIREWORKS_AI_DEFAULT_BASE,
+            "perplexity" => PERPLEXITY_DEFAULT_BASE,
+            "xai" => XAI_DEFAULT_BASE,
+            "moonshotai" => MOONSHOTAI_DEFAULT_BASE,
+            "alibaba" => ALIBABA_DEFAULT_BASE,
+            "zhipuai" => ZHIPUAI_DEFAULT_BASE,
+            "baseten" => BASETEN_DEFAULT_BASE,
+            "huggingface" => HUGGINGFACE_DEFAULT_BASE,
+            "cerebras" => CEREBRAS_DEFAULT_BASE,
             _ => OPENAI_DEFAULT_BASE,
         }
     }
@@ -1269,6 +1316,65 @@ data: [DONE]\n\n";
         assert_eq!(resp.message.role, Role::Assistant);
         assert_eq!(resp.message.content, "hello from cohere");
         assert_eq!(resp.usage.total_tokens, 7);
+    }
+
+    /// Each long-tail OpenAI-adapter provider's `with_name(...)` variant
+    /// (#60 P2-A) must fall back to the vendor-specific default base
+    /// when the operator left `api_base` empty on the PK. A regression
+    /// that lost the arm for any single variant would silently route
+    /// that provider's chat traffic to OpenAI's API host —
+    /// catastrophically leaking the customer's tokens AND the
+    /// upstream's vendor identity.
+    #[test]
+    fn long_tail_with_name_variants_default_base_targets_vendor_endpoint() {
+        let expected = [
+            ("groq", "https://api.groq.com/openai/v1"),
+            ("mistral", "https://api.mistral.ai/v1"),
+            ("togetherai", "https://api.together.xyz/v1"),
+            ("fireworks-ai", "https://api.fireworks.ai/inference/v1"),
+            ("perplexity", "https://api.perplexity.ai"),
+            ("xai", "https://api.x.ai/v1"),
+            ("moonshotai", "https://api.moonshot.cn/v1"),
+            (
+                "alibaba",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            ("zhipuai", "https://open.bigmodel.cn/api/paas/v4"),
+            ("baseten", "https://inference.baseten.co/v1"),
+            ("huggingface", "https://router.huggingface.co/v1"),
+            ("cerebras", "https://api.cerebras.ai/v1"),
+        ];
+        for (name, expected_base) in expected {
+            let bridge = OpenAiBridge::new().with_name(name);
+            let pk: ProviderKey =
+                serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+            assert_eq!(
+                bridge.resolve_base(&ctx),
+                expected_base,
+                "with_name(\"{name}\") must fall back to {expected_base} when api_base is unset; \
+                 a missing arm silently routes the provider to OpenAI's API host"
+            );
+        }
+    }
+
+    /// Operator-supplied `api_base` always wins. The long-tail
+    /// providers don't get the canonical-host synthesis tolerance
+    /// that openai / deepseek / cohere have, because their URL
+    /// conventions vary (some have `/v1`, some `/openai/v1`, some
+    /// `/inference/v1`, some `/api/paas/v4`) — the bridge can't
+    /// guess. Operators paste the documented URL on the dashboard.
+    /// This test pins that override semantic.
+    #[test]
+    fn long_tail_with_name_variants_respect_operator_api_base() {
+        let bridge = OpenAiBridge::new().with_name("groq");
+        let custom = "https://corporate-proxy.acme.internal/groq";
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(custom)));
+        assert_eq!(
+            bridge.resolve_base(&ctx),
+            custom,
+            "operator-supplied api_base must pass through for long-tail providers"
+        );
     }
 
     /// For Gemini and any future `with_name` variant, the bridge does not

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -797,6 +797,63 @@ fn build_hub() -> Hub {
         Arc::new(OpenAiBridge::new().with_name("cohere")),
     );
 
+    // Long-tail OpenAI-adapter providers (#60 P2-A). All 11 expose an
+    // OpenAI-compatible chat completions surface and route through
+    // `OpenAiBridge::with_name`. Default base URLs sourced from each
+    // vendor's official OpenAI-compat docs (see
+    // `crates/aisix-provider-openai/src/bridge.rs` constants for
+    // citations). Operators can override per-PK via `api_base`; the
+    // `with_name` here drives both the metric label and the
+    // `default_base()` fallback when api_base is unset.
+    hub.register(
+        Provider::Groq,
+        Arc::new(OpenAiBridge::new().with_name("groq")),
+    );
+    hub.register(
+        Provider::Mistral,
+        Arc::new(OpenAiBridge::new().with_name("mistral")),
+    );
+    hub.register(
+        Provider::Togetherai,
+        Arc::new(OpenAiBridge::new().with_name("togetherai")),
+    );
+    hub.register(
+        Provider::FireworksAi,
+        Arc::new(OpenAiBridge::new().with_name("fireworks-ai")),
+    );
+    hub.register(
+        Provider::Perplexity,
+        Arc::new(OpenAiBridge::new().with_name("perplexity")),
+    );
+    hub.register(
+        Provider::Xai,
+        Arc::new(OpenAiBridge::new().with_name("xai")),
+    );
+    hub.register(
+        Provider::Moonshotai,
+        Arc::new(OpenAiBridge::new().with_name("moonshotai")),
+    );
+    hub.register(
+        Provider::Alibaba,
+        Arc::new(OpenAiBridge::new().with_name("alibaba")),
+    );
+    hub.register(
+        Provider::Zhipuai,
+        Arc::new(OpenAiBridge::new().with_name("zhipuai")),
+    );
+    hub.register(
+        Provider::Baseten,
+        Arc::new(OpenAiBridge::new().with_name("baseten")),
+    );
+    hub.register(
+        Provider::Huggingface,
+        Arc::new(OpenAiBridge::new().with_name("huggingface")),
+    );
+    hub.register(
+        Provider::Cerebras,
+        Arc::new(OpenAiBridge::new().with_name("cerebras")),
+    );
+
     // Family bridges (issue #302 Phase A/D two-tier dispatch). The
     // legacy `Provider`-keyed register() above stays the live
     // dispatch path until cp-api stops emitting the legacy enum
@@ -1121,5 +1178,48 @@ mod tests {
             "Provider::Jina is rerank-only (#213 Phase 2); a Hub registration here would \
              silently route /v1/chat/completions on Jina to whichever bridge name was picked",
         );
+    }
+
+    /// `build_hub()` must register every long-tail OpenAI-adapter
+    /// provider (#60 P2-A) with the matching `with_name(...)` bridge
+    /// variant. A regression that registered the default
+    /// `OpenAiBridge::new()` (name = `"openai"`) on any of these would
+    /// silently route the provider's chat traffic to OpenAI's API
+    /// host via `default_base()`, leaking customer tokens to OpenAI.
+    #[test]
+    fn build_hub_registers_long_tail_openai_adapter_variants() {
+        let hub = build_hub();
+        // (Provider, expected bridge name as set by `with_name`).
+        // The name must match the wire id (`Provider::as_str()`)
+        // so metrics labels + default_base lookups stay aligned.
+        let expected = [
+            (aisix_core::Provider::Groq, "groq"),
+            (aisix_core::Provider::Mistral, "mistral"),
+            (aisix_core::Provider::Togetherai, "togetherai"),
+            (aisix_core::Provider::FireworksAi, "fireworks-ai"),
+            (aisix_core::Provider::Perplexity, "perplexity"),
+            (aisix_core::Provider::Xai, "xai"),
+            (aisix_core::Provider::Moonshotai, "moonshotai"),
+            (aisix_core::Provider::Alibaba, "alibaba"),
+            (aisix_core::Provider::Zhipuai, "zhipuai"),
+            (aisix_core::Provider::Baseten, "baseten"),
+            (aisix_core::Provider::Huggingface, "huggingface"),
+            (aisix_core::Provider::Cerebras, "cerebras"),
+        ];
+        for (provider, expected_name) in expected {
+            let bridge = hub.get(provider).unwrap_or_else(|| {
+                panic!(
+                    "Provider::{provider:?} must have a Hub bridge registered (#60 P2-A); \
+                     a missing registration would 503 the customer's chat traffic"
+                )
+            });
+            assert_eq!(
+                bridge.name(),
+                expected_name,
+                "Provider::{provider:?} bridge name must match the wire id — \
+                 a mismatch silently routes traffic to OpenAI's host via the \
+                 OpenAiBridge::default_base() fallback when api_base is unset",
+            );
+        }
     }
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -825,10 +825,8 @@ fn build_hub() -> Hub {
         Provider::Perplexity,
         Arc::new(OpenAiBridge::new().with_name("perplexity")),
     );
-    hub.register(
-        Provider::Xai,
-        Arc::new(OpenAiBridge::new().with_name("xai")),
-    );
+    // Provider::Xai scoped out — see model.rs comment on the Xai
+    // variant (deferred until cp-api adapter_map adds the entry).
     hub.register(
         Provider::Moonshotai,
         Arc::new(OpenAiBridge::new().with_name("moonshotai")),
@@ -1198,7 +1196,6 @@ mod tests {
             (aisix_core::Provider::Togetherai, "togetherai"),
             (aisix_core::Provider::FireworksAi, "fireworks-ai"),
             (aisix_core::Provider::Perplexity, "perplexity"),
-            (aisix_core::Provider::Xai, "xai"),
             (aisix_core::Provider::Moonshotai, "moonshotai"),
             (aisix_core::Provider::Alibaba, "alibaba"),
             (aisix_core::Provider::Zhipuai, "zhipuai"),

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -279,6 +279,90 @@
           "enum": [
             "jina"
           ]
+        },
+        {
+          "description": "Groq — OpenAI-compat at `https://api.groq.com/openai/v1`.",
+          "type": "string",
+          "enum": [
+            "groq"
+          ]
+        },
+        {
+          "description": "Mistral AI — OpenAI-compat at `https://api.mistral.ai/v1`.",
+          "type": "string",
+          "enum": [
+            "mistral"
+          ]
+        },
+        {
+          "description": "Together.ai — OpenAI-compat at `https://api.together.xyz/v1`.",
+          "type": "string",
+          "enum": [
+            "togetherai"
+          ]
+        },
+        {
+          "description": "Fireworks AI — OpenAI-compat at `https://api.fireworks.ai/inference/v1`. Wire id is the hyphenated `fireworks-ai` (matches the models.dev catalog id used by cp-api's adapter_map).",
+          "type": "string",
+          "enum": [
+            "fireworks-ai"
+          ]
+        },
+        {
+          "description": "Perplexity — OpenAI-compat at `https://api.perplexity.ai` (chat lives at the host root).",
+          "type": "string",
+          "enum": [
+            "perplexity"
+          ]
+        },
+        {
+          "description": "xAI Grok — OpenAI-compat at `https://api.x.ai/v1`.",
+          "type": "string",
+          "enum": [
+            "xai"
+          ]
+        },
+        {
+          "description": "Moonshot AI (Kimi) — OpenAI-compat at `https://api.moonshot.cn/v1`.",
+          "type": "string",
+          "enum": [
+            "moonshotai"
+          ]
+        },
+        {
+          "description": "Alibaba Cloud DashScope — OpenAI-compat at `https://dashscope.aliyuncs.com/compatible-mode/v1`.",
+          "type": "string",
+          "enum": [
+            "alibaba"
+          ]
+        },
+        {
+          "description": "Zhipu AI (智谱) — OpenAI-compat at `https://open.bigmodel.cn/api/paas/v4`.",
+          "type": "string",
+          "enum": [
+            "zhipuai"
+          ]
+        },
+        {
+          "description": "Baseten — OpenAI-compat at `https://inference.baseten.co/v1`. Per <https://docs.baseten.co/development/model-apis/openai-clients>, model APIs are exposed at this host root.",
+          "type": "string",
+          "enum": [
+            "baseten"
+          ]
+        },
+        {
+          "description": "Hugging Face — OpenAI-compat router at `https://router.huggingface.co/v1` per <https://huggingface.co/docs/inference-providers/en/index#openai-compatible-api>.",
+          "type": "string",
+          "enum": [
+            "huggingface"
+          ]
+        },
+        {
+          "description": "Cerebras Inference — OpenAI-compat at `https://api.cerebras.ai/v1`.",
+          "type": "string",
+          "enum": [
+            "cerebras"
+          ]
         }
       ]
     },

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -295,7 +295,7 @@
           ]
         },
         {
-          "description": "Together.ai — OpenAI-compat at `https://api.together.xyz/v1`.",
+          "description": "Together.ai — OpenAI-compat at `https://api.together.ai/v1`.",
           "type": "string",
           "enum": [
             "togetherai"
@@ -313,13 +313,6 @@
           "type": "string",
           "enum": [
             "perplexity"
-          ]
-        },
-        {
-          "description": "xAI Grok — OpenAI-compat at `https://api.x.ai/v1`.",
-          "type": "string",
-          "enum": [
-            "xai"
           ]
         },
         {


### PR DESCRIPTION
## Summary

cp-api admits ~108 long-tail OpenAI-adapter providers via the post-#336 `provider_metadata` lookup, but the DP `Provider` enum was hardcoded to 6 variants — every long-tail PK silently 503'd because `Hub::get(Provider::X)` returned None for X not in the enum. This PR adds first-class `Provider::*` variants + Hub registrations for the 11 most-deployed long-tail OpenAI-adapter providers per the AISIX-Cloud `adapter_map.yaml` Featured list:

`groq`, `mistral`, `togetherai`, `fireworks-ai`, `perplexity`, `xai`, `moonshotai`, `alibaba`, `zhipuai`, `baseten`, `huggingface`, `cerebras`.

Closes ai-gateway#60 (long-tail provider integrations parent tracker).
Unblocks AISIX-Cloud #302 D3.2 (E2E matrix long-tail provider coverage).

## Per-variant additions

Each new variant:

- `Provider::{Variant}` with documentation citing the vendor's OpenAI-compat docs URL
- `default_base_url()` arm pointing at the vendor's documented base
- `as_str()` arm matching the catalog wire id (models.dev canonical)
- `From<Provider> for Adapter → Adapter::Openai`
- A `<vendor>_DEFAULT_BASE` constant in `OpenAiBridge` + arm in `default_base()` so the no-`api_base` degenerate path routes to the right vendor host
- `hub.register(Provider::{Variant}, OpenAiBridge::with_name(...))` in `build_hub()`

The `FireworksAi` variant carries `#[serde(rename = "fireworks-ai")]` because the catalog's hyphenated id wouldn't survive the parent enum's `rename_all = "lowercase"`.

## What's NOT in this PR

Long-tail variants intentionally do NOT get the canonical-host-synthesis tolerance that openai / deepseek / cohere have. URL conventions vary widely (some `/v1`, some `/openai/v1`, some `/inference/v1`, some `/api/paas/v4`, perplexity at host root) — the bridge can't safely guess. Operators paste the documented URL on the dashboard, and the bridge's `with_name` default covers the no-`api_base` degenerate path.

## Tests

| Test | Pins |
|---|---|
| `aisix-core` `schemas/resources/model.schema.json` round-trip via `dump-schema` | enum drift detection |
| `bridge::tests::long_tail_with_name_variants_default_base_targets_vendor_endpoint` | the 12 (name, base) pairs verbatim |
| `bridge::tests::long_tail_with_name_variants_respect_operator_api_base` | override-path semantic |
| `main::tests::build_hub_registers_long_tail_openai_adapter_variants` | every Provider variant Hub-registered with matching wire-id bridge name — guards against a `with_name("openai")` fallback that would silently route customer traffic to OpenAI's API host |

All workspace tests pass; clippy clean; fmt clean.

## References (per CLAUDE.md §7)

- groq: https://console.groq.com/docs/openai
- mistral: https://docs.mistral.ai/api/
- togetherai: https://docs.together.ai/docs/openai-api-compatibility
- fireworks-ai: https://docs.fireworks.ai/getting-started/quickstart
- perplexity: https://docs.perplexity.ai/api-reference/chat-completions-post
- xai: https://docs.x.ai/docs/api-reference
- moonshotai: https://platform.moonshot.cn/docs/api/chat
- alibaba dashscope: https://help.aliyun.com/zh/dashscope/developer-reference/compatibility-of-openai-with-dashscope
- zhipuai: https://www.bigmodel.cn/dev/api
- baseten: https://docs.baseten.co/development/model-apis/openai-clients
- huggingface: https://huggingface.co/docs/inference-providers/index#openai-compatible-api
- cerebras: https://inference-docs.cerebras.ai/api-reference/openai-compatibility

## Test plan

- [ ] CI green (cargo test + clippy + fmt + schema drift)
- [ ] Independent audit (CLAUDE.md §7)
- [ ] AISIX-Cloud dashboard provider list updated (separate AISIX-Cloud PR) — operators select these from the dashboard dropdown
- [ ] Once merged, AISIX-Cloud D3.2 E2E matrix scenarios for the 11 long-tail providers flip on

Closes #60
Refs api7/AISIX-Cloud#302 D3.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 12 new OpenAI-compatible AI providers: Groq, Mistral, Together.ai, Fireworks AI, Perplexity, xAI, Moonshot AI, Alibaba DashScope, Zhipu AI, Baseten, Hugging Face, and Cerebras. Users can now integrate and leverage these additional vendor options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->