### PR TITLE
test(e2e): drive gateway through real Claude Code CLI

### DIFF
--- a/.github/workflows/real-chain.yml
+++ b/.github/workflows/real-chain.yml
@@ -24,8 +24,11 @@ permissions:
   contents: read
 
 concurrency:
+  # Cancel superseded runs — every `labeled` event re-triggers the
+  # workflow and each run burns real upstream quota; without
+  # cancellation a labeling spree stacks costs fast.
   group: real-chain-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   real-chain:
@@ -34,8 +37,11 @@ jobs:
     timeout-minutes: 30
     # Same fork-guard + label-gate shape as AISIX-Cloud's real-chain
     # workflow: secrets only flow on PRs from the same repo, and only
-    # when an opt-in label is set.
-    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'real chain test')) }}
+    # when an opt-in label is set. The `action != 'labeled'` clause
+    # narrows the label trigger to the relevant label name — otherwise
+    # *any* label change on a PR that already carries the gating label
+    # re-runs the workflow.
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'real chain test') && (github.event.action != 'labeled' || github.event.label.name == 'real chain test')) }}
     services:
       etcd:
         image: quay.io/coreos/etcd:v3.5.15
@@ -91,5 +97,11 @@ jobs:
           AISIX_BIN: ${{ github.workspace }}/target/debug/aisix
           AISIX_E2E_ETCD: http://127.0.0.1:2379
           RUN_CLAUDE_CODE_REAL_CHAIN: "1"
+          # Pin upstream deterministically — without REAL_CHAIN_UPSTREAM
+          # the test's pickUpstream() iterates UPSTREAMS in array order
+          # (OpenAI first), and if a future runner had both keys set
+          # the upstream would silently change across runs, making
+          # regression triage harder.
+          REAL_CHAIN_UPSTREAM: deepseek
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         run: pnpm exec vitest run src/cases/claude-code-cli-compat-e2e.test.ts

