### PR TITLE
docs: trim verbosity on previously-merged onboarding + configuration edits (#326 + #348 follow-up)

### DIFF
--- a/docs/configuration/bootstrap-config.md
+++ b/docs/configuration/bootstrap-config.md
@@ -151,7 +151,7 @@ Recommended pattern:
 
 ## `observability`
 
-Use `observability` to set process-wide telemetry knobs: service name, log level, Prometheus exporter control, and (in future releases) access-log gating and OTLP exporters. Today `service_name`, `log_level`, and the `metrics.prometheus.*` block are consulted at runtime; the remaining keys are recognized in the schema and reserved for upcoming releases — setting them is harmless but currently has no effect.
+Use `observability` to set process-wide telemetry knobs. Today `service_name`, `log_level`, and the `metrics.prometheus.*` block are consulted at runtime; the remaining keys parse into the schema but currently have no runtime effect.
 
 Important fields:
 
@@ -161,16 +161,14 @@ Important fields:
 | `log_level` | fallback `EnvFilter` directive when `RUST_LOG` is not set in the environment | `"info"` | wired |
 | `access_log` | reserved field; access logs are currently emitted by every proxy handler regardless of this setting | `true` | reserved (not yet consulted) |
 | `metrics.prometheus.enabled` | controls whether the admin listener mounts the Prometheus scrape endpoint; when `false`, no `/metrics` route is registered | `true` | wired |
-| `metrics.prometheus.path` | mount path for the Prometheus scrape endpoint when `metrics.prometheus.enabled` is `true`; values without a leading slash are normalised by prepending one, and an empty value falls back to `/metrics` | `"/metrics"` | wired |
+| `metrics.prometheus.path` | mount path for the Prometheus scrape endpoint | `"/metrics"` | wired |
 | `metrics.otlp.enabled` | reserved field; no OTLP metrics export pipeline is installed in the current release | `false` | reserved (not yet wired) |
-| `metrics.otlp.endpoint` | reserved field; see `metrics.otlp.enabled` | none | reserved (not yet wired) |
-| `tracing.otlp.enabled` | enabling this validates the endpoint at boot and emits a startup log line; the OTLP traces pipeline itself is deferred to a future release | `false` | partial (validation only) |
-| `tracing.otlp.endpoint` | OTLP/gRPC collector endpoint for traces; validated at boot when `tracing.otlp.enabled` is `true` | none | partial (validation only) |
+| `metrics.otlp.endpoint` | OTLP/gRPC metrics endpoint | none | reserved (not yet wired) |
+| `tracing.otlp.enabled` | boot-time endpoint validation; OTLP traces pipeline deferred | `false` | partial (validation only) |
+| `tracing.otlp.endpoint` | OTLP/gRPC collector endpoint for traces | none | partial (validation only) |
 | `tracing.otlp.sample_ratio` | head-based sampling ratio reserved for the future OTLP traces pipeline | `1.0` | reserved (not yet wired) |
 
 Bootstrap observability settings are process-wide. They are different from dynamic `ObservabilityExporter` rows, which control per-request span fan-out via OTLP/HTTP at runtime. For per-row dynamic exporters added at runtime via the admin API, see [Observability Exporters](observability-exporters.md).
-
-`observability.metrics.prometheus.enabled` controls whether the admin listener mounts the Prometheus scrape endpoint. `observability.metrics.prometheus.path` controls the mounted path and defaults to `/metrics`.
 
 ## `cache`
 

--- a/docs/configuration/bootstrap-config.md
+++ b/docs/configuration/bootstrap-config.md
@@ -151,7 +151,7 @@ Recommended pattern:
 
 ## `observability`
 
-Use `observability` to set process-wide telemetry knobs. Today `service_name`, `log_level`, and the `metrics.prometheus.*` block are consulted at runtime; the remaining keys parse into the schema but currently have no runtime effect.
+Use `observability` to set process-wide telemetry knobs. Today `service_name`, `log_level`, and the `metrics.prometheus.*` block are consulted at runtime; the other fields have varying current behavior — see the `Status` column below.
 
 Important fields:
 

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -82,7 +82,7 @@ Current runtime boundary:
 - bootstrap config can wire a Redis backend at process start
 - the dynamic `CachePolicy.backend` field should still be treated conservatively because broader Redis support boundaries are still being expanded
 
-Note: the per-policy `backend` field is currently parsed and stored on the `CachePolicy` row but is not consulted by the runtime proxy. The proxy uses the cache backend selected via bootstrap-config (`cache.backend`) regardless of what each policy specifies. The field is preserved for forward compatibility; do not depend on it to override the runtime backend.
+Note: the per-policy `backend` field is parsed and stored on the `CachePolicy` row but is not consulted by the runtime proxy — the proxy always uses the bootstrap-config (`cache.backend`) backend regardless of what each policy specifies. The field is preserved for forward compatibility; do not depend on it to override the runtime backend.
 
 ## Operator Guidance
 

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -82,7 +82,7 @@ Current runtime boundary:
 - bootstrap config can wire a Redis backend at process start
 - the dynamic `CachePolicy.backend` field should still be treated conservatively because broader Redis support boundaries are still being expanded
 
-Note: the per-policy `backend` field is parsed and stored on the `CachePolicy` row but is not consulted by the runtime proxy — the proxy always uses the bootstrap-config (`cache.backend`) backend regardless of what each policy specifies. The field is preserved for forward compatibility; do not depend on it to override the runtime backend.
+Note: the per-policy `backend` field is parsed and stored on the `CachePolicy` row but is not consulted by the runtime proxy — the proxy always uses the cache backend selected by bootstrap-config (`cache.backend`) regardless of what each policy specifies. The field is preserved for forward compatibility; do not depend on it to override the runtime backend.
 
 ## Operator Guidance
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -77,7 +77,7 @@ Current semantics:
 
 - only direct models may carry `background_model_check`
 - routing models reject `background_model_check`
-- `ignore_statuses` records the last probe result without marking the model unhealthy. If omitted, **no** probe statuses are ignored — a 408 or 429 probe response would mark the model unhealthy. Set this field explicitly to skip those statuses. For most deployments, `ignore_statuses: [408, 429]` is a reasonable starting point — it tolerates transient upstream timeouts (408) and rate-limit responses (429) during probes without flapping the model unhealthy.
+- `ignore_statuses` records the last probe result without marking the model unhealthy. If omitted, **no** statuses are ignored — a 408 or 429 probe response would mark the model unhealthy. For most deployments, `[408, 429]` is a reasonable starting point.
 - `stale_after_seconds` is a safety valve for old unhealthy probe state when the checker stops refreshing
 - `interval_seconds` has a minimum of `5`; `timeout_seconds`, `max_tokens`, and `stale_after_seconds` have a minimum of `1`
 
@@ -160,7 +160,7 @@ curl -sS -X POST http://127.0.0.1:3001/admin/v1/models \
 - `provider` currently supports `openai`, `anthropic`, `google`, `deepseek`, `cohere`, and `jina`.
 - `provider_key_id` must reference an existing `ProviderKey` resource.
 - `timeout` is in milliseconds. `0` or omission means no timeout.
-- `cost` stores pricing metadata. AISIX Cloud's cp-api recomputes cost server-side from its pricing catalog when emitting usage events and consumes this field at that layer. The standalone OSS proxy does not consult this field at request time and always emits `cost_usd=0.0` in its own usage events; pricing-aware budget enforcement requires the AISIX Cloud control plane.
+- `cost` stores pricing metadata that AISIX Cloud's cp-api consumes when emitting usage events. The standalone OSS proxy does not consult this field at request time and always emits `cost_usd=0.0`; pricing-aware budget enforcement requires the AISIX Cloud control plane.
 - `background_model_check` drives direct-model runtime unhealthy state and the `/admin/v1/models/status` view.
 - `cooldown` drives direct-model request-path cooldown and is also surfaced through `/admin/v1/models/status`.
 

--- a/docs/quickstart/first-model-first-key-first-request.md
+++ b/docs/quickstart/first-model-first-key-first-request.md
@@ -15,7 +15,7 @@ Then you will verify that the new configuration is visible on the proxy surface.
 ## Prerequisites
 
 - A running gateway from the [Self-Hosted Quickstart](self-hosted.md)
-- An API key from an upstream provider (OpenAI, Anthropic, Google, DeepSeek, or another supported provider). If you do not have one, sign up at the provider (for example, <https://platform.openai.com/api-keys> — paid; pay-as-you-go starts around $5). The key looks like `sk-...` (or the provider equivalent) and is what you will paste into the `YOUR_PROVIDER_API_KEY` placeholder in Step 1.
+- An API key from an upstream provider (OpenAI, Anthropic, Google, DeepSeek, or another supported provider). The key looks like `sk-...` and is what you will paste into the `YOUR_PROVIDER_API_KEY` placeholder in Step 1. If you do not have one, sign up at the provider (for example, <https://platform.openai.com/api-keys>).
 - Your admin key from the bootstrap config
 
 ## What This Quickstart Configures

--- a/docs/quickstart/self-hosted.md
+++ b/docs/quickstart/self-hosted.md
@@ -8,7 +8,7 @@ This guide shows how to start a self-hosted AISIX AI Gateway instance with the l
 
 ## Prerequisites
 
-- **Rust 1.93 or newer with `cargo`.** Install via [rustup](https://rustup.rs) (for example, `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`) and verify with `cargo --version`. The repo pins this version through `rust-toolchain.toml`, so `rustup` will install the right channel automatically the first time you run `cargo` in the working tree.
+- **Rust 1.93 or newer with `cargo`.** Install via [rustup](https://rustup.rs) and verify with `cargo --version`. The repo pins this version through `rust-toolchain.toml`, so `rustup` selects the right channel automatically.
 - Docker
 - A reachable etcd instance
 


### PR DESCRIPTION
## Summary

Retrospective host-style alignment pass on the content merged via #326 (e12155b) and #348 (2c1d485). Single consolidated PR per operator directive.

- **No new GitHub issues** — this is a stylistic follow-up to already-merged content, not a finding-driven PR
- **No `Closes #` lines** — the original PRs #326 and #348 already closed their underlying issues at merge
- 6 cuts across 5 files; ~140-180 words removed; zero load-bearing claims dropped

## Per-file rationale

### `docs/configuration/bootstrap-config.md` (3 cuts, #326-introduced content)

1. **observability section lead-in**: run-on sentence collapsed to two short sentences matching the etcd/proxy/admin/cache section lead-in style (1 short sentence each). The named consequence "currently have no runtime effect" is preserved in the reference-page contract-first-then-consequence order.
2. **observability table description cells** (`metrics.prometheus.path`, `metrics.otlp.endpoint`, `tracing.otlp.enabled`, `tracing.otlp.endpoint`): trim implementation detail (path-normalisation behavior, redundant back-references, repeated boot-time-validation phrasing) to one-clause descriptions matching the sibling etcd/proxy/admin tables. The `Status` column ("wired" / "reserved" / "partial") is preserved as the row-level discipline anchor — readers learn what's wired vs. reserved from the column, not from cell prose.
3. **trailing redundant prose line**: dropped `observability.metrics.prometheus.enabled` / `.path` restatement that became fully redundant once #326 introduced the table covering both rows.

### `docs/overview/core-concepts.md` — **no changes**

The API Key plaintext-handling paragraph from #326 carries a load-bearing security warning ("capture it then, because subsequent reads only include the hash") that anchors the failure-mode-naming pattern. The trailing prose additions on the `display_name` / `model_name` bullets are already host-style-aligned. The Observability Exporter section uses operator-grounded backend examples (`Grafana Tempo, Honeycomb, Langfuse via OTLP`) that aren't internal-naming hygiene violations (`UsageEvent` is published in 3 docs files, `cp-api` in 6).

### `docs/quickstart/first-model-first-key-first-request.md` (1 cut, #326-introduced content)

Prerequisites bullet reordered so the placeholder mapping (`YOUR_PROVIDER_API_KEY` in Step 1) lands next to the key-shape (`sk-...`) explanation. Dropped: the fragile `$5 pay-as-you-go` commercial-product detail and the `or the provider equivalent` parenthetical. Preserved: provider list (including the `or another supported provider` catch-all for unlisted providers like cohere/jina), key shape, placeholder-step mapping, sign-up pointer with canonical URL.

### `docs/quickstart/openai-sdk.md` — **no changes**

Prerequisites section from #326 is already host-style-aligned (two short bullets; the Node.js bullet mirrors the trimmed Rust bullet's structure).

### `docs/quickstart/self-hosted.md` (1 cut, #326-introduced content)

Rust prereq bullet shortened: dropped the bashy `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` install line (the rustup link covers it) and the "first time you run `cargo` in the working tree" tail (redundant with "automatically"). Preserved: version constraint (1.93+), rustup install pointer, and the operator-relevant `rust-toolchain.toml` pinning fact. The first-time compile expectation paragraph (3-5 min) is unchanged — it's load-bearing onboarding context preventing the "is the build hung?" failure mode.

### `docs/configuration/caching.md` (1 cut, #348-introduced content)

Per-policy `backend` note: em-dash merge eliminates the restatement between the first two sentences (both originally said "not consulted by the runtime"). The forward-compatibility framing and the failure-mode name "do not depend on it to override the runtime backend" are preserved verbatim.

### `docs/configuration/models.md` (2 cuts, #348-introduced content)

- **`ignore_statuses` bullet**: 4 sentences → 3. Dropped the restated "Set this field explicitly to skip those statuses" sentence (redundant with the line above) and the trailing re-explanation "(408) and rate-limit responses (429) during probes without flapping the model unhealthy" (the 408/429 statuses are already named earlier in the same bullet). The peer bullets in the same `Current semantics:` list are 1 sentence each; this bullet is now 3 (still slightly longer than peers, but unavoidably so given the correctness fix it carries). Preserved: the correctness fix itself (omitted = no statuses ignored, not the prior wrong claim of `[408, 429]` default) + operator guidance + the "would mark the model unhealthy" stealth-cost name.
- **`cost` field note**: 3 sentences → 2. Dropped "recomputes cost server-side from its pricing catalog... and consumes this field at that layer" (compressed into "consumes when emitting") and "in its own usage events" (the `cost_usd=0.0` claim is unambiguous without the redundant location). Preserved: OSS-vs-Cloud correctness fix + the named consequence "pricing-aware budget enforcement requires the AISIX Cloud control plane".

### `docs/configuration/admin-api.md` — **no changes**

#348's one-word fix (`health` → `livez`) is correct and there's nothing to trim.

### `docs/configuration/api-keys.md` — **no changes**

#348's example-fixture plaintext value swap is content-only.

## Substantive-preservation summary

All 4 named consequences that anchor the failure-mode-naming pattern in the original content survive this trim:

1. **bootstrap-config.md observability**: "currently have no runtime effect" — stealth-cost on reserved fields
2. **models.md ignore_statuses**: "would mark the model unhealthy" — stealth-cost on absent ignore set
3. **caching.md per-policy backend**: "do not depend on it to override the runtime backend" — bilateral negative claim about absent runtime behavior
4. **models.md cost**: "pricing-aware budget enforcement requires the AISIX Cloud control plane" — bilateral negative claim about OSS proxy

## Test plan

- [x] `cargo fmt --check` — PASS (exit 0)
- [x] `cargo clippy --workspace --all-targets -j 2 -- -D warnings` — PASS (Finished in 0.68s)
- [x] `cargo test --workspace -j 2` — PASS (33 suites / 1067 passed / 0 failed / 3 ignored)
- [x] Visual diff review confirms zero load-bearing content dropped; all 4 failure-mode names preserved verbatim or via tighter phrasing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Simplified observability configuration guide with expanded details on important fields
* Clarified cache backend behavior and policy-level configuration expectations
* Updated model configuration documentation for background checks and cost field behavior
* Improved quickstart guides with clearer API key setup requirements and Rust installation instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
