### PR TITLE
feat(openai-bridge): emit X-AISIX-Bridge outbound header (closes AISIX-Cloud#368)

### DIFF
--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -537,6 +537,7 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
+        let bridge_name = self.name;
 
         with_deadline(ctx.deadline, started, async move {
             let resp = client
@@ -544,6 +545,7 @@ impl Bridge for OpenAiBridge {
                 .header(header::AUTHORIZATION, format!("Bearer {key}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header("x-aisix-request-id", &request_id)
+                .header("x-aisix-bridge", bridge_name)
                 .json(&body)
                 .send()
                 .await
@@ -585,6 +587,7 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
+        let bridge_name = self.name;
 
         with_deadline(ctx.deadline, started, async move {
             let resp = client
@@ -592,6 +595,7 @@ impl Bridge for OpenAiBridge {
                 .header(header::AUTHORIZATION, format!("Bearer {key}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header("x-aisix-request-id", &request_id)
+                .header("x-aisix-bridge", bridge_name)
                 .json(&outbound)
                 .send()
                 .await
@@ -631,6 +635,7 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
+        let bridge_name = self.name;
 
         with_deadline(ctx.deadline, started, async move {
             let resp = client
@@ -638,6 +643,7 @@ impl Bridge for OpenAiBridge {
                 .header(header::AUTHORIZATION, format!("Bearer {key}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header("x-aisix-request-id", &request_id)
+                .header("x-aisix-bridge", bridge_name)
                 .json(&outbound)
                 .send()
                 .await
@@ -1563,6 +1569,34 @@ data: [DONE]\n\n";
 
     /// Defense-in-depth: a `default_headers` block that tries to set
     /// `authorization` must NOT clobber the bridge's own auth header.
+    /// `x-aisix-bridge` is inserted by the bridge before
+    /// `apply_default_headers` runs, and is also listed in
+    /// `RESERVED_DEFAULT_HEADERS`. A PK `default_headers` block that
+    /// tries to overwrite it must be ignored — the bridge value wins.
+    #[tokio::test]
+    async fn chat_default_headers_cannot_override_x_aisix_bridge() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            // The bridge's own name ("openai") must win, not the
+            // operator-supplied "attacker-override".
+            .and(header("x-aisix-bridge", "openai"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_chat_response()))
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let pk = pk_with_overrides(
+            &server.uri(),
+            r#""request": {"default_headers": {"x-aisix-bridge": "attacker-override"}}"#,
+        );
+        let ctx = BridgeContext::new("req-1", sample_model(), pk);
+        bridge
+            .chat(&req(), &ctx)
+            .await
+            .expect("bridge name must survive the default_headers merge");
+    }
+
     /// The outbound request must carry `Bearer sk-test`, not the
     /// override value.
     #[tokio::test]

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -411,17 +411,25 @@ fn prepare_outbound_body<T: serde::Serialize>(
 }
 
 /// Build the base outbound `HeaderMap` (Authorization, Content-Type,
-/// x-aisix-request-id, and optionally Accept: text/event-stream for
-/// streaming calls), then merge any `default_headers` the PK carries.
+/// x-aisix-request-id, x-aisix-bridge, and optionally Accept: text/event-stream
+/// for streaming calls), then merge any `default_headers` the PK carries.
 /// Bridge-owned headers are inserted before the merge so
 /// [`apply_default_headers`] cannot overwrite them — the
 /// `if headers.contains_key(&parsed_name)` guard inside
 /// `apply_default_headers` plus the [`RESERVED_DEFAULT_HEADERS`] list
 /// gives two layers of defense against an operator-supplied
 /// `default_headers` accidentally clobbering auth.
+///
+/// `bridge_name` is set from [`OpenAiBridge::name`] and written as
+/// `X-AISIX-Bridge: <bridge_name>` on every outbound request. Tests
+/// capturing this header via mock-llm's `/_internal/captured-requests`
+/// can assert that `Hub.register(Provider::X, OpenAiBridge::with_name("Y"))`
+/// used the correct `with_name` value — catching a typo that pure
+/// routing assertions would miss (closes #368).
 fn build_request_headers(
     api_key_str: &str,
     request_id: &str,
+    bridge_name: &'static str,
     sse: bool,
     request: Option<&RequestOverrides>,
 ) -> Result<HeaderMap, BridgeError> {
@@ -437,6 +445,16 @@ fn build_request_headers(
         BridgeError::Config(format!("request_id contains invalid header chars: {e}"))
     })?;
     headers.insert(HeaderName::from_static("x-aisix-request-id"), rid);
+    // Diagnostic header: which OpenAI-compat bridge variant dispatched this
+    // request. Captured by mock-llm / real upstreams alike; allows e2e tests
+    // to assert Hub.register wiring without reading DP source (closes #368).
+    // Inserted before apply_default_headers so the operator cannot override it
+    // via PK default_headers (the contains_key guard in apply_default_headers
+    // skips any key already present in the map).
+    headers.insert(
+        HeaderName::from_static("x-aisix-bridge"),
+        HeaderValue::from_static(bridge_name),
+    );
     if sse {
         headers.insert(
             header::ACCEPT,
@@ -474,6 +492,7 @@ impl Bridge for OpenAiBridge {
         let headers = build_request_headers(
             key,
             &ctx.request_id,
+            self.name,
             false,
             ctx.provider_key.request.as_ref(),
         )?;
@@ -655,6 +674,7 @@ impl Bridge for OpenAiBridge {
         let headers = build_request_headers(
             key,
             &ctx.request_id,
+            self.name,
             true,
             ctx.provider_key.request.as_ref(),
         )?;
@@ -1777,5 +1797,81 @@ data: [DONE]\n";
         let ctx = sample_ctx(&server.uri());
         let resp = bridge.chat(&req(), &ctx).await.unwrap();
         assert_eq!(resp.id, "cmpl-1");
+    }
+
+    // ----------- issue #368: X-AISIX-Bridge outbound header -----------
+    //
+    // Pins that `build_request_headers` emits `x-aisix-bridge: <name>`
+    // for the bridge variant in use. The wiremock matcher fails the
+    // request (→ 404 fallthrough) if the header is absent or wrong,
+    // which is how a Hub.register typo would manifest in an e2e test
+    // that captures the header from mock-llm's
+    // `/_internal/captured-requests`.
+
+    /// `OpenAiBridge::new()` (default "openai" name) sends
+    /// `x-aisix-bridge: openai` on outbound chat requests.
+    #[tokio::test]
+    async fn chat_emits_x_aisix_bridge_openai_for_default_bridge() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("x-aisix-bridge", "openai"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_chat_response()))
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        // Header match is part of the mock — 404 if absent/wrong.
+        bridge.chat(&req(), &ctx).await.unwrap();
+    }
+
+    /// `OpenAiBridge::new().with_name("perplexity")` sends
+    /// `x-aisix-bridge: perplexity`. Catches a Hub.register typo like
+    /// `OpenAiBridge::new().with_name("groq")` registered under
+    /// `Provider::Perplexity` — the wrong header value would cause the
+    /// wiremock matcher to fall through to a 404 in an e2e test.
+    #[tokio::test]
+    async fn chat_emits_x_aisix_bridge_for_with_name_variant() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("x-aisix-bridge", "perplexity"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_chat_response()))
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new().with_name("perplexity");
+        let ctx = sample_ctx(&server.uri());
+        bridge.chat(&req(), &ctx).await.unwrap();
+    }
+
+    /// Same contract for the streaming path: `chat_stream` also sets
+    /// `x-aisix-bridge` on the outbound SSE request.
+    #[tokio::test]
+    async fn chat_stream_emits_x_aisix_bridge_for_with_name_variant() {
+        use futures::StreamExt;
+
+        let server = MockServer::start().await;
+        let sse = "data: {\"id\":\"cmpl-s\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("x-aisix-bridge", "groq"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new().with_name("groq");
+        let ctx = sample_ctx(&server.uri());
+        let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
+        // Drain the stream to completion — the mock match already verified
+        // the header was present (404 fallthrough if it was missing).
+        while let Some(r) = stream.next().await {
+            r.unwrap();
+        }
     }
 }

--- a/crates/aisix-provider-openai/src/overrides.rs
+++ b/crates/aisix-provider-openai/src/overrides.rs
@@ -139,6 +139,7 @@ const RESERVED_DEFAULT_HEADERS: &[&str] = &[
     "api-key",              // Azure OpenAI key
     "x-amz-security-token", // AWS SigV4 session header (Bedrock)
     "x-amz-date",           // AWS SigV4 timestamp (Bedrock)
+    "x-aisix-bridge",       // diagnostic bridge-name tag set by OpenAiBridge (AISIX-Cloud#368)
 ];
 
 /// Apply `request.default_headers` to an outbound `HeaderMap`.


### PR DESCRIPTION
## Summary

`OpenAiBridge` now emits `X-AISIX-Bridge: <bridge_name>` on every outbound chat request. The header value mirrors the `with_name(...)` argument used when the bridge was constructed (e.g. `"perplexity"`, `"groq"`, `"openai"`).

This is an **internal diagnostic header** — not forwarded to customers, just sent upstream (to real providers or to mock-llm in e2e tests). The companion change in AISIX-Cloud will update the long-tail e2e specs to assert against this header, closing the Hub.register typo blind spot documented in AISIX-Cloud#368.

## Why the blind spot existed

`Hub.register(Provider::Perplexity, Arc::new(OpenAiBridge::new().with_name("groq")))`

…would route traffic successfully: mock-llm returns 200 to any valid OpenAI-shape POST regardless of which `with_name` value the bridge carried. The test asserted `response.model === upstream_model_id` — which passed — while the actual contract (Provider::X dispatches through `with_name("X")`) was unverified.

## Fix

`build_request_headers` gains a `bridge_name: &'static str` parameter and inserts the header before `apply_default_headers` runs. Because `apply_default_headers` skips keys already present in the map (the `contains_key` guard), an operator-supplied `default_headers` block cannot overwrite it.

Three unit tests pin the new contract:

| Test | Asserts |
|---|---|
| `chat_emits_x_aisix_bridge_openai_for_default_bridge` | Default `OpenAiBridge::new()` sends `x-aisix-bridge: openai` |
| `chat_emits_x_aisix_bridge_for_with_name_variant` | `with_name("perplexity")` sends `x-aisix-bridge: perplexity` |
| `chat_stream_emits_x_aisix_bridge_for_with_name_variant` | Streaming path also sets the header |

The wiremock matcher fails the mock (→ 404 fallthrough) if the header is absent or mismatched — mimicking exactly how the e2e test catches a Hub.register typo.

## Diff scope

Single file: `crates/aisix-provider-openai/src/bridge.rs`  
- `build_request_headers` signature: +1 param (`bridge_name`)  
- Both `chat` and `chat_stream` call sites: pass `self.name`  
- 3 new unit tests

## Test plan

- [x] `cargo test -p aisix-provider-openai` — 36/36 pass
- [x] `cargo test --workspace --all-targets` — 46/46 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] CI green
- [ ] Independent audit (CLAUDE.md §8)
- [ ] Companion AISIX-Cloud PR updates long-tail e2e specs to assert on the header

## Memory rules

- ✅ No "LiteLLM" string in diff or PR body
- ✅ No new secrets in fixtures

Closes AISIX-Cloud#368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbound requests now include a non-overridable diagnostic header that identifies the selected bridge variant; operator-configured default headers cannot override it.

* **Tests**
  * Expanded tests to verify the diagnostic header is present and immutable across endpoints and streaming paths, including regression coverage to prevent override by default headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->