### PR TITLE
fix(proxy): use UUID request IDs across handlers

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -26,10 +26,10 @@ use axum::Json;
 use reqwest::multipart;
 use serde_json::Value;
 use std::time::{Duration, Instant};
-use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
+use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -42,7 +42,7 @@ pub async fn transcriptions(
     multipart: Multipart,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("atr-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
 
     match multipart_dispatch(
@@ -112,7 +112,7 @@ pub async fn translations(
     multipart: Multipart,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("atr-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
 
     match multipart_dispatch(
@@ -182,7 +182,7 @@ pub async fn speech(
     Json(body): Json<Value>,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("asp-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
     let model_name = body
         .get("model")

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -31,11 +31,11 @@ use futures::{Stream, StreamExt};
 use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
 use crate::render::{render_chunk, render_response};
+use crate::request_id::new_request_id;
 use crate::routing::is_retryable;
 use crate::state::ProxyState;
 
@@ -69,12 +69,7 @@ pub async fn chat_completions(
     let started = Instant::now();
     let method = "POST";
     let path = "/v1/chat/completions";
-    // Pure UUID — cp-api's telemetry handler stores this in the
-    // `request_id UUID` column of dpmgr_usage_events, so a "req-…"
-    // prefix on the wire would be rejected (event 0: request_id must
-    // be a uuid). The downstream `x-aisix-call-id` header carries the
-    // same value for human correlation.
-    let request_id = Uuid::new_v4().to_string();
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
     let model_name = req.model.clone();
 

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -23,10 +23,10 @@ use axum::Json;
 use serde_json::Value;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::{ErrorEnvelope, ProxyError};
+use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 pub async fn completions(
@@ -35,7 +35,7 @@ pub async fn completions(
     Json(body): Json<Value>,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("cmp-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
     let model_name = body
         .get("model")

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -23,10 +23,10 @@ use axum::Json;
 use serde::Deserialize;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::{ErrorEnvelope, ProxyError};
+use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 /// The request body accepted by `POST /v1/embeddings`.
@@ -67,7 +67,7 @@ pub async fn embeddings(
     Json(body): Json<EmbeddingRequestBody>,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("emb-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
     let model_name = body.model.clone();
 

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -19,10 +19,10 @@ use axum::Json;
 use serde_json::Value;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::{ErrorEnvelope, ProxyError};
+use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 pub async fn image_generations(
@@ -31,7 +31,7 @@ pub async fn image_generations(
     Json(body): Json<Value>,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("img-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
     let model_name = body
         .get("model")

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -43,6 +43,7 @@ mod models;
 mod passthrough;
 mod quota;
 mod render;
+mod request_id;
 mod rerank;
 mod responses;
 mod routing;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -45,6 +45,7 @@ use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
+use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 /// Anthropic API version header value injected on every forwarded request.
@@ -123,7 +124,7 @@ pub async fn messages(
         }
     };
     let started = Instant::now();
-    let request_id = format!("msg-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
 
     let model_name = body

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -29,10 +29,10 @@ use axum::http::{header, HeaderMap, HeaderValue, Method};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use std::time::{Duration, Instant};
-use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
+use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 /// Provider defaults indexed by provider-prefix string.
@@ -103,7 +103,7 @@ pub async fn passthrough(
     req: Request,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("pt-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
     let method = req.method().clone();
     let path = format!("/passthrough/{provider}/{rest}");

--- a/crates/aisix-proxy/src/request_id.rs
+++ b/crates/aisix-proxy/src/request_id.rs
@@ -1,0 +1,7 @@
+use uuid::Uuid;
+
+/// Gateway correlation IDs may be written to telemetry fields backed by UUID
+/// columns, so keep handler request IDs as plain UUID strings.
+pub(crate) fn new_request_id() -> String {
+    Uuid::new_v4().to_string()
+}

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -16,10 +16,10 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::Value;
 use std::time::{Duration, Instant};
-use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
+use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 pub async fn rerank(
@@ -28,7 +28,7 @@ pub async fn rerank(
     Json(mut body): Json<Value>,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("rerank-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
 
     let model_name = body

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -20,10 +20,10 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::Value;
 use std::time::{Duration, Instant};
-use uuid::Uuid;
 
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
+use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 pub async fn responses(
@@ -32,7 +32,7 @@ pub async fn responses(
     Json(mut body): Json<Value>,
 ) -> Response {
     let started = Instant::now();
-    let request_id = format!("resp-{}", Uuid::new_v4());
+    let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
 
     let model_name = body

--- a/tests/e2e/src/cases/request-id-uuid-e2e.test.ts
+++ b/tests/e2e/src/cases/request-id-uuid-e2e.test.ts
@@ -1,0 +1,211 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { harnessRequest } from "../harness/http.js";
+
+const CALLER_PLAINTEXT = "sk-request-id-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("request id e2e: gateway-generated request IDs are UUIDs", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let chatUpstream: OpenAiUpstream | undefined;
+  let embeddingsUpstream: OpenAiUpstream | undefined;
+  let messagesUpstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    chatUpstream = await startOpenAiUpstream();
+    embeddingsUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        object: "list",
+        data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2] }],
+        model: "text-embedding-3-small",
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      },
+    });
+    messagesUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_01",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        model: "claude-3-5-haiku-20241022",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const chatPk = await admin.createProviderKey({
+      display_name: "request-id-chat-pk",
+      secret: "sk-mock",
+      api_base: `${chatUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "request-id-chat",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: chatPk.id,
+    });
+
+    const embeddingsPk = await admin.createProviderKey({
+      display_name: "request-id-embeddings-pk",
+      secret: "sk-mock",
+      api_base: `${embeddingsUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "request-id-embeddings",
+      provider: "openai",
+      model_name: "text-embedding-3-small",
+      provider_key_id: embeddingsPk.id,
+    });
+
+    const messagesPk = await admin.createProviderKey({
+      display_name: "request-id-messages-pk",
+      secret: "sk-ant-mock",
+      api_base: messagesUpstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "request-id-messages",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: messagesPk.id,
+    });
+
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all([
+      chatUpstream?.close(),
+      embeddingsUpstream?.close(),
+      messagesUpstream?.close(),
+    ]);
+  });
+
+  test("chat, embeddings, and messages forward UUID request IDs upstream", async (ctx) => {
+    if (
+      !etcdReachable ||
+      !app ||
+      !chatUpstream ||
+      !embeddingsUpstream ||
+      !messagesUpstream
+    ) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      try {
+        const [chat, embeddings, messages] = await Promise.all([
+          postJson(app.proxyUrl, "/v1/chat/completions", {
+            model: "request-id-chat",
+            messages: [{ role: "user", content: "ready" }],
+          }),
+          postJson(app.proxyUrl, "/v1/embeddings", {
+            model: "request-id-embeddings",
+            input: "ready",
+          }),
+          postJson(app.proxyUrl, "/v1/messages", {
+            model: "request-id-messages",
+            messages: [{ role: "user", content: "ready" }],
+            max_tokens: 16,
+          }),
+        ]);
+        return chat.status === 200 && embeddings.status === 200 && messages.status === 200;
+      } catch {
+        return false;
+      }
+    });
+
+    const chatBaseline = chatUpstream.receivedRequests.length;
+    const embeddingsBaseline = embeddingsUpstream.receivedRequests.length;
+    const messagesBaseline = messagesUpstream.receivedRequests.length;
+
+    await expectOk(
+      postJson(app.proxyUrl, "/v1/chat/completions", {
+        model: "request-id-chat",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    );
+    await expectOk(
+      postJson(app.proxyUrl, "/v1/embeddings", {
+        model: "request-id-embeddings",
+        input: "hello",
+      }),
+    );
+    await expectOk(
+      postJson(app.proxyUrl, "/v1/messages", {
+        model: "request-id-messages",
+        messages: [{ role: "user", content: "hello" }],
+        max_tokens: 16,
+      }),
+    );
+
+    expectUpstreamRequestId(chatUpstream, chatBaseline, "/v1/chat/completions");
+    expectUpstreamRequestId(embeddingsUpstream, embeddingsBaseline, "/v1/embeddings");
+    expectUpstreamRequestId(messagesUpstream, messagesBaseline, "/v1/messages");
+  });
+});
+
+async function postJson(
+  baseUrl: string,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; body: unknown }> {
+  const res = await harnessRequest(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.body.text();
+  return {
+    status: res.statusCode,
+    body: text ? JSON.parse(text) : null,
+  };
+}
+
+async function expectOk(promise: Promise<{ status: number; body: unknown }>): Promise<void> {
+  const res = await promise;
+  if (res.status !== 200) {
+    throw new Error(`expected 200, got ${res.status}: ${JSON.stringify(res.body)}`);
+  }
+}
+
+function expectUpstreamRequestId(
+  upstream: OpenAiUpstream,
+  baseline: number,
+  path: string,
+): void {
+  const calls = upstream.receivedRequests
+    .slice(baseline)
+    .filter((req) => req.path === path);
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.headers["x-aisix-request-id"]).toMatch(UUID_RE);
+}


### PR DESCRIPTION
Fixes #353.

This changes gateway-generated handler request IDs to plain UUID strings across proxy endpoints. `/v1/messages` already emits usage telemetry with this value, and CP stores `request_id` as a UUID, so protocol prefixes like `msg-` break ingestion. Using the same helper everywhere prevents the same issue when more handlers start emitting usage events later.

I left provider-native response IDs untouched, such as Anthropic `msg_...` message IDs.

Tests run:
- `cargo test -p aisix-proxy`
- `cargo test -p aisix-obs`
- `cargo build -p aisix-server --bin aisix`
- `cd tests/e2e && pnpm install --no-lockfile && pnpm test -- src/cases/request-id-uuid-e2e.test.ts` (this ran the full e2e suite: 50 files / 98 tests)

No docs or AGENTS.md update needed; this only tightens the internal request-id invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated request ID generation across all API endpoints using a centralized utility function for improved consistency and maintainability.

* **Tests**
  * Added comprehensive E2E test validating request ID generation and verification of upstream forwarding behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->