--- a/.github/workflows/real-chain.yml
+++ b/.github/workflows/real-chain.yml
@@ -1,0 +1,95 @@
+# Scheduled real-chain coverage.
+#
+# Drives the gateway's Anthropic-native /v1/messages endpoint through
+# the REAL Claude Code CLI (`claude -p`) against a real non-Anthropic
+# upstream (DeepSeek by default — the credential available in CI).
+# Catches regressions in cross-provider translation of the wire shape
+# that Anthropic-ecosystem clients actually emit but the in-repo
+# vitest mock-upstream tests do not generate.
+#
+# Gated separately from PR CI for the same reason as AISIX-Cloud's
+# real-chain.yml: spends real upstream quota.
+
+name: real chain
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  schedule:
+    # 08:00 Asia/Shanghai every day.
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: real-chain-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  real-chain:
+    name: claude-code-cli real-chain
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 30
+    # Same fork-guard + label-gate shape as AISIX-Cloud's real-chain
+    # workflow: secrets only flow on PRs from the same repo, and only
+    # when an opt-in label is set.
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'real chain test')) }}
+    services:
+      etcd:
+        image: quay.io/coreos/etcd:v3.5.15
+        env:
+          ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+          ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+        ports: ["2379:2379"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Validate required secrets
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: |
+          test -n "$DEEPSEEK_API_KEY" || {
+            echo "::error::DEEPSEEK_API_KEY is required (the test gates on at least one upstream credential)"
+            exit 1
+          }
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build aisix binary
+        run: cargo build -p aisix-server --bin aisix
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install Claude Code CLI
+        # https://code.claude.com/docs/en/setup — npm path is the
+        # reproducible CI install (avoids the native installer's
+        # auto-update side-effect mid-job).
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: e2e install
+        working-directory: tests/e2e
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run Claude Code CLI real-chain
+        working-directory: tests/e2e
+        env:
+          AISIX_BIN: ${{ github.workspace }}/target/debug/aisix
+          AISIX_E2E_ETCD: http://127.0.0.1:2379
+          RUN_CLAUDE_CODE_REAL_CHAIN: "1"
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: pnpm exec vitest run src/cases/claude-code-cli-compat-e2e.test.ts

--- a/tests/e2e/src/cases/claude-code-cli-compat-e2e.test.ts
+++ b/tests/e2e/src/cases/claude-code-cli-compat-e2e.test.ts
@@ -1,0 +1,219 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  waitConfigPropagation,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E client-compat: drive the gateway's Anthropic-native /v1/messages
+// endpoint through the REAL Claude Code CLI (`claude -p`), pointed at
+// a real upstream LLM through ANTHROPIC_BASE_URL.
+//
+// Sibling to openai-sdk-compat.test.ts. That file proves the gateway
+// speaks OpenAI Chat Completions to OpenAI-shape clients. This one
+// proves it speaks Anthropic Messages to the wire shape an
+// Anthropic-ecosystem client (Claude Code CLI, Claude Desktop, and the
+// official anthropic-sdk-{python,typescript}) actually emits — which
+// the hand-rolled harness does not.
+//
+// A `claude -p` invocation posts ~17KB to /v1/messages: a structured
+// `system` array, a tool catalogue (~30 Anthropic input_schema blocks),
+// `cache_control: {type: "ephemeral"}` markers, an `anthropic-beta`
+// header, and a `?beta=true` query suffix. A regression in any of:
+//
+//   - /v1/messages query-string tolerance (`?beta=true`)
+//   - x-api-key auth fallback (Authorization-Bearer is NOT sent)
+//   - anthropic-beta / anthropic-version header passthrough vs. strip
+//   - system: [{type:"text", text, cache_control?}] block parsing
+//   - tools[].input_schema → upstream tools[].function.parameters
+//     translation for non-Anthropic upstreams
+//
+// would break Claude Code customers but pass every existing test
+// (none of which generate this request shape).
+//
+// Gating: real upstream costs money, so the suite is opt-in.
+//   - RUN_CLAUDE_CODE_REAL_CHAIN=1 to acknowledge spend
+//   - OPENAI_API_KEY or DEEPSEEK_API_KEY for the upstream credential
+//   - `claude` CLI on PATH (skipped silently if not installed)
+//
+// References:
+// - Anthropic Messages API:
+//   https://docs.anthropic.com/en/api/messages
+// - Anthropic Node SDK wire shape (the SDK Claude Code uses):
+//   https://github.com/anthropics/anthropic-sdk-typescript
+// - Claude Code CLI flags: `claude --help` (--bare strips OAuth and
+//   keychain so auth is strictly $ANTHROPIC_API_KEY).
+
+const CALLER_PLAINTEXT = "sk-claude-code-cli-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+interface UpstreamProfile {
+  readonly envVar: "OPENAI_API_KEY" | "DEEPSEEK_API_KEY";
+  readonly provider: "openai" | "deepseek";
+  readonly upstreamModel: string;
+  readonly apiBase: string;
+}
+
+const UPSTREAMS: ReadonlyArray<UpstreamProfile> = [
+  {
+    envVar: "OPENAI_API_KEY",
+    provider: "openai",
+    upstreamModel: "gpt-4o-mini",
+    apiBase: "https://api.openai.com/v1",
+  },
+  {
+    envVar: "DEEPSEEK_API_KEY",
+    provider: "deepseek",
+    upstreamModel: "deepseek-chat",
+    apiBase: "https://api.deepseek.com/v1",
+  },
+];
+
+function pickUpstream(): UpstreamProfile | undefined {
+  return UPSTREAMS.find((u) => !!process.env[u.envVar]);
+}
+
+function claudeOnPath(): boolean {
+  // `claude -h` is the cheapest probe; if the CLI isn't installed
+  // spawnSync sets `error` and returns status null.
+  const probe = spawnSync("claude", ["-h"], { encoding: "utf-8" });
+  return probe.status === 0;
+}
+
+const RUN_REAL_CHAIN = process.env.RUN_CLAUDE_CODE_REAL_CHAIN === "1";
+const MODEL_ALIAS = "claude-code-cli-e2e";
+
+describe("claude code CLI compat: drive gateway through `claude -p`", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  let upstream: UpstreamProfile | undefined;
+  let claudeAvailable = false;
+
+  beforeAll(async () => {
+    if (!RUN_REAL_CHAIN) return;
+    upstream = pickUpstream();
+    if (!upstream) return;
+    claudeAvailable = claudeOnPath();
+    if (!claudeAvailable) return;
+
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "claude-code-cli-e2e-pk",
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      secret: process.env[upstream.envVar]!,
+      api_base: upstream.apiBase,
+    });
+    await admin.createModel({
+      display_name: MODEL_ALIAS,
+      provider: upstream.provider,
+      model_name: upstream.upstreamModel,
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [MODEL_ALIAS],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+  });
+
+  test("`claude -p` against gateway returns a non-empty assistant reply", async (ctx) => {
+    if (!RUN_REAL_CHAIN) {
+      ctx.skip();
+      return;
+    }
+    if (!upstream) {
+      ctx.skip();
+      return;
+    }
+    if (!claudeAvailable) {
+      ctx.skip();
+      return;
+    }
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // Snapshot propagation — poll via /v1/models so the model lookup
+    // path the dispatcher uses is the same one the test waits on.
+    // Mirrors the pattern in openai-sdk-compat.test.ts.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+          headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+        });
+        if (!r.ok) return false;
+        const body = (await r.json()) as { data?: Array<{ id?: string }> };
+        return (body.data ?? []).some((m) => m.id === MODEL_ALIAS);
+      } catch {
+        return false;
+      }
+    });
+
+    // `claude -p` runs print mode (non-interactive, single completion).
+    //
+    // `--bare` strips OAuth / keychain / hooks / skills / CLAUDE.md so
+    // auth is strictly ANTHROPIC_API_KEY — otherwise the developer's
+    // local OAuth session wins and our caller key is silently ignored.
+    //
+    // `--max-budget-usd 0.5` is a belt-and-suspenders cap; the prompt
+    // is small so a single completion costs fractions of a cent.
+    //
+    // `--disable-slash-commands` keeps the CLI from loading user
+    // skills at startup (additional latency, no value to the test).
+    const proxyUrl = app.proxyUrl;
+    const result = spawnSync(
+      "claude",
+      [
+        "-p",
+        "Reply with exactly the single word: ready",
+        "--bare",
+        "--model",
+        MODEL_ALIAS,
+        "--max-budget-usd",
+        "0.5",
+        "--disable-slash-commands",
+      ],
+      {
+        env: {
+          ...process.env,
+          ANTHROPIC_BASE_URL: proxyUrl,
+          ANTHROPIC_API_KEY: CALLER_PLAINTEXT,
+          DISABLE_AUTOUPDATER: "1",
+          CLAUDE_CODE_SIMPLE: "1",
+        },
+        encoding: "utf-8",
+        timeout: 90_000,
+      },
+    );
+
+    expect(
+      result.status,
+      `claude exited ${result.status}; stderr=${(result.stderr ?? "").slice(0, 2048)}`,
+    ).toBe(0);
+    expect(
+      (result.stdout ?? "").trim(),
+      "expected non-empty assistant output on stdout",
+    ).not.toBe("");
+    // The CLI surfaces gateway-side failures as `API Error: <status>`
+    // on stderr. Status === 0 already implies no fatal error, but
+    // pin stderr too so a CLI version that swallowed errors and
+    // exited 0 anyway would still fail the test.
+    expect(result.stderr ?? "").not.toMatch(/API Error:/);
+  }, 120_000);
+});

