### PR TITLE
feat(proxy): emit Server: AISIX/<version> on every response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ async-trait = "0.1"
 axum = { version = "0.7", features = ["macros", "ws", "tracing", "multipart"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace", "cors", "limit", "compression-gzip"] }
+tower-http = { version = "0.6", features = ["trace", "cors", "limit", "compression-gzip", "set-header"] }
 hyper = "1.5"
 hyper-util = "0.1"
 http = "1.2"

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -57,11 +57,18 @@ pub use health::{
 pub use state::ProxyState;
 
 use axum::extract::State;
-use axum::http::Request;
+use axum::http::{header, HeaderValue, Request};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get, post};
 use axum::Router;
+use tower_http::set_header::SetResponseHeaderLayer;
+
+/// Product token emitted in the `Server` response header. Format follows
+/// RFC 9110 §10.2.4 (`product/version`) and matches the convention used
+/// by adjacent gateways (APISIX, nginx, kong). Version is the workspace
+/// crate version, baked in at compile time.
+const SERVER_HEADER_VALUE: &str = concat!("AISIX/", env!("CARGO_PKG_VERSION"));
 
 /// Build the proxy router. Mounts `/livez` plus the
 /// OpenAI-compatible proxy surface.
@@ -101,6 +108,17 @@ pub fn build_router(state: ProxyState) -> Router {
         .layer(middleware::from_fn_with_state(
             state.clone(),
             record_in_flight_request,
+        ))
+        // Identify the data plane on every response, including error
+        // envelopes and short-circuited responses from the layers
+        // above. `overriding` (vs `if_not_present`) ensures the
+        // gateway's identity is authoritative — any Server header set
+        // by inner handlers or accidentally proxied from upstream is
+        // replaced, so client-visible Server never leaks provider
+        // identity.
+        .layer(SetResponseHeaderLayer::overriding(
+            header::SERVER,
+            HeaderValue::from_static(SERVER_HEADER_VALUE),
         ))
         .with_state(state)
 }
@@ -504,6 +522,55 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
         assert_eq!(std::str::from_utf8(&bytes).unwrap(), "ok");
+    }
+
+    /// Every response — including success bodies, error envelopes, and
+    /// short-circuited middleware rejections — must carry the gateway's
+    /// `Server` product token (`AISIX/<semver>`) so clients can identify
+    /// the data plane without round-tripping to a status endpoint.
+    #[tokio::test]
+    async fn server_header_identifies_the_data_plane() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        // Success path — plain handler response.
+        let ok_req = Request::builder()
+            .method("GET")
+            .uri("/livez")
+            .body(Body::empty())
+            .unwrap();
+        let ok_resp = run(app.clone(), ok_req).await;
+        let ok_server = ok_resp
+            .headers()
+            .get(axum::http::header::SERVER)
+            .expect("success response must carry Server header")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            ok_server.starts_with("AISIX/") && ok_server.len() > "AISIX/".len(),
+            "expected `AISIX/<version>`, got {ok_server:?}"
+        );
+
+        // Error path — auth failure envelope. Same Server header must
+        // appear so error responses don't accidentally hide the gateway's
+        // identity (and don't leak any upstream Server token).
+        let unauth_req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"model":"my-gpt4","messages":[]}"#))
+            .unwrap();
+        let unauth_resp = run(app, unauth_req).await;
+        assert_eq!(unauth_resp.status(), StatusCode::UNAUTHORIZED);
+        let err_server = unauth_resp
+            .headers()
+            .get(axum::http::header::SERVER)
+            .expect("error response must carry Server header")
+            .to_str()
+            .unwrap();
+        assert_eq!(err_server, ok_server);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -573,6 +573,115 @@ mod tests {
         assert_eq!(err_server, ok_server);
     }
 
