### PR TITLE
chore(clippy): allow too_many_arguments on cross_provider_dispatch (post-#363)

### DIFF
--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -574,6 +574,7 @@ fn anthropic_metrics_from_response_json(body: &Value) -> AnthropicUsageMetrics {
 /// 4. For streaming: bridge.chat_stream → AnthropicSseEncoder pumps
 ///    each ChatChunk through the message_start / content_block_* /
 ///    message_* state machine and writes SSE bytes
+#[allow(clippy::too_many_arguments)]
 async fn cross_provider_dispatch(
     state: &ProxyState,
     body: &Value,


### PR DESCRIPTION
## Summary

PR #363 (`fix(proxy): record messages stream telemetry`) added [`cross_provider_dispatch`](https://github.com/api7/ai-gateway/blob/main/crates/aisix-proxy/src/messages.rs#L577) with 11 args. clippy's `too_many_arguments` lint trips (threshold 7), so `lint (fmt + clippy)` has been failing on the workspace-wide check (`cargo clippy --workspace --all-targets -- -D warnings`) on every PR since #363 merged.

This is the same pattern that #366 just fixed for #362's fmt drift. Surgical 1-line restore so the queue can move.

## Why `#[allow]` not refactor

The codebase already uses `#[allow(clippy::too_many_arguments)]` on five other functions of similar dispatch / handler shape:

- `crates/aisix-proxy/src/chat.rs:1334, 1418, 1517`
- `crates/aisix-proxy/src/audio.rs:497`
- `crates/aisix-proxy/src/messages.rs:901`

So the established convention is the attribute, not a refactor. A proper context-struct refactor for the dispatch functions is the right follow-up; that's a separate, deeper change that shouldn't sit in front of CI green.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean locally on this branch (took a while from a cold cache; reusing the cache from #366's worktree the run completes faster).
- 1-line attribute add; no logic change, no test change.

## Surfaced from

Debugging the `lint (fmt + clippy)` job on [ai-gateway#360](https://github.com/api7/ai-gateway/pull/360) (the AISIX-Cloud#410 fix). Keeping isolated from #360 per surgical-changes discipline.