### PR TITLE
style(etcd): format loader test

### DIFF
--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -445,11 +445,7 @@ mod tests {
 
     #[test]
     fn provider_key_happy_path_accepts() {
-        let entries = vec![raw(
-            "/aisix/provider_keys/pk-1",
-            VALID_PROVIDER_KEY,
-            1,
-        )];
+        let entries = vec![raw("/aisix/provider_keys/pk-1", VALID_PROVIDER_KEY, 1)];
         let (snap, stats) = build_snapshot("/aisix", &entries);
         assert_eq!(stats.accepted, 1);
         assert_eq!(snap.provider_keys.len(), 1);


### PR DESCRIPTION
`cargo fmt --all -- --check` fails on `crates/aisix-etcd/src/loader.rs` because one loader test is not rustfmt-formatted. This PR only applies rustfmt output to that test; there is no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test formatting for improved code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->