### PR TITLE
fix(embeddings): accept base64 vectors from upstream — #393 customer-blocker

### DIFF
--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -368,12 +368,38 @@ pub struct ChatDelta {
 
 // ─── Embeddings ──────────────────────────────────────────────────────────────
 
+/// The vector returned on one embedding object. Untagged enum so JSON
+/// round-trips OpenAI's documented `string | array` shape on the
+/// `embedding` field (issue #393):
+///
+///   - `Float(vec![0.1, 0.2, ...])` → JSON array of numbers; what
+///     OpenAI returns when the request carries
+///     `encoding_format: "float"`.
+///   - `Base64("BASE64STRING")` → JSON string; what OpenAI returns
+///     when the request carries `encoding_format: "base64"` (the
+///     SDK default). Stored verbatim — the gateway is a pure
+///     pass-through for this field so callers who chose `base64`
+///     for payload-size reasons see the same bytes the upstream
+///     returned.
+///
+/// The gateway does NOT translate between the two formats. If a
+/// future caller needs cross-format translation, that belongs at
+/// the dispatcher, not the wire layer.
+///
+/// Reference: <https://platform.openai.com/docs/api-reference/embeddings/object>.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EmbeddingVector {
+    Float(Vec<f32>),
+    Base64(String),
+}
+
 /// Single embedding object as returned by a provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingObject {
     pub index: u32,
     pub object: String,
-    pub embedding: Vec<f32>,
+    pub embedding: EmbeddingVector,
 }
 
 /// Normalised embedding request.

--- a/crates/aisix-gateway/src/lib.rs
+++ b/crates/aisix-gateway/src/lib.rs
@@ -32,7 +32,7 @@ pub use bridge::{
 };
 pub use chat::{
     ChatChunk, ChatDelta, ChatFormat, ChatMessage, ChatResponse, EmbeddingObject, EmbeddingRequest,
-    EmbeddingResponse, EmbeddingUsage, FinishReason, Role, UsageStats,
+    EmbeddingResponse, EmbeddingUsage, EmbeddingVector, FinishReason, Role, UsageStats,
 };
 pub use hub::Hub;
 pub use sse::{SseDecoder, SseEvent};

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -29,7 +29,7 @@
 
 use aisix_gateway::{
     ChatChunk, ChatDelta, ChatFormat, ChatMessage, ChatResponse, EmbeddingObject, EmbeddingRequest,
-    EmbeddingResponse, EmbeddingUsage, FinishReason, Role, UsageStats,
+    EmbeddingResponse, EmbeddingUsage, EmbeddingVector, FinishReason, Role, UsageStats,
 };
 use serde::{Deserialize, Serialize};
 
@@ -364,11 +364,21 @@ pub(crate) struct OpenAiEmbedRequest<'a> {
 }
 
 /// One embedding object from OpenAI's response.
+///
+/// Issue #393: `embedding` is an `EmbeddingVector` (untagged enum
+/// over `Vec<f32>` / `String`) so the deserializer accepts both
+/// shapes OpenAI emits — `Vec<f32>` when the request carried
+/// `encoding_format: "float"`, and base64 `String` when it carried
+/// `encoding_format: "base64"` (the OpenAI SDK default). Pre-#393
+/// this field was strict-typed `Vec<f32>` and every default-SDK
+/// `embeddings.create({model, input})` call failed with
+/// `502 upstream_decode_error` because the deserializer rejected
+/// the string shape.
 #[derive(Debug, Deserialize)]
 pub(crate) struct OpenAiEmbeddingObject {
     pub index: u32,
     pub object: String,
-    pub embedding: Vec<f32>,
+    pub embedding: EmbeddingVector,
 }
 
 /// Usage block from OpenAI's embeddings response.
