### PR TITLE
fix(server, openai-bridge): close xai 500 trap via OpenAI/Anthropic family bridges

### DIFF
--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -71,13 +71,13 @@ pub enum Provider {
     /// Perplexity — OpenAI-compat at `https://api.perplexity.ai`
     /// (chat lives at the host root).
     Perplexity,
-    // xAI Grok was scoped out of this PR after audit: `xai` is not in
-    // AISIX-Cloud's `internal/cpapi/adapter_map/adapter_map.yaml`
-    // Featured table (PR #335 swapped xai → google for rank 8), so
-    // adding `Provider::Xai` here without a catalog entry would leave
-    // a DP variant cp-api can't write to. Tracked as a separate
-    // follow-up: add xai to adapter_map.yaml first, then a one-line
-    // Provider::Xai DP-side commit will follow.
+    /// xAI Grok — OpenAI-compat at `https://api.x.ai/v1`. Admitted
+    /// by cp-api via the models.dev catalog (`provider_metadata`)
+    /// long-tail path; closes the schema-validation half of
+    /// api7/AISIX-Cloud#417. The dispatch routing half is handled
+    /// by the `Adapter::Openai` family bridge registered in
+    /// `crates/aisix-server/src/main.rs::build_hub()`.
+    Xai,
     /// Moonshot AI (Kimi) — OpenAI-compat at `https://api.moonshot.cn/v1`.
     Moonshotai,
     /// Alibaba Cloud DashScope — OpenAI-compat at
@@ -114,6 +114,7 @@ impl Provider {
             Self::Togetherai => "https://api.together.ai/v1",
             Self::FireworksAi => "https://api.fireworks.ai/inference/v1",
             Self::Perplexity => "https://api.perplexity.ai",
+            Self::Xai => "https://api.x.ai/v1",
             Self::Moonshotai => "https://api.moonshot.cn/v1",
             Self::Alibaba => "https://dashscope.aliyuncs.com/compatible-mode/v1",
             Self::Zhipuai => "https://open.bigmodel.cn/api/paas/v4",
@@ -139,6 +140,7 @@ impl Provider {
             Self::Togetherai => "togetherai",
             Self::FireworksAi => "fireworks-ai",
             Self::Perplexity => "perplexity",
+            Self::Xai => "xai",
             Self::Moonshotai => "moonshotai",
             Self::Alibaba => "alibaba",
             Self::Zhipuai => "zhipuai",
@@ -219,6 +221,7 @@ impl From<Provider> for Adapter {
             | Provider::Togetherai
             | Provider::FireworksAi
             | Provider::Perplexity
+            | Provider::Xai
             | Provider::Moonshotai
             | Provider::Alibaba
             | Provider::Zhipuai

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -117,7 +117,7 @@ fn model_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "display_name":    { "type": "string", "minLength": 1 },
-            "provider":        { "type": "string", "enum": ["openai","anthropic","google","deepseek","cohere","jina","groq","mistral","togetherai","fireworks-ai","perplexity","moonshotai","alibaba","zhipuai","baseten","huggingface","cerebras"] },
+            "provider":        { "type": "string", "enum": ["openai","anthropic","google","deepseek","cohere","jina","groq","mistral","togetherai","fireworks-ai","perplexity","xai","moonshotai","alibaba","zhipuai","baseten","huggingface","cerebras"] },
             "model_name":      { "type": "string", "minLength": 1 },
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },
@@ -593,6 +593,22 @@ mod tests {
             "provider_key_id": "pk-1"
         });
         assert!(validate_model(&v).is_err());
+    }
+
+    /// `xai` was admitted by cp-api via `provider_metadata` (pricesync
+    /// from models.dev) before this PR, but the DP's closed-enum
+    /// schema rejected the Model row in `validate_model`, leaving the
+    /// row in `stats.rejections` and producing a 404 on chat.
+    /// Closes the schema-validation half of api7/AISIX-Cloud#417.
+    #[test]
+    fn model_with_xai_provider_passes() {
+        let v = json!({
+            "display_name": "x",
+            "provider": "xai",
+            "model_name": "grok-4",
+            "provider_key_id": "pk-1"
+        });
+        validate_model(&v).unwrap();
     }
 
     #[test]

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -92,9 +92,8 @@ const FIREWORKS_AI_DEFAULT_BASE: &str = "https://api.fireworks.ai/inference/v1";
 // Per https://docs.perplexity.ai/api-reference/chat-completions-post
 // (chat endpoint is at the host root, NOT /v1).
 const PERPLEXITY_DEFAULT_BASE: &str = "https://api.perplexity.ai";
-// xAI Grok scoped out: not in cp-api adapter_map.yaml today (#335
-// swapped xai → google for Featured rank 8); follow-up will add it
-// after the catalog catches up.
+// Per https://docs.x.ai/docs/api-reference (OpenAI-compat at /v1).
+const XAI_DEFAULT_BASE: &str = "https://api.x.ai/v1";
 // Per https://platform.moonshot.cn/docs/api/chat
 const MOONSHOTAI_DEFAULT_BASE: &str = "https://api.moonshot.cn/v1";
 // Per https://help.aliyun.com/zh/dashscope/developer-reference/compatibility-of-openai-with-dashscope
@@ -162,6 +161,7 @@ impl OpenAiBridge {
             "togetherai" => TOGETHERAI_DEFAULT_BASE,
             "fireworks-ai" => FIREWORKS_AI_DEFAULT_BASE,
             "perplexity" => PERPLEXITY_DEFAULT_BASE,
+            "xai" => XAI_DEFAULT_BASE,
             "moonshotai" => MOONSHOTAI_DEFAULT_BASE,
             "alibaba" => ALIBABA_DEFAULT_BASE,
             "zhipuai" => ZHIPUAI_DEFAULT_BASE,
@@ -195,12 +195,51 @@ impl OpenAiBridge {
     /// path is left as-is after suffix stripping — Gemini's `/v1beta/openai`
     /// prefix is non-trivial and operators typically copy-paste the full
     /// form.
-    fn resolve_base(&self, ctx: &BridgeContext) -> String {
+    fn resolve_base(&self, ctx: &BridgeContext) -> Result<String, BridgeError> {
         let raw = match ctx.provider_key.api_base.as_deref() {
             Some(b) if !b.trim().is_empty() => b.trim().to_string(),
-            _ => return self.default_base().to_string(),
+            _ => {
+                // Family-bridge safety: when `self.name == "openai"`
+                // (the `Adapter::Openai` family registration, see
+                // `crates/aisix-server/src/main.rs::build_hub()`), a
+                // non-openai vendor reaching this branch means cp-api
+                // failed to populate `api_base` for that PK. Falling
+                // back to `OPENAI_DEFAULT_BASE` here would route the
+                // vendor's traffic and API key to `api.openai.com`.
+                // Refuse loud. Closes the openrouter half of
+                // api7/AISIX-Cloud#417 (rank-9 Featured entry has no
+                // canonical `default_base_url`, so cp-api admission
+                // without explicit `api_base` lands here with an
+                // empty PK base).
+                //
+                // Legacy `Provider`-keyed registrations
+                // (`Provider::Groq`, `Provider::Cohere`, …) are
+                // unaffected — they use `with_name("groq")` etc.
+                // so `self.name != "openai"`. Pre-Phase-A rows
+                // (empty `provider` string) also pass through to
+                // the historical `default_base()` behavior.
+                // Normalize the vendor string before comparing so a
+                // crafted PK with `"OpenAI"` / `"openai "` / `" openai"`
+                // can't bypass the guard and silently route a
+                // non-openai customer's API key to api.openai.com.
+                // cp-api today rejects unknown strings at admission,
+                // but the DP is the security boundary and must not
+                // trust cp-api's normalization.
+                let pk_vendor_raw = ctx.provider_key.provider.as_str();
+                let pk_vendor = pk_vendor_raw.trim().to_ascii_lowercase();
+                if self.name == "openai" && !pk_vendor.is_empty() && pk_vendor != "openai" {
+                    return Err(BridgeError::Config(format!(
+                        "provider {pk_vendor_raw:?} has no api_base set; \
+                         the OpenAI-family bridge refuses to fall back to \
+                         api.openai.com to avoid routing {pk_vendor_raw:?}'s \
+                         API key to OpenAI. Set api_base on the provider \
+                         key, or switch to the BYO sentinel."
+                    )));
+                }
+                return Ok(self.default_base().to_string());
+            }
         };
-        normalize_api_base(&raw, self.name)
+        Ok(normalize_api_base(&raw, self.name))
     }
 }
 
@@ -478,7 +517,7 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -528,7 +567,7 @@ impl Bridge for OpenAiBridge {
         req: &EmbeddingRequest,
         ctx: &BridgeContext,
     ) -> Result<EmbeddingResponse, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -570,7 +609,7 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -618,7 +657,7 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -666,7 +705,7 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -1165,7 +1204,7 @@ data: [DONE]\n\n";
         let pk_default: ProviderKey =
             serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_default));
-        assert_eq!(bridge.resolve_base(&ctx), OPENAI_DEFAULT_BASE);
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), OPENAI_DEFAULT_BASE);
 
         // api_base override: trailing slash stripped.
         let pk_override: ProviderKey = serde_json::from_str(
@@ -1173,12 +1212,130 @@ data: [DONE]\n\n";
         )
         .unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_override));
