### PR TITLE
fix(usage): surface cache-counter fields on /v1/chat/completions (#542, #465)

### DIFF
--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -308,6 +308,20 @@ pub struct UsageStats {
     /// counter on top of input_tokens.
     #[serde(default)]
     pub cache_read_tokens: u32,
+    /// DeepSeek-native `prompt_cache_hit_tokens`, preserved verbatim
+    /// for client passthrough (#542). The canonical `cached_prompt_tokens`
+    /// above carries the *normalized* (OpenAI-shape) cache-hit count for
+    /// all providers; this Option carries the raw provider-native field
+    /// so a DeepSeek-aware client reading the native name still works.
+    /// `None` for providers that don't emit it — distinct from a real
+    /// `Some(0)` so the renderer only emits the field when the upstream
+    /// actually sent it. Bounded allowlist, not arbitrary passthrough.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_hit_tokens: Option<u32>,
+    /// DeepSeek-native `prompt_cache_miss_tokens`, preserved verbatim
+    /// (#542). See `prompt_cache_hit_tokens`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_miss_tokens: Option<u32>,
 }
 
 impl UsageStats {

--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -625,6 +625,33 @@ mod tests {
         assert_eq!(u.total_tokens, u32::MAX);
     }
 
+    /// PR #442 audit MEDIUM-4 (forward-compat): an *old-shape*
+    /// `UsageStats` JSON — written before the #542 native cache fields
+    /// existed — must still deserialize cleanly into the new struct,
+    /// defaulting the new Option fields to `None`. This pins the
+    /// new-DP-reads-old-cache direction of a mixed-version rolling
+    /// deploy (the `ChatResponse` type is persisted to the Redis cache).
+    /// The reverse direction (old DP reading new-shape) is bounded +
+    /// documented in the PR body.
+    #[test]
+    fn usage_stats_deserializes_old_shape_without_native_cache_fields() {
+        let old = r#"{
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+            "cached_prompt_tokens": 40,
+            "reasoning_tokens": 5,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0
+        }"#;
+        let u: UsageStats =
+            serde_json::from_str(old).expect("old-shape UsageStats must deserialize");
+        assert_eq!(u.prompt_tokens, 100);
+        assert_eq!(u.cached_prompt_tokens, 40);
+        assert_eq!(u.prompt_cache_hit_tokens, None);
+        assert_eq!(u.prompt_cache_miss_tokens, None);
+    }
+
     #[test]
     fn message_constructors_set_role() {
         assert_eq!(ChatMessage::system("x").role, Role::System);

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -483,6 +483,10 @@ pub fn response_into_chat_response(raw: AnthropicResponse) -> ChatResponse {
             // reasoning-tokens taxonomy; leave at 0.
             cached_prompt_tokens: 0,
             reasoning_tokens: 0,
+            // DeepSeek-native passthrough fields (#542) don't apply to
+            // Anthropic upstreams.
+            prompt_cache_hit_tokens: None,
+            prompt_cache_miss_tokens: None,
         })
         .unwrap_or_default();
 

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -265,6 +265,13 @@ fn into_usage(u: OpenAiUsage) -> UsageStats {
             .prompt_tokens_details
             .as_ref()
             .map(|d| d.cached_tokens)
+            // A *zeroed* nested detail must not mask a real native
+            // count (PR #442 audit MEDIUM-1): a hybrid OpenAI-compat
+            // proxy could send `prompt_tokens_details:{cached_tokens:0}`
+            // alongside a non-zero top-level `prompt_cache_hit_tokens`.
+            // Treat nested-zero as "no signal" so the native count
+            // wins; a genuine nested non-zero still takes precedence.
+            .filter(|&n| n > 0)
             .or(u.prompt_cache_hit_tokens)
             .unwrap_or(0),
         reasoning_tokens: u
@@ -612,6 +619,39 @@ mod tests {
         // (b) native fields preserved verbatim for passthrough
         assert_eq!(out.usage.prompt_cache_hit_tokens, Some(768));
         assert_eq!(out.usage.prompt_cache_miss_tokens, Some(232));
+    }
+
+    /// PR #442 audit MEDIUM-1: a hybrid OpenAI-compat upstream that
+    /// sends BOTH a nested `prompt_tokens_details.cached_tokens: 0`
+    /// AND a non-zero top-level `prompt_cache_hit_tokens` must not let
+    /// the zeroed nested detail mask the real native count. The
+    /// normalized `cached_prompt_tokens` should take the native 700.
+    #[test]
+    fn zeroed_nested_cache_detail_does_not_mask_native_count() {
+        let body = r#"{
+            "id": "cmpl-hybrid",
+            "object": "chat.completion",
+            "model": "some-compat-model",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 10,
+                "total_tokens": 1010,
+                "prompt_tokens_details": {"cached_tokens": 0},
+                "prompt_cache_hit_tokens": 700
+            }
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(
+            out.usage.cached_prompt_tokens, 700,
+            "zeroed nested cached_tokens must not mask the non-zero native count",
+        );
+        assert_eq!(out.usage.prompt_cache_hit_tokens, Some(700));
     }
 
     #[test]

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -182,6 +182,16 @@ pub struct OpenAiUsage {
     /// `completion_tokens`.
     #[serde(default)]
     pub completion_tokens_details: Option<OpenAiCompletionDetails>,
+    /// DeepSeek-native context-cache HIT count (#542). DeepSeek's
+    /// OpenAI-compatible response puts the cache counters at the top
+    /// level of `usage` (not nested under `prompt_tokens_details` like
+    /// OpenAI). Optional so OpenAI / other compat upstreams parse
+    /// without it.
+    #[serde(default)]
+    pub prompt_cache_hit_tokens: Option<u32>,
+    /// DeepSeek-native context-cache MISS count (#542).
+    #[serde(default)]
+    pub prompt_cache_miss_tokens: Option<u32>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -244,10 +254,18 @@ fn into_usage(u: OpenAiUsage) -> UsageStats {
         prompt_tokens: u.prompt_tokens,
         completion_tokens: u.completion_tokens,
         total_tokens: u.total_tokens,
+        // Normalize the cache-hit count into the canonical field for
+        // ALL providers (#542): OpenAI nests it under
+        // `prompt_tokens_details.cached_tokens`; DeepSeek puts it at the
+        // top level as `prompt_cache_hit_tokens`. Prefer the OpenAI
+        // nested form when present, else fall back to DeepSeek's native
+        // field. This is what surfaces as `prompt_tokens_details.cached_tokens`
+        // on the client response regardless of upstream.
         cached_prompt_tokens: u
             .prompt_tokens_details
             .as_ref()
             .map(|d| d.cached_tokens)
+            .or(u.prompt_cache_hit_tokens)
             .unwrap_or(0),
         reasoning_tokens: u
             .completion_tokens_details
@@ -259,6 +277,12 @@ fn into_usage(u: OpenAiUsage) -> UsageStats {
         // prompt rate for unset cache counters).
         cache_creation_tokens: 0,
         cache_read_tokens: 0,
+        // Preserve DeepSeek's native counters verbatim for passthrough
+        // (#542) so a client reading the native field names still works,
+        // alongside the normalized `cached_prompt_tokens` above. `None`
+        // for non-DeepSeek upstreams → the renderer omits the fields.
+        prompt_cache_hit_tokens: u.prompt_cache_hit_tokens,
+        prompt_cache_miss_tokens: u.prompt_cache_miss_tokens,
     }
 }
 
@@ -542,6 +566,52 @@ mod tests {
         assert_eq!(out.usage.cached_prompt_tokens, 800);
         assert_eq!(out.usage.completion_tokens, 500);
         assert_eq!(out.usage.reasoning_tokens, 200);
+        // OpenAI upstreams don't emit DeepSeek's native top-level cache
+        // counters — they stay None so the renderer omits them (#542).
+        assert_eq!(out.usage.prompt_cache_hit_tokens, None);
+        assert_eq!(out.usage.prompt_cache_miss_tokens, None);
+    }
+
+    /// Issue #542: DeepSeek's OpenAI-compatible response carries the
+    /// context-cache counters at the TOP LEVEL of `usage`
+    /// (`prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`), not
+    /// nested under `prompt_tokens_details` like OpenAI. The bridge
+    /// must (a) NORMALIZE the hit count into the canonical
+    /// `cached_prompt_tokens` so it surfaces as OpenAI-shape
+    /// `prompt_tokens_details.cached_tokens`, AND (b) PRESERVE the
+    /// native fields verbatim for passthrough. Mirrors the ecosystem's
+    /// hybrid (DeepSeek-native + OpenAI-canonical both present).
+    #[test]
+    fn deepseek_native_cache_counters_normalize_and_passthrough() {
+        // Verified shape from https://api-docs.deepseek.com — DeepSeek's
+        // usage object adds prompt_cache_hit_tokens / prompt_cache_miss_tokens.
+        let body = r#"{
+            "id": "cmpl-ds",
+            "object": "chat.completion",
+            "model": "deepseek-chat",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 100,
+                "total_tokens": 1100,
+                "prompt_cache_hit_tokens": 768,
+                "prompt_cache_miss_tokens": 232
+            }
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        // (a) normalized into the canonical cache-hit field
+        assert_eq!(
+            out.usage.cached_prompt_tokens, 768,
+            "DeepSeek prompt_cache_hit_tokens must normalize into cached_prompt_tokens",
+        );
+        // (b) native fields preserved verbatim for passthrough
+        assert_eq!(out.usage.prompt_cache_hit_tokens, Some(768));
+        assert_eq!(out.usage.prompt_cache_miss_tokens, Some(232));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/render.rs
+++ b/crates/aisix-proxy/src/render.rs
@@ -68,6 +68,73 @@ pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    /// OpenAI-canonical prompt-token breakdown. Emitted whenever the
+    /// gateway has a non-zero cache-hit count (#542) — for OpenAI it
+    /// comes from the upstream's `prompt_tokens_details.cached_tokens`,
+    /// for DeepSeek from the normalized native `prompt_cache_hit_tokens`.
+    /// Skipped (not `{}`) when there's nothing to report, so callers
+    /// that branch on the field's presence behave like they do against
+    /// api.openai.com.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+    /// OpenAI-canonical completion-token breakdown. Emitted when the
+    /// upstream reported reasoning tokens (o1/o3/DeepSeek-R1) (#542/#466).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens_details: Option<CompletionTokensDetails>,
+    /// DeepSeek-native cache-hit counter, passed through verbatim
+    /// (#542/#465) alongside the normalized `prompt_tokens_details`
+    /// above so DeepSeek-aware clients reading the native field name
+    /// still work. Omitted for upstreams that don't emit it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_hit_tokens: Option<u32>,
+    /// DeepSeek-native cache-miss counter, passed through verbatim
+    /// (#542/#465).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_miss_tokens: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct PromptTokensDetails {
+    /// Prompt tokens served from the provider's prompt cache.
+    pub cached_tokens: u32,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct CompletionTokensDetails {
+    /// o1 / o3 / DeepSeek-R1 reasoning tokens (subset of completion).
+    pub reasoning_tokens: u32,
+}
+
+impl Usage {
+    /// Build the client-facing usage envelope from the gateway's
+    /// canonical [`UsageStats`]. Centralises the normalize + native-
+    /// passthrough policy (#542) so the non-streaming and streaming
+    /// renderers stay in lock-step:
+    ///
+    /// - canonical triplet copied through
+    /// - `cached_prompt_tokens > 0` → emit OpenAI-shape
+    ///   `prompt_tokens_details.cached_tokens` (works for OpenAI's
+    ///   nested field AND DeepSeek's normalized native one)
+    /// - `reasoning_tokens > 0` → emit
+    ///   `completion_tokens_details.reasoning_tokens`
+    /// - DeepSeek-native `prompt_cache_hit_tokens` /
+    ///   `prompt_cache_miss_tokens` passed through verbatim when the
+    ///   upstream sent them (Some), omitted otherwise
+    fn from_stats(u: &aisix_gateway::UsageStats) -> Self {
+        Usage {
+            prompt_tokens: u.prompt_tokens,
+            completion_tokens: u.completion_tokens,
+            total_tokens: u.total_tokens,
+            prompt_tokens_details: (u.cached_prompt_tokens > 0).then_some(PromptTokensDetails {
+                cached_tokens: u.cached_prompt_tokens,
+            }),
+            completion_tokens_details: (u.reasoning_tokens > 0).then_some(CompletionTokensDetails {
+                reasoning_tokens: u.reasoning_tokens,
+            }),
+            prompt_cache_hit_tokens: u.prompt_cache_hit_tokens,
+            prompt_cache_miss_tokens: u.prompt_cache_miss_tokens,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -129,11 +196,7 @@ pub fn render_response(
             },
             finish_reason: finish_to_str(&resp.finish_reason).to_string(),
         }],
-        usage: Usage {
-            prompt_tokens: resp.usage.prompt_tokens,
-            completion_tokens: resp.usage.completion_tokens,
-            total_tokens: resp.usage.total_tokens,
-        },
+        usage: Usage::from_stats(&resp.usage),
     }
 }
 
@@ -164,11 +227,7 @@ pub fn render_chunk(
                 .as_ref()
                 .map(|f| finish_to_str(f).to_string()),
         }],
