### PR TITLE
feat(messages): route /v1/messages/count_tokens to Anthropic upstream (#418)

### DIFF
--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -175,30 +175,64 @@ async fn dispatch(
         *m = Value::String(upstream_model.clone());
     }
 
+    // Apply the PK's `request.*` override block to the outbound body,
+    // identically to the /v1/messages passthrough — count_tokens shares
+    // the same Anthropic ProviderKey, so operator-configured renames /
+    // constraints / defaults must reach this sibling route too. Apply
+    // order matches §5: renames → constraints → defaults; each is a
+    // no-op when its configured map is empty.
+    if let Some(r) = pk_entry.value.request.as_ref() {
+        aisix_provider_openai::overrides::apply_param_renames(body, &r.param_renames);
+        if let Some(constraints) = &r.param_constraints {
+            aisix_provider_openai::overrides::apply_param_constraints(body, constraints);
+        }
+        aisix_provider_openai::overrides::apply_default_body_fields(body, &r.default_body_fields);
+    }
+
     // `build_v1_url` tolerates an api_base with or without `/v1` (the
     // Anthropic dashboard placeholder and copy-pasted full URLs both
     // resolve to `…/v1/messages/count_tokens`).
     let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
     let url = crate::dispatch::build_v1_url(&base, "/messages/count_tokens");
 
-    // Anthropic auth shape: `x-api-key` + `anthropic-version`, NOT
-    // `Authorization: Bearer`. Identical to the /v1/messages passthrough.
+    // Build the outbound HeaderMap explicitly so the PK's
+    // `request.default_headers` block can inject operator-supplied
+    // headers (e.g. `anthropic-beta`) via the shared apply pipeline.
+    // The bridge-owned headers (x-api-key, anthropic-version,
+    // content-type, x-aisix-request-id) are inserted FIRST;
+    // `apply_default_headers` skips keys already present + the reserved
+    // auth-header blacklist (`x-api-key`), so operator headers can never
+    // clobber auth here (ai-gateway#337). Anthropic auth shape:
+    // `x-api-key` + `anthropic-version`, NOT `Authorization: Bearer`.
+    let mut headers = axum::http::HeaderMap::new();
     let api_key_hv = HeaderValue::from_str(api_key).map_err(|e| {
         ProxyError::Bridge(aisix_gateway::BridgeError::Config(format!(
             "api key contains invalid header chars: {e}"
         )))
     })?;
+    headers.insert(HeaderName::from_static("x-api-key"), api_key_hv);
+    headers.insert(
+        HeaderName::from_static("anthropic-version"),
+        HeaderValue::from_static(ANTHROPIC_VERSION),
+    );
+    headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    let rid_hv = HeaderValue::from_str(request_id).map_err(|e| {
+        ProxyError::Bridge(aisix_gateway::BridgeError::Config(format!(
+            "request_id contains invalid header chars: {e}"
+        )))
+    })?;
+    headers.insert(HeaderName::from_static("x-aisix-request-id"), rid_hv);
+    if let Some(r) = pk_entry.value.request.as_ref() {
+        aisix_provider_openai::overrides::apply_default_headers(&mut headers, &r.default_headers);
+    }
 
     let client = crate::http_client::client();
     let upstream_resp = client
         .post(&url)
-        .header(HeaderName::from_static("x-api-key"), api_key_hv)
-        .header(
-            HeaderName::from_static("anthropic-version"),
-            HeaderValue::from_static(ANTHROPIC_VERSION),
-        )
-        .header(axum::http::header::CONTENT_TYPE, "application/json")
-        .header("x-aisix-request-id", request_id)
+        .headers(headers)
         .json(body)
         .send()
         .await
@@ -219,7 +253,15 @@ async fn dispatch(
         let retry_after = aisix_gateway::parse_retry_after(upstream_resp.headers());
         let message = upstream_resp.text().await.unwrap_or_default();
         let truncated = if message.len() > 1024 {
-            format!("{}…", &message[..1024])
+            // Truncate on a UTF-8 char boundary — slicing at the raw byte
+            // index 1024 panics when it splits a multibyte codepoint,
+            // which a non-ASCII upstream error body can trigger on this
+            // error path.
+            let end = (0..=1024)
+                .rev()
+                .find(|&i| message.is_char_boundary(i))
+                .unwrap_or(0);
+            format!("{}…", &message[..end])
         } else {
             message
         };
@@ -465,6 +507,44 @@ mod tests {
         assert!(message.contains("Anthropic"), "got {message:?}");
     }
 
+    /// Regression: a >1024-byte upstream error body whose 1024th byte
+    /// falls mid-codepoint must not panic the handler — a raw
+    /// `&message[..1024]` slice would. Reaching the assertions at all
+    /// proves no panic; the upstream 5xx collapses to a gateway 5xx with
+    /// the Anthropic-shape error envelope.
+    #[tokio::test]
+    async fn oversize_non_ascii_upstream_error_does_not_panic() {
+        // 1023 ASCII bytes + a 3-byte '€' occupying bytes 1023..1026, so
+        // byte index 1024 lands in the middle of a multibyte character.
+        let big_body = format!("{}€", "a".repeat(1023));
+        assert!(!big_body.is_char_boundary(1024), "test setup invariant");
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .respond_with(ResponseTemplate::new(500).set_body_string(big_body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(anthropic_model("claude-haiku"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "claude-haiku",
+                "messages": [{"role": "user", "content": "hi"}]
+            })))
+            .await
+            .unwrap();
+
+        assert!(resp.status().is_server_error());
+        let bytes = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+    }
+
     /// #418 happy path: the route is registered, dispatches to the
     /// Anthropic upstream at `…/v1/messages/count_tokens`, rewrites the
     /// model field, sends the Anthropic auth headers, and returns the
@@ -508,5 +588,152 @@ mod tests {
         let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
         assert_eq!(sent["model"], "claude-haiku-4-5-20251001");
         assert_eq!(sent["messages"][0]["content"], "hello");
+    }
+
+    // ─── PK request.* overrides must apply identically to /v1/messages ──
+    //
+    // count_tokens shares the same Anthropic ProviderKey as /v1/messages,
+    // so the operator's `request.*` overrides must reach this sibling too.
+    // The mocks strict-match the EXPECTED post-override shape — if an
+    // override silently no-ops, the matcher rejects the request and
+    // wiremock 404s, surfacing here as a non-200.
+
+    fn anthropic_pk_with_overrides(
+        api_base: &str,
+        request_overrides: serde_json::Value,
+    ) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json = serde_json::json!({
+            "display_name": "anthropic-up",
+            "secret": "sk-ant-test",
+            "api_base": api_base,
+            "provider": "anthropic",
+            "adapter": "anthropic",
+            "request": request_overrides,
+        });
+        let pk: aisix_core::ProviderKey = serde_json::from_value(json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    /// The concrete count_tokens case: an operator `default_headers`
+    /// block injecting `anthropic-beta` must reach the upstream request.
+    #[tokio::test]
+    async fn applies_default_headers_anthropic_beta() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .and(header("anthropic-beta", "token-counting-2024-11-01"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "input_tokens": 5
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(anthropic_pk_with_overrides(
+            &upstream.uri(),
+            serde_json::json!({
+                "default_headers": {"anthropic-beta": "token-counting-2024-11-01"}
+            }),
+        ));
+        snap.models.insert(anthropic_model("claude-haiku"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "claude-haiku",
+                "messages": [{"role": "user", "content": "hi"}]
+            })))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "default_headers must inject anthropic-beta on count_tokens"
+        );
+    }
+
+    /// `param_renames` must rewrite the body field on the outbound
+    /// count_tokens request, exactly as on /v1/messages.
+    #[tokio::test]
+    async fn applies_param_renames() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .and(wiremock::matchers::body_partial_json(
+                serde_json::json!({"renamed_field": "v"}),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "input_tokens": 5
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(anthropic_pk_with_overrides(
+            &upstream.uri(),
+            serde_json::json!({
+                "param_renames": {"orig_field": "renamed_field"}
+            }),
+        ));
+        snap.models.insert(anthropic_model("claude-haiku"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "claude-haiku",
+                "messages": [{"role": "user", "content": "hi"}],
+                "orig_field": "v"
+            })))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "param_renames must rewrite orig_field → renamed_field on count_tokens"
+        );
+    }
+
+    /// Operator `default_headers` must NOT be able to overwrite the
+    /// gateway-owned `x-api-key` auth header (ai-gateway#337) — the
+    /// reserved blacklist in `apply_default_headers` protects it.
+    #[tokio::test]
+    async fn default_headers_cannot_overwrite_x_api_key() {
+        let upstream = MockServer::start().await;
+        // Mock only 200s when x-api-key is the PK secret, NOT the value
+        // the operator tried to smuggle via default_headers.
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .and(header("x-api-key", "sk-ant-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "input_tokens": 5
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(anthropic_pk_with_overrides(
+            &upstream.uri(),
+            serde_json::json!({
+                "default_headers": {"x-api-key": "attacker-key"}
+            }),
+        ));
+        snap.models.insert(anthropic_model("claude-haiku"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "claude-haiku",
+                "messages": [{"role": "user", "content": "hi"}]
+            })))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "the PK secret x-api-key must survive an operator default_headers override attempt"
+        );
     }
 }

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -305,10 +305,13 @@ async fn dispatch(
                 .insert(axum::http::header::CONTENT_TYPE, hv);
         }
     }
