### PR TITLE
refactor: #302 Phase A pure clean cut — delete Provider enum + with_name + per-vendor consts

### DIFF
--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -34,7 +34,7 @@ pub use models::{
     validate_observability_exporter, validate_provider_key, validate_rate_limit_policy, Adapter,
     AisixSnapshot, ApiKey, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
     GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern, Model, ObservabilityExporter,
-    OnAllFilteredPolicy, ParamConstraints, Provider, ProviderKey, RateLimit, RateLimitPolicy,
+    OnAllFilteredPolicy, ParamConstraints, ProviderKey, RateLimit, RateLimitPolicy,
     RequestOverrides, ResponseOverrides, Routing, RoutingStrategy, RoutingTarget, SchemaError,
     StreamDoneMarker, TelemetryTags, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -34,8 +34,7 @@ pub use guardrail::{
     GuardrailKind, KeywordConfig, KeywordPattern,
 };
 pub use model::{
-    Adapter, BackgroundModelCheck, CooldownConfig, Model, Provider,
-    DEFAULT_COOLDOWN_TRIGGER_STATUSES,
+    Adapter, BackgroundModelCheck, CooldownConfig, Model, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use observability_exporter::{ExporterKind, ObservabilityExporter, OtlpHttpConfig};
 pub use provider_key::{

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -1,9 +1,10 @@
 //! `Model` entity — the routing target users reference from API requests.
 //!
-//! A Model has a user-chosen unique `display_name`, an explicit
-//! `provider` enum, an upstream `model_name` (e.g. "gpt-4o"), and a
-//! `provider_key_id` referencing a [`ProviderKey`] entry that supplies
-//! the secret + optional `api_base` override.
+//! A Model has a user-chosen unique `display_name`, an open vendor
+//! string `provider` (e.g. `"openai"`, `"xai"`), an upstream
+//! `model_name` (e.g. `"gpt-4o"`), and a `provider_key_id` referencing
+//! a [`ProviderKey`] entry that supplies the secret + optional
+//! `api_base` override.
 //!
 //! Routing models — virtual routers that pick a target Model per request
 //! — set `routing` instead of `provider`/`model_name`/`provider_key_id`.
@@ -17,71 +18,26 @@ use super::rate_limit::RateLimit;
 use super::routing::Routing;
 use crate::resource::Resource;
 
-/// First-class upstream provider variants with specialized DP handling.
-///
-/// Kept narrow on purpose: only vendors whose code path diverges from
-/// the wire-shape default (`Adapter`-family bridge) live here. Every
-/// other catalog vendor cp-api admits (xai, openrouter, groq, mistral,
-/// fireworks-ai, perplexity, together, moonshot, alibaba, zhipu,
-/// baseten, huggingface, cerebras, …) flows through the `Adapter`
-/// family bridge without a DP enum variant — closes api7/AISIX-Cloud#302
-/// Phase A and api7/AISIX-Cloud#417.
-///
-/// Wire identity on `ProviderKey.provider` / `Model.provider` is a
-/// free-form string (`Option<String>`); this enum is reserved for the
-/// few code paths that still match on a fixed vendor set
-/// (Cohere/Jina native rerank, Anthropic-shape `/v1/messages` cross-
-/// provider routing).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum Provider {
-    Openai,
-    Anthropic,
-    Google,
-    Deepseek,
-    /// Cohere — `/v1/rerank` (native, via `aisix-proxy::rerank`) and
-    /// chat/completions / embeddings (via `OpenAiBridge::with_name("cohere")`
-    /// against `https://api.cohere.com/compatibility/v1`, per
-    /// <https://docs.cohere.com/reference/chat>).
-    Cohere,
-    /// Jina AI — currently exposed for `/v1/rerank` only (#213 Phase 2).
-    /// Jina's rerank wire shape is identity-mapped to the OpenAI-compat
-    /// shape (`{model, query, documents, top_n}` with Bearer auth at
-    /// `https://api.jina.ai/v1/rerank`), so the gateway forwards
-    /// verbatim with no transform.
-    Jina,
-}
-
-impl Provider {
-    /// Stable wire identity for this first-class variant. Matches the
-    /// models.dev catalog id cp-api stores on `ProviderKey.provider`.
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Openai => "openai",
-            Self::Anthropic => "anthropic",
-            Self::Google => "google",
-            Self::Deepseek => "deepseek",
-            Self::Cohere => "cohere",
-            Self::Jina => "jina",
-        }
-    }
-}
+// `Provider` enum removed as part of #302 Phase A clean cut. Vendor
+// identity is an open string on `ProviderKey.provider` /
+// `Model.provider` — DP no longer enumerates vendors at compile time.
+// Code paths that need vendor-aware dispatch (rerank, messages
+// cross-provider routing) compare the string directly.
 
 /// Wire-shape adapter used to talk to an upstream. This is the closed
 /// set of upstream protocols the gateway knows how to encode against —
 /// distinct from a vendor identity (which is captured separately on
-/// `ProviderKey`).
+/// `ProviderKey.provider` as an open string).
 ///
-/// Introduced as a skeleton for issue #302 Phase A. This type is purely
-/// additive in this PR: nothing in the gateway dispatches off `Adapter`
-/// yet, no entity field is changed, and `Provider` continues to drive
-/// all runtime behavior. Follow-up PRs in Phase A migrate entities and
-/// the Hub to consume `Adapter` directly.
+/// Post-#302 Phase A clean cut, dispatch is two-tier: the Hub looks up
+/// a specialized bridge by the open `ProviderKey.provider` string
+/// first, then falls back to the closed `Adapter` family bridge. Any
+/// new long-tail OpenAI-compat vendor cp-api admits (xai, openrouter,
+/// cerebras, …) routes through the `Adapter::Openai` family bridge
+/// without a DP code change.
 ///
 /// Note on serde casing: `Adapter` uses `kebab-case` so the `AzureOpenai`
-/// variant serializes as `"azure-openai"`. This intentionally differs
-/// from `Provider`'s `lowercase` casing, which produced no hyphens
-/// because all current `Provider` names are single tokens.
+/// variant serializes as `"azure-openai"`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum Adapter {
@@ -91,11 +47,6 @@ pub enum Adapter {
     Vertex,
     AzureOpenai,
 }
-
-// `From<Provider> for Adapter` removed: post-#302 Phase A nothing in
-// production reads it. Adapter identity lives on `ProviderKey.adapter`
-// directly, projected by cp-api per adapter_map.yaml. The legacy
-// Model.provider → Adapter mapping has no caller.
 
 /// Per-token cost for budget tracking. Both values are in USD per 1,000 tokens.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
@@ -544,24 +495,8 @@ mod tests {
         assert!(serde_json::from_str::<Adapter>("\"azure_openai\"").is_err());
     }
 
-    /// Every first-class `Provider` variant must have a non-empty
-    /// `as_str` wire id and a working `Adapter::from` arm. A
-    /// regression that added a new variant but forgot to update
-    /// either would compile fine but silently break dispatch
-    /// downstream.
-    #[test]
-    fn every_provider_variant_has_as_str_and_adapter() {
-        let variants = [
-            Provider::Openai,
-            Provider::Anthropic,
-            Provider::Google,
-            Provider::Deepseek,
-            Provider::Cohere,
-            Provider::Jina,
-        ];
-        for v in variants {
-            let id = v.as_str();
-            assert!(!id.is_empty(), "{v:?}: as_str must be non-empty");
-        }
-    }
+    // `every_provider_variant_has_as_str_and_adapter` removed —
+    // the `Provider` enum it pinned no longer exists post-#302
+    // Phase A. Vendor identity is now a free-form string on
+    // `ProviderKey.provider` / `Model.provider`.
 }