@@ -712,5 +722,96 @@ mod tests {
         let tool_msg = &json["messages"][2];
         assert_eq!(tool_msg["tool_call_id"], "c1");
         assert_eq!(tool_msg["role"], "tool");
+    }
+
+    /// Issue #393: OpenAI's embeddings response carries `embedding` as
+    /// either a JSON array (when the request set
+    /// `encoding_format: "float"`) OR a base64 string (when the
+    /// request set `encoding_format: "base64"`, which is the OpenAI
+    /// SDK default). Pre-fix the deserializer rejected the string
+    /// shape with `error decoding response body` → 502.
+    #[test]
+    fn embeddings_response_accepts_float_array() {
+        let body = r#"{
+            "object": "list",
+            "model": "text-embedding-3-small",
+            "data": [{
+                "index": 0,
+                "object": "embedding",
+                "embedding": [0.1, -0.2, 0.3]
+            }],
+            "usage": { "prompt_tokens": 1, "total_tokens": 1 }
+        }"#;
+        let raw: OpenAiEmbedResponse =
+            serde_json::from_str(body).expect("float-array embedding must deserialize");
+        let resp = embed_response_into(raw);
+        assert_eq!(resp.data.len(), 1);
+        match &resp.data[0].embedding {
+            EmbeddingVector::Float(v) => {
+                assert_eq!(v.len(), 3);
+                assert!((v[0] - 0.1).abs() < 1e-6);
+            }
+            EmbeddingVector::Base64(_) => {
+                panic!("float request must deserialize as EmbeddingVector::Float")
+            }
+        }
+    }
+
+    #[test]
+    fn embeddings_response_accepts_base64_string() {
+        // OpenAI returns base64 as a quoted JSON string. Pre-#393
+        // this was the bug — `Vec<f32>` deserializer rejected the
+        // string shape with `error decoding response body`.
+        let body = r#"{
+            "object": "list",
+            "model": "text-embedding-3-small",
+            "data": [{
+                "index": 0,
+                "object": "embedding",
+                "embedding": "ZAAAANSAAAA="
+            }],
+            "usage": { "prompt_tokens": 1, "total_tokens": 1 }
+        }"#;
+        let raw: OpenAiEmbedResponse =
+            serde_json::from_str(body).expect("base64-string embedding must deserialize");
+        let resp = embed_response_into(raw);
+        assert_eq!(resp.data.len(), 1);
+        match &resp.data[0].embedding {
+            EmbeddingVector::Base64(s) => assert_eq!(s, "ZAAAANSAAAA="),
+            EmbeddingVector::Float(_) => {
+                panic!("base64 string must deserialize as EmbeddingVector::Base64")
+            }
+        }
+    }
+
+    #[test]
+    fn embeddings_response_serializes_back_to_same_shape() {
+        // The pass-through contract: the JSON serialization of the
+        // gateway-internal EmbeddingObject MUST emit the same shape
+        // the upstream returned. Float → array, base64 → string. An
+        // SDK that asked for base64 sees a base64 string in the
+        // gateway's response; an SDK that asked for float sees an
+        // array. No format translation.
+        let float_obj = EmbeddingObject {
+            index: 0,
+            object: "embedding".to_string(),
+            embedding: EmbeddingVector::Float(vec![0.1, -0.2, 0.3]),
+        };
+        let s = serde_json::to_string(&float_obj).unwrap();
+        assert!(
+            s.contains(r#""embedding":[0.1,-0.2,0.3]"#),
+            "float must serialize as JSON array; got {s}"
+        );
+
+        let b64_obj = EmbeddingObject {
+            index: 0,
+            object: "embedding".to_string(),
+            embedding: EmbeddingVector::Base64("ZAAAANSAAAA=".to_string()),
+        };
+        let s = serde_json::to_string(&b64_obj).unwrap();
+        assert!(
+            s.contains(r#""embedding":"ZAAAANSAAAA=""#),
+            "base64 must serialize as JSON string; got {s}"
+        );
     }
 }

--- a/tests/e2e/src/cases/openai-embeddings-base64-e2e.test.ts
+++ b/tests/e2e/src/cases/openai-embeddings-base64-e2e.test.ts
@@ -1,0 +1,258 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: OpenAI client → OpenAI upstream — `/v1/embeddings` accepts both
+// `encoding_format: "float"` AND `encoding_format: "base64"`.
+//
+// Pins issue #393: the gateway-internal wire type for the upstream
+// embedding response was previously `Vec<f32>` (strict-typed). When
+// the upstream returns base64 (which the OpenAI SDK requests BY
+// DEFAULT — `client.embeddings.create({ model, input })` without an
+// explicit `encoding_format` sends `encoding_format: "base64"`),
+// the deserializer rejected the JSON string shape and the gateway
+// surfaced `502 upstream_decode_error`. This made the default SDK
+// embeddings path unusable.
+//
+// What this spec proves:
+//
+//   1. `encoding_format: "float"` round-trip — vectors come back as a
+//      JSON array of numbers. (Pre-fix this worked; pin it so a
+//      future refactor of the enum can't regress the float path.)
+//   2. `encoding_format: "base64"` round-trip — base64 string from
+//      the upstream reaches the SDK verbatim. (The #393 bug.)
+//   3. SDK default (no `encoding_format` argument) — the OpenAI
+//      client library defaults to `base64`. A vanilla
+//      `embeddings.create({ model, input })` MUST return 200 with
+//      the base64-string variant. This is the customer-facing
+//      contract the bug broke.
+//
+// References:
+// - OpenAI embeddings request/response shape:
+//   <https://platform.openai.com/docs/api-reference/embeddings>
+// - OpenAI Python SDK default encoding_format (base64 since v1.0):
+//   <https://github.com/openai/openai-python/blob/main/src/openai/resources/embeddings.py>
+//
+// Source-blind discipline: this spec asserts on the SDK-observed
+// shape only. The gateway's internal enum representation is an
+// implementation detail; the SDK contract is "embedding can be
+// either array-of-numbers OR base64 string per OpenAI's documented
+// `string | array` union".
+
+const CALLER_PLAINTEXT = "sk-openai-embed-b64-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// A short fixed-content embedding response is fine — the test
+// doesn't validate numerical accuracy, just the shape that reaches
+// the SDK.
+const FLOAT_VECTOR = [0.1, -0.2, 0.3, 0.4, -0.5];
+
+// Base64 encoding of a small Float32Array — what OpenAI would
+// emit on a base64 request. Hand-pinned: a 5-float vector encoded
+// as little-endian Float32 occupies 20 bytes; base64 of 20 bytes
+// is 28 chars (incl. padding). We don't need a "correct" base64
+// for any particular floats — just a valid base64-shaped string
+// that the gateway must pass through verbatim.
+const BASE64_VECTOR = "zczMPc3MzL3NzEw+zcxMPgAAAL8=";
+
+const FLOAT_RESPONSE = {
+  object: "list",
+  model: "text-embedding-3-small",
+  data: [
+    {
+      index: 0,
+      object: "embedding",
+      embedding: FLOAT_VECTOR,
+    },
+  ],
+  usage: { prompt_tokens: 2, total_tokens: 2 },
+};
+
+const BASE64_RESPONSE = {
+  object: "list",
+  model: "text-embedding-3-small",
+  data: [
+    {
+      index: 0,
+      object: "embedding",
+      embedding: BASE64_VECTOR,
+    },
+  ],
+  usage: { prompt_tokens: 2, total_tokens: 2 },
+};
+
+describe("OpenAI /v1/embeddings encoding_format (#393)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // Scripted upstream — readiness probe (chat) consumes step 0
+    // with a plain content response. The three test calls consume
+    // steps 1-3, each with the encoding-format-matched response.
+    upstream = await startOpenAiUpstream({
+      scriptedResponses: [
+        // Readiness probe via chat (the harness's waitConfigPropagation
+        // sends a /v1/chat/completions request — see existing specs).
+        {
+          nonStreamBody: {
+            id: "chatcmpl-ready",
+            object: "chat.completion",
+            created: 0,
+            model: "text-embedding-3-small",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "ready" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          },
+        },
+        // Test 1: explicit encoding_format: "float" → float array.
+        { nonStreamBody: FLOAT_RESPONSE },
+        // Test 2: explicit encoding_format: "base64" → base64 string.
+        { nonStreamBody: BASE64_RESPONSE },
+        // Test 3: SDK default (no encoding_format) → base64 string.
+        { nonStreamBody: BASE64_RESPONSE },
+      ],
+      nonStreamBody: FLOAT_RESPONSE,
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "openai-embed-b64-pk",
+      secret: "sk-openai-mock",
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "openai-embed-b64",
+      provider: "openai",
+      model_name: "text-embedding-3-small",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["openai-embed-b64"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("encoding_format=float → vectors come back as a JSON array", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Readiness probe — consume scripted step 0.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.chat.completions.create({
+          model: "openai-embed-b64",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+
+    // Float request — consume scripted step 1.
+    const resp = await client.embeddings.create({
+      model: "openai-embed-b64",
+      input: "hello",
+      encoding_format: "float",
+    });
+
+    expect(resp.data).toHaveLength(1);
+    expect(resp.data[0]?.object).toBe("embedding");
+    // Float request → SDK observes a number[] on `embedding`.
+    expect(Array.isArray(resp.data[0]?.embedding)).toBe(true);
+    const v = resp.data[0]?.embedding as unknown as number[];
+    expect(v).toHaveLength(FLOAT_VECTOR.length);
+    expect(v[0]).toBeCloseTo(FLOAT_VECTOR[0]!, 5);
+    expect(v[4]).toBeCloseTo(FLOAT_VECTOR[4]!, 5);
+  });
+
+  test("encoding_format=base64 → base64 string preserved end-to-end (#393)", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Explicit base64 request — consume scripted step 2.
+    const resp = await client.embeddings.create({
+      model: "openai-embed-b64",
+      input: "hello",
+      encoding_format: "base64",
+    });
+
+    expect(resp.data).toHaveLength(1);
+    // Base64 request → SDK observes a string on `embedding`. Pre-#393
+    // this would never reach the SDK — the gateway 502'd at
+    // deserialize time inside the OpenAI bridge.
+    expect(typeof resp.data[0]?.embedding).toBe("string");
+    expect(resp.data[0]?.embedding).toBe(BASE64_VECTOR);
+  });
+
+  test("SDK default (no encoding_format) → base64 round-trip works (#393 customer path)", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // The OpenAI SDK defaults `encoding_format` to "base64" since
+    // v1.0. A vanilla call without specifying the format MUST
+    // succeed — this is the path 99% of customer code hits, and
+    // the path #393 broke for every customer.
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    const resp = await client.embeddings.create({
+      model: "openai-embed-b64",
+      input: "hello",
+      // NO encoding_format argument — SDK default.
+    });
+
+    expect(resp.data).toHaveLength(1);
+    // SDK default is base64 → gateway must surface a string here.
+    expect(typeof resp.data[0]?.embedding).toBe("string");
+    expect(resp.data[0]?.embedding).toBe(BASE64_VECTOR);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #393. The gateway-internal type for the upstream embeddings response was `embedding: Vec<f32>` (strict-typed). When upstream returned a base64 string — the OpenAI SDK default — the deserializer rejected it and the gateway 502'd. Every vanilla `client.embeddings.create({ model, input })` call was broken.

## Fix

Add an untagged enum `EmbeddingVector { Float(Vec<f32>) | Base64(String) }` so the gateway accepts and round-trips both shapes per OpenAI's documented `string | array` union (<https://platform.openai.com/docs/api-reference/embeddings/object>). Pass-through, no internal translation — customers who chose base64 for payload-size reasons see the same bytes the upstream returned.

## Test coverage

- **Unit** (`crates/aisix-provider-openai/src/wire.rs`):
  - `embeddings_response_accepts_float_array`
  - `embeddings_response_accepts_base64_string` ← the #393 regression
  - `embeddings_response_serializes_back_to_same_shape`
- **E2E** (`tests/e2e/src/cases/openai-embeddings-base64-e2e.test.ts`):
  3 source-blind subtests:
  1. `encoding_format=float` → array round-trip
  2. `encoding_format=base64` → base64 string round-trip
  3. **SDK default** (no `encoding_format` argument) → base64 string round-trip (the customer-facing path #393 documents as broken)

## Why pass-through, not normalize-to-Vec<f32>

- Customers set `encoding_format: "base64"` for payload-size — re-encoding defeats the intent.
- The gateway forwards `encoding_format` verbatim to the upstream, so upstream-vs-client format mismatch never happens in practice.
- Matches the pass-through behavior of comparable open-source AI gateways and routing libraries (verified via internal triage of reference implementations cited in CLAUDE.md §7).
- Simpler — no base64 encode/decode hot path.

## Test plan

- [x] `cargo build --all` clean.
- [x] `cargo test -p aisix-provider-openai --lib wire::tests::embeddings` — 3/3 pass.
- [x] `pnpm test cases/openai-embeddings-base64-e2e` — 3/3 pass in 3.8s.
- [ ] CI green.

## Closes

- Closes #393