--- a/tests/e2e/src/cases/claude-code-cli-compat-e2e.test.ts
+++ b/tests/e2e/src/cases/claude-code-cli-compat-e2e.test.ts
@@ -115,11 +115,27 @@ const UPSTREAMS: ReadonlyArray<UpstreamProfile> = [
 
 // Honor an explicit override so CI matrices can pin a single upstream
 // deterministically even when more than one credential is in scope.
+//
+// Hard-fail on a pin whose key is missing — the contract of
+// `REAL_CHAIN_UPSTREAM=<x>` is "use <x>, not anything else". A silent
+// fallback to a different upstream would defeat the determinism the
+// env var exists for and let cross-provider regressions hide behind
+// non-deterministic CI runs.
 function pickUpstream(): UpstreamProfile | undefined {
   const pin = process.env.REAL_CHAIN_UPSTREAM?.toLowerCase();
   if (pin) {
     const explicit = UPSTREAMS.find((u) => u.provider === pin);
-    if (explicit && process.env[explicit.envVar]) return explicit;
+    if (!explicit) {
+      throw new Error(
+        `REAL_CHAIN_UPSTREAM=${pin} is not a known provider; known: ${UPSTREAMS.map((u) => u.provider).join(", ")}`,
+      );
+    }
+    if (!process.env[explicit.envVar]) {
+      throw new Error(
+        `REAL_CHAIN_UPSTREAM=${pin} requires ${explicit.envVar}; refusing to silently fall back to a different upstream`,
+      );
+    }
+    return explicit;
   }
   return UPSTREAMS.find((u) => !!process.env[u.envVar]);
 }
@@ -255,7 +271,6 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
   let app: SpawnedApp | undefined;
   let admin: AdminClient | undefined;
   let proxy: RecordingProxy | undefined;
-  let etcdReachable = false;
   let upstream: UpstreamProfile | undefined;
   let claudeProbe: ClaudeProbe = { available: false, missingFlags: [] };
 
@@ -283,8 +298,7 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
       );
     }
 
