### PR TITLE
fix: #302 Phase A clean cut — drop Provider enumeration for catalog vendors (closes AISIX-Cloud#417)

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -531,17 +531,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_model_with_invalid_provider_prefix_is_400_schema_error() {
-        // `mistral` was the original sentinel for "unknown provider"
-        // (rejected by the legacy 6-value allowlist). Since
-        // ai-gateway#345 first-classed 11 long-tail variants, mistral
-        // is now valid — use a string that's NOT in the post-#345
-        // 17-value list so the negative-test still pins the
-        // schema-rejection path.
+    async fn create_model_with_empty_display_name_is_400_schema_error() {
+        // After #302 Phase A `provider` is a free-form string — any
+        // catalog vendor cp-api admits flows through. The schema
+        // still rejects empty `display_name` (`minLength: 1`), which
+        // is what we exercise here as the canonical "bad input → 400"
+        // path. The old "unknown provider rejected" assertion is
+        // intentionally retired: the whole point of #302 Phase A is
+        // that the DP no longer enumerates vendors.
         let app = build_router(build_state());
         let body = json!({
-            "display_name": "x",
-            "provider": "this-is-not-a-provider-id",
+            "display_name": "",
+            "provider": "openai",
             "model_name": "x",
             "provider_key_id": "11111111-1111-1111-1111-111111111111"
         });

--- a/crates/aisix-admin/src/playground_handler.rs
+++ b/crates/aisix-admin/src/playground_handler.rs
@@ -49,7 +49,7 @@ pub async fn playground_chat_completions(
 
 #[cfg(test)]
 mod tests {
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AdminConfig, AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -97,8 +97,9 @@ mod tests {
     }
 
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        let json =
-            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
     }
@@ -119,7 +120,7 @@ mod tests {
 
         let snapshot = SnapshotHandle::new(snap);
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let proxy_state = ProxyState::new(snapshot.clone(), hub, &proxy_cfg()).without_cache();
         let proxy_router = aisix_proxy::build_router(proxy_state);
 

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -92,25 +92,10 @@ pub enum Adapter {
     AzureOpenai,
 }
 
-impl From<Provider> for Adapter {
-    /// Map the first-class `Provider` variants onto the `Adapter`
-    /// wire-shape set. Long-tail vendors no longer go through this —
-    /// they're free-form strings on `ProviderKey.provider` + cp-api
-    /// projects `adapter` directly.
-    fn from(provider: Provider) -> Self {
-        match provider {
-            Provider::Openai => Adapter::Openai,
-            Provider::Anthropic => Adapter::Anthropic,
-            // `Provider::Google` calls Gemini's OpenAI-compat endpoint
-            // (`/v1beta/openai`); the wire shape is `openai`. A future
-            // native Vertex AI dispatch would migrate this arm.
-            Provider::Google => Adapter::Openai,
-            Provider::Deepseek => Adapter::Openai,
-            Provider::Cohere => Adapter::Openai,
-            Provider::Jina => Adapter::Openai,
-        }
-    }
-}
+// `From<Provider> for Adapter` removed: post-#302 Phase A nothing in
+// production reads it. Adapter identity lives on `ProviderKey.adapter`
+// directly, projected by cp-api per adapter_map.yaml. The legacy
+// Model.provider → Adapter mapping has no caller.
 
 /// Per-token cost for budget tracking. Both values are in USD per 1,000 tokens.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
@@ -493,21 +478,9 @@ mod tests {
         assert_eq!(bg.ignore_statuses, vec![408, 429]);
     }
 
-    #[test]
-    fn adapter_from_provider_covers_every_variant() {
-        // Every Provider variant must map to a defined Adapter. This
-        // test exists to fail the build if a new Provider is added
-        // without an explicit From arm — the match in `From<Provider>`
-        // is exhaustive so the real safety net is the compiler, but
-        // pinning the chosen Adapter per variant guards against a
-        // future edit silently changing the mapping.
-        assert_eq!(Adapter::from(Provider::Openai), Adapter::Openai);
-        assert_eq!(Adapter::from(Provider::Anthropic), Adapter::Anthropic);
-        assert_eq!(Adapter::from(Provider::Google), Adapter::Openai);
-        assert_eq!(Adapter::from(Provider::Deepseek), Adapter::Openai);
-        assert_eq!(Adapter::from(Provider::Cohere), Adapter::Openai);
-        assert_eq!(Adapter::from(Provider::Jina), Adapter::Openai);
-    }
+    // `adapter_from_provider_covers_every_variant` removed alongside
+    // the `From<Provider> for Adapter` impl — both are dead post-#302
+    // Phase A. ProviderKey.adapter carries the Adapter directly.
 
     #[test]
     fn adapter_serializes_to_kebab_case_wire_strings() {
@@ -589,7 +562,6 @@ mod tests {
         for v in variants {
             let id = v.as_str();
             assert!(!id.is_empty(), "{v:?}: as_str must be non-empty");
-            let _: Adapter = Adapter::from(v);
         }
     }
 }

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -17,7 +17,21 @@ use super::rate_limit::RateLimit;
 use super::routing::Routing;
 use crate::resource::Resource;
 
-/// Supported upstream providers.
+/// First-class upstream provider variants with specialized DP handling.
+///
+/// Kept narrow on purpose: only vendors whose code path diverges from
+/// the wire-shape default (`Adapter`-family bridge) live here. Every
+/// other catalog vendor cp-api admits (xai, openrouter, groq, mistral,
+/// fireworks-ai, perplexity, together, moonshot, alibaba, zhipu,
+/// baseten, huggingface, cerebras, …) flows through the `Adapter`
+/// family bridge without a DP enum variant — closes api7/AISIX-Cloud#302
+/// Phase A and api7/AISIX-Cloud#417.
+///
+/// Wire identity on `ProviderKey.provider` / `Model.provider` is a
+/// free-form string (`Option<String>`); this enum is reserved for the
+/// few code paths that still match on a fixed vendor set
+/// (Cohere/Jina native rerank, Anthropic-shape `/v1/messages` cross-
+/// provider routing).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Provider {
@@ -28,101 +42,19 @@ pub enum Provider {
     /// Cohere — `/v1/rerank` (native, via `aisix-proxy::rerank`) and
     /// chat/completions / embeddings (via `OpenAiBridge::with_name("cohere")`
     /// against `https://api.cohere.com/compatibility/v1`, per
-    /// <https://docs.cohere.com/reference/chat>). Chat-compat is the
-    /// OpenAI-shape namespace Cohere ships alongside its native
-    /// `/v1/chat`. Chat-compat coverage today: the `command-r` /
-    /// `command-a` family per
-    /// <https://docs.cohere.com/v2/docs/compatibility-api>; legacy
-    /// `command` / `command-light` / `command-nightly` go to native
-    /// (not yet bridged) and will return upstream 400 if configured
-    /// against the chat-compat path.
+    /// <https://docs.cohere.com/reference/chat>).
     Cohere,
     /// Jina AI — currently exposed for `/v1/rerank` only (#213 Phase 2).
     /// Jina's rerank wire shape is identity-mapped to the OpenAI-compat
     /// shape (`{model, query, documents, top_n}` with Bearer auth at
     /// `https://api.jina.ai/v1/rerank`), so the gateway forwards
-    /// verbatim with no transform. Jina's chat / embeddings APIs are
-    /// out of scope for this phase.
+    /// verbatim with no transform.
     Jina,
-    // ─── OpenAI-adapter long-tail providers (#60 P2-A) ────────────────
-    //
-    // The 11 variants below all expose an OpenAI-compatible chat
-    // completions surface and route through `OpenAiBridge::with_name`
-    // — the same dispatch path Deepseek / Google already use. Default
-    // base URLs are sourced from each vendor's official OpenAI-compat
-    // documentation; operators can override via `ProviderKey.api_base`.
-    //
-    // serde casing is `lowercase` (inherited from the parent enum) so
-    // each variant's wire id is its single-token lowercase form. The
-    // `fireworks-ai` variant carries an explicit `#[serde(rename)]`
-    // because its catalog id (per models.dev) is hyphenated and would
-    // not survive the default lowercase rule.
-    /// Groq — OpenAI-compat at `https://api.groq.com/openai/v1`.
-    Groq,
-    /// Mistral AI — OpenAI-compat at `https://api.mistral.ai/v1`.
-    Mistral,
-    /// Together.ai — OpenAI-compat at `https://api.together.ai/v1`.
-    Togetherai,
-    /// Fireworks AI — OpenAI-compat at `https://api.fireworks.ai/inference/v1`.
-    /// Wire id is the hyphenated `fireworks-ai` (matches the
-    /// models.dev catalog id used by cp-api's adapter_map).
-    #[serde(rename = "fireworks-ai")]
-    FireworksAi,
-    /// Perplexity — OpenAI-compat at `https://api.perplexity.ai`
-    /// (chat lives at the host root).
-    Perplexity,
-    // xAI Grok was scoped out of this PR after audit: `xai` is not in
-    // AISIX-Cloud's `internal/cpapi/adapter_map/adapter_map.yaml`
-    // Featured table (PR #335 swapped xai → google for rank 8), so
-    // adding `Provider::Xai` here without a catalog entry would leave
-    // a DP variant cp-api can't write to. Tracked as a separate
-    // follow-up: add xai to adapter_map.yaml first, then a one-line
-    // Provider::Xai DP-side commit will follow.
-    /// Moonshot AI (Kimi) — OpenAI-compat at `https://api.moonshot.cn/v1`.
-    Moonshotai,
-    /// Alibaba Cloud DashScope — OpenAI-compat at
-    /// `https://dashscope.aliyuncs.com/compatible-mode/v1`.
-    Alibaba,
-    /// Zhipu AI (智谱) — OpenAI-compat at
-    /// `https://open.bigmodel.cn/api/paas/v4`.
-    Zhipuai,
-    /// Baseten — OpenAI-compat at `https://inference.baseten.co/v1`.
-    /// Per <https://docs.baseten.co/development/model-apis/openai-clients>,
-    /// model APIs are exposed at this host root.
-    Baseten,
-    /// Hugging Face — OpenAI-compat router at
-    /// `https://router.huggingface.co/v1` per
-    /// <https://huggingface.co/docs/inference-providers/en/index#openai-compatible-api>.
-    Huggingface,
-    /// Cerebras Inference — OpenAI-compat at `https://api.cerebras.ai/v1`.
-    Cerebras,
 }
 
 impl Provider {
-    pub const fn default_base_url(self) -> &'static str {
-        match self {
-            Self::Openai => "https://api.openai.com",
-            Self::Anthropic => "https://api.anthropic.com",
-            Self::Google => "https://generativelanguage.googleapis.com/v1beta/openai",
-            Self::Deepseek => "https://api.deepseek.com",
-            Self::Cohere => "https://api.cohere.com",
-            Self::Jina => "https://api.jina.ai",
-            // Long-tail OpenAI-adapter providers (#60 P2-A) — each
-            // url is the vendor's documented OpenAI-compat endpoint.
-            Self::Groq => "https://api.groq.com/openai/v1",
-            Self::Mistral => "https://api.mistral.ai/v1",
-            Self::Togetherai => "https://api.together.ai/v1",
-            Self::FireworksAi => "https://api.fireworks.ai/inference/v1",
-            Self::Perplexity => "https://api.perplexity.ai",
-            Self::Moonshotai => "https://api.moonshot.cn/v1",
-            Self::Alibaba => "https://dashscope.aliyuncs.com/compatible-mode/v1",
-            Self::Zhipuai => "https://open.bigmodel.cn/api/paas/v4",
-            Self::Baseten => "https://inference.baseten.co/v1",
-            Self::Huggingface => "https://router.huggingface.co/v1",
-            Self::Cerebras => "https://api.cerebras.ai/v1",
-        }
-    }
-
+    /// Stable wire identity for this first-class variant. Matches the
+    /// models.dev catalog id cp-api stores on `ProviderKey.provider`.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Openai => "openai",
@@ -131,20 +63,6 @@ impl Provider {
             Self::Deepseek => "deepseek",
             Self::Cohere => "cohere",
             Self::Jina => "jina",
-            // Long-tail OpenAI-adapter providers (#60 P2-A). The
-            // wire id matches the catalog id used by cp-api's
-            // adapter_map / models.dev.
-            Self::Groq => "groq",
-            Self::Mistral => "mistral",
-            Self::Togetherai => "togetherai",
-            Self::FireworksAi => "fireworks-ai",
-            Self::Perplexity => "perplexity",
-            Self::Moonshotai => "moonshotai",
-            Self::Alibaba => "alibaba",
-            Self::Zhipuai => "zhipuai",
-            Self::Baseten => "baseten",
-            Self::Huggingface => "huggingface",
-            Self::Cerebras => "cerebras",
         }
     }
 }
@@ -175,56 +93,21 @@ pub enum Adapter {
 }
 
 impl From<Provider> for Adapter {
-    /// Mapping from the current `Provider` enum onto the `Adapter`
-    /// wire-shape set, for use during the issue #302 Phase A skeleton
-    /// stage. This mapping is **not** wired into dispatch in this PR;
-    /// it exists as a forward-looking reference that follow-up Phase A
-    /// PRs will consume when migrating entities, the Hub, and Bridges
-    /// onto `Adapter`.
-    ///
-    /// Rationale per variant:
-    ///
-    /// - `Openai` / `Anthropic`: direct equivalents.
-    /// - `Google` → `Vertex`: forward-looking choice for the Phase A
-    ///   migration target. **Note:** this intentionally diverges from
-    ///   the current runtime behavior — `Provider::Google` today calls
-    ///   the Gemini Generative Language API via its OpenAI-compatible
-    ///   endpoint (`/v1beta/openai`), which is an `openai`-shaped
-    ///   wire. Any downstream PR that flips dispatch onto `Adapter`
-    ///   MUST either also migrate the Google bridge to native Vertex
-    ///   AI request encoding, or revisit this arm before merging — a
-    ///   silent flip would change the wire shape sent to Google
-    ///   upstreams. See issue #302 Phase A for the migration plan.
-    /// - `Deepseek` → `Openai`: DeepSeek exposes an OpenAI-compatible
-    ///   chat completions endpoint, so the adapter shape is `openai`.
-    /// - `Cohere` → `Openai`: the gateway currently talks to Cohere's
-    ///   OpenAI-compatible endpoints (#213 Phase 1 — rerank-only),
-    ///   so the wire adapter is `openai`. A native Cohere adapter is
-    ///   not part of this skeleton.
-    /// - `Jina` → `Openai`: Jina's rerank is identity-mapped to the
-    ///   OpenAI-compat rerank shape (#213 Phase 2), so the wire
-    ///   adapter is `openai`.
+    /// Map the first-class `Provider` variants onto the `Adapter`
+    /// wire-shape set. Long-tail vendors no longer go through this —
+    /// they're free-form strings on `ProviderKey.provider` + cp-api
+    /// projects `adapter` directly.
     fn from(provider: Provider) -> Self {
         match provider {
             Provider::Openai => Adapter::Openai,
             Provider::Anthropic => Adapter::Anthropic,
-            Provider::Google => Adapter::Vertex,
+            // `Provider::Google` calls Gemini's OpenAI-compat endpoint
+            // (`/v1beta/openai`); the wire shape is `openai`. A future
+            // native Vertex AI dispatch would migrate this arm.
+            Provider::Google => Adapter::Openai,
             Provider::Deepseek => Adapter::Openai,
             Provider::Cohere => Adapter::Openai,
             Provider::Jina => Adapter::Openai,
-            // All long-tail variants (#60 P2-A) expose OpenAI-compat
-            // chat surfaces and route through OpenAiBridge.
-            Provider::Groq
-            | Provider::Mistral
-            | Provider::Togetherai
-            | Provider::FireworksAi
-            | Provider::Perplexity
-            | Provider::Moonshotai
-            | Provider::Alibaba
-            | Provider::Zhipuai
-            | Provider::Baseten
-            | Provider::Huggingface
-            | Provider::Cerebras => Adapter::Openai,
         }
     }
 }
@@ -361,10 +244,17 @@ pub struct Model {
     /// the dashboard model list. `Resource::name()` returns this.
     pub display_name: String,
 
-    /// Upstream provider. None for routing models (the router picks
-    /// a target whose own `provider` is used at dispatch time).
+    /// Upstream vendor identity, free-form string (e.g. `"openai"`,
+    /// `"xai"`, `"openrouter"`, any models.dev catalog id). Carried
+    /// through to telemetry / logs but **not consumed by dispatch** —
+    /// routing reads `ProviderKey.adapter` + `ProviderKey.provider`
+    /// instead, so a new long-tail vendor admitted by cp-api works
+    /// without a DP code change. None for routing models.
+    ///
+    /// Closes the schema-validation half of api7/AISIX-Cloud#417 and
+    /// the dispatch half of api7/AISIX-Cloud#302 Phase A.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider: Option<Provider>,
+    pub provider: Option<String>,
 
     /// Upstream model id sent to the provider (e.g. "gpt-4o",
     /// "claude-sonnet-4-5"). None for routing models.
@@ -460,7 +350,7 @@ mod tests {
     fn deserialises_spec_sample() {
         let m: Model = serde_json::from_str(sample_json()).unwrap();
         assert_eq!(m.display_name, "my-gpt4");
-        assert_eq!(m.provider, Some(Provider::Openai));
+        assert_eq!(m.provider.as_deref(), Some("openai"));
         assert_eq!(m.model_name.as_deref(), Some("gpt-4o"));
         assert_eq!(
             m.provider_key_id.as_deref(),
@@ -613,7 +503,7 @@ mod tests {
         // future edit silently changing the mapping.
         assert_eq!(Adapter::from(Provider::Openai), Adapter::Openai);
         assert_eq!(Adapter::from(Provider::Anthropic), Adapter::Anthropic);
-        assert_eq!(Adapter::from(Provider::Google), Adapter::Vertex);
+        assert_eq!(Adapter::from(Provider::Google), Adapter::Openai);
         assert_eq!(Adapter::from(Provider::Deepseek), Adapter::Openai);
         assert_eq!(Adapter::from(Provider::Cohere), Adapter::Openai);
         assert_eq!(Adapter::from(Provider::Jina), Adapter::Openai);
@@ -681,43 +571,13 @@ mod tests {
         assert!(serde_json::from_str::<Adapter>("\"azure_openai\"").is_err());
     }
 
+    /// Every first-class `Provider` variant must have a non-empty
+    /// `as_str` wire id and a working `Adapter::from` arm. A
+    /// regression that added a new variant but forgot to update
+    /// either would compile fine but silently break dispatch
+    /// downstream.
     #[test]
-    fn provider_default_urls_are_stable() {
-        assert_eq!(
-            Provider::Openai.default_base_url(),
-            "https://api.openai.com"
-        );
-        assert_eq!(
-            Provider::Anthropic.default_base_url(),
-            "https://api.anthropic.com"
-        );
-        assert_eq!(
-            Provider::Google.default_base_url(),
-            "https://generativelanguage.googleapis.com/v1beta/openai"
-        );
-        assert_eq!(
-            Provider::Deepseek.default_base_url(),
-            "https://api.deepseek.com"
-        );
-        // #213 Phase 1 / Phase 2: rerank-only providers. Per audit
-        // LOW-3 on PR #229 — pin these too so a regression that
-        // swaps the host (e.g. Jina's `https://api.jina.ai` →
-        // `https://api.jina.com`) fails at the unit level.
-        assert_eq!(
-            Provider::Cohere.default_base_url(),
-            "https://api.cohere.com"
-        );
-        assert_eq!(Provider::Jina.default_base_url(), "https://api.jina.ai");
-    }
-
-    /// Every `Provider` variant must have a non-empty `default_base_url`,
-    /// `as_str`, and an `Adapter::from` arm. A regression that added a
-    /// new variant but forgot to update one of the three would compile
-    /// fine but silently break dispatch downstream — this iterator-based
-    /// test makes the regression class explicit (audit MEDIUM-2 on
-    /// PR #345).
-    #[test]
-    fn every_provider_variant_has_default_base_url_as_str_and_adapter() {
+    fn every_provider_variant_has_as_str_and_adapter() {
         let variants = [
             Provider::Openai,
             Provider::Anthropic,
@@ -725,28 +585,10 @@ mod tests {
             Provider::Deepseek,
             Provider::Cohere,
             Provider::Jina,
-            // Long-tail OpenAI-adapter providers (#60 P2-A).
-            Provider::Groq,
-            Provider::Mistral,
-            Provider::Togetherai,
-            Provider::FireworksAi,
-            Provider::Perplexity,
-            Provider::Moonshotai,
-            Provider::Alibaba,
-            Provider::Zhipuai,
-            Provider::Baseten,
-            Provider::Huggingface,
-            Provider::Cerebras,
         ];
         for v in variants {
-            let url = v.default_base_url();
-            assert!(
-                url.starts_with("https://"),
-                "{v:?}: default_base_url must be an https URL, got {url:?}",
-            );
             let id = v.as_str();
             assert!(!id.is_empty(), "{v:?}: as_str must be non-empty");
-            // Adapter::from must compile and return some variant.
             let _: Adapter = Adapter::from(v);
         }
     }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -117,7 +117,7 @@ fn model_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "display_name":    { "type": "string", "minLength": 1 },
-            "provider":        { "type": "string", "minLength": 1 },
+            "provider":        { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[a-z0-9][a-z0-9_-]*$" },
             "model_name":      { "type": "string", "minLength": 1 },
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -647,6 +647,26 @@ mod tests {
         }
     }
 
+    /// `maxLength: 64` bounds Prometheus label cardinality. The
+    /// longest real models.dev catalog id today is ~19 chars; the
+    /// cap is generous but finite. A regression that drops the cap
+    /// would let a crafted ~10KB vendor string flow into metric
+    /// labels.
+    #[test]
+    fn model_rejects_provider_string_over_maxlength() {
+        let too_long = "a".repeat(65);
+        let v = json!({
+            "display_name": "x",
+            "provider": too_long,
+            "model_name": "x",
+            "provider_key_id": "pk-1"
+        });
+        assert!(
+            validate_model(&v).is_err(),
+            "provider string > 64 chars MUST be rejected (Prometheus cardinality guard)",
+        );
+    }
+
     #[test]
     fn model_rejects_empty_provider_string() {
         let v = json!({

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -117,7 +117,12 @@ fn model_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "display_name":    { "type": "string", "minLength": 1 },
-            "provider":        { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[a-z0-9][a-z0-9_-]*$" },
+            // `provider` is the open vendor identity (models.dev catalog id
+            // — e.g. `openai`, `xai`, `wafer.ai`). The pattern accepts the
+            // dot character because at least one real models.dev id
+            // (`wafer.ai`) contains it; rejecting `.` would re-create the
+            // #417 bug class for that vendor.
+            "provider":        { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[a-z0-9][a-z0-9._-]*$" },
             "model_name":      { "type": "string", "minLength": 1 },
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },
@@ -588,7 +593,20 @@ mod tests {
     /// `minLength: 1`.
     #[test]
     fn model_accepts_arbitrary_provider_string() {
-        for provider in ["openai", "xai", "openrouter", "this-is-some-new-vendor"] {
+        // Every real models.dev catalog id must pass. `wafer.ai` is
+        // the load-bearing example: one real vendor has a dot in its
+        // id, so the schema pattern must accept `.` — rejecting it
+        // would re-create the #417 bug class for that vendor.
+        // `fireworks-ai` is the canonical hyphenated example.
+        for provider in [
+            "openai",
+            "xai",
+            "openrouter",
+            "wafer.ai",
+            "fireworks-ai",
+            "togetherai",
+            "this-is-some-new-vendor",
+        ] {
             let v = json!({
                 "display_name": "x",
                 "provider": provider,
@@ -598,6 +616,34 @@ mod tests {
             validate_model(&v).unwrap_or_else(|err| {
                 panic!("provider {provider:?} should validate after #302 Phase A; got {err:?}")
             });
+        }
+    }
+
+    /// Pattern guards against log-injection / cardinality explosion.
+    /// Each rejected case here is a string the round-1 audit listed
+    /// as a concern.
+    #[test]
+    fn model_rejects_provider_strings_outside_pattern() {
+        for bad in [
+            "\nfake_log_line",
+            "openai\nline2",
+            "with space",
+            "UPPER",
+            ".leading-dot",
+            "-leading-hyphen",
+            "_leading-underscore",
+            "trailing-byte\0",
+        ] {
+            let v = json!({
+                "display_name": "x",
+                "provider": bad,
+                "model_name": "x",
+                "provider_key_id": "pk-1"
+            });
+            assert!(
+                validate_model(&v).is_err(),
+                "provider {bad:?} MUST be rejected by the pattern guard",
+            );
         }
     }
 

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -117,7 +117,7 @@ fn model_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "display_name":    { "type": "string", "minLength": 1 },
-            "provider":        { "type": "string", "enum": ["openai","anthropic","google","deepseek","cohere","jina","groq","mistral","togetherai","fireworks-ai","perplexity","moonshotai","alibaba","zhipuai","baseten","huggingface","cerebras"] },
+            "provider":        { "type": "string", "minLength": 1 },
             "model_name":      { "type": "string", "minLength": 1 },
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },
@@ -580,19 +580,39 @@ mod tests {
         assert!(err.message.to_lowercase().contains("display_name"));
     }
 
+    /// Closed-enum on `provider` was the cause of api7/AISIX-Cloud#417
+    /// — any catalog vendor not in the DP enum (`xai`, `openrouter`,
+    /// future long-tail) failed schema validation at snapshot load
+    /// and silently disappeared from dispatch. Phase A opened the
+    /// field to a free-form string; the only invariant left is
+    /// `minLength: 1`.
     #[test]
-    fn model_unknown_provider_value_fails() {
-        // `mistral` USED to be an unknown provider (rejected by the
-        // 6-value allowlist) but is now first-class on the Hub via
-        // ai-gateway#345. Use a value that's NOT in the post-#345
-        // enum so the negative test still pins the rejection path.
+    fn model_accepts_arbitrary_provider_string() {
+        for provider in ["openai", "xai", "openrouter", "this-is-some-new-vendor"] {
+            let v = json!({
+                "display_name": "x",
+                "provider": provider,
+                "model_name": "x",
+                "provider_key_id": "pk-1"
+            });
+            validate_model(&v).unwrap_or_else(|err| {
+                panic!("provider {provider:?} should validate after #302 Phase A; got {err:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn model_rejects_empty_provider_string() {
         let v = json!({
             "display_name": "x",
-            "provider": "this-is-not-a-provider-id",
+            "provider": "",
             "model_name": "x",
             "provider_key_id": "pk-1"
         });
-        assert!(validate_model(&v).is_err());
+        assert!(
+            validate_model(&v).is_err(),
+            "empty `provider` must fail (minLength: 1)"
+        );
     }
 
     #[test]

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -349,9 +349,12 @@ mod tests {
 
     #[test]
     fn schema_failure_is_counted() {
+        // After #302 Phase A `provider` is a free-form string. Use a
+        // genuine schema violation (empty `display_name`) to keep the
+        // rejection-path test meaningful.
         let entries = vec![raw(
-            "/aisix/models/bad-provider",
-            br#"{"display_name":"x","provider":"this-is-not-a-provider-id","model_name":"large","provider_key_id":"pk-1"}"#,
+            "/aisix/models/bad-shape",
+            br#"{"display_name":"","provider":"openai","model_name":"large","provider_key_id":"pk-1"}"#,
             1,
         )];
         let (_snap, stats) = build_snapshot("/aisix", &entries);
@@ -404,7 +407,7 @@ mod tests {
     fn rejection_records_schema_failure() {
         let entries = vec![raw(
             "/aisix/models/bad",
-            br#"{"display_name":"x","provider":"this-is-not-a-provider-id","model_name":"l","provider_key_id":"pk"}"#,
+            br#"{"display_name":"","provider":"openai","model_name":"l","provider_key_id":"pk"}"#,
             1,
         )];
         let (_snap, stats) = build_snapshot("/aisix", &entries);

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -1128,9 +1128,13 @@ mod tests {
     // different successful apply_put does not hide an unrelated
     // rejection, and (4) fixing/deleting the rejected key clears it.
 
+    // Schema rejection bait: empty `display_name` violates the
+    // `minLength: 1` invariant. After #302 Phase A the `provider`
+    // field is free-form string, so we trigger rejection via a
+    // different required-field shape.
     const BAD_PROVIDER_MODEL: &[u8] = br#"{
-        "display_name":"x",
-        "provider":"this-is-not-a-provider-id",
+        "display_name":"",
+        "provider":"openai",
         "model_name":"l",
         "provider_key_id":"pk"
     }"#;

--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -459,7 +459,6 @@ pub trait Bridge: Send + Sync + 'static {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aisix_core::models::Provider;
 
     #[test]
     fn timeout_maps_to_504() {
@@ -570,6 +569,6 @@ mod tests {
     #[test]
     fn sample_model_resolves_to_openai() {
         let m = sample_model();
-        assert_eq!(m.provider, Some(Provider::Openai));
+        assert_eq!(m.provider.as_deref(), Some("openai"));
     }
 }

--- a/crates/aisix-gateway/src/hub.rs
+++ b/crates/aisix-gateway/src/hub.rs
@@ -1,58 +1,51 @@
 //! The [`Hub`] dispatches `ChatFormat` requests to the matching
-//! [`Bridge`] based on the target Model's `Provider` enum.
+//! [`Bridge`] based on the target [`ProviderKey`]'s vendor identity and
+//! wire-shape adapter. There is no per-`Provider`-enum lookup — vendor
+//! identity is an open string (`ProviderKey.provider`) and routing
+//! falls through a closed 5-value `Adapter` family enum.
 //!
 //! Hubs are constructed once at startup (spec §1 step 7 — before the
-//! proxy router is built) and hold an `Arc<dyn Bridge>` per provider.
-//! Lookups are `O(1)` — a 4-entry hashmap keyed on the Provider enum.
+//! proxy router is built) and hold:
 //!
-//! There is no fallback logic here — that is the proxy layer's job and
-//! lands in its own PR. The Hub exists purely to resolve Provider →
-//! Bridge cheaply and consistently.
-//!
-//! # Two-tier dispatch skeleton (issue #302 Phase A)
-//!
-//! In addition to the existing `Provider`-keyed registry, the Hub now
-//! also carries two forward-looking maps keyed by [`ProviderKey`]
-//! fields introduced in Phase A:
-//!
-//! - `family_bridges` — keyed on `Adapter` (wire shape: `openai`,
-//!   `anthropic`, `bedrock`, `vertex`, `azure-openai`). The default
-//!   bridge for any provider that matches that wire shape.
 //! - `specialized_bridges` — keyed on `ProviderKey.provider` (vendor
-//!   string, e.g. `"deepseek"`, `"jina"`). Used when a specific vendor
-//!   needs handling that diverges from its wire-shape default.
+//!   string, e.g. `"deepseek"`, `"cohere"`). Used when a specific
+//!   vendor needs handling that diverges from its wire-shape default
+//!   (e.g. DeepSeek's `reasoning_content` lift, Cohere's chat-compat
+//!   namespace).
+//! - `family_bridges` — keyed on [`Adapter`] (wire shape: `openai`,
+//!   `anthropic`, `bedrock`, `vertex`, `azure-openai`). The default
+//!   bridge for any vendor whose `ProviderKey.adapter` matches that
+//!   wire shape and has no specialized override.
 //!
 //! [`Hub::dispatch_two_tier`] looks up specialized first, then falls
-//! back to the family bridge. It is **not consumed by any caller** in
-//! this PR — `build_hub()` does not register family/specialized
-//! bridges and the proxy path continues to dispatch through the
-//! existing `Provider`-keyed `get()`. The new methods exist so future
-//! Phase A / Phase D sub-PRs can wire dispatch through them without
-//! re-touching this file.
+//! back to the family bridge. A new catalog vendor admitted by cp-api
+//! works without a DP code change: the family bridge for its adapter
+//! handles the request using `ProviderKey.api_base` for the upstream.
+//!
+//! Closes the dispatch half of api7/AISIX-Cloud#302 Phase A and the
+//! routing half of api7/AISIX-Cloud#417.
 
-use aisix_core::models::{Adapter, Provider, ProviderKey};
+use aisix_core::models::{Adapter, ProviderKey};
 use dashmap::DashMap;
 use std::sync::Arc;
 
 use crate::bridge::Bridge;
 
-/// Registry of providers → bridges.
+/// Registry of vendor strings + adapter families → bridges.
 ///
 /// `DashMap` lets us register bridges after construction (useful for tests
 /// and for future dynamic-reload scenarios) without taking out a lock on
 /// the lookup path.
 #[derive(Default)]
 pub struct Hub {
-    bridges: DashMap<Provider, Arc<dyn Bridge>>,
-    /// Wire-shape default bridges. Keyed on [`Adapter`]. Phase A
-    /// skeleton — empty until follow-up PRs register the per-family
-    /// default bridge. See module docs.
+    /// Wire-shape default bridges. Keyed on [`Adapter`] — the closed
+    /// 5-value protocol family enum. Every catalog vendor whose
+    /// `ProviderKey.adapter` matches one of these resolves here if
+    /// no specialized override is registered.
     family_bridges: DashMap<Adapter, Arc<dyn Bridge>>,
     /// Vendor-specific override bridges. Keyed on
-    /// `ProviderKey.provider` (vendor string). Phase A skeleton —
-    /// empty until follow-up PRs register specialized handlers for
-    /// vendors that diverge from their wire-shape default. See module
-    /// docs.
+    /// `ProviderKey.provider` (vendor string). Used when a specific
+    /// vendor needs handling that diverges from its wire-shape default.
     specialized_bridges: DashMap<String, Arc<dyn Bridge>>,
 }
 
@@ -61,51 +54,41 @@ impl Hub {
         Self::default()
     }
 
-    /// Register a bridge for a provider. Overwrites any previous entry,
-    /// which is what we want during live reconfigure — the etcd watcher
-    /// can swap a broken bridge without tearing down the Hub.
-    pub fn register(&self, provider: Provider, bridge: Arc<dyn Bridge>) {
-        self.bridges.insert(provider, bridge);
-    }
-
-    pub fn get(&self, provider: Provider) -> Option<Arc<dyn Bridge>> {
-        self.bridges.get(&provider).map(|r| r.clone())
-    }
-
-    pub fn providers(&self) -> Vec<Provider> {
-        self.bridges.iter().map(|r| *r.key()).collect()
-    }
-
-    pub fn len(&self) -> usize {
-        self.bridges.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.bridges.is_empty()
-    }
-
     /// Register the family-tier (wire-shape default) bridge for an
-    /// [`Adapter`]. Phase A skeleton — see module docs.
-    ///
-    /// Overwrites any previous entry for the same adapter, matching
-    /// the live-reconfigure semantics of [`Hub::register`].
+    /// [`Adapter`]. Overwrites any previous entry for the same adapter,
+    /// matching live-reconfigure semantics.
     pub fn register_family(&self, adapter: Adapter, bridge: Arc<dyn Bridge>) {
         self.family_bridges.insert(adapter, bridge);
     }
 
     /// Register a specialized (vendor-specific) bridge keyed on the
-    /// `ProviderKey.provider` vendor string. Phase A skeleton — see
-    /// module docs.
-    ///
-    /// Overwrites any previous entry for the same vendor key.
+    /// `ProviderKey.provider` vendor string. Overwrites any previous
+    /// entry for the same vendor key.
     pub fn register_specialized(&self, provider: impl Into<String>, bridge: Arc<dyn Bridge>) {
         self.specialized_bridges.insert(provider.into(), bridge);
+    }
+
+    /// Look up a specialized vendor bridge by its `ProviderKey.provider`
+    /// vendor string. Used by handlers (chat preflight, background
+    /// model checks) that need to confirm a vendor has a registered
+    /// bridge without committing to a full dispatch. Returns `None`
+    /// when no specialized override is registered — callers should
+    /// then fall through to `family_bridge_for` for the catalog
+    /// default path.
+    pub fn get_specialized(&self, provider: &str) -> Option<Arc<dyn Bridge>> {
+        self.specialized_bridges.get(provider).map(|r| r.clone())
+    }
+
+    /// Look up a family bridge by [`Adapter`]. Mirrors
+    /// [`Hub::get_specialized`] for the family tier.
+    pub fn family_bridge_for(&self, adapter: Adapter) -> Option<Arc<dyn Bridge>> {
+        self.family_bridges.get(&adapter).map(|r| r.clone())
     }
 
     /// Two-tier dispatch: specialized vendor bridge first, then the
     /// adapter-family default. Returns `None` if neither is registered
     /// — the caller decides how to report a missing bridge so this
-    /// layer stays panic-free. Phase A skeleton — see module docs.
+    /// layer stays panic-free.
     pub fn dispatch_two_tier(&self, pk: &ProviderKey) -> Option<Arc<dyn Bridge>> {
         if let Some(b) = self.specialized_bridges.get(&pk.provider) {
             return Some(b.clone());
@@ -124,7 +107,6 @@ impl std::fmt::Debug for Hub {
             .map(|r| r.key().clone())
             .collect();
         f.debug_struct("Hub")
-            .field("providers", &self.providers())
             .field("families", &families)
             .field("specialized", &specialized)
             .finish()
@@ -174,50 +156,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn empty_hub_returns_none_for_any_provider() {
-        let hub = Hub::new();
-        assert!(hub.is_empty());
-        assert!(hub.get(Provider::Openai).is_none());
-    }
-
-    #[test]
-    fn register_and_get_round_trip() {
-        let hub = Hub::new();
-        hub.register(
-            Provider::Openai,
-            Arc::new(StubBridge {
-                name: "stub-openai",
-            }),
-        );
-        let b = hub.get(Provider::Openai).unwrap();
-        assert_eq!(b.name(), "stub-openai");
-    }
-
-    #[test]
-    fn register_overwrites_previous_bridge_for_same_provider() {
-        let hub = Hub::new();
-        hub.register(Provider::Openai, Arc::new(StubBridge { name: "v1" }));
-        hub.register(Provider::Openai, Arc::new(StubBridge { name: "v2" }));
-        assert_eq!(hub.len(), 1);
-        assert_eq!(hub.get(Provider::Openai).unwrap().name(), "v2");
-    }
-
-    #[test]
-    fn providers_returns_all_registered_keys() {
-        let hub = Hub::new();
-        hub.register(Provider::Openai, Arc::new(StubBridge { name: "a" }));
-        hub.register(Provider::Anthropic, Arc::new(StubBridge { name: "b" }));
-        let mut ps = hub.providers();
-        ps.sort_by_key(|p| format!("{p:?}"));
-        assert_eq!(ps.len(), 2);
-    }
-
     #[tokio::test]
     async fn registered_bridge_is_callable() {
         let hub = Hub::new();
-        hub.register(Provider::Openai, Arc::new(StubBridge { name: "stub" }));
-        let bridge = hub.get(Provider::Openai).unwrap();
+        hub.register_specialized("openai", Arc::new(StubBridge { name: "stub" }));
+        let bridge = hub.get_specialized("openai").unwrap();
 
         let m = std::sync::Arc::new(
             serde_json::from_str::<aisix_core::Model>(
@@ -239,7 +182,7 @@ mod tests {
         assert_eq!(resp.finish_reason, FinishReason::Stop);
     }
 
-    // ---- two-tier dispatch (issue #302 Phase A skeleton) ----
+    // ---- two-tier dispatch (issue #302 Phase A) ----
 
     /// Build a `ProviderKey` carrying just the vendor + adapter fields
     /// the two-tier dispatcher reads. JSON deserialization matches the
@@ -353,10 +296,8 @@ mod tests {
     }
 
     #[test]
-    fn legacy_provider_registry_is_unaffected_by_two_tier_maps() {
-        // Registering only on the new tiers must not satisfy a lookup
-        // through the legacy `Provider`-keyed API, and vice versa.
-        // Co-existence is the explicit contract of this skeleton PR.
+    fn specialized_and_family_tiers_are_independent() {
+        // A registration on one tier must not surface in the other.
         let hub = Hub::new();
         hub.register_family(Adapter::Openai, Arc::new(StubBridge { name: "family" }));
         hub.register_specialized(
@@ -365,20 +306,16 @@ mod tests {
                 name: "specialized",
             }),
         );
-        assert!(hub.get(Provider::Openai).is_none());
-        assert!(hub.is_empty());
-
-        hub.register(Provider::Openai, Arc::new(StubBridge { name: "legacy" }));
-        // Legacy bump touches only the Provider-keyed map.
-        assert_eq!(hub.get(Provider::Openai).unwrap().name(), "legacy");
-        assert_eq!(hub.len(), 1);
-        // Two-tier maps still resolve their own registrations
-        // independently.
+        // Direct lookups return their own tier only.
         assert_eq!(
-            hub.dispatch_two_tier(&pk("deepseek", Some("openai")))
-                .unwrap()
-                .name(),
+            hub.family_bridge_for(Adapter::Openai).unwrap().name(),
+            "family"
+        );
+        assert_eq!(
+            hub.get_specialized("deepseek").unwrap().name(),
             "specialized"
         );
+        assert!(hub.family_bridge_for(Adapter::Anthropic).is_none());
+        assert!(hub.get_specialized("openai").is_none());
     }
 }

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -107,10 +107,35 @@ fn normalize_api_base(base: &str) -> String {
     trimmed.to_string()
 }
 
-fn resolve_base(ctx: &BridgeContext) -> String {
+fn resolve_base(ctx: &BridgeContext) -> Result<String, BridgeError> {
     match ctx.provider_key.api_base.as_deref() {
-        Some(b) if !b.trim().is_empty() => normalize_api_base(b.trim()),
-        _ => ANTHROPIC_DEFAULT_BASE.to_string(),
+        Some(b) if !b.trim().is_empty() => Ok(normalize_api_base(b.trim())),
+        _ => {
+            // Family-bridge safety: when `AnthropicBridge` is the
+            // family registration (registered via
+            // `register_family(Adapter::Anthropic, ...)`) AND the
+            // dispatching `ProviderKey.provider` identifies a vendor
+            // that ISN'T anthropic, refuse to fall back to
+            // `ANTHROPIC_DEFAULT_BASE` — that would silently route the
+            // vendor's API key to `api.anthropic.com`. Mirrors the
+            // OpenAI-family guard in
+            // `crates/aisix-provider-openai/src/bridge.rs::resolve_base`.
+            //
+            // Pre-Phase-A rows (empty `ProviderKey.provider`) fall
+            // through to the historical default-base path unchanged.
+            let pk_vendor_raw = ctx.provider_key.provider.as_str();
+            let pk_vendor_normalized = pk_vendor_raw.trim().to_ascii_lowercase();
+            if !pk_vendor_normalized.is_empty() && pk_vendor_normalized != "anthropic" {
+                return Err(BridgeError::Config(format!(
+                    "provider_key for vendor {pk_vendor_raw:?} has no api_base set; \
+                     the Anthropic-family bridge refuses to fall back to api.anthropic.com \
+                     to avoid routing {pk_vendor_raw:?}'s API key to Anthropic. cp-api \
+                     must populate api_base for every catalog vendor via adapter_map / \
+                     provider_metadata.api_base_url."
+                )));
+            }
+            Ok(ANTHROPIC_DEFAULT_BASE.to_string())
+        }
     }
 }
 
@@ -201,7 +226,7 @@ impl Bridge for AnthropicBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
-        let base = resolve_base(ctx);
+        let base = resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -245,7 +270,7 @@ impl Bridge for AnthropicBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let base = resolve_base(ctx);
+        let base = resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -571,7 +596,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         let pk_default: ProviderKey =
             serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_default));
-        assert!(!resolve_base(&ctx).is_empty());
+        assert!(!resolve_base(&ctx).unwrap().is_empty());
 
         // api_base override: trailing slash stripped.
         let pk_override: ProviderKey = serde_json::from_str(
@@ -579,7 +604,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         )
         .unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_override));
-        assert_eq!(resolve_base(&ctx), "https://proxy.example.com");
+        assert_eq!(resolve_base(&ctx).unwrap(), "https://proxy.example.com");
     }
 
     fn pk_with_base(api_base: &str) -> ProviderKey {
@@ -606,7 +631,7 @@ data: {\"type\":\"message_stop\"}\n\n";
             let pk = pk_with_base(form);
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
             assert_eq!(
-                resolve_base(&ctx),
+                resolve_base(&ctx).unwrap(),
                 canonical,
                 "form {form:?} should normalize to {canonical}",
             );
@@ -627,7 +652,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         ] {
             let pk = pk_with_base(form);
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
-            assert_eq!(resolve_base(&ctx), canonical);
+            assert_eq!(resolve_base(&ctx).unwrap(), canonical);
         }
     }
 }

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -195,12 +195,46 @@ impl OpenAiBridge {
     /// path is left as-is after suffix stripping — Gemini's `/v1beta/openai`
     /// prefix is non-trivial and operators typically copy-paste the full
     /// form.
-    fn resolve_base(&self, ctx: &BridgeContext) -> String {
+    fn resolve_base(&self, ctx: &BridgeContext) -> Result<String, BridgeError> {
         let raw = match ctx.provider_key.api_base.as_deref() {
             Some(b) if !b.trim().is_empty() => b.trim().to_string(),
-            _ => return self.default_base().to_string(),
+            _ => {
+                // Family-bridge safety: when this `OpenAiBridge` is the
+                // bare family registration (`name == "openai"`,
+                // registered via `register_family(Adapter::Openai, ...)`)
+                // AND the dispatching `ProviderKey.provider` identifies
+                // a vendor that ISN'T openai, refuse to fall back to
+                // `OPENAI_DEFAULT_BASE` — that would silently route the
+                // vendor's API key to `api.openai.com`. Closes the
+                // openrouter / xai / future-long-tail half of
+                // api7/AISIX-Cloud#417.
+                //
+                // Legacy named bridges (`with_name("groq")`,
+                // `with_name("cohere")`, …) have their own
+                // `default_base()` arm that points at the right host,
+                // so the guard only fires for the family-bridge path.
+                //
+                // Pre-Phase-A rows (empty `ProviderKey.provider`)
+                // fall through to the historical default-base path
+                // unchanged.
+                let pk_vendor_raw = ctx.provider_key.provider.as_str();
+                let pk_vendor_normalized = pk_vendor_raw.trim().to_ascii_lowercase();
+                if self.name == "openai"
+                    && !pk_vendor_normalized.is_empty()
+                    && pk_vendor_normalized != "openai"
+                {
+                    return Err(BridgeError::Config(format!(
+                        "provider_key for vendor {pk_vendor_raw:?} has no api_base set; \
+                         the OpenAI-family bridge refuses to fall back to api.openai.com \
+                         to avoid routing {pk_vendor_raw:?}'s API key to OpenAI. cp-api \
+                         must populate api_base for every catalog vendor via adapter_map / \
+                         provider_metadata.api_base_url."
+                    )));
+                }
+                return Ok(self.default_base().to_string());
+            }
         };
-        normalize_api_base(&raw, self.name)
+        Ok(normalize_api_base(&raw, self.name))
     }
 }
 
@@ -478,7 +512,7 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -528,7 +562,7 @@ impl Bridge for OpenAiBridge {
         req: &EmbeddingRequest,
         ctx: &BridgeContext,
     ) -> Result<EmbeddingResponse, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -570,7 +604,7 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -618,7 +652,7 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -666,7 +700,7 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let base = self.resolve_base(ctx);
+        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -1165,7 +1199,7 @@ data: [DONE]\n\n";
         let pk_default: ProviderKey =
             serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_default));
-        assert_eq!(bridge.resolve_base(&ctx), OPENAI_DEFAULT_BASE);
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), OPENAI_DEFAULT_BASE);
 
         // api_base override: trailing slash stripped.
         let pk_override: ProviderKey = serde_json::from_str(
@@ -1173,12 +1207,85 @@ data: [DONE]\n\n";
         )
         .unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_override));
-        assert_eq!(bridge.resolve_base(&ctx), "https://proxy.example.com/v1");
+        assert_eq!(
+            bridge.resolve_base(&ctx).unwrap(),
+            "https://proxy.example.com/v1"
+        );
     }
 
     fn pk_with_base(api_base: &str) -> ProviderKey {
         let cfg = format!(r#"{{"display_name":"x","secret":"k","api_base":"{api_base}"}}"#);
         serde_json::from_str(&cfg).unwrap()
+    }
+
+    /// `OpenAiBridge::new()` is the `Adapter::Openai` family bridge.
+    /// When it serves a non-openai vendor with empty `api_base` it
+    /// MUST refuse rather than fall back to `OPENAI_DEFAULT_BASE` —
+    /// that fallback would silently route the vendor's API key to
+    /// `api.openai.com`. Closes the openrouter / xai half of
+    /// api7/AISIX-Cloud#417.
+    #[test]
+    fn family_bridge_refuses_non_openai_vendor_with_empty_api_base() {
+        let bridge = OpenAiBridge::new();
+        for vendor in ["openrouter", "xai", "OpenRouter", " openrouter "] {
+            let pk: ProviderKey = serde_json::from_str(&format!(
+                r#"{{"display_name":"x","secret":"k","provider":"{vendor}","adapter":"openai"}}"#
+            ))
+            .unwrap();
+            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+            let err = bridge.resolve_base(&ctx).unwrap_err();
+            match err {
+                BridgeError::Config(msg) => {
+                    assert!(
+                        msg.contains("api_base") && msg.contains(vendor.trim()),
+                        "vendor {vendor:?}: error must name vendor + api_base; got: {msg}",
+                    );
+                }
+                other => panic!("vendor {vendor:?}: expected BridgeError::Config, got {other:?}"),
+            }
+        }
+    }
+
+    /// Pure-openai PK without `api_base` falls back to
+    /// `OPENAI_DEFAULT_BASE` — the historical legacy behavior. The
+    /// safety check above only fires for non-openai vendors.
+    #[test]
+    fn family_bridge_allows_openai_vendor_with_empty_api_base() {
+        let bridge = OpenAiBridge::new();
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"oai","secret":"sk-oai","provider":"openai","adapter":"openai"}"#,
+        )
+        .unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), OPENAI_DEFAULT_BASE);
+    }
+
+    /// Pre-Phase-A PK carries an empty `provider` string. The safety
+    /// check must NOT fire here — those rows route via the compat
+    /// shim in `crates/aisix-proxy/src/dispatch.rs::resolve_bridge`
+    /// to the specialized "openai" bridge. The bridge itself must
+    /// tolerate the legacy shape so the compat path doesn't 500.
+    #[test]
+    fn family_bridge_allows_legacy_empty_provider_with_empty_api_base() {
+        let bridge = OpenAiBridge::new();
+        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), OPENAI_DEFAULT_BASE);
+    }
+
+    /// xai happy path: cp-api populates `api_base` from the catalog
+    /// row (`provider_metadata.api_base_url` or adapter_map
+    /// `default_base_url`), so the family bridge sees a populated
+    /// base and dispatches normally to the vendor's upstream.
+    #[test]
+    fn family_bridge_allows_non_openai_vendor_with_populated_api_base() {
+        let bridge = OpenAiBridge::new();
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"xai","secret":"sk-xai","provider":"xai","adapter":"openai","api_base":"https://api.x.ai/v1"}"#,
+        )
+        .unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), "https://api.x.ai/v1");
     }
 
     /// All three OpenAI api_base forms a real operator might paste must
@@ -1199,7 +1306,7 @@ data: [DONE]\n\n";
         ] {
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
             assert_eq!(
-                bridge.resolve_base(&ctx),
+                bridge.resolve_base(&ctx).unwrap(),
                 canonical,
                 "form {form:?} should normalize to {canonical}",
             );
@@ -1222,7 +1329,7 @@ data: [DONE]\n\n";
         ] {
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
             assert_eq!(
-                bridge.resolve_base(&ctx),
+                bridge.resolve_base(&ctx).unwrap(),
                 canonical,
                 "form {form:?} should normalize to {canonical}",
             );
@@ -1237,7 +1344,10 @@ data: [DONE]\n\n";
         let bridge = OpenAiBridge::new().with_name("deepseek");
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
-        assert_eq!(bridge.resolve_base(&ctx), "https://api.deepseek.com");
+        assert_eq!(
+            bridge.resolve_base(&ctx).unwrap(),
+            "https://api.deepseek.com"
+        );
     }
 
     /// Gemini default must target the OpenAI-compatible `/v1beta/openai`
@@ -1248,7 +1358,7 @@ data: [DONE]\n\n";
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
         assert_eq!(
-            bridge.resolve_base(&ctx),
+            bridge.resolve_base(&ctx).unwrap(),
             "https://generativelanguage.googleapis.com/v1beta/openai",
         );
     }
@@ -1264,7 +1374,7 @@ data: [DONE]\n\n";
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
         assert_eq!(
-            bridge.resolve_base(&ctx),
+            bridge.resolve_base(&ctx).unwrap(),
             "https://api.cohere.com/compatibility/v1",
         );
     }
@@ -1290,7 +1400,7 @@ data: [DONE]\n\n";
         ] {
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
             assert_eq!(
-                bridge.resolve_base(&ctx),
+                bridge.resolve_base(&ctx).unwrap(),
                 canonical,
                 "form {form:?} should normalize to {canonical}",
             );
@@ -1300,7 +1410,7 @@ data: [DONE]\n\n";
         let custom = "https://proxy.acme.internal/cohere-chat";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(custom)));
         assert_eq!(
-            bridge.resolve_base(&ctx),
+            bridge.resolve_base(&ctx).unwrap(),
             custom,
             "non-canonical host must NOT be rewritten",
         );
@@ -1375,7 +1485,7 @@ data: [DONE]\n\n";
                 serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
             assert_eq!(
-                bridge.resolve_base(&ctx),
+                bridge.resolve_base(&ctx).unwrap(),
                 expected_base,
                 "with_name(\"{name}\") must fall back to {expected_base} when api_base is unset; \
                  a missing arm silently routes the provider to OpenAI's API host"
@@ -1396,7 +1506,7 @@ data: [DONE]\n\n";
         let custom = "https://corporate-proxy.acme.internal/groq";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(custom)));
         assert_eq!(
-            bridge.resolve_base(&ctx),
+            bridge.resolve_base(&ctx).unwrap(),
             custom,
             "operator-supplied api_base must pass through for long-tail providers"
         );
@@ -1412,20 +1522,20 @@ data: [DONE]\n\n";
         // Canonical form passes through.
         let canonical = "https://generativelanguage.googleapis.com/v1beta/openai";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(canonical)));
-        assert_eq!(bridge.resolve_base(&ctx), canonical);
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), canonical);
 
         // Endpoint suffix is stripped.
         let with_suffix =
             "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(with_suffix)));
-        assert_eq!(bridge.resolve_base(&ctx), canonical);
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), canonical);
 
         // Bare host is left as-is — the operator's responsibility to
         // include the unusual prefix. (See provider-keys.md for the
         // per-provider truth table.)
         let bare = "https://generativelanguage.googleapis.com";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(bare)));
