### PR TITLE
docs: correct configuration reference inaccuracies across admin-api, api-keys, caching, and models pages

### DIFF
--- a/docs/configuration/admin-api.md
+++ b/docs/configuration/admin-api.md
@@ -73,7 +73,7 @@ The current admin router exposes:
 
 Think about these routes in three groups:
 
-- public operator helpers: health, metrics, and OpenAPI discovery
+- public operator helpers: livez, metrics, and OpenAPI discovery
 - CRUD resources: models, API keys, provider keys, guardrails, cache policies, exporters
 - convenience operator workflow: the in-process playground
 

--- a/docs/configuration/api-keys.md
+++ b/docs/configuration/api-keys.md
@@ -83,7 +83,7 @@ Example response shape:
       "allowed_models": ["gpt-4o-prod"]
     }
   },
-  "plaintext": "sk-abcd1234ef567890"
+  "plaintext": "sk-550e8400e29b41d4a716446655440000"
 }
 ```
 

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -82,6 +82,8 @@ Current runtime boundary:
 - bootstrap config can wire a Redis backend at process start
 - the dynamic `CachePolicy.backend` field should still be treated conservatively because broader Redis support boundaries are still being expanded
 
+Note: the per-policy `backend` field is currently parsed and stored on the `CachePolicy` row but is not consulted by the runtime proxy. The proxy uses the cache backend selected via bootstrap-config (`cache.backend`) regardless of what each policy specifies. The field is preserved for forward compatibility; do not depend on it to override the runtime backend.
+
 ## Operator Guidance
 
 - start with `memory` plus a narrowly scoped policy

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -77,7 +77,7 @@ Current semantics:
 
 - only direct models may carry `background_model_check`
 - routing models reject `background_model_check`
-- `ignore_statuses` records the last probe result without marking the model unhealthy; the default ignored set is `[408, 429]`
+- `ignore_statuses` records the last probe result without marking the model unhealthy. If omitted, **no** probe statuses are ignored — a 408 or 429 probe response would mark the model unhealthy. Set this field explicitly to skip those statuses. For most deployments, `ignore_statuses: [408, 429]` is a reasonable starting point — it tolerates transient upstream timeouts (408) and rate-limit responses (429) during probes without flapping the model unhealthy.
 - `stale_after_seconds` is a safety valve for old unhealthy probe state when the checker stops refreshing
 - `interval_seconds` has a minimum of `5`; `timeout_seconds`, `max_tokens`, and `stale_after_seconds` have a minimum of `1`
 
@@ -160,7 +160,7 @@ curl -sS -X POST http://127.0.0.1:3001/admin/v1/models \
 - `provider` currently supports `openai`, `anthropic`, `google`, `deepseek`, `cohere`, and `jina`.
 - `provider_key_id` must reference an existing `ProviderKey` resource.
 - `timeout` is in milliseconds. `0` or omission means no timeout.
-- `cost` stores pricing metadata used by budget and usage accounting paths.
+- `cost` stores pricing metadata. AISIX Cloud's cp-api recomputes cost server-side from its pricing catalog when emitting usage events and consumes this field at that layer. The standalone OSS proxy does not consult this field at request time and always emits `cost_usd=0.0` in its own usage events; pricing-aware budget enforcement requires the AISIX Cloud control plane.
 - `background_model_check` drives direct-model runtime unhealthy state and the `/admin/v1/models/status` view.
 - `cooldown` drives direct-model request-path cooldown and is also surfaced through `/admin/v1/models/status`.
 


### PR DESCRIPTION
## Summary

Closes #347. Five surgical corrections to the configuration-reference cluster:

1. `admin-api.md:76` — group label "health" → "livez". `/livez` is the public route; `/admin/v1/health` requires admin auth.
2. `api-keys.md:86` — rotate response example: 16-char key suffix replaced with a 32-char suffix matching what callers actually receive (`Uuid::new_v4().as_simple()` produces 32 hex chars).
3. `caching.md` — explicit note that `CachePolicy.backend` is parsed and stored on each row but not consulted by any runtime consumer; the proxy uses the bootstrap-config (`cache.backend`) instead.
4. `models.md:80` — `background_model_check.ignore_statuses` default: `Vec<u16>` with `#[serde(default)]` resolves to `Vec::new()`, not `[408, 429]`. Re-presented `[408, 429]` as a recommended explicit setting.
5. `models.md:163` — `Model.cost` consumer split: AISIX Cloud's cp-api recomputes cost server-side; the standalone OSS proxy hard-codes `cost_usd = 0.0` and does not consult the field.

