### PR TITLE
docs(core): clarify Model.model_name is the upstream id (#302 / AISIX-Cloud#470)

### DIFF
--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -217,8 +217,24 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
 
-    /// Upstream model id sent to the provider (e.g. "gpt-4o",
-    /// "claude-sonnet-4-5"). None for routing models.
+    /// Upstream model id sent to the provider — the literal string
+    /// the upstream LLM API expects in its `model` field
+    /// (e.g. `"gpt-4o"`, `"claude-sonnet-4-5"`,
+    /// `"gpt-4o-mini-2024-08-06"`). `None` for routing models.
+    ///
+    /// **NOTE — this field name is a known footgun.** Some other proxy
+    /// gateways define a `model_name` field that holds the
+    /// *customer-facing alias* (the name a client SDK sends), with a
+    /// separate `model` sub-field holding the upstream id. In this
+    /// codebase the convention is reversed: `display_name` (above)
+    /// is the customer-facing alias, and **`model_name` is the
+    /// upstream id**. When reading or writing this struct, do not
+    /// assume the field name alone disambiguates the role — read
+    /// the docs.
+    ///
+    /// Renaming this field to `upstream_id` to remove the ambiguity
+    /// is tracked at api7/AISIX-Cloud#470 but deferred behind a
+    /// coordinated wire-format change across cp-api + dashboard.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_name: Option<String>,
 

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -44,7 +44,7 @@
       "type": "string"
     },
     "model_name": {
-      "description": "Upstream model id sent to the provider (e.g. \"gpt-4o\", \"claude-sonnet-4-5\"). None for routing models.",
+      "description": "Upstream model id sent to the provider — the literal string the upstream LLM API expects in its `model` field (e.g. `\"gpt-4o\"`, `\"claude-sonnet-4-5\"`, `\"gpt-4o-mini-2024-08-06\"`). `None` for routing models.\n\n**NOTE — this field name is a known footgun.** Some other proxy gateways define a `model_name` field that holds the *customer-facing alias* (the name a client SDK sends), with a separate `model` sub-field holding the upstream id. In this codebase the convention is reversed: `display_name` (above) is the customer-facing alias, and **`model_name` is the upstream id**. When reading or writing this struct, do not assume the field name alone disambiguates the role — read the docs.\n\nRenaming this field to `upstream_id` to remove the ambiguity is tracked at api7/AISIX-Cloud#470 but deferred behind a coordinated wire-format change across cp-api + dashboard.",
       "type": [
         "string",
         "null"


### PR DESCRIPTION
## Summary

The \`Model\` struct has two identifiers:

| Field | Role |
|---|---|
| \`display_name\` | Customer-facing alias the SDK sends in \`POST /v1/chat/completions { model: ... }\` |
| \`model_name\` | Upstream id the LLM API expects (e.g. \`"gpt-4o-mini-2024-08-06"\`) |

The field names alone don't make this obvious. Some other proxy gateways in the ecosystem use the name \`model_name\` to mean the **opposite** — i.e. the customer-facing alias — with a separate \`model\` sub-field for the upstream id. A reader who knows that convention from a neighbour project will get the AISIX struct backwards on first read.

This PR is a **14-line doc comment** on \`Model.model_name\` (\`crates/aisix-core/src/models/model.rs:220\`) that explicitly calls out the convention reversal. Zero behaviour change, zero wire change, no test impact.

## Why not just rename it?

Renaming \`model_name\` → \`upstream_id\` to remove the ambiguity is tracked at [api7/AISIX-Cloud#470](https://github.com/api7/AISIX-Cloud/issues/470). It's a coordinated wire-format change that touches ai-gateway + cp-api + dashboard + ~110 test fixtures + PG column. Cost-vs-benefit isn't there today — the field is internal-only (no customer-facing surface), and a doc comment captures 80% of the clarity benefit at 1% of the migration cost.

The rename can ride along the next big wire revision; until then, the comment carries the disambiguation.

## Test plan

- [ ] \`cargo check -p aisix-core\` — clean (verified locally)
- [ ] \`cargo fmt --check\` — applied (verified locally)
- [ ] No new tests needed (doc-only change)

Closes the doc-clarity half of the audit finding on #302 A2/B8/M19 (Model rename). cp-api side has a companion 1-line doc comment landing as a separate PR in api7/AISIX-Cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for model identifier fields, clarifying upstream naming conventions and their distinction from customer-facing aliases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->