### PR TITLE
fix(core): expand model.provider runtime JSON schema enum to match Provider variants (#345 follow-up)

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -532,11 +532,17 @@ mod tests {
 
     #[tokio::test]
     async fn create_model_with_invalid_provider_prefix_is_400_schema_error() {
+        // `mistral` was the original sentinel for "unknown provider"
+        // (rejected by the legacy 6-value allowlist). Since
+        // ai-gateway#345 first-classed 11 long-tail variants, mistral
+        // is now valid — use a string that's NOT in the post-#345
+        // 17-value list so the negative-test still pins the
+        // schema-rejection path.
         let app = build_router(build_state());
         let body = json!({
             "display_name": "x",
-            "provider": "mistral",
-            "model_name": "large",
+            "provider": "this-is-not-a-provider-id",
+            "model_name": "x",
             "provider_key_id": "11111111-1111-1111-1111-111111111111"
         });
         let resp = run(app, auth_req("POST", "/admin/v1/models", Some(body))).await;

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -117,7 +117,7 @@ fn model_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "display_name":    { "type": "string", "minLength": 1 },
-            "provider":        { "type": "string", "enum": ["openai","anthropic","google","deepseek","cohere","jina"] },
+            "provider":        { "type": "string", "enum": ["openai","anthropic","google","deepseek","cohere","jina","groq","mistral","togetherai","fireworks-ai","perplexity","moonshotai","alibaba","zhipuai","baseten","huggingface","cerebras"] },
             "model_name":      { "type": "string", "minLength": 1 },
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },
@@ -582,10 +582,14 @@ mod tests {
 
     #[test]
     fn model_unknown_provider_value_fails() {
+        // `mistral` USED to be an unknown provider (rejected by the
+        // 6-value allowlist) but is now first-class on the Hub via
+        // ai-gateway#345. Use a value that's NOT in the post-#345
+        // enum so the negative test still pins the rejection path.
         let v = json!({
             "display_name": "x",
-            "provider": "mistral",
-            "model_name": "large",
+            "provider": "this-is-not-a-provider-id",
+            "model_name": "x",
             "provider_key_id": "pk-1"
         });
         assert!(validate_model(&v).is_err());

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -351,7 +351,7 @@ mod tests {
     fn schema_failure_is_counted() {
         let entries = vec![raw(
             "/aisix/models/bad-provider",
-            br#"{"display_name":"x","provider":"mistral","model_name":"large","provider_key_id":"pk-1"}"#,
+            br#"{"display_name":"x","provider":"this-is-not-a-provider-id","model_name":"large","provider_key_id":"pk-1"}"#,
             1,
         )];
         let (_snap, stats) = build_snapshot("/aisix", &entries);
@@ -404,7 +404,7 @@ mod tests {
     fn rejection_records_schema_failure() {
         let entries = vec![raw(
             "/aisix/models/bad",
-            br#"{"display_name":"x","provider":"mistral","model_name":"l","provider_key_id":"pk"}"#,
+            br#"{"display_name":"x","provider":"this-is-not-a-provider-id","model_name":"l","provider_key_id":"pk"}"#,
             1,
         )];
         let (_snap, stats) = build_snapshot("/aisix", &entries);

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -1130,7 +1130,7 @@ mod tests {
 
     const BAD_PROVIDER_MODEL: &[u8] = br#"{
         "display_name":"x",
-        "provider":"mistral",
+        "provider":"this-is-not-a-provider-id",
         "model_name":"l",
         "provider_key_id":"pk"
     }"#;


### PR DESCRIPTION
## Summary

ai-gateway #345 (P2-A) added 11 long-tail OpenAI-adapter `Provider::*` variants + Hub registrations. The dashboard-side schema in `schemas/resources/model.schema.json` regenerated correctly. But there's a SEPARATELY-MAINTAINED hardcoded JSON schema in `crates/aisix-core/src/models/schema.rs::model_schema()` that backs `aisix-etcd::loader`'s runtime `validate_model` check — and nobody updated it.

Result: cp-api admits a groq/mistral/etc. ProviderKey and Model (per #336 long-tail admission). The DP's `aisix-etcd::loader` reads the Model from etcd and validates against the OLD 6-value schema:

```
schema validation failed at `/provider`: "groq" is not one of ["openai","anthropic","google","deepseek","cohere","jina"]
```

Model rejected. Never appears in `/v1/models`. Customer's chat 404s on the alias.

Surfaced by AISIX-Cloud PR #366 e2e — first iteration of the D3.2 long-tail matrix. The groq Model creation succeeded at cp-api but the DP never saw it. Logs showed the schema rejection.

## Fix

`crates/aisix-core/src/models/schema.rs:120` — extend the `provider` enum from 6 to 17 values to match every `Provider::as_str()` output post-#345.

The existing negative-test `model_unknown_provider_value_fails` used `"mistral"` as the "unknown value" sentinel. Since mistral is now valid, renamed the fixture string to `"this-is-not-a-provider-id"` so the negative-test still pins the rejection class.

## Why a separate schema even exists

`aisix-etcd::loader::validate_and_parse` runs schema validation BEFORE serde deserialization to fail-loud-and-skip on malformed entries (rather than crashing the DP). The schema is the gate; serde is the parser. Both must agree on the enum.

The dashboard-facing JSON schemas in `schemas/resources/*.schema.json` are GENERATED from the Rust types via `cargo run --bin dump-schema` (drift CI check enforces). The runtime validator's schema in `schema.rs` is hand-written and not gated by the drift check — a structural gap that this PR addresses with a behavioral fix only; a future refactor could fold the two sources together.

## Test plan

- [x] `cargo test -p aisix-core --lib schema` — 52 tests pass
- [x] clippy clean
- [x] fmt clean
- [ ] CI green
- [ ] Audit (CLAUDE.md §7)
- [ ] After merge + docker rebuild, AISIX-Cloud #366 D3.2 batch 1 e2e exercises the unblocked path

## References (per CLAUDE.md §7)

- ai-gateway#345 (merged) — Provider enum + Hub register
- aisix-etcd loader.rs:262 — the schema-rejection log path that surfaced the gap on PR #366 CI

Refs api7/AISIX-Cloud#366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded model provider validation to accept an extended set of provider identifiers during schema validation.

* **Tests**
  * Updated test cases to reflect the expanded provider validation rules, ensuring invalid providers continue to be properly rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->