### PR TITLE
feat(obs): prometheus counters for UsageEvent emission (#408)

### DIFF
--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -59,6 +59,20 @@ pub const M_BUDGET_RESET_SECONDS: &str = "aisix_budget_reset_seconds";
 pub const M_BUDGET_DETAILS_PRESENT: &str = "aisix_budget_details_present";
 pub const M_REDIS_FAILURES_TOTAL: &str = "aisix_redis_failures_total";
 pub const M_USAGE_EVENT_DROPS_TOTAL: &str = "aisix_usage_event_drops_total";
+/// Issue #408: counter for UsageEvents successfully enqueued onto the
+/// `UsageSink` (i.e. handed off to the telemetry worker for delivery
+/// to cp-api + per-env OTLP exporters). Operators slice this by:
+/// - `handler`: which OpenAI-shape handler emitted (chat /
+///   embeddings / responses / completions / rerank / audio /
+///   images / messages). Fixed enumeration, low cardinality.
+/// - `status_code`: bucketed as `2xx` / `4xx` / `5xx` (avoid the
+///   1000-value cardinality blowup of raw u16 codes).
+/// - `inbound_protocol`: `openai` / `anthropic`. Matches the
+///   wire-level field on UsageEvent.
+///
+/// Paired with `aisix_usage_event_drops_total{reason}` for the
+/// `try_send` failure paths (sink full / closed).
+pub const M_USAGE_EVENT_EMITS_TOTAL: &str = "aisix_usage_events_emitted_total";
 pub const M_OTLP_FANOUT_DROPS_TOTAL: &str = "aisix_otlp_fanout_drops_total";
 pub const M_OTLP_FANOUT_FAILURES_TOTAL: &str = "aisix_otlp_fanout_failures_total";
 
@@ -388,6 +402,29 @@ impl Metrics {
         });
     }
 
+    /// Issue #408: bump on a successful `UsageSink::try_emit` (the
+    /// event handed off to the telemetry worker). `handler` is the
+    /// OpenAI-shape endpoint name (`chat`, `embeddings`, etc.);
+    /// `status_code` is a raw u16 — bucketed here so prometheus
+    /// cardinality stays bounded. `inbound_protocol` mirrors the
+    /// wire-level field on `UsageEvent` (`openai` / `anthropic`).
+    pub fn record_usage_event_emit(
+        &self,
+        handler: &'static str,
+        status_code: u16,
+        inbound_protocol: &str,
+    ) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_USAGE_EVENT_EMITS_TOTAL,
+                "handler" => handler,
+                "status_code" => status_bucket(status_code),
+                "inbound_protocol" => inbound_protocol.to_string(),
+            )
+            .increment(1);
+        });
+    }
+
     pub fn record_otlp_fanout_drop(&self, exporter: &str, reason: &str) {
         metrics::with_local_recorder(&self.inner.recorder, || {
             metrics::counter!(
@@ -404,6 +441,21 @@ impl Metrics {
             metrics::counter!(M_OTLP_FANOUT_FAILURES_TOTAL, "exporter" => exporter.to_string())
                 .increment(1);
         });
+    }
+}
+
+/// Bucket an HTTP status code into one of `2xx` / `3xx` / `4xx` /
+/// `5xx` / `other` (the last covers 1xx and out-of-range). Used by
+/// the UsageEvent emission counter (#408) to keep prometheus label
+/// cardinality bounded — raw `u16` would explode to ~1000 series per
+/// handler×protocol combination.
+fn status_bucket(status: u16) -> &'static str {
+    match status {
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "other",
     }
 }
 

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -402,24 +402,31 @@ impl Metrics {
         });
     }
 
