### PR TITLE
chore(fmt): restore rustfmt on aisix-etcd loader test (post-#362)

### DIFF
--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -445,11 +445,7 @@ mod tests {
 
     #[test]
     fn provider_key_happy_path_accepts() {
-        let entries = vec![raw(
-            "/aisix/provider_keys/pk-1",
-            VALID_PROVIDER_KEY,
-            1,
-        )];
+        let entries = vec![raw("/aisix/provider_keys/pk-1", VALID_PROVIDER_KEY, 1)];
         let (snap, stats) = build_snapshot("/aisix", &entries);
         assert_eq!(stats.accepted, 1);
         assert_eq!(snap.provider_keys.len(), 1);


### PR DESCRIPTION
## Summary

PR #362 added `fn provider_key_happy_path_accepts()` with a multi-line `vec!` initializer that rustfmt collapses to a single line. main has been failing `lint (fmt + clippy)` on every PR since #362 merged (e.g. ai-gateway#360's [run](https://github.com/api7/ai-gateway/actions/runs/26216699513/job/77140800571) shows the diff at `crates/aisix-etcd/src/loader.rs:445`).

This is a pure 1-line fmt restore — no logic change.

## Verification

- `cargo fmt --all -- --check` clean locally on this branch (matches the CI command in `.github/workflows/ci.yml`).
- Toolchain: rustc 1.93.1 (pinned via `rust-toolchain.toml`), rustfmt 1.8.0-stable.

## Why a separate PR

Surfaced while debugging CI on ai-gateway#360 (the AISIX-Cloud#410 fix). Keeping this isolated from #360 per surgical-changes discipline — #360 doesn't touch loader.rs.