### PR TITLE
ci: trigger docs site publish on docs changes

### DIFF
--- a/.github/workflows/publish-docs-site.yml
+++ b/.github/workflows/publish-docs-site.yml
@@ -1,0 +1,23 @@
+name: Publish docs.api7.ai
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+jobs:
+  dispatch-docs-site:
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Trigger docs site production deploy
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.APISIX_WEBSITE_GITHUB_TOKEN }}
+          repository: api7/docs
+          event-type: ai-gateway-docs-updated
+          client-payload: >-
+            {
+              "ai_gateway_sha": "${{ github.sha }}",
+              "ai_gateway_ref": "${{ github.ref_name }}"
+            }

--- a/.github/workflows/publish-docs-site.yml
+++ b/.github/workflows/publish-docs-site.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Trigger docs site production deploy
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.APISIX_WEBSITE_GITHUB_TOKEN }}
+          token: ${{ secrets.API7_CROSS_REPO_GITHUB_TOKEN }}
           repository: api7/docs
           event-type: ai-gateway-docs-updated
           client-payload: >-


### PR DESCRIPTION
## Summary
- add a workflow that triggers `api7/docs` production deploy on pushes to `main` that change `docs/**`
- send the exact AI Gateway commit SHA in the dispatch payload so `api7/docs` can build the matching docs revision

## Related PR
- `api7/docs` PR #1659 adds the receiving `repository_dispatch` trigger and the external AI Gateway docs integration

## Notes
- this uses `secrets.API7_CROSS_REPO_GITHUB_TOKEN` for cross-repo dispatch to `api7/docs`