-    etcdReachable = await new EtcdClient().ping();
-    if (!etcdReachable) {
+    if (!(await new EtcdClient().ping())) {
       throw new Error(
         "RUN_CLAUDE_CODE_REAL_CHAIN=1 requires etcd reachable at AISIX_E2E_ETCD",
       );
@@ -373,11 +387,12 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
       DISABLE_AUTOUPDATER: "1",
       CLAUDE_CODE_SIMPLE: "1",
     };
+    const PROMPT = "Reply with exactly the single word: ready";
     const result = spawnSync(
       "claude",
       [
         "-p",
-        "Reply with exactly the single word: ready",
+        PROMPT,
         "--bare",
         "--model",
         MODEL_ALIAS,
@@ -456,12 +471,29 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
     // Upstream sees the provider-side model id (gpt-4o-mini /
     // deepseek-chat), not the gateway's display alias.
     expect(sentBody.model).toBe(upstream.upstreamModel);
-    // The user prompt must round-trip through the gateway's
-    // Anthropic-→-OpenAI body translation.
+    // The user prompt must round-trip verbatim through the gateway's
+    // Anthropic-→-OpenAI body translation, AND it must arrive in
+    // role=user. Asserting `role === "user"` separately catches a
+    // regression that moved the prompt into `system` (some bridges
+    // do this to honor cache_control); asserting `contains(PROMPT)`
+    // (the literal sent string, not a partial token) catches a
+    // regression where Claude Code's own system catalogue happens
+    // to contain a fragment of our test prompt and falsely satisfies
+    // a loose includes() check.
     const userMsgs = (sentBody.messages ?? []).filter((m) => m.role === "user");
-    expect(userMsgs.length).toBeGreaterThan(0);
-    const promptText = JSON.stringify(userMsgs).toLowerCase();
-    expect(promptText).toContain("ready");
+    expect(
+      userMsgs.length,
+      "gateway must keep the user prompt in role=user after Anthropic→OpenAI translation",
+    ).toBeGreaterThan(0);
+    const userContentText = userMsgs
+      .map((m) =>
+        typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+      )
+      .join("\n");
+    expect(
+      userContentText,
+      "user prompt must round-trip verbatim through translation",
+    ).toContain(PROMPT);
     // The CLI sends ~30 Anthropic-shape tools. The gateway must
     // translate them to the OpenAI `{type: "function", function: {…}}`
     // shape; a regression that dropped or mistranslated tool blocks

--- a/tests/e2e/src/cases/claude-code-cli-compat-e2e.test.ts
+++ b/tests/e2e/src/cases/claude-code-cli-compat-e2e.test.ts
@@ -1,9 +1,12 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { createServer, request as httpRequest, type Server } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   AdminClient,
   EtcdClient,
+  pickFreePort,
   spawnApp,
   waitConfigPropagation,
   type SpawnedApp,
@@ -18,40 +21,75 @@ import {
 // proves it speaks Anthropic Messages to the wire shape an
 // Anthropic-ecosystem client (Claude Code CLI, Claude Desktop, and the
 // official anthropic-sdk-{python,typescript}) actually emits — which
-// the hand-rolled harness does not.
+// the hand-rolled harness does not generate.
 //
 // A `claude -p` invocation posts ~17KB to /v1/messages: a structured
 // `system` array, a tool catalogue (~30 Anthropic input_schema blocks),
 // `cache_control: {type: "ephemeral"}` markers, an `anthropic-beta`
-// header, and a `?beta=true` query suffix. A regression in any of:
+// header, and a `?beta=true` query suffix.
 //
-//   - /v1/messages query-string tolerance (`?beta=true`)
-//   - x-api-key auth fallback (Authorization-Bearer is NOT sent)
-//   - anthropic-beta / anthropic-version header passthrough vs. strip
-//   - system: [{type:"text", text, cache_control?}] block parsing
-//   - tools[].input_schema → upstream tools[].function.parameters
-//     translation for non-Anthropic upstreams
+// To pin that the gateway both *received* this and *translated it
+// correctly* to the upstream wire shape, the test inserts a recording
+// reverse-proxy between the gateway and the real upstream:
 //
-// would break Claude Code customers but pass every existing test
-// (none of which generate this request shape).
+//   Claude Code CLI ──► gateway ──► recording proxy ──► real upstream
+//                                         │
+//                                         ▼
+//                                   captured request
+//
+// The proxy verbatim-forwards the gateway's outbound request to the
+// real upstream and returns the upstream's response. Captured requests
+// expose the gateway's cross-provider translation product, so a
+// regression that mangled the translation surfaces in the assertions
+// (not just "the CLI exited 0 because the upstream tolerated garbage").
 //
 // Gating: real upstream costs money, so the suite is opt-in.
 //   - RUN_CLAUDE_CODE_REAL_CHAIN=1 to acknowledge spend
 //   - OPENAI_API_KEY or DEEPSEEK_API_KEY for the upstream credential
-//   - `claude` CLI on PATH (skipped silently if not installed)
+//   - `claude` CLI on PATH with `--bare`, `--model`, `--max-budget-usd`,
+//     `--disable-slash-commands` available (probed at beforeAll)
+//
+// When RUN_CLAUDE_CODE_REAL_CHAIN=1 is set, any missing prerequisite
+// (no upstream key, no CLI, no required flag, no etcd) throws hard at
+// beforeAll — a "skip" in opt-in CI mode would silently turn the
+// workflow green without exercising the contract.
 //
 // References:
 // - Anthropic Messages API:
 //   https://docs.anthropic.com/en/api/messages
+// - OpenAI Chat Completions API (the cross-provider target shape):
+//   https://platform.openai.com/docs/api-reference/chat/create
 // - Anthropic Node SDK wire shape (the SDK Claude Code uses):
 //   https://github.com/anthropics/anthropic-sdk-typescript
 // - Claude Code CLI flags: `claude --help` (--bare strips OAuth and
 //   keychain so auth is strictly $ANTHROPIC_API_KEY).
+// - Claude Code CLI install:
+//   https://code.claude.com/docs/en/setup
 
 const CALLER_PLAINTEXT = "sk-claude-code-cli-caller";
 const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
+
+const REQUIRED_CLAUDE_FLAGS = [
+  "--bare",
+  "--model",
+  "--max-budget-usd",
+  "--disable-slash-commands",
+] as const;
+
+const SECRET_PATTERNS: ReadonlyArray<RegExp> = [
+  /sk-[A-Za-z0-9_\-]{8,}/g,
+  /Bearer\s+[A-Za-z0-9_\-.]+/gi,
+];
+
+function redactSecrets(s: string): string {
+  let out = s;
+  for (const pat of SECRET_PATTERNS) {
+    out = out.replace(pat, "[REDACTED]");
+  }
+  return out;
+}
 
 interface UpstreamProfile {
   readonly envVar: "OPENAI_API_KEY" | "DEEPSEEK_API_KEY";
@@ -75,15 +113,139 @@ const UPSTREAMS: ReadonlyArray<UpstreamProfile> = [
   },
 ];
 
+// Honor an explicit override so CI matrices can pin a single upstream
+// deterministically even when more than one credential is in scope.
 function pickUpstream(): UpstreamProfile | undefined {
+  const pin = process.env.REAL_CHAIN_UPSTREAM?.toLowerCase();
+  if (pin) {
+    const explicit = UPSTREAMS.find((u) => u.provider === pin);
+    if (explicit && process.env[explicit.envVar]) return explicit;
+  }
   return UPSTREAMS.find((u) => !!process.env[u.envVar]);
 }
 
-function claudeOnPath(): boolean {
-  // `claude -h` is the cheapest probe; if the CLI isn't installed
-  // spawnSync sets `error` and returns status null.
-  const probe = spawnSync("claude", ["-h"], { encoding: "utf-8" });
-  return probe.status === 0;
+interface ClaudeProbe {
+  readonly available: boolean;
+  readonly missingFlags: ReadonlyArray<string>;
+}
+
+function probeClaude(): ClaudeProbe {
+  const help = spawnSync("claude", ["--help"], { encoding: "utf-8" });
+  if (help.status !== 0) {
+    return { available: false, missingFlags: [...REQUIRED_CLAUDE_FLAGS] };
+  }
+  const text = `${help.stdout ?? ""}\n${help.stderr ?? ""}`;
+  const missing = REQUIRED_CLAUDE_FLAGS.filter((f) => !text.includes(f));
+  return { available: true, missingFlags: missing };
+}
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  search: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface RecordingProxy {
+  baseUrl: string;
+  received: CapturedRequest[];
+  close(): Promise<void>;
+}
+
+// Forward-proxy that records every inbound request and verbatim-relays
+// it to `upstreamBase` (https). The gateway treats this as its real
+// upstream — its outbound translated body and headers land in
+// `received[…].body / headers` for later assertion.
+async function startRecordingProxy(
+  upstreamBase: string,
+): Promise<RecordingProxy> {
+  const url = new URL(upstreamBase);
+  const isHttps = url.protocol === "https:";
+  const upstreamHost = url.hostname;
+  const upstreamPort = url.port ? Number(url.port) : isHttps ? 443 : 80;
+  const upstreamPath = url.pathname.replace(/\/$/, "");
+
+  const received: CapturedRequest[] = [];
+
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk: Buffer) => {
+      raw += chunk.toString("utf8");
+    });
+    req.on("end", () => {
+      const incomingUrl = new URL(req.url ?? "/", "http://placeholder");
+      received.push({
+        method: req.method ?? "GET",
+        path: incomingUrl.pathname,
+        search: incomingUrl.search,
+        headers: Object.fromEntries(
+          Object.entries(req.headers).map(([k, v]) => [
+            k,
+            Array.isArray(v) ? v.join(",") : (v ?? ""),
+          ]),
+        ),
+        body: raw,
+      });
+
+      // Strip hop-by-hop headers and rewrite Host before relaying.
+      const fwdHeaders: Record<string, string | string[]> = {};
+      for (const [k, v] of Object.entries(req.headers)) {
+        if (v === undefined) continue;
+        const lk = k.toLowerCase();
+        if (
+          lk === "host" ||
+          lk === "connection" ||
+          lk === "content-length" ||
+          lk === "transfer-encoding"
+        ) {
+          continue;
+        }
+        fwdHeaders[k] = v;
+      }
+      fwdHeaders.host = upstreamHost;
+
+      const relayPath = `${upstreamPath}${incomingUrl.pathname.replace(/^\/v1/, "")}${incomingUrl.search}`;
+      const relay = (isHttps ? httpsRequest : httpRequest)(
+        {
+          host: upstreamHost,
+          port: upstreamPort,
+          path: relayPath,
+          method: req.method ?? "GET",
+          headers: fwdHeaders,
+        },
+        (upRes) => {
+          res.statusCode = upRes.statusCode ?? 502;
+          for (const [k, v] of Object.entries(upRes.headers)) {
+            if (v !== undefined) res.setHeader(k, v);
+          }
+          upRes.pipe(res);
+        },
+      );
+      relay.on("error", (err) => {
+        res.statusCode = 502;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: { message: `proxy: ${err.message}` } }));
+      });
+      if (raw) relay.write(raw);
+      relay.end();
+    });
+  });
+
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) =>
+    server.listen(port, "127.0.0.1", resolve),
+  );
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    received,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
 }
 
 const RUN_REAL_CHAIN = process.env.RUN_CLAUDE_CODE_REAL_CHAIN === "1";
