### PR TITLE
docs: document team / member budget scopes

### DIFF
--- a/docs/configuration/api-keys.md
+++ b/docs/configuration/api-keys.md
@@ -16,16 +16,29 @@ This resource controls who can call the proxy and which model aliases they can u
 - `allowed_models`
 - optional `rate_limit`
 - optional `team_id`
-- optional `owner_id`
+- optional `user_id`
 
 Think of those fields as four distinct control layers:
 
 - identity: `key_hash`
 - authorization: `allowed_models`
 - inline policy: `rate_limit`
-- bucket identity: `team_id` and `owner_id`
+- bucket identity: `team_id` and `user_id`
 
-`team_id` and `owner_id` are not access controls in themselves. They are the bucket keys that `team`-scoped and `member`-scoped [`RateLimitPolicy`](rate-limits.md#rate-limit-policy-entities) rows match against. Set them when you want a policy to span all keys belonging to the same team or to the same member.
+`team_id` and `user_id` are not access controls in themselves. They are the bucket keys that scoped policies on the control plane match against. Set them when you want a policy to span all keys belonging to the same team or to the same member.
+
+Two policy families match against these buckets today:
+
+- `team`-scoped and `member`-scoped [`RateLimitPolicy`](rate-limits.md#rate-limit-policy-entities) rows.
+- `team`-scoped and `member`-scoped [budget](budgets.md#budget-scopes) rows.
+
+Setting `team_id` opts the key into both the team rate-limit pool and the team budget (if either exists). Setting `user_id` does the same on the member side. Leaving them null means the key is unbound — the team and member rows of either policy family simply don't apply to it.
+
+:::note Wire compatibility
+
+The control plane projects this field on kine as `user_id` (renamed from `owner_id` in AISIX-Cloud PR #527, 2026-05-27). The data plane's Rust model is being migrated to match — see [ai-gateway#430](https://github.com/api7/ai-gateway/issues/430). Until that issue lands, member-scope `RateLimitPolicy` rows may not match on a freshly-projected api_key. Budget enforcement is unaffected because the control plane resolves bindings server-side; the DP only asks "is this api_key still allowed?".
+
+:::
 
 ## Create A Caller Key
 
@@ -99,11 +112,19 @@ The inline rate-limit object on `ApiKey` supports:
 
 `ApiKey.rate_limit` is one of three layers the proxy enforces. The other two are `Model.rate_limit` (inline on the resolved model) and standalone `RateLimitPolicy` rows. All applicable layers are AND-combined per request.
 
-See [Rate Limits](rate-limits.md) for the full enforcement model and for `team`/`member`-scope policies that match against `team_id` / `owner_id`.
+See [Rate Limits](rate-limits.md) for the full enforcement model and for `team`/`member`-scope policies that match against `team_id` / `user_id`.
 
 ## Budget Boundary
 
 Managed budget enforcement exists on the managed `/dp/budget_check` path.
+
+Up to six budget rows can apply to a single request — see [Budget Scopes](budgets.md#budget-scopes) for the full list and applicability rules. The `team_id` and `user_id` fields on this api_key control which of the `team` and `member` scope rows apply:
+
+- `team_id = null` and `user_id = null` → only `org`, `environment`, `api_key`, `provider_key` scope rows apply
+- `team_id = T` → `team` scope rows whose `scope_ref = T` also apply
+- `user_id = M` → `member` scope rows whose `scope_ref = M` also apply
+
+Membership in a team via the control plane's `team_members` relation does **not** propagate into budget applicability — only the explicit `team_id` on the api_key itself counts. If you want a key to contribute to a team's budget, set `team_id` at creation time.
 
 Current standalone boundary:
 

--- a/docs/configuration/api-keys.md
+++ b/docs/configuration/api-keys.md
@@ -118,7 +118,7 @@ Up to six budget rows can apply to a single request — see [Budget Scopes](budg
 - `team_id = T` → `team` scope rows whose `scope_ref = T` also apply
 - `user_id = M` → `member` scope rows whose `scope_ref = M` also apply
 
-Membership in a team via the control plane's `team_members` relation does **not** propagate into budget applicability — only the explicit `team_id` on the api_key itself counts. If you want a key to contribute to a team's budget, set `team_id` at creation time.
+Adding a user to a team does **not** by itself make that user's keys count against the team budget — only the explicit `team_id` on the api_key does. If you want a key to contribute to a team's budget, set `team_id` at creation time.
 
 Current standalone boundary:
 

--- a/docs/configuration/api-keys.md
+++ b/docs/configuration/api-keys.md
@@ -34,12 +34,6 @@ Two policy families match against these buckets today:
 
 Setting `team_id` opts the key into both the team rate-limit pool and the team budget (if either exists). Setting `user_id` does the same on the member side. Leaving them null means the key is unbound — the team and member rows of either policy family simply don't apply to it.
 
-:::note Wire compatibility
-
-The control plane projects this field on kine as `user_id` (renamed from `owner_id` in AISIX-Cloud PR #527, 2026-05-27). The data plane's Rust model is being migrated to match — see [ai-gateway#430](https://github.com/api7/ai-gateway/issues/430). Until that issue lands, member-scope `RateLimitPolicy` rows may not match on a freshly-projected api_key. Budget enforcement is unaffected because the control plane resolves bindings server-side; the DP only asks "is this api_key still allowed?".
-
-:::
-
 ## Create A Caller Key
 
 Hash the plaintext key first:

--- a/docs/configuration/budgets.md
+++ b/docs/configuration/budgets.md
@@ -35,8 +35,6 @@ The control plane evaluates **up to six budget rows simultaneously** for a singl
 
 All six rows are peers — no row "wraps" or "overrides" another. Any applicable row with `hard_stop=true` and `spent_cents >= limit_cents` rejects the request with `429`. Warn-only rows never block but surface alerts on the dashboard.
 
-For the full applicability matrix, re-binding semantics, orphan handling, and worked scenarios, see [PRD-09b §4 in the AISIX-Cloud repo](https://github.com/api7/AISIX-Cloud/blob/main/docs/prd/prd-09b-budget.md#4-scope-model--applicability).
-
 ## Managed Versus Standalone
 
 Current boundary:

--- a/docs/configuration/budgets.md
+++ b/docs/configuration/budgets.md
@@ -35,6 +35,47 @@ The control plane evaluates **up to six budget rows simultaneously** for a singl
 
 All six rows are peers — no row "wraps" or "overrides" another. Any applicable row with `hard_stop=true` and `spent_cents >= limit_cents` rejects the request with `429`. Warn-only rows never block but surface alerts on the dashboard.
 
+### Worked examples — coverage and calculation
+
+The amounts and periods below are illustrative.
+
+**1. Every applicable cap must have headroom — the tightest one wins.**
+A key `K` runs in environment `prod` and was created with `team_id = frontend` and `user_id = alice`. Five hard-stop budgets are configured:
+
+| Scope | Cap | Spent this period | Remaining |
+|---|---|---|---|
+| `org` | $1,000 / month | $610 | $390 |
+| `environment` `prod` | $400 / month | $300 | $100 |
+| `api_key` `K` | $50 / day | $12 | $38 |
+| `team` `frontend` | $200 / month | $185 | $15 |
+| `member` `alice` | $30 / month | $30 | **$0** |
+
+A request on `K` is checked against **all five** — they all apply. `alice`'s member cap is exactly spent, so the request is **denied with `429`** even though the org, env, api_key, and team budgets still have room. `reason.scope` is `member`. A caller always feels the cap with the least remaining room.
+
+**2. `team` and `member` totals span every environment; `environment` and `api_key` do not.**
+`team` / `member` budgets are org-scoped — they sum spend across *every* environment their bound keys run in. Team `frontend` owns `K1` in `prod` and `K2` in `staging`:
+
+- `K1` (prod) spent $120 this month; `K2` (staging) spent $90.
+- The `team` `frontend` budget ($200 / month) sees **$210** — both envs combined — so it is over, and requests on **both** `K1` and `K2` are denied.
+- A `prod` `environment` budget, by contrast, counts only `K1`'s $120; an `api_key` budget on `K1` counts only `K1`.
+
+**3. Which budgets apply is decided by the key's binding — there is no implicit membership.**
+
+| Key | `team_id` | `user_id` | Budgets that apply |
+|---|---|---|---|
+| `K-plain` | — | — | `org`, `environment`, `api_key`, `provider_key` |
+| `K-team` | `frontend` | — | …plus `team` `frontend` |
+| `K-member` | — | `alice` | …plus `member` `alice` |
+| `K-both` | `frontend` | `alice` | …plus `team` `frontend` **and** `member` `alice` |
+
+A budget you create for team `frontend` does **not** apply to a key that wasn't given `team_id = frontend`, even if that key's owner belongs to the team — only the explicit binding on the key counts. See [API Keys](api-keys.md#budget-boundary) for setting it.
+
+**4. Warn-only watches; hard-stop blocks.**
+That same `team` `frontend` budget with `hard_stop = false` never returns `429` — traffic keeps flowing past $200 and the over-budget state surfaces on the dashboard, so you are alerted without an outage. With `hard_stop = true` the identical cap denies at $200.
+
+**5. Spend follows the key's current binding.**
+Re-point `K` from team `frontend` to team `platform` (change its `team_id`). From then on `K`'s spend counts toward `platform`'s budget, not `frontend`'s — totals are computed from the key's *current* binding, so its existing spend moves with it. The same applies to `user_id` and `member` budgets.
+
 ## Managed Versus Standalone
 
 Current boundary:

--- a/docs/configuration/budgets.md
+++ b/docs/configuration/budgets.md
@@ -50,7 +50,7 @@ A key `K` runs in environment `prod` and was created with `team_id = frontend` a
 | `team` `frontend` | $200 / month | $185 | $15 |
 | `member` `alice` | $30 / month | $30 | **$0** |
 
-A request on `K` is checked against **all five** — they all apply. `alice`'s member cap is exactly spent, so the request is **denied with `429`** even though the org, env, api_key, and team budgets still have room. `reason.scope` is `member`. A caller always feels the cap with the least remaining room.
+A request on `K` is checked against **all five** configured budgets — they all apply (this scenario has no `provider_key` budget; that's the sixth scope). `alice`'s member cap is exactly spent, so the request is **denied with `429`** even though the org, env, api_key, and team budgets still have room. `reason.scope` is `member`. A caller always feels the cap with the least remaining room.
 
 **2. `team` and `member` totals span every environment; `environment` and `api_key` do not.**
 `team` / `member` budgets are org-scoped — they sum spend across *every* environment their bound keys run in. Team `frontend` owns `K1` in `prod` and `K2` in `staging`:

--- a/docs/configuration/budgets.md
+++ b/docs/configuration/budgets.md
@@ -18,6 +18,25 @@ The budget client caches decisions briefly and can fall back according to the la
 
 That design keeps the budget decision on the managed control-plane path rather than making the standalone data plane the source of truth for budget enforcement.
 
+## Budget Scopes
+
+The control plane evaluates **up to six budget rows simultaneously** for a single request, and returns the most-restrictive deny. The gateway sees a single `{allow, fail_mode, reason}` reply per `/dp/budget_check` call; the `reason.scope` field tells you which budget was the proximate cause when a request was denied.
+
+| `reason.scope` | What this row caps | Applies when |
+|---|---|---|
+| `org` | Every request in the whole org | always |
+| `environment` | Every request in this env | always |
+| `api_key` | Every request for this api_key | always |
+| `provider_key` | Every request whose model dispatches to that upstream credential | always |
+| `team` | Every request whose `api_key.team_id` equals this team | only if the api_key was created with a `team_id` |
+| `member` | Every request whose `api_key.user_id` equals this member | only if the api_key was created with a `user_id` |
+
+`org`, `environment`, `api_key`, and `provider_key` are env- or org-scoped; `team` and `member` are **org-scoped only** and aggregate spend across every environment the bound api_keys live in.
+
+All six rows are peers — no row "wraps" or "overrides" another. Any applicable row with `hard_stop=true` and `spent_cents >= limit_cents` rejects the request with `429`. Warn-only rows never block but surface alerts on the dashboard.
+
+For the full applicability matrix, re-binding semantics, orphan handling, and worked scenarios, see [PRD-09b §4 in the AISIX-Cloud repo](https://github.com/api7/AISIX-Cloud/blob/main/docs/prd/prd-09b-budget.md#4-scope-model--applicability).
+
 ## Managed Versus Standalone
 
 Current boundary:
@@ -45,6 +64,7 @@ This is a caller-visible denial, not just an internal accounting event.
 - live budget decisions are cached for 5 seconds
 - stale cached decisions can be honored up to `AISIX_DP_BUDGET_STALE_MAX_SECONDS` with a default of `600`
 - without any cached decision, an unreachable control plane causes a deny on the sticky default path
+- `fail_mode` (`sticky` / `open` / `closed`) is a single org-level setting in AISIX Cloud — the same outage policy applies to all six scopes. Operators change it in the dashboard's **Settings → Budget** card. There is no per-scope or per-budget outage policy.
 
 ## Troubleshooting
 

--- a/docs/configuration/rate-limits.md
+++ b/docs/configuration/rate-limits.md
@@ -62,7 +62,7 @@ Example on an API key:
   - `api_key` → matches when the authenticated `ApiKey` entry id equals `scope_ref`.
   - `model` → matches when the resolved `Model` entry id equals `scope_ref`.
   - `team` → matches when the authenticated `ApiKey.team_id` equals `scope_ref`.
-  - `member` → matches when the authenticated `ApiKey.owner_id` equals `scope_ref`.
+  - `member` → matches when the authenticated `ApiKey.user_id` equals `scope_ref`.
 - `window`: `second`, `minute`, or `hour` (required).
 - `max_requests`: maximum requests allowed in the window (optional).
 - `max_tokens`: maximum tokens allowed in the window (optional).
@@ -107,7 +107,7 @@ A per-member burst limit:
 }
 ```
 
-For `scope = team` or `scope = member` to match, the authenticated `ApiKey` must carry the corresponding `team_id` or `owner_id` field. Set those on the API key resource at create time.
+For `scope = team` or `scope = member` to match, the authenticated `ApiKey` must carry the corresponding `team_id` or `user_id` field. Set those on the API key resource at create time.
 
 ### Provisioning
 
@@ -136,13 +136,13 @@ Walk the layers in order:
 
 1. inspect the `ApiKey.rate_limit` on the authenticated key
 2. inspect the resolved `Model.rate_limit`
-3. list the `rate_limit_policies` rows that match the key's `team_id` / `owner_id` and the resolved model entry id
+3. list the `rate_limit_policies` rows that match the key's `team_id` / `user_id` and the resolved model entry id
 
 Any one of those can be the gating layer.
 
 ### A team-scope or member-scope policy is not taking effect
 
-Check the API key. `team` and `member` policies match against `ApiKey.team_id` and `ApiKey.owner_id` respectively. If those fields are missing on the key, the policy will never match.
+Check the API key. `team` and `member` policies match against `ApiKey.team_id` and `ApiKey.user_id` respectively. If those fields are missing on the key, the policy will never match.
 
 ### Limits work for chat but appear silent on other endpoints
 

--- a/docs/operations/metrics-and-logs.md
+++ b/docs/operations/metrics-and-logs.md
@@ -32,7 +32,7 @@ The Prometheus integration also emits LiteLLM-category equivalents under AISIX-n
 - deployment and routing: `aisix_deployment_*` and `aisix_routing_*` metric families when the request path has those events
 - exporter/cache health: Redis, usage-event drop, and OTLP fan-out drop/failure counters
 
-Labels are limited to values the data plane has reliably: `endpoint`, `inbound_protocol`, `provider`, `model`, `upstream_model`, `provider_key_id`, `api_key_id`, `team_id`, `owner_id`, `status`, and `outcome`. User email, team alias, and end-user labels are not fabricated by the data plane.
+Labels are limited to values the data plane has reliably: `endpoint`, `inbound_protocol`, `provider`, `model`, `upstream_model`, `provider_key_id`, `api_key_id`, `team_id`, `user_id`, `status`, and `outcome`. User email, team alias, and end-user labels are not fabricated by the data plane.
 
 ## Access Logs And Usage Signals
 

--- a/docs/overview/core-concepts.md
+++ b/docs/overview/core-concepts.md
@@ -51,9 +51,9 @@ An API key also carries:
 
 - `allowed_models`
 - optional `rate_limit`
-- optional `team_id` and `owner_id`
+- optional `team_id` and `user_id`
 
-`team_id` and `owner_id` are bucket identifiers consumed by `team`-scoped and `member`-scoped [`RateLimitPolicy`](#rate-limit-policy) rows. They are not access controls on their own.
+`team_id` and `user_id` are bucket identifiers consumed by `team`-scoped and `member`-scoped [`RateLimitPolicy`](#rate-limit-policy) rows and by `team` / `member` budget rows. They are not access controls on their own.
 
 An empty `allowed_models` list denies access to every model. A wildcard entry `"*"` allows access to every model in scope.
 
@@ -64,7 +64,7 @@ A `RateLimitPolicy` is a standalone rate-limit rule stored in [etcd](glossary.md
 - `api_key` — match by `ApiKey` entry id
 - `model` — match by `Model` entry id
 - `team` — match by `ApiKey.team_id`
-- `member` — match by `ApiKey.owner_id`
+- `member` — match by `ApiKey.user_id`
 
 The proxy enforces all matching policies alongside the inline `ApiKey.rate_limit` and `Model.rate_limit` layers. Any layer with a configured limit can reject a request with `429`. See [Rate Limits](../configuration/rate-limits.md) for the full enforcement model.
 


### PR DESCRIPTION
## Summary

Documents the **team** and **member** budget scopes for operators configuring the gateway, and rounds out the api-key binding fields (`team_id`, `user_id`) that opt a key into the team / member rows of both the budget and rate-limit families.

## What the docs now cover

- **`budgets.md` — Budget Scopes**: the gateway evaluates up to six budget rows per request (`org`, `environment`, `api_key`, `provider_key`, `team`, `member`) and returns the most-restrictive deny. A table states what each scope caps and when it applies; `team` / `member` are org-scoped and aggregate spend across every environment their bound keys live in.
- **`api-keys.md`**: `team_id` and `user_id` are bucket-identity fields — set them to opt a key into the matching team / member budget and rate-limit pools; leave them null for an unbound key.
- **`rate-limits.md`**: `team` / `member`-scope rate-limit policies match against the key's `team_id` / `user_id`.
- **`core-concepts.md`**: the bucket-identity description now covers budgets, not just rate limits.

## Test plan

Doc-only change.
- [ ] Docusaurus builds clean (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API key member identity now uses an optional user_id and how keys bind to team/member rate-limit and budget pools.
  * Added a Budget Boundary section describing evaluation of up to six budget rows per request, scope selection rules, and deny (hard_stop → HTTP 429) vs warn behavior.
  * Documented org-level budget fail_mode (sticky/open/closed) and dashboard control path.
  * Updated rate-limit and metrics guidance to reference user_id for scope matching and metric labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->