### PR TITLE
feat: rename API key owner_id to user_id

### DIFF
--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -38,7 +38,7 @@ pub struct ApiKey {
     /// Org member who owns this key. Used for matching member-scope
     /// rate limit policies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub owner_id: Option<String>,
+    pub user_id: Option<String>,
 
     /// etcd-key uuid; filled by the loader, never in the JSON payload.
     #[serde(skip)]
@@ -155,7 +155,7 @@ mod tests {
             allowed_models: vec![],
             rate_limit: None,
             team_id: None,
-            owner_id: None,
+            user_id: None,
             runtime_id: String::new(),
         };
         assert!(!k.can_access("my-gpt4"));
@@ -221,24 +221,24 @@ mod tests {
     }
 
     #[test]
-    fn deserialises_with_team_and_owner_fields() {
+    fn deserialises_with_team_and_user_fields() {
         let k: ApiKey = serde_json::from_str(&format!(
             r#"{{
               "key_hash": "{SAMPLE_HASH}",
               "allowed_models": ["gpt-4o"],
               "team_id": "team-uuid-1",
-              "owner_id": "member-uuid-1"
+              "user_id": "member-uuid-1"
             }}"#
         ))
         .unwrap();
         assert_eq!(k.team_id.as_deref(), Some("team-uuid-1"));
-        assert_eq!(k.owner_id.as_deref(), Some("member-uuid-1"));
+        assert_eq!(k.user_id.as_deref(), Some("member-uuid-1"));
     }
 
     #[test]
-    fn absent_team_owner_fields_default_to_none() {
+    fn absent_team_user_fields_default_to_none() {
         let k = sample();
         assert!(k.team_id.is_none());
-        assert!(k.owner_id.is_none());
+        assert!(k.user_id.is_none());
     }
 }

--- a/crates/aisix-core/src/models/rate_limit_policy.rs
+++ b/crates/aisix-core/src/models/rate_limit_policy.rs
@@ -5,7 +5,7 @@
 //! - `api_key` — matches by API key entry ID
 //! - `model`   — matches by model entry ID
 //! - `team`    — matches by team ID on the API key
-//! - `member`  — matches by owner ID on the API key
+//! - `member`  — matches by user ID on the API key
 //!
 //! The proxy iterates all policies on each request, converts the
 //! `window`+`max_requests`/`max_tokens` into a `RateLimit`, and

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -268,8 +268,18 @@ fn apikey_schema() -> Value {
                 "items": { "type": "string" }
             },
             "rate_limit": { "$ref": "#/$defs/rate_limit" },
-            "team_id": { "type": "string", "minLength": 1 },
-            "user_id": { "type": "string", "minLength": 1 }
+            "team_id": {
+                "anyOf": [
+                    { "type": "string", "minLength": 1 },
+                    { "type": "null" }
+                ]
+            },
+            "user_id": {
+                "anyOf": [
+                    { "type": "string", "minLength": 1 },
+                    { "type": "null" }
+                ]
+            }
         },
         "$defs": {
             "rate_limit": {
@@ -796,6 +806,17 @@ mod tests {
             "allowed_models":["gpt-4o"],
             "team_id": "team-uuid-1",
             "user_id": "member-uuid-1"
+        });
+        validate_apikey(&v).unwrap();
+    }
+
+    #[test]
+    fn apikey_with_null_team_and_user_fields_passes() {
+        let v = json!({
+            "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
+            "allowed_models":["gpt-4o"],
+            "team_id": null,
+            "user_id": null
         });
         validate_apikey(&v).unwrap();
     }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -269,7 +269,7 @@ fn apikey_schema() -> Value {
             },
             "rate_limit": { "$ref": "#/$defs/rate_limit" },
             "team_id": { "type": "string", "minLength": 1 },
