### PR TITLE
ci: build Docker images from poc branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,7 @@ name: docker-image
 # Tag strategy. Every push always carries a :sha-<shortsha> tag for
 # traceability; the other tags layer on top based on the trigger:
 #   - push to main              → :dev + :sha-<shortsha>
+#   - push to poc               → :poc + :sha-<shortsha>
 #   - push tag vX.Y.Z           → :X.Y.Z + :X.Y + :X + :latest
 #                                 + :sha-<shortsha>
 #   - pull request              → build-only (no push), sanity check
@@ -12,7 +13,7 @@ name: docker-image
 
 on:
   push:
-    branches: [main]
+    branches: [main, poc]
     tags: ["v*.*.*"]
   pull_request:
     branches: [main]
@@ -67,6 +68,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=poc,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/poc' }}
             type=ref,event=pr
             type=sha,prefix=sha-,format=short
             type=semver,pattern={{version}}


### PR DESCRIPTION
This lets the Docker image workflow run when the `poc` branch is updated. Pushes to `poc` publish the moving `poc` image tag alongside the existing `sha-<shortsha>` tag, so the PoC environment can consume curated backports without following `main`/`dev`.

No code tests were added because this only changes the GitHub Actions trigger and Docker tag metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build process to generate tagged images for additional development branches, expanding the build pipeline's scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->