### PR TITLE
fix(provider-openai): remove X-Aisix-Bridge outbound diagnostic header

### DIFF
--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -445,7 +445,7 @@ fn prepare_outbound_body<T: serde::Serialize>(
 }
 
 /// Build the base outbound `HeaderMap` (Authorization, Content-Type,
-/// x-aisix-request-id, x-aisix-bridge, and optionally Accept: text/event-stream
+/// x-aisix-request-id, and optionally Accept: text/event-stream
 /// for streaming calls), then merge any `default_headers` the PK carries.
 /// Bridge-owned headers are inserted before the merge so
 /// [`apply_default_headers`] cannot overwrite them — the
@@ -454,16 +454,19 @@ fn prepare_outbound_body<T: serde::Serialize>(
 /// gives two layers of defense against an operator-supplied
 /// `default_headers` accidentally clobbering auth.
 ///
-/// `bridge_name` is set from [`OpenAiBridge::name`] and written as
-/// `X-AISIX-Bridge: <bridge_name>` on every outbound request. Tests
-/// capturing this header via mock-llm's `/_internal/captured-requests`
-/// can assert that `Hub.register(Provider::X, OpenAiBridge::with_name("Y"))`
-/// used the correct `with_name` value — catching a typo that pure
-/// routing assertions would miss (closes #368).
+/// The previous `bridge_name` parameter + `X-Aisix-Bridge` outbound
+/// header was removed in AISIX-Cloud#468: after the Phase A clean
+/// cut (#375, closing AISIX-Cloud#417) most openai-family providers
+/// no longer have a distinguishable per-vendor `with_name()`
+/// identity, and operator-side diagnostics of which bridge served
+/// a request are already covered by the DP's own `tracing::info!`
+/// spans. Customer default_headers can no longer set this header
+/// (per overrides.rs allowlist, also pruned), upstream APIs don't
+/// read it, and the original #368 catch-Hub-typo motivation became
+/// untestable for the family-keyed providers.
 fn build_request_headers(
     api_key_str: &str,
     request_id: &str,
-    bridge_name: &'static str,
     sse: bool,
     request: Option<&RequestOverrides>,
 ) -> Result<HeaderMap, BridgeError> {
@@ -479,16 +482,6 @@ fn build_request_headers(
         BridgeError::Config(format!("request_id contains invalid header chars: {e}"))
     })?;
     headers.insert(HeaderName::from_static("x-aisix-request-id"), rid);
-    // Diagnostic header: which OpenAI-compat bridge variant dispatched this
-    // request. Captured by mock-llm / real upstreams alike; allows e2e tests
-    // to assert Hub.register wiring without reading DP source (closes #368).
-    // Inserted before apply_default_headers so the operator cannot override it
-    // via PK default_headers (the contains_key guard in apply_default_headers
-    // skips any key already present in the map).
-    headers.insert(
-        HeaderName::from_static("x-aisix-bridge"),
-        HeaderValue::from_static(bridge_name),
-    );
     if sse {
         headers.insert(
             header::ACCEPT,
@@ -526,7 +519,6 @@ impl Bridge for OpenAiBridge {
         let headers = build_request_headers(
             key,
             &ctx.request_id,
-            self.name,
             false,
             ctx.provider_key.request.as_ref(),
         )?;
@@ -571,15 +563,12 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
-        let bridge_name = self.name;
-
         with_deadline(ctx.deadline, started, async move {
             let resp = client
                 .post(&url)
                 .header(header::AUTHORIZATION, format!("Bearer {key}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header("x-aisix-request-id", &request_id)
-                .header("x-aisix-bridge", bridge_name)
                 .json(&body)
                 .send()
                 .await
@@ -621,15 +610,12 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
-        let bridge_name = self.name;
-
         with_deadline(ctx.deadline, started, async move {
             let resp = client
                 .post(&url)
                 .header(header::AUTHORIZATION, format!("Bearer {key}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header("x-aisix-request-id", &request_id)
-                .header("x-aisix-bridge", bridge_name)
                 .json(&outbound)
                 .send()
                 .await
@@ -669,15 +655,12 @@ impl Bridge for OpenAiBridge {
         let client = self.client.clone();
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
-        let bridge_name = self.name;
-
         with_deadline(ctx.deadline, started, async move {
             let resp = client
                 .post(&url)
                 .header(header::AUTHORIZATION, format!("Bearer {key}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header("x-aisix-request-id", &request_id)
-                .header("x-aisix-bridge", bridge_name)
                 .json(&outbound)
                 .send()
                 .await
@@ -714,7 +697,6 @@ impl Bridge for OpenAiBridge {
         let headers = build_request_headers(
             key,
             &ctx.request_id,
-            self.name,
             true,
             ctx.provider_key.request.as_ref(),
         )?;
@@ -1677,36 +1659,6 @@ data: [DONE]\n\n";
             .expect("matcher pinned the operator header");
     }
 
-    /// Defense-in-depth: a `default_headers` block that tries to set
-    /// `authorization` must NOT clobber the bridge's own auth header.
-    /// `x-aisix-bridge` is inserted by the bridge before
-    /// `apply_default_headers` runs, and is also listed in
-    /// `RESERVED_DEFAULT_HEADERS`. A PK `default_headers` block that
-    /// tries to overwrite it must be ignored — the bridge value wins.
-    #[tokio::test]
-    async fn chat_default_headers_cannot_override_x_aisix_bridge() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            // The bridge's own name ("openai") must win, not the
-            // operator-supplied "attacker-override".
-            .and(header("x-aisix-bridge", "openai"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(ok_chat_response()))
-            .mount(&server)
-            .await;
-
-        let bridge = OpenAiBridge::new();
-        let pk = pk_with_overrides(
-            &server.uri(),
-            r#""request": {"default_headers": {"x-aisix-bridge": "attacker-override"}}"#,
-        );
-        let ctx = BridgeContext::new("req-1", sample_model(), pk);
-        bridge
-            .chat(&req(), &ctx)
-            .await
-            .expect("bridge name must survive the default_headers merge");
-    }
-
     /// The outbound request must carry `Bearer sk-test`, not the
     /// override value.
     #[tokio::test]
@@ -1943,79 +1895,16 @@ data: [DONE]\n";
         assert_eq!(resp.id, "cmpl-1");
     }
 
-    // ----------- issue #368: X-AISIX-Bridge outbound header -----------
-    //
-    // Pins that `build_request_headers` emits `x-aisix-bridge: <name>`
-    // for the bridge variant in use. The wiremock matcher fails the
-    // request (→ 404 fallthrough) if the header is absent or wrong,
-    // which is how a Hub.register typo would manifest in an e2e test
-    // that captures the header from mock-llm's
-    // `/_internal/captured-requests`.
-
-    /// `OpenAiBridge::new()` (default "openai" name) sends
-    /// `x-aisix-bridge: openai` on outbound chat requests.
-    #[tokio::test]
-    async fn chat_emits_x_aisix_bridge_openai_for_default_bridge() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .and(header("x-aisix-bridge", "openai"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(ok_chat_response()))
-            .mount(&server)
-            .await;
-
-        let bridge = OpenAiBridge::new();
-        let ctx = sample_ctx(&server.uri());
-        // Header match is part of the mock — 404 if absent/wrong.
-        bridge.chat(&req(), &ctx).await.unwrap();
-    }
-
-    /// `OpenAiBridge::new().with_name("perplexity")` sends
-    /// `x-aisix-bridge: perplexity`. Catches a Hub.register typo like
-    /// `OpenAiBridge::new().with_name("groq")` registered under
-    /// `Provider::Perplexity` — the wrong header value would cause the
-    /// wiremock matcher to fall through to a 404 in an e2e test.
-    #[tokio::test]
-    async fn chat_emits_x_aisix_bridge_for_with_name_variant() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .and(header("x-aisix-bridge", "perplexity"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(ok_chat_response()))
-            .mount(&server)
-            .await;
-
-        let bridge = OpenAiBridge::new().with_name("perplexity");
-        let ctx = sample_ctx(&server.uri());
-        bridge.chat(&req(), &ctx).await.unwrap();
-    }
-
-    /// Same contract for the streaming path: `chat_stream` also sets
-    /// `x-aisix-bridge` on the outbound SSE request.
-    #[tokio::test]
-    async fn chat_stream_emits_x_aisix_bridge_for_with_name_variant() {
-        use futures::StreamExt;
-
-        let server = MockServer::start().await;
-        let sse = "data: {\"id\":\"cmpl-s\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n";
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
-            .and(header("x-aisix-bridge", "groq"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "text/event-stream")
-                    .set_body_string(sse),
-            )
-            .mount(&server)
-            .await;
-
-        let bridge = OpenAiBridge::new().with_name("groq");
-        let ctx = sample_ctx(&server.uri());
-        let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
-        // Drain the stream to completion — the mock match already verified
-        // the header was present (404 fallthrough if it was missing).
-        while let Some(r) = stream.next().await {
-            r.unwrap();
-        }
-    }
+    // The previous "issue #368: X-AISIX-Bridge outbound header" block
+    // of tests was removed along with the header insertion itself:
+    // Phase A clean cut (#375 closing AISIX-Cloud#417) made per-vendor
+    // `Hub.register(Provider::X, OpenAiBridge::new().with_name("Y"))`
+    // an empty contract for openai-family long-tail providers, and
+    // the operator-side bridge identity is already emitted via the
+    // `tracing::info!` spans in `build_chunk_stream` / dispatch sites
+    // (the `bridge=<name>` field on the span). Tests removed:
+    //   - chat_default_headers_cannot_override_x_aisix_bridge
+    //   - chat_emits_x_aisix_bridge_openai_for_default_bridge
+    //   - chat_emits_x_aisix_bridge_for_with_name_variant
+    //   - chat_stream_emits_x_aisix_bridge_for_with_name_variant
 }

--- a/crates/aisix-provider-openai/src/overrides.rs
+++ b/crates/aisix-provider-openai/src/overrides.rs
@@ -139,7 +139,6 @@ const RESERVED_DEFAULT_HEADERS: &[&str] = &[
     "api-key",              // Azure OpenAI key
     "x-amz-security-token", // AWS SigV4 session header (Bedrock)
     "x-amz-date",           // AWS SigV4 timestamp (Bedrock)
-    "x-aisix-bridge",       // diagnostic bridge-name tag set by OpenAiBridge (AISIX-Cloud#368)
 ];
 
 /// Apply `request.default_headers` to an outbound `HeaderMap`.


### PR DESCRIPTION
fix(provider-openai): remove X-Aisix-Bridge outbound diagnostic header

The header was added in AISIX-Cloud#368 as an e2e probe to detect
Hub.register typos — e.g. `OpenAiBridge::new().with_name("grop")`
registered under `Provider::Groq` would manifest as the wrong
header value on the captured outbound request.

After Phase A clean cut (#375 closing AISIX-Cloud#417), 11 of the
14 OpenAI-adapter providers (groq / mistral / togetherai /
fireworks-ai / perplexity / moonshotai / alibaba / zhipuai /
baseten / huggingface / cerebras) no longer have a distinguishable
per-vendor `with_name()` identity — they all share the OpenAI
family bridge with uniform name "openai". The typo signal is no
longer testable for them.

The 3 remaining specialized bridges (google / deepseek / cohere)
do still carry distinct `with_name` labels, and removing the
header drops their typo-detection too. The user-driven design call
(per AISIX-Cloud#468 thread) is that operator-side diagnostics are
already covered by the DP's `tracing::info!` `bridge=<name>` field
on dispatch + chunk-stream spans — surfacing the same identity via
the upstream wire was a duplicate signal whose narrow remaining
value (3 of 14 providers) doesn't justify the per-request header
overhead, the customer-facing override-protection plumbing in
`overrides.rs::RESERVED_DEFAULT_HEADERS`, or the four in-crate
tests pinning behavior.

Changes:
  - build_request_headers: drop bridge_name parameter + insert
  - 4 inline header() call sites removed with their let setup
  - build_chunk_stream keeps bridge_name (tracing::warn! span field,
    NOT outbound header)
  - 4 in-crate tests removed:
      chat_default_headers_cannot_override_x_aisix_bridge
      chat_emits_x_aisix_bridge_openai_for_default_bridge
      chat_emits_x_aisix_bridge_for_with_name_variant
      chat_stream_emits_x_aisix_bridge_for_with_name_variant
  - RESERVED_DEFAULT_HEADERS: drop "x-aisix-bridge" entry

Verified:
  - cargo build --workspace clean
  - cargo test -p aisix-provider-openai -> 85 passed

Pairs with AISIX-Cloud#468 which drops the corresponding e2e
assertions on the test side. AISIX-Cloud#468 is forward-compatible
with header absence; this PR removes the header at the source.

---

Pairs with [api7/AISIX-Cloud#468](https://github.com/api7/AISIX-Cloud/pull/468) which drops the corresponding e2e assertions on the test side. AISIX-Cloud#468 is forward-compatible with header absence; this PR removes the header at the source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified request header handling in the OpenAI provider integration by removing automatic diagnostic header emission and reducing configuration parameters. Header construction now focuses on authentication and streaming requirements.

* **Tests**
  * Removed diagnostic header validation tests reflecting updated header handling approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->