### PR TITLE
fix(openai): surface non-streaming reasoning_content (#466)

### DIFF
--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -682,6 +682,44 @@ mod tests {
         assert_eq!(reasoning, "Let me think step by step... 6 times 7 is 42.");
     }
 
+    /// Issue #466 (audit LOW): a reasoning model that also calls a
+    /// tool returns BOTH `tool_calls` and `reasoning_content` on the
+    /// same message. Both must land in `extra` under their own keys
+    /// (independent inserts, no collision).
+    #[test]
+    fn non_streaming_tool_calls_and_reasoning_content_coexist() {
+        let body = r#"{
+            "id": "cmpl-r1-tool",
+            "object": "chat.completion",
+            "model": "deepseek-reasoner",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_content": "I should call the time tool.",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_time", "arguments": "{}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8, "total_tokens": 13}
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert!(
+            out.message.extra.contains_key("tool_calls"),
+            "tool_calls must be preserved alongside reasoning_content",
+        );
+        assert_eq!(
+            out.message.extra["reasoning_content"],
+            "I should call the time tool.",
+        );
+    }
+
     /// Issue #466 companion: a response WITHOUT reasoning_content (the
     /// common non-reasoning model case) must not add a spurious empty
     /// field to extra.

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -166,6 +166,16 @@ pub struct OpenAiResponseMessage {
     pub content: Option<String>,
     #[serde(default)]
     pub tool_calls: Option<Vec<serde_json::Value>>,
+    /// DeepSeek-reasoner (and other reasoning models) return the
+    /// chain-of-thought text at `message.reasoning_content` on the
+    /// non-streaming path (#466). Without this field it was silently
+    /// dropped at deserialization — the streaming path already
+    /// surfaces it via `extract_reasoning_field`, but non-streaming
+    /// had no capture. Forwarded to the client verbatim via
+    /// `ChatMessage.extra` so OpenAI-SDK clients see
+    /// `choices[0].message.reasoning_content`.
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -220,6 +230,21 @@ pub fn response_into_chat_response(mut raw: OpenAiResponse) -> ChatResponse {
                     extra.insert(
                         "tool_calls".to_string(),
                         serde_json::Value::Array(tool_calls),
+                    );
+                }
+            }
+            // #466: surface DeepSeek-reasoner's reasoning_content on the
+            // non-streaming path. Stashed in `extra` so render.rs's
+            // RenderedMessage (which flattens `extra`) emits it as
+            // `message.reasoning_content` on the wire — matching the
+            // streaming path's `delta.reasoning_content`. Skip empty
+            // strings so a model that returns `""` doesn't add a noise
+            // field.
+            if let Some(reasoning) = c.message.reasoning_content {
+                if !reasoning.is_empty() {
+                    extra.insert(
+                        "reasoning_content".to_string(),
+                        serde_json::Value::String(reasoning),
                     );
                 }
             }
@@ -619,6 +644,66 @@ mod tests {
         // (b) native fields preserved verbatim for passthrough
         assert_eq!(out.usage.prompt_cache_hit_tokens, Some(768));
         assert_eq!(out.usage.prompt_cache_miss_tokens, Some(232));
+    }
+
+    /// Issue #466: DeepSeek-reasoner returns `reasoning_content` on the
+    /// non-streaming `choices[0].message`. The bridge must capture it
+    /// (it was silently dropped pre-fix — the response message struct
+    /// had no field for it) and surface it via `ChatMessage.extra` so
+    /// render.rs flattens it back onto `message.reasoning_content` for
+    /// the SDK client.
+    #[test]
+    fn non_streaming_reasoning_content_surfaces_via_extra() {
+        let body = r#"{
+            "id": "cmpl-r1",
+            "object": "chat.completion",
+            "model": "deepseek-reasoner",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "The answer is 42.",
+                    "reasoning_content": "Let me think step by step... 6 times 7 is 42."
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.message.content, "The answer is 42.");
+        let reasoning = out
+            .message
+            .extra
+            .get("reasoning_content")
+            .expect("reasoning_content must be captured into message.extra (#466)")
+            .as_str()
+            .unwrap();
+        assert_eq!(reasoning, "Let me think step by step... 6 times 7 is 42.");
+    }
+
+    /// Issue #466 companion: a response WITHOUT reasoning_content (the
+    /// common non-reasoning model case) must not add a spurious empty
+    /// field to extra.
+    #[test]
+    fn non_streaming_without_reasoning_content_adds_no_extra_field() {
+        let body = r#"{
+            "id": "cmpl-plain",
+            "object": "chat.completion",
+            "model": "gpt-4o",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert!(
+            !out.message.extra.contains_key("reasoning_content"),
+            "no reasoning_content field when upstream didn't send one",
+        );
     }
 
     /// PR #442 audit MEDIUM-1: a hybrid OpenAI-compat upstream that