-        usage: chunk.usage.map(|u| Usage {
-            prompt_tokens: u.prompt_tokens,
-            completion_tokens: u.completion_tokens,
-            total_tokens: u.total_tokens,
-        }),
+        usage: chunk.usage.as_ref().map(Usage::from_stats),
     }
 }
 
@@ -268,6 +327,114 @@ mod tests {
         assert_eq!(json["choices"][0]["message"]["role"], "assistant");
         assert_eq!(json["choices"][0]["message"]["content"], "hello");
         assert_eq!(json["usage"]["total_tokens"], 5);
+        // No cache / reasoning / native fields when the upstream
+        // reported none — the nested objects must be ABSENT, not
+        // emitted as empty `{}` (#542). OpenAI SDK clients branch on
+        // presence.
+        assert!(
+            json["usage"].get("prompt_tokens_details").is_none(),
+            "prompt_tokens_details must be omitted when no cache hit"
+        );
+        assert!(json["usage"].get("completion_tokens_details").is_none());
+        assert!(json["usage"].get("prompt_cache_hit_tokens").is_none());
+    }
+
+    /// Issue #542 (OpenAI half): when the gateway has a non-zero
+    /// cache-hit / reasoning count, the client response must carry the
+    /// OpenAI-canonical nested breakdown objects (pre-fix these were
+    /// silently dropped by the renderer).
+    #[test]
+    fn render_response_emits_openai_canonical_usage_details() {
+        let usage = UsageStats {
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            total_tokens: 1500,
+            cached_prompt_tokens: 800,
+            reasoning_tokens: 200,
+            ..UsageStats::default()
+        };
+        let r = ChatResponse {
+            id: "cmpl-1".into(),
+            model: "m".into(),
+            message: ChatMessage::assistant("hi"),
+            finish_reason: FinishReason::Stop,
+            usage,
+        };
+        let json = serde_json::to_value(render_response(0, r, "m")).unwrap();
+        assert_eq!(json["usage"]["prompt_tokens_details"]["cached_tokens"], 800);
+        assert_eq!(
+            json["usage"]["completion_tokens_details"]["reasoning_tokens"],
+            200
+        );
+        // OpenAI upstream → no DeepSeek-native fields.
+        assert!(json["usage"].get("prompt_cache_hit_tokens").is_none());
+    }
+
+    /// Issue #542 (DeepSeek half, hybrid): the response must carry BOTH
+    /// the normalized OpenAI-shape `prompt_tokens_details.cached_tokens`
+    /// AND the DeepSeek-native `prompt_cache_hit_tokens` /
+    /// `prompt_cache_miss_tokens` passed through verbatim. Matches the
+    /// ecosystem's hybrid so clients reading either field name work.
+    #[test]
+    fn render_response_emits_deepseek_native_and_normalized_cache() {
+        let usage = UsageStats {
+            prompt_tokens: 1000,
+            completion_tokens: 100,
+            total_tokens: 1100,
+            // Normalized from DeepSeek's prompt_cache_hit_tokens by the
+            // bridge.
+            cached_prompt_tokens: 768,
+            prompt_cache_hit_tokens: Some(768),
+            prompt_cache_miss_tokens: Some(232),
+            ..UsageStats::default()
+        };
+        let r = ChatResponse {
+            id: "cmpl-ds".into(),
+            model: "deepseek-chat".into(),
+            message: ChatMessage::assistant("hi"),
+            finish_reason: FinishReason::Stop,
+            usage,
+        };
+        let json = serde_json::to_value(render_response(0, r, "ds-alias")).unwrap();
+        // Normalized OpenAI-canonical shape
+        assert_eq!(json["usage"]["prompt_tokens_details"]["cached_tokens"], 768);
+        // Native passthrough
+        assert_eq!(json["usage"]["prompt_cache_hit_tokens"], 768);
+        assert_eq!(json["usage"]["prompt_cache_miss_tokens"], 232);
+    }
+
+    /// Issue #542: the streaming renderer (`render_chunk`) must apply
+    /// the same usage policy as `render_response` — the terminal chunk's
+    /// usage carries the nested details + native passthrough. A
+    /// regression that only fixed the non-streaming path would let
+    /// streaming DeepSeek/OpenAI clients lose cache visibility.
+    #[test]
+    fn render_chunk_emits_usage_details_on_terminal_chunk() {
+        let usage = UsageStats {
+            prompt_tokens: 50,
+            completion_tokens: 10,
+            total_tokens: 60,
+            cached_prompt_tokens: 32,
+            prompt_cache_hit_tokens: Some(32),
+            prompt_cache_miss_tokens: Some(18),
+            ..UsageStats::default()
+        };
+        let chunk = ChatChunk {
+            id: "c".into(),
+            model: "m".into(),
+            delta: aisix_gateway::ChatDelta {
+                role: None,
+                content: None,
+                tool_calls: None,
+                reasoning_content: None,
+            },
+            finish_reason: Some(FinishReason::Stop),
+            usage: Some(usage),
+        };
+        let json = serde_json::to_value(render_chunk(0, chunk, "m")).unwrap();
+        assert_eq!(json["usage"]["prompt_tokens_details"]["cached_tokens"], 32);
+        assert_eq!(json["usage"]["prompt_cache_hit_tokens"], 32);
+        assert_eq!(json["usage"]["prompt_cache_miss_tokens"], 18);
     }
 
     /// Pins the AISIX-Cloud#410 contract: when the upstream returns one

