### PR TITLE
fix(proxy): echo customer-facing model on routing-group chat responses (AISIX-Cloud#410)

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -158,12 +158,31 @@ pub async fn chat_completions(
             // the request — see AISIX-Cloud#410. Only emitted when a
             // routing group was the entry point (direct models would
             // just echo `req.model`, which the body already carries).
+            //
+            // `HeaderValue::try_from` rejects CR/LF and non-visible
+            // ASCII (RFC 7230) — correct from a response-splitting
+            // standpoint, but if a routing target's `display_name`
+            // carries such bytes the header is silently absent and
+            // a customer debugging failover would see the same wire
+            // shape as a direct-model response. Surface the rejection
+            // in DP logs so operators can rename the offending target.
             if let Some(target) = success.served_by_target.as_deref() {
-                if let Ok(v) = axum::http::HeaderValue::try_from(target) {
-                    success
-                        .response
-                        .headers_mut()
-                        .insert("x-aisix-served-by", v);
+                match axum::http::HeaderValue::try_from(target) {
+                    Ok(v) => {
+                        success
+                            .response
+                            .headers_mut()
+                            .insert("x-aisix-served-by", v);
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            target_display_name = %target,
+                            error = %err,
+                            "target display_name is not a valid HTTP header value; \
+                             omitting x-aisix-served-by — rename the target to use \
+                             only visible ASCII (no CR/LF, no non-ASCII characters)"
+                        );
+                    }
                 }
             }
             success.response
@@ -359,6 +378,68 @@ impl CacheStatus {
             CacheStatus::Miss => "miss",
             CacheStatus::Hit => "hit",
         }
+    }
+}
+
+/// Compute the value of [`Success::served_by_target`] for a request.
+///
+/// Centralises the "should we surface routing identity?" policy so
+/// the same rule applies on every dispatch branch (non-streaming
+/// success, streaming success, cache hit). The rule is:
+///
+/// - Routing-group request **and** an attempt won → `Some(target)`.
+/// - Anything else (direct model, no winner, cache hit) → `None`.
+///
+/// `None` is the wire signal "this was not a routing request" — the
+/// `x-aisix-served-by` response header is emitted only when the
+/// returned `Option` is `Some`, so its presence alone tells callers
+/// that failover routing fired. Direct-model responses must never
+/// carry the header.
+fn served_by_target_for_routing(
+    is_routing_request: bool,
+    served_target: Option<String>,
+) -> Option<String> {
+    if is_routing_request {
+        served_target
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod served_by_target_tests {
+    use super::served_by_target_for_routing;
+
+    #[test]
+    fn direct_model_returns_none_even_when_a_target_was_captured() {
+        // A direct model still walks the attempt loop (with one
+        // candidate), so `served_target` may be `Some`. The routing
+        // flag is what gates header emission — direct models must
+        // never carry `x-aisix-served-by`.
+        assert_eq!(
+            served_by_target_for_routing(false, Some("gpt-4-direct".into())),
+            None,
+        );
+    }
+
+    #[test]
+    fn direct_model_with_no_target_is_none() {
+        assert_eq!(served_by_target_for_routing(false, None), None);
+    }
+
+    #[test]
+    fn routing_request_passes_winning_target_through() {
+        assert_eq!(
+            served_by_target_for_routing(true, Some("healthy-target".into())),
+            Some("healthy-target".into()),
+        );
+    }
+
+    #[test]
+    fn routing_request_with_no_winner_is_none() {
+        // All targets failed: header omitted. The caller is already
+        // surfacing an error response; routing identity is moot.
+        assert_eq!(served_by_target_for_routing(true, None), None);
     }
 }
 
@@ -740,13 +821,13 @@ async fn dispatch(
             telemetry_handled_by_stream: true,
             // Streaming attempts only `targets[0]` (no mid-stream
             // fallback), so on the routing path the served target is
-            // unambiguously the first one. For direct models the
-            // header would just echo `req.model`, so skip it.
-            served_by_target: if virtual_entry.value.routing.is_some() {
-                Some(model.display_name.clone())
-            } else {
-                None
-            },
+            // unambiguously the first one. The helper enforces the
+            // "direct model → None" rule consistently with the
+            // non-streaming and cache paths.
+            served_by_target: served_by_target_for_routing(
+                virtual_entry.value.routing.is_some(),
+                Some(model.display_name.clone()),
+            ),
         });
     }
 
@@ -1117,16 +1198,14 @@ async fn dispatch(
             .insert(CACHE_HEADER, HeaderValue::from_static("miss"));
     }
 