-            "owner_id": { "type": "string", "minLength": 1 }
+            "user_id": { "type": "string", "minLength": 1 }
         },
         "$defs": {
             "rate_limit": {
@@ -790,12 +790,12 @@ mod tests {
     }
 
     #[test]
-    fn apikey_with_team_and_owner_fields_passes() {
+    fn apikey_with_team_and_user_fields_passes() {
         let v = json!({
             "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
             "allowed_models":["gpt-4o"],
             "team_id": "team-uuid-1",
-            "owner_id": "member-uuid-1"
+            "user_id": "member-uuid-1"
         });
         validate_apikey(&v).unwrap();
     }

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -857,6 +857,7 @@ mod tests {
         assert!(rendered.contains(M_LLM_TTFT));
         assert!(rendered.contains("endpoint=\"/v1/chat/completions\""));
         assert!(rendered.contains("team_id=\"team-1\""));
+        assert!(rendered.contains("user_id=\"user-1\""));
     }
 
     #[test]

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -224,7 +224,7 @@ impl Metrics {
                 "provider_key_id" => labels.provider_key_id.to_string(),
                 "api_key_id" => labels.api_key_id.to_string(),
                 "team_id" => labels.team_id.to_string(),
-                "owner_id" => labels.owner_id.to_string(),
+                "user_id" => labels.user_id.to_string(),
                 "status" => labels.status.to_string(),
                 "outcome" => labels.outcome.as_str().to_string(),
             )
@@ -248,7 +248,7 @@ impl Metrics {
                 "provider_key_id" => labels.provider_key_id.to_string(),
                 "api_key_id" => labels.api_key_id.to_string(),
                 "team_id" => labels.team_id.to_string(),
-                "owner_id" => labels.owner_id.to_string(),
+                "user_id" => labels.user_id.to_string(),
                 "status" => labels.status.to_string(),
                 "outcome" => labels.outcome.as_str().to_string(),
             )
@@ -291,7 +291,7 @@ impl Metrics {
                 "provider_key_id" => labels.provider_key_id.to_string(),
                 "api_key_id" => labels.api_key_id.to_string(),
                 "team_id" => labels.team_id.to_string(),
-                "owner_id" => labels.owner_id.to_string(),
+                "user_id" => labels.user_id.to_string(),
             )
             .record(ttft.as_secs_f64());
         });
@@ -476,7 +476,7 @@ pub struct RequestLabels<'a> {
     pub provider_key_id: &'a str,
     pub api_key_id: &'a str,
     pub team_id: &'a str,
-    pub owner_id: &'a str,
+    pub user_id: &'a str,
     pub status: u16,
     pub outcome: RequestOutcome,
 }
@@ -492,7 +492,7 @@ impl Default for RequestLabels<'_> {
             provider_key_id: "unknown",
             api_key_id: "unknown",
             team_id: "unknown",
-            owner_id: "unknown",
+            user_id: "unknown",
             status: 0,
             outcome: RequestOutcome::UpstreamError,
         }
@@ -511,7 +511,7 @@ impl RequestLabels<'_> {
             "provider_key_id" => self.provider_key_id.to_string(),
             "api_key_id" => self.api_key_id.to_string(),
             "team_id" => self.team_id.to_string(),
-            "owner_id" => self.owner_id.to_string(),
+            "user_id" => self.user_id.to_string(),
             "status" => self.status.to_string(),
             "outcome" => self.outcome.as_str().to_string(),
         )
@@ -529,7 +529,7 @@ pub struct UsageLabels<'a> {
     pub provider_key_id: &'a str,
     pub api_key_id: &'a str,
     pub team_id: &'a str,
-    pub owner_id: &'a str,
+    pub user_id: &'a str,
 }
 
 impl Default for UsageLabels<'_> {
@@ -543,7 +543,7 @@ impl Default for UsageLabels<'_> {
             provider_key_id: "unknown",
             api_key_id: "unknown",
             team_id: "unknown",
-            owner_id: "unknown",
+            user_id: "unknown",
         }
     }
 }
@@ -560,7 +560,7 @@ impl UsageLabels<'_> {
             "provider_key_id" => self.provider_key_id.to_string(),
             "api_key_id" => self.api_key_id.to_string(),
             "team_id" => self.team_id.to_string(),
-            "owner_id" => self.owner_id.to_string(),
+            "user_id" => self.user_id.to_string(),
         )
         .increment(value);
     }