-        assert_eq!(bridge.resolve_base(&ctx), "https://proxy.example.com/v1");
+        assert_eq!(
+            bridge.resolve_base(&ctx).unwrap(),
+            "https://proxy.example.com/v1"
+        );
     }
 
     fn pk_with_base(api_base: &str) -> ProviderKey {
         let cfg = format!(r#"{{"display_name":"x","secret":"k","api_base":"{api_base}"}}"#);
         serde_json::from_str(&cfg).unwrap()
+    }
+
+    /// `Adapter::Openai` family bridge (`OpenAiBridge::new()`, name =
+    /// `"openai"`) must refuse to dispatch a non-openai vendor whose
+    /// `ProviderKey.api_base` is empty. Falling back to
+    /// `OPENAI_DEFAULT_BASE` here would send the vendor's API key to
+    /// `api.openai.com`. Closes the openrouter half of #417 (rank-9
+    /// Featured catalog entry has no canonical `default_base_url`, so
+    /// cp-api admission without an explicit `api_base` lands here
+    /// with an empty PK base).
+    #[test]
+    fn family_bridge_refuses_non_openai_vendor_with_empty_api_base() {
+        let bridge = OpenAiBridge::new();
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"or","secret":"sk-or","provider":"openrouter","adapter":"openai"}"#,
+        )
+        .unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        let err = bridge.resolve_base(&ctx).unwrap_err();
+        match err {
+            BridgeError::Config(msg) => {
+                assert!(
+                    msg.contains("openrouter") && msg.contains("api_base"),
+                    "error must name the vendor and the missing field; got: {msg}"
+                );
+            }
+            other => panic!("expected BridgeError::Config, got {other:?}"),
+        }
+    }
+
+    /// Pure-openai PK without `api_base` falls back to
+    /// `OPENAI_DEFAULT_BASE` — the historical behavior the legacy
+    /// `hub.register(Provider::Openai, …)` path relied on. The
+    /// safety check above only fires for non-openai vendors.
+    #[test]
+    fn family_bridge_allows_openai_vendor_with_empty_api_base() {
+        let bridge = OpenAiBridge::new();
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"oai","secret":"sk-oai","provider":"openai","adapter":"openai"}"#,
+        )
+        .unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), OPENAI_DEFAULT_BASE);
+    }
+
+    /// Pre-Phase-A PK schema carries an empty `provider` string. The
+    /// safety check must NOT fire here — those rows route through the
+    /// legacy `hub.get(Provider::Openai)` path with the historical
+    /// `OPENAI_DEFAULT_BASE` fallback. A regression that errored on
+    /// empty `provider` would 500 every legacy-schema chat.
+    #[test]
+    fn family_bridge_allows_legacy_empty_provider_with_empty_api_base() {
+        let bridge = OpenAiBridge::new();
+        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), OPENAI_DEFAULT_BASE);
+    }
+
+    /// MEDIUM-2 from #365 audit: the guard normalizes the PK vendor
+    /// before comparing. A crafted PK carrying `provider="OpenAI"`
+    /// (capitalized) or `provider="openai "` (trailing whitespace)
+    /// must NOT bypass the guard and silently route to api.openai.com
+    /// — cp-api today rejects unknown strings at admission, but the
+    /// DP is the security boundary and must not trust cp-api's
+    /// normalization. cp-api still gets the unnormalized vendor id
+    /// in the error message so operators can identify the row.
+    #[test]
+    fn family_bridge_normalizes_vendor_before_compare() {
+        let bridge = OpenAiBridge::new();
+
+        // Whitespace-padded — must NOT match "openai" exactly, but
+        // also must NOT bypass the guard.
+        let pk: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"x","secret":"k","provider":" openai "}"#)
+                .unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        // Whitespace-only normalizes to "openai" — same vendor, not
+        // routed to a different upstream; falls back to default base.
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), OPENAI_DEFAULT_BASE);
+
+        // Crafted casing for a different vendor — must trip the
+        // guard. Without normalization, `"XAI" != "openai"` is true
+        // and the guard fires; with normalization, `"xai" != "openai"`
+        // also fires. Both paths catch it; this test pins that the
+        // guard does not silently fall back to OpenAI.
+        let pk: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"x","secret":"k","provider":"XAI"}"#).unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        let err = bridge.resolve_base(&ctx).unwrap_err();
+        match err {
+            BridgeError::Config(msg) => {
+                // Error message echoes the unnormalized vendor id
+                // so the operator can identify the bad PK row.
+                assert!(
+                    msg.contains("\"XAI\"") && msg.contains("api_base"),
+                    "error must surface the original vendor id; got: {msg}"
+                );
+            }
+            other => panic!("expected BridgeError::Config, got {other:?}"),
+        }
+    }
+
+    /// The xai happy path: cp-api populates `api_base` from
+    /// `provider_metadata.api_base_url` (handlers.go createProviderKey
+    /// gate at 2537-2557), so the family bridge sees a populated base
+    /// and dispatches normally.
+    #[test]
+    fn family_bridge_allows_non_openai_vendor_with_populated_api_base() {
+        let bridge = OpenAiBridge::new();
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"xai","secret":"sk-xai","provider":"xai","adapter":"openai","api_base":"https://api.x.ai/v1"}"#,
+        )
+        .unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), "https://api.x.ai/v1");
     }
 
     /// All three OpenAI api_base forms a real operator might paste must
