### PR TITLE
fix(errors): parse upstream error body regardless of Content-Type (#543)

### DIFF
--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -234,18 +234,18 @@ pub async fn capture_upstream_error_http(
     parse: impl FnOnce(&[u8]) -> Option<UpstreamErrorView>,
 ) -> BridgeError {
     let retry_after = parse_retry_after(resp.headers());
-    let content_type = resp
-        .headers()
-        .get(http::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(str::to_ascii_lowercase);
     let body = read_body_capped(resp, MAX_UPSTREAM_ERROR_BODY_BYTES).await;
-    let parsed = content_type
-        .as_deref()
-        .map(content_type_is_json)
-        .unwrap_or(false)
-        .then(|| parse(&body))
-        .flatten()
+    // Parse the error envelope opportunistically, regardless of the
+    // upstream's Content-Type (#543). OpenAI's 401 `invalid_api_key`
+    // path (and edge / proxy layers fronting some upstreams) return the
+    // JSON error body labelled with a non-`application/json`
+    // Content-Type; gating the parse on Content-Type silently dropped
+    // `code` / `param` and dumped the raw body into `message`. The
+    // per-bridge `parse` fn is the real validator — it requires the
+    // provider's `{"error": {...}}` shape and returns `None` on any
+    // non-matching body (HTML error pages, plain text, 5xx bodies), so
+    // attempting it unconditionally is safe and strictly more robust.
+    let parsed = parse(&body)
         // Truncate every parsed string at the same cap as the outer
         // `message`. Otherwise a hostile or buggy upstream emitting a
         // 60 KB `error.message` / `error.code` / `error.type` /

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -455,6 +455,42 @@ mod tests {
         }
     }
 
+    /// Issue #543 (audit MEDIUM): the shared `capture_upstream_error_http`
+    /// no longer gates parsing on Content-Type, so the Anthropic bridge
+    /// must ALSO surface the parsed envelope when the upstream labels a
+    /// JSON error body with a non-`application/json` Content-Type. Guards
+    /// the shared-fn change on the Anthropic side.
+    #[tokio::test]
+    async fn non_streaming_400_non_json_content_type_still_surfaces_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(400).set_body_raw(
+                r#"{"error":{"type":"invalid_request","message":"bad"}}"#.as_bytes(),
+                "text/plain",
+            ))
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        match err {
+            BridgeError::UpstreamStatus {
+                status,
+                message,
+                parsed,
+                ..
+            } => {
+                assert_eq!(status, 400);
+                assert_eq!(message, "bad");
+                let parsed = parsed.expect("envelope must parse regardless of Content-Type");
+                assert_eq!(parsed.kind.as_deref(), Some("invalid_request"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn non_streaming_decode_error_on_malformed_body() {
         let server = MockServer::start().await;

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -934,6 +934,100 @@ mod tests {
         }
     }
 
+    // Canonical OpenAI 401 invalid_api_key error body (#543).
+    const OPENAI_401_BODY: &str = r#"{"error":{"message":"Incorrect API key provided: sk-inval***c66a. You can find your API key at https://platform.openai.com/account/api-keys.","type":"invalid_request_error","code":"invalid_api_key","param":null}}"#;
+
+    /// Baseline: a 401 whose JSON error body is labelled
+    /// `application/json` parses correctly — `code` reaches the
+    /// envelope. (Already worked pre-#543.)
+    #[tokio::test]
+    async fn non_streaming_401_json_content_type_surfaces_code() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_raw(
+                OPENAI_401_BODY.as_bytes(),
+                "application/json; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        let bridge = OpenAiBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        match err {
+            BridgeError::UpstreamStatus { parsed, .. } => {
+                assert_eq!(
+                    parsed.and_then(|p| p.code),
+                    Some("invalid_api_key".to_string())
+                );
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    /// Issue #543: the SAME JSON error body labelled with a
+    /// non-`application/json` Content-Type (as OpenAI's 401 path / an
+    /// edge layer returns it) must STILL surface `code` / `param`.
+    /// Pre-fix the Content-Type gate skipped the parse, dumping the raw
+    /// body into `message` and emitting an empty `code`.
+    #[tokio::test]
+    async fn non_streaming_401_non_json_content_type_still_surfaces_code() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(401).set_body_raw(OPENAI_401_BODY.as_bytes(), "text/plain"),
+            )
+            .mount(&server)
+            .await;
+        let bridge = OpenAiBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        match err {
+            BridgeError::UpstreamStatus {
+                parsed, message, ..
+            } => {
+                let parsed = parsed.expect("error envelope must parse regardless of Content-Type");
+                assert_eq!(parsed.code.as_deref(), Some("invalid_api_key"));
+                assert_eq!(parsed.kind.as_deref(), Some("invalid_request_error"));
+                // `message` must be the clean upstream message, NOT the
+                // raw JSON-stringified body.
+                assert!(
+                    message.starts_with("Incorrect API key provided"),
+                    "message must be the parsed upstream message, got: {message}",
+                );
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    /// A genuinely non-JSON error body (HTML / plain text, no
+    /// `{"error":...}`) must still fall back cleanly — parse returns
+    /// None, no panic. Guards the opportunistic-parse change against
+    /// over-parsing.
+    #[tokio::test]
+    async fn non_streaming_non_json_error_body_falls_back() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(502)
+                    .set_body_raw(b"<html>502 Bad Gateway</html>", "text/html"),
+            )
+            .mount(&server)
+            .await;
+        let bridge = OpenAiBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        match err {
+            BridgeError::UpstreamStatus { parsed, status, .. } => {
+                assert_eq!(status, 502);
+                assert!(parsed.is_none(), "non-JSON body must not parse into a view");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn non_streaming_decode_error_on_malformed_body() {
         let server = MockServer::start().await;

--- a/tests/e2e/src/cases/upstream-401-error-code-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-401-error-code-e2e.test.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: upstream 401 bad-key error envelope must preserve `error.code`
+// even when the JSON body is labelled with a non-`application/json`
+// Content-Type (#543).
+//
+// Pre-fix, the DP gated upstream error-body parsing on Content-Type.
+// OpenAI's 401 `invalid_api_key` path (and edge/proxy layers fronting
+// some upstreams) return the JSON error body with a non-JSON
+// Content-Type, so the DP skipped the parse — dumping the raw body
+// into `message` and emitting an EMPTY `error.code`. Customer SDKs
+// that branch on `error.code === "invalid_api_key"` to decide whether
+// to refresh credentials couldn't classify the error.
+//
+// This drives a real /v1/chat/completions through the DP against a
+// mock upstream that returns the canonical OpenAI 401 body with a
+// `text/plain` Content-Type, and asserts the client-visible envelope
+// still carries `code: "invalid_api_key"`.
+//
+// References:
+// - OpenAI error envelope: https://platform.openai.com/docs/guides/error-codes/api-errors
+// - Issue: api7/AISIX-Cloud#543
+
+const CALLER_PLAINTEXT = "sk-401-code-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const OPENAI_401_BODY = {
+  error: {
+    message:
+      "Incorrect API key provided: sk-inval***c66a. You can find your API key at https://platform.openai.com/account/api-keys.",
+    type: "invalid_request_error",
+    code: "invalid_api_key",
+    param: null,
+  },
+};
+
+describe("upstream 401 error.code preserved across Content-Type (#543)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // Upstream returns the canonical OpenAI 401 JSON body but labels it
+    // `text/plain` — the exact shape #543 was surfaced on.
+    upstream = await startOpenAiUpstream({
+      status: 401,
+      errorBody: OPENAI_401_BODY,
+      errorContentType: "text/plain",
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "err401-pk",
+      secret: "sk-mock-bad",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "err401-gpt",
+      provider: "openai",
+      model_name: "gpt-4o",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["err401-gpt"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("401 with non-JSON content-type still surfaces error.code (#543)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // Propagation probe: the model must be live (any non-5xx-from-DP
+    // response means config propagated; the upstream always 401s).
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          },
+          body: JSON.stringify({
+            model: "err401-gpt",
+            messages: [{ role: "user", content: "probe" }],
+          }),
+        });
+        // 401 propagated correctly is what we want; 404 = model not yet live.
+        return r.status === 401;
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      },
+      body: JSON.stringify({
+        model: "err401-gpt",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    // DP forwards the upstream 401 status.
+    expect(res.status).toBe(401);
+
+    const body = (await res.json()) as {
+      error?: { message?: string; type?: string; code?: string };
+    };
+    expect(body.error, JSON.stringify(body)).toBeDefined();
+    // The fix: `code` is preserved (pre-#543 it was empty/absent).
+    expect(body.error!.code).toBe("invalid_api_key");
+    // `message` is the clean upstream message, NOT the raw
+    // JSON-stringified body.
+    expect(body.error!.message).toContain("Incorrect API key provided");
+    expect(body.error!.message).not.toContain('"error"');
+  });
+});

--- a/tests/e2e/src/harness/upstream-openai.ts
+++ b/tests/e2e/src/harness/upstream-openai.ts
@@ -14,6 +14,13 @@ export interface OpenAiUpstreamOptions {
   status?: number;
   /** Body to return when `status` >= 400. */
   errorBody?: unknown;
+  /**
+   * Content-Type for the error body (default `application/json`). Lets
+   * tests reproduce upstreams / edge layers that return a JSON error
+   * body labelled with a non-JSON Content-Type (e.g. OpenAI's 401
+   * `invalid_api_key` path — see #543).
+   */
+  errorContentType?: string;
   /** Drop the connection after writing this many SSE events. */
   disconnectAfterEvents?: number;
   /** Per-request response script; used in order before static opts. */
@@ -33,6 +40,8 @@ export interface OpenAiUpstreamStep {
   eventDelayMs?: number;
   status?: number;
   errorBody?: unknown;
+  /** Content-Type for the error body (default `application/json`). See #543. */
+  errorContentType?: string;
   disconnectAfterEvents?: number;
   /** Extra response headers, same semantics as on the top-level options. */
   responseHeaders?: Record<string, string>;
@@ -88,7 +97,10 @@ export async function startOpenAiUpstream(
       const status = step.status ?? 200;
       if (status >= 400) {
         res.statusCode = status;
-        res.setHeader("content-type", "application/json");
+        res.setHeader(
+          "content-type",
+          step.errorContentType ?? opts.errorContentType ?? "application/json",
+        );
         res.end(JSON.stringify(step.errorBody ?? { error: { message: "mock error" } }));
         return;
       }


### PR DESCRIPTION
## Summary

Fixes **api7/AISIX-Cloud#543**.

The 401 bad-key path returned an **empty `error.code`** (inconsistent with 400/404, which preserve it). A customer SDK that branches on `error.code === "invalid_api_key"` to refresh credentials couldn't classify the error.

## Root cause (proven by probe)

`capture_upstream_error_http` gated the upstream error-envelope parse on `content_type_is_json`. A disambiguation probe (real OpenAI bridge + wiremock) showed:

| Upstream 401 Content-Type | `parsed` | client `error.code` |
|---|---|---|
| `application/json` | `Some` | `invalid_api_key` ✓ |
| `text/plain` (same JSON body) | `None` | empty ✗ |

OpenAI's 401 `invalid_api_key` response (and edge/proxy layers fronting some upstreams) return the JSON error body labelled with a non-`application/json` Content-Type → the gate skipped the parse → `code`/`param` dropped, raw body dumped into `message`. (64 KB body cap ruled out truncation; routing preserves the original `BridgeError`, so not a re-wrap.)

## Fix

Parse the error body **opportunistically, regardless of Content-Type**. The per-bridge `parse` fn is the real validator — both `parse_openai_error_envelope` and `parse_anthropic_error_envelope` require the provider's `{"error": {...}}` shape and return `None` on any non-matching body (HTML pages, plain text, 5xx bodies), so attempting it unconditionally is safe and strictly more robust. The Content-Type heuristic was an unnecessary failure point. Only behavioural change.

## Test plan

- [x] `non_streaming_401_json_content_type_surfaces_code` — baseline (already worked)
- [x] `non_streaming_401_non_json_content_type_still_surfaces_code` — **the #543 regression**: text/plain + JSON body → `code`+`type` surfaced, clean `message`
- [x] `non_streaming_non_json_error_body_falls_back` — real non-JSON (HTML 502) → `parsed=None`, no over-parsing
- [x] e2e `upstream-401-error-code-e2e.test.ts` — real /v1/chat/completions through the DP against a mock returning the canonical OpenAI 401 body with `text/plain` Content-Type; asserts client `error.code = "invalid_api_key"` + clean `message`. Harness gained an `errorContentType` option. **Verified locally against the aisix-e2e stack.**
- [x] All aisix-gateway (51) / openai (66) / anthropic (88) / proxy (342) lib tests pass — no regression from dropping the gate.
- [x] `cargo clippy --all-targets -- -D warnings` clean.

## References

- OpenAI error envelope: <https://platform.openai.com/docs/guides/error-codes/api-errors>
- Issue: api7/AISIX-Cloud#543