### PR TITLE
feat(audio,images): emit UsageEvent on success (#406, #407)

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -1002,4 +1002,21 @@ mod tests {
         assert_eq!(event.model_id, "m-2");
         assert_eq!(event.inbound_protocol, "openai");
     }
+
+    /// gpt-4o-transcribe with a non-default `response_format` can return
+    /// the *duration* usage variant — `{"type":"duration","seconds":N}` —
+    /// which carries no `input_tokens`. `extract_token_usage` must degrade
+    /// that to `None` (→ a zero-token emit, never a panic or mis-parse),
+    /// consistent with the duration-cost being a cross-repo follow-up.
+    /// Per OpenAI's `usage` oneOf (TranscriptTextUsageTokens |
+    /// TranscriptTextUsageDuration):
+    /// <https://platform.openai.com/docs/api-reference/audio/json-object>
+    #[test]
+    fn extract_token_usage_ignores_duration_variant() {
+        let v = serde_json::json!({
+            "text": "hello world",
+            "usage": {"type": "duration", "seconds": 42.7}
+        });
+        assert_eq!(super::extract_token_usage(&v), None);
+    }
 }

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -17,7 +17,7 @@
 //! Auth and model authorisation follow the same rules as every other
 //! proxy endpoint.
 
-use aisix_obs::{AccessLog, RequestOutcome};
+use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::body::Bytes;
 use axum::extract::{Multipart, State};
 use axum::http::{header, HeaderMap};
@@ -31,6 +31,22 @@ use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
 use crate::request_id::new_request_id;
 use crate::state::ProxyState;