--- a/tests/e2e/src/cases/deepseek-reasoning-content-e2e.test.ts
+++ b/tests/e2e/src/cases/deepseek-reasoning-content-e2e.test.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: DeepSeek-reasoner `reasoning_content` pass-through on the
+// non-streaming /v1/chat/completions path (#466).
+//
+// Pre-fix the DP's non-streaming response parser had no field for the
+// upstream `choices[0].message.reasoning_content`, so DeepSeek's
+// chain-of-thought text was silently dropped — the final answer came
+// back but the reasoning trace did not. (The streaming path already
+// surfaced it via the reasoning-field extractor; only non-streaming
+// was affected.)
+//
+// We assert against the raw response JSON because `reasoning_content`
+// is a DeepSeek extension not on the typed OpenAI SDK surface — the
+// wire body is what reasoning-aware clients and observability consume.
+//
+// References:
+// - DeepSeek reasoning API: https://api-docs.deepseek.com/guides/reasoning_model
+// - Issue: api7/AISIX-Cloud#466
+
+const CALLER_PLAINTEXT = "sk-ds-reasoning-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const REASONING_TEXT =
+  "Let me work through this. 6 times 7. 6*7 = 42. So the answer is 42.";
+const FINAL_ANSWER = "The answer is 42.";
+
+describe("deepseek reasoning_content passthrough on /v1/chat/completions (#466)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // DeepSeek-reasoner non-streaming response: message carries both
+    // `content` (final answer) and `reasoning_content` (chain-of-thought).
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-ds-reasoner",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "deepseek-reasoner",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: FINAL_ANSWER,
+              reasoning_content: REASONING_TEXT,
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 12, completion_tokens: 40, total_tokens: 52 },
+      },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // DeepSeek dispatches through the OpenAI-compat family bridge.
+    const pk = await admin.createProviderKey({
+      display_name: "ds-reasoning-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+      provider: "deepseek",
+      adapter: "openai",
+    });
+    await admin.createModel({
+      display_name: "ds-reasoner",
+      provider: "deepseek",
+      model_name: "deepseek-reasoner",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["ds-reasoner"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("non-streaming response surfaces choices[0].message.reasoning_content (#466)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          },
+          body: JSON.stringify({
+            model: "ds-reasoner",
+            messages: [{ role: "user", content: "probe" }],
+          }),
+        });
+        return r.ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      },
+      body: JSON.stringify({
+        model: "ds-reasoner",
+        messages: [{ role: "user", content: "What is 6 times 7?" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      choices: { message: Record<string, unknown> }[];
+    };
+    const message = body.choices[0]?.message;
+    expect(message, JSON.stringify(body)).toBeDefined();
+    // Final answer still byte-for-byte.
+    expect(message.content).toBe(FINAL_ANSWER);
+    // Reasoning trace now surfaced (pre-#466 this was dropped).
+    expect(
+      message.reasoning_content,
+      `reasoning_content missing from message: ${JSON.stringify(message)}`,
+    ).toBe(REASONING_TEXT);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **api7/AISIX-Cloud#466**.

DeepSeek-reasoner returns the chain-of-thought at `choices[0].message.reasoning_content` on the **non-streaming** `/v1/chat/completions` response. The DP's response parser (`OpenAiResponseMessage`) had no field for it → silently dropped at deserialization. The final answer came back; the reasoning trace did not.

The **streaming** path already surfaces it (via `extract_reasoning_field` → `delta.reasoning_content`); only non-streaming was broken.

## Fix (minimal)

- `OpenAiResponseMessage`: + `Option<String> reasoning_content`
- `response_into_chat_response`: when present + non-empty, stash in `ChatMessage.extra["reasoning_content"]`

`render.rs::RenderedMessage` already `#[serde(flatten)]`s `extra`, so it re-emits on the wire as `message.reasoning_content` — matching the streaming path's `delta.reasoning_content`. **No render.rs change needed.** Empty strings skipped (no noise field for non-reasoning models).

## Test plan
- [x] `non_streaming_reasoning_content_surfaces_via_extra` — parse → `extra` carries the trace
- [x] `non_streaming_without_reasoning_content_adds_no_extra_field` — no spurious field for normal responses
- [x] e2e `deepseek-reasoning-content-e2e.test.ts` — real non-streaming `/v1/chat/completions` through the DP against a deepseek-reasoner-shape upstream; asserts the **raw** response message carries both `content` and `reasoning_content`. **Verified locally against the aisix-e2e stack.**
- [x] All 84 `aisix-provider-openai` lib tests pass; `cargo clippy --all-targets -- -D warnings` clean.

## Scope
Completes the DeepSeek Tier-1 cluster: #245 (Anthropic streaming usage), #542/#465 (cache counters), and now #466 (reasoning_content text). #465's cache-counter half was fixed in #442; this is the distinct reasoning-*text* field.

## References
- DeepSeek reasoning model docs: <https://api-docs.deepseek.com/guides/reasoning_model>
- Issue: api7/AISIX-Cloud#466