@@ -583,7 +583,7 @@ impl UsageLabels<'_> {
             "provider_key_id" => self.provider_key_id.to_string(),
             "api_key_id" => self.api_key_id.to_string(),
             "team_id" => self.team_id.to_string(),
-            "owner_id" => self.owner_id.to_string(),
+            "user_id" => self.user_id.to_string(),
         )
         .increment(micro_usd as u64);
     }
@@ -659,7 +659,7 @@ impl DeploymentState {
 pub struct BudgetLabels<'a> {
     pub api_key_id: &'a str,
     pub team_id: &'a str,
-    pub owner_id: &'a str,
+    pub user_id: &'a str,
 }
 
 impl Default for BudgetLabels<'_> {
@@ -667,7 +667,7 @@ impl Default for BudgetLabels<'_> {
         Self {
             api_key_id: "unknown",
             team_id: "unknown",
-            owner_id: "unknown",
+            user_id: "unknown",
         }
     }
 }
@@ -678,7 +678,7 @@ impl BudgetLabels<'_> {
             metric,
             "api_key_id" => self.api_key_id.to_string(),
             "team_id" => self.team_id.to_string(),
-            "owner_id" => self.owner_id.to_string(),
+            "user_id" => self.user_id.to_string(),
         )
         .set(value);
     }
@@ -806,7 +806,7 @@ mod tests {
             provider_key_id: "pk-1",
             api_key_id: "ak-1",
             team_id: "team-1",
-            owner_id: "owner-1",
+            user_id: "user-1",
             status: 200,
             outcome: RequestOutcome::Success,
         };
