### PR TITLE
docs: symlink AGENTS.md -> CLAUDE.md for codex compat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` as a symlink to `CLAUDE.md` so Codex (which reads `AGENTS.md` by convention) and Claude Code (which reads `CLAUDE.md`) share the same set of behavioral guidelines from one source of truth.
- Avoids the drift that would result from keeping two independent copies.

## Why a symlink instead of two files?

Two independent files require manual sync on every change. Drift is silent — one tool's rules quietly diverge from the other's. A symlink keeps a single canonical file (`CLAUDE.md`) and lets every other entry point alias to it.

## Caveat: Windows contributors

Git stores symlinks as a special file mode (120000) and resolves them natively on macOS / Linux / CI. On Windows, contributors must either enable Developer Mode or run `git config --global core.symlinks true` for the link to resolve. Without that, `AGENTS.md` materializes as a one-line text file containing the literal string `CLAUDE.md`.

If Windows support becomes a real constraint later, we can switch to two files + a pre-commit hook to enforce parity.

## Test plan

- [x] `git ls-files --stage AGENTS.md` reports mode `120000` (symlink), not `100644`
- [x] `readlink AGENTS.md` resolves to `CLAUDE.md`
- [x] `head AGENTS.md` returns the CLAUDE.md content