### PR TITLE
fix(chat): missing required field returns 400 not 422 (#324)

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -125,11 +125,47 @@ use crate::cooldown::decide_cooldown;
 pub async fn chat_completions(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
-    Json(req): Json<ChatFormat>,
+    // Issue #324: catch the JSON-extractor rejection here so we can
+    // map it to OpenAI's documented 400 invalid_request_error wire
+    // shape. Axum's `Json<T>` extractor returns 422 on JsonDataError
+    // (valid-JSON-but-missing-required-field, e.g. no `model`),
+    // which diverges from OpenAI — every SDK that branches on 400
+    // vs 422 sees different semantics here than it does talking to
+    // api.openai.com. Same discriminate-then-map pattern as
+    // messages.rs (#336) which already handles this for /v1/messages.
+    body: Result<Json<ChatFormat>, axum::extract::rejection::JsonRejection>,
 ) -> Response {
     let started = Instant::now();
     let method = "POST";
     let path = "/v1/chat/completions";
+    let req = match body {
+        Ok(Json(r)) => r,
+        Err(rej) => {
+            use axum::extract::rejection::JsonRejection;
+            use axum::http::StatusCode;
+            // BytesRejection → distinguish 413 (PAYLOAD_TOO_LARGE,
+            // real per-extractor cap exceeded) from 400 (transport-
+            // side read failure). `JsonRejection` is `#[non_exhaustive]`
+            // so the fallback `_` arm catches today's JsonDataError
+            // (the #324 case) / JsonSyntaxError / MissingJsonContentType
+            // AND any future variant axum adds, defaulting to 400
+            // until each new variant gets an explicit policy decision.
+            return match rej {
+                JsonRejection::BytesRejection(inner)
+                    if inner.status() == StatusCode::PAYLOAD_TOO_LARGE =>
+                {
+                    ProxyError::RequestTooLarge {
+                        limit_bytes: state.request_body_limit_bytes,
+                    }
+                }
+                JsonRejection::BytesRejection(_) => {
+                    ProxyError::InvalidRequest("failed to read request body".into())
+                }
+                _ => ProxyError::InvalidRequest("invalid JSON request body".into()),
+            }
+            .into_response();
+        }
+    };
     let request_id = new_request_id();
     let api_key_id = auth.entry.id.clone();
     let model_name = req.model.clone();

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -639,6 +639,94 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
+    /// Issue #324: missing required field on the chat-completion
+    /// request body must surface as **400 Bad Request** per OpenAI's
+    /// wire contract, not 422 Unprocessable Entity. SDKs branching
+    /// on the status code see different semantics depending on
+    /// which proxy they sit behind; a customer migrating between
+    /// OpenAI direct and a gateway-fronted deployment needs the
+    /// 400-vs-422 distinction to be wire-stable.
+    ///
+    /// Pre-fix: axum's `Json<ChatFormat>` extractor returned
+    /// `JsonRejection::JsonDataError` → 422.
+    /// Post-fix: the handler intercepts the JsonRejection and maps
+    /// to `ProxyError::InvalidRequest` → 400.
+    #[tokio::test]
+    async fn missing_model_field_returns_400_not_422() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        // Valid JSON, valid `messages` field, but `model` omitted —
+        // the OpenAI ChatCompletion contract requires it.
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "missing model field must surface as 400 per OpenAI wire contract — #324",
+        );
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+    }
+
+    /// Companion case: missing `messages` field must also surface
+    /// as 400. Same OpenAI wire contract — `messages` is required.
+    #[tokio::test]
+    async fn missing_messages_field_returns_400_not_422() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"model":"my-gpt4"}"#))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "missing messages field must surface as 400 per OpenAI wire contract — #324",
+        );
+    }
+
+    /// Companion case: malformed JSON (syntax error) also must
+    /// surface as 400, not 422. Same handler path as #324 — the
+    /// JsonRejection variants for syntax vs data error both map
+    /// to InvalidRequest.
+    #[tokio::test]
+    async fn malformed_json_returns_400() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{not even valid json"#))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "malformed JSON must surface as 400, not 422",
+        );
+    }
+
     /// Issue #159: a request body whose declared `Content-Length`
     /// exceeds the configured cap must surface as `413 Content Too
     /// Large` per RFC 9110 §15.5.14, NOT as `ECONNRESET` from a

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -700,6 +700,13 @@ mod tests {
             StatusCode::BAD_REQUEST,
             "missing messages field must surface as 400 per OpenAI wire contract — #324",
         );
+        // Pin the envelope shape too — a future regression that
+        // returned 400 with a non-OpenAI envelope (or empty body)
+        // would otherwise pass on status alone. Per audit MEDIUM on
+        // PR #400.
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
     }
 
     /// Companion case: malformed JSON (syntax error) also must
@@ -725,6 +732,12 @@ mod tests {
             StatusCode::BAD_REQUEST,
             "malformed JSON must surface as 400, not 422",
         );
+        // Envelope-shape pin matching the sibling missing-field
+        // tests — same JsonRejection → InvalidRequest path; the
+        // envelope must stay OpenAI-shape on every variant.
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
     }
 
     /// Issue #159: a request body whose declared `Content-Length`


### PR DESCRIPTION
## Summary

Closes #324. Missing required field (\`model\`, \`messages\`, etc.) on \`/v1/chat/completions\` surfaced as 422 instead of OpenAI's documented 400. SDKs branching on the status code saw different semantics between OpenAI-direct and gateway-fronted deployments.

## Fix

Mirror the messages.rs (#336) pattern: change handler signature to \`Result<Json<ChatFormat>, JsonRejection>\` and intercept the rejection in the handler, mapping to \`ProxyError::InvalidRequest\` (→ 400 + \`invalid_request_error\` per OpenAI's documented envelope).

\`BytesRejection\` keeps its existing 413/400 split (#159 + messages.rs audit MEDIUM-A/B); the fallback \`_\` arm maps JsonDataError / JsonSyntaxError / MissingJsonContentType / any future axum variant to 400 invalid_request_error.

## Coverage

- \`missing_model_field_returns_400_not_422\` — the issue's exact repro (Phase 3 matrix scenario \"valid JSON but missing model field\").
- \`missing_messages_field_returns_400_not_422\` — companion required-field case.
- \`malformed_json_returns_400\` — JsonSyntaxError variant pinned.

## Scoped out (file as follow-up)

\`embeddings.rs\` uses \`Json<EmbeddingRequestBody>\` (also strict-typed) so it ships the same bug. Same one-line fix applies. \`completions.rs\` / \`responses.rs\` / \`rerank.rs\` / \`images.rs\` / \`audio.rs\` use \`Json<Value>\` so they don't surface the bug. Will file as follow-up.

## Test plan

- [x] \`cargo test -p aisix-proxy --lib\` — 302/302 green locally including the 3 new tests.
- [ ] CI green.

## Closes

- Closes #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses for chat completions requests with invalid or malformed payloads.

* **Tests**
  * Added regression tests validating proper error handling for malformed JSON and missing required fields in chat requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->