### PR TITLE
fix(vertex,azure): reject embedded path in authority/api_base overrides (#435)

### DIFF
--- a/crates/aisix-provider-azure-openai/src/aad_token_mint.rs
+++ b/crates/aisix-provider-azure-openai/src/aad_token_mint.rs
@@ -154,14 +154,17 @@ impl AadCredentials {
             // is a valid origin. A real path segment would silently redirect
             // the token endpoint (e.g. `.../evil/{tenant}/oauth2/v2.0/token`).
             // A bare trailing slash is tolerated for symmetry with the Vertex
-            // `resolve_api_base` check. `host` has no `@`/`?`/`#` here, so
-            // echoing it is safe. Audit #434 LOW-1 / #435.
+            // `resolve_api_base` check. Backslashes are rejected too: the
+            // WHATWG URL parser the HTTP client uses normalizes `\` to `/` on
+            // http(s) URLs, so `host\evil` injects a path exactly like
+            // `host/evil`. `host` has no `@`/`?`/`#` here, so echoing it is
+            // safe. Audit #434 LOW-1 / #435 (+ #464 audit MEDIUM).
             let after_scheme = host
                 .split_once("://")
                 .map(|(_, rest)| rest)
                 .unwrap_or(host)
                 .trim_end_matches('/');
-            if after_scheme.contains('/') {
+            if after_scheme.contains('/') || after_scheme.contains('\\') {
                 return Err(BridgeError::Config(format!(
                     "azure aad credentials.authority_host must be a bare origin \
                      (scheme://host[:port]) with no path, got {host:?}"
@@ -670,6 +673,27 @@ mod tests {
                 authority_host: Some(host.into()),
             };
             assert!(creds.validate().is_ok(), "{host} should validate");
+        }
+    }
+
+    #[test]
+    fn validate_rejects_authority_host_with_backslash_path() {
+        // #464 audit: the WHATWG URL parser the HTTP client uses normalizes
+        // `\` to `/` on http(s) URLs, so `host\evil` injects a path just like
+        // `host/evil` — it must be rejected the same way.
+        let creds = AadCredentials {
+            tenant_id: "t".into(),
+            client_id: "app".into(),
+            client_secret: "s".into(),
+            authority_host: Some("https://login.microsoftonline.us\\evil".into()),
+        };
+        let err = creds.validate().err().unwrap();
+        match err {
+            BridgeError::Config(msg) => assert!(
+                msg.contains("bare origin") && msg.contains("no path"),
+                "expected a bare-origin/no-path rejection; got {msg}"
+            ),
+            other => panic!("expected Config, got {other:?}"),
         }
     }
 

--- a/crates/aisix-provider-azure-openai/src/aad_token_mint.rs
+++ b/crates/aisix-provider-azure-openai/src/aad_token_mint.rs
@@ -150,6 +150,23 @@ impl AadCredentials {
                      scheme, got {host:?}"
                 )));
             }
+            // Reject an embedded path component — only `scheme://host[:port]`
+            // is a valid origin. A real path segment would silently redirect
+            // the token endpoint (e.g. `.../evil/{tenant}/oauth2/v2.0/token`).
+            // A bare trailing slash is tolerated for symmetry with the Vertex
+            // `resolve_api_base` check. `host` has no `@`/`?`/`#` here, so
+            // echoing it is safe. Audit #434 LOW-1 / #435.
+            let after_scheme = host
+                .split_once("://")
+                .map(|(_, rest)| rest)
+                .unwrap_or(host)
+                .trim_end_matches('/');
+            if after_scheme.contains('/') {
+                return Err(BridgeError::Config(format!(
+                    "azure aad credentials.authority_host must be a bare origin \
+                     (scheme://host[:port]) with no path, got {host:?}"
+                )));
+            }
         }
         Ok(())
     }