+
+/// Per-request payload from a successful multipart dispatch
+/// (transcriptions/translations) — adds `model_id` + parsed `usage` to
+/// the response/model/provider triplet so the handler can emit a
+/// UsageEvent (#406).
+struct AudioDispatchSuccess {
+    response: Response,
+    model_name: String,
+    provider: String,
+    model_id: String,
+    /// `(prompt_tokens, completion_tokens)` from the upstream `usage`
+    /// block when the model returns one (gpt-4o-transcribe). `None` for
+    /// whisper-1 (no usage block) — those still emit a zero-token event
+    /// so the request is visible + attributed.
+    usage: Option<(u32, u32)>,
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // /v1/audio/transcriptions
@@ -56,26 +72,27 @@ pub async fn transcriptions(
     )
     .await
     {
-        Ok((resp, model_name, provider)) => {
+        Ok(success) => {
             let elapsed = started.elapsed();
             emit_access_log(
                 "POST",
                 "/v1/audio/transcriptions",
-                &model_name,
-                &provider,
+                &success.model_name,
+                &success.provider,
                 &api_key_id,
                 200,
                 elapsed,
                 &request_id,
             );
             state.metrics.record_request(
-                &provider,
-                &model_name,
+                &success.provider,
+                &success.model_name,
                 200,
                 RequestOutcome::Success,
                 elapsed,
             );
-            resp
+            emit_audio_usage(&state, &request_id, &success, &api_key_id, elapsed);
+            success.response
         }
         Err(err) => {
             let status = err.status().as_u16();
@@ -126,26 +143,27 @@ pub async fn translations(
     )
     .await
     {
-        Ok((resp, model_name, provider)) => {
+        Ok(success) => {
             let elapsed = started.elapsed();
             emit_access_log(
                 "POST",
                 "/v1/audio/translations",
-                &model_name,
-                &provider,
+                &success.model_name,
+                &success.provider,
                 &api_key_id,
                 200,
                 elapsed,
                 &request_id,
             );
             state.metrics.record_request(
-                &provider,
-                &model_name,
+                &success.provider,
+                &success.model_name,
                 200,
                 RequestOutcome::Success,
                 elapsed,
             );
-            resp
+            emit_audio_usage(&state, &request_id, &success, &api_key_id, elapsed);
+            success.response
         }
         Err(err) => {
             let status = err.status().as_u16();
@@ -191,7 +209,7 @@ pub async fn speech(
         .to_string();
 
     match speech_dispatch(&state, &auth, body, &request_id).await {
-        Ok((resp, provider)) => {
+        Ok((resp, provider, model_id)) => {
             let elapsed = started.elapsed();
             emit_access_log(
                 "POST",
@@ -209,6 +227,21 @@ pub async fn speech(
                 200,
                 RequestOutcome::Success,
                 elapsed,
+            );
+            // Issue #406: /v1/audio/speech (TTS) returns binary audio
+            // with no usage block — emit a zero-token UsageEvent so the
+            // request is visible in /logs and attributed to the api_key.
+            // (TTS is billed per input character; that cost basis is the
+            // same cross-repo follow-up as audio duration.)
+            emit_usage_event(
+                &state,
+                &request_id,
+                &model_id,
+                &api_key_id,
+                200,
+                elapsed,
+                0,
+                0,
             );
             resp
         }
@@ -249,7 +282,7 @@ async fn multipart_dispatch(
     mut multipart: Multipart,
     upstream_path: &str,
     request_id: &str,
-) -> Result<(Response, String, String), ProxyError> {
+) -> Result<AudioDispatchSuccess, ProxyError> {
     // Collect all fields first so we can find `model` before building the
     // outgoing reqwest multipart.
     let mut fields: Vec<(String, Option<String>, Option<String>, Bytes)> = Vec::new();
@@ -382,18 +415,36 @@ async fn multipart_dispatch(
         })
         .map_err(ProxyError::Bridge)?;
 
+    // Parse the response body best-effort for a `usage` token block
+    // (gpt-4o-transcribe returns one; whisper-1 returns none, and the
+    // `text`/`srt`/`vtt` response_formats aren't JSON at all). Parse
+    // failure or absence → None → zero-token emit. Done before the
+    // bytes move into the Body.
+    let usage = serde_json::from_slice::<Value>(&body_bytes)
+        .ok()
+        .as_ref()
+        .and_then(extract_token_usage);
+
     let mut out = axum::response::Response::new(axum::body::Body::from(body_bytes));
     copy_response_header(&upstream_headers, &mut out, header::CONTENT_TYPE);
-    Ok((out, model_name, provider_label))
+    Ok(AudioDispatchSuccess {
+        response: out,
+        model_name,
+        provider: provider_label,
+        model_id: model_entry.id.to_string(),
+        usage,
+    })
 }
 
 /// JSON passthrough for `/v1/audio/speech` — returns binary audio bytes.
+/// Returns `(response, provider_label, model_id)`; `model_id` lets the
+/// handler attribute a (zero-token) UsageEvent (#406).
 async fn speech_dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
     mut body: Value,
     request_id: &str,
-) -> Result<(Response, String), ProxyError> {
+) -> Result<(Response, String, String), ProxyError> {
     let model_name = body
         .get("model")
         .and_then(|v| v.as_str())
@@ -485,7 +536,85 @@ async fn speech_dispatch(
 
     let mut out = axum::response::Response::new(axum::body::Body::from(body_bytes));
     copy_response_header(&upstream_headers, &mut out, header::CONTENT_TYPE);
-    Ok((out, provider_label))
+    Ok((out, provider_label, model_entry.id.to_string()))
+}
+
+/// Pull `(prompt_tokens, completion_tokens)` from an audio response
+/// `usage` block. gpt-4o-transcribe returns
+/// `usage: {type:"tokens", input_tokens, output_tokens, ...}`;
+/// whisper-1 (and the `text`/`srt`/`vtt` response formats) return no
+/// token block → `None`. Spec:
+/// <https://platform.openai.com/docs/api-reference/audio/json-object>
+fn extract_token_usage(body: &Value) -> Option<(u32, u32)> {
+    let usage = body.get("usage")?;
+    let input = usage.get("input_tokens").and_then(Value::as_u64)? as u32;
+    let output = usage
+        .get("output_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as u32;
+    Some((input, output))
+}
+
+/// Emit a UsageEvent for a successful transcription/translation. Tokens
+/// come from the upstream `usage` block when present (gpt-4o-transcribe);
+/// zero otherwise (whisper-1) — the request is still visible/attributed.
+fn emit_audio_usage(
+    state: &ProxyState,
+    request_id: &str,
+    success: &AudioDispatchSuccess,
+    api_key_id: &str,
+    elapsed: Duration,
+) {
+    let (prompt_tokens, completion_tokens) = success.usage.unwrap_or((0, 0));
+    emit_usage_event(
+        state,
+        request_id,
+        &success.model_id,
+        api_key_id,
+        200,
+        elapsed,
+        prompt_tokens,
+        completion_tokens,
+    );
+}
+
+/// Issue #406: push one `UsageEvent` onto cp-api's telemetry sink and
+/// fan it out to per-env OTLP exporters. Mirrors
+/// `embeddings::emit_usage_event` (#402). `inbound_protocol = "openai"`.
+/// Tokens are populated when the upstream returned a `usage` block
+/// (gpt-4o-transcribe); zero otherwise — duration-based cost (whisper-1)
+/// is a documented cross-repo follow-up (needs duration on the wire +
+/// cp-api pricing).
+#[allow(clippy::too_many_arguments)]
+fn emit_usage_event(
+    state: &ProxyState,
+    request_id: &str,
+    model_id: &str,
+    api_key_id: &str,
+    status_code: u16,
+    elapsed: Duration,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+) {
+    let event = UsageEvent {
+        request_id: request_id.to_string(),
+        occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        model_id: model_id.to_string(),
+        api_key_id: api_key_id.to_string(),
+        prompt_tokens,
+        completion_tokens,
+        latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
+        status_code,
+        inbound_protocol: "openai".to_string(),
+        ..Default::default()
+    };
+    // Handler label "audio" — bucketed prometheus counter (#408).
+    state.usage_sink.try_emit("audio", event.clone());
+    let snap = state.snapshot.load();
+    let exporters = snap.observability_exporters.entries();
+    state
+        .otlp_fan_out
+        .fan_out(&event, exporters.iter().map(|e| &e.value));
 }
 
 fn copy_response_header(src: &HeaderMap, dst: &mut Response, name: header::HeaderName) {
@@ -706,5 +835,171 @@ mod tests {
             .unwrap();
         let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    fn build_app_with_sink(
+        snap: AisixSnapshot,
+        tx: tokio::sync::mpsc::Sender<aisix_obs::UsageEvent>,
+    ) -> axum::Router {
+        use aisix_obs::UsageSink;
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        crate::build_router(state)
+    }
+
+    /// A minimal multipart body carrying `model` + a tiny fake audio
+    /// `file` field — enough for the gateway to extract the model and
+    /// forward the form.
+    fn transcription_multipart(model: &str) -> (String, axum::body::Body) {
+        let body = format!(
+            "--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n{model}\r\n\
+             --b\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.mp3\"\r\n\
+             Content-Type: audio/mpeg\r\n\r\nID3fakeaudio\r\n--b--\r\n"
+        );
+        (
+            "multipart/form-data; boundary=b".to_string(),
+            axum::body::Body::from(body),
+        )
+    }
+
+    /// Issue #406: gpt-4o-transcribe returns a `usage` token block —
+    /// a successful transcription must emit a UsageEvent with those
+    /// tokens, attributed to the api_key + model, inbound_protocol
+    /// "openai".
+    #[tokio::test]
+    async fn transcriptions_emit_usage_event_with_tokens() {
+        let upstream = MockServer::start().await;
+        let body = serde_json::json!({
+            "text": "hello world",
+            "usage": {
+                "type": "tokens",
+                "input_tokens": 14,
+                "output_tokens": 4,
+                "total_tokens": 18
+            }
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-transcribe"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = transcription_multipart("my-transcribe");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted for /v1/audio/transcriptions 200")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.prompt_tokens, 14);
+        assert_eq!(event.completion_tokens, 4);
+        assert_eq!(event.status_code, 200);
+        assert_eq!(event.api_key_id, "k-1");
+        assert_eq!(event.model_id, "m-1");
+        assert_eq!(event.inbound_protocol, "openai");
+    }
+
+    /// Issue #406: whisper-1 `{"text":"..."}` has no `usage` block —
+    /// the request still emits a zero-token UsageEvent so it's visible
+    /// in /logs and attributed (duration-based cost is a cross-repo
+    /// follow-up).
+    #[tokio::test]
+    async fn transcriptions_emit_zero_token_event_without_usage() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"text": "hi"})),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-whisper"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = transcription_multipart("my-whisper");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("zero-token UsageEvent must still be emitted (visibility)")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.prompt_tokens, 0);
+        assert_eq!(event.completion_tokens, 0);
+        assert_eq!(event.model_id, "m-1");
+        assert_eq!(event.inbound_protocol, "openai");
+    }
+
+    /// Issue #406: TTS speech returns binary audio (no usage). It still
+    /// emits a zero-token UsageEvent so the request is visible +
+    /// attributed.
+    #[tokio::test]
+    async fn speech_emits_zero_token_usage_event() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "audio/mpeg")
+                    .set_body_bytes(b"ID3\x03\x00\x00\x00".to_vec()),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(tts_model("my-tts"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/speech")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(
+                r#"{"model":"my-tts","input":"Hello","voice":"alloy"}"#,
+            ))
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("speech must emit a zero-token UsageEvent (visibility)")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.prompt_tokens, 0);
+        assert_eq!(event.completion_tokens, 0);
+        assert_eq!(event.model_id, "m-2");
+        assert_eq!(event.inbound_protocol, "openai");
     }
 }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -11,7 +11,7 @@
 //! 8. Providers that don't support image generation return 501.
 
 use aisix_gateway::{BridgeContext, BridgeError};
-use aisix_obs::{AccessLog, RequestOutcome};
+use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -24,6 +24,26 @@ use crate::auth::AuthenticatedKey;
 use crate::error::{ErrorEnvelope, ProxyError};
 use crate::request_id::new_request_id;
 use crate::state::ProxyState;
+
+/// Per-request payload from a successful dispatch — carries the
+/// response + the bits the handler needs to emit a UsageEvent (#407).
+struct ImageDispatchSuccess {
+    response: Response,
+    provider: String,
+    /// UUID of the resolved Model row — required for UsageEvent
+    /// `model_id`. Always present on success.
+    model_id: String,
+    /// `(prompt_tokens, completion_tokens)` from the upstream `usage`
+    /// block when the model returns one (gpt-image-1). `None` for
+    /// models that don't (dall-e-3) — those still emit a zero-token
+    /// event so the request is visible + attributed.
+    usage: Option<(u32, u32)>,
+    /// `false` on the 501 NotImplemented branch (provider lacks image
+    /// generation → no upstream call). Gates emission so the
+    /// not-implemented path stays out of /logs (same convention as
+    /// embeddings #402).
+    upstream_called: bool,
+}
 
 pub async fn image_generations(
     State(state): State<ProxyState>,
@@ -40,24 +60,46 @@ pub async fn image_generations(
         .to_string();
 
     match dispatch(&state, &auth, body, &request_id).await {
-        Ok((resp, provider)) => {
+        Ok(success) => {
             let elapsed = started.elapsed();
             emit_access_log(
                 &model_name,
-                &provider,
+                &success.provider,
                 &api_key_id,
                 200,
                 elapsed,
                 &request_id,
             );
             state.metrics.record_request(
-                &provider,
+                &success.provider,
                 &model_name,
                 200,
                 RequestOutcome::Success,
                 elapsed,
             );
-            resp
+            // Issue #407: emit UsageEvent so cp-api's budget ledger +
+            // /logs see image-generation traffic. Pre-#407 the handler
+            // dropped the event entirely. Emit on a real upstream call
+            // (even zero tokens — request visible/attributed); skip the
+            // 501 NotImplemented path. Tokens come from the upstream
+            // `usage` block when present (gpt-image-1); dall-e-3 has no
+            // usage block → zero tokens (precise per-image cost is a
+            // documented cross-repo follow-up — needs image-count /
+            // size / quality on the wire + cp-api pricing).
+            if success.upstream_called {
+                let (prompt_tokens, completion_tokens) = success.usage.unwrap_or((0, 0));
+                emit_usage_event(
+                    &state,
+                    &request_id,
+                    &success.model_id,
+                    &api_key_id,
+                    200,
+                    elapsed,
+                    prompt_tokens,
+                    completion_tokens,
+                );
+            }
+            success.response
         }
         Err(err) => {
             let status = err.status().as_u16();
@@ -87,7 +129,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: Value,
     request_id: &str,
-) -> Result<(Response, String), ProxyError> {
+) -> Result<ImageDispatchSuccess, ProxyError> {
     let model_name = body
         .get("model")
         .and_then(|v| v.as_str())
@@ -142,16 +184,86 @@ async fn dispatch(
     let provider_label = provider.to_ascii_lowercase();
 
     match bridge.generate_image(&body, &ctx).await {
-        Ok(resp_json) => Ok((Json(resp_json).into_response(), provider_label)),
+        Ok(resp_json) => {
+            // Extract usage tokens (gpt-image-1 returns a `usage` block;
+            // dall-e-3 doesn't) BEFORE moving resp_json into the
+            // Response, so the success struct carries typed counters.
+            let usage = extract_token_usage(&resp_json);
+            Ok(ImageDispatchSuccess {
+                response: Json(resp_json).into_response(),
+                provider: provider_label,
+                model_id: model_entry.id.to_string(),
+                usage,
+                upstream_called: true,
+            })
+        }
         Err(BridgeError::Config(msg)) if msg.contains("does not support image generation") => {
             let env = ErrorEnvelope::new(msg, "not_implemented");
-            Ok((
-                (StatusCode::NOT_IMPLEMENTED, Json(env)).into_response(),
-                provider_label,
-            ))
+            Ok(ImageDispatchSuccess {
+                response: (StatusCode::NOT_IMPLEMENTED, Json(env)).into_response(),
+                provider: provider_label,
+                model_id: model_entry.id.to_string(),
+                usage: None,
+                // No upstream call happened → handler skips emit.
+                upstream_called: false,
+            })
         }
         Err(e) => Err(ProxyError::Bridge(e)),
     }
+}
+
+/// Pull `(prompt_tokens, completion_tokens)` from an OpenAI image
+/// response `usage` block. gpt-image-1 returns
+/// `usage: {input_tokens, output_tokens, total_tokens, ...}`; dall-e-2/3
+/// return no `usage` block → `None`. Wire shape:
+/// <https://platform.openai.com/docs/api-reference/images/object>
+fn extract_token_usage(body: &Value) -> Option<(u32, u32)> {
+    let usage = body.get("usage")?;
+    let input = usage.get("input_tokens").and_then(Value::as_u64)? as u32;
+    let output = usage
+        .get("output_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as u32;
+    Some((input, output))
+}
+
+/// Issue #407: push one `UsageEvent` onto cp-api's telemetry sink and
+/// fan it out to per-env OTLP exporters. Mirrors
+/// `embeddings::emit_usage_event` (#402). `inbound_protocol = "openai"`
+/// (images are an OpenAI-shape endpoint). Tokens are populated when the
+/// upstream returned a `usage` block (gpt-image-1); zero otherwise —
+/// the per-image cost basis (n × size × quality) is a cross-repo
+/// follow-up needing a UsageEvent wire extension + cp-api pricing.
+#[allow(clippy::too_many_arguments)]
+fn emit_usage_event(
+    state: &ProxyState,
+    request_id: &str,
+    model_id: &str,
+    api_key_id: &str,
+    status_code: u16,
+    elapsed: Duration,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+) {
+    let event = UsageEvent {
+        request_id: request_id.to_string(),
+        occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        model_id: model_id.to_string(),
+        api_key_id: api_key_id.to_string(),
+        prompt_tokens,
+        completion_tokens,
+        latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
+        status_code,
+        inbound_protocol: "openai".to_string(),
+        ..Default::default()
+    };
+    // Handler label "images" — bucketed prometheus counter (#408).
+    state.usage_sink.try_emit("images", event.clone());
+    let snap = state.snapshot.load();
+    let exporters = snap.observability_exporters.entries();
+    state
+        .otlp_fan_out
+        .fan_out(&event, exporters.iter().map(|e| &e.value));
 }
 
 fn emit_access_log(
@@ -189,6 +301,7 @@ mod tests {
     use aisix_core::snapshot::SnapshotHandle;
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
     use aisix_gateway::Hub;
+    use aisix_obs::UsageEvent;
     use aisix_provider_openai::OpenAiBridge;
     use axum::body::to_bytes;
     use axum::http::{Request, StatusCode};
@@ -405,5 +518,101 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    fn build_app_with_sink(
+        snap: AisixSnapshot,
+        tx: tokio::sync::mpsc::Sender<UsageEvent>,
+    ) -> axum::Router {
+        use aisix_obs::UsageSink;
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        crate::build_router(state)
+    }
+
+    /// Issue #407: gpt-image-1 returns a `usage` token block — a
+    /// successful generation must emit a UsageEvent carrying those
+    /// tokens, attributed to the api_key + model, inbound_protocol
+    /// "openai".
+    #[tokio::test]
+    async fn emits_usage_event_with_tokens_when_upstream_returns_usage() {
+        let upstream = MockServer::start().await;
+        let body = serde_json::json!({
+            "created": 1_700_000_000i64,
+            "data": [{"b64_json": "aGVsbG8="}],
+            "usage": {
+                "input_tokens": 50,
+                "output_tokens": 1568,
+                "total_tokens": 1618,
+                "input_tokens_details": {"text_tokens": 10, "image_tokens": 40}
+            }
+        });
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("gpt-image"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let req = serde_json::json!({"model": "gpt-image", "prompt": "a cat", "n": 1});
+        let resp = tower::ServiceExt::oneshot(app, make_req(req))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted for /v1/images/generations 200")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.prompt_tokens, 50);
+        assert_eq!(event.completion_tokens, 1568);
+        assert_eq!(event.status_code, 200);
+        assert_eq!(event.api_key_id, "k-1");
+        assert_eq!(event.model_id, "m-1");
+        assert_eq!(event.inbound_protocol, "openai");
+    }
+
+    /// Issue #407: dall-e-3 returns NO `usage` block — the request still
+    /// emits a zero-token UsageEvent so it's visible in /logs and
+    /// attributed (precise per-image cost is a cross-repo follow-up).
+    #[tokio::test]
+    async fn emits_zero_token_event_when_upstream_omits_usage() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("dall-e"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let req = serde_json::json!({"model": "dall-e", "prompt": "a dog", "n": 1});
+        let resp = tower::ServiceExt::oneshot(app, make_req(req))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("zero-token UsageEvent must still be emitted (visibility)")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.prompt_tokens, 0);
+        assert_eq!(event.completion_tokens, 0);
+        assert_eq!(event.status_code, 200);
+        assert_eq!(event.model_id, "m-1");
+        assert_eq!(event.inbound_protocol, "openai");
     }
 }

--- a/tests/e2e/src/cases/audio-images-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/audio-images-usage-e2e.test.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+import { beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: UsageEvent emission on /v1/images/generations (#407) and
+// /v1/audio/transcriptions (#406) — completes the #226 non-chat
+// UsageEvent tracker (6/6 endpoints).
+//
+// Pre-fix both handlers emitted only an AccessLog + metrics; no
+// UsageEvent → the requests were invisible to cp-api's budget ledger
+// and /logs analytics. This drives real requests through the DP binary
+// and asserts the DP's own `aisix_usage_events_emitted_total` counter
+// (added in #408) increments for handler="images" / handler="audio".
+//
+// Token-based cost (gpt-image-1 / gpt-4o-transcribe usage blocks) is
+// covered by the Rust unit tests; legacy duration/per-image cost
+// (whisper-1 / dall-e-3) is a documented cross-repo follow-up.
+//
+// References:
+// - OpenAI images object (usage): https://platform.openai.com/docs/api-reference/images/object
+// - OpenAI audio (usage): https://platform.openai.com/docs/api-reference/audio
+// - Issues: api7/AISIX-Cloud#406, #407
+
+const CALLER_PLAINTEXT = "sk-audio-images-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("audio + images UsageEvent emission (#406/#407)", () => {
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+  });
+
+  test("image generation emits a usage event (handler=images, #407)", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const upstream: OpenAiUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        created: 1_700_000_000,
+        data: [{ b64_json: "aGVsbG8=" }],
+        usage: { input_tokens: 50, output_tokens: 1568, total_tokens: 1618 },
+      },
+    });
+    const app: SpawnedApp = await spawnApp();
+    try {
+      const admin = new AdminClient(app.adminUrl, app.adminKey);
+      const pk = await admin.createProviderKey({
+        display_name: "img-usage-pk",
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      await admin.createModel({
+        display_name: "img-usage",
+        provider: "openai",
+        model_name: "gpt-image-1",
+        provider_key_id: pk.id,
+      });
+      await admin.createApiKey({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: ["img-usage"],
+      });
+
+      const call = () =>
+        fetch(`${app.proxyUrl}/v1/images/generations`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          },
+          body: JSON.stringify({ model: "img-usage", prompt: "a cat", n: 1 }),
+        });
+      await waitConfigPropagation(async () => (await call()).ok);
+      expect((await call()).status).toBe(200);
+
+      const emitted = await pollUsageEmitted(app.adminUrl, "images");
+      expect(emitted, "handler=images emit counter must be > 0 (#407)").toBeGreaterThan(0);
+    } finally {
+      await app.exit();
+      await upstream.close();
+    }
+  });
+
+  test("audio transcription emits a usage event (handler=audio, #406)", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const upstream: OpenAiUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        text: "hello world",
+        usage: { type: "tokens", input_tokens: 14, output_tokens: 4, total_tokens: 18 },
+      },
+    });
+    const app: SpawnedApp = await spawnApp();
+    try {
+      const admin = new AdminClient(app.adminUrl, app.adminKey);
+      const pk = await admin.createProviderKey({
+        display_name: "audio-usage-pk",
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      await admin.createModel({
+        display_name: "audio-usage",
+        provider: "openai",
+        model_name: "gpt-4o-transcribe",
+        provider_key_id: pk.id,
+      });
+      await admin.createApiKey({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: ["audio-usage"],
+      });
+
+      const call = () => {
+        const form = new FormData();
+        form.set("model", "audio-usage");
+        form.set("file", new Blob([new Uint8Array([0x49, 0x44, 0x33])], { type: "audio/mpeg" }), "a.mp3");
+        return fetch(`${app.proxyUrl}/v1/audio/transcriptions`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+          body: form,
+        });
+      };
+      await waitConfigPropagation(async () => (await call()).ok);
+      expect((await call()).status).toBe(200);
+
+      const emitted = await pollUsageEmitted(app.adminUrl, "audio");
+      expect(emitted, "handler=audio emit counter must be > 0 (#406)").toBeGreaterThan(0);
+    } finally {
+      await app.exit();
+      await upstream.close();
+    }
+  });
+});
+
+/**
+ * Poll /metrics until the `aisix_usage_events_emitted_total` counter
+ * for the given handler appears non-zero (the DP emits the event
+ * synchronously on the request path, but the scrape is eventually
+ * consistent). Bounded so a regression (no emit) fails rather than
+ * hangs. Sums all label-sets for the handler.
+ */
+async function pollUsageEmitted(adminUrl: string, handler: string): Promise<number> {
+  const deadline = Date.now() + 5_000;
+  let total = 0;
+  while (Date.now() < deadline) {
+    const text = await fetch(`${adminUrl}/metrics`).then((r) => r.text());
+    total = 0;
+    for (const line of text.split("\n")) {
+      if (!line.startsWith("aisix_usage_events_emitted_total{")) continue;
+      if (!line.includes(`handler="${handler}"`)) continue;
+      const v = Number.parseFloat(line.split("}").at(-1)?.trim() ?? "");
+      if (!Number.isNaN(v)) total += v;
+    }
+    if (total > 0) break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return total;
+}


### PR DESCRIPTION
## What

Completes the **#226 non-chat UsageEvent tracker** — the final 2 of 6 endpoints. `/v1/audio/{transcriptions,translations,speech}` and `/v1/images/generations` previously emitted only an `AccessLog` + Prometheus metrics on success, **never a `UsageEvent`**. That traffic was invisible to cp-api's budget ledger and the customer-facing `/logs` usage analytics.

## How

Token-MVP, identical in shape to the four already-shipped #226 endpoints (embeddings / responses / completions / rerank): emit a `UsageEvent` on a **real upstream call** (audit-M1 emit-on-success semantics), populating prompt/completion tokens from the upstream `usage` block when the model returns one, zero otherwise.

| Endpoint | Modern model (token usage) | Legacy model (no usage block) | No upstream call |
|---|---|---|---|
| images | `gpt-image-1` → `usage.{input_tokens,output_tokens}` | `dall-e-2/3` → zero-token event (still visible + attributed) | 501 NotImplemented → **no emit** |
| audio transcribe/translate | `gpt-4o-transcribe` → `usage` token block | `whisper-1` + text/srt/vtt formats → zero-token event | — |
| audio speech (TTS) | — (binary response) | always zero-token event (visible + attributed) | — |

`handler` labels `"images"` / `"audio"` feed the #408 `aisix_usage_events_emitted_total` counter; `inbound_protocol="openai"`.

### Known follow-up (cross-repo, documented — not blocking)

Per the competitive review of comparable open-source gateways, **audio is billed by duration-seconds** and **images by `(model,size,quality)×n`** — neither maps to tokens for the legacy models. Surfacing that precise cost basis needs a `UsageEvent` wire extension (`audio_duration_seconds` / `image_count`+`size`+`quality`) **plus** cp-api pricing. This MVP closes the **visibility** gap fully and the **token-cost** gap for the modern token-returning models. Tracked as a separate cross-repo item.

## Tests

- **2 images unit tests** — gpt-image-1 token usage; dall-e zero-token. Real axum router + wiremock upstream + `UsageSink`.
- **3 audio unit tests** — gpt-4o-transcribe token usage; whisper zero-token; speech zero-token. Real multipart parsing.
- **1 audio pure-function test** — duration-usage variant (`{type:"duration",seconds}`) degrades to zero-token (audit LOW-1).
- **e2e `audio-images-usage-e2e.test.ts`** — drives real `/v1/images/generations` + `/v1/audio/transcriptions` through the DP binary, asserts `aisix_usage_events_emitted_total{handler=...}` increments. **Verified locally against a live etcd.**
- All `aisix-proxy` lib tests pass; `clippy --all-targets` clean; `fmt` clean.

## Independent audit (CLAUDE.md §8) — verdict CLEAR

A cold third-party agent reviewed across correctness / reliability / security / leakage / breaking-changes / e2e. No HIGH. Findings resolved:

- **LOW-1 (correctness)** — no test pinned the OpenAI `usage` *duration* variant for `gpt-4o-transcribe`. **Addressed**: added `extract_token_usage_ignores_duration_variant` (commit `0a78117`).
- **MEDIUM-1 (e2e/coverage)** — the 501-NotImplemented → no-emit gate has no *direct negative* test; this hole is shared across the **whole #226 family** (also the merged embeddings/completions siblings), not specific to this PR, which sits at exact parity with the four merged siblings. **Justified + filed as #456** to backfill it consistently across the family rather than as an asymmetric one-off. Agreed not to block merge (audit concurred: "Neither blocks merge").

Verified clean on security, sensitive-info leakage (UsageEvent carries only UUIDs + counts; no prompt/audio/image bytes, no provider secret), and breaking changes (dispatch return-type changes are all private; UsageEvent wire shape unchanged).

## Sources

- OpenAI images object `usage`: https://platform.openai.com/docs/api-reference/images/object
- OpenAI audio `usage` (tokens|duration oneOf): https://platform.openai.com/docs/api-reference/audio/json-object
- Cost-basis (duration / per-image) cross-checked against comparable open-source multi-provider gateways.

Closes #406, Closes #407. Parent: #226. Follow-ups: #456, #429.