@@ -1199,7 +1356,7 @@ data: [DONE]\n\n";
         ] {
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
             assert_eq!(
-                bridge.resolve_base(&ctx),
+                bridge.resolve_base(&ctx).unwrap(),
                 canonical,
                 "form {form:?} should normalize to {canonical}",
             );
@@ -1222,7 +1379,7 @@ data: [DONE]\n\n";
         ] {
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
             assert_eq!(
-                bridge.resolve_base(&ctx),
+                bridge.resolve_base(&ctx).unwrap(),
                 canonical,
                 "form {form:?} should normalize to {canonical}",
             );
@@ -1237,7 +1394,10 @@ data: [DONE]\n\n";
         let bridge = OpenAiBridge::new().with_name("deepseek");
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
-        assert_eq!(bridge.resolve_base(&ctx), "https://api.deepseek.com");
+        assert_eq!(
+            bridge.resolve_base(&ctx).unwrap(),
+            "https://api.deepseek.com"
+        );
     }
 
     /// Gemini default must target the OpenAI-compatible `/v1beta/openai`
@@ -1248,7 +1408,7 @@ data: [DONE]\n\n";
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
         assert_eq!(
-            bridge.resolve_base(&ctx),
+            bridge.resolve_base(&ctx).unwrap(),
             "https://generativelanguage.googleapis.com/v1beta/openai",
         );
     }