Doc-only diff. No code, schemas, configs, or test fixtures touched.

## Changes

| File | Change |
| --- | --- |
| `docs/configuration/admin-api.md` | Group label on line 76 changed from "public operator helpers: health, metrics, and OpenAPI discovery" to "public operator helpers: livez, metrics, and OpenAPI discovery". |
| `docs/configuration/api-keys.md` | Rotate response example on line 86: `sk-abcd1234ef567890` (16 hex) replaced with `sk-550e8400e29b41d4a716446655440000` (32 hex) to match `Uuid::new_v4().as_simple()` output. |
| `docs/configuration/caching.md` | Added a one-paragraph note after the `CachePolicy.backend`-conservative bullet (line 83) explicitly stating the field is parsed but not consulted by the runtime proxy, that the runtime backend selection comes from bootstrap-config (`cache.backend`), and that the field is preserved for forward compatibility. |
| `docs/configuration/models.md` | Bullet on line 80 rewritten: removed the misleading `[408, 429]` default claim and stated that without an explicit value no probe statuses are ignored, then re-presented `[408, 429]` as a recommended explicit setting with the operational rationale (tolerates transient 408/429 during probes). |
| `docs/configuration/models.md` | Bullet on line 163 rewritten: `Model.cost` description now makes the substrate split explicit — AISIX Cloud's cp-api consumes the field; the standalone OSS proxy does not consult it at request time and emits `cost_usd=0.0`; pricing-aware budget enforcement requires the Cloud control plane. |

Net diff: 4 files, `+6 / -4`. Source: `git diff --stat`.

## Test plan

Doc-only diff — no `.rs` files, schemas, configs, or test fixtures touched. The cargo trio was still run end-to-end as the canonical pre-merge gate. The first `cargo test --workspace` invocation OOMed under default parallelism (this VPS has 8 GB and the workspace compiles 30+ crate test binaries); re-ran with `cargo test --workspace -j 2` (and `CARGO_BUILD_JOBS=2`) to cap compile concurrency — all suites green.

- [x] `cargo fmt --check` — PASS (exit 0).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — PASS (exit 0, 18.30s, no warnings).
- [x] `cargo test --workspace -j 2` — PASS (exit 0, 33 suites all green; 1067 tests passed, 0 failed, 3 ignored).
- [x] `grep -rln <each affected page> tests/e2e/` for all 4 pages returns empty. `pnpm test` under `tests/e2e/` is not applicable for this diff.

### `cargo clippy` tail

```text
    Checking aisix-provider-azure-openai v0.1.0 (/root/GitHub/ai-gateway/crates/aisix-provider-azure-openai)
    Checking aisix-proxy v0.1.0 (/root/GitHub/ai-gateway/crates/aisix-proxy)
    Checking aisix-admin v0.1.0 (/root/GitHub/ai-gateway/crates/aisix-admin)
    Checking aisix-server v0.1.0 (/root/GitHub/ai-gateway/crates/aisix-server)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.30s
```

### `cargo test` summary

```text
33 test-suite-result lines, all 'ok'. Aggregate: 1067 tests passed, 0 failed, 3 ignored across the workspace (unit suites + doc-tests). Tally is higher than the post-#338 baseline (1041) because PRs #341/#343/#345/#346 added test coverage for new Provider variants, Hub registrations, the OpenAI-adapter long-tail providers, and the Anthropic-shape error envelope on /v1/messages.
```

## Affected pages