@@ -822,7 +822,7 @@ mod tests {
                 provider_key_id: "pk-1",
                 api_key_id: "ak-1",
                 team_id: "team-1",
-                owner_id: "owner-1",
+                user_id: "user-1",
             },
             LlmUsage {
                 input_tokens: 5,
@@ -841,7 +841,7 @@ mod tests {
                 provider_key_id: "pk-1",
                 api_key_id: "ak-1",
                 team_id: "team-1",
-                owner_id: "owner-1",
+                user_id: "user-1",
             },
             Duration::from_millis(42),
         );

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -182,7 +182,7 @@ pub async fn chat_completions(
                 &model_name,
                 &api_key_id,
                 auth.key().team_id.as_deref(),
-                auth.key().owner_id.as_deref(),
+                auth.key().user_id.as_deref(),
                 status,
                 &success,
                 elapsed,
@@ -846,7 +846,7 @@ async fn dispatch(
         let model_id_for_telem = model_id.clone();
         let api_key_id_for_telem = auth.entry.id.clone();
         let team_id_for_metrics = auth.key().team_id.clone();
-        let owner_id_for_metrics = auth.key().owner_id.clone();
+        let user_id_for_metrics = auth.key().user_id.clone();
         let provider_for_metrics = provider.to_ascii_lowercase();
         let model_for_metrics = req.model.clone();
         let provider_key_id_for_metrics = pk_entry.id.clone();
@@ -962,7 +962,7 @@ async fn dispatch(
                         provider_key_id: &provider_key_id_for_metrics,
                         api_key_id: &api_key_id_for_telem,
                         team_id: team_id_for_metrics.as_deref().unwrap_or("unknown"),
-                        owner_id: owner_id_for_metrics.as_deref().unwrap_or("unknown"),
+                        user_id: user_id_for_metrics.as_deref().unwrap_or("unknown"),
                     },
                     LlmUsage {
                         input_tokens: comp.prompt_tokens,
@@ -981,7 +981,7 @@ async fn dispatch(
                         provider_key_id: &provider_key_id_for_metrics,
                         api_key_id: &api_key_id_for_telem,
                         team_id: team_id_for_metrics.as_deref().unwrap_or("unknown"),
-                        owner_id: owner_id_for_metrics.as_deref().unwrap_or("unknown"),
+                        user_id: user_id_for_metrics.as_deref().unwrap_or("unknown"),
                     },
                     Duration::from_millis(u64::from(comp.ttft_ms)),
                 );
@@ -1585,7 +1585,7 @@ fn record_success(
     model: &str,
     api_key_id: &str,
     team_id: Option<&str>,
-    owner_id: Option<&str>,
+    user_id: Option<&str>,
     status: u16,
     s: &Success,
     elapsed: Duration,
@@ -1601,7 +1601,7 @@ fn record_success(
         provider_key_id: &s.provider_key_id,
         api_key_id,
         team_id: team_id.unwrap_or("unknown"),
-        owner_id: owner_id.unwrap_or("unknown"),
+        user_id: user_id.unwrap_or("unknown"),
         status,
         outcome,
     };
@@ -1620,7 +1620,7 @@ fn record_success(
             provider_key_id: &s.provider_key_id,
             api_key_id,
             team_id: team_id.unwrap_or("unknown"),
-            owner_id: owner_id.unwrap_or("unknown"),
+            user_id: user_id.unwrap_or("unknown"),
         },
         LlmUsage {
             input_tokens: s.prompt_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
@@ -1639,7 +1639,7 @@ fn record_budget_gauges(
     let labels = aisix_obs::BudgetLabels {
         api_key_id: &auth.entry.id,
         team_id: auth.key().team_id.as_deref().unwrap_or("unknown"),
-        owner_id: auth.key().owner_id.as_deref().unwrap_or("unknown"),
+        user_id: auth.key().user_id.as_deref().unwrap_or("unknown"),
     };
     if let Some(budget) = budget {
         metrics.set_budget_gauges(

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -136,7 +136,7 @@ pub async fn messages(
                 provider_key_id: &provider_key_id,
                 api_key_id: &api_key_id,
                 team_id: auth.key().team_id.as_deref().unwrap_or("unknown"),
-                owner_id: auth.key().owner_id.as_deref().unwrap_or("unknown"),
+                user_id: auth.key().user_id.as_deref().unwrap_or("unknown"),
                 status,
                 outcome,
             };
@@ -153,7 +153,7 @@ pub async fn messages(
                     &provider_key_id,
                     &upstream_model,
                     auth.key().team_id.as_deref(),
-                    auth.key().owner_id.as_deref(),
+                    auth.key().user_id.as_deref(),
                     status,
                     elapsed,
                     metrics,
@@ -193,7 +193,7 @@ pub async fn messages(
                 "unknown",
                 "unknown",
                 auth.key().team_id.as_deref(),
-                auth.key().owner_id.as_deref(),
+                auth.key().user_id.as_deref(),
                 status,
                 elapsed,
                 AnthropicUsageMetrics::default(),
@@ -259,7 +259,7 @@ async fn dispatch(
             started,
             &auth.entry.id,
             auth.key().team_id.clone(),
-            auth.key().owner_id.clone(),
+            auth.key().user_id.clone(),
         )
         .await;
     }
@@ -545,7 +545,7 @@ async fn cross_provider_dispatch(
     started: Instant,
     api_key_id: &str,
     team_id: Option<String>,
-    owner_id: Option<String>,
+    user_id: Option<String>,
 ) -> Result<DispatchOutcome, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
     use aisix_provider_anthropic::{
@@ -621,7 +621,7 @@ async fn cross_provider_dispatch(
         let provider_key_id_for_telem = provider_key_id.to_string();
         let upstream_model_for_telem = upstream_model.clone();
         let team_id_for_telem = team_id;
-        let owner_id_for_telem = owner_id;
+        let user_id_for_telem = user_id;
         let started_for_telem = started;
         let sse_body = build_anthropic_sse_stream(upstream, encoder, started, move |comp| {
             let metrics = AnthropicUsageMetrics {
@@ -644,7 +644,7 @@ async fn cross_provider_dispatch(
                 &provider_key_id_for_telem,
                 &upstream_model_for_telem,
                 team_id_for_telem.as_deref(),
-                owner_id_for_telem.as_deref(),
+                user_id_for_telem.as_deref(),
                 200,
                 started_for_telem.elapsed(),
                 metrics,
@@ -873,7 +873,7 @@ fn emit_anthropic_usage_event(
     provider_key_id: &str,
     upstream_model: &str,
     team_id: Option<&str>,
-    owner_id: Option<&str>,
+    user_id: Option<&str>,
     status_code: u16,
     elapsed: Duration,
     metrics: AnthropicUsageMetrics,
@@ -932,7 +932,7 @@ fn emit_anthropic_usage_event(
             provider_key_id,
             api_key_id,
             team_id: team_id.unwrap_or("unknown"),
-            owner_id: owner_id.unwrap_or("unknown"),
+            user_id: user_id.unwrap_or("unknown"),
         },
         LlmUsage {
             input_tokens: metrics.prompt_tokens,
@@ -954,7 +954,7 @@ fn emit_anthropic_usage_event(
                 provider_key_id,
                 api_key_id,
                 team_id: team_id.unwrap_or("unknown"),
-                owner_id: owner_id.unwrap_or("unknown"),
+                user_id: user_id.unwrap_or("unknown"),
             },
             Duration::from_millis(u64::from(metrics.ttft_ms)),
         );

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -139,7 +139,7 @@ fn reserve_layers<'a>(
             "api_key" => policy.scope_ref == auth.entry.id,
             "model" => model_rl.is_some_and(|m| policy.scope_ref == m.entry_id),
             "team" => auth.key().team_id.as_deref() == Some(policy.scope_ref.as_str()),
-            "member" => auth.key().owner_id.as_deref() == Some(policy.scope_ref.as_str()),
+            "member" => auth.key().user_id.as_deref() == Some(policy.scope_ref.as_str()),
             _ => false,
         };
         if !applies {
@@ -173,7 +173,7 @@ pub(crate) async fn enforce<'a>(
     let budget_labels = aisix_obs::BudgetLabels {
         api_key_id: &auth.entry.id,
         team_id: auth.key().team_id.as_deref().unwrap_or("unknown"),
-        owner_id: auth.key().owner_id.as_deref().unwrap_or("unknown"),
+        user_id: auth.key().user_id.as_deref().unwrap_or("unknown"),
     };
     if let Some(budget) = decision.budget.as_ref() {
         state.metrics.set_budget_gauges(

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -18,13 +18,6 @@
       "description": "SHA-256 hex of the plaintext bearer. Secondary-indexed for O(1) auth — the proxy hashes incoming bearers before lookup.",
       "type": "string"
     },
-    "owner_id": {
-      "description": "Org member who owns this key. Used for matching member-scope rate limit policies.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "rate_limit": {
       "anyOf": [
         {
@@ -37,6 +30,13 @@
     },
     "team_id": {
       "description": "Team this API key belongs to. Used for matching team-scope rate limit policies.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "user_id": {
+      "description": "Org member who owns this key. Used for matching member-scope rate limit policies.",
       "type": [
         "string",
         "null"

--- a/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
@@ -79,6 +79,7 @@ describe("prometheus metrics e2e", () => {
     );
     expect(text).toContain('team_id="unknown"');
     expect(text).toContain('user_id="unknown"');
+    expect(text).not.toContain("owner_id=");
   });
 
   test("custom prometheus path is used for scrapes", async (ctx) => {

--- a/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
@@ -78,7 +78,7 @@ describe("prometheus metrics e2e", () => {
       /aisix_llm_requests_total\{[^}]*endpoint="\/v1\/chat\/completions"[^}]*model="prometheus-gpt"[^}]*status="200"/,
     );
     expect(text).toContain('team_id="unknown"');
-    expect(text).toContain('owner_id="unknown"');
+    expect(text).toContain('user_id="unknown"');
   });
 
   test("custom prometheus path is used for scrapes", async (ctx) => {


### PR DESCRIPTION
API key ownership in the PRD is modeled as `user_id`, not `owner_id`. This updates the DP resource model/schema and attribution labels to use `user_id` consistently.

The API key payload now accepts and emits `user_id`; `owner_id` is no longer part of the DP schema. Team-scoped rate-limit matching still uses `team_id`, and member-scoped policy matching now compares against API key `user_id`.

This is intentionally breaking to match the PRD contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched API key identity from owner-based to user-based across the system (rate limits, quotas, metrics, and request handling).
* **Documentation**
  * Clarified rate-limit member scope now matches by user identity.
* **Tests**
  * Updated unit and e2e tests and schema validations to use and validate the new user_id field and its nullable behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->