@@ -92,19 +254,43 @@ const MODEL_ALIAS = "claude-code-cli-e2e";
 describe("claude code CLI compat: drive gateway through `claude -p`", () => {
   let app: SpawnedApp | undefined;
   let admin: AdminClient | undefined;
+  let proxy: RecordingProxy | undefined;
   let etcdReachable = false;
   let upstream: UpstreamProfile | undefined;
-  let claudeAvailable = false;
+  let claudeProbe: ClaudeProbe = { available: false, missingFlags: [] };
 
   beforeAll(async () => {
     if (!RUN_REAL_CHAIN) return;
+
+    // In real-chain mode every prerequisite is required. A `ctx.skip()`
+    // here would let the workflow exit 0 with the contract un-pinned.
     upstream = pickUpstream();
-    if (!upstream) return;
-    claudeAvailable = claudeOnPath();
-    if (!claudeAvailable) return;
+    if (!upstream) {
+      throw new Error(
+        "RUN_CLAUDE_CODE_REAL_CHAIN=1 requires OPENAI_API_KEY or DEEPSEEK_API_KEY",
+      );
+    }
+
+    claudeProbe = probeClaude();
+    if (!claudeProbe.available) {
+      throw new Error(
+        "RUN_CLAUDE_CODE_REAL_CHAIN=1 requires `claude` on PATH; install via https://code.claude.com/docs/en/setup",
+      );
+    }
+    if (claudeProbe.missingFlags.length > 0) {
+      throw new Error(
+        `installed \`claude\` is missing required flags: ${claudeProbe.missingFlags.join(", ")}; upgrade or pin a known-good version`,
+      );
+    }
 
     etcdReachable = await new EtcdClient().ping();
-    if (!etcdReachable) return;
+    if (!etcdReachable) {
+      throw new Error(
+        "RUN_CLAUDE_CODE_REAL_CHAIN=1 requires etcd reachable at AISIX_E2E_ETCD",
+      );
+    }
+
+    proxy = await startRecordingProxy(upstream.apiBase);
 
     app = await spawnApp();
     admin = new AdminClient(app.adminUrl, app.adminKey);
@@ -113,7 +299,10 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
       display_name: "claude-code-cli-e2e-pk",
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       secret: process.env[upstream.envVar]!,
-      api_base: upstream.apiBase,
+      // Point the gateway at the recording proxy. The proxy verbatim-
+      // forwards to the real upstream and captures the outbound body
+      // for the wire-shape assertions below.
+      api_base: proxy.baseUrl,
     });
     await admin.createModel({
       display_name: MODEL_ALIAS,
@@ -129,29 +318,21 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
 
   afterAll(async () => {
     await app?.exit();
+    await proxy?.close();
   });
 
-  test("`claude -p` against gateway returns a non-empty assistant reply", async (ctx) => {
+  test("`claude -p` against gateway → real upstream — round-trip + cross-provider translation", async (ctx) => {
     if (!RUN_REAL_CHAIN) {
       ctx.skip();
       return;
     }
-    if (!upstream) {
-      ctx.skip();
-      return;
-    }
-    if (!claudeAvailable) {
-      ctx.skip();
-      return;
-    }
-    if (!etcdReachable || !app) {
-      ctx.skip();
-      return;
+    // beforeAll throws (not skips) if anything is missing in CI mode,
+    // so we either have everything or the suite already aborted. The
+    // narrowing assertions below let strict mode reason about it.
+    if (!app || !proxy || !upstream) {
+      throw new Error("beforeAll did not initialize the fixture");
     }
 
-    // Snapshot propagation — poll via /v1/models so the model lookup
-    // path the dispatcher uses is the same one the test waits on.
-    // Mirrors the pattern in openai-sdk-compat.test.ts.
     await waitConfigPropagation(async () => {
       try {
         const r = await fetch(`${app!.proxyUrl}/v1/models`, {
@@ -165,6 +346,10 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
       }
     });
 
+    // Baseline-isolate the readiness probe so wire-shape assertions
+    // match the test call's request, not the probe's.
+    const baseline = proxy.received.length;
+
     // `claude -p` runs print mode (non-interactive, single completion).
     //
     // `--bare` strips OAuth / keychain / hooks / skills / CLAUDE.md so
@@ -176,7 +361,18 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
     //
     // `--disable-slash-commands` keeps the CLI from loading user
     // skills at startup (additional latency, no value to the test).
-    const proxyUrl = app.proxyUrl;
+    //
+    // Minimal env passthrough: only the variables Claude Code needs
+    // to function. Avoids leaking unrelated CI secrets into the
+    // subprocess's diagnostic surfaces.
+    const minimalEnv: Record<string, string> = {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      ANTHROPIC_BASE_URL: app.proxyUrl,
+      ANTHROPIC_API_KEY: CALLER_PLAINTEXT,
+      DISABLE_AUTOUPDATER: "1",
+      CLAUDE_CODE_SIMPLE: "1",
+    };
     const result = spawnSync(
       "claude",
       [
@@ -189,31 +385,93 @@ describe("claude code CLI compat: drive gateway through `claude -p`", () => {
         "0.5",
         "--disable-slash-commands",
       ],
-      {
-        env: {
-          ...process.env,
-          ANTHROPIC_BASE_URL: proxyUrl,
-          ANTHROPIC_API_KEY: CALLER_PLAINTEXT,
-          DISABLE_AUTOUPDATER: "1",
-          CLAUDE_CODE_SIMPLE: "1",
-        },
-        encoding: "utf-8",
-        timeout: 90_000,
-      },
+      { env: minimalEnv, encoding: "utf-8", timeout: 90_000 },
     );
 
+    // Branch on signal first — `spawnSync` returns `status: null`,
+    // `signal: "SIGTERM"` on timeout. Without this, the assertion
+    // below fails as "expected null to be 0" and hides the real
+    // failure mode (timeout) under what looks like a clean exit
+    // mismatch.
+    if (result.signal) {
+      throw new Error(
+        `claude killed by ${result.signal} after 90s (likely gateway or upstream hang); stderr=${redactSecrets((result.stderr ?? "").slice(0, 1024))}`,
+      );
+    }
+
+    const safeStderr = redactSecrets((result.stderr ?? "").slice(0, 2048));
     expect(
       result.status,
-      `claude exited ${result.status}; stderr=${(result.stderr ?? "").slice(0, 2048)}`,
+      `claude exited ${result.status}; stderr=${safeStderr}`,
     ).toBe(0);
+    const stdout = (result.stdout ?? "").trim();
+    // A useful response is non-empty and free of recognisable error
+    // shapes — strong enough to fail when the gateway short-circuits
+    // with an error envelope that the CLI surfaces as a benign-
+    // looking string instead of a non-zero exit code.
+    expect(stdout, "expected non-empty assistant output").not.toBe("");
+    expect(stdout.length, "expected substantive response").toBeGreaterThan(2);
     expect(
-      (result.stdout ?? "").trim(),
-      "expected non-empty assistant output on stdout",
-    ).not.toBe("");
-    // The CLI surfaces gateway-side failures as `API Error: <status>`
-    // on stderr. Status === 0 already implies no fatal error, but
-    // pin stderr too so a CLI version that swallowed errors and
-    // exited 0 anyway would still fail the test.
-    expect(result.stderr ?? "").not.toMatch(/API Error:/);
-  }, 120_000);
+      stdout,
+      `assistant output looks like an error envelope: ${stdout.slice(0, 200)}`,
+    ).not.toMatch(/\b(error|denied|forbidden|unauthorized|not found|invalid)\b/i);
+    expect(safeStderr).not.toMatch(/API Error:/);
+
+    // Wire-shape pinning at the proxy: the gateway must have emitted
+    // OpenAI-compat chat completions for the OpenAI/DeepSeek upstream
+    // (both providers share the OpenAI wire shape).
+    //
+    // Without these assertions the test only proves the round-trip
+    // completed — a regression that dropped tool definitions on
+    // translation or sent an Anthropic-shape body to the OpenAI
+    // upstream could still pass (the upstream might 200 on a
+    // partially-mangled body and the CLI render whatever text
+    // came back).
+    const upstreamRequests = proxy.received.slice(baseline);
+    expect(
+      upstreamRequests.length,
+      "gateway should have forwarded at least one upstream call",
+    ).toBeGreaterThan(0);
+
+    const chat = upstreamRequests.find((r) =>
+      r.path.includes("/chat/completions"),
+    );
+    expect(
+      chat,
+      `no /chat/completions in upstream calls; saw ${upstreamRequests.map((r) => r.path).join(", ")}`,
+    ).toBeDefined();
+    expect(chat!.method).toBe("POST");
+    // Gateway → real upstream auth uses Bearer (the provider key's
+    // secret), not the Anthropic-shape x-api-key the CLI sent inbound.
+    expect(
+      chat!.headers.authorization ?? "",
+      "gateway must auth to upstream with Bearer + provider-key secret",
+    ).toMatch(/^Bearer\s+\S+/);
+
+    const sentBody = JSON.parse(chat!.body) as {
+      model?: string;
+      messages?: Array<{ role?: string; content?: unknown }>;
+      tools?: Array<{ type?: string; function?: { name?: string } }>;
+    };
+    // Upstream sees the provider-side model id (gpt-4o-mini /
+    // deepseek-chat), not the gateway's display alias.
+    expect(sentBody.model).toBe(upstream.upstreamModel);
+    // The user prompt must round-trip through the gateway's
+    // Anthropic-→-OpenAI body translation.
+    const userMsgs = (sentBody.messages ?? []).filter((m) => m.role === "user");
+    expect(userMsgs.length).toBeGreaterThan(0);
+    const promptText = JSON.stringify(userMsgs).toLowerCase();
+    expect(promptText).toContain("ready");
+    // The CLI sends ~30 Anthropic-shape tools. The gateway must
+    // translate them to the OpenAI `{type: "function", function: {…}}`
+    // shape; a regression that dropped or mistranslated tool blocks
+    // surfaces here.
+    expect(
+      (sentBody.tools ?? []).length,
+      "gateway must translate Claude Code tool catalogue to OpenAI tools[]",
+    ).toBeGreaterThan(0);
+    const firstTool = sentBody.tools![0];
+    expect(firstTool.type).toBe("function");
+    expect(typeof firstTool.function?.name).toBe("string");
+  }, 180_000);
 });


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/src/cases/claude-code-cli-compat-e2e.test.ts` — drives the gateway's Anthropic-native `/v1/messages` endpoint through the real `claude -p` CLI, with `ANTHROPIC_BASE_URL` pointed at the test gateway and a real non-Anthropic upstream (OpenAI or DeepSeek) behind it.
- Adds `.github/workflows/real-chain.yml` — PR-label-gated workflow modeled on AISIX-Cloud's `real-chain.yml`. Validates secrets, builds the binary, installs the Claude Code CLI via npm, runs only this new test.

## Why this matters

`openai-sdk-compat.test.ts` already proves the gateway speaks OpenAI Chat Completions to OpenAI-shape clients. This sibling proves it speaks Anthropic Messages to the wire shape an Anthropic-ecosystem client (Claude Code CLI, Claude Desktop, anthropic-sdk-{python,typescript}) actually emits — which the hand-rolled harness does not generate.

A `claude -p` invocation posts ~17KB to `/v1/messages`:
- structured `system` array with `cache_control: { type: "ephemeral" }` markers
- a tool catalogue of ~30 entries in Anthropic `input_schema` shape
- `anthropic-beta` header (`prompt-caching-scope-…,claude-code-…,advisor-tool-…`)
- `?beta=true` query suffix
- `x-api-key` auth header (Anthropic shape, not `Authorization: Bearer`)

A regression in any of:
- `/v1/messages?…` query-string tolerance
- `x-api-key` auth fallback
- `anthropic-beta` / `anthropic-version` header passthrough vs. strip
- `system: [{type:"text", text, cache_control?}]` block parsing
- `tools[].input_schema` → upstream `tools[].function.parameters` translation for non-Anthropic upstreams

would break Claude Code customers but pass every existing test.

## Gating

Test default-skips unless **all** of:
- `RUN_CLAUDE_CODE_REAL_CHAIN=1` (acknowledges real-upstream spend)
- `OPENAI_API_KEY` **or** `DEEPSEEK_API_KEY` (upstream credential)
- `claude` CLI on `PATH`

The new workflow gates on the `real chain test` PR label + the in-repo fork guard, matching AISIX-Cloud's pattern. PRs without the label do not trigger this workflow.

## References

- Anthropic Messages API spec: https://docs.anthropic.com/en/api/messages
- Anthropic Node SDK (the wire shape Claude Code uses): https://github.com/anthropics/anthropic-sdk-typescript
- Claude Code CLI setup (npm install path): https://code.claude.com/docs/en/setup
- \`--bare\` flag (strips OAuth/keychain so auth is strictly \`\$ANTHROPIC_API_KEY\`): \`claude --help\`
- Companion DP-side PR: https://github.com/api7/AISIX-Cloud/pull/508

## Test plan

- [ ] \`real-chain\` workflow turns green on this PR (label triggers it)
- [ ] On a separate PR that breaks \`x-api-key\` auth, this test fails before merge
- [ ] On a separate PR that breaks Anthropic→OpenAI tool translation, this test fails before merge
- [ ] Without \`RUN_CLAUDE_CODE_REAL_CHAIN=1\`, the default \`pnpm test\` matrix still skips this case cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an opt-in end-to-end test that exercises the CLI against a configurable live upstream to validate request translation, authentication, and tool/function shaping.

* **Chores**
  * Added an automated workflow to run these compatibility checks on schedule, via manual dispatch, and on pull requests, with required API key validation and environment setup for reliable E2E runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->