### PR TITLE
fix(guardrails): add azure_content_safety to loader JSON schema oneOf

### DIFF
--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -409,7 +409,7 @@ fn guardrail_schema() -> Value {
             "enabled":    { "type": "boolean" },
             "hook_point": { "enum": ["input", "output", "both"] },
             "fail_open":  { "type": "boolean" },
-            "kind":       { "enum": ["keyword", "bedrock"] }
+            "kind":       { "enum": ["keyword", "bedrock", "azure_content_safety"] }
         },
         "oneOf": [
             {
@@ -436,6 +436,20 @@ fn guardrail_schema() -> Value {
                     "region":             { "type": "string", "minLength": 1 },
                     "aws_credentials":    { "$ref": "#/$defs/bedrock_aws_credentials" },
                     "latency_mode":       { "$ref": "#/$defs/bedrock_latency_mode" }
+                }
+            },
+            {
+                // kind=azure_content_safety — Azure AI Content Safety
+                // Prompt Shield. Mirrors AzureContentSafetyConfig in
+                // guardrail.rs: endpoint + api_key required, timeout_ms
+                // optional (u32, defaults to 5000 on the struct).
+                "type": "object",
+                "required": ["kind", "endpoint", "api_key"],
+                "properties": {
+                    "kind":       { "const": "azure_content_safety" },
+                    "endpoint":   { "type": "string", "minLength": 1 },
+                    "api_key":    { "type": "string", "minLength": 1 },
+                    "timeout_ms": { "type": "integer", "minimum": 0, "maximum": 4_294_967_295u64 }
                 }
             }
         ],
@@ -1096,6 +1110,43 @@ mod tests {
             "latency_mode": { "kind": "serial" }
         });
         // Phase 4 will add role_arn; today it's rejected.
+        assert!(validate_guardrail(&v).is_err());
+    }
+
+    #[test]
+    fn guardrail_azure_content_safety_passes() {
+        // Regression for #437: the loader JSON schema must accept the
+        // azure_content_safety kind, not just the Rust struct. timeout_ms
+        // omitted here — it's optional (defaults to 5000 on the struct).
+        let v = json!({
+            "name": "prompt-shield",
+            "kind": "azure_content_safety",
+            "hook_point": "input",
+            "endpoint": "https://my-resource.cognitiveservices.azure.com",
+            "api_key": "plaintext-key"
+        });
+        validate_guardrail(&v).unwrap();
+    }
+
+    #[test]
+    fn guardrail_azure_content_safety_with_timeout_passes() {
+        let v = json!({
+            "name": "prompt-shield",
+            "kind": "azure_content_safety",
+            "endpoint": "https://r.cognitiveservices.azure.com",
+            "api_key": "k",
+            "timeout_ms": 3000
+        });
+        validate_guardrail(&v).unwrap();
+    }
+
+    #[test]
+    fn guardrail_azure_content_safety_missing_api_key_rejected() {
+        let v = json!({
+            "name": "g",
+            "kind": "azure_content_safety",
+            "endpoint": "https://r.cognitiveservices.azure.com"
+        });
         assert!(validate_guardrail(&v).is_err());
     }
 

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1150,6 +1150,38 @@ mod tests {
         assert!(validate_guardrail(&v).is_err());
     }
 
+    #[test]
+    fn guardrail_azure_content_safety_max_timeout_passes() {
+        // Guards the exact regression class of #437: the loader schema
+        // must accept everything AzureContentSafetyConfig's timeout_ms
+        // (u32) accepts, INCLUDING u32::MAX. A future edit that tightens
+        // the schema below u32::MAX would make the loader stricter than
+        // the struct and silently drop valid rows — this test fails loud.
+        let v = json!({
+            "name": "g",
+            "kind": "azure_content_safety",
+            "endpoint": "https://r.cognitiveservices.azure.com",
+            "api_key": "k",
+            "timeout_ms": 4_294_967_295u64
+        });
+        validate_guardrail(&v).unwrap();
+    }
+
+    #[test]
+    fn guardrail_azure_content_safety_timeout_overflow_rejected() {
+        // u32::MAX + 1 — beyond what the struct can deserialize. The
+        // schema must reject it at the gate so the loader skips the row
+        // cleanly instead of surfacing an opaque serde error downstream.
+        let v = json!({
+            "name": "g",
+            "kind": "azure_content_safety",
+            "endpoint": "https://r.cognitiveservices.azure.com",
+            "api_key": "k",
+            "timeout_ms": 4_294_967_296u64
+        });
+        assert!(validate_guardrail(&v).is_err());
+    }
+
     // ---- rate_limit_policy schema tests ----
 
     #[test]


### PR DESCRIPTION
## Summary

The DP loader (`aisix_etcd`) validates each guardrail kine entry against the JSON schema in `crates/aisix-core/src/models/schema.rs` **before** deserializing into the Rust `Guardrail` struct. That schema's `kind` enum and `oneOf` listed only `keyword` and `bedrock` — so every `azure_content_safety` guardrail was rejected and **silently skipped at load time**, even though the struct (`guardrail.rs`) and the check (`aisix-guardrails/src/prompt_shield.rs`) both already support it on `main`:

```
aisix_etcd::loader: schema validation failed; skipping .../guardrails/<id>
  {... "kind":"azure_content_safety" ...} is not valid under any of the schemas listed in the 'oneOf' keyword
```

Net effect: ACS Prompt Shield guardrails never take effect — chats are never blocked.

Fixes #437.

## Change

`guardrail_schema()` in `schema.rs`:
- Add `azure_content_safety` to the top-level `kind` enum.
- Add an `azure_content_safety` `oneOf` branch mirroring `AzureContentSafetyConfig` (`guardrail.rs`): `endpoint` + `api_key` required & non-empty, `timeout_ms` optional `u32` (struct default 5000).

## Why unit tests caught it but the existing test didn't

`azure_content_safety_kind_parses` (guardrail.rs) exercises **serde** deserialization only. The loader's **JSON-schema gate** is a separate code path that no test covered. This PR adds three schema-level regression tests:
- `guardrail_azure_content_safety_passes` (no timeout → default)
- `guardrail_azure_content_safety_with_timeout_passes`
- `guardrail_azure_content_safety_missing_api_key_rejected`

## Validation

- `cargo test -p aisix-core --lib guardrail` → 17 passed (incl. the 3 new).
- `cargo clippy -p aisix-core --lib` clean; `cargo fmt --check` clean.
- Full cross-repo e2e: surfaced by the AISIX-Cloud P1 ACS suite (api7/AISIX-Cloud#551). With cp-api ready (api7/AISIX-Cloud#567 merged) + this fix, the chain to green is complete; the e2e's DP-mediated 422 + wire-shape assertions validate once a `:dev` image is built from this.

## Discovery context

Found while validating api7/AISIX-Cloud#551 end-to-end against a real stack — the cp-api half accepted/projected the ACS guardrail (201) but the DP dropped it at this schema gate. Last DP-side piece for #379 P1 Prompt Shield.

## Test plan

- [x] `cargo test -p aisix-core --lib guardrail` (17 pass)
- [x] `cargo clippy` / `cargo fmt --check` clean
- [ ] CI green
- [ ] Independent audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure Content Safety as a guardrail option with configurable endpoint, API key, and optional timeout.
* **Tests**
  * Expanded validation tests covering required fields, optional timeout, and timeout boundary behavior (maximum accepted value and overflow rejection).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->