-        assert_eq!(bridge.resolve_base(&ctx), bare);
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), bare);
     }
 
     // ----------- issue #302 §5 wire-in: RequestOverrides -----------

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -302,7 +302,7 @@ async fn multipart_dispatch(
     // (e.g. `/audio/transcriptions`) so this code is agnostic to
     // whether the customer's api_base ends in /v1 or not.
     let url = crate::dispatch::build_v1_url(&base, upstream_path);
-    let provider_label = format!("{provider:?}").to_lowercase();
+    let provider_label = provider.to_ascii_lowercase();
 
     // Rebuild the multipart form with `model` rewritten.
     let mut form = multipart::Form::new();
@@ -421,7 +421,7 @@ async fn speech_dispatch(
     let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
 
     let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
-    let provider_label = format!("{provider:?}").to_lowercase();
+    let provider_label = provider.to_ascii_lowercase();
 
     // Rewrite model field.
     if let Some(m) = body.get_mut("model") {

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -297,7 +297,7 @@ async fn multipart_dispatch(
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
     let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
 
-    let base = crate::dispatch::resolve_base_url(provider, &pk_entry.value);
+    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
     // build_v1_url owns the /v1 prefix; callers pass the suffix
     // (e.g. `/audio/transcriptions`) so this code is agnostic to
     // whether the customer's api_base ends in /v1 or not.
@@ -420,7 +420,7 @@ async fn speech_dispatch(
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
     let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
 
-    let base = crate::dispatch::resolve_base_url(provider, &pk_entry.value);
+    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
     let provider_label = format!("{provider:?}").to_lowercase();
 
     // Rewrite model field.
@@ -525,7 +525,7 @@ fn emit_access_log(
 // from there to avoid creating multiple global Clients.
 #[cfg(test)]
 mod tests {
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -574,8 +574,9 @@ mod tests {
     }
 
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        let json =
-            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
     }
@@ -597,7 +598,7 @@ mod tests {
 
     fn build_app(snap: AisixSnapshot) -> axum::Router {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
     }

--- a/crates/aisix-proxy/src/background.rs
+++ b/crates/aisix-proxy/src/background.rs
@@ -106,7 +106,7 @@ async fn check_direct_model(
         dispatch::require_provider(model).map_err(|e| BridgeError::Config(e.to_string()))?;
     let pk_entry = dispatch::resolve_provider_key(snapshot, model)
         .map_err(|e| BridgeError::Config(e.to_string()))?;
-    let bridge = dispatch::resolve_bridge(hub, &pk_entry.value)
+    let bridge = dispatch::resolve_bridge(hub, &pk_entry.value, model.provider.as_deref())
         .ok_or_else(|| BridgeError::Config("no bridge registered for provider".into()))?;
 
     let req = ChatFormat {

--- a/crates/aisix-proxy/src/background.rs
+++ b/crates/aisix-proxy/src/background.rs
@@ -102,12 +102,11 @@ async fn check_direct_model(
     cfg: &BackgroundModelCheck,
     request_id: &str,
 ) -> Result<(), BridgeError> {
-    let provider =
+    let _provider =
         dispatch::require_provider(model).map_err(|e| BridgeError::Config(e.to_string()))?;
     let pk_entry = dispatch::resolve_provider_key(snapshot, model)
         .map_err(|e| BridgeError::Config(e.to_string()))?;
-    let bridge = hub
-        .get(provider)
+    let bridge = dispatch::resolve_bridge(hub, &pk_entry.value)
         .ok_or_else(|| BridgeError::Config("no bridge registered for provider".into()))?;
 
     let req = ChatFormat {
@@ -140,7 +139,7 @@ fn background_status_code(err: &BridgeError) -> Option<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_provider_openai::OpenAiBridge;
     use reqwest::Client;
@@ -158,7 +157,7 @@ mod tests {
 
     fn provider_key_entry(id: &str, api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let cfg = format!(
-            r#"{{"display_name":"pk-{id}","secret":"sk-upstream","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"pk-{id}","secret":"sk-upstream","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&cfg).unwrap();
         ResourceEntry::new(id, pk, 1)
@@ -200,7 +199,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snapshot = Arc::new(AisixSnapshot::new());
         snapshot
             .provider_keys
@@ -231,7 +230,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snapshot = Arc::new(AisixSnapshot::new());
         snapshot
             .provider_keys

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -509,8 +509,13 @@ async fn dispatch(
     // single bad provider doesn't take down the whole request.
     if attempt_models.len() == 1 {
         let only = &attempt_models[0].model;
-        let provider = crate::dispatch::require_provider(only).map_err(with_model)?;
-        if state.hub.get(provider).is_none() {
+        let _provider = crate::dispatch::require_provider(only).map_err(with_model)?;
+        // Pre-flight the PK-based two-tier dispatch so a missing
+        // family/specialized bridge surfaces as 503 here, before
+        // we commit to a long upstream call.
+        let pk_entry =
+            crate::dispatch::resolve_provider_key(&snapshot, only).map_err(with_model)?;
+        if crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value).is_none() {
             return Err(with_model(ProxyError::ProviderUnavailable));
         }
     }
@@ -534,7 +539,7 @@ async fn dispatch(
         let provider = crate::dispatch::require_provider(model).map_err(with_model)?;
         let pk_entry =
             crate::dispatch::resolve_provider_key(&snapshot, model).map_err(with_model)?;
-        let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, provider)
+        let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
             .ok_or_else(|| with_model(ProxyError::ProviderUnavailable))?;
         let model_arc = Arc::new(model.clone());
         let pk_arc = Arc::new(pk_entry.value.clone());
@@ -786,7 +791,8 @@ async fn dispatch(
                 let provider_label = attempt_models[0]
                     .model
                     .provider
-                    .map(|p| format!("{p:?}").to_lowercase())
+                    .as_deref()
+                    .map(|p| p.to_ascii_lowercase())
                     .unwrap_or_else(|| "unknown".into());
                 let provider_key_id = attempt_models[0]
                     .model
@@ -868,7 +874,7 @@ async fn dispatch(
 
     for attempt in &attempt_models {
         let model = &attempt.model;
-        let Some(provider) = model.provider else {
+        let Some(provider) = model.provider.as_deref() else {
             last_err = Some(BridgeError::Config("model has no provider".into()));
             continue;
         };
@@ -885,8 +891,7 @@ async fn dispatch(
         // → adapter family) first; fall back to the legacy
         // Provider-keyed registry when the new fields aren't filled in
         // on this PK yet. See crate::dispatch::resolve_bridge.
-        let Some(bridge) = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, provider)
-        else {
+        let Some(bridge) = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value) else {
             last_err = Some(BridgeError::Config(
                 "no bridge registered for provider".into(),
             ));
@@ -901,7 +906,7 @@ async fn dispatch(
                 Ok(resp) => {
                     state.health.record_success(&model.display_name);
                     state.runtime_status.mark_healthy(&attempt.id);
-                    chosen_provider = Some(format!("{provider:?}").to_lowercase());
+                    chosen_provider = Some(provider.to_ascii_lowercase());
                     chosen_provider_key_id = Some(pk_entry.id.clone());
                     chosen_upstream_model =
                         Some(model.upstream_model().unwrap_or("unknown").to_string());

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -515,7 +515,9 @@ async fn dispatch(
         // we commit to a long upstream call.
         let pk_entry =
             crate::dispatch::resolve_provider_key(&snapshot, only).map_err(with_model)?;
-        if crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value).is_none() {
+        if crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, only.provider.as_deref())
+            .is_none()
+        {
             return Err(with_model(ProxyError::ProviderUnavailable));
         }
     }
@@ -539,8 +541,9 @@ async fn dispatch(
         let provider = crate::dispatch::require_provider(model).map_err(with_model)?;
         let pk_entry =
             crate::dispatch::resolve_provider_key(&snapshot, model).map_err(with_model)?;
-        let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
-            .ok_or_else(|| with_model(ProxyError::ProviderUnavailable))?;
+        let bridge =
+            crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, model.provider.as_deref())
+                .ok_or_else(|| with_model(ProxyError::ProviderUnavailable))?;
         let model_arc = Arc::new(model.clone());
         let pk_arc = Arc::new(pk_entry.value.clone());
         let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
@@ -567,7 +570,7 @@ async fn dispatch(
         let api_key_id_for_telem = auth.entry.id.clone();
         let team_id_for_metrics = auth.key().team_id.clone();
         let owner_id_for_metrics = auth.key().owner_id.clone();
-        let provider_for_metrics = format!("{provider:?}").to_lowercase();
+        let provider_for_metrics = provider.to_ascii_lowercase();
         let model_for_metrics = req.model.clone();
         let provider_key_id_for_metrics = pk_entry.id.clone();
         let upstream_model_for_metrics = model.upstream_model().unwrap_or("unknown").to_string();
@@ -687,7 +690,7 @@ async fn dispatch(
             Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
         return Ok(Success {
             response: response.into_response(),
-            provider: format!("{provider:?}").to_lowercase(),
+            provider: provider.to_ascii_lowercase(),
             model_id: model_id.clone(),
             // Token totals are populated on the SSE stream's terminal
             // chunk and forwarded into telemetry from on_complete; the
@@ -887,11 +890,17 @@ async fn dispatch(
                 continue;
             }
         };
-        // Phase D cutover join point: try two-tier (specialized vendor
-        // → adapter family) first; fall back to the legacy
-        // Provider-keyed registry when the new fields aren't filled in
-        // on this PK yet. See crate::dispatch::resolve_bridge.
-        let Some(bridge) = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value) else {
+        // Two-tier dispatch via `Hub::dispatch_two_tier`: specialized
+        // vendor (ProviderKey.provider) first, then adapter family
+        // (ProviderKey.adapter). The legacy `Provider`-keyed registry
+        // is gone after #302 Phase A. `resolve_bridge` carries a
+        // one-cycle compat shim for pre-Phase-A PK rows that still
+        // have empty `provider` and `adapter: None` on disk — those
+        // resolve via `Model.provider` (passed below). Once cp-api
+        // has backfilled every PK, the shim becomes unreachable.
+        let Some(bridge) =
+            crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, model.provider.as_deref())
+        else {
             last_err = Some(BridgeError::Config(
                 "no bridge registered for provider".into(),
             ));

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -116,14 +116,15 @@ async fn dispatch(
     let provider = crate::dispatch::require_provider(model)?;
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
-    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
-        .ok_or(ProxyError::ProviderUnavailable)?;
+    let bridge =
+        crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, model.provider.as_deref())
+            .ok_or(ProxyError::ProviderUnavailable)?;
 
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
     let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
 
-    let provider_label = format!("{provider:?}").to_lowercase();
+    let provider_label = provider.to_ascii_lowercase();
 
     match bridge.complete(&body, &ctx).await {
         Ok(resp_json) => Ok((Json(resp_json).into_response(), provider_label)),

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -116,7 +116,7 @@ async fn dispatch(
     let provider = crate::dispatch::require_provider(model)?;
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
-    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, provider)
+    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
     let model_arc = Arc::new(model.clone());
@@ -168,7 +168,7 @@ fn emit_access_log(
 
 #[cfg(test)]
 mod tests {
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -204,8 +204,9 @@ mod tests {
     }
 
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        let json =
-            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
     }
@@ -227,7 +228,7 @@ mod tests {
 
     fn build_app(snap: AisixSnapshot) -> axum::Router {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
     }

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -27,19 +27,42 @@ use crate::error::ProxyError;
 
 /// Resolve the Bridge to dispatch this request through.
 ///
-/// Sole path is `Hub::dispatch_two_tier`: specialized vendor first,
-/// then adapter family. The legacy `Provider`-keyed registry is gone
-/// — vendor identity flows through `ProviderKey.provider` (open
-/// string) + `ProviderKey.adapter` (closed 5-value enum), so any
-/// catalog provider cp-api admits (xai, openrouter, future long-tail)
-/// resolves without DP knowing the vendor name at compile time.
+/// Primary path: `Hub::dispatch_two_tier` — specialized vendor first
+/// (keyed on `ProviderKey.provider`), then adapter family (keyed on
+/// `ProviderKey.adapter`). Vendor identity is an open string;
+/// adapter is the closed 5-value enum. Any catalog vendor cp-api
+/// admits (xai, openrouter, future long-tail) resolves through the
+/// family fallthrough without a DP code change.
 ///
-/// Returns `None` when the ProviderKey carries no `adapter` (a
-/// pre-Phase-A row that escaped the schema migration) AND no
-/// specialized bridge is registered for its vendor string. Caller
-/// surfaces this as 503 "no dispatch path".
-pub(crate) fn resolve_bridge(hub: &Hub, provider_key: &ProviderKey) -> Option<Arc<dyn Bridge>> {
-    hub.dispatch_two_tier(provider_key)
+/// Compat shim: pre-Phase-A `ProviderKey` rows still on disk have
+/// empty `provider` AND `adapter: None`. For those, fall back to
+/// the specialized registry keyed on `Model.provider`. This keeps
+/// existing on-disk data routable through the upgrade cycle. Once
+/// cp-api has backfilled every PK with `provider` + `adapter`,
+/// the fallback path becomes unreachable and can be removed.
+///
+/// Returns `None` when the two-tier path AND the compat fallback
+/// both miss — caller surfaces this as 503 "no dispatch path".
+pub(crate) fn resolve_bridge(
+    hub: &Hub,
+    provider_key: &ProviderKey,
+    model_provider: Option<&str>,
+) -> Option<Arc<dyn Bridge>> {
+    if let Some(b) = hub.dispatch_two_tier(provider_key) {
+        return Some(b);
+    }
+    // One-cycle compat for pre-Phase-A PK rows. cp-api now writes
+    // `provider` + `adapter` for every PK row; once any pre-cutover
+    // rows have been re-saved (or the operator's etcd has been wiped
+    // and reseeded), this `if` body becomes unreachable.
+    if provider_key.provider.is_empty() && provider_key.adapter.is_none() {
+        if let Some(mp) = model_provider {
+            if !mp.is_empty() {
+                return hub.get_specialized(mp);
+            }
+        }
+    }
+    None
 }
 
 /// Look up the `ProviderKey` a given `Model` references. Returns a
@@ -601,7 +624,7 @@ mod tests {
             hub.register_specialized("openai", Arc::new(StubBridge { name: "legacy" }));
 
             let pk = pk_with_provider_and_adapter("deepseek", Some("openai"));
-            let bridge = resolve_bridge(&hub, &pk).unwrap();
+            let bridge = resolve_bridge(&hub, &pk, None).unwrap();
             assert_eq!(bridge.name(), "specialized");
         }
 
@@ -614,28 +637,68 @@ mod tests {
             // pk.provider = "unknown-vendor" → no specialized; pk.adapter
             // = Openai → family hit.
             let pk = pk_with_provider_and_adapter("unknown-vendor", Some("openai"));
-            let bridge = resolve_bridge(&hub, &pk).unwrap();
+            let bridge = resolve_bridge(&hub, &pk, None).unwrap();
             assert_eq!(bridge.name(), "family");
         }
 
-        /// Phase A drops the legacy `Provider`-keyed registry. A PK
-        /// with empty `provider` AND `adapter: None` has nothing to
-        /// dispatch on — caller surfaces 503. The old legacy fallback
-        /// test (`legacy_fallback_when_both_new_tiers_miss`) is gone
-        /// because there's no legacy tier left.
+        /// A PK with empty `provider` AND `adapter: None` plus no
+        /// `Model.provider` to fall back on has nothing to dispatch
+        /// on — caller surfaces 503.
         #[test]
-        fn none_when_neither_tier_matches() {
+        fn none_when_neither_tier_matches_and_no_model_compat() {
             let hub = Hub::new();
             hub.register_specialized("openai", Arc::new(StubBridge { name: "vendor" }));
             let pk = pk_with_provider_and_adapter("", None);
-            assert!(resolve_bridge(&hub, &pk).is_none());
+            assert!(resolve_bridge(&hub, &pk, None).is_none());
         }
 
         #[test]
         fn none_when_nothing_registered() {
             let hub = Hub::new();
             let pk = pk_with_provider_and_adapter("", None);
-            assert!(resolve_bridge(&hub, &pk).is_none());
+            assert!(resolve_bridge(&hub, &pk, None).is_none());
+        }
+
+        /// One-cycle compat for pre-Phase-A PK rows. A PK with empty
+        /// `provider` AND `adapter: None` (on-disk shape pre-cutover)
+        /// resolves through the specialized registry keyed on the
+        /// Model's vendor string, so existing data stays routable
+        /// across the upgrade without forcing operators to re-save
+        /// every PK first.
+        #[test]
+        fn legacy_pk_with_empty_fields_falls_back_to_model_provider() {
+            let hub = Hub::new();
+            hub.register_specialized(
+                "openai",
+                Arc::new(StubBridge {
+                    name: "specialized-openai",
+                }),
+            );
+            // Pre-Phase-A PK shape: no `provider`, no `adapter`.
+            let pk = pk_with_provider_and_adapter("", None);
+            let bridge = resolve_bridge(&hub, &pk, Some("openai")).unwrap();
+            assert_eq!(bridge.name(), "specialized-openai");
+        }
+
+        /// Compat shim must NOT fire when the PK carries either
+        /// `provider` or `adapter` — those rows go through the
+        /// two-tier path and miss authoritatively if nothing matches.
+        /// A future PR that drops `Adapter::Openai` family must FAIL
+        /// the test below, not get rescued by the compat shim.
+        #[test]
+        fn compat_shim_does_not_fire_for_post_phase_a_pk() {
+            let hub = Hub::new();
+            hub.register_specialized(
+                "openai",
+                Arc::new(StubBridge {
+                    name: "specialized-openai",
+                }),
+            );
+            // Post-Phase-A PK: `provider:"xai"` + `adapter: None`
+            // (specialized miss; no Adapter::Openai family registered;
+            // compat shim must NOT fire because `provider` is non-empty).
+            let pk = pk_with_provider_and_adapter("xai", None);
+            assert!(resolve_bridge(&hub, &pk, Some("openai")).is_none());
         }
     }
 }

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -58,6 +58,19 @@ pub(crate) fn resolve_bridge(
     if provider_key.provider.is_empty() && provider_key.adapter.is_none() {
         if let Some(mp) = model_provider {
             if !mp.is_empty() {
+                // Emit a tracing::warn! so an operator (or SREs reading
+                // logs) can detect un-migrated PK rows still in the
+                // wild. The "one-cycle" deprecation promise is only
+                // enforceable if dispatching through the shim is
+                // observable.
+                tracing::warn!(
+                    target: "aisix_proxy::dispatch",
+                    pk_display_name = %provider_key.display_name,
+                    model_provider = %mp,
+                    "compat shim: pre-Phase-A PK row (empty `provider` + `adapter: None`) \
+                     dispatched via Model.provider fallback — re-save this PK to remove the \
+                     legacy code path"
+                );
                 return hub.get_specialized(mp);
             }
         }
@@ -685,8 +698,16 @@ mod tests {
         /// two-tier path and miss authoritatively if nothing matches.
         /// A future PR that drops `Adapter::Openai` family must FAIL
         /// the test below, not get rescued by the compat shim.
+        ///
+        /// This test pins the regression vector exactly: PK has
+        /// `provider:"vendor-without-specialized"` + `adapter:Some(Openai)`,
+        /// hub has NO `Adapter::Openai` family registered. The
+        /// two-tier path returns None on both layers. The compat
+        /// shim must NOT rescue this because `provider` is non-empty.
+        /// If a future PR drops `Adapter::Openai` family registration
+        /// in `build_hub()`, this test fires.
         #[test]
-        fn compat_shim_does_not_fire_for_post_phase_a_pk() {
+        fn compat_shim_does_not_rescue_missing_family_for_post_phase_a_pk() {
             let hub = Hub::new();
             hub.register_specialized(
                 "openai",
@@ -694,11 +715,16 @@ mod tests {
                     name: "specialized-openai",
                 }),
             );
-            // Post-Phase-A PK: `provider:"xai"` + `adapter: None`
-            // (specialized miss; no Adapter::Openai family registered;
-            // compat shim must NOT fire because `provider` is non-empty).
-            let pk = pk_with_provider_and_adapter("xai", None);
-            assert!(resolve_bridge(&hub, &pk, Some("openai")).is_none());
+            // `vendor-without-specialized` is not registered as
+            // specialized; `Adapter::Openai` is not registered as
+            // family. Compat shim must not fire because `provider`
+            // is non-empty.
+            let pk = pk_with_provider_and_adapter("vendor-without-specialized", Some("openai"));
+            assert!(
+                resolve_bridge(&hub, &pk, Some("openai")).is_none(),
+                "compat shim MUST NOT rescue a missing Adapter::Openai family — \
+                 provider is non-empty, so post-Phase-A path is authoritative",
+            );
         }
     }
 }

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -19,7 +19,6 @@
 
 use std::sync::Arc;
 
-use aisix_core::models::Provider;
 use aisix_core::resource::ResourceEntry;
 use aisix_core::{AisixSnapshot, Model, ProviderKey};
 use aisix_gateway::{Bridge, Hub};
@@ -28,41 +27,19 @@ use crate::error::ProxyError;
 
 /// Resolve the Bridge to dispatch this request through.
 ///
-/// Tries the two-tier dispatch first (specialized vendor → adapter
-/// family), and falls back to the legacy `Provider`-keyed registry if
-/// neither tier matches. This is the Phase D cutover join point: new
-/// `ProviderKey` payloads carrying `adapter` and `provider` hit the
-/// two-tier path; pre-cutover payloads (`adapter: None`, empty
-/// `provider`) fall through to the legacy registry unchanged.
+/// Sole path is `Hub::dispatch_two_tier`: specialized vendor first,
+/// then adapter family. The legacy `Provider`-keyed registry is gone
+/// — vendor identity flows through `ProviderKey.provider` (open
+/// string) + `ProviderKey.adapter` (closed 5-value enum), so any
+/// catalog provider cp-api admits (xai, openrouter, future long-tail)
+/// resolves without DP knowing the vendor name at compile time.
 ///
-/// Returns `None` only when both layers miss — i.e. the operator has no
-/// bridge wired for this request at all.
-pub(crate) fn resolve_bridge(
-    hub: &Hub,
-    provider_key: &ProviderKey,
-    provider: Provider,
-) -> Option<Arc<dyn Bridge>> {
-    if let Some(bridge) = hub.dispatch_two_tier(provider_key) {
-        return Some(bridge);
-    }
-    // Legacy fallback. Emit a tracing::debug! when the PK carries the
-    // new-shape fields (`provider` or `adapter`) but the two-tier path
-    // still missed — post-cutover this is the early signal that a
-    // specialized Bridge name was misregistered (typo, runtime
-    // unregister) or that the adapter map missed an entry. Pre-cutover
-    // PKs (empty provider + adapter: None) take the silent path because
-    // they're the dominant case.
-    let pk_carries_new_fields = !provider_key.provider.is_empty() || provider_key.adapter.is_some();
-    if pk_carries_new_fields {
-        tracing::debug!(
-            target: "aisix_proxy::dispatch",
-            pk_provider = %provider_key.provider,
-            pk_adapter = ?provider_key.adapter,
-            legacy_provider = ?provider,
-            "two-tier dispatch missed for new-shape ProviderKey; falling back to legacy hub.get"
-        );
-    }
-    hub.get(provider)
+/// Returns `None` when the ProviderKey carries no `adapter` (a
+/// pre-Phase-A row that escaped the schema migration) AND no
+/// specialized bridge is registered for its vendor string. Caller
+/// surfaces this as 503 "no dispatch path".
+pub(crate) fn resolve_bridge(hub: &Hub, provider_key: &ProviderKey) -> Option<Arc<dyn Bridge>> {
+    hub.dispatch_two_tier(provider_key)
 }
 
 /// Look up the `ProviderKey` a given `Model` references. Returns a
@@ -87,9 +64,13 @@ pub(crate) fn resolve_provider_key(
     })
 }
 
-/// Required `provider` for a non-routing Model. 400 if absent.
-pub(crate) fn require_provider(model: &Model) -> Result<Provider, ProxyError> {
-    model.provider.ok_or_else(|| {
+/// Required `provider` (vendor id, free-form string) for a non-routing
+/// Model. 400 if absent. Dispatch routing reads
+/// `ProviderKey.adapter` + `ProviderKey.provider` — this helper just
+/// confirms the Model has a non-routing shape and returns the vendor
+/// id for telemetry / logs.
+pub(crate) fn require_provider(model: &Model) -> Result<&str, ProxyError> {
+    model.provider.as_deref().ok_or_else(|| {
         ProxyError::InvalidRequest(format!(
             "model {:?} has no provider (routing models can't be dispatched directly)",
             model.display_name
@@ -159,10 +140,15 @@ fn strip_endpoint_suffix(base: &str) -> &str {
 /// pasting the full upstream URL into `api_base` by stripping any
 /// trailing endpoint suffix — see [`API_BASE_ENDPOINT_SUFFIXES`] for
 /// the full list and [`build_v1_url`] for the matching `/v1` synthesis.
-pub(crate) fn resolve_base_url(provider: Provider, provider_key: &ProviderKey) -> String {
+pub(crate) fn resolve_base_url(provider_key: &ProviderKey) -> Result<String, ProxyError> {
     match provider_key.api_base.as_deref() {
-        Some(b) if !b.trim().is_empty() => strip_endpoint_suffix(b.trim()).to_string(),
-        _ => provider.default_base_url().to_string(),
+        Some(b) if !b.trim().is_empty() => Ok(strip_endpoint_suffix(b.trim()).to_string()),
+        _ => Err(ProxyError::InvalidRequest(format!(
+            "provider_key {:?} has no api_base — cp-api must populate api_base \
+             for every catalog vendor (the DP does not enumerate per-vendor \
+             default URLs)",
+            provider_key.display_name
+        ))),
     }
 }
 
@@ -229,7 +215,7 @@ mod tests {
     fn snapshot_with(provider_key_id: &str) -> AisixSnapshot {
         let snap = AisixSnapshot::new();
         let pk: ProviderKey = serde_json::from_str(
-            r#"{"display_name":"openai-prod","secret":"sk-x","api_base":"https://proxy.example.com/v1"}"#,
+            r#"{"display_name":"openai-prod","secret":"sk-x","api_base":"https://proxy.example.com/v1","provider":"openai","adapter":"openai"}"#,
         )
         .unwrap();
         snap.provider_keys
@@ -295,7 +281,7 @@ mod tests {
     #[test]
     fn require_provider_returns_provider_for_direct_model() {
         let m = direct_model("pk-1");
-        assert_eq!(require_provider(&m).unwrap(), Provider::Openai);
+        assert_eq!(require_provider(&m).unwrap(), "openai");
     }
 
     #[test]
@@ -309,15 +295,28 @@ mod tests {
         let snap = snapshot_with("pk-1");
         let m = direct_model("pk-1");
         let pk_entry = resolve_provider_key(&snap, &m).unwrap();
-        let base = resolve_base_url(Provider::Openai, &pk_entry.value);
+        let base = resolve_base_url(&pk_entry.value).unwrap();
         assert_eq!(base, "https://proxy.example.com/v1");
     }
 
+    /// Empty `api_base` on the PK is now an error — the DP no longer
+    /// fabricates per-vendor defaults. cp-api populates api_base for
+    /// every catalog vendor (handlers.go createProviderKey gate +
+    /// featured `default_base_url`); refusing here turns any cp-api
+    /// admission gap into a loud 400 instead of a silent mis-route.
     #[test]
-    fn resolve_base_url_falls_back_to_provider_default_when_override_blank() {
+    fn resolve_base_url_errors_when_api_base_missing() {
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
-        let base = resolve_base_url(Provider::Anthropic, &pk);
-        assert_eq!(base, Provider::Anthropic.default_base_url());
+        let err = resolve_base_url(&pk).unwrap_err();
+        match err {
+            ProxyError::InvalidRequest(msg) => {
+                assert!(
+                    msg.contains("api_base"),
+                    "error must mention api_base; got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidRequest, got {other:?}"),
+        }
     }
 
     fn pk_with_base(api_base: &str) -> ProviderKey {
@@ -363,7 +362,7 @@ mod tests {
         ];
         for (paste, endpoint) in cases {
             let pk = pk_with_base(paste);
-            let base = resolve_base_url(Provider::Openai, &pk);
+            let base = resolve_base_url(&pk).unwrap();
             let url = build_v1_url(&base, endpoint);
             let expected = format!("https://api.openai.com/v1{endpoint}");
             assert_eq!(
@@ -384,7 +383,7 @@ mod tests {
             "https://api.deepseek.com/embeddings",
         ] {
             let pk = pk_with_base(paste);
-            let base = resolve_base_url(Provider::Deepseek, &pk);
+            let base = resolve_base_url(&pk).unwrap();
             let url = build_v1_url(&base, "/chat/completions");
             assert_eq!(
                 url, "https://api.deepseek.com/v1/chat/completions",
@@ -406,7 +405,7 @@ mod tests {
             "https://api.anthropic.com/v1/messages/",
         ] {
             let pk = pk_with_base(paste);
-            let base = resolve_base_url(Provider::Anthropic, &pk);
+            let base = resolve_base_url(&pk).unwrap();
             assert_eq!(
                 build_v1_url(&base, "/messages"),
                 "https://api.anthropic.com/v1/messages",
@@ -422,14 +421,14 @@ mod tests {
     fn resolve_base_url_passes_non_canonical_hosts_through() {
         let pk = pk_with_base("https://proxy.example.com/openai-shim");
         assert_eq!(
-            resolve_base_url(Provider::Openai, &pk),
+            resolve_base_url(&pk).unwrap(),
             "https://proxy.example.com/openai-shim",
         );
 
         // Suffix stripping still applies on non-canonical hosts —
         // operator pasting the full upstream URL is still recovered.
         let pk = pk_with_base("https://proxy.example.com/openai-shim/v1/responses");
-        let base = resolve_base_url(Provider::Openai, &pk);
+        let base = resolve_base_url(&pk).unwrap();
         assert_eq!(
             build_v1_url(&base, "/responses"),
             "https://proxy.example.com/openai-shim/v1/responses",
@@ -440,7 +439,7 @@ mod tests {
     #[test]
     fn resolve_base_url_trims_whitespace_and_endpoint_suffix() {
         let pk = pk_with_base("  https://api.openai.com/v1/chat/completions/  ");
-        let base = resolve_base_url(Provider::Openai, &pk);
+        let base = resolve_base_url(&pk).unwrap();
         assert_eq!(
             build_v1_url(&base, "/chat/completions"),
             "https://api.openai.com/v1/chat/completions",
@@ -599,10 +598,10 @@ mod tests {
                 }),
             );
             hub.register_family(Adapter::Openai, Arc::new(StubBridge { name: "family" }));
-            hub.register(Provider::Openai, Arc::new(StubBridge { name: "legacy" }));
+            hub.register_specialized("openai", Arc::new(StubBridge { name: "legacy" }));
 
             let pk = pk_with_provider_and_adapter("deepseek", Some("openai"));
-            let bridge = resolve_bridge(&hub, &pk, Provider::Openai).unwrap();
+            let bridge = resolve_bridge(&hub, &pk).unwrap();
             assert_eq!(bridge.name(), "specialized");
         }
 
@@ -610,33 +609,33 @@ mod tests {
         fn family_hit_when_specialized_misses() {
             let hub = Hub::new();
             hub.register_family(Adapter::Openai, Arc::new(StubBridge { name: "family" }));
-            hub.register(Provider::Openai, Arc::new(StubBridge { name: "legacy" }));
+            hub.register_specialized("openai", Arc::new(StubBridge { name: "legacy" }));
 
             // pk.provider = "unknown-vendor" → no specialized; pk.adapter
             // = Openai → family hit.
             let pk = pk_with_provider_and_adapter("unknown-vendor", Some("openai"));
-            let bridge = resolve_bridge(&hub, &pk, Provider::Openai).unwrap();
+            let bridge = resolve_bridge(&hub, &pk).unwrap();
             assert_eq!(bridge.name(), "family");
         }
 
+        /// Phase A drops the legacy `Provider`-keyed registry. A PK
+        /// with empty `provider` AND `adapter: None` has nothing to
+        /// dispatch on — caller surfaces 503. The old legacy fallback
+        /// test (`legacy_fallback_when_both_new_tiers_miss`) is gone
+        /// because there's no legacy tier left.
         #[test]
-        fn legacy_fallback_when_both_new_tiers_miss() {
+        fn none_when_neither_tier_matches() {
             let hub = Hub::new();
-            // No family / specialized registered — only legacy.
-            hub.register(Provider::Openai, Arc::new(StubBridge { name: "legacy" }));
-
-            // Today's on-disk PK shape: empty provider + adapter: None.
-            // The two-tier path returns None on both layers; legacy serves.
+            hub.register_specialized("openai", Arc::new(StubBridge { name: "vendor" }));
             let pk = pk_with_provider_and_adapter("", None);
-            let bridge = resolve_bridge(&hub, &pk, Provider::Openai).unwrap();
-            assert_eq!(bridge.name(), "legacy");
+            assert!(resolve_bridge(&hub, &pk).is_none());
         }
 
         #[test]
         fn none_when_nothing_registered() {
             let hub = Hub::new();
             let pk = pk_with_provider_and_adapter("", None);
-            assert!(resolve_bridge(&hub, &pk, Provider::Openai).is_none());
+            assert!(resolve_bridge(&hub, &pk).is_none());
         }
     }
 }

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -136,8 +136,9 @@ async fn dispatch(
     let provider = crate::dispatch::require_provider(model)?;
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
-    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
-        .ok_or(ProxyError::ProviderUnavailable)?;
+    let bridge =
+        crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, model.provider.as_deref())
+            .ok_or(ProxyError::ProviderUnavailable)?;
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&body.model, &model_entry.id, &model_entry.value);
@@ -172,7 +173,7 @@ async fn dispatch(
             // EmbeddingResponse.usage; thread it through so TPM works
             // here even though other handlers commit 0.
             reservation.commit_tokens(embed_resp.usage.total_tokens as u64);
-            let provider_label = format!("{provider:?}").to_lowercase();
+            let provider_label = provider.to_ascii_lowercase();
             Ok((Json(embed_resp).into_response(), provider_label))
         }
         Err(BridgeError::Config(msg)) if msg.contains("does not support embeddings") => {
@@ -183,7 +184,7 @@ async fn dispatch(
             let env = ErrorEnvelope::new(msg, "not_implemented");
             Ok((
                 (StatusCode::NOT_IMPLEMENTED, Json(env)).into_response(),
-                format!("{provider:?}").to_lowercase(),
+                provider.to_ascii_lowercase(),
             ))
         }
         Err(e) => {

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -136,7 +136,7 @@ async fn dispatch(
     let provider = crate::dispatch::require_provider(model)?;
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
-    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, provider)
+    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
     let model_rl =
@@ -224,7 +224,7 @@ fn emit_access_log(
 
 #[cfg(test)]
 mod tests {
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -260,8 +260,9 @@ mod tests {
     }
 
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        let json =
-            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
     }
@@ -283,7 +284,7 @@ mod tests {
 
     fn build_app(snap: AisixSnapshot) -> axum::Router {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
     }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -131,8 +131,9 @@ async fn dispatch(
     let provider = crate::dispatch::require_provider(model)?.to_string();
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
-    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
-        .ok_or(ProxyError::ProviderUnavailable)?;
+    let bridge =
+        crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, model.provider.as_deref())
+            .ok_or(ProxyError::ProviderUnavailable)?;
 
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -121,24 +121,24 @@ async fn dispatch(
     // verbatim. Reject explicitly with 400 (parallel to
     // /v1/responses §4.6) so the configuration error is visible
     // at the gateway boundary.
-    if model.provider != Some(aisix_core::models::Provider::Openai) {
+    if model.provider.as_deref() != Some("openai") {
         return Err(ProxyError::InvalidRequest(format!(
             "model `{model_name}` is not an OpenAI provider; \
              /v1/images/generations requires OpenAI"
         )));
     }
 
-    let provider = crate::dispatch::require_provider(model)?;
+    let provider = crate::dispatch::require_provider(model)?.to_string();
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
 
-    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value, provider)
+    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
     let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
 
-    let provider_label = format!("{provider:?}").to_lowercase();
+    let provider_label = provider.to_ascii_lowercase();
 
     match bridge.generate_image(&body, &ctx).await {
         Ok(resp_json) => Ok((Json(resp_json).into_response(), provider_label)),
@@ -179,7 +179,7 @@ fn emit_access_log(
 
 #[cfg(test)]
 mod tests {
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -228,8 +228,9 @@ mod tests {
     }
 
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        let json =
-            format!(r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}"}}"#);
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-up","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
     }
@@ -251,7 +252,7 @@ mod tests {
 
     fn build_app(snap: AisixSnapshot) -> axum::Router {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
     }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -264,7 +264,7 @@ async fn livez(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -327,7 +327,7 @@ mod tests {
 
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let cfg = format!(
-            r#"{{"display_name":"openai-up","secret":"sk-upstream","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"openai-up","secret":"sk-upstream","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&cfg).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
@@ -444,7 +444,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -579,7 +579,7 @@ mod tests {
     #[tokio::test]
     async fn model_not_in_allowed_list_returns_403() {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         // ApiKey allows only "other-model", the caller asks for "my-gpt4".
         let snap = seed_snapshot("my-gpt4", &["other-model"], "http://unused");
         let app = build_router(build_state(snap, hub));
@@ -912,7 +912,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -939,7 +939,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -982,7 +982,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -1028,7 +1028,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -1070,7 +1070,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -1126,7 +1126,7 @@ mod tests {
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-claude"]));
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
         let app = build_router(build_state(snap, hub));
 
         let body = serde_json::json!({
@@ -1175,7 +1175,7 @@ mod tests {
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-claude"]));
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
         let app = build_router(build_state(snap, hub));
 
         let body = serde_json::json!({
@@ -1228,7 +1228,7 @@ mod tests {
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-claude"]));
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
         let app = build_router(build_state(snap, hub));
 
         let body = serde_json::json!({
@@ -1268,7 +1268,7 @@ mod tests {
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -1327,7 +1327,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -1403,7 +1403,7 @@ data: <not valid json>\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let app = build_router(build_state(snap, hub));
 
@@ -1514,7 +1514,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(
             KeywordBlocklist::output_only(vec![KeywordRule::literal("secret-string")]),
@@ -1615,7 +1615,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1692,7 +1692,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1757,7 +1757,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1819,7 +1819,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1873,7 +1873,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
 
         let state = build_state(snap, hub);
@@ -1928,7 +1928,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -1982,7 +1982,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         // Cache gate opens only when an enabled policy exists in
         // snapshot. Without this seed step the test would 200 but
@@ -2057,7 +2057,7 @@ data: [DONE]\n\n";
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         seed_cache_policy(&snap, "test-cache");
         let state = build_state_with_cache(snap, hub).with_usage_sink(UsageSink::new(tx));
@@ -2123,7 +2123,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         seed_cache_policy(&snap, "test-cache");
         let state = build_state_with_cache(snap, hub);
@@ -2184,7 +2184,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         // The api key + model are named "my-gpt4"; the policy below
         // pins applies_to to a different model name so no request in
         // this test matches.
@@ -2247,7 +2247,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         // The disabled policy applies_to="all" (would match every
         // request), but `enabled: false` MUST cause the find-first-
@@ -2306,7 +2306,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         seed_cache_policy_with_applies_to(&snap, "scoped", "model:my-gpt4");
         let state = build_state_with_cache(snap, hub);
@@ -2362,7 +2362,7 @@ data: [DONE]\n\n";
 
     fn pk_entry_with_id(pk_id: &str, api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let cfg = format!(
-            r#"{{"display_name":"openai-{pk_id}","secret":"sk-upstream","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"openai-{pk_id}","secret":"sk-upstream","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&cfg).unwrap();
         ResourceEntry::new(pk_id, pk, 1)
@@ -2422,7 +2422,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -2492,7 +2492,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -2565,7 +2565,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -2640,7 +2640,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -2724,7 +2724,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -2797,7 +2797,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -2874,7 +2874,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.provider_keys
@@ -2947,7 +2947,7 @@ data: [DONE]\n\n";
         // Routing references a Model that isn't in the snapshot — this
         // is a misconfiguration and should surface as a clean 400.
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = AisixSnapshot::new();
         snap.models.insert(routing_entry(
@@ -2998,7 +2998,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot_with_limits(
             "my-gpt4",
             &["my-gpt4"],
@@ -3066,7 +3066,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
 
         let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(KeywordBlocklist::new(
@@ -3128,7 +3128,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(KeywordBlocklist::new(
             vec![KeywordRule::literal("forbidden-token")],
@@ -3187,7 +3187,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
 
         let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(
@@ -3269,7 +3269,7 @@ data: [DONE]\n\n";
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let guardrails = Arc::new(GuardrailChain::new(vec![Arc::new(
             KeywordBlocklist::output_only(vec![KeywordRule::literal("secret-string")]),
@@ -3353,7 +3353,7 @@ data: [DONE]\n\n";
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
         let app = build_router(state);
@@ -3426,7 +3426,7 @@ data: [DONE]\n\n";
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
         let app = build_router(state);
@@ -3514,7 +3514,7 @@ data: [DONE]\n\n";
             .await;
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(openai_test_bridge()));
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
         let state = build_state(snap, hub).with_budget_client(Arc::new(BudgetClient::new(
@@ -3598,24 +3598,44 @@ data: [DONE]\n\n";
         id: &'static str,
         secret: &str,
         api_base: &str,
+        provider: &str,
+        adapter: &str,
     ) -> ResourceEntry<aisix_core::ProviderKey> {
         let cfg = format!(
-            r#"{{"display_name":"matrix-up","secret":"{secret}","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"matrix-up","secret":"{secret}","api_base":"{api_base}","provider":"{provider}","adapter":"{adapter}"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&cfg).unwrap();
         ResourceEntry::new(id, pk, 1)
     }
 
     fn matrix_anthropic_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        matrix_pk_entry(MATRIX_ANTHROPIC_PK_ID, "sk-ant-test", api_base)
+        matrix_pk_entry(
+            MATRIX_ANTHROPIC_PK_ID,
+            "sk-ant-test",
+            api_base,
+            "anthropic",
+            "anthropic",
+        )
     }
 
     fn matrix_gemini_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        matrix_pk_entry(MATRIX_GOOGLE_PK_ID, "ya29-test", api_base)
+        matrix_pk_entry(
+            MATRIX_GOOGLE_PK_ID,
+            "ya29-test",
+            api_base,
+            "google",
+            "openai",
+        )
     }
 
     fn matrix_deepseek_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        matrix_pk_entry(MATRIX_DEEPSEEK_PK_ID, "sk-deepseek", api_base)
+        matrix_pk_entry(
+            MATRIX_DEEPSEEK_PK_ID,
+            "sk-deepseek",
+            api_base,
+            "deepseek",
+            "openai",
+        )
     }
 
     /// (OpenAI inbound) × (Anthropic upstream) × (non-streaming).
@@ -3648,7 +3668,7 @@ data: [DONE]\n\n";
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-claude"]));
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
         let app = build_router(build_state(snap, hub));
 
         let body = serde_json::json!({
@@ -3709,7 +3729,7 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-claude"]));
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
         let app = build_router(build_state(snap, hub));
 
         let body = serde_json::json!({
@@ -3777,10 +3797,7 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-gemini"]));
         let hub = Arc::new(Hub::new());
-        hub.register(
-            Provider::Google,
-            Arc::new(OpenAiBridge::new().with_name("google")),
-        );
+        hub.register_specialized("google", Arc::new(OpenAiBridge::new().with_name("google")));
         let app = build_router(build_state(snap, hub));
 
         let body = serde_json::json!({
@@ -3834,8 +3851,8 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-deepseek"]));
         let hub = Arc::new(Hub::new());
-        hub.register(
-            Provider::Deepseek,
+        hub.register_specialized(
+            "deepseek",
             Arc::new(OpenAiBridge::new().with_name("deepseek")),
         );
         let app = build_router(build_state(snap, hub));

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -602,8 +602,9 @@ async fn cross_provider_dispatch(
             ProxyError::InvalidRequest(format!("model `{model_name}` has no provider prefix"))
         })?
         .to_string();
-    let bridge: Arc<dyn Bridge> = crate::dispatch::resolve_bridge(&state.hub, provider_key)
-        .ok_or(ProxyError::ProviderUnavailable)?;
+    let bridge: Arc<dyn Bridge> =
+        crate::dispatch::resolve_bridge(&state.hub, provider_key, model.provider.as_deref())
+            .ok_or(ProxyError::ProviderUnavailable)?;
 
     // Parse the Anthropic-shape body into the gateway's normalised
     // ChatFormat. Errors here are 400 — the request is malformed

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -33,7 +33,6 @@
 //! status-to-type mapping. (`/v1/chat/completions` continues to emit
 //! the OpenAI-shape envelope with its DP-stable taxonomy.)
 
-use aisix_core::models::Provider;
 use aisix_obs::{AccessLog, LlmUsage, RequestLabels, RequestOutcome, UsageEvent, UsageLabels};
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
@@ -288,7 +287,7 @@ async fn dispatch(
     // The Anthropic-upstream branch below stays as a byte-for-byte
     // passthrough to preserve features (cache_control, thinking
     // blocks, …) the cross-provider path can't lossily round-trip.
-    if model.provider != Some(Provider::Anthropic) {
+    if model.provider.as_deref() != Some("anthropic") {
         return cross_provider_dispatch(
             state,
             body,
@@ -337,7 +336,7 @@ async fn dispatch(
     // where the customer mistakenly puts `/v1` in the Anthropic
     // api_base (the dashboard placeholder uses the OpenAI form, so
     // this is a copy-paste hazard).
-    let base = crate::dispatch::resolve_base_url(Provider::Anthropic, &pk_entry.value);
+    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
     let url = crate::dispatch::build_v1_url(&base, "/messages");
 
     // Check if the request wants streaming.
@@ -574,6 +573,7 @@ fn anthropic_metrics_from_response_json(body: &Value) -> AnthropicUsageMetrics {
 /// 4. For streaming: bridge.chat_stream → AnthropicSseEncoder pumps
 ///    each ChatChunk through the message_start / content_block_* /
 ///    message_* state machine and writes SSE bytes
+#[allow(clippy::too_many_arguments)]
 async fn cross_provider_dispatch(
     state: &ProxyState,
     body: &Value,
@@ -595,12 +595,15 @@ async fn cross_provider_dispatch(
     };
     use std::sync::Arc;
 
-    let provider = model.provider.ok_or_else(|| {
-        ProxyError::InvalidRequest(format!("model `{model_name}` has no provider prefix"))
-    })?;
-    let bridge: Arc<dyn Bridge> =
-        crate::dispatch::resolve_bridge(&state.hub, provider_key, provider)
-            .ok_or(ProxyError::ProviderUnavailable)?;
+    let provider = model
+        .provider
+        .as_deref()
+        .ok_or_else(|| {
+            ProxyError::InvalidRequest(format!("model `{model_name}` has no provider prefix"))
+        })?
+        .to_string();
+    let bridge: Arc<dyn Bridge> = crate::dispatch::resolve_bridge(&state.hub, provider_key)
+        .ok_or(ProxyError::ProviderUnavailable)?;
 
     // Parse the Anthropic-shape body into the gateway's normalised
     // ChatFormat. Errors here are 400 — the request is malformed
@@ -630,7 +633,7 @@ async fn cross_provider_dispatch(
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(provider_key.clone());
     let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
-    let provider_label = format!("{provider:?}").to_lowercase();
+    let provider_label = provider.to_ascii_lowercase();
     let provider_key_id = model.provider_key_id.as_deref().unwrap_or("unknown");
     let upstream_model = model.upstream_model().unwrap_or("unknown").to_string();
 
@@ -1007,7 +1010,7 @@ fn emit_access_log(
 
 #[cfg(test)]
 mod tests {
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -1082,7 +1085,7 @@ mod tests {
 
     fn anthropic_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let json = format!(
-            r#"{{"display_name":"anthropic-up","secret":"sk-ant-test","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"anthropic-up","secret":"sk-ant-test","api_base":"{api_base}","provider":"anthropic","adapter":"anthropic"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(ANTHROPIC_PK_ID, pk, 1)
@@ -1090,7 +1093,7 @@ mod tests {
 
     fn openai_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let json = format!(
-            r#"{{"display_name":"openai-up","secret":"sk-openai-test","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"openai-up","secret":"sk-openai-test","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(OPENAI_PK_ID, pk, 1)
@@ -1119,7 +1122,7 @@ mod tests {
 
     fn build_app(snap: AisixSnapshot) -> axum::Router {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
         let handle = SnapshotHandle::new(snap);
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
     }
@@ -1531,8 +1534,8 @@ mod tests {
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
 
@@ -1593,8 +1596,8 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
 
@@ -1657,8 +1660,8 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         let state = crate::ProxyState::new(handle, hub, &cfg())
             .without_cache()
@@ -1859,7 +1862,7 @@ data: [DONE]\n\n";
 
     fn gemini_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let json = format!(
-            r#"{{"display_name":"gemini-up","secret":"ya29-test","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"gemini-up","secret":"ya29-test","api_base":"{api_base}","provider":"google","adapter":"openai"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(GOOGLE_PK_ID, pk, 1)
@@ -1867,7 +1870,7 @@ data: [DONE]\n\n";
 
     fn deepseek_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let json = format!(
-            r#"{{"display_name":"deepseek-up","secret":"sk-deepseek","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"deepseek-up","secret":"sk-deepseek","api_base":"{api_base}","provider":"deepseek","adapter":"openai"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(DEEPSEEK_PK_ID, pk, 1)
@@ -1918,11 +1921,8 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
-        hub.register(
-            Provider::Google,
-            Arc::new(OpenAiBridge::new().with_name("google")),
-        );
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("google", Arc::new(OpenAiBridge::new().with_name("google")));
         let handle = SnapshotHandle::new(snap);
         let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
 
@@ -1969,9 +1969,9 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
-        hub.register(
-            Provider::Deepseek,
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        hub.register_specialized(
+            "deepseek",
             Arc::new(OpenAiBridge::new().with_name("deepseek")),
         );
         let handle = SnapshotHandle::new(snap);
@@ -2040,7 +2040,7 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
     /// OpenAi-compat `/chat/completions` endpoint with OpenAi-shape
     /// SSE deltas, so the assertion shape is identical.
     async fn assert_anthropic_streams_through_openai_compat_upstream(
-        bridge_provider: Provider,
+        bridge_provider: &str,
         bridge: Arc<dyn aisix_gateway::Bridge>,
         model_entry: ResourceEntry<Model>,
         model_name: &str,
@@ -2068,8 +2068,12 @@ data: [DONE]\n\n";
             .provider_key_id
             .clone()
             .expect("matrix fixtures must reference a provider_key_id");
+        // The PK's vendor identity must match `bridge_provider` so
+        // `dispatch_two_tier` hits the specialized bridge this test
+        // registered. `adapter: "openai"` is right for both gemini
+        // and deepseek (OpenAI-compat wire shapes).
         let pk_json = format!(
-            r#"{{"display_name":"matrix-up","secret":"k","api_base":"{}"}}"#,
+            r#"{{"display_name":"matrix-up","secret":"k","api_base":"{}","provider":"{bridge_provider}","adapter":"openai"}}"#,
             upstream.uri()
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();
@@ -2080,8 +2084,8 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
-        hub.register(bridge_provider, bridge);
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        hub.register_specialized(bridge_provider, bridge);
         let handle = SnapshotHandle::new(snap);
         let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
 
@@ -2116,7 +2120,7 @@ data: [DONE]\n\n";
     async fn matrix_anthropic_in_gemini_upstream_streaming() {
         use aisix_provider_openai::OpenAiBridge;
         assert_anthropic_streams_through_openai_compat_upstream(
-            Provider::Google,
+            "google",
             Arc::new(OpenAiBridge::new().with_name("google")),
             // Placeholder; helper rebuilds with the wiremock uri.
             gemini_model("my-claude-via-gemini"),
@@ -2129,7 +2133,7 @@ data: [DONE]\n\n";
     async fn matrix_anthropic_in_deepseek_upstream_streaming() {
         use aisix_provider_openai::OpenAiBridge;
         assert_anthropic_streams_through_openai_compat_upstream(
-            Provider::Deepseek,
+            "deepseek",
             Arc::new(OpenAiBridge::new().with_name("deepseek")),
             deepseek_model("my-claude-via-ds"),
             "my-claude-via-ds",

--- a/crates/aisix-proxy/src/models.rs
+++ b/crates/aisix-proxy/src/models.rs
@@ -78,8 +78,7 @@ pub async fn list_models(
             let owned_by = snapshot
                 .models
                 .get_by_name(name)
-                .and_then(|e| e.value.provider)
-                .map(|p| p.as_str().to_string())
+                .and_then(|e| e.value.provider.as_ref().cloned())
                 .unwrap_or_else(|| "aisix".to_string());
 
             ModelObject {
@@ -102,7 +101,7 @@ pub async fn list_models(
 
 #[cfg(test)]
 mod tests {
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -123,7 +122,7 @@ mod tests {
 
     fn build_app(snapshot: AisixSnapshot) -> Router {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snapshot);
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
     }
@@ -145,7 +144,7 @@ mod tests {
 
     fn provider_key_entry() -> ResourceEntry<aisix_core::ProviderKey> {
         let pk: aisix_core::ProviderKey =
-            serde_json::from_str(r#"{"display_name":"openai-up","secret":"sk-up"}"#).unwrap();
+            serde_json::from_str(r#"{"display_name":"openai-up","secret":"sk-up","provider":"openai","adapter":"openai"}"#).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
     }
 

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -173,7 +173,8 @@ async fn dispatch(
         .find(|e| {
             e.value
                 .provider
-                .map(|p| p.as_str().eq_ignore_ascii_case(&provider_lower))
+                .as_deref()
+                .map(|p| p.eq_ignore_ascii_case(&provider_lower))
                 .unwrap_or(false)
         })
         .ok_or_else(|| {
@@ -497,15 +498,16 @@ mod tests {
     }
 
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        let json =
-            format!(r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}"}}"#);
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
     }
 
     fn anthropic_provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
         let json = format!(
-            r#"{{"display_name":"anthropic-up","secret":"sk-ant-test","api_base":"{api_base}"}}"#
+            r#"{{"display_name":"anthropic-up","secret":"sk-ant-test","api_base":"{api_base}","provider":"anthropic","adapter":"anthropic"}}"#
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -122,7 +122,7 @@ async fn dispatch(
     // unchanged.
     let provider_label = model
         .provider
-        .map(|p| p.as_str().to_string())
+        .clone()
         .unwrap_or_else(|| "unknown".to_string());
 
     // Per #168 + #213 Phases 1–2: `/v1/rerank` accepts OpenAI-,
@@ -354,8 +354,9 @@ mod tests {
     }
 
     fn provider_key_entry(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        let json =
-            format!(r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}"}}"#);
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(PK_ID, pk, 1)
     }
@@ -516,7 +517,7 @@ mod tests {
         // The gateway's `build_v1_url` produces `/v1/rerank` correctly
         // for both `https://api.jina.ai` and `https://api.jina.ai/v1`.
         let pk_json = format!(
-            r#"{{"display_name":"jina-up","secret":"jina_mock_secret","api_base":"{}"}}"#,
+            r#"{{"display_name":"jina-up","secret":"jina_mock_secret","api_base":"{}","provider":"jina"}}"#,
             upstream.uri()
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();
@@ -592,7 +593,7 @@ mod tests {
         // gateway's `build_v1_url` appends /v1/rerank correctly for
         // both `https://api.cohere.com` and `https://api.cohere.com/v1`.
         let pk_json = format!(
-            r#"{{"display_name":"cohere-up","secret":"sk-cohere-mock","api_base":"{}"}}"#,
+            r#"{{"display_name":"cohere-up","secret":"sk-cohere-mock","api_base":"{}","provider":"cohere","adapter":"openai"}}"#,
             upstream.uri()
         );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -12,7 +12,6 @@
 //! Only OpenAI models support this endpoint. Non-OpenAI models receive a
 //! 400 with an explanatory message.
 
-use aisix_core::models::Provider;
 use aisix_obs::{AccessLog, RequestOutcome};
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
@@ -115,7 +114,7 @@ async fn dispatch(
     let model = &model_entry.value;
 
     // Responses API is only available for OpenAI.
-    if model.provider != Some(Provider::Openai) {
+    if model.provider.as_deref() != Some("openai") {
         return Err(ProxyError::InvalidRequest(format!(
             "model `{model_name}` is not an OpenAI provider; /v1/responses requires OpenAI"
         )));
@@ -130,7 +129,7 @@ async fn dispatch(
         *m = Value::String(upstream_model.clone());
     }
 
-    let base = crate::dispatch::resolve_base_url(Provider::Openai, &pk_entry.value);
+    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
     // build_v1_url tolerates both `https://api.openai.com` (provider
     // default) and `https://api.openai.com/v1` (the OpenAI-SDK form
     // the dashboard's provider-keys placeholder pre-fills). Without
@@ -253,7 +252,7 @@ fn emit_access_log(
 
 #[cfg(test)]
 mod tests {
-    use aisix_core::models::Provider;
+
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
@@ -294,15 +293,16 @@ mod tests {
     }
 
     fn openai_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
-        let json =
-            format!(r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}"}}"#);
+        let json = format!(
+            r#"{{"display_name":"openai-up","secret":"sk-test","api_base":"{api_base}","provider":"openai","adapter":"openai"}}"#
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
         ResourceEntry::new(OPENAI_PK_ID, pk, 1)
     }
 
     fn anthropic_pk() -> ResourceEntry<aisix_core::ProviderKey> {
         let pk: aisix_core::ProviderKey =
-            serde_json::from_str(r#"{"display_name":"anthropic-up","secret":"sk-ant-test"}"#)
+            serde_json::from_str(r#"{"display_name":"anthropic-up","secret":"sk-ant-test","provider":"anthropic","adapter":"anthropic"}"#)
                 .unwrap();
         ResourceEntry::new(ANTHROPIC_PK_ID, pk, 1)
     }
@@ -330,7 +330,7 @@ mod tests {
 
     fn build_app(snap: AisixSnapshot) -> axum::Router {
         let hub = Arc::new(Hub::new());
-        hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
     }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -23,7 +23,7 @@ mod telemetry;
 
 use aisix_admin::{AdminState, ConfigStore, EtcdConfigStore};
 use aisix_cache::{Cache, MemoryCache, RedisCache};
-use aisix_core::models::{Adapter, Provider};
+use aisix_core::models::Adapter;
 use aisix_core::{CacheBackend, Config, EtcdConfig, EtcdTlsConfig};
 use aisix_etcd::{EtcdConfigProvider, SnapshotCache, Supervisor};
 use aisix_gateway::Hub;
@@ -782,103 +782,62 @@ fn load_heartbeat_config_from_disk(
 /// (closes #332).
 fn build_hub() -> Hub {
     let hub = Hub::new();
-    hub.register(Provider::Openai, Arc::new(OpenAiBridge::new()));
-    hub.register(Provider::Anthropic, Arc::new(AnthropicBridge::new()));
-    hub.register(
-        Provider::Google,
-        Arc::new(OpenAiBridge::new().with_name("google")),
-    );
-    hub.register(
-        Provider::Deepseek,
-        Arc::new(OpenAiBridge::new().with_name("deepseek")),
-    );
-    hub.register(
-        Provider::Cohere,
-        Arc::new(OpenAiBridge::new().with_name("cohere")),
-    );
 
-    // Long-tail OpenAI-adapter providers (#60 P2-A). All 11 expose an
-    // OpenAI-compatible chat completions surface and route through
-    // `OpenAiBridge::with_name`. Default base URLs sourced from each
-    // vendor's official OpenAI-compat docs (see
-    // `crates/aisix-provider-openai/src/bridge.rs` constants for
-    // citations). Operators can override per-PK via `api_base`; the
-    // `with_name` here drives both the metric label and the
-    // `default_base()` fallback when api_base is unset.
-    hub.register(
-        Provider::Groq,
-        Arc::new(OpenAiBridge::new().with_name("groq")),
-    );
-    hub.register(
-        Provider::Mistral,
-        Arc::new(OpenAiBridge::new().with_name("mistral")),
-    );
-    hub.register(
-        Provider::Togetherai,
-        Arc::new(OpenAiBridge::new().with_name("togetherai")),
-    );
-    hub.register(
-        Provider::FireworksAi,
-        Arc::new(OpenAiBridge::new().with_name("fireworks-ai")),
-    );
-    hub.register(
-        Provider::Perplexity,
-        Arc::new(OpenAiBridge::new().with_name("perplexity")),
-    );
-    // Provider::Xai scoped out — see model.rs comment on the Xai
-    // variant (deferred until cp-api adapter_map adds the entry).
-    hub.register(
-        Provider::Moonshotai,
-        Arc::new(OpenAiBridge::new().with_name("moonshotai")),
-    );
-    hub.register(
-        Provider::Alibaba,
-        Arc::new(OpenAiBridge::new().with_name("alibaba")),
-    );
-    hub.register(
-        Provider::Zhipuai,
-        Arc::new(OpenAiBridge::new().with_name("zhipuai")),
-    );
-    hub.register(
-        Provider::Baseten,
-        Arc::new(OpenAiBridge::new().with_name("baseten")),
-    );
-    hub.register(
-        Provider::Huggingface,
-        Arc::new(OpenAiBridge::new().with_name("huggingface")),
-    );
-    hub.register(
-        Provider::Cerebras,
-        Arc::new(OpenAiBridge::new().with_name("cerebras")),
-    );
-
-    // Family bridges (issue #302 Phase A/D two-tier dispatch). The
-    // legacy `Provider`-keyed register() above stays the live
-    // dispatch path until cp-api stops emitting the legacy enum
-    // field; this only adds the new-schema-keyed lookup so a
-    // catalog row with `adapter: "<wire>"` can resolve to a real
-    // bridge instead of falling through to the legacy fallback.
+    // ─── Family bridges (closed 5-value Adapter enum) ────────────────
     //
-    // All non-OpenAI-compat adapters are SKELETON bridges today —
-    // they return a clear `BridgeError::Config` referencing
-    // api7/AISIX-Cloud#302 Phases E/F/G. Registering them now lets
-    // the dispatch path light up the moment cp-api starts shipping
-    // adapter strings, instead of having the catalog be permanently
-    // inaccessible.
+    // Catches every catalog vendor whose `ProviderKey.adapter` matches
+    // one of these. Any new long-tail OpenAI-compat vendor cp-api
+    // admits (xai, openrouter, cerebras, moonshotai, …) routes here
+    // through `Hub::dispatch_two_tier` without a DP code change.
     //
-    // CUTOVER CAUTION: cp-api today blocks the catalog providers
-    // these bridges serve (`google-vertex`, `azure`, `amazon-bedrock`)
-    // at createProviderKey via `isSupportedProvider` (handlers.go).
-    // The moment that gate is loosened — which Phase B is actively
-    // enabling — every chat through one of those provider_keys will
-    // route here and hit a NOT-IMPLEMENTED skeleton, taking the
-    // matching catalog from "works via OpenAI-compat" to "500: not
-    // implemented" in a single cp-api flip. The cutover order MUST
-    // be: per-adapter dispatch PR (D5.2 / D6.1 / D7.1) → cp-api flip
-    // catalog for that adapter.
+    // CUTOVER CAUTION (non-openai families): cp-api admits
+    // `google-vertex`, `azure`, `amazon-bedrock` Provider Keys via
+    // its adapter_map (#302 Phase B). The Vertex / Azure / Bedrock
+    // bridges below are functional implementations (Phases E/F/G).
+    hub.register_family(Adapter::Openai, Arc::new(OpenAiBridge::new()));
+    hub.register_family(Adapter::Anthropic, Arc::new(AnthropicBridge::new()));
     hub.register_family(Adapter::Vertex, Arc::new(VertexBridge::new()));
     hub.register_family(Adapter::AzureOpenai, Arc::new(AzureOpenAiBridge::new()));
     hub.register_family(Adapter::Bedrock, Arc::new(BedrockBridge::new()));
+
+    // ─── Specialized vendor bridges (open string, vendor identity) ───
+    //
+    // Override the family default for vendors whose handling diverges
+    // from the wire-shape baseline. Each vendor is keyed on its
+    // models.dev catalog id, matching `ProviderKey.provider`.
+    //
+    // - `google`: OpenAI-compat Gemini at `/v1beta/openai` (matches
+    //   `OpenAiBridge::default` but tagged for metrics + log labels).
+    // - `deepseek`: OpenAI-compat with `delta.reasoning_content` lift
+    //   for the R1 family (the `with_name` value drives the metric
+    //   label so dashboards can slice DeepSeek-specific reasoning
+    //   traffic).
+    // - `cohere`: chat-compat namespace at `/compatibility/v1`. cp-api
+    //   stores Cohere's PK with `adapter: "openai"` and the bridge
+    //   here handles the chat path; the `/v1/rerank` native path is
+    //   keyed off `ProviderKey.provider == "cohere"` in
+    //   `crates/aisix-proxy/src/rerank.rs`.
+    //
+    // Every other catalog vendor (groq, mistral, xai, openrouter,
+    // fireworks-ai, perplexity, moonshotai, alibaba, zhipuai,
+    // baseten, huggingface, cerebras, togetherai, plus the long
+    // tail) falls through to `Adapter::Openai` family above. The DP
+    // does NOT enumerate them. cp-api populates `api_base` from
+    // adapter_map's `default_base_url` or `provider_metadata.api_base_url`.
+    // First-class vendors with their canonical metric labels. `openai`
+    // / `anthropic` shadow the family bridge — same bridge instance,
+    // explicit registration here keeps test fixtures and pre-Phase-A
+    // payloads (which carry `provider` but may not yet carry
+    // `adapter`) routing correctly without falling through to the
+    // None branch in `dispatch_two_tier`.
+    hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+    hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+    hub.register_specialized("google", Arc::new(OpenAiBridge::new().with_name("google")));
+    hub.register_specialized(
+        "deepseek",
+        Arc::new(OpenAiBridge::new().with_name("deepseek")),
+    );
+    hub.register_specialized("cohere", Arc::new(OpenAiBridge::new().with_name("cohere")));
 
     hub
 }
@@ -1146,77 +1105,87 @@ mod tests {
     /// `build_hub()` must register `Provider::Cohere` against the
     /// `with_name("cohere")` variant of [`OpenAiBridge`] — the only
     /// thing that ties the Provider enum to the chat-compat URL
-    /// (closes #332). A regression that registered `OpenAiBridge::new()`
-    /// (default name = `"openai"`) or omitted the registration would
-    /// flip the bridge label on metrics and (more importantly) the
-    /// `default_base()` fallback, silently routing Cohere chat to
-    /// OpenAI's host.
+    /// `build_hub()` must register `cohere` as a specialized bridge
+    /// against `OpenAiBridge::with_name("cohere")` so chat-compat
+    /// traffic carries the right metric label and resolves through
+    /// the chat-compat namespace (closes #332).
     #[test]
     fn build_hub_registers_cohere_chat_compat_variant() {
         let hub = build_hub();
         let bridge = hub
-            .get(aisix_core::Provider::Cohere)
-            .expect("Provider::Cohere must have a Hub bridge registered for chat-compat");
+            .get_specialized("cohere")
+            .expect("cohere must have a specialized bridge for chat-compat");
         assert_eq!(
             bridge.name(),
             "cohere",
-            "Hub.register(Provider::Cohere, …) MUST use OpenAiBridge::with_name(\"cohere\") — \
-             a `with_name(\"openai\")` fallback would route Cohere chat to OpenAI's host",
+            "specialized cohere bridge MUST be `OpenAiBridge::with_name(\"cohere\")` so \
+             the metric label is `cohere` and dashboards keep working",
         );
     }
 
-    /// Companion to the cohere check above: Jina deliberately stays
-    /// rerank-only per #213 Phase 2. A future PR that flips Jina to
-    /// chat-compat must update this assertion deliberately.
+    /// `build_hub()` must NOT register `jina` as a specialized chat
+    /// bridge. Jina is rerank-only (#213 Phase 2) — its
+    /// `/v1/chat/completions` traffic falls through to the family
+    /// bridge `Adapter::Openai`, which is fine because the chat
+    /// envelope is OpenAI-shaped if cp-api populates `adapter`.
+    /// Registering a specialized Jina chat bridge here would
+    /// silently change the metric label / behavior on a future
+    /// `provider: "jina"` chat request.
     #[test]
     fn build_hub_does_not_register_jina_for_chat() {
         let hub = build_hub();
         assert!(
-            hub.get(aisix_core::Provider::Jina).is_none(),
-            "Provider::Jina is rerank-only (#213 Phase 2); a Hub registration here would \
-             silently route /v1/chat/completions on Jina to whichever bridge name was picked",
+            hub.get_specialized("jina").is_none(),
+            "jina is rerank-only (#213 Phase 2); a specialized chat bridge here would \
+             change the metric label silently on the first jina chat request",
         );
     }
 
-    /// `build_hub()` must register every long-tail OpenAI-adapter
-    /// provider (#60 P2-A) with the matching `with_name(...)` bridge
-    /// variant. A regression that registered the default
-    /// `OpenAiBridge::new()` (name = `"openai"`) on any of these would
-    /// silently route the provider's chat traffic to OpenAI's API
-    /// host via `default_base()`, leaking customer tokens to OpenAI.
+    /// `build_hub()` MUST register `Adapter::Openai` as a family
+    /// bridge so any catalog vendor admitted by cp-api with
+    /// `adapter: "openai"` (xai, openrouter, groq, mistral, etc. —
+    /// every models.dev long-tail) resolves through the family
+    /// fallthrough. Without it, dispatch returns None and the
+    /// customer sees a 503. Closes the dispatch half of
+    /// api7/AISIX-Cloud#417.
     #[test]
-    fn build_hub_registers_long_tail_openai_adapter_variants() {
+    fn build_hub_registers_openai_family_bridge_for_long_tail_catalog_vendors() {
         let hub = build_hub();
-        // (Provider, expected bridge name as set by `with_name`).
-        // The name must match the wire id (`Provider::as_str()`)
-        // so metrics labels + default_base lookups stay aligned.
-        let expected = [
-            (aisix_core::Provider::Groq, "groq"),
-            (aisix_core::Provider::Mistral, "mistral"),
-            (aisix_core::Provider::Togetherai, "togetherai"),
-            (aisix_core::Provider::FireworksAi, "fireworks-ai"),
-            (aisix_core::Provider::Perplexity, "perplexity"),
-            (aisix_core::Provider::Moonshotai, "moonshotai"),
-            (aisix_core::Provider::Alibaba, "alibaba"),
-            (aisix_core::Provider::Zhipuai, "zhipuai"),
-            (aisix_core::Provider::Baseten, "baseten"),
-            (aisix_core::Provider::Huggingface, "huggingface"),
-            (aisix_core::Provider::Cerebras, "cerebras"),
-        ];
-        for (provider, expected_name) in expected {
-            let bridge = hub.get(provider).unwrap_or_else(|| {
-                panic!(
-                    "Provider::{provider:?} must have a Hub bridge registered (#60 P2-A); \
-                     a missing registration would 503 the customer's chat traffic"
-                )
-            });
-            assert_eq!(
-                bridge.name(),
-                expected_name,
-                "Provider::{provider:?} bridge name must match the wire id — \
-                 a mismatch silently routes traffic to OpenAI's host via the \
-                 OpenAiBridge::default_base() fallback when api_base is unset",
-            );
-        }
+        // Synthesize a PK for a vendor that's NOT in the specialized
+        // registrations above (e.g. xai). It must resolve via the
+        // family bridge.
+        let pk: aisix_core::ProviderKey = serde_json::from_str(
+            r#"{"display_name":"xai-pk","secret":"sk-test","provider":"xai","adapter":"openai","api_base":"https://api.x.ai/v1"}"#,
+        )
+        .unwrap();
+        let bridge = hub.dispatch_two_tier(&pk).unwrap_or_else(|| {
+            panic!(
+                "Adapter::Openai family bridge must be registered so any catalog \
+                 vendor admitted by cp-api with `adapter: \"openai\"` resolves \
+                 through the family fallthrough — a missing family bridge \
+                 re-introduces api7/AISIX-Cloud#417"
+            )
+        });
+        assert_eq!(
+            bridge.name(),
+            "openai",
+            "OpenAI family bridge MUST be the bare `OpenAiBridge::new()` so it \
+             dispatches through `ProviderKey.api_base` for any vendor",
+        );
+    }
+
+    /// `build_hub()` MUST register `Adapter::Anthropic` as a family
+    /// bridge for symmetry with `Adapter::Openai`.
+    #[test]
+    fn build_hub_registers_anthropic_family_bridge() {
+        let hub = build_hub();
+        let pk: aisix_core::ProviderKey = serde_json::from_str(
+            r#"{"display_name":"anth-compat-pk","secret":"sk-test","provider":"some-anthropic-compat","adapter":"anthropic","api_base":"https://example.com"}"#,
+        )
+        .unwrap();
+        let bridge = hub
+            .dispatch_two_tier(&pk)
+            .unwrap_or_else(|| panic!("Adapter::Anthropic family bridge must be registered"));
+        assert_eq!(bridge.name(), "anthropic");
     }
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1175,10 +1175,20 @@ mod tests {
     }
 
     /// `build_hub()` MUST register `Adapter::Anthropic` as a family
-    /// bridge for symmetry with `Adapter::Openai`.
+    /// bridge for symmetry with `Adapter::Openai`. The Anthropic
+    /// family bridge serves any Anthropic-compat vendor cp-api admits.
     #[test]
     fn build_hub_registers_anthropic_family_bridge() {
         let hub = build_hub();
+        // Tighten: assert the dispatch comes from the family tier,
+        // not from an accidentally-registered specialized bridge.
+        // The bare vendor string `"some-anthropic-compat"` is not in
+        // the specialized list, so `dispatch_two_tier` must fall
+        // through to the `Adapter::Anthropic` family registration.
+        assert!(
+            hub.get_specialized("some-anthropic-compat").is_none(),
+            "`some-anthropic-compat` must not be specialized; the test must exercise the family tier"
+        );
         let pk: aisix_core::ProviderKey = serde_json::from_str(
             r#"{"display_name":"anth-compat-pk","secret":"sk-test","provider":"some-anthropic-compat","adapter":"anthropic","api_base":"https://example.com"}"#,
         )
@@ -1186,6 +1196,10 @@ mod tests {
         let bridge = hub
             .dispatch_two_tier(&pk)
             .unwrap_or_else(|| panic!("Adapter::Anthropic family bridge must be registered"));
-        assert_eq!(bridge.name(), "anthropic");
+        assert_eq!(
+            bridge.name(),
+            "anthropic",
+            "family Anthropic bridge MUST be the bare `AnthropicBridge::new()`",
+        );
     }
 }

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -51,14 +51,10 @@
       ]
     },
     "provider": {
-      "description": "Upstream provider. None for routing models (the router picks a target whose own `provider` is used at dispatch time).",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Provider"
-        },
-        {
-          "type": "null"
-        }
+      "description": "Upstream vendor identity, free-form string (e.g. `\"openai\"`, `\"xai\"`, `\"openrouter\"`, any models.dev catalog id). Carried through to telemetry / logs but **not consumed by dispatch** — routing reads `ProviderKey.adapter` + `ProviderKey.provider` instead, so a new long-tail vendor admitted by cp-api works without a DP code change. None for routing models.\n\nCloses the schema-validation half of api7/AISIX-Cloud#417 and the dispatch half of api7/AISIX-Cloud#302 Phase A.",
+      "type": [
+        "string",
+        "null"
       ]
     },
     "provider_key_id": {
@@ -250,111 +246,6 @@
           "type": "string",
           "enum": [
             "original_order"
-          ]
-        }
-      ]
-    },
-    "Provider": {
-      "description": "Supported upstream providers.",
-      "oneOf": [
-        {
-          "type": "string",
-          "enum": [
-            "openai",
-            "anthropic",
-            "google",
-            "deepseek"
-          ]
-        },
-        {
-          "description": "Cohere — `/v1/rerank` (native, via `aisix-proxy::rerank`) and chat/completions / embeddings (via `OpenAiBridge::with_name(\"cohere\")` against `https://api.cohere.com/compatibility/v1`, per <https://docs.cohere.com/reference/chat>). Chat-compat is the OpenAI-shape namespace Cohere ships alongside its native `/v1/chat`. Chat-compat coverage today: the `command-r` / `command-a` family per <https://docs.cohere.com/v2/docs/compatibility-api>; legacy `command` / `command-light` / `command-nightly` go to native (not yet bridged) and will return upstream 400 if configured against the chat-compat path.",
-          "type": "string",
-          "enum": [
-            "cohere"
-          ]
-        },
-        {
-          "description": "Jina AI — currently exposed for `/v1/rerank` only (#213 Phase 2). Jina's rerank wire shape is identity-mapped to the OpenAI-compat shape (`{model, query, documents, top_n}` with Bearer auth at `https://api.jina.ai/v1/rerank`), so the gateway forwards verbatim with no transform. Jina's chat / embeddings APIs are out of scope for this phase.",
-          "type": "string",
-          "enum": [
-            "jina"
-          ]
-        },
-        {
-          "description": "Groq — OpenAI-compat at `https://api.groq.com/openai/v1`.",
-          "type": "string",
-          "enum": [
-            "groq"
-          ]
-        },
-        {
-          "description": "Mistral AI — OpenAI-compat at `https://api.mistral.ai/v1`.",
-          "type": "string",
-          "enum": [
-            "mistral"
-          ]
-        },
-        {
-          "description": "Together.ai — OpenAI-compat at `https://api.together.ai/v1`.",
-          "type": "string",
-          "enum": [
-            "togetherai"
-          ]
-        },
-        {
-          "description": "Fireworks AI — OpenAI-compat at `https://api.fireworks.ai/inference/v1`. Wire id is the hyphenated `fireworks-ai` (matches the models.dev catalog id used by cp-api's adapter_map).",
-          "type": "string",
-          "enum": [
-            "fireworks-ai"
-          ]
-        },
-        {
-          "description": "Perplexity — OpenAI-compat at `https://api.perplexity.ai` (chat lives at the host root).",
-          "type": "string",
-          "enum": [
-            "perplexity"
-          ]
-        },
-        {
-          "description": "Moonshot AI (Kimi) — OpenAI-compat at `https://api.moonshot.cn/v1`.",
-          "type": "string",
-          "enum": [
-            "moonshotai"
-          ]
-        },
-        {
-          "description": "Alibaba Cloud DashScope — OpenAI-compat at `https://dashscope.aliyuncs.com/compatible-mode/v1`.",
-          "type": "string",
-          "enum": [
-            "alibaba"
-          ]
-        },
-        {
-          "description": "Zhipu AI (智谱) — OpenAI-compat at `https://open.bigmodel.cn/api/paas/v4`.",
-          "type": "string",
-          "enum": [
-            "zhipuai"
-          ]
-        },
-        {
-          "description": "Baseten — OpenAI-compat at `https://inference.baseten.co/v1`. Per <https://docs.baseten.co/development/model-apis/openai-clients>, model APIs are exposed at this host root.",
-          "type": "string",
-          "enum": [
-            "baseten"
-          ]
-        },
-        {
-          "description": "Hugging Face — OpenAI-compat router at `https://router.huggingface.co/v1` per <https://huggingface.co/docs/inference-providers/en/index#openai-compatible-api>.",
-          "type": "string",
-          "enum": [
-            "huggingface"
-          ]
-        },
-        {
-          "description": "Cerebras Inference — OpenAI-compat at `https://api.cerebras.ai/v1`.",
-          "type": "string",
-          "enum": [
-            "cerebras"
           ]
         }
       ]


### PR DESCRIPTION
Closes [api7/AISIX-Cloud#417](https://github.com/api7/AISIX-Cloud/issues/417) and lands the dispatch half of [api7/AISIX-Cloud#302 Phase A](https://github.com/api7/AISIX-Cloud/issues/302). Supersedes #365 (band-aid Provider::Xai approach, closed).

## The bug class this kills

Pre-#302 the DP enumerated every catalog vendor as a closed `Provider` enum variant. cp-api admitted any models.dev provider (xai, openrouter, future long-tail) but `Model` rows with an un-enumerated `provider` string failed `validate_model` at snapshot load — silently dropped to `stats.rejections`. Customer chat → 404 model_not_found. Adding `Provider::Xai` just repaints the bug; the next long-tail repeats it.

## What this PR does

**Schema** (`crates/aisix-core/src/models/schema.rs`)
- `model_schema()` `provider` field: closed-enum → `{type:"string", minLength:1, maxLength:64, pattern:"^[a-z0-9][a-z0-9._-]*$"}`. Pattern accepts the dot character because at least one real models.dev id (`wafer.ai`) contains it; bounded length + character set guard against log-injection / Prometheus cardinality explosion.

**Model entity** (`crates/aisix-core/src/models/model.rs`)
- `Model.provider`: `Option<Provider>` → `Option<String>`. Vendor identity is open string; routing reads `ProviderKey`.
- `Provider` enum trimmed 17 → 6 first-class variants. 11 long-tail variants deleted (Groq / Mistral / Togetherai / FireworksAi / Perplexity / Moonshotai / Alibaba / Zhipuai / Baseten / Huggingface / Cerebras).
- `default_base_url` method removed — DP no longer enumerates per-vendor URLs.

**Hub** (`crates/aisix-gateway/src/hub.rs`)
- Drop per-`Provider` registry. Hub now has only `specialized_bridges` (open string vendor) + `family_bridges` (closed 5-value `Adapter`). `dispatch_two_tier` is the only dispatch entry.

**Dispatch** (`crates/aisix-proxy/src/dispatch.rs`)
- `resolve_bridge(hub, pk, model_provider)`: legacy fallback gone. Includes a one-cycle compat shim for pre-Phase-A PK rows (empty `provider` + `adapter: None`) falling back to `hub.get_specialized(Model.provider)`. Emits `tracing::warn!(target: \"aisix_proxy::dispatch\", ...)` so operators can detect un-migrated rows.
- `require_provider`: `Provider` → `&str`.
- `resolve_base_url(pk) -> Result`: errors loud when api_base is empty; cp-api must populate.

**Bridge safety guards** (`crates/aisix-provider-openai/src/bridge.rs`, `crates/aisix-provider-anthropic/src/bridge.rs`)
- `OpenAiBridge::resolve_base` and `AnthropicBridge::resolve_base` now return `Result<String, BridgeError>` and refuse to fall back to `OPENAI_DEFAULT_BASE` / `ANTHROPIC_DEFAULT_BASE` when the family bridge serves a non-openai / non-anthropic vendor with empty `api_base`. Vendor string normalized (`trim()` + `to_ascii_lowercase()`) before comparing. Closes the credential-leak primitive surfaced in the round-1 audit.

**Proxy handlers**
- All 10 endpoint handlers (audio / images / completions / messages / responses / embeddings / chat / background / rerank / passthrough) dispatch via `ProviderKey` through `Hub::dispatch_two_tier`.
- Endpoint guards (images / responses / messages) use string compare instead of `Provider::Xxx`.
- Metric `provider_label`: `format!(\"{provider:?}\").to_lowercase()` → `provider.to_ascii_lowercase()` (5 sites; `Debug` on `&str` was producing quoted strings).

**`build_hub()`** (`crates/aisix-server/src/main.rs`)
- 5 family bridges registered (all `Adapter` variants).
- 5 specialized vendor bridges (openai / anthropic / google / deepseek / cohere) for canonical metric labels + specialized handling.

**Schema regen**: `schemas/resources/model.schema.json` re-emitted.

## Net effect

Any new long-tail vendor cp-api admits (xai, openrouter, wafer.ai, or one we haven't heard of yet) routes through the `Adapter::Openai` family bridge with no DP code change.

## Test plan

- [x] `cargo test --workspace` — 1095+ tests, 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Schema regen committed
- [x] **End-to-end xai chat round-trip e2e** ran locally against rebuilt DP image (`aisix:phase-a-clean-cut`) + rebuilt cp-api (`aisix-e2e-api` from current main with #336 admission gate). `dp-catalog-non-featured-routing-live.spec.ts`: 1 passed, 8.7s. Full chain — tenant signup → environment → gateway cert → startDP → POST xai PK (201) → POST Model (201) → POST ApiKey (201) → poll DP `/v1/models` → POST `/v1/chat/completions` (200) → OpenAI envelope shape + upstream model echo verified. Spec lives in [api7/AISIX-Cloud#429](https://github.com/api7/AISIX-Cloud/pull/429).

## Audit response

Two independent audit passes ([CLAUDE.md §8](https://github.com/api7/ai-gateway/blob/main/CLAUDE.md#8-independent-audit-before-merge)).

**Round 1**:
- HIGH-1 (CRITICAL — family bridge silently routed non-openai keys to api.openai.com): **addressed** — safety guard restored in OpenAiBridge + AnthropicBridge with vendor normalization (4 new tests).
- HIGH-2 (`format!(\"{provider:?}\")` emitted quoted metric labels): **addressed** — 5 call sites converted to `.to_ascii_lowercase()`.
- HIGH-3 (pre-Phase-A PK rows 503 on upgrade): **addressed** — compat shim with deprecation telemetry.
- MEDIUM-1 (provider unbounded string — log injection / cardinality): **addressed** — schema pattern + maxLength.
- MEDIUM-2 (stale chat.rs comment): **addressed**.
- MEDIUM-3 (dead `From<Provider> for Adapter`): **addressed** — impl + test deleted.
- LOW-2 (Anthropic family test): **addressed** — pre-flight specialized-miss assertion.

**Round 2**:
- NEW HIGH (regex rejected `wafer.ai`, real models.dev catalog id): **addressed** — pattern broadened to allow `.`, positive tests for wafer.ai / fireworks-ai / togetherai added.
- MEDIUM-1 (regression-guard test was vacuous due to `adapter:None`): **addressed** — rewritten with `adapter:Some(Openai)` so a future PR that drops `Adapter::Openai` family fires the test.
- MEDIUM-3 (compat shim was silent): **addressed** — `tracing::warn!` emitted whenever the shim fires.

## Follow-up issues filed during this PR

- [api7/AISIX-Cloud#430](https://github.com/api7/AISIX-Cloud/issues/430) — chat round-trip e2e (spec landed in #429)
- [api7/AISIX-Cloud#431](https://github.com/api7/AISIX-Cloud/issues/431) — cp-api openrouter admission gate (separate cp-api bug)
- [api7/ai-gateway#367](https://github.com/api7/ai-gateway/issues/367) — BridgeError taxonomy refactor (`Config` → 400 for customer-fixable cases)
- [api7/ai-gateway#368](https://github.com/api7/ai-gateway/issues/368) — audio/images/completions Hub dispatch parity (out of #375 scope)