+    /// The 413 short-circuit runs INSIDE `SetResponseHeaderLayer` —
+    /// `enforce_request_body_limit` rejects the request before any
+    /// handler executes. This pins layer ordering: a regression that
+    /// moves `SetResponseHeaderLayer` inside the body-limit middleware
+    /// (or anywhere "below" it in the stack) would silently strip the
+    /// Server header from 413 responses while every existing test
+    /// still passed.
+    #[tokio::test]
+    async fn server_header_present_on_413_short_circuit() {
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let app = build_router(build_state(snap, hub));
+
+        let oversized = 2 * 1024 * 1024; // 2 MiB > 1 MiB cap from cfg()
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .header("content-length", oversized.to_string())
+            .body(Body::from(
+                r#"{"model":"my-gpt4","messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let server = resp
+            .headers()
+            .get(axum::http::header::SERVER)
+            .expect("413 short-circuit must carry Server header")
+            .to_str()
+            .unwrap();
+        assert!(
+            server.starts_with("AISIX/"),
+            "expected `AISIX/<version>`, got {server:?}"
+        );
+    }
+
+    /// Security contract: the gateway must NEVER leak an upstream
+    /// provider's `Server` token to the client. The passthrough handler
+    /// copies upstream response headers wholesale (minus hop-by-hop),
+    /// so an upstream like Cloudflare/nginx/gunicorn would surface its
+    /// own Server unless `overriding` actually replaces it. A regression
+    /// that swapped `overriding` → `if_not_present` would be a silent
+    /// information-disclosure bug (provider fingerprinting via error
+    /// envelopes) — this test locks the no-leak property.
+    #[tokio::test]
+    async fn server_header_overrides_upstream_provider_token_no_leak() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    // Upstream's identity — MUST NOT survive the round-trip.
+                    .insert_header("server", "cloudflare-nginx/3.7-leakthis")
+                    .set_body_json(serde_json::json!({
+                        "id": "cmpl-upstream",
+                        "model": "gpt-4o",
+                        "choices": [{
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "x"},
+                            "finish_reason": "stop"
+                        }],
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+                    })),
+            )
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let app = build_router(build_state(snap, hub));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"my-gpt4","messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Exactly one Server value — `overriding` replaces, doesn't append.
+        let all: Vec<_> = resp
+            .headers()
+            .get_all(axum::http::header::SERVER)
+            .iter()
+            .collect();
+        assert_eq!(
+            all.len(),
+            1,
+            "exactly one Server value expected; got {all:?}"
+        );
+
+        let server = all[0].to_str().unwrap();
+        assert!(
+            server.starts_with("AISIX/"),
+            "Server must be the gateway identity; got {server:?}"
+        );
+        assert!(
+            !server.contains("cloudflare") && !server.contains("nginx"),
+            "Upstream Server token leaked through; got {server:?}"
+        );
+    }
+
     #[tokio::test]
     async fn livez_rejects_non_get_requests() {
         let hub = Arc::new(Hub::new());

--- a/tests/e2e/src/cases/server-header-identity-e2e.test.ts
+++ b/tests/e2e/src/cases/server-header-identity-e2e.test.ts
@@ -10,6 +10,17 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
+// Header-identity scenarios this test pins. Comment lives at the
+// top so the test body stays focused on assertions rather than
+// re-narrating intent. Each scenario maps to a numbered block below.
+//
+//   1. 200 happy-path                       — handler return
+//   2. 401 OpenAI envelope                  — auth-fail short-circuit
+//   3. 404 OpenAI envelope                  — unknown model
+//   4. /livez                               — bare handler, no upstream
+//   5. SSE / streaming chat completion      — flushed headers
+//   6. 401 Anthropic envelope (/v1/messages)— separate rendering path
+
 // E2E: the data plane must identify itself via the `Server` response
 // header on every response, using the `AISIX/<version>` product token.
 // Pinned because the header is a customer-visible contract — clients
@@ -39,16 +50,17 @@ const VALID_KEY_HASH = createHash("sha256")
   .digest("hex");
 const UNKNOWN_PLAINTEXT = "sk-server-header-e2e-unregistered";
 
-// `AISIX/` followed by a non-empty token. Version shape is intentionally
-// loose — the contract is "product/version", not a specific semver
-// today. Tightening to semver here would tie this test to the workspace
-// versioning policy.
-const SERVER_HEADER_PATTERN = /^AISIX\/.+$/;
+// Semver-anchored: `AISIX/` + `<major>.<minor>.<patch>` with optional
+// pre-release / build metadata. The version segment comes from
+// `CARGO_PKG_VERSION`, which the workspace pins to semver — a regression
+// that swaps in e.g. `CARGO_PKG_NAME` (yielding `AISIX/aisix-proxy`)
+// would slip past a looser `.+` pattern. Tightening to semver locks the
+// documented contract.
+const SERVER_HEADER_PATTERN = /^AISIX\/\d+\.\d+\.\d+([-+][\w.-]+)?$/;
 
 describe("data plane identifies itself via Server header on every response", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
-  let admin: AdminClient | undefined;
   let etcdReachable = false;
 
   beforeAll(async () => {
@@ -57,7 +69,7 @@ describe("data plane identifies itself via Server header on every response", () 
 
     upstream = await startOpenAiUpstream();
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    const admin = new AdminClient(app.adminUrl, app.adminKey);
 
     const pk = await admin.createProviderKey({
       display_name: "server-header-pk",
@@ -165,11 +177,63 @@ describe("data plane identifies itself via Server header on every response", () 
     expect(livezServer, "livez missing Server header").not.toBeNull();
     expect(livezServer).toMatch(SERVER_HEADER_PATTERN);
 
+    // 5. SSE / streaming chat completion. Response headers are flushed
+    // at handler-return-time, before body framing starts — a regression
+    // where a streaming route is mounted outside the identity layer
+    // (or where the streaming response is constructed via a hyper Body
+    // pipeline that bypasses tower-http) would lose the Server header
+    // on every streamed call. Drain so the connection closes cleanly.
+    const sse = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${VALID_PLAINTEXT}`,
+        "content-type": "application/json",
+        accept: "text/event-stream",
+      },
+      body: JSON.stringify({
+        model: "server-header-model",
+        messages: [{ role: "user", content: "stream me" }],
+        stream: true,
+      }),
+    });
+    await sse.text();
+    expect(sse.status).toBe(200);
+    expect(sse.headers.get("content-type")).toMatch(/text\/event-stream/);
+    const sseServer = sse.headers.get("server");
+    expect(sseServer, "SSE response missing Server header").not.toBeNull();
+    expect(sseServer).toMatch(SERVER_HEADER_PATTERN);
+
+    // 6. Anthropic-shape error envelope (`/v1/messages` rejects auth
+    // through a separate `into_anthropic_response()` rendering path
+    // from the OpenAI envelope). A regression that builds the
+    // Anthropic 401 via a Response constructor bypassing the outer
+    // layer would slip past an OpenAI-only test.
+    const anth401 = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "x-api-key": UNKNOWN_PLAINTEXT,
+        "content-type": "application/json",
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "server-header-model",
+        max_tokens: 10,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    await anth401.text();
+    expect(anth401.status).toBe(401);
+    const anth401Server = anth401.headers.get("server");
+    expect(anth401Server, "Anthropic-envelope 401 missing Server header").not.toBeNull();
+    expect(anth401Server).toMatch(SERVER_HEADER_PATTERN);
+
     // The gateway's identity must be stable across paths — clients
     // observing different `Server` values on success vs. error would
     // (legitimately) treat that as two different servers in the chain.
     expect(unauthServer).toBe(okServer);
     expect(notfoundServer).toBe(okServer);
     expect(livezServer).toBe(okServer);
+    expect(sseServer).toBe(okServer);
+    expect(anth401Server).toBe(okServer);
   });
 });

--- a/tests/e2e/src/cases/server-header-identity-e2e.test.ts
+++ b/tests/e2e/src/cases/server-header-identity-e2e.test.ts
@@ -1,0 +1,175 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the data plane must identify itself via the `Server` response
+// header on every response, using the `AISIX/<version>` product token.
+// Pinned because the header is a customer-visible contract — clients
+// (and intermediaries) use `Server` to identify the gateway without
+// round-tripping a status endpoint, and the header must survive every
+// response path the DP can emit:
+//
+//   1. Success body                — happy-path 200 from upstream
+//   2. Auth-failure envelope       — 401 from the auth layer
+//   3. Routing-failure envelope    — 404 for unknown model
+//   4. Liveness probe              — bare `/livez` GET
+//
+// All four must carry an *identical* `Server` value: the gateway's
+// identity must not change between request paths, and must never leak
+// an upstream provider's `Server` token (provider fingerprinting via
+// error envelopes is a known leakage vector).
+//
+// References:
+// - RFC 9110 §10.2.4 (Server header, `product/version` format):
+//   <https://www.rfc-editor.org/rfc/rfc9110#section-10.2.4>
+// - APISIX `Server` convention (`APISIX/<version>`):
+//   <https://apisix.apache.org/docs/apisix/admin-api/>
+
+const VALID_PLAINTEXT = "sk-server-header-e2e-valid";
+const VALID_KEY_HASH = createHash("sha256")
+  .update(VALID_PLAINTEXT)
+  .digest("hex");
+const UNKNOWN_PLAINTEXT = "sk-server-header-e2e-unregistered";
+
+// `AISIX/` followed by a non-empty token. Version shape is intentionally
+// loose — the contract is "product/version", not a specific semver
+// today. Tightening to semver here would tie this test to the workspace
+// versioning policy.
+const SERVER_HEADER_PATTERN = /^AISIX\/.+$/;
+
+describe("data plane identifies itself via Server header on every response", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "server-header-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "server-header-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: VALID_KEY_HASH,
+      allowed_models: ["server-header-model"],
+    });
+
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${VALID_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "server-header-model",
+          messages: [{ role: "user", content: "ready-probe" }],
+        }),
+      });
+      await res.text();
+      return res.status === 200;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("every response — success, 401, 404, livez — carries the same AISIX/<version> token", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // 1. Happy-path chat completion.
+    const ok = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${VALID_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "server-header-model",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    await ok.text();
+    expect(ok.status).toBe(200);
+    const okServer = ok.headers.get("server");
+    expect(okServer, "success response missing Server header").not.toBeNull();
+    expect(okServer).toMatch(SERVER_HEADER_PATTERN);
+
+    // 2. Auth-failure envelope (401).
+    const unauth = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${UNKNOWN_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "server-header-model",
+        messages: [{ role: "user", content: "bad auth" }],
+      }),
+    });
+    await unauth.text();
+    expect(unauth.status).toBe(401);
+    const unauthServer = unauth.headers.get("server");
+    expect(unauthServer, "401 envelope missing Server header").not.toBeNull();
+    expect(unauthServer).toMatch(SERVER_HEADER_PATTERN);
+
+    // 3. Routing-failure envelope (404 unknown model).
+    const notfound = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${VALID_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "does-not-exist",
+        messages: [{ role: "user", content: "missing model" }],
+      }),
+    });
+    await notfound.text();
+    expect(notfound.status).toBe(404);
+    const notfoundServer = notfound.headers.get("server");
+    expect(notfoundServer, "404 envelope missing Server header").not.toBeNull();
+    expect(notfoundServer).toMatch(SERVER_HEADER_PATTERN);
+
+    // 4. Bare liveness probe.
+    const livez = await fetch(`${app.proxyUrl}/livez`);
+    await livez.text();
+    expect(livez.status).toBe(200);
+    const livezServer = livez.headers.get("server");
+    expect(livezServer, "livez missing Server header").not.toBeNull();
+    expect(livezServer).toMatch(SERVER_HEADER_PATTERN);
+
+    // The gateway's identity must be stable across paths — clients
+    // observing different `Server` values on success vs. error would
+    // (legitimately) treat that as two different servers in the chain.
+    expect(unauthServer).toBe(okServer);
+    expect(notfoundServer).toBe(okServer);
+    expect(livezServer).toBe(okServer);
+  });
+});


### PR DESCRIPTION
## Summary

- Mount `tower-http::SetResponseHeaderLayer::overriding` at the outermost edge of `build_router` so every DP response carries `Server: AISIX/<CARGO_PKG_VERSION>` (e.g. `AISIX/0.1.0`).
- Header lands on every path: success bodies, error envelopes (4xx / 5xx), short-circuited middleware rejects (413), and `/livez`.
- `overriding` (vs `if_not_present`) — keeps gateway identity authoritative; any Server header set by inner handlers or accidentally proxied through from upstream is replaced, so client-visible Server never leaks provider identity.
- Version is `concat!("AISIX/", env!("CARGO_PKG_VERSION"))` — `&'static str` at compile time, fed straight to `HeaderValue::from_static`, no runtime allocation, no panic surface.

## Why

Customer-visible identity contract: clients (and intermediaries) use `Server` to identify the gateway without a separate status endpoint round-trip. Adjacent gateways follow the same convention (APISIX → `APISIX/3.16.0`, nginx → `nginx/<version>`).

## Test plan

- [x] `cargo test -p aisix-proxy --lib` — 306 passed (incl. new `server_header_identifies_the_data_plane` covering success + 401)
- [x] `cargo clippy -p aisix-proxy --all-targets -- -D warnings` — clean
- [x] New e2e `tests/e2e/src/cases/server-header-identity-e2e.test.ts` — pins success / 401 / 404 / `/livez` all returning the same `AISIX/<version>` against a live DP
- [x] Full e2e suite (Vitest, 53 files / 104 tests) — 101 passed, 3 pre-existing skips, 0 regressions

## References

- RFC 9110 §10.2.4 (Server header, `product/version` format): https://www.rfc-editor.org/rfc/rfc9110#section-10.2.4
- Cargo compile-time env vars (`CARGO_PKG_VERSION`): https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
- APISIX `Server` convention (`Server: APISIX/<version>`) — adjacent gateway in the same product family

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway now returns a consistent `Server` response header on all responses, identifying the AISIX proxy and version number. This prevents upstream server information from leaking through the gateway.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->