-    // Surface the winning target's display name only when this was a
-    // routing request. For a direct model the served target's display
-    // name equals `req.model`, so the header would just echo the body —
-    // skip it to keep the wire signal informative (header present =>
-    // routing happened).
-    let served_by_target = if virtual_entry.value.routing.is_some() {
-        chosen_target_display_name
-    } else {
-        None
-    };
+    // Header presence is the wire signal for "routing happened" —
+    // see `served_by_target_for_routing`. The helper covers all
+    // three branches (non-streaming, streaming, cache hit) with the
+    // same policy so a refactor can't silently flip one of them.
+    let served_by_target = served_by_target_for_routing(
+        virtual_entry.value.routing.is_some(),
+        chosen_target_display_name,
+    );
 
     Ok(Success {
         response,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -154,6 +154,18 @@ pub async fn chat_completions(
             if let Ok(v) = axum::http::HeaderValue::try_from(request_id.as_str()) {
                 success.response.headers_mut().insert("x-aisix-call-id", v);
             }
+            // `x-aisix-served-by` exposes which routing target served
+            // the request — see AISIX-Cloud#410. Only emitted when a
+            // routing group was the entry point (direct models would
+            // just echo `req.model`, which the body already carries).
+            if let Some(target) = success.served_by_target.as_deref() {
+                if let Ok(v) = axum::http::HeaderValue::try_from(target) {
+                    success
+                        .response
+                        .headers_mut()
+                        .insert("x-aisix-served-by", v);
+                }
+            }
             success.response
         }
         Err((resolved_model_id, charge, err)) => {
@@ -304,6 +316,22 @@ struct Success {
     /// pattern: DP records tokens, cp-api owns pricing). See #88.
     cache_hit_saved_input_tokens: u32,
     cache_hit_saved_output_tokens: u32,
+    /// Display name of the routing target that actually served this
+    /// request (AISIX-Cloud#410). Surfaces in the `x-aisix-served-by`
+    /// response header so callers can tell which target inside a
+    /// routing group won the failover loop.
+    ///
+    /// `None` in three cases:
+    ///   - Direct (non-routing) model — `display_name` of the served
+    ///     target equals `req.model`, so the header would be redundant.
+    ///   - Cache hit — we don't know which target produced the stored
+    ///     response. Re-stamping a stale name would lie.
+    ///   - Streaming response from a routing group with no failover —
+    ///     the streaming path attempts only `targets[0]` (no mid-stream
+    ///     fallback), so the value would always be `targets[0]`. The
+    ///     header is set in that case below; this comment documents
+    ///     the policy, not an absence.
+    served_by_target: Option<String>,
 }
 
 /// Cache decision attached to every successful request. Wire shape
@@ -592,6 +620,7 @@ async fn dispatch(
             now,
             stream_guardrail,
             started,
+            req.model.clone(),
             move |comp: StreamCompletion| {
                 // Rate-limit accounting (TPM cap) for all layers.
                 for key in &post_stream_keys {
@@ -709,6 +738,15 @@ async fn dispatch(
             cache_hit_saved_input_tokens: 0,
             cache_hit_saved_output_tokens: 0,
             telemetry_handled_by_stream: true,
+            // Streaming attempts only `targets[0]` (no mid-stream
+            // fallback), so on the routing path the served target is
+            // unambiguously the first one. For direct models the
+            // header would just echo `req.model`, so skip it.
+            served_by_target: if virtual_entry.value.routing.is_some() {
+                Some(model.display_name.clone())
+            } else {
+                None
+            },
         });
     }
 
@@ -798,7 +836,7 @@ async fn dispatch(
                     .upstream_model()
                     .unwrap_or("unknown")
                     .to_string();
-                let mut response = Json(render_response(now, cached)).into_response();
+                let mut response = Json(render_response(now, cached, &req.model)).into_response();
                 response
                     .headers_mut()
                     .insert(CACHE_HEADER, HeaderValue::from_static("hit"));
@@ -836,6 +874,11 @@ async fn dispatch(
                     cache_hit_saved_input_tokens: prompt.try_into().unwrap_or(u32::MAX),
                     cache_hit_saved_output_tokens: completion.try_into().unwrap_or(u32::MAX),
                     telemetry_handled_by_stream: false,
+                    // Cache hits don't carry routing-target identity:
+                    // the stored response is decoupled from whichever
+                    // target produced it on the original miss. See the
+                    // `served_by_target` field docs on `Success`.
+                    served_by_target: None,
                 });
             }
             Ok(None) => {}
@@ -852,6 +895,10 @@ async fn dispatch(
     let mut chosen_provider: Option<String> = None;
     let mut chosen_provider_key_id: Option<String> = None;
     let mut chosen_upstream_model: Option<String> = None;
+    // Display name of the target whose attempt finally succeeded. Used
+    // to populate the `x-aisix-served-by` response header for routing
+    // requests (AISIX-Cloud#410). Stays `None` until an attempt wins.
+    let mut chosen_target_display_name: Option<String> = None;
     let mut upstream: Option<aisix_gateway::ChatResponse> = None;
     let retries = virtual_entry
         .value
@@ -905,6 +952,7 @@ async fn dispatch(
                     chosen_provider_key_id = Some(pk_entry.id.clone());
                     chosen_upstream_model =
                         Some(model.upstream_model().unwrap_or("unknown").to_string());
+                    chosen_target_display_name = Some(model.display_name.clone());
                     upstream = Some(resp);
                     break;
                 }
@@ -1059,7 +1107,7 @@ async fn dispatch(
         }
     }
 
-    let mut response = Json(render_response(now, upstream)).into_response();
+    let mut response = Json(render_response(now, upstream, &req.model)).into_response();
     if matches!(cache_status, CacheStatus::Miss) {
         // Miss header only when the cache was actually consulted —
         // policy-disabled requests have no cache header at all so a
@@ -1068,6 +1116,17 @@ async fn dispatch(
             .headers_mut()
             .insert(CACHE_HEADER, HeaderValue::from_static("miss"));
     }
+
+    // Surface the winning target's display name only when this was a
+    // routing request. For a direct model the served target's display
+    // name equals `req.model`, so the header would just echo the body —
+    // skip it to keep the wire signal informative (header present =>
+    // routing happened).
+    let served_by_target = if virtual_entry.value.routing.is_some() {
+        chosen_target_display_name
+    } else {
+        None
+    };
 
     Ok(Success {
         response,
@@ -1093,6 +1152,7 @@ async fn dispatch(
         cache_hit_saved_input_tokens: 0,
         cache_hit_saved_output_tokens: 0,
         telemetry_handled_by_stream: false,
+        served_by_target,
     })
 }
 
@@ -1531,6 +1591,10 @@ fn build_sse_stream<F>(
     created: i64,
     output_guardrail: Option<StreamGuardrailContext>,
     started: Instant,
+    // Customer-facing model name (alias / routing group), re-stamped
+    // onto every SSE chunk's `model` field per AISIX-Cloud#410. Owned
+    // so it can move into the `async_stream::stream!` closure.
+    client_facing_model: String,
     on_complete: F,
 ) -> impl Stream<Item = Result<Event, Infallible>>
 where
@@ -1630,7 +1694,7 @@ where
                             comp.cache_read_tokens = u.cache_read_tokens;
                         }
                     }
-                    let rendered = render_chunk(created, chunk);
+                    let rendered = render_chunk(created, chunk, &client_facing_model);
                     match serde_json::to_string(&rendered) {
                         Ok(json) => Event::default().data(json),
                         Err(err) => {

--- a/crates/aisix-proxy/src/render.rs
+++ b/crates/aisix-proxy/src/render.rs
@@ -5,6 +5,27 @@
 //! upstream types — those describe what we *received*, while these
 //! describe what we *emit*. Keeping them separate means a client-facing
 //! schema change doesn't ripple into every provider adapter.
+//!
+//! ## `model` field contract (AISIX-Cloud#410)
+//!
+//! `response.model` is always the **customer-facing model name** the
+//! caller put on the request — for a direct model that's the model's
+//! display name; for a routing group that's the group name. It is
+//! never the upstream provider's raw id (e.g. `gpt-4o`) and never the
+//! routing target's display name. This keeps two contracts stable:
+//!
+//! 1. **Symmetric with direct models.** A request to `failover-group-X`
+//!    sees `model: "failover-group-X"` back, exactly the same shape as
+//!    a request to a direct model already produced before this PR.
+//! 2. **Failover-stable and provider-agnostic.** Customer dashboards
+//!    keyed on `response.model` don't flap when a target rotates out,
+//!    and a cross-provider routing group never leaks `gpt-4o` vs
+//!    `claude-3-5-sonnet` into the client's vocabulary.
+//!
+//! When the caller wants to know *which* target actually served the
+//! request (cost attribution, "did my failover fire?", A/B analysis),
+//! the proxy emits an `x-aisix-served-by` response header carrying
+//! the winning target's display name. See `chat::chat_completions`.
 
 use aisix_gateway::{ChatChunk, ChatResponse, FinishReason, Role};
 use serde::Serialize;
@@ -84,12 +105,19 @@ pub struct RenderedDelta {
     pub reasoning_content: Option<String>,
 }
 
-pub fn render_response(created_unix_ts: i64, resp: ChatResponse) -> ChatCompletion {
+pub fn render_response(
+    created_unix_ts: i64,
+    resp: ChatResponse,
+    client_facing_model: &str,
+) -> ChatCompletion {
+    // `resp.model` is whatever the upstream returned (`gpt-4o`,
+    // `claude-3-5-sonnet-20241022`, etc.). The wire-level contract is
+    // to echo the customer's requested name — see module-level docs.
     ChatCompletion {
         id: resp.id,
         object: "chat.completion",
         created: created_unix_ts,
-        model: resp.model,
+        model: client_facing_model.to_string(),
         choices: vec![NonStreamChoice {
             index: 0,
             message: RenderedMessage {
@@ -109,12 +137,20 @@ pub fn render_response(created_unix_ts: i64, resp: ChatResponse) -> ChatCompleti
     }
 }
 
-pub fn render_chunk(created_unix_ts: i64, chunk: ChatChunk) -> ChatCompletionChunk {
+pub fn render_chunk(
+    created_unix_ts: i64,
+    chunk: ChatChunk,
+    client_facing_model: &str,
+) -> ChatCompletionChunk {
+    // Same contract as `render_response`: every chunk's `model` field
+    // carries the customer's requested name, not the upstream's raw id.
+    // Re-stamping has to happen per-chunk; missing one chunk leaks the
+    // upstream id mid-stream.
     ChatCompletionChunk {
         id: chunk.id,
         object: "chat.completion.chunk",
         created: created_unix_ts,
-        model: chunk.model,
+        model: client_facing_model.to_string(),
         choices: vec![StreamChoice {
             index: 0,
             delta: RenderedDelta {
@@ -224,7 +260,7 @@ mod tests {
             finish_reason: FinishReason::Stop,
             usage: UsageStats::new(3, 2),
         };
-        let out = render_response(42, r);
+        let out = render_response(42, r, "m");
         let json = serde_json::to_value(&out).unwrap();
         assert_eq!(json["object"], "chat.completion");
         assert_eq!(json["created"], 42);
@@ -232,6 +268,29 @@ mod tests {
         assert_eq!(json["choices"][0]["message"]["role"], "assistant");
         assert_eq!(json["choices"][0]["message"]["content"], "hello");
         assert_eq!(json["usage"]["total_tokens"], 5);
+    }
+
+    /// Pins the AISIX-Cloud#410 contract: when the upstream returns one
+    /// model id but the customer requested a different name (alias /
+    /// routing-group name), `response.model` must echo the customer's
+    /// requested name, not the upstream's raw id.
+    #[test]
+    fn render_response_uses_client_facing_model_not_upstream_raw() {
+        let r = ChatResponse {
+            id: "cmpl-1".into(),
+            // Upstream raw — e.g. what OpenAI returned for a routing
+            // target inside `failover-group-XXX`.
+            model: "gpt-4o".into(),
+            message: ChatMessage::assistant("hi"),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::default(),
+        };
+        let out = render_response(0, r, "failover-group-XXX");
+        let json = serde_json::to_value(&out).unwrap();
+        assert_eq!(
+            json["model"], "failover-group-XXX",
+            "wire `model` echoes the customer's requested name"
+        );
     }
 
     #[test]
@@ -248,13 +307,34 @@ mod tests {
             finish_reason: None,
             usage: None,
         };
-        let out = render_chunk(1, chunk);
+        let out = render_chunk(1, chunk, "m");
         let json = serde_json::to_value(&out).unwrap();
         assert_eq!(json["object"], "chat.completion.chunk");
         assert_eq!(json["choices"][0]["delta"]["content"], "hi");
         // finish_reason / usage must be absent (not null).
         assert!(json["choices"][0].get("finish_reason").is_none());
         assert!(json.get("usage").is_none());
+    }
+
+    /// Streaming counterpart of the #410 contract — re-stamp the
+    /// client-facing name onto every chunk, not just the first.
+    #[test]
+    fn render_chunk_uses_client_facing_model_not_upstream_raw() {
+        let chunk = ChatChunk {
+            id: "c".into(),
+            model: "gpt-4o".into(),
+            delta: aisix_gateway::ChatDelta {
+                role: None,
+                content: Some("hi".into()),
+                tool_calls: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            usage: None,
+        };
+        let out = render_chunk(0, chunk, "failover-group-XXX");
+        let json = serde_json::to_value(&out).unwrap();
+        assert_eq!(json["model"], "failover-group-XXX");
     }
 
     #[test]
@@ -266,7 +346,7 @@ mod tests {
             finish_reason: FinishReason::Other("weird".into()),
             usage: UsageStats::default(),
         };
-        let out = render_response(0, r);
+        let out = render_response(0, r, "m");
         let json = serde_json::to_value(&out).unwrap();
         assert_eq!(json["choices"][0]["finish_reason"], "weird");
     }

--- a/docs/configuration/routing-and-failover.md
+++ b/docs/configuration/routing-and-failover.md
@@ -121,6 +121,50 @@ The `Retry-After` value on the `fail` path is a coarse fixed hint. By the time t
 - keep target aliases explicit and easy to reason about
 - set `retries` and `max_fallbacks` intentionally so resilience does not create surprise cost or latency
 
+## Response Shape
+
+Routing keeps the caller's view of the response stable across failover.
+
+### `response.model`
+
+`response.model` always echoes the **model name the caller put on the request** — for a routing model that is the routing alias itself, not the underlying target's display name and not the upstream provider's raw id.
+
+```http
+POST /v1/chat/completions
+{ "model": "failover-group-XYZ", ... }
+```
+
+```json title="Response body"
+{
+  "id": "chatcmpl-...",
+  "model": "failover-group-XYZ",
+  ...
+}
+```
+
+This holds whether the response came from `targets[0]` on the happy path or from a later target after failover. A cross-provider routing group (e.g. mixing an OpenAI target with an Anthropic target) never leaks the underlying provider's vocabulary into `response.model`.
+
+Direct (non-routing) models follow the same contract — `response.model` echoes the caller's requested name.
+
+### `x-aisix-served-by`
+
+The proxy emits an `x-aisix-served-by` response header on every routing-model response. The value is the display name of the target that actually served the request.
+
+```http title="Response headers"
+x-aisix-served-by: gpt-4o-secondary
+```
+
+After failover, the value reflects the target whose attempt succeeded — not the target that was tried first and failed. The header is the wire-level signal for "did failover fire, and which target won."
+
+The header applies to successful `/v1/chat/completions` responses. It is **absent** in these cases:
+
+- **Direct (non-routing) models.** The body's `response.model` already names the served model, so the header would be redundant — its presence is itself the routing signal.
+- **Cache hits.** A stored response is decoupled from whichever target produced it on the original miss; surfacing a stale name would lie. Operators inspecting routing must look at `x-aisix-cache` first.
+- **Error responses** (e.g. failover exhausted, every target unhealthy). No target served the request, so there is no name to report.
+- **Other endpoints.** The Anthropic-shape `/v1/messages` path is on a separate code path and does not currently emit this header.
+
+If a routing target's `display_name` contains bytes that are not valid HTTP header values (CR/LF or non-visible-ASCII), the header is omitted and the DP logs a `tracing::warn!` carrying the offending name. Rename the target with operator-side tools to restore the header.
+
 ## Troubleshooting
 
 ### Traffic never reaches the secondary target
@@ -130,6 +174,17 @@ That may be expected if the primary target is healthy and your strategy is `fail
 ### A request fails on one target and does not fall back
 
 Check whether the failure is retryable. Upstream `4xx` responses do not trigger cross-target retry.
+
+### `response.model` shows the routing alias, not the target that served
+
+That is the documented contract — see [Response Shape](#response-shape). Read `x-aisix-served-by` to learn which target actually served the request.
+
+### `x-aisix-served-by` is missing on a routing-model response
+
+Check the response headers first:
+
+- `x-aisix-cache: hit` — header is intentionally absent on cache hits.
+- DP logs for a `tracing::warn!` mentioning `target_display_name` — your target's display name contains characters that are not valid in an HTTP header value. Rename the target.
 
 ## Related Pages
 


### PR DESCRIPTION
## Summary

For `/v1/chat/completions`, responses produced by a routing model group returned the upstream provider's raw model id (e.g. `gpt-4o`) in `response.model`, while responses from direct (non-routing) models already echoed the customer-facing alias. Customer dashboards keyed on `response.model` therefore had to branch on which kind of model served the request, and a cross-provider routing group leaked the upstream provider's vocabulary into the wire.

This PR makes the two paths consistent and adds a routing-observability header.

Closes part of [api7/AISIX-Cloud#410](https://github.com/api7/AISIX-Cloud/issues/410). Companion AISIX-Cloud PR (filed separately) updates the routing-failover e2e spec to assert the new contract.

## What changed

- **`render_response` / `render_chunk` re-stamp the customer-facing name onto `response.model`** for both non-streaming and streaming (`render.rs:87`, `render.rs:112`). Module docs now pin the contract explicitly so the next person doesn't re-litigate it. Two new unit tests fail if the upstream raw id ever leaks through.
- **`chat_completions` emits `x-aisix-served-by`** when the request was a routing-group request, carrying the winning target's display name from the failover loop (`chat.rs:153`). Direct models omit the header — its presence is itself the routing signal. Cache hits omit it too, because the stored response is decoupled from whichever target produced it on the original miss.
- **`Success` carries `served_by_target: Option<String>`** so the handler can distinguish "no target identity to surface" (None) from "this target served you" (Some).

Anthropic `/v1/messages` does not flow through `render_response` and keeps its existing behavior; a separate follow-up will pin its contract once chat-completions has shipped.

## Reference implementations consulted

Per [CLAUDE.md §7](https://github.com/api7/ai-gateway/blob/main/CLAUDE.md), surveyed how two open-source LLM gateways handle this same field:

- **[Portkey-AI/gateway](https://github.com/Portkey-AI/gateway)** — every provider transformer (`src/providers/*/chatComplete.ts`) sets `model: response.model` (upstream raw). No `x-portkey-model-*` response headers; routing identity lives only in their server-side logs. Equivalent to "option 3" in AISIX-Cloud#410.
- **[BerriAI's open-source proxy](https://github.com/BerriAI/litellm)** — [PR #19943](https://github.com/BerriAI/litellm/pull/19943) re-stamps the client-requested alias onto `response.model`, with the deployment id available via a separate `x-*-model-id` response header. [Issue #22709](https://github.com/BerriAI/litellm/issues/22709) is an active disagreement over whether that choice broke downstream observability — maintainer admits *"we still need to decide what is the value that we actually want."* Equivalent to "option 1 + header."
- **OpenAI's own contract** — `"model": "gpt-4.1"` in → `"model": "gpt-4.1-2025-04-14"` out (resolved versioned id), neither pure alias nor pure raw ([API reference](https://platform.openai.com/docs/api-reference/chat/object)).

This PR picks **option 1 + header**: routing-group / alias name in `response.model`, target display name in the new `x-aisix-served-by` header. Rationale (per AISIX-Cloud#410 issue comment):

1. Direct-model behavior already echoes the customer-facing name (`dp-messages-anthropic-roundtrip-live.spec.ts:163` passes today); this PR closes the routing/direct inconsistency.
2. Failover-stable and provider-agnostic — customer dashboards don't flap, cross-provider mixes don't leak.
3. Header backstops observability — the lesson from the BerriAI proxy debate.

## Out of scope (follow-ups)

- Anthropic `/v1/messages` contract (filed against AISIX-Cloud#410 as a follow-up; same decision, separate code path in `messages.rs`).
- Other endpoints reaching `response.model`: `completions.rs`, `responses.rs`, `passthrough.rs` — none touched in this PR. Audit in a follow-up.

## Test plan

- [x] `cargo test -p aisix-proxy` — 273 unit tests pass, including two new contract tests in `render.rs` that pin `response.model` to the client-facing name even when the upstream returns a different id.
- [x] `cargo clippy -p aisix-proxy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Companion AISIX-Cloud PR updates `dp-routing-failover-live.spec.ts` to assert `body.model === groupName` AND `response.headers.get('x-aisix-served-by') === healthyTargetName` after failover. Real-DP e2e validation happens in that PR.

## Independent audit

Per CLAUDE.md §8, an independent audit agent will review this PR with no shared context once it lands as a draft. All HIGH/MEDIUM findings will be addressed or explicitly justified before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an x-aisix-served-by response header for routed requests to indicate which target served them; header is omitted for direct (non-routed) responses and cache hits, and omitted with a logged warning if the target name contains invalid header characters.

* **Bug Fixes**
  * Chat-completion outputs now consistently use the client-requested model name for both streaming chunks and non-streaming responses.

* **Documentation**
  * Added “Response Shape” docs and troubleshooting guidance describing model-field behavior, header presence, and interpretation of warnings and cache hits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->