@@ -1264,7 +1424,7 @@ data: [DONE]\n\n";
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
         assert_eq!(
-            bridge.resolve_base(&ctx),
+            bridge.resolve_base(&ctx).unwrap(),
             "https://api.cohere.com/compatibility/v1",
         );
     }
@@ -1290,7 +1450,7 @@ data: [DONE]\n\n";
         ] {
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
             assert_eq!(
-                bridge.resolve_base(&ctx),
+                bridge.resolve_base(&ctx).unwrap(),
                 canonical,
                 "form {form:?} should normalize to {canonical}",
             );
@@ -1300,7 +1460,7 @@ data: [DONE]\n\n";
         let custom = "https://proxy.acme.internal/cohere-chat";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(custom)));
         assert_eq!(
-            bridge.resolve_base(&ctx),
+            bridge.resolve_base(&ctx).unwrap(),
             custom,
             "non-canonical host must NOT be rewritten",
         );
@@ -1375,7 +1535,7 @@ data: [DONE]\n\n";
                 serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
             assert_eq!(
-                bridge.resolve_base(&ctx),
+                bridge.resolve_base(&ctx).unwrap(),
                 expected_base,
                 "with_name(\"{name}\") must fall back to {expected_base} when api_base is unset; \
                  a missing arm silently routes the provider to OpenAI's API host"
@@ -1396,7 +1556,7 @@ data: [DONE]\n\n";
         let custom = "https://corporate-proxy.acme.internal/groq";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(custom)));
         assert_eq!(
-            bridge.resolve_base(&ctx),
+            bridge.resolve_base(&ctx).unwrap(),
             custom,
             "operator-supplied api_base must pass through for long-tail providers"
         );