--- a/crates/aisix-proxy/src/render.rs
+++ b/crates/aisix-proxy/src/render.rs
@@ -128,9 +128,11 @@ impl Usage {
             prompt_tokens_details: (u.cached_prompt_tokens > 0).then_some(PromptTokensDetails {
                 cached_tokens: u.cached_prompt_tokens,
             }),
-            completion_tokens_details: (u.reasoning_tokens > 0).then_some(CompletionTokensDetails {
-                reasoning_tokens: u.reasoning_tokens,
-            }),
+            completion_tokens_details: (u.reasoning_tokens > 0).then_some(
+                CompletionTokensDetails {
+                    reasoning_tokens: u.reasoning_tokens,
+                },
+            ),
             prompt_cache_hit_tokens: u.prompt_cache_hit_tokens,
             prompt_cache_miss_tokens: u.prompt_cache_miss_tokens,
         }

--- a/tests/e2e/src/cases/usage-cache-counters-e2e.test.ts
+++ b/tests/e2e/src/cases/usage-cache-counters-e2e.test.ts
@@ -1,0 +1,273 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: cache-counter pass-through on /v1/chat/completions usage (#542).
+//
+// Pre-fix the DP's response renderer copied only the canonical
+// {prompt,completion,total}_tokens triplet and DROPPED the cache
+// counters the upstream reported, so customers lost all prompt-cache
+// visibility (cost transparency + billing-audit + cache tuning broken).
+//
+// The fix is the ecosystem-proven HYBRID:
+//   - OpenAI upstream → emit `usage.prompt_tokens_details.cached_tokens`
+//     (OpenAI-canonical nested shape) from the upstream's nested field
+//   - DeepSeek upstream → BOTH normalize the native top-level
+//     `prompt_cache_hit_tokens` into `prompt_tokens_details.cached_tokens`
+//     AND pass the native `prompt_cache_hit_tokens` /
+//     `prompt_cache_miss_tokens` through verbatim
+//
+// We assert against the raw response JSON (not the typed OpenAI SDK
+// object) because the DeepSeek-native fields aren't on the SDK's typed
+// surface — the wire body is what billing pipelines consume.
+//
+// References:
+// - OpenAI usage object: https://platform.openai.com/docs/api-reference/chat/object
+// - DeepSeek usage extension: https://api-docs.deepseek.com
+// - Issue: api7/AISIX-Cloud#542 (+ #465)
+
+const CALLER_PLAINTEXT = "sk-cache-counters-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+async function chatUsage(
+  proxyUrl: string,
+  model: string,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { usage?: Record<string, unknown> };
+  return body.usage ?? {};
+}
+
+describe("usage cache-counter passthrough on /v1/chat/completions (#542)", () => {
+  let app: SpawnedApp | undefined;
+  let openaiUpstream: OpenAiUpstream | undefined;
+  let deepseekUpstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // OpenAI-shape upstream: cache hit nested under prompt_tokens_details.
+    openaiUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-oai-cache",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+        ],
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 50,
+          total_tokens: 1050,
+          prompt_tokens_details: { cached_tokens: 800 },
+        },
+      },
+    });
+
+    // DeepSeek-shape upstream: cache counters at the top level of usage.
+    deepseekUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-ds-cache",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "deepseek-chat",
+        choices: [
+          { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+        ],
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 50,
+          total_tokens: 1050,
+          prompt_cache_hit_tokens: 768,
+          prompt_cache_miss_tokens: 232,
+        },
+      },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // Post-#302 Phase A: cp-api writes `provider` + `adapter` on every
+    // PK row; the snapshot's two-tier dispatch needs both. DeepSeek
+    // dispatches through the OpenAI-compat family bridge (`adapter:
+    // "openai"`) — the same bridge whose usage parser this PR fixes.
+    const oaiPk = await admin.createProviderKey({
+      display_name: "cache-oai-pk",
+      secret: "sk-mock",
+      api_base: `${openaiUpstream.baseUrl}/v1`,
+      provider: "openai",
+      adapter: "openai",
+    });
+    await admin.createModel({
+      display_name: "cache-oai",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: oaiPk.id,
+    });
+
+    const dsPk = await admin.createProviderKey({
+      display_name: "cache-ds-pk",
+      secret: "sk-mock",
+      api_base: `${deepseekUpstream.baseUrl}/v1`,
+      provider: "deepseek",
+      adapter: "openai",
+    });
+    await admin.createModel({
+      display_name: "cache-ds",
+      provider: "deepseek",
+      model_name: "deepseek-chat",
+      provider_key_id: dsPk.id,
+    });
+
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["cache-oai", "cache-ds"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await openaiUpstream?.close();
+    await deepseekUpstream?.close();
+  });
+
+  test("OpenAI upstream → usage.prompt_tokens_details.cached_tokens reaches the client (#542)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    await waitConfigPropagation(async () => {
+      try {
+        const u = await chatUsage(app!.proxyUrl, "cache-oai");
+        return typeof u.prompt_tokens === "number";
+      } catch {
+        return false;
+      }
+    });
+
+    const usage = await chatUsage(app.proxyUrl, "cache-oai");
+    // Pre-#542 the whole nested object was dropped.
+    expect(usage.prompt_tokens_details, JSON.stringify(usage)).toBeDefined();
+    expect(
+      (usage.prompt_tokens_details as Record<string, unknown>).cached_tokens,
+    ).toBe(800);
+    // Canonical triplet still byte-for-byte.
+    expect(usage.prompt_tokens).toBe(1000);
+    expect(usage.total_tokens).toBe(1050);
+  });
+
+  test("DeepSeek upstream → native prompt_cache_hit_tokens AND normalized prompt_tokens_details both present (#542 hybrid)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    await waitConfigPropagation(async () => {
+      try {
+        const u = await chatUsage(app!.proxyUrl, "cache-ds");
+        return typeof u.prompt_tokens === "number";
+      } catch {
+        return false;
+      }
+    });
+
+    const usage = await chatUsage(app.proxyUrl, "cache-ds");
+    // (a) native fields passed through verbatim — what a DeepSeek-aware
+    //     client / billing reconciler reads. Pre-#542 these were dropped.
+    expect(usage.prompt_cache_hit_tokens, JSON.stringify(usage)).toBe(768);
+    expect(usage.prompt_cache_miss_tokens).toBe(232);
+    // (b) ALSO normalized into the OpenAI-canonical nested shape so a
+    //     standard OpenAI SDK client reading prompt_tokens_details works
+    //     across providers.
+    expect(usage.prompt_tokens_details, JSON.stringify(usage)).toBeDefined();
+    expect(
+      (usage.prompt_tokens_details as Record<string, unknown>).cached_tokens,
+    ).toBe(768);
+  });
+
+  test("no cache fields emitted when upstream reports none (#542 — absent, not empty)", async (ctx) => {
+    if (!etcdReachable || !app || !openaiUpstream) {
+      ctx.skip();
+      return;
+    }
+    // Reuse the OpenAI model but point a fresh upstream with NO cache
+    // details, to confirm the renderer omits the nested object entirely
+    // rather than emitting an empty `{}` (OpenAI SDK clients branch on
+    // presence).
+    const plainUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-plain",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+        ],
+        usage: { prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 },
+      },
+    });
+    const plainApp = await spawnApp();
+    try {
+      const plainAdmin = new AdminClient(plainApp.adminUrl, plainApp.adminKey);
+      const pk = await plainAdmin.createProviderKey({
+        display_name: "cache-plain-pk",
+        secret: "sk-mock",
+        api_base: `${plainUpstream.baseUrl}/v1`,
+        provider: "openai",
+        adapter: "openai",
+      });
+      await plainAdmin.createModel({
+        display_name: "cache-plain",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+      await plainAdmin.createApiKey({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: ["cache-plain"],
+      });
+
+      await waitConfigPropagation(async () => {
+        try {
+          const u = await chatUsage(plainApp.proxyUrl, "cache-plain");
+          return typeof u.prompt_tokens === "number";
+        } catch {
+          return false;
+        }
+      });
+
+      const usage = await chatUsage(plainApp.proxyUrl, "cache-plain");
+      expect(usage.prompt_tokens).toBe(7);
+      expect(usage.prompt_tokens_details).toBeUndefined();
+      expect(usage.prompt_cache_hit_tokens).toBeUndefined();
+      expect(usage.completion_tokens_details).toBeUndefined();
+    } finally {
+      await plainApp.exit();
+      await plainUpstream.close();
+    }
+  });
+});