-    resp.headers_mut().insert(
-        HeaderName::from_static("x-aisix-request-id"),
-        HeaderValue::from_str(request_id).unwrap_or_else(|_| HeaderValue::from_static("")),
-    );
+    // Only emit the request-id header when it parses — matching the
+    // /v1/messages handler. An empty fallback value would hurt log
+    // correlation more than an absent header.
+    if let Ok(hv) = HeaderValue::from_str(request_id) {
+        resp.headers_mut()
+            .insert(HeaderName::from_static("x-aisix-request-id"), hv);
+    }
 
     Ok((resp, "anthropic".to_string()))
 }

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -1,0 +1,512 @@
+//! `POST /v1/messages/count_tokens` — Anthropic token-counting passthrough.
+//!
+//! The Anthropic SDK exposes this as `anthropic.messages.countTokens(...)`,
+//! the documented endpoint customers use to size a prompt (messages +
+//! system + tools + images) before issuing a paid `/v1/messages` call.
+//! Claude Code and most Anthropic-SDK apps call it, so a gateway that
+//! omits the route forces callers to over-provision or bypass it (#418).
+//!
+//! This is the sibling sub-route of `/v1/messages`: same model-alias
+//! resolution, same `x-api-key` + `anthropic-version` auth shape, same
+//! Anthropic-shape error envelope (#336). The only differences from the
+//! `/v1/messages` Anthropic passthrough are the upstream suffix
+//! (`/messages/count_tokens`), the absence of streaming, and the tiny
+//! `{"input_tokens": <int>}` response, which is forwarded verbatim.
+//!
+//! Scope: Anthropic-backed models only. `count_tokens` has no upstream
+//! equivalent for OpenAI/Gemini/DeepSeek, so a non-Anthropic Model is
+//! rejected with a 400 at the gateway boundary (parallel to `/v1/rerank`
+//! §168 / `/v1/responses` §4.6) rather than dispatched to an upstream
+//! that would 404 — and rather than the gateway emitting a misleading
+//! 404 of its own, which was the bug this route closes.
+//!
+//! Reference:
+//! - Anthropic Count Message Tokens API:
+//!   <https://platform.claude.com/docs/en/api/messages-count-tokens>
+//!   (`POST /v1/messages/count_tokens` → `{"input_tokens": <int>}`).
+//! - LiteLLM exposes the same route as a user-facing passthrough
+//!   (<https://docs.litellm.ai/docs/anthropic_count_tokens>) and had the
+//!   identical "route missing from the list" bug (BerriAI/litellm#15006).
+
+use aisix_obs::{AccessLog, RequestOutcome};
+use axum::extract::rejection::JsonRejection;
+use axum::extract::State;
+use axum::http::{HeaderName, HeaderValue};
+use axum::response::Response;
+use axum::Json;
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+use crate::auth::AuthenticatedKey;
+use crate::error::ProxyError;
+use crate::messages::ANTHROPIC_VERSION;
+use crate::request_id::new_request_id;
+use crate::state::ProxyState;
+
+pub async fn count_tokens(
+    State(state): State<ProxyState>,
+    auth: Result<AuthenticatedKey, ProxyError>,
+    body: Result<Json<Value>, JsonRejection>,
+) -> Response {
+    // Auth / body-extractor rejections must render the Anthropic-shape
+    // envelope so the Claude SDK's parser recognises them (#336) — same
+    // policy as /v1/messages. The shared helper keeps the body-rejection
+    // discrimination (malformed JSON vs 413 cap vs transport error) in
+    // lockstep with the sibling route.
+    let auth = match auth {
+        Ok(a) => a,
+        Err(e) => return e.into_anthropic_response(),
+    };
+    let Json(mut body) = match body {
+        Ok(j) => j,
+        Err(rej) => {
+            return crate::error::proxy_error_from_json_rejection(
+                rej,
+                state.request_body_limit_bytes,
+            )
+            .into_anthropic_response();
+        }
+    };
+
+    let started = Instant::now();
+    let request_id = new_request_id();
+    let api_key_id = auth.entry.id.clone();
+
+    let model_name = body
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    match dispatch(&state, &auth, &mut body, &request_id).await {
+        Ok((resp, provider)) => {
+            let elapsed = started.elapsed();
+            let status = resp.status().as_u16();
+            emit_access_log(
+                &model_name,
+                &provider,
+                &api_key_id,
+                status,
+                elapsed,
+                &request_id,
+            );
+            state.metrics.record_request(
+                &provider,
+                &model_name,
+                status,
+                RequestOutcome::from_status(status),
+                elapsed,
+            );
+            resp
+        }
+        Err(err) => {
+            let status = err.status().as_u16();
+            let elapsed = started.elapsed();
+            emit_access_log(
+                &model_name,
+                "unknown",
+                &api_key_id,
+                status,
+                elapsed,
+                &request_id,
+            );
+            state.metrics.record_request(
+                "unknown",
+                &model_name,
+                status,
+                RequestOutcome::from_status(status),
+                elapsed,
+            );
+            // Anthropic-shape envelope (#336) — count_tokens callers are
+            // the Anthropic SDK, not OpenAI-compatible clients.
+            err.into_anthropic_response()
+        }
+    }
+}
+
+async fn dispatch(
+    state: &ProxyState,
+    auth: &AuthenticatedKey,
+    body: &mut Value,
+    request_id: &str,
+) -> Result<(Response, String), ProxyError> {
+    let snapshot = state.snapshot.load();
+
+    let model_name = body
+        .get("model")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ProxyError::InvalidRequest("`model` field missing".into()))?
+        .to_string();
+
+    let model_entry = snapshot
+        .models
+        .get_by_name(&model_name)
+        .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
+
+    if !auth.key().can_access(&model_name) {
+        return Err(ProxyError::ModelForbidden(model_name.clone()));
+    }
+
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
+
+    let model = &model_entry.value;
+
+    // count_tokens is an Anthropic Messages sub-route; only Anthropic
+    // exposes it at `…/v1/messages/count_tokens`. Reject any other
+    // provider at the boundary with a 400 rather than dispatching to an
+    // upstream that would 404 (parallel to /v1/rerank's provider gate).
+    if model.provider.as_deref() != Some("anthropic") {
+        return Err(ProxyError::InvalidRequest(format!(
+            "model `{model_name}` is not an Anthropic provider; \
+             /v1/messages/count_tokens requires an Anthropic-backed model"
+        )));
+    }
+
+    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
+    let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
+
+    // Rewrite the `model` field to the upstream value, exactly as the
+    // /v1/messages passthrough does — the caller speaks the gateway's
+    // display name; the upstream expects its own id.
+    if let Some(m) = body.get_mut("model") {
+        *m = Value::String(upstream_model.clone());
+    }
+
+    // `build_v1_url` tolerates an api_base with or without `/v1` (the
+    // Anthropic dashboard placeholder and copy-pasted full URLs both
+    // resolve to `…/v1/messages/count_tokens`).
+    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
+    let url = crate::dispatch::build_v1_url(&base, "/messages/count_tokens");
+
+    // Anthropic auth shape: `x-api-key` + `anthropic-version`, NOT
+    // `Authorization: Bearer`. Identical to the /v1/messages passthrough.
+    let api_key_hv = HeaderValue::from_str(api_key).map_err(|e| {
+        ProxyError::Bridge(aisix_gateway::BridgeError::Config(format!(
+            "api key contains invalid header chars: {e}"
+        )))
+    })?;
+
+    let client = crate::http_client::client();
+    let upstream_resp = client
+        .post(&url)
+        .header(HeaderName::from_static("x-api-key"), api_key_hv)
+        .header(
+            HeaderName::from_static("anthropic-version"),
+            HeaderValue::from_static(ANTHROPIC_VERSION),
+        )
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .header("x-aisix-request-id", request_id)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| {
+            crate::cooldown::note_failure(
+                &state.runtime_status,
+                &model_entry.id,
+                model.cooldown.as_ref(),
+                aisix_gateway::BridgeError::Transport(e.to_string()),
+            )
+        })
+        .map_err(ProxyError::Bridge)?;
+
+    let status = upstream_resp.status();
+
+    if !status.is_success() {
+        let status_u16 = status.as_u16();
+        let retry_after = aisix_gateway::parse_retry_after(upstream_resp.headers());
+        let message = upstream_resp.text().await.unwrap_or_default();
+        let truncated = if message.len() > 1024 {
+            format!("{}…", &message[..1024])
+        } else {
+            message
+        };
+        let err = aisix_gateway::BridgeError::upstream_status_with_retry_after(
+            status_u16,
+            truncated,
+            retry_after,
+        );
+        if let Some((ttl, reason)) = crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+        {
+            state
+                .runtime_status
+                .mark_cooldown(&model_entry.id, ttl, reason);
+        }
+        return Err(ProxyError::Bridge(err));
+    }
+
+    state.health.record_success(&model_name);
+    state.runtime_status.mark_healthy(&model_entry.id);
+
+    // Forward the `{"input_tokens": <int>}` response body verbatim — the
+    // gateway adds nothing to the token-counting contract.
+    let upstream_headers = upstream_resp.headers().clone();
+    let body_bytes = upstream_resp
+        .bytes()
+        .await
+        .map_err(|e| {
+            crate::cooldown::note_failure(
+                &state.runtime_status,
+                &model_entry.id,
+                model.cooldown.as_ref(),
+                aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
+            )
+        })
+        .map_err(ProxyError::Bridge)?;
+
+    let mut resp = axum::response::Response::new(axum::body::Body::from(body_bytes));
+    if let Some(ct) = upstream_headers.get("content-type") {
+        if let Ok(hv) = HeaderValue::from_bytes(ct.as_bytes()) {
+            resp.headers_mut()
+                .insert(axum::http::header::CONTENT_TYPE, hv);
+        }
+    }
+    resp.headers_mut().insert(
+        HeaderName::from_static("x-aisix-request-id"),
+        HeaderValue::from_str(request_id).unwrap_or_else(|_| HeaderValue::from_static("")),
+    );
+
+    Ok((resp, "anthropic".to_string()))
+}
+
+fn emit_access_log(
+    model: &str,
+    provider: &str,
+    api_key_id: &str,
+    status: u16,
+    elapsed: Duration,
+    request_id: &str,
+) {
+    AccessLog {
+        method: "POST",
+        path: "/v1/messages/count_tokens",
+        status,
+        latency: elapsed,
+        provider: Some(provider),
+        model: Some(model),
+        api_key_id: Some(api_key_id),
+        prompt_tokens: None,
+        completion_tokens: None,
+        total_tokens: None,
+        request_id,
+        served_by_model: None,
+        routing_attempt_count: None,
+        routing_fallback_count: None,
+        routing_attempts: None,
+    }
+    .emit();
+}
+
+#[cfg(test)]
+mod tests {
+    use aisix_core::resource::ResourceEntry;
+    use aisix_core::snapshot::SnapshotHandle;
+    use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
+    use aisix_gateway::Hub;
+    use axum::body::to_bytes;
+    use axum::http::{Request, StatusCode};
+    use std::sync::Arc;
+    use tower::ServiceExt;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn cfg() -> ProxyConfig {
+        ProxyConfig {
+            addr: "127.0.0.1:0".into(),
+            request_body_limit_bytes: 1_048_576,
+            tls: None,
+        }
+    }
+
+    const PK_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn anthropic_model(name: &str) -> ResourceEntry<Model> {
+        let json = format!(
+            r#"{{"display_name":"{name}","provider":"anthropic","model_name":"claude-haiku-4-5-20251001","provider_key_id":"{PK_ID}"}}"#
+        );
+        let m: Model = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn openai_model(name: &str) -> ResourceEntry<Model> {
+        let json = format!(
+            r#"{{"display_name":"{name}","provider":"openai","model_name":"gpt-4o","provider_key_id":"{PK_ID}"}}"#
+        );
+        let m: Model = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("m-1", m, 1)
+    }
+
+    fn anthropic_pk(api_base: &str) -> ResourceEntry<aisix_core::ProviderKey> {
+        let json = format!(
+            r#"{{"display_name":"anthropic-up","secret":"sk-ant-test","api_base":"{api_base}","provider":"anthropic","adapter":"anthropic"}}"#
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new(PK_ID, pk, 1)
+    }
+
+    fn new_snap(api_base: &str) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(anthropic_pk(api_base));
+        snap
+    }
+
+    fn apikey_entry(allowed: &[&str]) -> ResourceEntry<ApiKey> {
+        // SHA-256 of "sk-caller".
+        let json = format!(
+            r#"{{"key_hash":"8b6712790a2089c67aa97a2d80022df18cc65c7814350e33baebe79aab508891","allowed_models":{}}}"#,
+            serde_json::to_string(&allowed).unwrap()
+        );
+        let k: ApiKey = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("k-1", k, 1)
+    }
+
+    fn build_app(snap: AisixSnapshot) -> axum::Router {
+        let hub = Arc::new(Hub::new());
+        let handle = SnapshotHandle::new(snap);
+        crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
+    }
+
+    fn make_req(body: serde_json::Value) -> Request<axum::body::Body> {
+        // Anthropic SDK auth shape: x-api-key + anthropic-version.
+        Request::builder()
+            .method("POST")
+            .uri("/v1/messages/count_tokens")
+            .header("x-api-key", "sk-caller")
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_returns_401_anthropic_envelope() {
+        let snap = new_snap("http://unused");
+        let app = build_app(snap);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages/count_tokens")
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(
+                r#"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        // Anthropic-shape envelope: `{type:"error", error:{type,message}}`.
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "authentication_error");
+    }
+
+    #[tokio::test]
+    async fn unknown_model_returns_404() {
+        let snap = new_snap("http://unused");
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "no-such-model",
+                "messages": [{"role": "user", "content": "hi"}]
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn forbidden_model_returns_403() {
+        let snap = new_snap("http://unused");
+        snap.models.insert(anthropic_model("claude-haiku"));
+        snap.apikeys.insert(apikey_entry(&["other-model"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "claude-haiku",
+                "messages": [{"role": "user", "content": "hi"}]
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// A non-Anthropic Model has no upstream count_tokens surface;
+    /// reject at the boundary with 400 (Anthropic-shape) rather than
+    /// 404-ing the caller or dispatching to an upstream that would 404.
+    #[tokio::test]
+    async fn non_anthropic_provider_returns_400() {
+        let snap = AisixSnapshot::new();
+        let pk_json = r#"{"display_name":"openai-up","secret":"sk-openai","api_base":"https://api.openai.com","provider":"openai","adapter":"openai"}"#;
+        let pk: aisix_core::ProviderKey = serde_json::from_str(pk_json).unwrap();
+        snap.provider_keys.insert(ResourceEntry::new(PK_ID, pk, 1));
+        snap.models.insert(openai_model("gpt-model"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-model",
+                "messages": [{"role": "user", "content": "hi"}]
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        let message = v["error"]["message"].as_str().unwrap();
+        assert!(message.contains("Anthropic"), "got {message:?}");
+    }
+
+    /// #418 happy path: the route is registered, dispatches to the
+    /// Anthropic upstream at `…/v1/messages/count_tokens`, rewrites the
+    /// model field, sends the Anthropic auth headers, and returns the
+    /// `{"input_tokens": <n>}` body verbatim.
+    #[tokio::test]
+    async fn happy_path_forwards_to_anthropic_count_tokens() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .and(header("x-api-key", "sk-ant-test"))
+            .and(header("anthropic-version", "2023-06-01"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "input_tokens": 17
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(anthropic_model("claude-haiku"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "claude-haiku",
+                "messages": [{"role": "user", "content": "hello"}]
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["input_tokens"], 17);
+
+        // The model field must be rewritten to the upstream id, and the
+        // request must reach the count_tokens sub-route (not /v1/messages).
+        let received = upstream.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/v1/messages/count_tokens");
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["model"], "claude-haiku-4-5-20251001");
+        assert_eq!(sent["messages"][0]["content"], "hello");
+    }
+}

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -382,6 +382,47 @@ impl ProxyError {
     }
 }
 
+/// Map an axum `JsonRejection` (the body-extractor failure on a POST
+/// handler) onto the internal [`ProxyError`] taxonomy. The caller
+/// decides the wire envelope (`into_response` for OpenAI shape /
+/// `into_anthropic_response` for the Anthropic shape) — this helper
+/// only classifies the failure.
+///
+/// Shared by `/v1/messages` and `/v1/messages/count_tokens` so the two
+/// Anthropic-protocol handlers can't drift on the discrimination rules
+/// below:
+///
+/// - `BytesRejection` is a composite rejection whose inner
+///   `FailedToBufferBody` has two variants: `LengthLimitError`
+///   (`413 PAYLOAD_TOO_LARGE` — the configured body cap was exceeded
+///   during read; the chunked / no-Content-Length case the
+///   `enforce_request_body_limit` middleware can't catch up front) and
+///   `UnknownBodyError` (`400 BAD_REQUEST` — a transport-side body-read
+///   failure, e.g. peer reset mid-body). They MUST map to
+///   `RequestTooLarge` vs `InvalidRequest` respectively, because the
+///   Anthropic SDK's non-retriable-cap branch assumes a true cap hit —
+///   mislabelling a transport failure as `request_too_large` breaks it.
+///   Discriminate via the rejection's own `.status()`.
+/// - `JsonRejection` is `#[non_exhaustive]`, so the fallback arm catches
+///   today's `JsonDataError` / `JsonSyntaxError` / `MissingJsonContentType`
+///   AND any future variant axum adds, defaulting to a 400
+///   `invalid_request_error` until each gets an explicit policy.
+pub(crate) fn proxy_error_from_json_rejection(
+    rej: axum::extract::rejection::JsonRejection,
+    limit_bytes: usize,
+) -> ProxyError {
+    use axum::extract::rejection::JsonRejection;
+    match rej {
+        JsonRejection::BytesRejection(inner) if inner.status() == StatusCode::PAYLOAD_TOO_LARGE => {
+            ProxyError::RequestTooLarge { limit_bytes }
+        }
+        JsonRejection::BytesRejection(_) => {
+            ProxyError::InvalidRequest("failed to read request body".into())
+        }
+        _ => ProxyError::InvalidRequest("invalid JSON request body".into()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -31,6 +31,7 @@ pub mod budget;
 mod chat;
 mod completions;
 pub(crate) mod cooldown;
+mod count_tokens;
 mod dispatch;
 mod embeddings;
 mod error;
@@ -82,6 +83,10 @@ pub fn build_router(state: ProxyState) -> Router {
         .route("/v1/embeddings", post(embeddings::embeddings))
         .route("/v1/images/generations", post(images::image_generations))
         .route("/v1/messages", post(messages::messages))
+        .route(
+            "/v1/messages/count_tokens",
+            post(count_tokens::count_tokens),
+        )
         .route("/v1/rerank", post(rerank::rerank))
         .route("/v1/responses", post(responses::responses))
         .route("/v1/audio/transcriptions", post(audio::transcriptions))
@@ -135,7 +140,7 @@ async fn record_in_flight_request(
 }
 
 fn inbound_protocol_for_endpoint(endpoint: &str) -> &'static str {
-    if endpoint == "/v1/messages" {
+    if endpoint == "/v1/messages" || endpoint == "/v1/messages/count_tokens" {
         "anthropic"
     } else {
         "openai"
@@ -207,7 +212,8 @@ async fn enforce_request_body_limit(
     // near-zero, but non-SDK callers (curl, custom clients) could
     // hit it. Accept both forms.
     let path = request.uri().path();
-    let is_anthropic_path = path == "/v1/messages" || path == "/v1/messages/";
+    let is_anthropic_path =
+        path == "/v1/messages" || path == "/v1/messages/" || path == "/v1/messages/count_tokens";
     let render = |e: ProxyError| -> Response {
         if is_anthropic_path {
             e.into_anthropic_response()

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -49,7 +49,9 @@ use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
 /// Anthropic API version header value injected on every forwarded request.
-const ANTHROPIC_VERSION: &str = "2023-06-01";
+/// Shared with the `/v1/messages/count_tokens` handler so both Anthropic
+/// passthrough paths pin the same version.
+pub(crate) const ANTHROPIC_VERSION: &str = "2023-06-01";
 
 pub async fn messages(
     State(state): State<ProxyState>,
@@ -68,58 +70,15 @@ pub async fn messages(
     let Json(mut body) = match body {
         Ok(j) => j,
         Err(rej) => {
-            use axum::extract::rejection::JsonRejection;
-            use axum::http::StatusCode;
-            // Audit MEDIUM-1: replace `JsonRejection::body_text()`
-            // with stable customer-friendly phrases — axum's internal
-            // wording could drift between releases and silently leak
-            // into the customer-facing envelope.
-            //
-            // Audit MEDIUM-A (3rd audit): discriminate
-            // `BytesRejection` (DefaultBodyLimit fired during read)
-            // from JSON parse errors. Chunked oversize-body callers
-            // (no Content-Length, so `enforce_request_body_limit`
-            // can't decide on the declared size) reach this rejection
-            // when the per-extractor cap fires — they MUST surface as
-            // 413 request_too_large per Anthropic SDK ErrorType
-            // taxonomy, not 400 invalid_request_error.
-            //
-            // Audit MEDIUM-B (4th audit): `BytesRejection` is a
-            // composite rejection — its inner `FailedToBufferBody`
-            // has TWO variants: `LengthLimitError` (status
-            // PAYLOAD_TOO_LARGE — real cap exceeded) and
-            // `UnknownBodyError` (status BAD_REQUEST — transport-
-            // side body-read failure, e.g. peer reset mid-body, hyper
-            // decoder error). The earlier `BytesRejection(_)` blanket
-            // arm mis-labelled transport failures as
-            // `request_too_large`, breaking the Claude SDK's
-            // non-retriable-cap branch (which assumes a true cap
-            // hit). Discriminate via the rejection's own `.status()`
-            // method (exposed by axum's composite_rejection macro,
-            // recursively delegated to the inner variant's
-            // `define_rejection! #[status = ...]`).
-            //
-            // `JsonRejection` is `#[non_exhaustive]` (axum-core
-            // 0.5.6 macros.rs:157), so the fallback `_` arm catches
-            // both today's `JsonDataError` / `JsonSyntaxError` /
-            // `MissingJsonContentType` AND any future variant axum
-            // adds — defaulting to 400 `invalid_request_error` until
-            // each new variant gets an explicit policy decision.
-            return match rej {
-                JsonRejection::BytesRejection(inner)
-                    if inner.status() == StatusCode::PAYLOAD_TOO_LARGE =>
-                {
-                    ProxyError::RequestTooLarge {
-                        limit_bytes: state.request_body_limit_bytes,
-                    }
-                }
-                JsonRejection::BytesRejection(_) => {
-                    // UnknownBodyError or any future composite arm —
-                    // transport-side failure, NOT a size cap.
-                    ProxyError::InvalidRequest("failed to read request body".into())
-                }
-                _ => ProxyError::InvalidRequest("invalid JSON request body".into()),
-            }
+            // Classify the body-extractor failure (malformed JSON vs
+            // 413 cap vs transport read error) via the shared helper so
+            // /v1/messages and /v1/messages/count_tokens stay in lockstep
+            // on the discrimination rules, then render the Anthropic-
+            // shape envelope the Claude SDK can parse (#336).
+            return crate::error::proxy_error_from_json_rejection(
+                rej,
+                state.request_body_limit_bytes,
+            )
             .into_anthropic_response();
         }
     };

--- a/tests/e2e/src/cases/anthropic-count-tokens-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-count-tokens-e2e.test.ts
@@ -1,0 +1,185 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: Anthropic `/v1/messages/count_tokens` through the DP (#418).
+//
+// The Anthropic SDK exposes this as `anthropic.messages.countTokens(...)`
+// — the documented, billing-relevant endpoint callers use to size a
+// prompt before a paid `/v1/messages` call. Before #418 the route was
+// unregistered and the DP returned a bare 404. This test drives the
+// endpoint the way a real Anthropic-SDK / Claude-Code caller does (raw
+// HTTP with the `x-api-key` + `anthropic-version` auth shape, since there
+// is no Anthropic SDK in this harness) and asserts the externally
+// observable contract:
+//
+//   - the caller gets 200 with `{"input_tokens": <number>}`;
+//   - the gateway forwarded to the Anthropic upstream's
+//     `/v1/messages/count_tokens` sub-route (NOT `/v1/messages`);
+//   - it rewrote the `model` alias to the upstream id;
+//   - it spoke the Anthropic auth shape (`x-api-key` +
+//     `anthropic-version`), not `Authorization: Bearer`.
+//
+// The mock-upstream harness is path-agnostic, so feeding it the
+// count_tokens response body lets it stand in for Anthropic's
+// `/v1/messages/count_tokens`. `receivedRequests` confirms the path and
+// request shape the gateway actually sent.
+//
+// Reference:
+// - Anthropic Count Message Tokens API:
+//   <https://platform.claude.com/docs/en/api/messages-count-tokens>
+//   (`POST /v1/messages/count_tokens` → `{"input_tokens": <int>}`).
+
+const CALLER_PLAINTEXT = "sk-ct-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const UPSTREAM_MODEL_ID = "claude-haiku-4-5-20251001";
+const MODEL_ALIAS = "ct-e2e";
+
+describe("anthropic count_tokens e2e: /v1/messages/count_tokens through the DP (#418)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      // Anthropic's documented count_tokens response shape.
+      nonStreamBody: { input_tokens: 42 },
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // Anthropic bridge appends the path to the bare host (no `/v1`).
+    const pk = await admin.createProviderKey({
+      display_name: "ct-e2e-pk",
+      secret: "sk-ant-mock",
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: MODEL_ALIAS,
+      provider: "anthropic",
+      model_name: UPSTREAM_MODEL_ID,
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [MODEL_ALIAS],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("counts tokens against the Anthropic upstream and returns input_tokens", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const countTokens = (model: string) =>
+      fetch(`${app!.proxyUrl}/v1/messages/count_tokens`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": CALLER_PLAINTEXT,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+
+    // Wait for config propagation by probing the route itself — this
+    // also proves the route is registered (a 404 would never become ok).
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await countTokens(MODEL_ALIAS);
+        return r.ok;
+      } catch {
+        return false;
+      }
+    });
+
+    // Baseline-isolate so the assertions below match THIS call, not the
+    // readiness probe (which also lands on /v1/messages/count_tokens).
+    const baseline = upstream.receivedRequests.length;
+
+    const res = await countTokens(MODEL_ALIAS);
+
+    // Caller-visible contract: 200 + the documented count_tokens body.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { input_tokens?: unknown };
+    expect(typeof body.input_tokens).toBe("number");
+    expect(body.input_tokens).toBe(42);
+
+    // Request-side wire shape. Pin the sub-route explicitly: a regression
+    // that routed count_tokens to `/v1/messages` (or any other path)
+    // would still 200 against the path-agnostic mock without this.
+    const ctReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages/count_tokens");
+    expect(ctReq).toBeDefined();
+
+    // model alias rewritten to the upstream id.
+    const sentBody = JSON.parse(ctReq!.body) as {
+      model?: string;
+      messages?: Array<{ role?: string; content?: unknown }>;
+    };
+    expect(sentBody.model).toBe(UPSTREAM_MODEL_ID);
+    expect(sentBody.messages?.[0]?.role).toBe("user");
+
+    // Anthropic auth shape forwarded to upstream — not Bearer. A
+    // regression that forwarded the OpenAI auth shape would 401 in
+    // production but pass against the permissive mock without this.
+    expect(ctReq!.headers["x-api-key"]).toBe("sk-ant-mock");
+    expect(ctReq!.headers["anthropic-version"]).toBeDefined();
+    expect(ctReq!.headers["authorization"]).toBeUndefined();
+  });
+
+  test("count_tokens on an unknown model returns 404, not a bare route 404", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    // The route exists; an unknown model must surface the gateway's
+    // model-not-found path. This guards against a future regression that
+    // unregisters the route (which would 404 every model identically).
+    const res = await fetch(`${app.proxyUrl}/v1/messages/count_tokens`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": CALLER_PLAINTEXT,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "no-such-model",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(res.status).toBe(404);
+    // Anthropic-shape error envelope so the Claude SDK can parse it.
+    const body = (await res.json()) as {
+      type?: string;
+      error?: { type?: string };
+    };
+    expect(body.type).toBe("error");
+    expect(body.error?.type).toBe("not_found_error");
+  });
+});


### PR DESCRIPTION
## Summary

`/v1/messages/count_tokens` returned a bare **404** through the DP because the route was never registered — `count_tokens` appeared nowhere in the codebase. The Anthropic SDK's `messages.countTokens(...)` (used by Claude Code and most Anthropic-SDK apps to size a prompt before a paid `/v1/messages` call) threw `404 (no body)`. Fixes #418.

This registers `/v1/messages/count_tokens` as a passthrough to the Anthropic upstream, the sibling of the already-working `/v1/messages` route.

## What changed

- **`count_tokens.rs` (new)** — handler mirroring the `rerank.rs` passthrough structure. Reuses the existing dispatch helpers (`resolve_provider_key`, `require_secret`, `require_upstream_model`, `resolve_base_url`, `build_v1_url`), sends the `x-api-key` + `anthropic-version` auth shape, rewrites the model alias to the upstream id, and forwards the `{"input_tokens": <int>}` body verbatim.
- **`lib.rs`** — registers the route; adds the path to `inbound_protocol_for_endpoint` (anthropic label) and `is_anthropic_path` (so body-limit 413s render the Anthropic envelope).
- **`error.rs`** — extracts `proxy_error_from_json_rejection` (malformed-JSON vs 413-cap vs transport-error discrimination) into a shared helper.
- **`messages.rs`** — rewired to that helper (removing a ~50-line inline duplicate); `ANTHROPIC_VERSION` made `pub(crate)` and reused.

## Scope decision

Anthropic-backed models only — the issue's scope and what the Anthropic SDK targets. A non-Anthropic model returns a clean **400** (`count_tokens` has no OpenAI/Gemini/DeepSeek upstream equivalent) rather than a misleading 404, and without fabricating a local estimate. Errors use the Anthropic-shape envelope (#336).

## Reference implementations / upstream spec (per CLAUDE.md §7)

- **Anthropic Count Message Tokens API** — `POST /v1/messages/count_tokens` → `{"input_tokens": <int>}`, headers `x-api-key` + `anthropic-version`: <https://platform.claude.com/docs/en/api/messages-count-tokens>
- **LiteLLM** exposes the same route as a user-facing passthrough (<https://docs.litellm.ai/docs/anthropic_count_tokens>) and shipped the *identical* "route missing from the list" bug (BerriAI/litellm#15006) — direct prior art for both the bug class and the fix.

## Testing

- **5 unit tests** (`count_tokens.rs`): 401 (Anthropic envelope), 404 unknown model, 403 forbidden, 400 non-Anthropic provider, happy-path passthrough asserting upstream URL / model rewrite / auth headers.
- **2 e2e tests** (`anthropic-count-tokens-e2e.test.ts`) against the real backend + etcd: `200` with `input_tokens`, correct upstream sub-route (`/v1/messages/count_tokens`, not `/v1/messages`), model rewrite, `x-api-key`/`anthropic-version` forwarded (no `Authorization`); plus unknown-model `404` with the Anthropic error envelope.
- Full proxy suite **313 passed**; sibling `/v1/messages`, tools-cross-provider, and body-edges e2e (the refactored paths) **6 passed**; `cargo fmt --check` + `clippy` clean.

The original repro no longer reproduces: the route now returns 200 instead of a bare 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /v1/messages/count_tokens (Anthropic-compatible) with authentication, access control, quota/rate limits, metrics, and access logs; forwards to upstream with model rewriting and Anthropic headers.

* **Bug Fixes**
  * Unified JSON/body-limit error handling and Anthropic-shaped error envelopes; safe truncation of oversized/non‑UTF8 upstream error bodies; prevent operator headers from overwriting gateway auth header.

* **Tests**
  * New end-to-end tests covering success, auth, unknown/forbidden models, provider mapping, header behavior, and error truncation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->