@@ -1412,20 +1572,20 @@ data: [DONE]\n\n";
         // Canonical form passes through.
         let canonical = "https://generativelanguage.googleapis.com/v1beta/openai";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(canonical)));
-        assert_eq!(bridge.resolve_base(&ctx), canonical);
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), canonical);
 
         // Endpoint suffix is stripped.
         let with_suffix =
             "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(with_suffix)));
-        assert_eq!(bridge.resolve_base(&ctx), canonical);
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), canonical);
 
         // Bare host is left as-is — the operator's responsibility to
         // include the unusual prefix. (See provider-keys.md for the
         // per-provider truth table.)
         let bare = "https://generativelanguage.googleapis.com";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(bare)));
-        assert_eq!(bridge.resolve_base(&ctx), bare);
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), bare);
     }
 
     // ----------- issue #302 §5 wire-in: RequestOverrides -----------

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -825,8 +825,10 @@ fn build_hub() -> Hub {
         Provider::Perplexity,
         Arc::new(OpenAiBridge::new().with_name("perplexity")),
     );
-    // Provider::Xai scoped out — see model.rs comment on the Xai
-    // variant (deferred until cp-api adapter_map adds the entry).
+    hub.register(
+        Provider::Xai,
+        Arc::new(OpenAiBridge::new().with_name("xai")),
+    );
     hub.register(
         Provider::Moonshotai,
         Arc::new(OpenAiBridge::new().with_name("moonshotai")),
@@ -879,6 +881,28 @@ fn build_hub() -> Hub {
     hub.register_family(Adapter::Vertex, Arc::new(VertexBridge::new()));
     hub.register_family(Adapter::AzureOpenai, Arc::new(AzureOpenAiBridge::new()));
     hub.register_family(Adapter::Bedrock, Arc::new(BedrockBridge::new()));
+
+    // OpenAI / Anthropic family fallthrough (closes
+    // api7/AISIX-Cloud#417). cp-api admits any models.dev provider
+    // (e.g. `xai`) and projects `adapter: "openai"` per
+    // adapter_map.yaml's default rule (internal/cpapi/adapter_map),
+    // but without these family registrations `dispatch_two_tier`
+    // misses on the specialized tier, falls through to legacy
+    // `hub.get(Provider::<vendor>)`, and 500s for any vendor not
+    // enumerated in the legacy `Provider` enum.
+    //
+    // The legacy per-Provider `hub.register(Provider::Xxx, ...)`
+    // above stays as live dispatch for `pk.adapter: None` rows
+    // (pre-Phase-A schema). For new-schema rows
+    // (`pk.adapter: Some(Adapter::Openai)`), the family bridge
+    // resolves first and reads `ProviderKey.api_base` directly —
+    // cp-api guarantees a non-empty api_base for non-featured
+    // catalog rows by populating from `provider_metadata.api_base_url`
+    // before persisting (handlers.go createProviderKey gate), so the
+    // bridge never falls back to its `default_base()` constant for
+    // long-tail vendors.
+    hub.register_family(Adapter::Openai, Arc::new(OpenAiBridge::new()));
+    hub.register_family(Adapter::Anthropic, Arc::new(AnthropicBridge::new()));
 
     hub
 }
@@ -1196,6 +1220,7 @@ mod tests {
             (aisix_core::Provider::Togetherai, "togetherai"),
             (aisix_core::Provider::FireworksAi, "fireworks-ai"),
             (aisix_core::Provider::Perplexity, "perplexity"),
+            (aisix_core::Provider::Xai, "xai"),
             (aisix_core::Provider::Moonshotai, "moonshotai"),
             (aisix_core::Provider::Alibaba, "alibaba"),
             (aisix_core::Provider::Zhipuai, "zhipuai"),
@@ -1218,5 +1243,60 @@ mod tests {
                  OpenAiBridge::default_base() fallback when api_base is unset",
             );
         }
+    }
+
+    /// `build_hub()` must register `Adapter::Openai` as a family
+    /// bridge so any non-enumerated catalog provider (e.g. `xai`,
+    /// `openrouter`, any future models.dev long-tail) routes via
+    /// `dispatch_two_tier`'s family fall-through instead of falling
+    /// past it into legacy `hub.get(Provider::<vendor>)` and 500-ing
+    /// when the enum variant is missing. Closes
+    /// api7/AISIX-Cloud#417 — `xai` was admitted by cp-api via the
+    /// adapter_map default rule but had no DP `Provider` variant.
+    #[test]
+    fn build_hub_registers_openai_family_bridge_for_non_enumerated_vendors() {
+        let hub = build_hub();
+        // `xai` is the exact case that #417 surfaced — admitted by
+        // cp-api's `isAcceptedProvider` via `provider_metadata` but
+        // not in the legacy `Provider` enum. With the family bridge
+        // registered, the new-schema PK (carrying `adapter: openai`
+        // from cp-api's adapter_map default rule) resolves via
+        // `dispatch_two_tier` and dispatches against the
+        // `ProviderKey.api_base` cp-api populated from
+        // `provider_metadata.api_base_url`.
+        let json =
+            r#"{"display_name":"xai-pk","secret":"sk-test","provider":"xai","adapter":"openai"}"#;
+        let pk: aisix_core::ProviderKey = serde_json::from_str(json).unwrap();
+        let bridge = hub.dispatch_two_tier(&pk).unwrap_or_else(|| {
+            panic!(
+                "Adapter::Openai family bridge must be registered so non-enumerated \
+                 catalog vendors (xai, openrouter, future long-tail) resolve via \
+                 dispatch_two_tier — a missing family bridge re-introduces #417"
+            )
+        });
+        assert_eq!(
+            bridge.name(),
+            "openai",
+            "Adapter::Openai family bridge must be the bare OpenAiBridge::new() — \
+             a `with_name(...)` variant here would mis-label every non-enumerated \
+             vendor's traffic to the chosen name",
+        );
+    }
+
+    /// Companion to the OpenAI family check above: `Adapter::Anthropic`
+    /// must also be registered so the same fall-through works for any
+    /// Anthropic-compat vendor cp-api admits via the default rule.
+    #[test]
+    fn build_hub_registers_anthropic_family_bridge() {
+        let hub = build_hub();
+        let json = r#"{"display_name":"anthropic-compat-pk","secret":"sk-test","provider":"future-anthropic-compat","adapter":"anthropic"}"#;
+        let pk: aisix_core::ProviderKey = serde_json::from_str(json).unwrap();
+        let bridge = hub.dispatch_two_tier(&pk).unwrap_or_else(|| {
+            panic!(
+                "Adapter::Anthropic family bridge must be registered for symmetry \
+                 with Adapter::Openai — see issue #302 Phase A two-tier dispatch"
+            )
+        });
+        assert_eq!(bridge.name(), "anthropic");
     }
 }

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -316,6 +316,13 @@
           ]
         },
         {
+          "description": "xAI Grok — OpenAI-compat at `https://api.x.ai/v1`. Admitted by cp-api via the models.dev catalog (`provider_metadata`) long-tail path; closes the schema-validation half of api7/AISIX-Cloud#417. The dispatch routing half is handled by the `Adapter::Openai` family bridge registered in `crates/aisix-server/src/main.rs::build_hub()`.",
+          "type": "string",
+          "enum": [
+            "xai"
+          ]
+        },
+        {
           "description": "Moonshot AI (Kimi) — OpenAI-compat at `https://api.moonshot.cn/v1`.",
           "type": "string",
           "enum": [


### PR DESCRIPTION
## Summary

Closes the DP-side half of [api7/AISIX-Cloud#417](https://github.com/api7/AISIX-Cloud/issues/417). The e2e companion (admission assertion + no-api_base variant) lands in [api7/AISIX-Cloud#429](https://github.com/api7/AISIX-Cloud/pull/429).

## What was broken

The #417 trap had **two** independent gaps stacked. Audit caught the second one:

1. **Schema validation gap** — `crates/aisix-core/src/models/schema.rs::model_schema()` had a closed `provider` enum that did not include `xai`. cp-api was projecting Model rows with `"provider": "xai"` (since #336's long-tail admission), but the DP rejected them at `validate_model` → silently pushed to `stats.rejections`. Customer chat → 404 model_not_found.

2. **Routing gap** — even after the schema is fixed, the DP's `Hub::dispatch_two_tier` had no `Adapter::Openai` family bridge registered. The legacy `hub.get(Provider::<vendor>)` fallback had no entry for `Xai`, returning `None` → 500.

This PR closes both.

## Fix

1. `crates/aisix-core/src/models/model.rs` — add `Provider::Xai` variant + `default_base_url` + `as_str` + `From<Provider> for Adapter` arms. xai's wire id is `xai`, default upstream is `https://api.x.ai/v1`, adapter family is `openai`.

2. `crates/aisix-core/src/models/schema.rs` — add `"xai"` to `model_schema()`'s `provider` enum. Companion test `model_with_xai_provider_passes` pins the contract.

3. `crates/aisix-provider-openai/src/bridge.rs` — add `XAI_DEFAULT_BASE` const + `"xai" => XAI_DEFAULT_BASE` arm in `default_base()` so the `with_name("xai")` bridge variant has a proper fallback when `api_base` is unset.

4. `crates/aisix-server/src/main.rs::build_hub()` —
   - register `Provider::Xai` against `OpenAiBridge::new().with_name("xai")` (legacy path);
   - **also** register `Adapter::Openai` + `Adapter::Anthropic` as family bridges (`Hub::dispatch_two_tier` fall-through). The family registrations close the bug-class for any future long-tail cp-api admits via `provider_metadata` but the DP hasn't enumerated yet.

5. `crates/aisix-provider-openai/src/bridge.rs::resolve_base()` — defensive guard: when the family bridge sees a non-openai vendor with an empty `api_base`, return `BridgeError::Config` instead of falling back to `OPENAI_DEFAULT_BASE`. Without this, a PK carrying `provider: "openrouter"` (Featured rank-9 with no canonical default) + empty `api_base` would silently route the customer's openrouter API key to `api.openai.com`. The vendor string is normalized (`trim` + `to_ascii_lowercase`) before comparing to prevent case-/whitespace-crafted bypasses. The unnormalized vendor id is preserved in the error message so operators can identify the row.

## Test plan

- [x] `cargo test --workspace` — all green (271 / 90 / 65 / ... per crate; 0 failed)
- [x] `cargo clippy -p aisix-core -p aisix-provider-openai -p aisix-server -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 9 new + updated unit tests:
  - `model_with_xai_provider_passes` (schema)
  - `build_hub_registers_openai_family_bridge_for_non_enumerated_vendors`
  - `build_hub_registers_anthropic_family_bridge`
  - `build_hub_registers_long_tail_openai_adapter_variants` (extended to include xai)
  - `family_bridge_refuses_non_openai_vendor_with_empty_api_base`
  - `family_bridge_allows_openai_vendor_with_empty_api_base`
  - `family_bridge_allows_legacy_empty_provider_with_empty_api_base`
  - `family_bridge_allows_non_openai_vendor_with_populated_api_base`
  - `family_bridge_normalizes_vendor_before_compare`
- [x] e2e (api7/AISIX-Cloud#429) — `cpapi-provider-admission-live.spec.ts`: 4 passed, 1 skipped (openrouter `.fixme`), 0 failed. Includes a no-`api_base` xai variant that pins the exact #417 repro shape.

## Audit response

Independent audit ([fresh subagent](https://github.com/api7/ai-gateway/blob/main/CLAUDE.md#8-independent-audit-before-merge)) flagged:

- **HIGH-1 (Model rows rejected at snapshot load due to closed schema enum)** — **addressed** in this PR (Provider::Xai variant + schema enum entry).
- **HIGH-2 (no DP chat round-trip e2e)** — **deferred** to api7/AISIX-Cloud#430. The DP image in `compose.e2e.yml` would need to include this PR's family-bridge fix for the e2e to demonstrate the closed bug.
- **MEDIUM-1 (`BridgeError::Config → 500` should be 400 for customer-fixable cases)** — **deferred** to api7/ai-gateway#367. Touches all bridges + every match arm; bigger refactor than #417 scope. Today the customer gets a clear `config_error` envelope, just on a 5xx — message clarity is the immediate win.
- **MEDIUM-2 (case-sensitive vendor compare bypasses guard)** — **addressed** in this PR (`trim` + `to_ascii_lowercase` normalization + companion test).
- **MEDIUM-3 (audio/images/completions handlers don't use Hub)** — **deferred** to api7/ai-gateway#368.
- **LOW-1 (Anthropic safety guard mirror)** — deferred; tracked in api7/ai-gateway#368 broader discussion.
- **LOW-2 (reqwest client cost)** — no-op; one new client per family registration at boot.

## What is not in this PR

- BridgeError taxonomy split (HTTP status mapping) — api7/ai-gateway#367
- Audio / images / completions Hub dispatch parity — api7/ai-gateway#368
- DP-mediated chat round-trip e2e for catalog routing — api7/AISIX-Cloud#430
- cp-api admission gate fix for openrouter without `api_base` — api7/AISIX-Cloud#431
- Cleanup of the 11 long-tail per-Provider registrations + enum variants (clean-cut per [#302](https://github.com/api7/AISIX-Cloud/issues/302) TL;DR) — the family-bridge fallthrough this PR adds unblocks that refactor.