--- a/crates/aisix-core/src/models/provider_key.rs
+++ b/crates/aisix-core/src/models/provider_key.rs
@@ -42,8 +42,12 @@ pub struct ProviderKey {
     /// plaintext here.
     pub secret: String,
 
-    /// Override for the upstream base URL. Empty/None means the
-    /// provider default applies (see `Provider::default_base_url`).
+    /// Override for the upstream base URL. Empty/None is rejected by
+    /// the family bridges for any vendor whose identity isn't
+    /// `"openai"` — see `OpenAiBridge::resolve_base` for the safety
+    /// guard that prevents a missing api_base from silently routing
+    /// non-OpenAI traffic to `api.openai.com`. cp-api populates this
+    /// from `adapter_map.yaml`'s `default_base_url` / `provider_metadata.api_base_url`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_base: Option<String>,
 

--- a/crates/aisix-core/src/models/provider_key.rs
+++ b/crates/aisix-core/src/models/provider_key.rs
@@ -43,11 +43,15 @@ pub struct ProviderKey {
     pub secret: String,
 
     /// Override for the upstream base URL. Empty/None is rejected by
-    /// the family bridges for any vendor whose identity isn't
-    /// `"openai"` — see `OpenAiBridge::resolve_base` for the safety
-    /// guard that prevents a missing api_base from silently routing
-    /// non-OpenAI traffic to `api.openai.com`. cp-api populates this
-    /// from `adapter_map.yaml`'s `default_base_url` / `provider_metadata.api_base_url`.
+    /// every family bridge whose canonical-vendor identity doesn't
+    /// match the PK's `provider`: the OpenAI-family bridge refuses
+    /// to fall back to `api.openai.com` for a vendor other than
+    /// `"openai"`, and the Anthropic-family bridge refuses to fall
+    /// back to `api.anthropic.com` for a vendor other than
+    /// `"anthropic"`. See `OpenAiBridge::resolve_base` /
+    /// `AnthropicBridge::resolve_base` for the safety guards. cp-api
+    /// populates this from `adapter_map.yaml`'s `default_base_url` /
+    /// `provider_metadata.api_base_url`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_base: Option<String>,
 

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -40,7 +40,6 @@ pub const ANTHROPIC_DEFAULT_BASE: &str = "https://api.anthropic.com";
 
 pub struct AnthropicBridge {
     client: Client,
-    name: &'static str,
     api_version: &'static str,
 }
 
@@ -52,14 +51,8 @@ impl AnthropicBridge {
     pub fn with_client(client: Client) -> Self {
         Self {
             client,
-            name: "anthropic",
             api_version: ANTHROPIC_VERSION,
         }
-    }
-
-    pub fn with_name(mut self, name: &'static str) -> Self {
-        self.name = name;
-        self
     }
 
     pub fn with_api_version(mut self, v: &'static str) -> Self {
@@ -218,7 +211,7 @@ where
 #[async_trait]
 impl Bridge for AnthropicBridge {
     fn name(&self) -> &'static str {
-        self.name
+        "anthropic"
     }
 
     async fn chat(

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -119,12 +119,25 @@ fn resolve_base(ctx: &BridgeContext) -> Result<String, BridgeError> {
             let pk_vendor_raw = ctx.provider_key.provider.as_str();
             let pk_vendor_normalized = pk_vendor_raw.trim().to_ascii_lowercase();
             if !pk_vendor_normalized.is_empty() && pk_vendor_normalized != "anthropic" {
+                // Operator-facing detail (route, provider topology,
+                // remediation steps) goes to logs only — keep the
+                // customer-visible 500 body short and free of
+                // internal-product taxonomy (cp-api / adapter_map /
+                // provider_metadata field names are not part of any
+                // wire contract a customer should depend on).
+                tracing::error!(
+                    target: "aisix_provider_anthropic::bridge",
+                    pk_display_name = %ctx.provider_key.display_name,
+                    pk_vendor = %pk_vendor_raw,
+                    "provider_key has no api_base; family bridge refusing fallback to \
+                     api.anthropic.com. Operator action: populate `api_base` on the \
+                     ProviderKey resource (managed deployments: via adapter_map / \
+                     provider_metadata.api_base_url on the control plane; standalone: \
+                     directly on the resource)."
+                );
                 return Err(BridgeError::Config(format!(
-                    "provider_key for vendor {pk_vendor_raw:?} has no api_base set; \
-                     the Anthropic-family bridge refuses to fall back to api.anthropic.com \
-                     to avoid routing {pk_vendor_raw:?}'s API key to Anthropic. cp-api \
-                     must populate api_base for every catalog vendor via adapter_map / \
-                     provider_metadata.api_base_url."
+                    "provider_key for vendor {pk_vendor_raw:?} has no upstream base URL \
+                     configured"
                 )));
             }
             Ok(ANTHROPIC_DEFAULT_BASE.to_string())
@@ -647,5 +660,71 @@ data: {\"type\":\"message_stop\"}\n\n";
             let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
             assert_eq!(resolve_base(&ctx).unwrap(), canonical);
         }
+    }
+
+    /// Family-bridge safety: when `AnthropicBridge` serves a non-anthropic
+    /// vendor with empty `api_base` it MUST refuse rather than fall back
+    /// to `ANTHROPIC_DEFAULT_BASE` — that fallback would silently route
+    /// the vendor's API key to `api.anthropic.com`. Mirror of the OpenAI
+    /// guard in `crates/aisix-provider-openai/src/bridge.rs`.
+    #[test]
+    fn family_bridge_refuses_non_anthropic_vendor_with_empty_api_base() {
+        for vendor in [
+            "bedrock-anthropic",
+            "vertex-anthropic",
+            "BedrockAnthropic",
+            " bedrock-anthropic ",
+        ] {
+            let pk: ProviderKey = serde_json::from_str(&format!(
+                r#"{{"display_name":"x","secret":"k","provider":"{vendor}","adapter":"anthropic"}}"#
+            ))
+            .unwrap();
+            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+            let err = resolve_base(&ctx).unwrap_err();
+            match err {
+                BridgeError::Config(msg) => {
+                    assert!(
+                        msg.contains("base URL") && msg.contains(vendor.trim()),
+                        "vendor {vendor:?}: error must name vendor + base URL; got: {msg}",
+                    );
+                    // Sensitive-info-leakage guard: internal product
+                    // taxonomy must not leak into the customer-visible
+                    // 500 body. Those identifiers go to tracing only.
+                    for forbidden in ["cp-api", "adapter_map", "provider_metadata"] {
+                        assert!(
+                            !msg.contains(forbidden),
+                            "vendor {vendor:?}: error body must not leak \
+                             internal-product taxonomy {forbidden:?}; got: {msg}",
+                        );
+                    }
+                }
+                other => panic!("vendor {vendor:?}: expected BridgeError::Config, got {other:?}"),
+            }
+        }
+    }
+
+    /// Pure-anthropic PK without `api_base` falls back to
+    /// `ANTHROPIC_DEFAULT_BASE` — the historical legacy behavior. The
+    /// safety check above only fires for non-anthropic vendors.
+    #[test]
+    fn family_bridge_allows_anthropic_vendor_with_empty_api_base() {
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"a","secret":"sk-a","provider":"anthropic","adapter":"anthropic"}"#,
+        )
+        .unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(resolve_base(&ctx).unwrap(), ANTHROPIC_DEFAULT_BASE);
+    }
+
+    /// Pre-Phase-A PK carries an empty `provider` string. The safety
+    /// check must NOT fire here — those rows route via the compat
+    /// shim in `crates/aisix-proxy/src/dispatch.rs::resolve_bridge`
+    /// to the specialized "anthropic" bridge. The bridge itself must
+    /// tolerate the legacy shape so the compat path doesn't 500.
+    #[test]
+    fn family_bridge_allows_legacy_empty_provider_with_empty_api_base() {
+        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
+        assert_eq!(resolve_base(&ctx).unwrap(), ANTHROPIC_DEFAULT_BASE);
     }
 }

--- a/crates/aisix-provider-azure-openai/src/lib.rs
+++ b/crates/aisix-provider-azure-openai/src/lib.rs
@@ -24,7 +24,7 @@
 //!   bridge supports api-key only (the common case). AAD support will
 //!   land alongside the cp-api `auth_scheme` field becoming routable.
 //!
-//! # Why Azure-OpenAI is a separate bridge (not OpenAiBridge::with_name)
+//! # Why Azure-OpenAI is a separate `Adapter::AzureOpenai` family bridge
 //!
 //! 1. **Auth header differs** — Azure uses `api-key: <key>`, not
 //!    `Authorization: Bearer <key>`. The OpenAiBridge's header-builder

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -45,68 +45,12 @@ use crate::wire::{
     OpenAiStreamChunk,
 };
 
-/// Fallback OpenAI host used when the Model doesn't set `api_base` and
-/// the Provider enum's default is also missing. In practice an operator
-/// configures `api_base: "https://api.openai.com/v1"` on the Model so
-/// this constant only covers degenerate config paths.
+/// Default OpenAI upstream host. Used only when `ProviderKey.api_base`
+/// is empty AND the dispatching PK identifies the openai vendor — the
+/// family-bridge safety guard in `resolve_base` refuses this fallback
+/// for any non-openai vendor (would otherwise leak the vendor's API
+/// key to api.openai.com).
 pub const OPENAI_DEFAULT_BASE: &str = "https://api.openai.com/v1";
-
-/// Fallback host for the `deepseek`-named variant of this bridge, so a
-/// `with_name("deepseek")` instance without an explicit `api_base`
-/// dispatches to DeepSeek rather than OpenAI.
-const DEEPSEEK_DEFAULT_BASE: &str = "https://api.deepseek.com";
-
-/// Fallback host for the `google`-named variant of this bridge, so a
-/// `with_name("google")` instance without an explicit `api_base`
-/// dispatches to Google's OpenAI-compatible Gemini endpoint.
-const GOOGLE_DEFAULT_BASE: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
-
-/// Fallback host for the `cohere`-named variant of this bridge, so a
-/// `with_name("cohere")` instance without an explicit `api_base`
-/// dispatches to Cohere's [OpenAI-compatible chat
-/// endpoint](https://docs.cohere.com/reference/chat) at
-/// `/compatibility/v1`. Cohere's native chat surface (`/v1/chat`) has a
-/// different wire shape; the `/compatibility/v1` namespace mirrors the
-/// OpenAI `/chat/completions` shape verbatim, so `OpenAiBridge` can
-/// serve it directly. `Provider::Cohere.default_base_url()` returns
-/// the bare host because the rerank path (`/v1/rerank`) builds its own
-/// URL — that constant stays as-is.
-const COHERE_DEFAULT_BASE: &str = "https://api.cohere.com/compatibility/v1";
-
-// ─── Long-tail OpenAI-adapter provider default base URLs (#60 P2-A) ──
-//
-// Each constant is the vendor's documented OpenAI-compat chat
-// endpoint. Operators can override per-PK via `api_base`; these
-// constants only cover the degenerate config path where no api_base
-// is set on the resource. URLs sourced from each vendor's official
-// docs cited inline.
-//
-// Per https://console.groq.com/docs/openai
-const GROQ_DEFAULT_BASE: &str = "https://api.groq.com/openai/v1";
-// Per https://docs.mistral.ai/api/
-const MISTRAL_DEFAULT_BASE: &str = "https://api.mistral.ai/v1";
-// Per https://docs.together.ai/docs/openai-api-compatibility
-const TOGETHERAI_DEFAULT_BASE: &str = "https://api.together.ai/v1";
-// Per https://docs.fireworks.ai/getting-started/quickstart
-const FIREWORKS_AI_DEFAULT_BASE: &str = "https://api.fireworks.ai/inference/v1";
-// Per https://docs.perplexity.ai/api-reference/chat-completions-post
-// (chat endpoint is at the host root, NOT /v1).
-const PERPLEXITY_DEFAULT_BASE: &str = "https://api.perplexity.ai";
-// xAI Grok scoped out: not in cp-api adapter_map.yaml today (#335
-// swapped xai → google for Featured rank 8); follow-up will add it
-// after the catalog catches up.
-// Per https://platform.moonshot.cn/docs/api/chat
-const MOONSHOTAI_DEFAULT_BASE: &str = "https://api.moonshot.cn/v1";
-// Per https://help.aliyun.com/zh/dashscope/developer-reference/compatibility-of-openai-with-dashscope
-const ALIBABA_DEFAULT_BASE: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
-// Per https://www.bigmodel.cn/dev/api (OpenAI-compat at /api/paas/v4)
-const ZHIPUAI_DEFAULT_BASE: &str = "https://open.bigmodel.cn/api/paas/v4";
-// Per https://docs.baseten.co/development/model-apis/openai-clients
-const BASETEN_DEFAULT_BASE: &str = "https://inference.baseten.co/v1";
-// Per https://huggingface.co/docs/inference-providers/index#openai-compatible-api
-const HUGGINGFACE_DEFAULT_BASE: &str = "https://router.huggingface.co/v1";
-// Per https://inference-docs.cerebras.ai/api-reference/openai-compatibility
-const CEREBRAS_DEFAULT_BASE: &str = "https://api.cerebras.ai/v1";
 
 /// Path suffixes the bridge appends to `api_base` when building upstream
 /// URLs. If an operator accidentally pastes the full upstream URL into
@@ -124,7 +68,6 @@ const OPENAI_ENDPOINT_SUFFIXES: &[&str] = &[
 
 pub struct OpenAiBridge {
     client: Client,
-    name: &'static str,
 }
 
 impl OpenAiBridge {
@@ -133,43 +76,7 @@ impl OpenAiBridge {
     }
 
     pub fn with_client(client: Client) -> Self {
-        Self {
-            client,
-            name: "openai",
-        }
-    }
-
-    /// Same transport but a caller-chosen `name()` — used by OpenAI-compat
-    /// providers (DeepSeek, Gemini-OAI) so their metrics labels are distinct.
-    pub fn with_name(mut self, name: &'static str) -> Self {
-        self.name = name;
-        self
-    }
-
-    /// Default upstream base for this bridge variant. The bridge factory
-    /// wraps with `with_name("deepseek")` / `with_name("google")` to
-    /// retarget; the default base follows the same retargeting so a
-    /// degenerate config (no `api_base` on the Model) still reaches the
-    /// right host.
-    fn default_base(&self) -> &'static str {
-        match self.name {
-            "deepseek" => DEEPSEEK_DEFAULT_BASE,
-            "google" => GOOGLE_DEFAULT_BASE,
-            "cohere" => COHERE_DEFAULT_BASE,
-            // Long-tail OpenAI-adapter providers (#60 P2-A).
-            "groq" => GROQ_DEFAULT_BASE,
-            "mistral" => MISTRAL_DEFAULT_BASE,
-            "togetherai" => TOGETHERAI_DEFAULT_BASE,
-            "fireworks-ai" => FIREWORKS_AI_DEFAULT_BASE,
-            "perplexity" => PERPLEXITY_DEFAULT_BASE,
-            "moonshotai" => MOONSHOTAI_DEFAULT_BASE,
-            "alibaba" => ALIBABA_DEFAULT_BASE,
-            "zhipuai" => ZHIPUAI_DEFAULT_BASE,
-            "baseten" => BASETEN_DEFAULT_BASE,
-            "huggingface" => HUGGINGFACE_DEFAULT_BASE,
-            "cerebras" => CEREBRAS_DEFAULT_BASE,
-            _ => OPENAI_DEFAULT_BASE,
-        }
+        Self { client }
     }
 
     /// Resolve `ProviderKey.api_base` into the canonical base URL the
@@ -181,60 +88,43 @@ impl OpenAiBridge {
     /// - accidental endpoint suffix (e.g. `/chat/completions` pasted
     ///   along with the host)
     /// - bare canonical OpenAI host without `/v1` (the bridge adds it)
-    /// - canonical DeepSeek host with an extra `/v1` segment (the
-    ///   bridge strips it — DeepSeek serves OpenAI-compatible endpoints
-    ///   at the host root)
     ///
-    /// `/v1` synthesis and stripping happens **only for the canonical
-    /// upstream host of each provider**. Corporate proxies, alternative
-    /// deployments, and any non-default path the operator chose on
-    /// purpose pass through unchanged after suffix stripping — the
-    /// operator's intent on a non-canonical host wins.
+    /// `/v1` synthesis happens **only for the canonical OpenAI host**.
+    /// Corporate proxies, alternative deployments, and any non-default
+    /// path the operator chose on purpose pass through unchanged after
+    /// suffix stripping — the operator's intent on a non-canonical
+    /// host wins.
     ///
-    /// For the `gemini` variant and any future `with_name` variant, the
-    /// path is left as-is after suffix stripping — Gemini's `/v1beta/openai`
-    /// prefix is non-trivial and operators typically copy-paste the full
-    /// form.
+    /// Family-bridge safety: when the dispatching `ProviderKey.provider`
+    /// identifies a vendor that ISN'T openai AND `api_base` is empty,
+    /// the bridge refuses to fall back to `OPENAI_DEFAULT_BASE` — that
+    /// would silently route the vendor's API key to `api.openai.com`.
+    /// Closes the openrouter / xai / future-long-tail half of
+    /// api7/AISIX-Cloud#417. cp-api must populate `api_base` for every
+    /// catalog vendor via adapter_map / provider_metadata.api_base_url.
     fn resolve_base(&self, ctx: &BridgeContext) -> Result<String, BridgeError> {
         let raw = match ctx.provider_key.api_base.as_deref() {
             Some(b) if !b.trim().is_empty() => b.trim().to_string(),
             _ => {
-                // Family-bridge safety: when this `OpenAiBridge` is the
-                // bare family registration (`name == "openai"`,
-                // registered via `register_family(Adapter::Openai, ...)`)
-                // AND the dispatching `ProviderKey.provider` identifies
-                // a vendor that ISN'T openai, refuse to fall back to
-                // `OPENAI_DEFAULT_BASE` — that would silently route the
-                // vendor's API key to `api.openai.com`. Closes the
-                // openrouter / xai / future-long-tail half of
-                // api7/AISIX-Cloud#417.
-                //
-                // Legacy named bridges (`with_name("groq")`,
-                // `with_name("cohere")`, …) have their own
-                // `default_base()` arm that points at the right host,
-                // so the guard only fires for the family-bridge path.
-                //
-                // Pre-Phase-A rows (empty `ProviderKey.provider`)
-                // fall through to the historical default-base path
-                // unchanged.
+                // Vendor identity is the open-string `ProviderKey.provider`.
+                // Normalize (trim + ascii_lowercase) before comparing so a
+                // crafted PK with `"OpenAI"` / `"openai "` cannot bypass
+                // the guard.
                 let pk_vendor_raw = ctx.provider_key.provider.as_str();
                 let pk_vendor_normalized = pk_vendor_raw.trim().to_ascii_lowercase();
-                if self.name == "openai"
-                    && !pk_vendor_normalized.is_empty()
-                    && pk_vendor_normalized != "openai"
-                {
+                if !pk_vendor_normalized.is_empty() && pk_vendor_normalized != "openai" {
                     return Err(BridgeError::Config(format!(
                         "provider_key for vendor {pk_vendor_raw:?} has no api_base set; \
-                         the OpenAI-family bridge refuses to fall back to api.openai.com \
-                         to avoid routing {pk_vendor_raw:?}'s API key to OpenAI. cp-api \
-                         must populate api_base for every catalog vendor via adapter_map / \
+                         the OpenAI bridge refuses to fall back to api.openai.com to avoid \
+                         routing {pk_vendor_raw:?}'s API key to OpenAI. cp-api must populate \
+                         api_base for every catalog vendor via adapter_map / \
                          provider_metadata.api_base_url."
                     )));
                 }
-                return Ok(self.default_base().to_string());
+                return Ok(OPENAI_DEFAULT_BASE.to_string());
             }
         };
-        Ok(normalize_api_base(&raw, self.name))
+        Ok(normalize_api_base(&raw))
     }
 }
 
@@ -273,14 +163,9 @@ fn strip_known_endpoint(base: &str) -> &str {
 /// a non-canonical host is trusted as-is.
 ///
 /// See [`OpenAiBridge::resolve_base`] for accepted forms.
-fn normalize_api_base(base: &str, provider: &str) -> String {
+fn normalize_api_base(base: &str) -> String {
     let stripped = strip_known_endpoint(base);
-    match provider {
-        "openai" => normalize_canonical_openai(stripped),
-        "deepseek" => normalize_canonical_deepseek(stripped),
-        "cohere" => normalize_canonical_cohere(stripped),
-        _ => stripped.to_string(),
-    }
+    normalize_canonical_openai(stripped)
 }
 
 /// Canonical OpenAI hosts. Both schemes covered for ops convenience —
@@ -294,44 +179,6 @@ fn normalize_canonical_openai(base: &str) -> String {
     for host in OPENAI_CANONICAL_HOSTS {
         if base == *host {
             return format!("{host}/v1");
-        }
-    }
-    base.to_string()
-}
-
-/// Canonical DeepSeek hosts.
-const DEEPSEEK_CANONICAL_HOSTS: &[&str] = &["https://api.deepseek.com", "http://api.deepseek.com"];
-
-/// Strip the `/v1` segment when the operator added it on the canonical
-/// DeepSeek host (a common copy-paste habit from OpenAI conventions).
-/// DeepSeek serves OpenAI-compatible endpoints at the host root.
-fn normalize_canonical_deepseek(base: &str) -> String {
-    for host in DEEPSEEK_CANONICAL_HOSTS {
-        let with_v1 = format!("{host}/v1");
-        if base == with_v1 {
-            return host.to_string();
-        }
-    }
-    base.to_string()
-}
-
-/// Canonical Cohere hosts.
-const COHERE_CANONICAL_HOSTS: &[&str] = &["https://api.cohere.com", "http://api.cohere.com"];
-
-/// Add the `/compatibility/v1` segment if and only if the operator
-/// pasted the bare canonical Cohere host. The Cohere rerank endpoint
-/// at `/v1/rerank` builds its own URL outside this bridge — that path
-/// continues to use the bare host. For chat completions Cohere serves
-/// an OpenAI-shape envelope at `/compatibility/v1/chat/completions`
-/// (per <https://docs.cohere.com/reference/chat>), so the bridge
-/// synthesizes the right prefix when the operator left it off.
-///
-/// Anything past the host root is left as-is — corporate proxies and
-/// alternative deployments win.
-fn normalize_canonical_cohere(base: &str) -> String {
-    for host in COHERE_CANONICAL_HOSTS {
-        if base == *host {
-            return format!("{host}/compatibility/v1");
         }
     }
     base.to_string()
@@ -454,12 +301,13 @@ fn prepare_outbound_body<T: serde::Serialize>(
 /// gives two layers of defense against an operator-supplied
 /// `default_headers` accidentally clobbering auth.
 ///
-/// `bridge_name` is set from [`OpenAiBridge::name`] and written as
-/// `X-AISIX-Bridge: <bridge_name>` on every outbound request. Tests
-/// capturing this header via mock-llm's `/_internal/captured-requests`
-/// can assert that `Hub.register(Provider::X, OpenAiBridge::with_name("Y"))`
-/// used the correct `with_name` value — catching a typo that pure
-/// routing assertions would miss (closes #368).
+/// `bridge_name` is the static name returned by [`Bridge::name`] for
+/// the family bridge that dispatched the request (e.g. `"openai"`,
+/// `"anthropic"`), written as `X-AISIX-Bridge: <bridge_name>` on every
+/// outbound request. Tests capturing this header via mock-llm's
+/// `/_internal/captured-requests` can assert which family bridge
+/// handled the call — catching mis-routing that pure response-shape
+/// assertions would miss.
 fn build_request_headers(
     api_key_str: &str,
     request_id: &str,
@@ -504,7 +352,7 @@ fn build_request_headers(
 #[async_trait]
 impl Bridge for OpenAiBridge {
     fn name(&self) -> &'static str {
-        self.name
+        "openai"
     }
 
     async fn chat(
@@ -526,7 +374,7 @@ impl Bridge for OpenAiBridge {
         let headers = build_request_headers(
             key,
             &ctx.request_id,
-            self.name,
+            "openai",
             false,
             ctx.provider_key.request.as_ref(),
         )?;
@@ -571,7 +419,7 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
-        let bridge_name = self.name;
+        let bridge_name = "openai";
 
         with_deadline(ctx.deadline, started, async move {
             let resp = client
@@ -621,7 +469,7 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
-        let bridge_name = self.name;
+        let bridge_name = "openai";
 
         with_deadline(ctx.deadline, started, async move {
             let resp = client
@@ -669,7 +517,7 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
-        let bridge_name = self.name;
+        let bridge_name = "openai";
 
         with_deadline(ctx.deadline, started, async move {
             let resp = client
@@ -714,7 +562,7 @@ impl Bridge for OpenAiBridge {
         let headers = build_request_headers(
             key,
             &ctx.request_id,
-            self.name,
+            "openai",
             true,
             ctx.provider_key.request.as_ref(),
         )?;
@@ -751,7 +599,7 @@ impl Bridge for OpenAiBridge {
             .response
             .as_ref()
             .and_then(|r| r.stream_done_marker);
-        let bridge_name = self.name;
+        let bridge_name = "openai";
         let request_id_for_log = ctx.request_id.clone();
 
         let byte_stream = resp.bytes_stream();
@@ -1313,229 +1161,26 @@ data: [DONE]\n\n";
         }
     }
 
-    /// DeepSeek serves OpenAI-compatible paths at the host root; pasting
-    /// `/v1` (a common copy-paste habit from OpenAI) must be tolerated.
+    /// A non-canonical host (corporate proxy, alternative deployment,
+    /// any vendor that isn't api.openai.com) passes through verbatim
+    /// after endpoint-suffix stripping. The family bridge no longer
+    /// synthesizes vendor-specific URL prefixes — operators paste the
+    /// documented URL on the dashboard.
     #[test]
-    fn deepseek_api_base_tolerance_bare_host_and_v1_form() {
-        let bridge = OpenAiBridge::new().with_name("deepseek");
-        let canonical = "https://api.deepseek.com";
+    fn non_openai_host_passes_through_verbatim_after_suffix_strip() {
+        let bridge = OpenAiBridge::new();
 
-        for form in [
-            "https://api.deepseek.com",
-            "https://api.deepseek.com/",
-            "https://api.deepseek.com/v1",
-            "https://api.deepseek.com/v1/",
-            "https://api.deepseek.com/chat/completions",
-        ] {
-            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
-            assert_eq!(
-                bridge.resolve_base(&ctx).unwrap(),
-                canonical,
-                "form {form:?} should normalize to {canonical}",
-            );
-        }
-    }
-
-    /// DeepSeek without an explicit api_base must default to the DeepSeek
-    /// host, not the OpenAI host. Regression for a long-standing default
-    /// fallback bug exposed during the api_base tolerance work.
-    #[test]
-    fn deepseek_default_base_targets_deepseek_not_openai() {
-        let bridge = OpenAiBridge::new().with_name("deepseek");
-        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
-        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
-        assert_eq!(
-            bridge.resolve_base(&ctx).unwrap(),
-            "https://api.deepseek.com"
-        );
-    }
-
-    /// Gemini default must target the OpenAI-compatible `/v1beta/openai`
-    /// path rather than falling through to the OpenAI host.
-    #[test]
-    fn gemini_default_base_targets_gemini_v1beta_openai() {
-        let bridge = OpenAiBridge::new().with_name("google");
-        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
-        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
-        assert_eq!(
-            bridge.resolve_base(&ctx).unwrap(),
-            "https://generativelanguage.googleapis.com/v1beta/openai",
-        );
-    }
-
-    /// `with_name("cohere")` default must target Cohere's
-    /// OpenAI-compatible `/compatibility/v1` namespace rather than
-    /// falling through to OpenAI's host. The dashboard placeholder
-    /// (`https://api.cohere.com`) is the rerank path; for chat the
-    /// bridge synthesizes the right suffix (closes #332).
-    #[test]
-    fn cohere_default_base_targets_compatibility_v1() {
-        let bridge = OpenAiBridge::new().with_name("cohere");
-        let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
-        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
-        assert_eq!(
-            bridge.resolve_base(&ctx).unwrap(),
-            "https://api.cohere.com/compatibility/v1",
-        );
-    }
-
-    /// Operators copy-paste the bare canonical Cohere host
-    /// (`https://api.cohere.com`) from rerank docs / the dashboard
-    /// placeholder. For chat the bridge synthesizes
-    /// `/compatibility/v1` so a misconfigured-but-recoverable
-    /// `api_base` still routes to Cohere's chat-compat endpoint.
-    /// Non-canonical hosts (corporate proxies) pass through verbatim
-    /// — operator-intent on a custom host wins.
-    #[test]
-    fn cohere_api_base_tolerance_bare_host_synthesizes_compatibility_prefix() {
-        let bridge = OpenAiBridge::new().with_name("cohere");
-        let canonical = "https://api.cohere.com/compatibility/v1";
-
-        for form in [
-            "https://api.cohere.com",
-            "https://api.cohere.com/",
-            "https://api.cohere.com/compatibility/v1",
-            "https://api.cohere.com/compatibility/v1/",
-            "https://api.cohere.com/compatibility/v1/chat/completions",
-        ] {
-            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(form)));
-            assert_eq!(
-                bridge.resolve_base(&ctx).unwrap(),
-                canonical,
-                "form {form:?} should normalize to {canonical}",
-            );
-        }
-
-        // Non-canonical host passes through after suffix stripping.
-        let custom = "https://proxy.acme.internal/cohere-chat";
-        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(custom)));
-        assert_eq!(
-            bridge.resolve_base(&ctx).unwrap(),
-            custom,
-            "non-canonical host must NOT be rewritten",
-        );
-    }
-
-    /// End-to-end chat flow through the `cohere`-named bridge:
-    /// outbound URL matches the chat-compat namespace and the
-    /// OpenAI envelope round-trips without translation. Pins the
-    /// contract Hub.register relies on.
-    #[tokio::test]
-    async fn cohere_chat_compat_round_trips_openai_envelope() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .and(header("authorization", "Bearer cohere-key"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "id": "cmpl-cohere",
-                "model": "command-r",
-                "choices": [{
-                    "index": 0,
-                    "message": {"role": "assistant", "content": "hello from cohere"},
-                    "finish_reason": "stop"
-                }],
-                "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}
-            })))
-            .mount(&server)
-            .await;
-
-        let bridge = OpenAiBridge::new().with_name("cohere");
-        let pk_json = format!(
-            r#"{{"display_name":"cohere-prod","secret":"cohere-key","api_base":"{}"}}"#,
-            server.uri()
-        );
-        let pk: Arc<ProviderKey> = Arc::new(serde_json::from_str(&pk_json).unwrap());
-        let ctx = BridgeContext::new("rid", sample_model(), pk);
-        let resp = bridge.chat(&req(), &ctx).await.unwrap();
-
-        assert_eq!(resp.id, "cmpl-cohere");
-        assert_eq!(resp.message.role, Role::Assistant);
-        assert_eq!(resp.message.content, "hello from cohere");
-        assert_eq!(resp.usage.total_tokens, 7);
-    }
-
-    /// Each long-tail OpenAI-adapter provider's `with_name(...)` variant
-    /// (#60 P2-A) must fall back to the vendor-specific default base
-    /// when the operator left `api_base` empty on the PK. A regression
-    /// that lost the arm for any single variant would silently route
-    /// that provider's chat traffic to OpenAI's API host —
-    /// catastrophically leaking the customer's tokens AND the
-    /// upstream's vendor identity.
-    #[test]
-    fn long_tail_with_name_variants_default_base_targets_vendor_endpoint() {
-        let expected = [
-            ("groq", "https://api.groq.com/openai/v1"),
-            ("mistral", "https://api.mistral.ai/v1"),
-            ("togetherai", "https://api.together.ai/v1"),
-            ("fireworks-ai", "https://api.fireworks.ai/inference/v1"),
-            ("perplexity", "https://api.perplexity.ai"),
-            ("moonshotai", "https://api.moonshot.cn/v1"),
-            (
-                "alibaba",
-                "https://dashscope.aliyuncs.com/compatible-mode/v1",
-            ),
-            ("zhipuai", "https://open.bigmodel.cn/api/paas/v4"),
-            ("baseten", "https://inference.baseten.co/v1"),
-            ("huggingface", "https://router.huggingface.co/v1"),
-            ("cerebras", "https://api.cerebras.ai/v1"),
-        ];
-        for (name, expected_base) in expected {
-            let bridge = OpenAiBridge::new().with_name(name);
-            let pk: ProviderKey =
-                serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
-            let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk));
-            assert_eq!(
-                bridge.resolve_base(&ctx).unwrap(),
-                expected_base,
-                "with_name(\"{name}\") must fall back to {expected_base} when api_base is unset; \
-                 a missing arm silently routes the provider to OpenAI's API host"
-            );
-        }
-    }
-
-    /// Operator-supplied `api_base` always wins. The long-tail
-    /// providers don't get the canonical-host synthesis tolerance
-    /// that openai / deepseek / cohere have, because their URL
-    /// conventions vary (some have `/v1`, some `/openai/v1`, some
-    /// `/inference/v1`, some `/api/paas/v4`) — the bridge can't
-    /// guess. Operators paste the documented URL on the dashboard.
-    /// This test pins that override semantic.
-    #[test]
-    fn long_tail_with_name_variants_respect_operator_api_base() {
-        let bridge = OpenAiBridge::new().with_name("groq");
-        let custom = "https://corporate-proxy.acme.internal/groq";
-        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(custom)));
-        assert_eq!(
-            bridge.resolve_base(&ctx).unwrap(),
-            custom,
-            "operator-supplied api_base must pass through for long-tail providers"
-        );
-    }
-
-    /// For Gemini and any future `with_name` variant, the bridge does not
-    /// synthesize a `/v1beta/openai` prefix — the path is non-trivial. It
-    /// still strips an accidentally-pasted endpoint suffix.
-    #[test]
-    fn gemini_api_base_strips_endpoint_suffix_but_does_not_synthesize_prefix() {
-        let bridge = OpenAiBridge::new().with_name("google");
-
-        // Canonical form passes through.
-        let canonical = "https://generativelanguage.googleapis.com/v1beta/openai";
-        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(canonical)));
-        assert_eq!(bridge.resolve_base(&ctx).unwrap(), canonical);
-
-        // Endpoint suffix is stripped.
+        // Endpoint suffix is stripped on any host.
         let with_suffix =
             "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+        let canonical = "https://generativelanguage.googleapis.com/v1beta/openai";
         let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(with_suffix)));
         assert_eq!(bridge.resolve_base(&ctx).unwrap(), canonical);
 
-        // Bare host is left as-is — the operator's responsibility to
-        // include the unusual prefix. (See provider-keys.md for the
-        // per-provider truth table.)
-        let bare = "https://generativelanguage.googleapis.com";
-        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(bare)));
-        assert_eq!(bridge.resolve_base(&ctx).unwrap(), bare);
+        // Corporate proxy: pass-through.
+        let custom = "https://corporate-proxy.acme.internal/groq";
+        let ctx = BridgeContext::new("rid", sample_model(), Arc::new(pk_with_base(custom)));
+        assert_eq!(bridge.resolve_base(&ctx).unwrap(), custom);
     }
 
     // ----------- issue #302 §5 wire-in: RequestOverrides -----------
@@ -1970,37 +1615,17 @@ data: [DONE]\n";
         bridge.chat(&req(), &ctx).await.unwrap();
     }
 
-    /// `OpenAiBridge::new().with_name("perplexity")` sends
-    /// `x-aisix-bridge: perplexity`. Catches a Hub.register typo like
-    /// `OpenAiBridge::new().with_name("groq")` registered under
-    /// `Provider::Perplexity` — the wrong header value would cause the
-    /// wiremock matcher to fall through to a 404 in an e2e test.
+    /// Streaming path also sets `x-aisix-bridge: openai` on the
+    /// outbound SSE request.
     #[tokio::test]
-    async fn chat_emits_x_aisix_bridge_for_with_name_variant() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .and(header("x-aisix-bridge", "perplexity"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(ok_chat_response()))
-            .mount(&server)
-            .await;
-
-        let bridge = OpenAiBridge::new().with_name("perplexity");
-        let ctx = sample_ctx(&server.uri());
-        bridge.chat(&req(), &ctx).await.unwrap();
-    }
-
-    /// Same contract for the streaming path: `chat_stream` also sets
-    /// `x-aisix-bridge` on the outbound SSE request.
-    #[tokio::test]
-    async fn chat_stream_emits_x_aisix_bridge_for_with_name_variant() {
+    async fn chat_stream_emits_x_aisix_bridge_openai() {
         use futures::StreamExt;
 
         let server = MockServer::start().await;
         let sse = "data: {\"id\":\"cmpl-s\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n";
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
-            .and(header("x-aisix-bridge", "groq"))
+            .and(header("x-aisix-bridge", "openai"))
             .respond_with(
                 ResponseTemplate::new(200)
                     .insert_header("content-type", "text/event-stream")
@@ -2009,7 +1634,7 @@ data: [DONE]\n";
             .mount(&server)
             .await;
 
-        let bridge = OpenAiBridge::new().with_name("groq");
+        let bridge = OpenAiBridge::new();
         let ctx = sample_ctx(&server.uri());
         let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
         // Drain the stream to completion — the mock match already verified

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -113,12 +113,25 @@ impl OpenAiBridge {
                 let pk_vendor_raw = ctx.provider_key.provider.as_str();
                 let pk_vendor_normalized = pk_vendor_raw.trim().to_ascii_lowercase();
                 if !pk_vendor_normalized.is_empty() && pk_vendor_normalized != "openai" {
+                    // Operator-facing detail (route, provider topology,
+                    // remediation steps) goes to logs only — keep the
+                    // customer-visible 500 body short and free of
+                    // internal-product taxonomy (cp-api / adapter_map /
+                    // provider_metadata field names are not part of any
+                    // wire contract a customer should depend on).
+                    tracing::error!(
+                        target: "aisix_provider_openai::bridge",
+                        pk_display_name = %ctx.provider_key.display_name,
+                        pk_vendor = %pk_vendor_raw,
+                        "provider_key has no api_base; family bridge refusing fallback to \
+                         api.openai.com. Operator action: populate `api_base` on the \
+                         ProviderKey resource (managed deployments: via adapter_map / \
+                         provider_metadata.api_base_url on the control plane; standalone: \
+                         directly on the resource)."
+                    );
                     return Err(BridgeError::Config(format!(
-                        "provider_key for vendor {pk_vendor_raw:?} has no api_base set; \
-                         the OpenAI bridge refuses to fall back to api.openai.com to avoid \
-                         routing {pk_vendor_raw:?}'s API key to OpenAI. cp-api must populate \
-                         api_base for every catalog vendor via adapter_map / \
-                         provider_metadata.api_base_url."
+                        "provider_key for vendor {pk_vendor_raw:?} has no upstream base URL \
+                         configured"
                     )));
                 }
                 return Ok(OPENAI_DEFAULT_BASE.to_string());
@@ -153,14 +166,15 @@ fn strip_known_endpoint(base: &str) -> &str {
     trimmed
 }
 
-/// Provider-aware `api_base` normalization for the OpenAI-compatible
-/// bridge.
+/// `api_base` normalization for the OpenAI-compatible family bridge.
 ///
-/// Normalization is intentionally **conservative**: it only adjusts
-/// `/v1` segments for the canonical upstream host of each provider.
-/// Corporate proxies, alternative deployments, and test mocks pass
-/// through verbatim after suffix stripping — the operator's path on
-/// a non-canonical host is trusted as-is.
+/// Normalization is intentionally **conservative**: it only
+/// synthesizes the `/v1` segment when the operator pasted the bare
+/// canonical `https://api.openai.com` host (a common copy-paste
+/// habit). Corporate proxies, alternative deployments, and every
+/// non-OpenAI vendor's upstream host pass through verbatim after
+/// suffix stripping — the operator's path on a non-canonical host
+/// is trusted as-is.
 ///
 /// See [`OpenAiBridge::resolve_base`] for accepted forms.
 fn normalize_api_base(base: &str) -> String {
@@ -1085,9 +1099,19 @@ data: [DONE]\n\n";
             match err {
                 BridgeError::Config(msg) => {
                     assert!(
-                        msg.contains("api_base") && msg.contains(vendor.trim()),
-                        "vendor {vendor:?}: error must name vendor + api_base; got: {msg}",
+                        msg.contains("base URL") && msg.contains(vendor.trim()),
+                        "vendor {vendor:?}: error must name vendor + base URL; got: {msg}",
                     );
+                    // Sensitive-info-leakage guard: internal product
+                    // taxonomy must not leak into the customer-visible
+                    // 500 body. Those identifiers go to tracing only.
+                    for forbidden in ["cp-api", "adapter_map", "provider_metadata"] {
+                        assert!(
+                            !msg.contains(forbidden),
+                            "vendor {vendor:?}: error body must not leak \
+                             internal-product taxonomy {forbidden:?}; got: {msg}",
+                        );
+                    }
                 }
                 other => panic!("vendor {vendor:?}: expected BridgeError::Config, got {other:?}"),
             }

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -191,9 +191,10 @@ pub(crate) fn resolve_base_url(provider_key: &ProviderKey) -> Result<String, Pro
 /// Build a `/v1`-prefixed upstream URL while tolerating either
 /// convention for the configured `api_base`:
 ///
-/// * `https://api.openai.com` builds `…/v1/<path>` — the provider
-///   default convention used by `Provider::Openai.default_base_url()`
-///   and `aisix-proxy`'s pre-existing handlers.
+/// * `https://api.openai.com` builds `…/v1/<path>` — the bare-host
+///   convention `OpenAiBridge::resolve_base` synthesizes when the
+///   operator leaves the trailing `/v1` off (the same form
+///   `aisix-proxy`'s pre-existing handlers use directly).
 /// * `https://api.openai.com/v1` also builds `…/v1/<path>` — the
 ///   OpenAI SDK convention every published example uses, and the
 ///   exact placeholder the dashboard's provider-keys form pre-fills.
@@ -488,8 +489,8 @@ mod tests {
 
     #[test]
     fn build_v1_url_appends_v1_when_base_lacks_it() {
-        // Provider-default convention (Provider::Openai.default_base_url()
-        // returns `https://api.openai.com`, no /v1).
+        // Bare-host convention: the operator pasted
+        // `https://api.openai.com` without the trailing `/v1`.
         assert_eq!(
             build_v1_url("https://api.openai.com", "/responses"),
             "https://api.openai.com/v1/responses",

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -3850,14 +3850,15 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         assert!(body.contains("data: [DONE]"));
     }
 
-    /// (OpenAI inbound) × (Gemini upstream). Gemini's bridge is a
-    /// thin wrapper around the OpenAi-compat `/chat/completions`
-    /// endpoint, so the upstream wire is OpenAI-shape — but the
-    /// `Hub.get(Provider::Google)` lookup must still resolve to the
-    /// Gemini-specific bridge instance (different metrics label,
-    /// different default base URL behavior).
+    /// (OpenAI inbound) × (Gemini upstream). Gemini is served by the
+    /// `Adapter::Openai` family bridge — cp-api stores the Gemini PK
+    /// with `adapter: "openai"` and `api_base` pointing at Google's
+    /// `/v1beta/openai` compat endpoint. The integration test pins
+    /// that an inbound OpenAI request resolves through the family
+    /// bridge and round-trips Gemini's OpenAI-shape response.
     #[tokio::test]
     async fn matrix_openai_in_gemini_upstream_non_streaming() {
+        use aisix_core::Adapter;
         use aisix_provider_openai::OpenAiBridge;
 
         let upstream = MockServer::start().await;
@@ -3882,7 +3883,7 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-gemini"]));
         let hub = Arc::new(Hub::new());
-        hub.register_specialized("google", Arc::new(OpenAiBridge::new().with_name("google")));
+        hub.register_family(Adapter::Openai, Arc::new(OpenAiBridge::new()));
         let app = build_router(build_state(snap, hub));
 
         let body = serde_json::json!({
@@ -3904,12 +3905,15 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         assert_eq!(v["usage"]["total_tokens"], 9);
     }
 
-    /// (OpenAI inbound) × (DeepSeek upstream). Mirrors the Gemini
-    /// case: DeepSeek's bridge is OpenAi-compat with Bearer auth +
-    /// a different `name()` for metrics. The integration test pins
-    /// that `Provider::Deepseek` resolves correctly.
+    /// (OpenAI inbound) × (DeepSeek upstream). DeepSeek is served by
+    /// the `Adapter::Openai` family bridge — cp-api stores the
+    /// DeepSeek PK with `adapter: "openai"` and `api_base` pointing
+    /// at `https://api.deepseek.com`. The integration test pins
+    /// that an inbound OpenAI request resolves through the family
+    /// bridge and round-trips DeepSeek's OpenAI-shape response.
     #[tokio::test]
     async fn matrix_openai_in_deepseek_upstream_non_streaming() {
+        use aisix_core::Adapter;
         use aisix_provider_openai::OpenAiBridge;
 
         let upstream = MockServer::start().await;
@@ -3936,10 +3940,7 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         snap.apikeys
             .insert(apikey_entry("sk-caller", &["my-deepseek"]));
         let hub = Arc::new(Hub::new());
-        hub.register_specialized(
-            "deepseek",
-            Arc::new(OpenAiBridge::new().with_name("deepseek")),
-        );
+        hub.register_family(Adapter::Openai, Arc::new(OpenAiBridge::new()));
         let app = build_router(build_state(snap, hub));
 
         let body = serde_json::json!({

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1926,8 +1926,11 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
-        hub.register_specialized("google", Arc::new(OpenAiBridge::new().with_name("google")));
+        hub.register_family(
+            aisix_core::Adapter::Anthropic,
+            Arc::new(AnthropicBridge::new()),
+        );
+        hub.register_family(aisix_core::Adapter::Openai, Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
 
@@ -1974,11 +1977,11 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
-        hub.register_specialized(
-            "deepseek",
-            Arc::new(OpenAiBridge::new().with_name("deepseek")),
+        hub.register_family(
+            aisix_core::Adapter::Anthropic,
+            Arc::new(AnthropicBridge::new()),
         );
+        hub.register_family(aisix_core::Adapter::Openai, Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
 
@@ -2043,10 +2046,11 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
     /// Helper for the streaming variants of (Anthropic inbound) ×
     /// (Gemini | DeepSeek upstream). Both upstreams expose the
     /// OpenAi-compat `/chat/completions` endpoint with OpenAi-shape
-    /// SSE deltas, so the assertion shape is identical.
+    /// SSE deltas, so the assertion shape is identical. The PK is
+    /// stamped with `adapter: "openai"` so the family bridge handles
+    /// dispatch.
     async fn assert_anthropic_streams_through_openai_compat_upstream(
         bridge_provider: &str,
-        bridge: Arc<dyn aisix_gateway::Bridge>,
         model_entry: ResourceEntry<Model>,
         model_name: &str,
     ) {
@@ -2089,8 +2093,14 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());
-        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
-        hub.register_specialized(bridge_provider, bridge);
+        hub.register_family(
+            aisix_core::Adapter::Anthropic,
+            Arc::new(AnthropicBridge::new()),
+        );
+        hub.register_family(
+            aisix_core::Adapter::Openai,
+            Arc::new(aisix_provider_openai::OpenAiBridge::new()),
+        );
         let handle = SnapshotHandle::new(snap);
         let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
 
@@ -2123,10 +2133,8 @@ data: [DONE]\n\n";
 
     #[tokio::test]
     async fn matrix_anthropic_in_gemini_upstream_streaming() {
-        use aisix_provider_openai::OpenAiBridge;
         assert_anthropic_streams_through_openai_compat_upstream(
             "google",
-            Arc::new(OpenAiBridge::new().with_name("google")),
             // Placeholder; helper rebuilds with the wiremock uri.
             gemini_model("my-claude-via-gemini"),
             "my-claude-via-gemini",
@@ -2136,10 +2144,8 @@ data: [DONE]\n\n";
 
     #[tokio::test]
     async fn matrix_anthropic_in_deepseek_upstream_streaming() {
-        use aisix_provider_openai::OpenAiBridge;
         assert_anthropic_streams_through_openai_compat_upstream(
             "deepseek",
-            Arc::new(OpenAiBridge::new().with_name("deepseek")),
             deepseek_model("my-claude-via-ds"),
             "my-claude-via-ds",
         )

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -110,15 +110,16 @@ async fn dispatch(
 
     let model = &model_entry.value;
 
-    // Provider routing key, derived from `model.provider` as a
+    // Provider routing key, derived from `Model.provider` as a
     // lowercase string. Per #302 Phase A this dispatch path
     // identifies Cohere/Jina by their models.dev catalog id rather
     // than by a closed enum variant — the `Provider` enum was
-    // collapsed into the open `ProviderKey.provider` string and
-    // closed 5-value `Adapter` set, and rerank's vendor-specific
-    // wire shape (Cohere/Jina each have a native rerank surface)
-    // doesn't fit either of those, so it stays keyed on the
-    // catalog string. The string values ("openai", "cohere",
+    // collapsed into the open `ProviderKey.provider` string + the
+    // closed 5-value `Adapter` set used by `Hub::dispatch_two_tier`,
+    // but rerank's vendor-specific wire shape (Cohere/Jina each
+    // have a native rerank surface that bypasses the Bridge trait)
+    // doesn't fit either of those, so this path stays keyed on
+    // `Model.provider`. The string values ("openai", "cohere",
     // "jina") are the same labels emitted in metrics/access logs
     // today, so dashboards keep working unchanged.
     let provider_label = model
@@ -252,14 +253,16 @@ async fn dispatch(
 }
 
 /// Default upstream host for the rerank-supporting providers,
-/// keyed by the lowercase provider string. Per #302 Phase A this
-/// is a string-keyed match: the `Provider` enum has been replaced
-/// with the open `ProviderKey.provider` string, and rerank's
-/// vendor-specific wire shapes (Cohere and Jina each have a
-/// native rerank surface) don't fit the closed 5-value `Adapter`
-/// set the family bridges use. The `{"openai", "cohere", "jina"}`
-/// set mirrors the rerank gate in `dispatch`; any other string
-/// returns `None` and the caller falls back to OpenAI's host.
+/// keyed by the lowercase `Model.provider` string. Per #302 Phase A
+/// this is a string-keyed match: the `Provider` enum has been
+/// replaced by `ProviderKey.adapter` (closed 5-value enum) +
+/// `ProviderKey.provider` (open string) for dispatch via
+/// `Hub::dispatch_two_tier`, but rerank's vendor-specific wire
+/// shapes (Cohere and Jina each have a native rerank surface) don't
+/// fit either of those, so this helper stays keyed on
+/// `Model.provider`. The `{"openai", "cohere", "jina"}` set mirrors
+/// the rerank gate in `dispatch`; any other string returns `None`
+/// and the caller falls back to OpenAI's host.
 fn default_base_for_provider(provider: &str) -> Option<String> {
     match provider {
         "openai" => Some("https://api.openai.com".to_string()),

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -112,14 +112,15 @@ async fn dispatch(
 
     // Provider routing key, derived from `model.provider` as a
     // lowercase string. Per #302 Phase A this dispatch path
-    // identifies Cohere/Jina by string rather than by `Provider`
-    // enum variant so that, when the `Provider` enum is later
-    // collapsed into the closed `Adapter` set, this file does not
-    // depend on variants (`Provider::Cohere`, `Provider::Jina`)
-    // that are slated for removal. The string values
-    // ("openai", "cohere", "jina") are the same labels emitted in
-    // metrics/access logs today, so dashboards keep working
-    // unchanged.
+    // identifies Cohere/Jina by their models.dev catalog id rather
+    // than by a closed enum variant — the `Provider` enum was
+    // collapsed into the open `ProviderKey.provider` string and
+    // closed 5-value `Adapter` set, and rerank's vendor-specific
+    // wire shape (Cohere/Jina each have a native rerank surface)
+    // doesn't fit either of those, so it stays keyed on the
+    // catalog string. The string values ("openai", "cohere",
+    // "jina") are the same labels emitted in metrics/access logs
+    // today, so dashboards keep working unchanged.
     let provider_label = model
         .provider
         .clone()
@@ -252,12 +253,13 @@ async fn dispatch(
 
 /// Default upstream host for the rerank-supporting providers,
 /// keyed by the lowercase provider string. Per #302 Phase A this
-/// is intentionally a string-keyed match (not a `Provider` enum
-/// match) so the file does not depend on `Provider::Cohere` /
-/// `Provider::Jina` variants that are slated for removal. The
-/// `{"openai", "cohere", "jina"}` set mirrors the rerank gate in
-/// `dispatch`; any other string returns `None` and the caller
-/// falls back to OpenAI's host.
+/// is a string-keyed match: the `Provider` enum has been replaced
+/// with the open `ProviderKey.provider` string, and rerank's
+/// vendor-specific wire shapes (Cohere and Jina each have a
+/// native rerank surface) don't fit the closed 5-value `Adapter`
+/// set the family bridges use. The `{"openai", "cohere", "jina"}`
+/// set mirrors the rerank gate in `dispatch`; any other string
+/// returns `None` and the caller falls back to OpenAI's host.
 fn default_base_for_provider(provider: &str) -> Option<String> {
     match provider {
         "openai" => Some("https://api.openai.com".to_string()),

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -766,20 +766,16 @@ fn load_heartbeat_config_from_disk(
 /// Hub. The Hub is created once at startup; future dynamic reload
 /// lands behind the same `register()` call.
 ///
-/// `Provider::Jina` is intentionally NOT registered: per #213 Phase 2
-/// Jina is exposed only via `/v1/rerank`, which is a verbatim HTTP
-/// forward (`aisix-proxy::rerank`) and bypasses the Bridge trait
-/// entirely.
+/// Jina is intentionally NOT registered: per #213 Phase 2 Jina is
+/// exposed only via `/v1/rerank`, which is a verbatim HTTP forward
+/// (`aisix-proxy::rerank`) and bypasses the Bridge trait entirely.
 ///
-/// `Provider::Cohere` is registered against the OpenAI-compatible
-/// chat endpoint at `https://api.cohere.com/compatibility/v1` (per
-/// <https://docs.cohere.com/reference/chat>). Cohere's rerank surface
-/// at `/v1/rerank` continues to bypass the Bridge via
-/// `aisix-proxy::rerank` — the bridge here only serves `chat/completions`,
-/// `embeddings`, and the other OpenAI-shape endpoints the bridge
-/// supports. The chat-compat namespace gives an exact OpenAI envelope
-/// shape so `OpenAiBridge::with_name("cohere")` can serve it directly
-/// (closes #332).
+/// Cohere chat is served by the `Adapter::Openai` family bridge —
+/// cp-api stores Cohere's PK with `adapter: "openai"` and `api_base`
+/// pointing at `https://api.cohere.com/compatibility/v1` (per
+/// <https://docs.cohere.com/reference/chat>). Cohere's `/v1/rerank`
+/// native surface is keyed off `ProviderKey.provider == "cohere"` in
+/// `crates/aisix-proxy/src/rerank.rs` and bypasses the Bridge.
 fn build_hub() -> Hub {
     let hub = Hub::new();
 
@@ -800,44 +796,22 @@ fn build_hub() -> Hub {
     hub.register_family(Adapter::AzureOpenai, Arc::new(AzureOpenAiBridge::new()));
     hub.register_family(Adapter::Bedrock, Arc::new(BedrockBridge::new()));
 
-    // ─── Specialized vendor bridges (open string, vendor identity) ───
+    // ─── Specialized vendor bridges (one-cycle compat shim) ──────────
     //
-    // Override the family default for vendors whose handling diverges
-    // from the wire-shape baseline. Each vendor is keyed on its
-    // models.dev catalog id, matching `ProviderKey.provider`.
+    // Pre-Phase-A ProviderKeys on disk may carry `provider` but no
+    // `adapter` field (cp-api started writing `adapter` at the same
+    // commit as Phase A — older rows haven't been resaved). Without
+    // these explicit specialized registrations, `dispatch_two_tier`
+    // would fall through to the None branch and 503 those PKs.
     //
-    // - `google`: OpenAI-compat Gemini at `/v1beta/openai` (matches
-    //   `OpenAiBridge::default` but tagged for metrics + log labels).
-    // - `deepseek`: OpenAI-compat with `delta.reasoning_content` lift
-    //   for the R1 family (the `with_name` value drives the metric
-    //   label so dashboards can slice DeepSeek-specific reasoning
-    //   traffic).
-    // - `cohere`: chat-compat namespace at `/compatibility/v1`. cp-api
-    //   stores Cohere's PK with `adapter: "openai"` and the bridge
-    //   here handles the chat path; the `/v1/rerank` native path is
-    //   keyed off `ProviderKey.provider == "cohere"` in
-    //   `crates/aisix-proxy/src/rerank.rs`.
-    //
-    // Every other catalog vendor (groq, mistral, xai, openrouter,
-    // fireworks-ai, perplexity, moonshotai, alibaba, zhipuai,
-    // baseten, huggingface, cerebras, togetherai, plus the long
-    // tail) falls through to `Adapter::Openai` family above. The DP
-    // does NOT enumerate them. cp-api populates `api_base` from
-    // adapter_map's `default_base_url` or `provider_metadata.api_base_url`.
-    // First-class vendors with their canonical metric labels. `openai`
-    // / `anthropic` shadow the family bridge — same bridge instance,
-    // explicit registration here keeps test fixtures and pre-Phase-A
-    // payloads (which carry `provider` but may not yet carry
-    // `adapter`) routing correctly without falling through to the
-    // None branch in `dispatch_two_tier`.
+    // Only `openai` and `anthropic` are registered — every other
+    // vendor only existed in the catalog post-Phase-A (Phase A added
+    // them as long-tail OpenAI-compat) and is guaranteed to have
+    // `adapter` populated, so the family bridge above already covers
+    // them. Once cp-api has resaved all pre-Phase-A rows these two
+    // entries become safe to delete.
     hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
     hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
-    hub.register_specialized("google", Arc::new(OpenAiBridge::new().with_name("google")));
-    hub.register_specialized(
-        "deepseek",
-        Arc::new(OpenAiBridge::new().with_name("deepseek")),
-    );
-    hub.register_specialized("cohere", Arc::new(OpenAiBridge::new().with_name("cohere")));
 
     hub
 }
@@ -1102,24 +1076,20 @@ mod tests {
         assert!(err.to_string().contains("cp_base_url"), "unexpected: {err}");
     }
 
-    /// `build_hub()` must register `Provider::Cohere` against the
-    /// `with_name("cohere")` variant of [`OpenAiBridge`] — the only
-    /// thing that ties the Provider enum to the chat-compat URL
-    /// `build_hub()` must register `cohere` as a specialized bridge
-    /// against `OpenAiBridge::with_name("cohere")` so chat-compat
-    /// traffic carries the right metric label and resolves through
-    /// the chat-compat namespace (closes #332).
+    /// `build_hub()` must NOT register `cohere` as a specialized chat
+    /// bridge. Post-#302 Phase A, Cohere's chat surface is served by
+    /// the `Adapter::Openai` family bridge: cp-api stores Cohere's PK
+    /// with `adapter: "openai"` and `api_base: "https://api.cohere.com/compatibility/v1"`
+    /// (per <https://docs.cohere.com/reference/chat>). A specialized
+    /// chat bridge here would re-introduce the vendor-enumeration
+    /// pattern the clean cut deleted.
     #[test]
-    fn build_hub_registers_cohere_chat_compat_variant() {
+    fn build_hub_does_not_register_cohere_as_specialized_chat_bridge() {
         let hub = build_hub();
-        let bridge = hub
-            .get_specialized("cohere")
-            .expect("cohere must have a specialized bridge for chat-compat");
-        assert_eq!(
-            bridge.name(),
-            "cohere",
-            "specialized cohere bridge MUST be `OpenAiBridge::with_name(\"cohere\")` so \
-             the metric label is `cohere` and dashboards keep working",
+        assert!(
+            hub.get_specialized("cohere").is_none(),
+            "cohere chat must fall through to `Adapter::Openai` family — \
+             a specialized chat registration re-introduces the deleted vendor-enumeration pattern",
         );
     }
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -774,7 +774,7 @@ fn load_heartbeat_config_from_disk(
 /// cp-api stores Cohere's PK with `adapter: "openai"` and `api_base`
 /// pointing at `https://api.cohere.com/compatibility/v1` (per
 /// <https://docs.cohere.com/reference/chat>). Cohere's `/v1/rerank`
-/// native surface is keyed off `ProviderKey.provider == "cohere"` in
+/// native surface is keyed off `Model.provider == "cohere"` in
 /// `crates/aisix-proxy/src/rerank.rs` and bypasses the Bridge.
 fn build_hub() -> Hub {
     let hub = Hub::new();
@@ -1170,6 +1170,49 @@ mod tests {
             bridge.name(),
             "anthropic",
             "family Anthropic bridge MUST be the bare `AnthropicBridge::new()`",
+        );
+    }
+
+    /// `build_hub()` MUST keep `register_specialized("openai", …)` so
+    /// `crates/aisix-proxy/src/dispatch.rs::resolve_bridge`'s
+    /// compat-shim fallback (`hub.get_specialized(Model.provider)`)
+    /// resolves a pre-Phase-A PK row (empty `provider`, no `adapter`).
+    /// A future PR that drops this registration prematurely — before
+    /// cp-api has re-saved every legacy PK — would silently 503 those
+    /// rows. This test pins the shim contract end-to-end against the
+    /// real `build_hub()` registry (not a stub Hub), so it fails the
+    /// moment the registration disappears.
+    #[test]
+    fn build_hub_compat_shim_resolves_pre_phase_a_openai_pk() {
+        let hub = build_hub();
+        let bridge = hub
+            .get_specialized("openai")
+            .expect("openai compat shim must dispatch pre-Phase-A PK rows");
+        assert_eq!(
+            bridge.name(),
+            "openai",
+            "specialized 'openai' compat shim MUST be `OpenAiBridge::new()` \
+             (returning bridge name 'openai') so pre-Phase-A PK rows with \
+             empty `provider` + no `adapter` resolve via \
+             `dispatch::resolve_bridge`'s `hub.get_specialized(Model.provider)` \
+             fallback",
+        );
+    }
+
+    /// Parallel of the openai compat-shim test, for the Anthropic side.
+    #[test]
+    fn build_hub_compat_shim_resolves_pre_phase_a_anthropic_pk() {
+        let hub = build_hub();
+        let bridge = hub
+            .get_specialized("anthropic")
+            .expect("anthropic compat shim must dispatch pre-Phase-A PK rows");
+        assert_eq!(
+            bridge.name(),
+            "anthropic",
+            "specialized 'anthropic' compat shim MUST be `AnthropicBridge::new()` \
+             so pre-Phase-A PK rows with empty `provider` + no `adapter` resolve \
+             via `dispatch::resolve_bridge`'s `hub.get_specialized(Model.provider)` \
+             fallback",
         );
     }
 }

--- a/schemas/resources/provider_key.schema.json
+++ b/schemas/resources/provider_key.schema.json
@@ -19,7 +19,7 @@
       ]
     },
     "api_base": {
-      "description": "Override for the upstream base URL. Empty/None means the provider default applies (see `Provider::default_base_url`).",
+      "description": "Override for the upstream base URL. Empty/None is rejected by the family bridges for any vendor whose identity isn't `\"openai\"` — see `OpenAiBridge::resolve_base` for the safety guard that prevents a missing api_base from silently routing non-OpenAI traffic to `api.openai.com`. cp-api populates this from `adapter_map.yaml`'s `default_base_url` / `provider_metadata.api_base_url`.",
       "type": [
         "string",
         "null"
@@ -75,7 +75,7 @@
   "additionalProperties": false,
   "definitions": {
     "Adapter": {
-      "description": "Wire-shape adapter used to talk to an upstream. This is the closed set of upstream protocols the gateway knows how to encode against — distinct from a vendor identity (which is captured separately on `ProviderKey`).\n\nIntroduced as a skeleton for issue #302 Phase A. This type is purely additive in this PR: nothing in the gateway dispatches off `Adapter` yet, no entity field is changed, and `Provider` continues to drive all runtime behavior. Follow-up PRs in Phase A migrate entities and the Hub to consume `Adapter` directly.\n\nNote on serde casing: `Adapter` uses `kebab-case` so the `AzureOpenai` variant serializes as `\"azure-openai\"`. This intentionally differs from `Provider`'s `lowercase` casing, which produced no hyphens because all current `Provider` names are single tokens.",
+      "description": "Wire-shape adapter used to talk to an upstream. This is the closed set of upstream protocols the gateway knows how to encode against — distinct from a vendor identity (which is captured separately on `ProviderKey.provider` as an open string).\n\nPost-#302 Phase A clean cut, dispatch is two-tier: the Hub looks up a specialized bridge by the open `ProviderKey.provider` string first, then falls back to the closed `Adapter` family bridge. Any new long-tail OpenAI-compat vendor cp-api admits (xai, openrouter, cerebras, …) routes through the `Adapter::Openai` family bridge without a DP code change.\n\nNote on serde casing: `Adapter` uses `kebab-case` so the `AzureOpenai` variant serializes as `\"azure-openai\"`.",
       "type": "string",
       "enum": [
         "openai",

--- a/schemas/resources/provider_key.schema.json
+++ b/schemas/resources/provider_key.schema.json
@@ -19,7 +19,7 @@
       ]
     },
     "api_base": {
-      "description": "Override for the upstream base URL. Empty/None is rejected by the family bridges for any vendor whose identity isn't `\"openai\"` — see `OpenAiBridge::resolve_base` for the safety guard that prevents a missing api_base from silently routing non-OpenAI traffic to `api.openai.com`. cp-api populates this from `adapter_map.yaml`'s `default_base_url` / `provider_metadata.api_base_url`.",
+      "description": "Override for the upstream base URL. Empty/None is rejected by every family bridge whose canonical-vendor identity doesn't match the PK's `provider`: the OpenAI-family bridge refuses to fall back to `api.openai.com` for a vendor other than `\"openai\"`, and the Anthropic-family bridge refuses to fall back to `api.anthropic.com` for a vendor other than `\"anthropic\"`. See `OpenAiBridge::resolve_base` / `AnthropicBridge::resolve_base` for the safety guards. cp-api populates this from `adapter_map.yaml`'s `default_base_url` / `provider_metadata.api_base_url`.",
       "type": [
         "string",
         "null"

--- a/tests/e2e/src/cases/cross-provider-matrix-e2e.test.ts
+++ b/tests/e2e/src/cases/cross-provider-matrix-e2e.test.ts
@@ -130,6 +130,15 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
         display_name: `${tc.displayPrefix}-pk-non-stream`,
         secret: "sk-mock",
         api_base: `${upstream.baseUrl}/v1`,
+        // Post-#302 Phase A: cp-api writes `provider` + `adapter` on
+        // every PK row. Without these the snapshot's
+        // `Hub::dispatch_two_tier` misses both tiers (empty `provider`
+        // string + None `adapter`) and the dispatch falls into the
+        // legacy `Model.provider` compat shim — which now only covers
+        // `openai` / `anthropic`, so `google` / `deepseek` 503. The
+        // matrix tests exercise the post-Phase-A admission contract.
+        provider: tc.provider,
+        adapter: "openai",
       });
       const modelName = `${tc.displayPrefix}-non-stream`;
       await admin.createModel({
@@ -223,6 +232,10 @@ describe("cross-provider matrix: OpenAI-compat upstreams", () => {
         display_name: `${tc.displayPrefix}-pk-stream`,
         secret: "sk-mock",
         api_base: `${upstream.baseUrl}/v1`,
+        // Same post-Phase-A admission-contract requirement as the
+        // non-streaming fixture above — see that comment.
+        provider: tc.provider,
+        adapter: "openai",
       });
       const modelName = `${tc.displayPrefix}-stream`;
       await admin.createModel({

--- a/tests/e2e/src/cases/error-envelope-normalization-e2e.test.ts
+++ b/tests/e2e/src/cases/error-envelope-normalization-e2e.test.ts
@@ -54,6 +54,12 @@ const CALLER_KEY_HASH = createHash("sha256")
 
 interface ProviderCase {
   readonly provider: "anthropic" | "google" | "deepseek";
+  // Post-#302 Phase A wire-shape adapter cp-api stamps on the PK
+  // alongside `provider`. `Hub::dispatch_two_tier` routes to the
+  // `Adapter::Anthropic` family bridge for `"anthropic"` and to
+  // `Adapter::Openai` for every OpenAI-compat vendor (google +
+  // deepseek here, plus any long-tail vendor cp-api admits later).
+  readonly adapter: "openai" | "anthropic";
   readonly upstreamModelId: string;
   readonly displayName: string;
   // The wire shape the upstream sends back on a 400. Each provider
@@ -76,6 +82,7 @@ interface ProviderCase {
 const CASES: ReadonlyArray<ProviderCase> = [
   {
     provider: "anthropic",
+    adapter: "anthropic",
     upstreamModelId: "claude-3-5-haiku-20241022",
     displayName: "err-norm-anthropic",
     // Anthropic native 400 per
@@ -94,6 +101,7 @@ const CASES: ReadonlyArray<ProviderCase> = [
   },
   {
     provider: "google",
+    adapter: "openai",
     upstreamModelId: "gemini-2.0-flash",
     displayName: "err-norm-google",
     // The google bridge talks to Google's OpenAI-compatibility
@@ -114,6 +122,7 @@ const CASES: ReadonlyArray<ProviderCase> = [
   },
   {
     provider: "deepseek",
+    adapter: "openai",
     upstreamModelId: "deepseek-chat",
     displayName: "err-norm-deepseek",
     // DeepSeek is OpenAI-compatible per
@@ -177,6 +186,13 @@ describe("error envelope normalization e2e: provider-native 4xx → OpenAI-shape
         display_name: `${tc.displayName}-pk`,
         secret: "sk-mock",
         api_base: `${upstream.baseUrl}${tc.apiBaseSuffix}`,
+        // Post-#302 Phase A: `Hub::dispatch_two_tier` needs the PK
+        // to carry both `provider` (vendor identity, open string)
+        // and `adapter` (closed 5-value enum) so the dispatch hits
+        // the right family bridge. cp-api writes these for every
+        // PK row in production; the test mirrors that contract.
+        provider: tc.provider,
+        adapter: tc.adapter,
       });
       await admin.createModel({
         display_name: tc.displayName,


### PR DESCRIPTION
## Context

Follow-up to #375. That PR shipped the round-3 "trim + add safety guards" state but stopped short of the full deletion the design called for. This PR finishes the clean cut.

The shipped #375 left these alive even though no dispatch path uses them after Phase A:

1. `Provider` enum (6 variants) + `as_str()` + re-exports through `aisix-core::{lib, models}`.
2. `OpenAiBridge::with_name()` + `name` field (and the parallel `AnthropicBridge::with_name` + `name` field, unused at every call site).
3. 14 per-vendor `*_DEFAULT_BASE` consts + `default_base()` method on `OpenAiBridge` with its match arms.
4. `normalize_canonical_deepseek` / `normalize_canonical_cohere` helpers + `DEEPSEEK_CANONICAL_HOSTS` / `COHERE_CANONICAL_HOSTS` consts.
5. `register_specialized("google" / "deepseek" / "cohere", …)` in `build_hub()`.

This PR deletes all of them. Vendor identity is now exclusively the open `ProviderKey.provider` string + closed 5-value `Adapter` set on `ProviderKey.adapter`, dispatched through `Hub::dispatch_two_tier`.

## What stays

`register_specialized("openai", …)` + `register_specialized("anthropic", …)` in `build_hub()` — pre-Phase-A PKs on disk may carry `provider` but no `adapter` field; these two registrations keep them dispatchable through the one-cycle compat shim in `crates/aisix-proxy/src/dispatch.rs::resolve_bridge`. Every other vendor only existed post-Phase-A, so cp-api always wrote `adapter` for them and the family bridge above already covers them.

## Safety guard preserved

`OpenAiBridge::resolve_base` still refuses to fall back to `OPENAI_DEFAULT_BASE` for any non-`"openai"` vendor whose PK reaches the bridge with empty `api_base`. Tests in `crates/aisix-provider-openai/src/bridge.rs`:
- `family_bridge_refuses_non_openai_vendor_with_empty_api_base` — 4 vendor strings (xai, openrouter, cased + whitespace variants).
- `family_bridge_allows_openai_vendor_with_empty_api_base` — happy path.
- `family_bridge_allows_legacy_empty_provider_with_empty_api_base` — pre-Phase-A row that goes through the specialized "openai" compat shim.
- `family_bridge_allows_non_openai_vendor_with_populated_api_base` — xai happy path.

## Behavior change: `x-aisix-bridge` outbound header

This is a wire-protocol behavior change: the OpenAI family bridge now emits `x-aisix-bridge: openai` for **every** vendor that routes through `Adapter::Openai`, instead of the per-vendor catalog name (`groq`, `deepseek`, `google`, etc.). Vendor identity now lives on the access log's `provider` label (sourced from `ProviderKey.provider`), not on the bridge header.

This breaks the matrix-tests in AISIX-Cloud's e2e suite that assert per-vendor header values; the test-side update is tracked in [api7/AISIX-Cloud#464](https://github.com/api7/AISIX-Cloud/issues/464). The PR description on #464 will be updated alongside this PR to point here (the previous body referenced #375 incorrectly).

## Diff size

−464 net LOC in `crates/`. `cargo fmt + clippy + test --workspace` all clean on this branch.

## Stale doc-comment fixups (in-scope)

Replaced `Provider::default_base_url` / `Provider::Cohere` / `OpenAiBridge::with_name` references in:
- `crates/aisix-core/src/models/provider_key.rs` (api_base doc)
- `crates/aisix-core/src/models/model.rs` (Adapter doc + module header)
- `crates/aisix-proxy/src/dispatch.rs` (build_v1_url tests)
- `crates/aisix-proxy/src/rerank.rs` (provider routing key doc)
- `crates/aisix-provider-azure-openai/src/lib.rs` (header)

## Audit

Round-1 audit of #375 surfaced 4 HIGHs against the shipped main state (anthropic safety-guard test missing, PK schema unbounded, no family-only integration test, no build_hub + pre-Phase-A integration test). Those will be addressed in a separate follow-up PR — this PR's scope is strictly the deletion the design called for. Fresh audit will run against this PR's HEAD.

Refs: AISIX-Cloud#417, ai-gateway#302 Phase A, AISIX-Cloud#464.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Provider routing now uses free-form provider strings with adapter-family fallback; compile-time Provider enum removed
  * Standardized bridge identifiers so OpenAI/Anthropic remain specialized while other vendors route via adapter families
  * Simplified per-bridge naming and request headers for consistent cross-provider behavior

* **Bug Fixes**
  * Tighter validation for missing API base URLs with clearer, customer-facing error messages

* **Documentation**
  * Updated docs and schema to describe the two-tier dispatch model and routing/validation behavior

* **Tests**
  * Expanded unit and e2e coverage to validate family-bridge safety and adapter-based routing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->