@@ -614,6 +631,45 @@ mod tests {
         match err {
             BridgeError::Config(msg) => assert!(msg.contains("http:// or https://")),
             other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_authority_host_with_embedded_path() {
+        // #435: a path segment would silently redirect the token endpoint
+        // (e.g. `.../evil/{tenant}/oauth2/v2.0/token`) — reject it.
+        let creds = AadCredentials {
+            tenant_id: "t".into(),
+            client_id: "app".into(),
+            client_secret: "s".into(),
+            authority_host: Some("https://login.microsoftonline.us/evil".into()),
+        };
+        let err = creds.validate().err().unwrap();
+        match err {
+            BridgeError::Config(msg) => assert!(
+                msg.contains("bare origin") && msg.contains("no path"),
+                "expected a bare-origin/no-path rejection; got {msg}"
+            ),
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_allows_authority_host_bare_origin_with_port() {
+        // A `host:port` origin (no path) must still validate — the path
+        // rejection must not false-positive on the `:port` colon, and a
+        // bare trailing slash is tolerated (trimmed at URL-build time).
+        for host in [
+            "https://login.microsoftonline.us:8443",
+            "https://login.microsoftonline.us/",
+        ] {
+            let creds = AadCredentials {
+                tenant_id: "t".into(),
+                client_id: "app".into(),
+                client_secret: "s".into(),
+                authority_host: Some(host.into()),
+            };
+            assert!(creds.validate().is_ok(), "{host} should validate");
         }
     }
 

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -215,14 +215,17 @@ impl VertexBridge {
             // is a valid origin. A bare trailing slash is fine (trimmed
             // below); a real path segment (e.g. `.../evil`) would silently
             // redirect every upstream call onto the wrong path, so fail fast
-            // with a clear Config error. `b` has no `@`/`?`/`#` at this point
-            // (rejected above), so echoing it is safe. Audit #434 LOW-1 / #435.
+            // with a clear Config error. Backslashes are rejected too: the
+            // WHATWG URL parser the HTTP client uses normalizes `\` to `/` on
+            // http(s) URLs, so `host\evil` injects a path exactly like
+            // `host/evil`. `b` has no `@`/`?`/`#` here (rejected above), so
+            // echoing it is safe. Audit #434 LOW-1 / #435 (+ #464 audit MEDIUM).
             let after_scheme = b
                 .split_once("://")
                 .map(|(_, rest)| rest)
                 .unwrap_or(b)
                 .trim_end_matches('/');
-            if after_scheme.contains('/') {
+            if after_scheme.contains('/') || after_scheme.contains('\\') {
                 return Err(BridgeError::Config(format!(
                     "vertex provider_key api_base must be a bare origin \
                      (scheme://host[:port]) with no path, got {b:?}",
@@ -2131,6 +2134,27 @@ mod tests {
             .resolve_api_base("us-central1", Some("https://proxy.internal:8443"))
             .unwrap();
         assert_eq!(resolved, "https://proxy.internal:8443");
+    }
+
+    #[test]
+    fn resolve_api_base_rejects_backslash_path() {
+        // #464 audit: the WHATWG URL parser the HTTP client uses normalizes
+        // `\` to `/` on http(s) URLs, so `host\evil` injects a path just like
+        // `host/evil` — it must be rejected the same way.
+        let bridge = VertexBridge::new();
+        let err = bridge
+            .resolve_api_base("us-central1", Some("https://proxy.internal\\evil"))
+            .err()
+            .unwrap();
+        match err {
+            BridgeError::Config(msg) => {
+                assert!(
+                    msg.contains("bare origin") && msg.contains("no path"),
+                    "expected a bare-origin/no-path rejection; got {msg}"
+                );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -211,6 +211,23 @@ impl VertexBridge {
                     "vertex provider_key api_base must not contain a fragment, got {b:?}",
                 )));
             }
+            // Reject an embedded path component — only `scheme://host[:port]`
+            // is a valid origin. A bare trailing slash is fine (trimmed
+            // below); a real path segment (e.g. `.../evil`) would silently
+            // redirect every upstream call onto the wrong path, so fail fast
+            // with a clear Config error. `b` has no `@`/`?`/`#` at this point
+            // (rejected above), so echoing it is safe. Audit #434 LOW-1 / #435.
+            let after_scheme = b
+                .split_once("://")
+                .map(|(_, rest)| rest)
+                .unwrap_or(b)
+                .trim_end_matches('/');
+            if after_scheme.contains('/') {
+                return Err(BridgeError::Config(format!(
+                    "vertex provider_key api_base must be a bare origin \
+                     (scheme://host[:port]) with no path, got {b:?}",
+                )));
+            }
             return Ok(b.trim_end_matches('/').to_string());
         }
         Ok(format!("https://{region}-aiplatform.googleapis.com"))
@@ -2082,6 +2099,38 @@ mod tests {
             }
             other => panic!("expected Config error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn resolve_api_base_rejects_embedded_path() {
+        // #435: an api_base with a real path segment would silently redirect
+        // every upstream call onto the wrong path — reject it with a clear
+        // Config error rather than 404-ing the operator later.
+        let bridge = VertexBridge::new();
+        let err = bridge
+            .resolve_api_base("us-central1", Some("https://proxy.internal/evil"))
+            .err()
+            .unwrap();
+        match err {
+            BridgeError::Config(msg) => {
+                assert!(
+                    msg.contains("bare origin") && msg.contains("no path"),
+                    "expected a bare-origin/no-path rejection; got {msg}"
+                );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_api_base_allows_bare_origin_with_port() {
+        // The path rejection must not false-positive on a `:port` origin —
+        // `host:port` has no `/` after the scheme.
+        let bridge = VertexBridge::new();
+        let resolved = bridge
+            .resolve_api_base("us-central1", Some("https://proxy.internal:8443"))
+            .unwrap();
+        assert_eq!(resolved, "https://proxy.internal:8443");
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes #435. Both platform-adapter bridges accept an operator-supplied origin override for an auth/data endpoint and already reject scheme / userinfo / query / fragment, but **neither rejected an embedded path component**:

- **Vertex** `resolve_api_base` (`crates/aisix-provider-vertex/src/bridge.rs`) — an `api_base` with a trailing path segment was accepted verbatim, silently redirecting every upstream call onto the wrong path.
- **Azure** `AadCredentials::validate` (`crates/aisix-provider-azure-openai/src/aad_token_mint.rs`) — same gap; a path segment would redirect the token endpoint (e.g. `https://login.microsoftonline.us/evil/{tenant}/oauth2/v2.0/token`).

## Fix

After the existing scheme check on both, reject a path segment so only `scheme://host[:port]` is accepted:

```rust
let after_scheme = b.split_once("://").map(|(_, r)| r).unwrap_or(b).trim_end_matches('/');
if after_scheme.contains('/') { return Err(BridgeError::Config("... bare origin ... no path ...")); }
```

Two deliberate details:
- **Trailing slash stays tolerated** — the check `trim_end_matches('/')` before testing, because Vertex already trims a trailing slash on return and Azure's `resolve_token_endpoint` trims it at URL-build time (both have existing tests for that). So `https://host/` validates; `https://host/evil` does not.
- **Runs after the userinfo/query/fragment rejections** — those reject with a fixed, no-echo message; the new path check echoes `{value:?}`, but at that point the value provably has no `@`/`?`/`#`, so it can't leak pasted `user:pass@host` credentials.

## Severity
LOW (per #435). The field is operator-supplied config from their own ProviderKey secret, not attacker-controlled request input — the failure mode is an operator typo producing a clean `Config` error instead of a confusing 404 token-mint / wrong upstream path. The host portion is whatever DNS name the operator chose, so there's no host-redirect or `client_secret`-exfiltration vector; a path prefix can't change the destination host.

## Tests
Per bridge:
- rejection: `https://host/evil` → `Config` error mentioning "bare origin" / "no path"
- allow (false-positive guard): `https://host:8443` (the `:port` colon must not trip the `/` check); Azure also re-confirms a bare trailing slash validates
- existing trailing-slash-trim tests still pass

`cargo test -p aisix-provider-vertex -p aisix-provider-azure-openai` → 92 + 68 passed. `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Azure AD credential authority host validation to ensure proper endpoint configuration and reject malformed paths.
  * Strengthened Vertex provider API base validation to enforce strict origin format requirements and reject embedded path components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->