### PR TITLE
docs: adapter protocol families + BYO + 3 platform-adapter integration guides (#302 Phase H)

### DIFF
--- a/docs/configuration/byo-endpoint.md
+++ b/docs/configuration/byo-endpoint.md
@@ -1,0 +1,197 @@
+---
+title: Bring your own endpoint
+description: Route AISIX AI Gateway to a private or self-hosted OpenAI-compatible endpoint such as vLLM, SGLang, or Ollama, including custom per-token pricing for budget tracking.
+sidebar_position: 42
+keywords:
+  - AISIX AI Gateway
+  - bring your own endpoint
+  - vLLM
+  - SGLang
+  - Ollama
+  - OpenAI-compatible API
+---
+
+A bring-your-own (BYO) endpoint is any OpenAI-compatible HTTP server you operate yourself — a [vLLM](https://docs.vllm.ai/) or [SGLang](https://docs.sglang.ai/) inference server, an [Ollama](https://ollama.com/) host, or a self-hosted proxy in front of your own models. This page shows how to register one against AISIX AI Gateway so callers reach it through the same OpenAI-compatible proxy surface and the same caller API keys as any catalog provider.
+
+A BYO endpoint uses the `openai` adapter family. The gateway sends a standard `POST /chat/completions` to your endpoint and renders the response back to the caller as an OpenAI chat-completions envelope.
+
+## When to use this
+
+- Use this when you run an inference server that exposes the OpenAI chat-completions API (vLLM, SGLang, Ollama, LiteLLM-style proxies, or your own service).
+- Use this when you want a private or air-gapped model to share the gateway's auth, allowlist, rate limiting, and usage accounting.
+- Do not use this for AWS Bedrock, Google Vertex AI, or Azure OpenAI — those have native wire shapes and dedicated guides: [AWS Bedrock](../integration/upstream-bedrock.md), [Google Vertex AI](../integration/upstream-vertex.md), [Azure OpenAI](../integration/upstream-azure-openai.md).
+
+## How it works
+
+A BYO endpoint is configured through two resources, exactly like a catalog upstream:
+
+1. A [provider key](provider-keys.md) holding the endpoint's credential (`secret`) and its base URL (`api_base`).
+2. A direct [model](models.md) that maps a caller-facing alias (`display_name`) to the upstream model id (`model_name`) and references the provider key.
+
+The difference from a catalog provider is that **you set `api_base` explicitly**. The OpenAI-family bridge only falls back to `https://api.openai.com` when the provider key's vendor identity is `openai` (or empty). For any other vendor it refuses to guess a base URL and returns an error, so a BYO key without `api_base` will fail dispatch. Set `api_base` to your endpoint's root.
+
+Outside the canonical OpenAI host, the gateway trusts your `api_base` verbatim — it appends the endpoint path (`/chat/completions`) but does not synthesize a `/v1` segment. If your server serves the OpenAI API at `http://10.0.0.5:8000/v1`, set exactly that. See [Provider keys § `api_base` behavior](provider-keys.md#api_base-behavior) for the full normalization rules.
+
+## Prerequisites
+
+- A running self-hosted gateway (admin on `:3001`, proxy on `:3000`). See the [Self-Hosted Quickstart](../quickstart/self-hosted.md).
+- Your admin key from the bootstrap config.
+- A reachable OpenAI-compatible endpoint. The examples below assume vLLM at `http://10.0.0.5:8000/v1` serving the model id `meta-llama/Llama-3.1-8B-Instruct`.
+
+:::note vLLM, SGLang, and Ollama base URLs
+- **vLLM** serves the OpenAI API under `/v1` (for example `http://host:8000/v1`).
+- **SGLang** also serves under `/v1` (for example `http://host:30000/v1`).
+- **Ollama** serves its OpenAI-compatible surface under `/v1` (for example `http://host:11434/v1`).
+
+Use the `/v1` form for all three. The gateway appends `/chat/completions` to whatever you supply.
+:::
+
+## Configuration
+
+### Step 1: Create the provider key
+
+Many self-hosted inference servers do not require an API key. The `secret` field is required by the schema, so use a non-empty placeholder when your endpoint is unauthenticated — the bridge sends it as the bearer token and your server ignores it.
+
+:::warning Production credentials
+The standalone gateway stores `secret` as plaintext under the etcd `prefix` from [`config.yaml`](bootstrap-config.md). For production, front etcd with encryption-at-rest, restrict etcd network access to the gateway, or use AISIX Cloud's managed [Provider Key Rotation](../cloud/provider-key-rotation.md), where the secret stays in the control plane and only the projected reference reaches the data plane.
+:::
+
+```bash title="Create a BYO provider key"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/provider_keys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "vllm-internal",
+    "provider": "vllm",
+    "adapter": "openai",
+    "secret": "not-used-by-vllm",
+    "api_base": "http://10.0.0.5:8000/v1"
+  }'
+```
+
+Field notes:
+
+- `provider` is a free-form vendor identity. Use any short label (`vllm`, `sglang`, `ollama`, `internal-proxy`); it is for your own readability and metrics. It must not be `openai` unless you genuinely point at OpenAI, because that would let the bridge fall back to the public OpenAI host if `api_base` were ever cleared.
+- `adapter` pins the wire shape to `openai`. For a BYO OpenAI-compatible endpoint this is the only valid value.
+- `api_base` is required and trusted verbatim.
+
+Capture the returned `id` for the next step. The admin API returns a `ResourceEntry` with an `id` field; the [first-request quickstart](../quickstart/first-model-first-key-first-request.md#step-1-create-a-provider-key) shows a `jq`-capturing one-liner if you want to script it.
+
+### Step 2: Create the model
+
+Map a caller-facing alias to the upstream model id your endpoint serves.
+
+```bash title="Create a model for the BYO endpoint"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/models \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "llama-3-internal",
+    "provider": "vllm",
+    "model_name": "meta-llama/Llama-3.1-8B-Instruct",
+    "provider_key_id": "YOUR_PROVIDER_KEY_ID",
+    "cost": {
+      "input_per_1k": 0.0,
+      "output_per_1k": 0.0
+    }
+  }'
+```
+
+- `display_name` is the alias callers send in `model` and the value `response.model` echoes back.
+- `model_name` is the upstream id your endpoint expects — for vLLM and SGLang this is the served model name; for Ollama it is the local model tag (for example `llama3.1:8b`).
+- `cost` is optional; see [BYO pricing](#byo-pricing) below.
+
+### Step 3: Create a caller API key
+
+The data plane stores `key_hash`, not plaintext. Hash a plaintext caller key, then create the key resource scoped to your new alias.
+
+```bash title="Hash a plaintext caller key"
+printf 'sk-demo-caller' | sha256sum | cut -d' ' -f1
+```
+
+```bash title="Create a caller API key"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/apikeys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_hash": "YOUR_CALLER_KEY_HASH",
+    "allowed_models": ["llama-3-internal"]
+  }'
+```
+
+### Step 4: Send a request
+
+Admin writes propagate to the proxy asynchronously; allow about a second, or poll `/v1/models` until the alias appears.
+
+```bash title="Send a chat completion to the BYO endpoint"
+curl -sS -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama-3-internal",
+    "messages": [
+      {"role": "user", "content": "Say hello from the internal model."}
+    ]
+  }'
+```
+
+## BYO pricing
+
+Catalog providers carry pricing from the models.dev catalog. A BYO endpoint is not in that catalog, so the gateway has no price for it unless you set one. Attach a `cost` block to the model to enable per-token budget accounting:
+
+```json title="Model cost block"
+{
+  "cost": {
+    "input_per_1k": 0.10,
+    "output_per_1k": 0.30
+  }
+}
+```
+
+Both values are in USD per 1,000 tokens. `input_per_1k` applies to prompt tokens and `output_per_1k` to completion tokens; the gateway multiplies each token count by its rate and sums them. Both fields are required when the `cost` block is present.
+
+:::note Pricing is enforced in AISIX Cloud, not standalone
+The standalone OSS proxy stores `cost` but does not consult it at request time — it always emits `cost_usd=0.0`. Pricing-aware budget enforcement runs through the AISIX Cloud control plane, which reads the `cost` block when emitting usage events. Set `cost` on a BYO model so that a future managed deployment, or your own usage-event consumer, has the per-token rate available. See [Models § field notes](models.md#field-notes) and [Budgets](budgets.md).
+:::
+
+## Verification
+
+A `200` alone does not prove the gateway reached your endpoint and applied the alias contract. Verify the two observable facts that do.
+
+### The alias is restored on `response.model`
+
+```bash title="Confirm response.model echoes your alias"
+curl -sS -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"llama-3-internal","messages":[{"role":"user","content":"ping"}]}' \
+  | grep -o '"model":"[^"]*"'
+```
+
+Expected: `"model":"llama-3-internal"` — your caller-facing alias, **not** the upstream `meta-llama/Llama-3.1-8B-Instruct`. This proves the request resolved through your model and the gateway restored the alias on the way out. If you see the upstream id instead, the request did not flow through the gateway's render path.
+
+### The endpoint actually received the request
+
+Confirm the request reached your server, not the public OpenAI host. Check your endpoint's access log for a `POST /v1/chat/completions` entry, or temporarily point `api_base` at an unreachable host and confirm the gateway returns an upstream error rather than a `200`:
+
+```bash title="Negative check — unreachable endpoint surfaces an upstream error"
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"llama-3-internal","messages":[{"role":"user","content":"ping"}]}'
+```
+
+With a healthy endpoint, expect `200`. With `api_base` pointing at a dead host, expect a `5xx` upstream error — confirming dispatch targets your `api_base` and not a default.
+
+## Limitations
+
+- BYO is for OpenAI-compatible chat-completions endpoints. Endpoints with a non-OpenAI wire shape need a native adapter — see [Adapter protocol families](../reference/adapters.md).
+- A missing `api_base` on a non-`openai` vendor fails dispatch with a configuration error. Always set `api_base` for BYO.
+- Standalone deployments record but do not enforce `cost`; see [BYO pricing](#byo-pricing).
+
+## Related pages
+
+- [Provider keys](provider-keys.md) — the credential resource and the full `api_base` normalization rules.
+- [Models](models.md) — direct and routing model configuration, including the `cost` block.
+- [Adapter protocol families](../reference/adapters.md) — why a BYO OpenAI-compatible endpoint uses the `openai` adapter.
+- [OpenAI-compatible API](../integration/openai-compatible-api.md) — the proxy surface callers use to reach the endpoint.

--- a/docs/integration/upstream-azure-openai.md
+++ b/docs/integration/upstream-azure-openai.md
@@ -1,0 +1,259 @@
+---
+title: Azure OpenAI upstream
+description: Route AISIX AI Gateway to Azure OpenAI Service with either an api-key or Entra ID (AAD) credential, including deployment URLs, national-cloud authority hosts, and end-to-end chat examples.
+sidebar_position: 33
+keywords:
+  - AISIX AI Gateway
+  - Azure OpenAI
+  - Entra ID
+  - api-key
+  - AI gateway
+---
+
+AISIX AI Gateway can route requests to [Azure OpenAI Service](https://learn.microsoft.com/en-us/azure/ai-services/openai/) so callers reach your Azure deployments through the gateway's OpenAI-compatible proxy. This page shows how to register an Azure credential under either supported auth scheme, how the gateway builds the deployment URL, and how to verify a request reached Azure with the correct auth header.
+
+Azure OpenAI uses the `azure-openai` adapter family. The wire shape is OpenAI chat-completions; Azure differs on the URL pattern (deployment-keyed), the auth header, and tolerance for Azure's content-filter response blocks.
+
+## When to use this
+
+- Use this when your OpenAI models run on Azure OpenAI Service and you want them behind the gateway's auth, allowlist, rate limiting, and usage accounting.
+- Use this when you authenticate to Azure with a resource api-key, or with Entra ID (Azure AD) `client_credentials`.
+- For models you host yourself, see [Bring your own endpoint](../configuration/byo-endpoint.md) instead.
+
+## How it works
+
+The gateway builds the Azure chat-completions URL from the deployment name (the model's `model_name`) and the resource (the provider key's `api_base`):
+
+```text
+https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<version>
+```
+
+The auth scheme is detected from the **shape** of the provider key's `secret`:
+
+- A bare string secret → the `api-key: <secret>` header (Azure's resource-key scheme; **not** `Authorization: Bearer`).
+- A JSON object secret `{tenant_id, client_id, client_secret, ...}` → the Entra ID (AAD) `client_credentials` flow. The gateway mints an OAuth2 access token and sends `Authorization: Bearer <token>`.
+
+The gateway reuses the OpenAI chat-completions wire and tolerates Azure's `prompt_filter_results` / `content_filter_results` response extensions, so a content-filtered response still deserializes cleanly.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant Proxy as AISIX proxy (:3000)
+    participant Bridge as Azure OpenAI bridge
+    participant AAD as Entra ID (AAD)
+    participant Azure as Azure OpenAI deployment
+
+    Client->>Proxy: POST /v1/chat/completions (model = your-alias)
+    Note over Proxy: resolve alias → Model + ProviderKey (adapter=azure-openai)
+    Proxy->>Bridge: dispatch
+    alt secret is JSON (AAD)
+        Bridge->>AAD: client_credentials → access token (cached)
+        AAD-->>Bridge: access_token
+        Note over Bridge: Authorization: Bearer <token>
+    else secret is a bare string
+        Note over Bridge: api-key: <secret>
+    end
+    Bridge->>Azure: POST /openai/deployments/<d>/chat/completions?api-version=<v>
+    Azure-->>Bridge: response (may include content_filter_results)
+    Bridge-->>Proxy: normalized chat response
+    Note over Proxy: restore response.model = your-alias
+    Proxy-->>Client: OpenAI-shaped JSON
+```
+
+## Prerequisites
+
+- A running self-hosted gateway (admin on `:3001`, proxy on `:3000`). See the [Self-Hosted Quickstart](../quickstart/self-hosted.md).
+- Your admin key from the bootstrap config.
+- An Azure OpenAI resource and a deployment, plus either the resource api-key or an Entra ID app registration (`tenant_id`, `client_id`, `client_secret`) granted access to the resource.
+
+## Configuration
+
+Both auth schemes share the same model and caller-key steps; only the provider-key `secret` differs.
+
+:::warning Production credentials
+The standalone gateway stores `secret` as plaintext under the etcd `prefix` from [`config.yaml`](../configuration/bootstrap-config.md). For production, front etcd with encryption-at-rest, restrict etcd network access to the gateway, or use AISIX Cloud's managed [Provider Key Rotation](../cloud/provider-key-rotation.md), where the secret stays in the control plane and only the projected reference reaches the data plane.
+:::
+
+### Step 1: Create the Azure provider key
+
+#### Option A — api-key auth
+
+The `secret` is the verbatim resource api-key string. `api_base` is the resource host.
+
+```bash title="Create an Azure provider key (api-key auth)"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/provider_keys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "azure-prod",
+    "provider": "azure",
+    "adapter": "azure-openai",
+    "secret": "YOUR_AZURE_API_KEY",
+    "api_base": "https://acme-west.openai.azure.com"
+  }'
+```
+
+#### Option B — Entra ID (AAD) auth
+
+The `secret` is a JSON object. Its `{` prefix is what tells the gateway to use the AAD `client_credentials` flow.
+
+```bash title="Create an Azure provider key (AAD auth)"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/provider_keys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "azure-aad-prod",
+    "provider": "azure",
+    "adapter": "azure-openai",
+    "secret": "{\"tenant_id\":\"YOUR_TENANT_ID\",\"client_id\":\"YOUR_CLIENT_ID\",\"client_secret\":\"YOUR_CLIENT_SECRET\"}",
+    "api_base": "https://acme-west.openai.azure.com"
+  }'
+```
+
+The AAD `secret` fields are:
+
+| Field | Required | Description |
+|---|---|---|
+| `tenant_id` | Yes | Entra ID tenant UUID (or vanity domain). Interpolated into the token endpoint path. |
+| `client_id` | Yes | App-registration (application) UUID. |
+| `client_secret` | Yes | The client secret value (not the secret id). |
+| `authority_host` | No | AAD authority origin. Omit for public Azure (defaults to `https://login.microsoftonline.com`). Set it for a national / sovereign cloud — `https://login.microsoftonline.us` (US Government) or `https://login.chinacloudapi.cn` (China, 21Vianet). Must be a bare http(s) origin; the gateway appends the tenant and the `/oauth2/v2.0/token` path. |
+
+For a national-cloud tenant, add `authority_host` to the JSON secret:
+
+```json title="AAD secret with national-cloud authority host"
+{
+  "tenant_id": "YOUR_TENANT_ID",
+  "client_id": "YOUR_CLIENT_ID",
+  "client_secret": "YOUR_CLIENT_SECRET",
+  "authority_host": "https://login.microsoftonline.us"
+}
+```
+
+The minted token is cached in-process, keyed by `(tenant_id, client_id)`, and refreshed about 60 seconds before its reported expiry.
+
+For both options, `adapter` must be `azure-openai` and `provider` is a free-form vendor label (`azure` matches the AISIX Cloud catalog id). Capture the returned `id` for the next step.
+
+#### `api_base` and the API version
+
+`api_base` is the Azure resource host. The gateway accepts three shapes:
+
+- The canonical resource URL `https://<resource>.openai.azure.com` (the resource name is extracted from the host).
+- A bare resource name (for example `acme-west`).
+- A verbatim override URL whose host does **not** end in `.openai.azure.com` — used for a corporate proxy, a private-VPC endpoint, or a mock. The gateway appends `/openai/deployments/<deployment>/chat/completions?api-version=<version>` to whatever you supply. (Verbatim overrides must not embed userinfo, a query string, or a fragment.)
+
+The gateway pins a GA `api-version` default (`2024-10-21`). Azure deprecates older API versions on a [published schedule](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation), so treat the default as a stop-gap and plan to track the version your deployment requires.
+
+### Step 2: Create the model
+
+`model_name` is the Azure **deployment** name (the name you gave the deployment in the Azure portal), not the underlying model id. The customer-facing alias is `display_name`.
+
+```bash title="Create a model for an Azure deployment"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/models \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "gpt-4o-azure",
+    "provider": "azure",
+    "model_name": "gpt4o-prod",
+    "provider_key_id": "YOUR_PROVIDER_KEY_ID"
+  }'
+```
+
+### Step 3: Create a caller API key
+
+```bash title="Hash a plaintext caller key"
+printf 'sk-demo-caller' | sha256sum | cut -d' ' -f1
+```
+
+```bash title="Create a caller API key"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/apikeys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_hash": "YOUR_CALLER_KEY_HASH",
+    "allowed_models": ["gpt-4o-azure"]
+  }'
+```
+
+### Step 4: Send a request
+
+Allow about a second for the configuration to propagate, then call the gateway. The request is identical regardless of which auth scheme the provider key uses.
+
+```bash title="Send a chat completion to Azure"
+curl -sS -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o-azure",
+    "messages": [
+      {"role": "user", "content": "Say hello from Azure OpenAI."}
+    ]
+  }'
+```
+
+Expected response (OpenAI-shaped, alias restored):
+
+```json title="200 OK"
+{
+  "id": "cmpl-azure-...",
+  "object": "chat.completion",
+  "model": "gpt-4o-azure",
+  "choices": [
+    {
+      "index": 0,
+      "message": {"role": "assistant", "content": "Hello from Azure OpenAI!"},
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {"prompt_tokens": 7, "completion_tokens": 5, "total_tokens": 12}
+}
+```
+
+## Verification
+
+Confirm the observable facts a `200` does not, by itself, prove.
+
+### `response.model` is the alias, not the deployment name
+
+```bash title="Confirm alias restore"
+curl -sS -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-azure","messages":[{"role":"user","content":"ping"}]}' \
+  | grep -o '"model":"[^"]*"'
+```
+
+Expected: `"model":"gpt-4o-azure"` — your alias, not the deployment `gpt4o-prod`. This is the gateway-wide alias-restore contract.
+
+### The outbound auth header matches the credential scheme
+
+The gateway's e2e coverage asserts the outbound shape against a mock Azure: for an api-key provider key the request carries the `api-key` header (and **no** `Authorization` header); for an AAD provider key it carries `Authorization: Bearer <minted-token>`. In both cases the outbound URL is `/openai/deployments/<deployment>/chat/completions?api-version=<version>` with the deployment taken from the model's `model_name`.
+
+Confirm the auth path indirectly:
+
+```bash title="Negative check — bad credentials surface as upstream auth failure"
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-azure","messages":[{"role":"user","content":"ping"}]}'
+```
+
+With a valid credential, expect `200`. With an invalid api-key, or invalid AAD client credentials, expect a configuration or upstream error — confirming the gateway selected the auth scheme and dispatched to Azure. Upstream Azure error envelopes (which can contain the deployment name and resource host) are redacted to a canned, status-keyed message before reaching the caller.
+
+## Content-filter tolerance
+
+Azure attaches `prompt_filter_results` and `content_filter_results` blocks to successful responses. The gateway tolerates these extension fields and returns the standard OpenAI envelope unchanged — a content-annotated `200` from Azure still deserializes and reaches the caller as a normal chat completion. A request that Azure blocks for a content-policy violation surfaces as an upstream error with the Azure error code preserved for downstream translation.
+
+## Limitations
+
+- The `api-version` default is a GA stop-gap; track the version your deployment requires and plan for Azure's deprecation schedule.
+- Verbatim `api_base` overrides accept any reachable host; a typo routes traffic to wherever that host resolves. Double-check the override URL.
+- The AAD path mints a token per `(tenant_id, client_id)` and caches it; a revoked client secret surfaces as an upstream auth failure on the next mint.
+
+## Related pages
+
+- [Adapter protocol families](../reference/adapters.md) — where Azure OpenAI fits among the five adapters.
+- [Provider keys](../configuration/provider-keys.md) — the credential resource and `api_base` behavior.
+- [AWS Bedrock upstream](upstream-bedrock.md) and [Google Vertex AI upstream](upstream-vertex.md) — the other specialized-family guides.

--- a/docs/integration/upstream-bedrock.md
+++ b/docs/integration/upstream-bedrock.md
@@ -1,0 +1,216 @@
+---
+title: AWS Bedrock upstream
+description: Route AISIX AI Gateway to AWS Bedrock with SigV4 credentials, including Anthropic and Converse publisher dispatch, cross-region inference profiles, and an end-to-end chat example.
+sidebar_position: 31
+keywords:
+  - AISIX AI Gateway
+  - AWS Bedrock
+  - SigV4
+  - Converse API
+  - AI gateway
+---
+
+AISIX AI Gateway can route requests to [AWS Bedrock](https://docs.aws.amazon.com/bedrock/) so callers reach Claude, Llama, Mistral, Amazon Nova, Cohere, and other Bedrock-hosted models through the gateway's OpenAI-compatible proxy. This page shows how to register Bedrock credentials, how the gateway picks the right Bedrock wire shape per model, and how to verify a request reached Bedrock with the correct signing.
+
+Bedrock uses the `bedrock` adapter family. The gateway signs every outbound call with AWS SigV4 through the AWS SDK and renders the response back to the caller as an OpenAI chat-completions envelope.
+
+## When to use this
+
+- Use this when your models run on AWS Bedrock and you want them behind the gateway's auth, allowlist, rate limiting, and usage accounting.
+- Use this when you need cross-region inference profiles (`us.`, `eu.`, `apac.`, `global.`, `us-gov.`).
+- For models you host yourself, see [Bring your own endpoint](../configuration/byo-endpoint.md) instead.
+
+## How it works
+
+The gateway resolves the Bedrock publisher from the model id and dispatches to the matching wire shape:
+
+- **Anthropic** (`anthropic.claude-*`) — dispatched through the legacy Bedrock `/invoke` route (`InvokeModel`) with an Anthropic Messages JSON body. The `model` field is stripped (Bedrock keys dispatch off the URL path) and `anthropic_version: "bedrock-2023-05-31"` is added.
+- **All other publishers** (`meta.llama*`, `mistral.*`, `amazon.titan-*`, `amazon.nova-*`, `cohere.command*`, `ai21.jamba-*`, and other catalog publishers) — dispatched through the unified [Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) (`/converse`).
+
+Authentication is AWS SigV4, computed by the AWS SDK from the credentials in the provider key's `secret`. The model's `model_name` is the Bedrock model id and is passed to Bedrock verbatim, including any cross-region inference profile prefix.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant Proxy as AISIX proxy (:3000)
+    participant Bridge as Bedrock bridge
+    participant Bedrock as AWS Bedrock Runtime
+
+    Client->>Proxy: POST /v1/chat/completions (model = your-alias)
+    Note over Proxy: resolve alias → Model + ProviderKey (adapter=bedrock)
+    Proxy->>Bridge: dispatch
+    Note over Bridge: resolve publisher from model_name
+    alt anthropic.claude-*
+        Bridge->>Bedrock: POST /model/<id>/invoke (SigV4)
+    else other publishers
+        Bridge->>Bedrock: POST /model/<id>/converse (SigV4)
+    end
+    Bedrock-->>Bridge: provider-native response
+    Bridge-->>Proxy: normalized chat response
+    Note over Proxy: restore response.model = your-alias
+    Proxy-->>Client: OpenAI-shaped JSON
+```
+
+## Prerequisites
+
+- A running self-hosted gateway (admin on `:3001`, proxy on `:3000`). See the [Self-Hosted Quickstart](../quickstart/self-hosted.md).
+- Your admin key from the bootstrap config.
+- AWS credentials with `bedrock:InvokeModel` (and `bedrock:Converse`) permission, and a Bedrock model you have requested access to in the target region.
+
+## Configuration
+
+### Step 1: Create the Bedrock provider key
+
+The `secret` is a JSON-encoded AWS credential blob. The base URL is not part of the secret — leave `api_base` unset for standard AWS, or set it to a private Bedrock endpoint (VPC endpoint) if you have one.
+
+:::warning Production credentials
+The standalone gateway stores `secret` as plaintext under the etcd `prefix` from [`config.yaml`](../configuration/bootstrap-config.md). For production, front etcd with encryption-at-rest, restrict etcd network access to the gateway, or use AISIX Cloud's managed [Provider Key Rotation](../cloud/provider-key-rotation.md), where the secret stays in the control plane and only the projected reference reaches the data plane.
+:::
+
+```bash title="Create a Bedrock provider key"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/provider_keys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "bedrock-prod",
+    "provider": "amazon-bedrock",
+    "adapter": "bedrock",
+    "secret": "{\"access_key_id\":\"YOUR_AWS_ACCESS_KEY_ID\",\"secret_access_key\":\"YOUR_AWS_SECRET_ACCESS_KEY\",\"region\":\"us-west-2\"}"
+  }'
+```
+
+The `secret` value is a JSON string. Its fields are:
+
+| Field | Required | Description |
+|---|---|---|
+| `access_key_id` | Yes | AWS access key id. |
+| `secret_access_key` | Yes | AWS secret access key. |
+| `region` | Yes | AWS region the dispatch targets, e.g. `us-west-2`. Bedrock's endpoint is region-keyed (`bedrock-runtime.<region>.amazonaws.com`), so this is required. |
+| `session_token` | No | AWS STS session token. Set it for assume-role / temporary credentials; omit it for long-lived static keys. |
+
+`adapter` must be `bedrock` — this is the dispatch key that routes the provider key to the Bedrock bridge. `provider` is a free-form vendor label (`amazon-bedrock` matches the AISIX Cloud catalog id).
+
+Capture the returned `id` for the next step.
+
+### Step 2: Create the model
+
+`model_name` is the Bedrock model id. The customer-facing alias is `display_name`.
+
+```bash title="Create a model for Claude on Bedrock"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/models \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "claude-bedrock",
+    "provider": "amazon-bedrock",
+    "model_name": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "provider_key_id": "YOUR_PROVIDER_KEY_ID"
+  }'
+```
+
+For a Converse-path model, set `model_name` to the publisher's Bedrock id, for example `meta.llama3-3-70b-instruct-v1:0` or `amazon.nova-pro-v1:0`.
+
+#### Cross-region inference profiles
+
+To use a [cross-region inference profile](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html), prefix the model id with the geography (`us.`, `eu.`, `apac.`, `global.`, or `us-gov.`):
+
+```json title="Cross-region model_name"
+{
+  "model_name": "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+}
+```
+
+The gateway uses the prefix only to resolve the publisher; the full prefixed id is passed to Bedrock verbatim on the outbound call.
+
+### Step 3: Create a caller API key
+
+```bash title="Hash a plaintext caller key"
+printf 'sk-demo-caller' | sha256sum | cut -d' ' -f1
+```
+
+```bash title="Create a caller API key"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/apikeys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_hash": "YOUR_CALLER_KEY_HASH",
+    "allowed_models": ["claude-bedrock"]
+  }'
+```
+
+### Step 4: Send a request
+
+Allow about a second for the configuration to propagate to the proxy, then call the gateway.
+
+```bash title="Send a chat completion to Bedrock"
+curl -sS -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-bedrock",
+    "messages": [
+      {"role": "user", "content": "Say hello from Bedrock."}
+    ]
+  }'
+```
+
+Expected response (OpenAI-shaped, alias restored):
+
+```json title="200 OK"
+{
+  "id": "msg_01...",
+  "object": "chat.completion",
+  "model": "claude-bedrock",
+  "choices": [
+    {
+      "index": 0,
+      "message": {"role": "assistant", "content": "Hello from Bedrock!"},
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {"prompt_tokens": 9, "completion_tokens": 5, "total_tokens": 14}
+}
+```
+
+## Verification
+
+Confirm the two observable facts a `200` does not, by itself, prove.
+
+### `response.model` is the alias, not the Bedrock id
+
+```bash title="Confirm alias restore"
+curl -sS -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-bedrock","messages":[{"role":"user","content":"ping"}]}' \
+  | grep -o '"model":"[^"]*"'
+```
+
+Expected: `"model":"claude-bedrock"` — your alias, not `anthropic.claude-3-5-sonnet-20241022-v2:0`. This is the gateway-wide alias-restore contract; the Bedrock adapter flows through the same render path as every other family.
+
+### The outbound request is SigV4-signed against the Converse or invoke route
+
+The gateway's own e2e coverage asserts the outbound shape against a mock Bedrock: the request carries an `Authorization: AWS4-HMAC-SHA256 Credential=...` header (SigV4, **not** a Bearer token) and hits `/model/<modelId>/converse` for Converse-path publishers (or `/model/<modelId>/invoke` for `anthropic.*`). You cannot read AWS's inbound headers directly, but you can confirm the signing path indirectly:
+
+```bash title="Negative check — bad credentials surface as upstream auth failure"
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-bedrock","messages":[{"role":"user","content":"ping"}]}'
+```
+
+With a correctly-scoped key, expect `200`. With invalid AWS credentials on the provider key, expect a `5xx` upstream error — confirming the SDK signed and dispatched to Bedrock rather than short-circuiting. Upstream AWS error envelopes (which can contain account ids and IAM role names) are redacted to a canned, status-keyed message before reaching the caller.
+
+## Limitations
+
+- **Streaming** dispatches all publishers through the Converse stream API (`/converse-stream`). Confirm streaming behavior against your specific publisher.
+- **Anthropic on Bedrock** uses the legacy `/invoke` route for non-streaming chat to preserve the Anthropic Messages body shape; other publishers use Converse.
+- Upstream error detail from AWS is intentionally redacted in the customer-visible error to avoid leaking operator-internal identifiers (ARNs, region, account id).
+
+## Related pages
+
+- [Adapter protocol families](../reference/adapters.md) — where Bedrock fits among the five adapters.
+- [Provider keys](../configuration/provider-keys.md) — the credential resource and `api_base` behavior.
+- [OpenAI-compatible API](openai-compatible-api.md) — the proxy surface callers use.
+- [Google Vertex AI upstream](upstream-vertex.md) and [Azure OpenAI upstream](upstream-azure-openai.md) — the other specialized-family guides.

--- a/docs/integration/upstream-vertex.md
+++ b/docs/integration/upstream-vertex.md
@@ -1,0 +1,219 @@
+---
+title: Google Vertex AI upstream
+description: Route AISIX AI Gateway to Google Vertex AI Gemini with a service-account credential, including in-process OAuth token minting and an end-to-end chat example.
+sidebar_position: 32
+keywords:
+  - AISIX AI Gateway
+  - Google Vertex AI
+  - Gemini
+  - service account
+  - AI gateway
+---
+
+AISIX AI Gateway can route requests to [Google Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs) so callers reach Gemini models through the gateway's OpenAI-compatible proxy. This page shows how to register a GCP credential, how the gateway mints an OAuth2 token for each call, and how to verify a request reached Vertex with Bearer auth.
+
+Vertex uses the `vertex` adapter family. The gateway builds Gemini's native `:generateContent` request, authenticates with a GCP OAuth2 Bearer token, and renders the response back to the caller as an OpenAI chat-completions envelope.
+
+## When to use this
+
+- Use this when your Gemini models run on Google Vertex AI and you want them behind the gateway's auth, allowlist, rate limiting, and usage accounting.
+- Use this when you want the gateway to mint and cache GCP access tokens from a service-account key, rather than managing token refresh yourself.
+- For models you host yourself, see [Bring your own endpoint](../configuration/byo-endpoint.md) instead.
+
+## How it works
+
+The gateway resolves the Vertex publisher from the model id. **Gemini** (`gemini-*`) is the currently wired publisher; see [Limitations](#limitations) for the rest.
+
+For a Gemini model the gateway:
+
+1. Reads the GCP credential from the provider key's `secret`.
+2. Obtains an OAuth2 access token — either the pre-minted `access_token` you supplied, or one minted in-process from a `service_account_json` (see [Token minting](#token-minting)).
+3. POSTs the Gemini `generateContent` body to `{base}/v1/projects/<project>/locations/<region>/publishers/google/models/<model>:generateContent` with `Authorization: Bearer <token>`. Streaming uses `:streamGenerateContent?alt=sse`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant Proxy as AISIX proxy (:3000)
+    participant Bridge as Vertex bridge
+    participant Google as Google OAuth2
+    participant Vertex as Vertex AI (Gemini)
+
+    Client->>Proxy: POST /v1/chat/completions (model = your-alias)
+    Note over Proxy: resolve alias → Model + ProviderKey (adapter=vertex)
+    Proxy->>Bridge: dispatch
+    alt service_account_json
+        Bridge->>Google: signed JWT → access token (cached)
+        Google-->>Bridge: access_token
+    else pre-minted access_token
+        Note over Bridge: use token verbatim
+    end
+    Bridge->>Vertex: POST ...:generateContent (Bearer token)
+    Vertex-->>Bridge: Gemini response
+    Bridge-->>Proxy: normalized chat response
+    Note over Proxy: restore response.model = your-alias
+    Proxy-->>Client: OpenAI-shaped JSON
+```
+
+## Token minting
+
+The provider key's `secret` is a JSON object carrying `project`, `region`, and **exactly one** of two credential modes:
+
+- **`service_account_json`** (recommended) — the full GCP service-account JSON key, as emitted by `gcloud iam service-accounts keys create`. The gateway signs a JWT with the service account's RSA private key (RS256), exchanges it for an OAuth2 access token at the service account's `token_uri` (the standard [JWT-bearer assertion grant](https://developers.google.com/identity/protocols/oauth2/service-account)), and caches the token in-process. The cached token is refreshed about 60 seconds before its reported expiry, so an in-flight request never lands on an expired token.
+- **`access_token`** — a pre-minted GCP OAuth2 bearer token you manage and refresh yourself (GCP token TTL is roughly one hour). Useful for short-lived test rigs or when you already operate a token-mint pipeline.
+
+Setting both, or neither, fails at registration time with a clear error.
+
+## Prerequisites
+
+- A running self-hosted gateway (admin on `:3001`, proxy on `:3000`). See the [Self-Hosted Quickstart](../quickstart/self-hosted.md).
+- Your admin key from the bootstrap config.
+- A GCP project with the Vertex AI API enabled, a region (for example `us-central1`), and a service-account key with the Vertex AI user role.
+
+## Configuration
+
+### Step 1: Create the Vertex provider key
+
+The `secret` is a JSON string. The example below uses the `service_account_json` mode. Embed the service-account JSON as a nested object inside the secret.
+
+:::warning Production credentials
+The standalone gateway stores `secret` as plaintext under the etcd `prefix` from [`config.yaml`](../configuration/bootstrap-config.md). For production, front etcd with encryption-at-rest, restrict etcd network access to the gateway, or use AISIX Cloud's managed [Provider Key Rotation](../cloud/provider-key-rotation.md), where the secret stays in the control plane and only the projected reference reaches the data plane.
+:::
+
+```bash title="Create a Vertex provider key (service-account mode)"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/provider_keys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "vertex-prod",
+    "provider": "google-vertex",
+    "adapter": "vertex",
+    "secret": "{\"project\":\"my-gcp-project\",\"region\":\"us-central1\",\"service_account_json\":{\"type\":\"service_account\",\"private_key\":\"-----BEGIN PRIVATE KEY-----\\nYOUR_SERVICE_ACCOUNT_PRIVATE_KEY\\n-----END PRIVATE KEY-----\\n\",\"client_email\":\"vertex-sa@my-gcp-project.iam.gserviceaccount.com\",\"token_uri\":\"https://oauth2.googleapis.com/token\"}}"
+  }'
+```
+
+The `secret` fields are:
+
+| Field | Required | Description |
+|---|---|---|
+| `project` | Yes | GCP project id (named or numeric), e.g. `my-gcp-project`. |
+| `region` | Yes | Vertex AI region, e.g. `us-central1`, `europe-west4`. Drives the `<region>-aiplatform.googleapis.com` host. |
+| `service_account_json` | One of the two | The full GCP service-account JSON key. The gateway mints tokens in-process. Mutually exclusive with `access_token`. |
+| `access_token` | One of the two | A pre-minted GCP OAuth2 token you refresh yourself. Mutually exclusive with `service_account_json`. |
+
+`adapter` must be `vertex`. `provider` is a free-form vendor label (`google-vertex` matches the AISIX Cloud catalog id).
+
+If you operate behind a corporate proxy, set `api_base` on the provider key to your proxy host; it overrides the regional `<region>-aiplatform.googleapis.com` host. The bridge appends the `/v1/projects/.../publishers/google/models/<model>:generateContent` path itself.
+
+Capture the returned `id` for the next step.
+
+### Step 2: Create the model
+
+`model_name` is the Gemini publisher model id. The customer-facing alias is `display_name`.
+
+```bash title="Create a Gemini model"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/models \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "gemini-prod",
+    "provider": "google-vertex",
+    "model_name": "gemini-1.5-pro",
+    "provider_key_id": "YOUR_PROVIDER_KEY_ID"
+  }'
+```
+
+### Step 3: Create a caller API key
+
+```bash title="Hash a plaintext caller key"
+printf 'sk-demo-caller' | sha256sum | cut -d' ' -f1
+```
+
+```bash title="Create a caller API key"
+curl -sS -X POST http://127.0.0.1:3001/admin/v1/apikeys \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_hash": "YOUR_CALLER_KEY_HASH",
+    "allowed_models": ["gemini-prod"]
+  }'
+```
+
+### Step 4: Send a request
+
+Allow about a second for the configuration to propagate, then call the gateway. Gemini requires at least one user or assistant turn — a system-only request is rejected before dispatch.
+
+```bash title="Send a chat completion to Vertex"
+curl -sS -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-prod",
+    "messages": [
+      {"role": "user", "content": "Say hello from Vertex."}
+    ]
+  }'
+```
+
+Expected response (OpenAI-shaped, alias restored):
+
+```json title="200 OK"
+{
+  "object": "chat.completion",
+  "model": "gemini-prod",
+  "choices": [
+    {
+      "index": 0,
+      "message": {"role": "assistant", "content": "Hello from Vertex!"},
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {"prompt_tokens": 4, "completion_tokens": 4, "total_tokens": 8}
+}
+```
+
+## Verification
+
+Confirm the two observable facts a `200` does not, by itself, prove.
+
+### `response.model` is the alias, not the Gemini id
+
+```bash title="Confirm alias restore"
+curl -sS -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gemini-prod","messages":[{"role":"user","content":"ping"}]}' \
+  | grep -o '"model":"[^"]*"'
+```
+
+Expected: `"model":"gemini-prod"` — your alias, not `gemini-1.5-pro`. This is the gateway-wide alias-restore contract.
+
+### The outbound request hits `:generateContent` with a Bearer token
+
+The gateway's e2e coverage asserts the outbound shape against a mock Vertex: the request carries `Authorization: Bearer <token>` and hits `/v1/projects/<project>/locations/<region>/publishers/google/models/<model>:generateContent`. Confirm the auth/mint path indirectly:
+
+```bash title="Negative check — bad credentials surface as upstream auth failure"
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-caller" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gemini-prod","messages":[{"role":"user","content":"ping"}]}'
+```
+
+With a valid service-account key, expect `200`. With an invalid private key or revoked service account, expect a configuration or upstream error — confirming the gateway minted (or attempted to mint) a token and dispatched to Vertex. Upstream Vertex error envelopes (which can contain your GCP project id) are redacted to a canned, status-keyed message before reaching the caller.
+
+## Limitations
+
+The Vertex adapter currently supports **Gemini** models. The following Vertex publishers are recognized by the model-id resolver but are **not yet implemented** for dispatch:
+
+- **Anthropic on Vertex** (`claude-*`, the `rawPredict` wire shape)
+- **Llama on Vertex** (`meta/llama-*` / `llama*`)
+- Mistral and AI21 on Vertex
+
+Requests for these publishers return a clear "not yet implemented" error. Do not register them as live models. See the [Roadmap](../roadmap.md) for direction.
+
+## Related pages
+
+- [Adapter protocol families](../reference/adapters.md) — where Vertex fits among the five adapters.
+- [Provider keys](../configuration/provider-keys.md) — the credential resource and `api_base` behavior.
+- [AWS Bedrock upstream](upstream-bedrock.md) and [Azure OpenAI upstream](upstream-azure-openai.md) — the other specialized-family guides.
+- [Roadmap](../roadmap.md) — planned Vertex publisher support.

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -1,0 +1,104 @@
+---
+title: Adapter protocol families
+description: Reference for the five adapter protocol families in AISIX AI Gateway — how each upstream wire shape is dispatched, and how catalog and bring-your-own providers map onto them.
+sidebar_position: 66
+keywords:
+  - AISIX AI Gateway
+  - adapter
+  - Bedrock
+  - Vertex
+  - Azure OpenAI
+  - AI gateway
+---
+
+An **adapter** is the upstream wire shape AISIX AI Gateway encodes a request into when it dispatches to a provider. The gateway knows a closed set of five adapter protocol families. Every upstream — whether it comes from the curated catalog or you bring your own endpoint — resolves to exactly one of them.
+
+This page explains the five families, how a model resolves to a bridge at request time, and how the catalog and bring-your-own (BYO) modes select an adapter. Use it to decide which integration guide to follow and what credential shape a given upstream needs.
+
+## The five adapter families
+
+The adapter set is fixed in code as a closed enum (`Adapter` in `aisix-core`). It serializes in `kebab-case`, so the Azure family is the wire string `azure-openai`.
+
+| Adapter | Wire shape | Bridge crate | Auth | Integration guide |
+|---|---|---|---|---|
+| `openai` | OpenAI chat completions (`POST /chat/completions`) | `aisix-provider-openai` | `Authorization: Bearer` (`api-key` reuse for OpenAI-compatible vendors) | [OpenAI-compatible API](../integration/openai-compatible-api.md), [BYO endpoint](../configuration/byo-endpoint.md) |
+| `anthropic` | Anthropic Messages (`POST /v1/messages`) | `aisix-provider-anthropic` | `x-api-key` + `anthropic-version` | [Anthropic Messages](../integration/anthropic-messages.md) |
+| `bedrock` | AWS Bedrock Runtime — Converse (`/converse`) and the Anthropic `/invoke` route | `aisix-provider-bedrock` | AWS SigV4 | [AWS Bedrock upstream](../integration/upstream-bedrock.md) |
+| `vertex` | Google Vertex AI Gemini (`:generateContent`) | `aisix-provider-vertex` | OAuth2 Bearer (GCP) | [Google Vertex AI upstream](../integration/upstream-vertex.md) |
+| `azure-openai` | Azure OpenAI Service (`/openai/deployments/<deployment>/chat/completions`) | `aisix-provider-azure-openai` | `api-key` header **or** Entra ID (AAD) Bearer | [Azure OpenAI upstream](../integration/upstream-azure-openai.md) |
+
+The `openai` family is the broadest. Besides OpenAI itself, every OpenAI-compatible catalog vendor (DeepSeek, Groq, Mistral, Together.ai, Fireworks, Perplexity, and others) and every BYO OpenAI-compatible endpoint (vLLM, SGLang, Ollama, a self-hosted proxy) dispatches through the same OpenAI bridge — they differ only in `api_base` and credential.
+
+## Specialized bridges, not one generic client
+
+Each adapter family is a distinct `Bridge` implementation. The gateway does not normalize every provider into one OpenAI-shaped HTTP call. Instead, a per-family bridge owns the request encoding, the auth scheme, the URL construction, and the response decoding for that upstream's native protocol:
+
+- The **OpenAI** and **Azure OpenAI** bridges speak the OpenAI chat-completions wire. Azure differs on the URL pattern (deployment-keyed), the auth header (`api-key` instead of `Authorization`), and tolerance for Azure's `prompt_filter_results` / `content_filter_results` response extensions.
+- The **Anthropic** bridge speaks the Anthropic Messages wire and translates Anthropic-shaped requests bidirectionally for non-Anthropic upstreams (see [Anthropic Messages](../integration/anthropic-messages.md)).
+- The **Bedrock** bridge dispatches through the AWS SDK with SigV4 signing. Anthropic-on-Bedrock models use the legacy `/invoke` route with an Anthropic Messages body; all other publishers use the unified Converse API.
+- The **Vertex** bridge builds Gemini's `:generateContent` request body and mints a GCP OAuth2 token from the service-account credential before each call.
+
+Whatever the upstream protocol, the customer-facing contract stays OpenAI-shaped: the response is rendered back as an OpenAI chat-completions envelope, and `response.model` echoes your model alias rather than the upstream id. That alias restore is gateway-wide and applies identically across all five families.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant Proxy as AISIX proxy (:3000)
+    participant Hub as Bridge hub
+    participant Bridge as Family bridge
+    participant Upstream as Upstream provider
+
+    Client->>Proxy: POST /v1/chat/completions (model = your-alias)
+    Note over Proxy: resolve alias → Model + ProviderKey
+    Proxy->>Hub: dispatch by adapter
+    Hub->>Bridge: select family bridge
+    Bridge->>Upstream: provider-native request (SigV4 / Bearer / api-key)
+    Upstream-->>Bridge: provider-native response
+    Bridge-->>Proxy: normalized chat response
+    Note over Proxy: restore response.model = your-alias
+    Proxy-->>Client: OpenAI-shaped JSON
+```
+
+## How a model resolves to a bridge
+
+A direct [model](../configuration/models.md) references a [provider key](../configuration/provider-keys.md) by `provider_key_id`. At dispatch time the gateway selects the bridge from the provider key in two tiers:
+
+1. **Specialized vendor lookup** — keyed on the provider key's `provider` (vendor identity). Only `openai` and `anthropic` are registered as specialized vendors today; this tier mainly serves pre-existing keys.
+2. **Adapter family lookup** — keyed on the provider key's `adapter` field. This is how `bedrock`, `vertex`, and `azure-openai` keys reach their bridge, and how any OpenAI-compatible vendor reaches the OpenAI bridge.
+
+For the three specialized upstreams (Bedrock, Vertex, Azure OpenAI), set `adapter` on the provider key to `bedrock`, `vertex`, or `azure-openai`. The bridge then reads the model's `model_name` as the upstream id (Bedrock model id, Vertex publisher model, or Azure deployment name) and the provider key's `secret` / `api_base` for credentials and endpoint.
+
+:::note
+The `adapter` field is the dispatch key for the specialized families. The `model_name` on a model is always the **upstream** identifier; the customer-facing alias is the model's `display_name`, which is what the caller sends in `model` and what `response.model` echoes back.
+:::
+
+## Catalog versus bring-your-own
+
+A provider key's telemetry tags carry a `kind` of either `catalog` or `byo` (the `telemetry_tags.kind` field). The two modes choose an adapter differently:
+
+- **Catalog** — the upstream comes from a curated, models.dev-driven catalog. In AISIX Cloud, the control plane maps each catalog provider to its adapter automatically (for example, `amazon-bedrock` → `bedrock`, `azure` → `azure-openai`, `google-vertex` → `vertex`, `deepseek` → `openai`). You select a provider; the adapter is implied.
+- **Bring-your-own (BYO)** — the upstream is a private or self-hosted endpoint that is not in the catalog. You set the adapter explicitly. In the self-hosted gateway you set `provider` + `api_base` (and, for the specialized families, `adapter`) directly on the provider key through the admin API. In AISIX Cloud, BYO endpoints are admitted through a BYO path that lets you pick one of the five adapters for the endpoint.
+
+### Featured versus non-featured catalog providers
+
+Within the catalog, a subset of providers is **featured** — the curated, ranked set the dashboard surfaces first (OpenAI, Anthropic, Amazon Bedrock, Azure, Google Vertex, DeepSeek, and others). Non-featured catalog providers still resolve to an adapter through the same catalog mapping; they are simply not promoted in the dashboard's ranked list. Featured status affects discovery and presentation, not dispatch — both featured and non-featured providers run through the same five bridges.
+
+:::note Self-hosted versus Cloud
+The catalog mapping and the featured ranking are AISIX Cloud control-plane behavior. The self-hosted gateway does not ship a catalog: you set `provider`, `api_base`, and `adapter` on each provider key yourself. The dispatch tiers above are identical in both modes — only the source of the field values differs.
+:::
+
+## Current capability per family
+
+Each integration guide documents the exact current behavior, including per-family limitations. In summary:
+
+- **Bedrock** — chat is wired for Anthropic (Claude on Bedrock, via `/invoke`) and for all other publishers through the Converse API. Cross-region inference profile prefixes (`us.`, `eu.`, `apac.`, `global.`, `us-gov.`) are supported.
+- **Vertex** — Gemini chat and streaming are wired. Anthropic-on-Vertex and Llama-on-Vertex are not yet implemented; see [Google Vertex AI upstream § Limitations](../integration/upstream-vertex.md#limitations) and the [Roadmap](../roadmap.md).
+- **Azure OpenAI** — chat and streaming are wired for both the `api-key` and the Entra ID (AAD) `client_credentials` auth schemes.
+
+## Related pages
+
+- [Provider keys](../configuration/provider-keys.md) — the credential resource every adapter dispatch reads from.
+- [Provider compatibility](provider-compatibility.md) — the current provider set and per-endpoint support boundaries.
+- [BYO endpoint](../configuration/byo-endpoint.md) — point the OpenAI adapter at a private or self-hosted endpoint.
+- [AWS Bedrock upstream](../integration/upstream-bedrock.md), [Google Vertex AI upstream](../integration/upstream-vertex.md), [Azure OpenAI upstream](../integration/upstream-azure-openai.md) — the three specialized-family guides.

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -36,7 +36,7 @@ Each adapter family is a distinct `Bridge` implementation. The gateway does not 
 - The **OpenAI** and **Azure OpenAI** bridges speak the OpenAI chat-completions wire. Azure differs on the URL pattern (deployment-keyed), the auth header (`api-key` instead of `Authorization`), and tolerance for Azure's `prompt_filter_results` / `content_filter_results` response extensions.
 - The **Anthropic** bridge speaks the Anthropic Messages wire and translates Anthropic-shaped requests bidirectionally for non-Anthropic upstreams (see [Anthropic Messages](../integration/anthropic-messages.md)).
 - The **Bedrock** bridge dispatches through the AWS SDK with SigV4 signing. Anthropic-on-Bedrock models use the legacy `/invoke` route with an Anthropic Messages body; all other publishers use the unified Converse API.
-- The **Vertex** bridge builds Gemini's `:generateContent` request body and mints a GCP OAuth2 token from the service-account credential before each call.
+- The **Vertex** bridge builds Gemini's `:generateContent` request body and authenticates with a GCP OAuth2 Bearer token — either minted in-process from a service-account credential and cached, or supplied pre-minted (see [Google Vertex AI upstream § Token minting](../integration/upstream-vertex.md#token-minting)).
 
 Whatever the upstream protocol, the customer-facing contract stays OpenAI-shaped: the response is rendered back as an OpenAI chat-completions envelope, and `response.model` echoes your model alias rather than the upstream id. That alias restore is gateway-wide and applies identically across all five families.
 


### PR DESCRIPTION
## Summary

Phase H documentation subset for #302 — 5 new pages, each grounded in current `origin/main` code (every field name, secret shape, dispatch claim, and curl example verified against source):

| Page | What it covers |
|---|---|
| `reference/adapters.md` | The 5 adapter protocol families + two-tier dispatch (specialized-by-`provider` → family-by-`adapter`) + specialized bridges vs OpenAI-compat reuse + catalog/BYO + featured/non-featured |
| `configuration/byo-endpoint.md` | BYO OpenAI-compatible endpoint (vLLM/SGLang/Ollama/proxy): `provider`+`adapter:openai`+`api_base`+`secret`, Model `cost` block, standalone-pricing caveat |
| `integration/upstream-bedrock.md` | SigV4 JSON secret, Anthropic `/invoke` vs Converse dispatch, cross-region inference profiles |
| `integration/upstream-vertex.md` | SA-JSON→JWT→OAuth mint (+ pre-minted token mode), Gemini dispatch, roadmap note for Anthropic/Llama-on-Vertex |
| `integration/upstream-azure-openai.md` | Deployment URL + api_version, BOTH auth schemes (api-key + AAD `client_credentials` with `authority_host`, the seam from #434), content-filter tolerance |

## Accuracy verification (against origin/main)

Confirmed by reading source — not assumed:
- `Adapter` enum = `{Openai, Anthropic, Bedrock, Vertex, AzureOpenai}`; dispatch via `resolve_bridge` → `dispatch_two_tier` (`crates/aisix-proxy/src/dispatch.rs`).
- `ProviderKey` has `provider: String` + `adapter: Option<Adapter>`; `telemetry_tags.kind` = `catalog`/`byo`.
- Bedrock secret parses `session_token?` (`bedrock/src/bridge.rs:268`); `chat_stream` routes all publishers (incl. Anthropic) through Converse stream; non-stream Anthropic uses `/invoke`.
- Vertex secret = exactly one of `service_account_json` / `access_token`; non-Gemini publishers return a "not yet implemented" `Config` error (`vertex/src/bridge.rs:533`).
- Azure `AzureSecret::parse` detects api-key (bare string) vs AAD (JSON `{`); `authority_host` optional override (#434).
- Standalone emits `cost_usd=0.0`; cp-api recomputes server-side (`chat.rs:908`).

## Scope

Only the 5 new files. Each has frontmatter (no `sidebar_position` collision), a Verification section that checks an observable contract (alias-restore + outbound auth/URL shape, not just 200), and the plaintext-secret production warning.

## Follow-ups (NOT in this PR — flagged for separate work)

- `reference/provider-compatibility.md` + `overview/feature-matrix.md` still describe the old 6-value provider enum and don't mention the 5 adapter families — should backlink `adapters.md`.
- `configuration/provider-keys.md` documents only `display_name`/`secret`/`api_base` — `provider`, `adapter`, and `telemetry_tags` are now on the struct; should be documented + backlink the 3 upstream guides.
- `configuration/models.md` (~line 160) has a **stale** claim that `provider` is a closed enum (`openai/anthropic/google/deepseek/cohere/jina`); on origin/main it's a free-form string — pre-existing doc bug to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for configuring bring-your-own endpoints and routing traffic to Azure OpenAI, AWS Bedrock, and Google Vertex AI services.
  * Added adapter family reference documentation detailing supported protocol families and request routing mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->