-    /// Issue #408: bump on a successful `UsageSink::try_emit` (the
-    /// event handed off to the telemetry worker). `handler` is the
-    /// OpenAI-shape endpoint name (`chat`, `embeddings`, etc.);
-    /// `status_code` is a raw u16 — bucketed here so prometheus
-    /// cardinality stays bounded. `inbound_protocol` mirrors the
-    /// wire-level field on `UsageEvent` (`openai` / `anthropic`).
+    /// Issue #408: bump on every `UsageSink::try_emit` call (the
+    /// handler's emission intent — paired with the drops counter so
+    /// the invariant `emitted == delivered + dropped` holds strictly).
+    ///
+    /// All three labels are `&'static str` so prometheus cardinality
+    /// is type-system-bounded:
+    /// - `handler`: OpenAI-shape endpoint name (`chat`, `embeddings`,
+    ///   `messages`, etc.)
+    /// - `status_code`: bucketed by `status_bucket()` (one of `2xx` /
+    ///   `3xx` / `4xx` / `5xx` / `other`) — never a raw u16
+    /// - `inbound_protocol`: normalised by the caller to one of
+    ///   `"openai"` / `"anthropic"` / `"other"` (audit MEDIUM-3 —
+    ///   `&'static str` here prevents user-controlled cardinality)
     pub fn record_usage_event_emit(
         &self,
         handler: &'static str,
         status_code: u16,
-        inbound_protocol: &str,
+        inbound_protocol: &'static str,
     ) {
         metrics::with_local_recorder(&self.inner.recorder, || {
             metrics::counter!(
                 M_USAGE_EVENT_EMITS_TOTAL,
                 "handler" => handler,
                 "status_code" => status_bucket(status_code),
-                "inbound_protocol" => inbound_protocol.to_string(),
+                "inbound_protocol" => inbound_protocol,
             )
             .increment(1);
         });
@@ -872,5 +879,31 @@ mod tests {
             rendered.contains(" 0"),
             "expected gauge to return to zero:\n{rendered}"
         );
+    }
+
+    /// Issue #408 audit MEDIUM-2: pin every boundary of
+    /// `status_bucket` so an off-by-one (e.g. `200..299` excluding
+    /// 299) would surface as a CI failure rather than slipping
+    /// past as silent re-labelling. Covers all 5 buckets including
+    /// the dead-code `3xx` / `other` arms which have no live caller
+    /// today.
+    #[test]
+    fn status_bucket_boundaries_are_inclusive() {
+        // 2xx
+        assert_eq!(status_bucket(200), "2xx");
+        assert_eq!(status_bucket(299), "2xx");
+        // 3xx
+        assert_eq!(status_bucket(300), "3xx");
+        assert_eq!(status_bucket(399), "3xx");
+        // 4xx
+        assert_eq!(status_bucket(400), "4xx");
+        assert_eq!(status_bucket(499), "4xx");
+        // 5xx
+        assert_eq!(status_bucket(500), "5xx");
+        assert_eq!(status_bucket(599), "5xx");
+        // out-of-range → other
+        assert_eq!(status_bucket(199), "other");
+        assert_eq!(status_bucket(600), "other");
+        assert_eq!(status_bucket(0), "other");
     }
 }

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -293,7 +293,12 @@ fn is_false(b: &bool) -> bool {
 /// can externally assert emission without a cp-api receiver in the
 /// loop. Counter is bumped on emission *intent* (i.e. every call to
 /// `try_emit`); drops counter is the subset that failed to enqueue.
-/// Invariant: `emitted - drops ≈ delivered`.
+/// Invariant (audit HIGH-1): `emitted == delivered + dropped`. Every
+/// emit increments exactly one of these:
+/// - delivered: channel accepted the event
+/// - dropped (reason=sink_full): worker overloaded
+/// - dropped (reason=sink_closed): worker shut down
+/// - dropped (reason=sink_disabled): no sink wired (legacy / dev mode)
 #[derive(Debug, Clone)]
 pub struct UsageSink {
     tx: Option<tokio::sync::mpsc::Sender<UsageEvent>>,
@@ -344,16 +349,35 @@ impl UsageSink {
     /// `"embeddings"`, `"messages"`, `"responses"`, etc. Keep it
     /// `&'static str` so cardinality stays bounded.
     pub fn try_emit(&self, handler: &'static str, event: UsageEvent) {
+        // Normalise inbound_protocol to a fixed `&'static str` set at
+        // the boundary (audit MEDIUM-3). This both kills the heap
+        // alloc per call AND pins prometheus cardinality at the type
+        // level: a future caller that sets `event.inbound_protocol`
+        // to user-controlled data still produces a bounded label.
+        let bounded_protocol: &'static str = match event.inbound_protocol.as_str() {
+            "openai" => "openai",
+            "anthropic" => "anthropic",
+            _ => "other",
+        };
+
         // Bump the emit counter on *intent* — handler tried to emit.
-        // Subtract `drops_total` for delivered-event rate. Disabled
-        // sinks still bump because operators want to see "handler
-        // wanted to emit but no sink was wired" via a metric, not
-        // silent zeros.
+        // Audit HIGH-1: paired with a drops counter bump on every
+        // failure path (including `sink_disabled`) so the invariant
+        // `emitted == delivered + dropped` holds strictly.
         if let Some(m) = &self.metrics {
-            m.record_usage_event_emit(handler, event.status_code, &event.inbound_protocol);
+            m.record_usage_event_emit(handler, event.status_code, bounded_protocol);
         }
 
-        let Some(tx) = &self.tx else { return };
+        let Some(tx) = &self.tx else {
+            // No sink wired (legacy / dev mode). Counted as a drop
+            // with reason=sink_disabled so operators can see "DP
+            // intended to emit but no sink was wired" — silent
+            // zeros would otherwise hide the misconfiguration.
+            if let Some(m) = &self.metrics {
+                m.record_usage_event_drop("sink_disabled");
+            }
+            return;
+        };
 
         if let Err(err) = tx.try_send(event) {
             // `Full` = worker is overloaded; `Closed` = worker shut
@@ -456,10 +480,14 @@ mod tests {
         );
     }
 
-    /// Issue #408: when `try_send` fails (channel full / closed),
-    /// the drops counter bumps with the right reason and the emit
-    /// counter still records the intent. Invariant:
-    /// `emitted == delivered + dropped`.
+    /// Issue #408 audit HIGH-2: when `try_send` fails the emit
+    /// counter still bumps for *intent* and the drops counter
+    /// bumps for *outcome*. Strict numeric invariant pinned:
+    /// `emit_total == delivered + drops_total`. After two calls
+    /// (one delivered, one dropped on a capacity-1 channel) the
+    /// scrape must show `emit_total == 2` and `drops_total == 1`.
+    /// A regression that double-bumped emit on drop, or skipped
+    /// emit when the channel rejected, would fail here.
     #[tokio::test]
     async fn dropped_event_records_reason_and_keeps_emit_count() {
         let metrics = crate::metrics::Metrics::new(false);
@@ -476,18 +504,166 @@ mod tests {
         sink.try_emit("chat", event()); // dropped (channel full)
 
         let rendered = metrics.render();
+        // Numeric assertions (audit HIGH-2): name-only checks let a
+        // double-bump regression through. Pin exact values.
+        let emit_value = parse_counter_value(
+            &rendered,
+            "aisix_usage_events_emitted_total",
+            &[("handler", "chat"), ("status_code", "2xx")],
+        );
+        assert_eq!(emit_value, 2, "emit must be exactly 2:\n{rendered}");
+
+        let drop_value = parse_counter_value(
+            &rendered,
+            "aisix_usage_event_drops_total",
+            &[("reason", "sink_full")],
+        );
+        assert_eq!(
+            drop_value, 1,
+            "drops_total{{reason=sink_full}} must be exactly 1:\n{rendered}",
+        );
+    }
+
+    /// Issue #408 audit MEDIUM-1: the `sink_closed` reason path must
+    /// be covered independently of `sink_full`. A future refactor that
+    /// swapped the labels would only be caught by exercising both
+    /// arms of the match.
+    #[tokio::test]
+    async fn dropped_event_with_closed_receiver_records_sink_closed_reason() {
+        let metrics = crate::metrics::Metrics::new(false);
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        drop(rx); // close the receiver before any send
+        let sink = UsageSink::new(tx).with_metrics(metrics.clone());
+
+        sink.try_emit(
+            "chat",
+            UsageEvent {
+                status_code: 200,
+                inbound_protocol: "openai".into(),
+                ..Default::default()
+            },
+        );
+
+        let rendered = metrics.render();
+        let drop_value = parse_counter_value(
+            &rendered,
+            "aisix_usage_event_drops_total",
+            &[("reason", "sink_closed")],
+        );
+        assert_eq!(
+            drop_value, 1,
+            "drops_total{{reason=sink_closed}} must be 1 when receiver was dropped:\n{rendered}",
+        );
+    }
+
+    /// Issue #408 audit HIGH-1: a `disabled()` sink with metrics
+    /// attached must still preserve `emitted == delivered + dropped`.
+    /// The drop is recorded with `reason=sink_disabled` so operators
+    /// can see "DP intended to emit but no sink was wired" rather
+    /// than silent zeros.
+    #[tokio::test]
+    async fn disabled_sink_with_metrics_records_sink_disabled_drop() {
+        let metrics = crate::metrics::Metrics::new(false);
+        let sink = UsageSink::disabled().with_metrics(metrics.clone());
+
+        sink.try_emit(
+            "chat",
+            UsageEvent {
+                status_code: 200,
+                inbound_protocol: "openai".into(),
+                ..Default::default()
+            },
+        );
+        sink.try_emit(
+            "chat",
+            UsageEvent {
+                status_code: 200,
+                inbound_protocol: "openai".into(),
+                ..Default::default()
+            },
+        );
+
+        let rendered = metrics.render();
+        // Both calls bump emit; both calls bump drop with sink_disabled.
+        // Invariant: emit (2) == delivered (0) + drops (2).
+        let emit_value = parse_counter_value(
+            &rendered,
+            "aisix_usage_events_emitted_total",
+            &[("handler", "chat"), ("status_code", "2xx")],
+        );
+        assert_eq!(
+            emit_value, 2,
+            "emit must be 2 even on disabled sink:\n{rendered}"
+        );
+
+        let drop_value = parse_counter_value(
+            &rendered,
+            "aisix_usage_event_drops_total",
+            &[("reason", "sink_disabled")],
+        );
+        assert_eq!(
+            drop_value, 2,
+            "drops_total{{reason=sink_disabled}} must be 2:\n{rendered}",
+        );
+    }
+
+    /// Issue #408 audit MEDIUM-3: a wire-level `inbound_protocol`
+    /// outside the documented set must be normalised to `"other"`
+    /// rather than landing on the metric as a user-controlled
+    /// cardinality vector. This pins the boundary defence.
+    #[tokio::test]
+    async fn unknown_inbound_protocol_buckets_into_other() {
+        let metrics = crate::metrics::Metrics::new(false);
+        let (tx, _rx) = tokio::sync::mpsc::channel(8);
+        let sink = UsageSink::new(tx).with_metrics(metrics.clone());
+
+        sink.try_emit(
+            "chat",
+            UsageEvent {
+                status_code: 200,
+                // A future / out-of-spec value that some future
+                // caller might set. Must NOT land on the wire as a
+                // label value.
+                inbound_protocol: "evil-cardinality-bomb".into(),
+                ..Default::default()
+            },
+        );
+
+        let rendered = metrics.render();
         assert!(
-            rendered.contains("aisix_usage_events_emitted_total"),
-            "emit counter must be present:\n{rendered}",
+            !rendered.contains("evil-cardinality-bomb"),
+            "user-controlled inbound_protocol must not leak into the label:\n{rendered}",
         );
         assert!(
-            rendered.contains("aisix_usage_event_drops_total"),
-            "drops counter must be present after a drop:\n{rendered}",
+            rendered.contains("inbound_protocol=\"other\""),
+            "unknown inbound_protocol must bucket to \"other\":\n{rendered}",
         );
-        assert!(
-            rendered.contains("reason=\"sink_full\""),
-            "drop reason must be sink_full when channel was at capacity:\n{rendered}",
-        );
+    }
+
+    /// Helper: pull the integer counter value from a prometheus
+    /// scrape, matching by metric name and all required label pairs.
+    /// Returns 0 if no matching line. Robust to label ordering in
+    /// the scrape output.
+    #[cfg(test)]
+    fn parse_counter_value(scrape: &str, name: &str, labels: &[(&str, &str)]) -> u64 {
+        for line in scrape.lines() {
+            if !line.starts_with(&format!("{name}{{")) {
+                continue;
+            }
+            let all_match = labels
+                .iter()
+                .all(|(k, v)| line.contains(&format!("{k}=\"{v}\"")));
+            if !all_match {
+                continue;
+            }
+            // Format: `metric{labels} <value>`
+            if let Some(value_str) = line.rsplit_once(' ').map(|(_, v)| v.trim()) {
+                if let Ok(v) = value_str.parse::<u64>() {
+                    return v;
+                }
+            }
+        }
+        0
     }
 
     #[test]

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -281,27 +281,54 @@ fn is_false(b: &bool) -> bool {
 /// by an mpsc::Sender; `try_emit` is non-blocking and silently drops
 /// the event if the worker's queue is full (avoids back-pressuring
 /// the request hot path on a wedged CP). Drops are counted via
-/// tracing::warn! so observers can see a wedge.
+/// tracing::warn! and (when a `Metrics` handle is attached) the
+/// `aisix_usage_event_drops_total{reason}` prometheus counter so
+/// observers can see a wedge.
 ///
 /// In a deployment without CP-side telemetry (legacy / dev), the
 /// handle's `tx` is `None` and `try_emit` is a no-op.
+///
+/// Issue #408: the sink also bumps `aisix_usage_events_emitted_total
+/// {handler, status_code, inbound_protocol}` on every call so e2e
+/// can externally assert emission without a cp-api receiver in the
+/// loop. Counter is bumped on emission *intent* (i.e. every call to
+/// `try_emit`); drops counter is the subset that failed to enqueue.
+/// Invariant: `emitted - drops ≈ delivered`.
 #[derive(Debug, Clone)]
 pub struct UsageSink {
     tx: Option<tokio::sync::mpsc::Sender<UsageEvent>>,
+    metrics: Option<crate::metrics::Metrics>,
 }
 
 impl UsageSink {
     /// Build a real sink backed by an mpsc::Sender. The receiving end
-    /// is owned by the worker spawned in aisix-server.
+    /// is owned by the worker spawned in aisix-server. No prometheus
+    /// counter wiring until `with_metrics` is also called.
     pub fn new(tx: tokio::sync::mpsc::Sender<UsageEvent>) -> Self {
-        Self { tx: Some(tx) }
+        Self {
+            tx: Some(tx),
+            metrics: None,
+        }
     }
 
     /// Build a no-op sink. `try_emit` drops events silently — used
     /// when the DP runs without a configured CP (dev / standalone
     /// modes) so handlers don't have to special-case Optional fields.
     pub fn disabled() -> Self {
-        Self { tx: None }
+        Self {
+            tx: None,
+            metrics: None,
+        }
+    }
+
+    /// Attach a Metrics handle so `try_emit` bumps the #408 emission
+    /// and drops counters. Optional — without it, the sink behaves
+    /// exactly as the pre-#408 sink (channel send only, no counters).
+    /// The server bootstrap calls this in managed mode after building
+    /// the shared `Metrics` instance.
+    pub fn with_metrics(mut self, metrics: crate::metrics::Metrics) -> Self {
+        self.metrics = Some(metrics);
+        self
     }
 
     /// Non-blocking emit. Returns immediately:
@@ -311,13 +338,35 @@ impl UsageSink {
     ///   error to the caller — request handlers must NOT fail because
     ///   telemetry can't keep up.
     /// - `Ok(())` no-op on a `disabled()` sink.
-    pub fn try_emit(&self, event: UsageEvent) {
+    ///
+    /// `handler` is a fixed-set label for the prometheus
+    /// `aisix_usage_events_emitted_total` counter (#408): `"chat"`,
+    /// `"embeddings"`, `"messages"`, `"responses"`, etc. Keep it
+    /// `&'static str` so cardinality stays bounded.
+    pub fn try_emit(&self, handler: &'static str, event: UsageEvent) {
+        // Bump the emit counter on *intent* — handler tried to emit.
+        // Subtract `drops_total` for delivered-event rate. Disabled
+        // sinks still bump because operators want to see "handler
+        // wanted to emit but no sink was wired" via a metric, not
+        // silent zeros.
+        if let Some(m) = &self.metrics {
+            m.record_usage_event_emit(handler, event.status_code, &event.inbound_protocol);
+        }
+
         let Some(tx) = &self.tx else { return };
+
         if let Err(err) = tx.try_send(event) {
-            // Both `Full` and `Closed` end up here. Full = worker is
-            // overloaded; Closed = worker shut down cleanly. Either
-            // way the event is gone — log once per drop and move on.
-            tracing::warn!(error = %err, "usage event dropped (sink full or closed)");
+            // `Full` = worker is overloaded; `Closed` = worker shut
+            // down cleanly. Either way the event is gone — record the
+            // distinction so the operator knows *why* the wedge.
+            let reason = match err {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => "sink_full",
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => "sink_closed",
+            };
+            if let Some(m) = &self.metrics {
+                m.record_usage_event_drop(reason);
+            }
+            tracing::warn!(reason = reason, "usage event dropped");
         }
     }
 }
@@ -331,16 +380,16 @@ mod tests {
         let sink = UsageSink::disabled();
         // Doesn't panic; doesn't allocate a worker. Two emits in a
         // row also fine.
-        sink.try_emit(sample_event("req-1"));
-        sink.try_emit(sample_event("req-2"));
+        sink.try_emit("test", sample_event("req-1"));
+        sink.try_emit("test", sample_event("req-2"));
     }
 
     #[tokio::test]
     async fn emit_into_real_channel_arrives_in_order() {
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let sink = UsageSink::new(tx);
-        sink.try_emit(sample_event("req-a"));
-        sink.try_emit(sample_event("req-b"));
+        sink.try_emit("test", sample_event("req-a"));
+        sink.try_emit("test", sample_event("req-b"));
         let a = rx.recv().await.unwrap();
         let b = rx.recv().await.unwrap();
         assert_eq!(a.request_id, "req-a");
@@ -354,8 +403,91 @@ mod tests {
         // hot path.
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         let sink = UsageSink::new(tx);
-        sink.try_emit(sample_event("req-1"));
-        sink.try_emit(sample_event("req-2")); // dropped, logged
+        sink.try_emit("test", sample_event("req-1"));
+        sink.try_emit("test", sample_event("req-2")); // dropped, logged
+    }
+
+    /// Issue #408: a `try_emit` call with a Metrics handle attached
+    /// must bump `aisix_usage_events_emitted_total` exactly once per
+    /// call. The status_code label is bucketed (2xx / 4xx / 5xx)
+    /// rather than raw to keep prometheus cardinality bounded.
+    #[tokio::test]
+    async fn emits_counter_increments_per_call() {
+        let metrics = crate::metrics::Metrics::new(false);
+        let (tx, _rx) = tokio::sync::mpsc::channel(8);
+        let sink = UsageSink::new(tx).with_metrics(metrics.clone());
+
+        sink.try_emit(
+            "chat",
+            UsageEvent {
+                status_code: 200,
+                inbound_protocol: "openai".into(),
+                ..Default::default()
+            },
+        );
+        sink.try_emit(
+            "embeddings",
+            UsageEvent {
+                status_code: 200,
+                inbound_protocol: "openai".into(),
+                ..Default::default()
+            },
+        );
+
+        let rendered = metrics.render();
+        // The exact text format is metrics-rs's choice; assert both
+        // the metric name and label combinations are present, and
+        // value reaches 1 per (handler, status_code, inbound_protocol).
+        assert!(
+            rendered.contains("aisix_usage_events_emitted_total"),
+            "counter must appear in scrape:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("handler=\"chat\"") && rendered.contains("handler=\"embeddings\""),
+            "per-handler labels must be present:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("status_code=\"2xx\""),
+            "status_code must be bucketed (2xx), not raw 200:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("inbound_protocol=\"openai\""),
+            "inbound_protocol label must be present:\n{rendered}",
+        );
+    }
+
+    /// Issue #408: when `try_send` fails (channel full / closed),
+    /// the drops counter bumps with the right reason and the emit
+    /// counter still records the intent. Invariant:
+    /// `emitted == delivered + dropped`.
+    #[tokio::test]
+    async fn dropped_event_records_reason_and_keeps_emit_count() {
+        let metrics = crate::metrics::Metrics::new(false);
+        let (tx, _rx) = tokio::sync::mpsc::channel(1); // capacity 1
+        let sink = UsageSink::new(tx).with_metrics(metrics.clone());
+
+        let event = || UsageEvent {
+            status_code: 200,
+            inbound_protocol: "openai".into(),
+            ..Default::default()
+        };
+
+        sink.try_emit("chat", event()); // delivered
+        sink.try_emit("chat", event()); // dropped (channel full)
+
+        let rendered = metrics.render();
+        assert!(
+            rendered.contains("aisix_usage_events_emitted_total"),
+            "emit counter must be present:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("aisix_usage_event_drops_total"),
+            "drops counter must be present after a drop:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("reason=\"sink_full\""),
+            "drop reason must be sink_full when channel was at capacity:\n{rendered}",
+        );
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1737,7 +1737,10 @@ fn emit_usage_event(
         pk_label: sanitize_tag(tags.pk_label.unwrap_or_default()),
         byo_label: sanitize_tag(tags.byo_label.unwrap_or_default()),
     };
-    state.usage_sink.try_emit(event.clone());
+    // Handler label "chat" matches the documented enumeration for
+    // `aisix_usage_events_emitted_total` (#408). Keep `&'static str`
+    // so prometheus cardinality stays bounded.
+    state.usage_sink.try_emit("chat", event.clone());
     // Per-env OTLP/HTTP fan-out. The snapshot's exporter table is
     // empty for envs that haven't configured any, so this is a cheap
     // no-op on the common path. Spawned tasks own the POST work and

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -357,7 +357,8 @@ fn emit_usage_event(
         inbound_protocol: "openai".to_string(),
         ..Default::default()
     };
-    state.usage_sink.try_emit(event.clone());
+    // Handler label "embeddings" — bucketed prometheus counter (#408).
+    state.usage_sink.try_emit("embeddings", event.clone());
     // Per-env OTLP/HTTP fan-out — same shape as chat.rs:1334. The
     // snapshot's exporter table is empty for envs that haven't
     // configured any, so this is a cheap no-op on the common path.

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -915,7 +915,9 @@ fn emit_anthropic_usage_event(
         byo_label: sanitize_tag(tags.byo_label.unwrap_or_default()),
         ..Default::default()
     };
-    state.usage_sink.try_emit(event.clone());
+    // Handler label "messages" — Anthropic /v1/messages inbound
+    // path. Bucketed prometheus counter (#408).
+    state.usage_sink.try_emit("messages", event.clone());
     let exporters = snap.observability_exporters.entries();
     state
         .otlp_fan_out

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -386,7 +386,10 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         cache.clone(),
         &cfg.proxy,
     );
-    proxy_state = proxy_state.with_usage_sink(usage_sink);
+    // Wire the prometheus emit/drop counters into the sink (#408)
+    // so a real DP scrape surfaces UsageEvent throughput without
+    // needing cp-api or an OTLP receiver in the loop.
+    proxy_state = proxy_state.with_usage_sink(usage_sink.with_metrics((*metrics).clone()));
     if let Some(client) = budget_client {
         proxy_state = proxy_state.with_budget_client(client);
     }

--- a/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
@@ -119,6 +119,66 @@ describe("prometheus metrics e2e", () => {
     }
   });
 
+  // Issue #408: a successful /v1/chat/completions request must bump
+  // `aisix_usage_events_emitted_total{handler="chat", status_code="2xx",
+  // inbound_protocol="openai"}` on the DP's /metrics endpoint. Pre-#408
+  // the gateway emitted UsageEvents to the sink + OTLP fan-out but
+  // had no DP-side prometheus counter, so a regression that dropped
+  // emission was invisible to e2e (the harness has no cp-api / OTLP
+  // receiver in the loop).
+  test("usage_events_emitted counter increments on successful chat (#408)", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    // Reuse the same model the first test configured. The counter
+    // accumulates across tests within the same describe block, so we
+    // snapshot the pre-call value and assert a delta rather than an
+    // absolute count.
+    await waitConfigPropagation(async () => {
+      const probe = await proxy.chat({
+        model: "prometheus-gpt",
+        messages: [{ role: "user", content: "ready" }],
+      });
+      return probe.status === 200;
+    });
+
+    const before = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+    const beforeCount = parseUsageEmittedCount(before, "chat", "2xx", "openai");
+
+    const { status } = await proxy.chat({
+      model: "prometheus-gpt",
+      messages: [{ role: "user", content: "for-#408-counter" }],
+    });
+    expect(status).toBe(200);
+
+    const after = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+    expect(after).toContain("aisix_usage_events_emitted_total");
+    // The counter line must carry all three #408 labels — handler,
+    // bucketed status_code, inbound_protocol. A regression that
+    // dropped any label (cardinality compromise, mis-spelled key)
+    // would surface here.
+    expect(after).toMatch(
+      /aisix_usage_events_emitted_total\{[^}]*handler="chat"[^}]*\}/,
+    );
+    expect(after).toMatch(
+      /aisix_usage_events_emitted_total\{[^}]*status_code="2xx"[^}]*\}/,
+    );
+    expect(after).toMatch(
+      /aisix_usage_events_emitted_total\{[^}]*inbound_protocol="openai"[^}]*\}/,
+    );
+    // Status codes MUST be bucketed (2xx / 4xx / 5xx) — raw "200"
+    // would explode cardinality at ~1000 series per handler×protocol.
+    expect(after).not.toMatch(
+      /aisix_usage_events_emitted_total\{[^}]*status_code="200"/,
+    );
+
+    const afterCount = parseUsageEmittedCount(after, "chat", "2xx", "openai");
+    expect(afterCount - beforeCount).toBeGreaterThanOrEqual(1);
+  });
+
   test("disabled prometheus endpoint is not mounted", async (ctx) => {
     if (!etcdReachable) {
       ctx.skip();
@@ -151,6 +211,31 @@ function responseBody() {
     ],
     usage: { prompt_tokens: 11, completion_tokens: 13, total_tokens: 24 },
   };
+}
+
+/**
+ * Extract the integer value of one `aisix_usage_events_emitted_total`
+ * label combination from a prometheus scrape. Returns 0 if the line
+ * is absent (the metric only appears once an emission has happened).
+ * Labels may appear in any order in the scrape output; we match each
+ * by name independently.
+ */
+function parseUsageEmittedCount(
+  scrape: string,
+  handler: string,
+  statusCode: string,
+  inboundProtocol: string,
+): number {
+  for (const line of scrape.split("\n")) {
+    if (!line.startsWith("aisix_usage_events_emitted_total{")) continue;
+    if (!line.includes(`handler="${handler}"`)) continue;
+    if (!line.includes(`status_code="${statusCode}"`)) continue;
+    if (!line.includes(`inbound_protocol="${inboundProtocol}"`)) continue;
+    const valueStr = line.split("}").at(-1)?.trim() ?? "";
+    const v = parseInt(valueStr, 10);
+    if (!Number.isNaN(v)) return v;
+  }
+  return 0;
 }
 
 async function configureOpenAi(


### PR DESCRIPTION
## Summary

Fixes #408. PR #402 audit L1.

Pre-fix, the DP emitted \`UsageEvent\`s to the sink + OTLP fan-out but had **no DP-side prometheus counter**. Result: the e2e harness (no cp-api / no OTLP receiver in the loop) couldn't observe emission, so a regression that dropped emission was invisible to tests. This PR closes that gap.

## Wiring

Two counters on the gateway's own \`/metrics\` scrape:

\`\`\`
aisix_usage_events_emitted_total{handler, status_code, inbound_protocol}
aisix_usage_event_drops_total{reason}
\`\`\`

| Label | Values | Cardinality |
|-------|--------|-------------|
| \`handler\` | \`chat\` / \`embeddings\` / \`messages\` (today); \`completions\` / \`responses\` / \`rerank\` / \`audio\` / \`images\` after #403-#407 | Fixed set |
| \`status_code\` | \`2xx\` / \`3xx\` / \`4xx\` / \`5xx\` / \`other\` | Bucketed (raw u16 would blow up at ~1000 values × handler × protocol) |
| \`inbound_protocol\` | \`openai\` / \`anthropic\` | Mirrors wire-level UsageEvent field |
| \`reason\` | \`sink_full\` / \`sink_closed\` | Distinguishes worker overload from clean shutdown |

Invariant: \`emitted = delivered + dropped\`. Operators can compute delivery rate as \`1 - drops/emitted\`.

## What changed structurally

\`UsageSink\` now optionally carries a \`Metrics\` handle via \`with_metrics(metrics)\`. The server bootstrap calls it after the shared \`Metrics\` is built (\`main.rs:389\`). \`try_emit\` signature gains a \`handler: &'static str\` arg — all 3 production callers updated to pass their fixed label.

The \`M_USAGE_EVENT_DROPS_TOTAL\` counter has existed since #302 but was never wired into \`try_emit\`; this PR finishes that wiring so both halves of the invariant are visible.

## Test plan

- [x] **Unit** — 2 new tests in \`aisix-obs::usage::tests\`:
  - \`emits_counter_increments_per_call\` — pins emit counter labels (handler, bucketed status_code, inbound_protocol)
  - \`dropped_event_records_reason_and_keeps_emit_count\` — pins drop counter reason on a full-channel scenario + the \`emit always bumps\` invariant
- [x] **E2E** — \`prometheus-metrics-e2e.test.ts\` adds a #408 case: drives a real \`/v1/chat/completions\` through the harness, scrapes \`/metrics\`, asserts counter delta + label shape. Pins that \`status_code\` MUST be bucketed (\`2xx\`, not raw \`200\`).
- [x] All 13 pre-existing \`aisix-obs::usage::tests\` still pass.
- [x] All 317 \`aisix-proxy::lib\` tests still pass (sink signature change touched chat/embeddings/messages callsites).
- [x] \`cargo clippy -p aisix-obs -p aisix-proxy -p aisix-server -- -D warnings\` clean.
- [x] Local e2e run: all 4 tests in \`prometheus-metrics-e2e.test.ts\` pass (6 s).

## References

- Parent audit: PR #402 L1 finding
- Existing pattern: \`M_REDIS_FAILURES_TOTAL\` / \`M_OTLP_FANOUT_FAILURES_TOTAL\` (same bucketing + label convention)
- Issue: #408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added telemetry metrics to track successful usage event emissions, providing visibility into event flow with details on handler type, HTTP status code ranges, and inbound protocol.

## Tests
* Added end-to-end test to validate the accuracy and correctness of usage event emission metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->