- `docs/configuration/admin-api.md`
- `docs/configuration/api-keys.md`
- `docs/configuration/caching.md`
- `docs/configuration/models.md`

## Pre-merge-check verification log

Issue #347 called out three pre-merge checks. All three resolved as follows:

1. **`ignore_statuses` default re-verified at PR-time HEAD.** Field declaration on `origin/main` at `71ea97e` is at `crates/aisix-core/src/models/model.rs:259-260` (drifted from `:159-160` cited in the issue body — file reorganization between audit-window and PR-window; substance unchanged). Declaration is verbatim: `#[serde(default, skip_serializing_if = "Vec::is_empty")] pub ignore_statuses: Vec<u16>`. No custom `default = "..."` attribute, so the `#[serde(default)]` resolves to `<Vec<u16> as Default>::default()` = `Vec::new()`. Consumer at `crates/aisix-proxy/src/background.rs:84,88` is unchanged: `cfg.ignore_statuses.contains(&status)` against the empty default, so the silent-failure mode is exactly as documented.
2. **`Model.cost` hard-code re-verified at PR-time HEAD.** `crates/aisix-proxy/src/chat.rs:989` still reads `let cost_usd = 0.0;`, preceded by the explanatory comment at `:987-988`: *"cp-api recomputes cost server-side from its pricing catalog when ingesting telemetry; the DP just records 0.0 on the wire."* The chat.rs file also hard-codes `cost_usd: 0.0` at four additional call sites (`:242`, `:648`, `:699`, `:832`), confirming the pattern is workspace-wide, not just at one site. No `Model.cost` field read site exists in `crates/aisix-proxy/`.
3. **All 5 anchors re-grep'd against current HEAD.** No consumer landed between the issue's audit window (`71ea97e`) and PR open (also `71ea97e`):
   - `/livez` route mount on `crates/aisix-admin/src/lib.rs:67` ✓
   - `/admin/v1/health` admin-scoped mount on `crates/aisix-admin/src/lib.rs:145` ✓
   - `Uuid::new_v4().as_simple()` for rotate plaintext on `crates/aisix-admin/src/apikeys_handlers.rs:168` ✓
   - Zero hits for `entry.value.backend` / `policy.backend` / `cache_policy.backend` consumers in `crates/` ✓
   - `cfg.ignore_statuses.contains(...)` consumer on `crates/aisix-proxy/src/background.rs:84,88` ✓
   - `let cost_usd = 0.0;` hard-code on `crates/aisix-proxy/src/chat.rs:989` ✓

### `Model.cost` example placeholder note

The 32-char replacement plaintext in the rotate example is `sk-550e8400e29b41d4a716446655440000`. The 32-hex segment is the canonical "all-zeros after the variant byte" UUID example value used as a placeholder across many published examples; it is structurally identical to a real `Uuid::new_v4().as_simple()` output (no hyphens, 32 hex chars) without being a copy of any real generated key.

### Coexistence with PR #326 and PR #344

This PR's affected pages (`admin-api.md`, `api-keys.md`, `caching.md`, `models.md`) do not overlap with PR #326 or PR #344's affected files (which cover the overview / quickstart / bootstrap-config cluster). No `git merge-tree` collision check needed — disjoint file sets.

## References

- #347 — *docs: Configuration reference corrections across admin-api, api-keys, caching, and models pages* (this PR closes it)
- #326 — *docs: fix new-developer onboarding gaps across overview, quickstart, and configuration pages* (companion PR; established consumer-trace discipline for Status-column rows)
- #344 — *docs: add glossary page + first-use linking + quickstart shell-mechanics framing + polish* (companion PR; extended consumer-trace discipline to inline mini-defs)
- #249 — `docs: rebuild customer-facing docs across overview, config, cloud, ops, reference, and tutorials` (the docs rebuild whose pages this PR amends)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Clarified public operator helper routes listed in admin API documentation
* Updated API key rotation example in configuration guide
* Added cache backend behavior clarification explaining runtime configuration precedence
* Enhanced model configuration documentation with health check status handling and cost calculation details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->