--- a/tests/e2e/src/cases/usage-cache-counters-e2e.test.ts
+++ b/tests/e2e/src/cases/usage-cache-counters-e2e.test.ts
@@ -270,4 +270,126 @@ describe("usage cache-counter passthrough on /v1/chat/completions (#542)", () =>
       await plainUpstream.close();
     }
   });
+
+  test("streaming DeepSeek → terminal chunk carries native + normalized cache counters (#542 audit MEDIUM-7)", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    // DeepSeek streaming puts the usage block (incl. native cache
+    // counters) on the terminal chunk. The harness wraps each
+    // streamEvent as `data: <event>\n\n`; the DP parses via the
+    // OpenAI-compat stream path → render_chunk applies the same
+    // usage policy as the non-streaming path.
+    const streamUpstream = await startOpenAiUpstream({
+      streamEvents: [
+        JSON.stringify({
+          id: "cmpl-ds-stream",
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: "deepseek-chat",
+          choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+        }),
+        JSON.stringify({
+          id: "cmpl-ds-stream",
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: "deepseek-chat",
+          choices: [{ index: 0, delta: { content: "hi" }, finish_reason: null }],
+        }),
+        // Terminal chunk: finish_reason set + usage with DeepSeek
+        // native cache counters.
+        JSON.stringify({
+          id: "cmpl-ds-stream",
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: "deepseek-chat",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: {
+            prompt_tokens: 1000,
+            completion_tokens: 50,
+            total_tokens: 1050,
+            prompt_cache_hit_tokens: 640,
+            prompt_cache_miss_tokens: 360,
+          },
+        }),
+        "[DONE]",
+      ],
+    });
+    const streamApp = await spawnApp();
+    try {
+      const streamAdmin = new AdminClient(streamApp.adminUrl, streamApp.adminKey);
+      const pk = await streamAdmin.createProviderKey({
+        display_name: "cache-ds-stream-pk",
+        secret: "sk-mock",
+        api_base: `${streamUpstream.baseUrl}/v1`,
+        provider: "deepseek",
+        adapter: "openai",
+      });
+      await streamAdmin.createModel({
+        display_name: "cache-ds-stream",
+        provider: "deepseek",
+        model_name: "deepseek-chat",
+        provider_key_id: pk.id,
+      });
+      await streamAdmin.createApiKey({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: ["cache-ds-stream"],
+      });
+
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await fetch(`${streamApp.proxyUrl}/v1/chat/completions`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              authorization: `Bearer ${CALLER_PLAINTEXT}`,
+            },
+            body: JSON.stringify({
+              model: "cache-ds-stream",
+              stream: true,
+              messages: [{ role: "user", content: "probe" }],
+            }),
+          });
+          return r.ok;
+        } catch {
+          return false;
+        }
+      });
+
+      const res = await fetch(`${streamApp.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        },
+        body: JSON.stringify({
+          model: "cache-ds-stream",
+          stream: true,
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+      expect(res.status).toBe(200);
+
+      // Find the SSE chunk that carries the usage block and inspect it.
+      const sse = await res.text();
+      const usageChunk = sse
+        .split("\n")
+        .filter((l) => l.startsWith("data: ") && l.includes("\"usage\""))
+        .map((l) => JSON.parse(l.slice("data: ".length)))
+        .find((c) => c.usage);
+      expect(usageChunk, `no usage chunk in stream:\n${sse}`).toBeDefined();
+      const usage = usageChunk.usage as Record<string, unknown>;
+      // Native passthrough on the streaming path
+      expect(usage.prompt_cache_hit_tokens).toBe(640);
+      expect(usage.prompt_cache_miss_tokens).toBe(360);
+      // Normalized OpenAI-canonical shape on the streaming path
+      expect(
+        (usage.prompt_tokens_details as Record<string, unknown>).cached_tokens,
+      ).toBe(640);
+    } finally {
+      await streamApp.exit();
+      await streamUpstream.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes **api7/AISIX-Cloud#542** + the cache-counter half of **#465**.

Pre-fix, the DP's client-response renderer copied only `{prompt,completion,total}_tokens` and **dropped every cache counter** the upstream reported. Customers lost all prompt-cache visibility on `/v1/chat/completions` — cost transparency, billing audit, and cache-effectiveness tuning all broke.

## Fix — the ecosystem hybrid (normalize + native passthrough)

Researched against reference open-source gateway implementations' usage-normalization handling + the upstream provider specs. They do **both**: normalize provider-native cache fields into OpenAI's canonical nested shape, *and* preserve the native fields. We do the same:

| Upstream | Normalized (OpenAI-canonical) | Native passthrough |
|---|---|---|
| OpenAI | `usage.prompt_tokens_details.cached_tokens` (+ `completion_tokens_details.reasoning_tokens`) | — |
| DeepSeek | `prompt_cache_hit_tokens` → `prompt_tokens_details.cached_tokens` | `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` verbatim |

So an OpenAI-SDK client reading the standard nested field works across all providers, **and** a DeepSeek-aware client reading the native name also works — both satisfied **without rewriting** the cp-api real-chain tests (#530/#532) that assert each shape.

### Divergence from the reference implementations (named per §7)
They pass through *arbitrary* extra usage params (dynamic `setattr`); we use an **explicit allowlist** of known native fields, because `UsageStats` is `deny_unknown_fields` and Rust is statically typed — safer, no upstream-private-field leak.

## Changes
- `aisix-gateway` `UsageStats`: + `Option<u32>` `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` (bounded native carrier, skip-when-None)
- `aisix-provider-openai` `wire.rs`: parse DeepSeek top-level cache fields; normalize hit → `cached_prompt_tokens` (OpenAI nested wins when present) + carry native verbatim
- `aisix-provider-anthropic` `wire.rs`: new fields = None
- `aisix-proxy` `render.rs`: `Usage` gains the nested details + native fields; shared `Usage::from_stats` keeps non-streaming + streaming renderers in lock-step (skip-when-zero → absent ≠ empty `{}`)

## Test plan
- [x] `wire.rs`: `deepseek_native_cache_counters_normalize_and_passthrough` (normalize + native preserved); OpenAI test extended to assert native fields stay `None`
- [x] `render.rs`: OpenAI canonical details; DeepSeek hybrid; streaming-chunk parity; absent-not-empty-when-no-cache
- [x] e2e `usage-cache-counters-e2e.test.ts`: real `/v1/chat/completions` through the DP for OpenAI (nested) + DeepSeek (hybrid) + no-cache (absent). **Verified locally against the aisix-e2e stack — 3/3 pass.**
- [x] Full regression: aisix-proxy 342, aisix-gateway 50, aisix-provider-openai 81 — all pass
- [x] `cargo clippy -- -D warnings` clean

## Scope note
Fixes the **cache-counter** half of #465 (same root cause). #466 (DeepSeek `reasoning_content` *text*, distinct from the `reasoning_tokens` *count*) is a separate concern, not covered here — will follow up.

## References
- Issues: api7/AISIX-Cloud#542, #465 (+ surfacing PRs #530/#532, tracker #533)
- OpenAI usage object: <https://platform.openai.com/docs/api-reference/chat/object>
- DeepSeek usage extension: <https://api-docs.deepseek.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enhanced cache counter reporting in usage statistics.
  * Extended usage responses to include detailed token breakdown and cache metrics for improved visibility.
  * Improved normalization across providers for consistent cache metric handling.

* **Tests**
  * Added E2E test suite verifying cache counter passthrough behavior across multiple upstream providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/ai-gateway/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Cross-version / rolling-deploy note (audit MEDIUM-4)

`UsageStats` is `#[serde(deny_unknown_fields)]` and is embedded in `ChatResponse`, which is persisted to the Redis response cache. The two new native fields are `#[serde(default, skip_serializing_if = "Option::is_none")]`:

- **New DP reads an old-shape cache entry** → fields absent → default `None`. Safe; pinned by `usage_stats_deserializes_old_shape_without_native_cache_fields`.
- **Old DP reads a new-shape cache entry** (mixed-version rolling deploy, only when a DeepSeek/OpenAI cache-hit response was written by a new DP) → `deny_unknown_fields` rejects the decode → the cache GET returns a `CacheError` → the request is treated as a **cache miss** and re-fetched from the upstream.

**Blast radius is bounded and accepted:** no customer-facing error, no data loss, cache-only, TTL-scoped, and limited to the rolling-deploy window for the subset of cache entries carrying the new fields. Telemetry is unaffected (it uses the separate `UsageEvent` struct, not `UsageStats`). We keep `deny_unknown_fields` for its drift-detection value rather than weakening the type for this short, self-healing window.
