### PR TITLE
chore(fmt): restore rustfmt on aisix-admin apikey-rotate concurrent test (post-#374)

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -914,8 +914,16 @@ mod tests {
 
         let resp_a = task_a.await.unwrap();
         let resp_b = task_b.await.unwrap();
-        assert_eq!(resp_a.status(), StatusCode::OK, "concurrent rotation a must succeed");
-        assert_eq!(resp_b.status(), StatusCode::OK, "concurrent rotation b must succeed");
+        assert_eq!(
+            resp_a.status(),
+            StatusCode::OK,
+            "concurrent rotation a must succeed"
+        );
+        assert_eq!(
+            resp_b.status(),
+            StatusCode::OK,
+            "concurrent rotation b must succeed"
+        );
 
         let body_a = body_json(resp_a).await;
         let body_b = body_json(resp_b).await;
@@ -924,9 +932,15 @@ mod tests {
         let rev_a = body_a["entry"]["revision"].as_u64().unwrap();
         let rev_b = body_b["entry"]["revision"].as_u64().unwrap();
 
-        assert_ne!(plain_a, plain_b, "two rotations must yield distinct plaintexts");
+        assert_ne!(
+            plain_a, plain_b,
+            "two rotations must yield distinct plaintexts"
+        );
         assert!(rev_a >= 2 && rev_b >= 2);
-        assert_ne!(rev_a, rev_b, "concurrent rotations must produce distinct revisions");
+        assert_ne!(
+            rev_a, rev_b,
+            "concurrent rotations must produce distinct revisions"
+        );
 
         // Final stored state matches the winner (highest revision).
         // The loser's plaintext must NOT still be admitted — that
@@ -939,9 +953,20 @@ mod tests {
         )
         .await;
         let final_entry = body_json(resp).await;
-        let final_hash = final_entry["value"]["key_hash"].as_str().unwrap().to_string();
-        let winner_plain = if rev_a > rev_b { plain_a.clone() } else { plain_b.clone() };
-        let loser_plain = if rev_a > rev_b { plain_b.clone() } else { plain_a.clone() };
+        let final_hash = final_entry["value"]["key_hash"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let winner_plain = if rev_a > rev_b {
+            plain_a.clone()
+        } else {
+            plain_b.clone()
+        };
+        let loser_plain = if rev_a > rev_b {
+            plain_b.clone()
+        } else {
+            plain_a.clone()
+        };
         assert_eq!(
             final_hash,
             aisix_core::ApiKey::hash_bearer(&winner_plain),


### PR DESCRIPTION
## Summary

PR #374 introduced two `assert_eq!` calls in `concurrent_rotation_both_succeed_with_no_double_decrement` that rustfmt expands across 5 lines each. `cargo fmt --all -- --check` (the CI command) has been failing on every PR since #374 merged.

Third one of these in a row, same pattern as #366 (post-#362) and #369 (post-#363) — surgical fmt restore. Diff is the rustfmt-expansion exactly, no logic change.

## Verification

- `cargo fmt --all -- --check` clean locally on this branch.
- `cargo clippy --workspace --all-targets -- -D warnings` clean (verified after #369 merged).

## Surfaced from

Debugging `lint (fmt + clippy)` on [ai-gateway#360](https://github.com/api7/ai-gateway/pull/360) (the AISIX-Cloud#410 fix) after rebasing onto fresh main with #369 landed.

## Suggestion (out of scope)

Three consecutive merge-with-broken-CI events on `lint (fmt + clippy)` suggests the workflow's failure on the offending PR didn't block the merge. Worth a separate look at branch protection rules — but that's not this PR.