### PR TITLE
fix(proxy): dispatch Model Groups across passthrough endpoints (#471)

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -38,25 +38,12 @@ use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
 use crate::render::{render_chunk, render_response};
 use crate::request_id::new_request_id;
-use crate::routing::is_retryable;
+use crate::routing::{is_retryable, resolve_attempt_models, AttemptModel};
 use crate::state::ProxyState;
 
 /// Header set on every non-streaming response indicating whether the
 /// response came from the cache (`hit`) or the upstream (`miss`).
 pub const CACHE_HEADER: &str = "x-aisix-cache";
-
-/// Default Retry-After (in seconds) returned to the client when every
-/// candidate is background-unhealthy and no cooldown timer is available
-/// to derive a more precise hint. Operators tune per-model cooldown
-/// TTLs via `cooldown.default_seconds`; this is only the all-unhealthy
-/// fallback for the `on_all_filtered: fail` path.
-const FALLBACK_ALL_UNHEALTHY_RETRY_AFTER: Duration = Duration::from_secs(30);
-
-#[derive(Clone)]
-struct AttemptModel {
-    id: String,
-    model: aisix_core::Model,
-}
 
 #[derive(Clone, Default)]
 struct RoutingTelemetry {
@@ -720,49 +707,15 @@ async fn dispatch(
     // Resolve the attempt-list of underlying Model entries. For a
     // routing model we walk targets per the configured strategy; for a
     // single-provider Model we just dispatch to it directly.
-    let attempt_models: Vec<AttemptModel> =
-        if let Some(routing) = virtual_entry.value.routing.as_ref() {
-            let names = state.routing.pick_targets(&req.model, routing);
-            if names.is_empty() {
-                return Err(with_model(ProxyError::InvalidRequest(
-                    "routing model has no targets".into(),
-                )));
-            }
-            let mut resolved = Vec::with_capacity(names.len());
-            for name in &names {
-                let target_entry = snapshot.models.get_by_name(name).ok_or_else(|| {
-                    with_model(ProxyError::InvalidRequest(format!(
-                        "routing target {name:?} does not resolve to a Model"
-                    )))
-                })?;
-                resolved.push(AttemptModel {
-                    id: target_entry.id.clone(),
-                    model: target_entry.value.clone(),
-                });
-            }
-            match filter_attempt_models(
-                &state.runtime_status,
-                resolved,
-                routing.on_all_filtered_or_default(),
-            ) {
-                FilterOutcome::Selected(list) => list,
-                FilterOutcome::AllUnhealthy { retry_after_secs } => {
-                    tracing::warn!(
-                        virtual_model = %req.model,
-                        retry_after_secs,
-                        "all routing candidates are unavailable; failing fast",
-                    );
-                    return Err(with_model(ProxyError::AllCandidatesUnavailable {
-                        retry_after_secs,
-                    }));
-                }
-            }
-        } else {
-            vec![AttemptModel {
-                id: virtual_entry.id.clone(),
-                model: virtual_entry.value.clone(),
-            }]
-        };
+    let attempt_models: Vec<AttemptModel> = resolve_attempt_models(
+        &state.routing,
+        &state.runtime_status,
+        &snapshot,
+        &req.model,
+        &virtual_entry.id,
+        &virtual_entry.value,
+    )
+    .map_err(&with_model)?;
 
     // For non-routing requests, surface a misconfigured bridge as a
     // proper 503 rather than burying it inside a generic Bridge error.
@@ -1482,88 +1435,6 @@ async fn dispatch(
         served_by_target,
         routing,
     })
-}
-
-/// Outcome of routing-candidate filtering. Lifts the "all candidates
-/// excluded" case out into a typed result so the dispatch loop can
-/// short-circuit to a 503 + Retry-After instead of sending traffic to
-/// a target we just confirmed is bad.
-enum FilterOutcome {
-    /// At least one candidate survived the filter. The returned vector
-    /// is the filtered attempt list, in the original strategy order
-    /// minus the excluded entries.
-    Selected(Vec<AttemptModel>),
-    /// Every candidate is currently background-unhealthy and the
-    /// routing model is configured with `on_all_filtered: fail`. The
-    /// caller should surface a 503 with the supplied Retry-After hint
-    /// (in seconds), if any.
-    AllUnhealthy { retry_after_secs: Option<u64> },
-}
-
-fn filter_attempt_models(
-    runtime_status: &crate::ModelRuntimeStatusTracker,
-    attempts: Vec<AttemptModel>,
-    policy: aisix_core::OnAllFilteredPolicy,
-) -> FilterOutcome {
-    use aisix_core::OnAllFilteredPolicy;
-
-    let mut healthy = Vec::new();
-    let mut cooldown_only = Vec::new();
-    let mut unhealthy_count = 0usize;
-
-    for attempt in attempts.iter().cloned() {
-        let stale_after = attempt
-            .model
-            .background_model_check
-            .as_ref()
-            .map(|cfg| Duration::from_secs(cfg.stale_after_seconds));
-        let snapshot = runtime_status.status_with_stale(&attempt.id, stale_after);
-        match snapshot.status {
-            crate::RuntimeStatus::Unhealthy => unhealthy_count += 1,
-            crate::RuntimeStatus::Cooldown => cooldown_only.push(attempt),
-            crate::RuntimeStatus::Healthy | crate::RuntimeStatus::NotApplicable => {
-                healthy.push(attempt)
-            }
-        }
-    }
-
-    if !healthy.is_empty() {
-        return FilterOutcome::Selected(healthy);
-    }
-    // No healthy candidates — prefer cooldown over unhealthy when
-    // some non-unhealthy candidates exist. Sending to a target whose
-    // cooldown timer hasn't expired is still better than sending to
-    // a target that an active probe just confirmed is broken.
-    if unhealthy_count < attempts.len() && !cooldown_only.is_empty() {
-        let filtered: Vec<AttemptModel> = attempts
-            .into_iter()
-            .filter(|attempt| {
-                let stale_after = attempt
-                    .model
-                    .background_model_check
-                    .as_ref()
-                    .map(|cfg| Duration::from_secs(cfg.stale_after_seconds));
-                runtime_status.should_skip_for_routing(&attempt.id, stale_after)
-                    != crate::RuntimeStatus::Unhealthy
-            })
-            .collect();
-        return FilterOutcome::Selected(filtered);
-    }
-    // All candidates are excluded. Policy decides.
-    //
-    // Retry-After for the fail path is a coarse fallback (30s by
-    // default — see FALLBACK_ALL_UNHEALTHY_RETRY_AFTER). We could
-    // try to derive it from per-candidate cooldown timers, but the
-    // categorisation above routes cooldown candidates into
-    // `cooldown_only` (returned via the Selected branch above), so
-    // by construction every candidate that reaches here is in the
-    // background-unhealthy state and has no cooldown timer to read.
-    match policy {
-        OnAllFilteredPolicy::Fail => FilterOutcome::AllUnhealthy {
-            retry_after_secs: Some(FALLBACK_ALL_UNHEALTHY_RETRY_AFTER.as_secs()),
-        },
-        OnAllFilteredPolicy::OriginalOrder => FilterOutcome::Selected(attempts),
-    }
 }
 
 /// Wire-shape label for `FinishReason`. cp-api stores this verbatim
@@ -2690,127 +2561,6 @@ mod cooldown_tests {
     fn config_error_never_cools_down() {
         // Misconfig = WE are wrong; cooling down doesn't help.
         assert!(decide_cooldown(&BridgeError::Config("bad key".into()), None).is_none());
-    }
-}
-
-#[cfg(test)]
-mod filter_tests {
-    use super::*;
-    use aisix_core::{Model, OnAllFilteredPolicy};
-    use std::time::Duration as StdDuration;
-
-    fn am(id: &str) -> AttemptModel {
-        let model: Model = serde_json::from_str(&format!(
-            r#"{{
-              "display_name": "{id}",
-              "provider": "openai",
-              "model_name": "gpt-4o-mini",
-              "provider_key_id": "pk-{id}"
-            }}"#
-        ))
-        .unwrap();
-        AttemptModel {
-            id: id.to_string(),
-            model,
-        }
-    }
-
-    #[test]
-    fn healthy_only_returns_all_healthy() {
-        let t = crate::ModelRuntimeStatusTracker::new();
-        let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 2);
-            }
-            other => panic!(
-                "expected Selected, got {:?}",
-                std::mem::discriminant(&other)
-            ),
-        }
-    }
-
-    #[test]
-    fn cooldown_skipped_when_healthy_present() {
-        let t = crate::ModelRuntimeStatusTracker::new();
-        t.mark_cooldown("a", StdDuration::from_secs(30), "retryable_failure");
-        let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 1);
-                assert_eq!(list[0].id, "b");
-            }
-            _ => panic!("expected Selected"),
-        }
-    }
-
-    #[test]
-    fn all_unhealthy_fail_policy_returns_retry_after_hint() {
-        // H3 contract: every candidate background-unhealthy, no
-        // cooldown timer → return 503 + fallback Retry-After (30s
-        // default). The dispatch loop converts this to a
-        // ProxyError::AllCandidatesUnavailable.
-        let t = crate::ModelRuntimeStatusTracker::new();
-        t.mark_unhealthy("a", Some(503), "background_check_failed");
-        t.mark_unhealthy("b", Some(503), "background_check_failed");
-        let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
-            FilterOutcome::AllUnhealthy { retry_after_secs } => {
-                assert_eq!(retry_after_secs, Some(30));
-            }
-            _ => panic!("expected AllUnhealthy"),
-        }
-    }
-
-    #[test]
-    fn one_cooldown_with_all_else_unhealthy_keeps_the_cooldown_candidate() {
-        // Mixed scenario: candidates a/b are background-unhealthy, c
-        // is in cooldown. The filter should pick c (cooldown beats
-        // unhealthy), not fail.
-        let t = crate::ModelRuntimeStatusTracker::new();
-        t.mark_unhealthy("a", Some(503), "background_check_failed");
-        t.mark_unhealthy("b", Some(503), "background_check_failed");
-        t.mark_cooldown("c", StdDuration::from_secs(30), "x");
-        let attempts = vec![am("a"), am("b"), am("c")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 1);
-                assert_eq!(list[0].id, "c");
-            }
-            _ => panic!("expected Selected with cooldown candidate"),
-        }
-    }
-
-    #[test]
-    fn all_unhealthy_original_order_policy_returns_full_list() {
-        // Legacy opt-in: send to all candidates regardless.
-        let t = crate::ModelRuntimeStatusTracker::new();
-        t.mark_unhealthy("a", Some(503), "background_check_failed");
-        t.mark_unhealthy("b", Some(503), "background_check_failed");
-        let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::OriginalOrder) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 2);
-            }
-            _ => panic!("expected Selected under OriginalOrder policy"),
-        }
-    }
-
-    #[test]
-    fn cooldown_no_unhealthy_returns_cooldown_candidates() {
-        // No healthy, no unhealthy — all candidates have a cooldown
-        // timer set. Routing should still pick from them (better than
-        // erroring out when we don't have evidence anyone is *broken*).
-        let t = crate::ModelRuntimeStatusTracker::new();
-        t.mark_cooldown("a", StdDuration::from_secs(30), "x");
-        t.mark_cooldown("b", StdDuration::from_secs(30), "x");
-        let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 2);
-            }
-            _ => panic!("expected Selected for cooldown-only"),
-        }
     }
 }
 

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -57,7 +57,7 @@ pub async fn count_tokens(
         Ok(a) => a,
         Err(e) => return e.into_anthropic_response(),
     };
-    let Json(mut body) = match body {
+    let Json(body) = match body {
         Ok(j) => j,
         Err(rej) => {
             return crate::error::proxy_error_from_json_rejection(
@@ -78,7 +78,7 @@ pub async fn count_tokens(
         .unwrap_or("")
         .to_string();
 
-    match dispatch(&state, &auth, &mut body, &request_id).await {
+    match dispatch(&state, &auth, &body, &request_id).await {
         Ok((resp, provider)) => {
             let elapsed = started.elapsed();
             let status = resp.status().as_u16();
@@ -127,7 +127,7 @@ pub async fn count_tokens(
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
-    body: &mut Value,
+    body: &Value,
     request_id: &str,
 ) -> Result<(Response, String), ProxyError> {
     let snapshot = state.snapshot.load();
@@ -151,20 +151,83 @@ async fn dispatch(
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
-    let model = &model_entry.value;
+    // Resolve the attempt list (routing-aware). count_tokens is
+    // Anthropic-only, so we attempt the group's Anthropic targets in
+    // order; a direct model resolves to itself (#471).
+    let attempt_models = crate::routing::resolve_attempt_models(
+        &state.routing,
+        &state.runtime_status,
+        &snapshot,
+        &model_name,
+        &model_entry.id,
+        &model_entry.value,
+    )?;
+    let retry_on_429 = model_entry
+        .value
+        .routing
+        .as_ref()
+        .map(|r| r.retry_on_429_or_default())
+        .unwrap_or(false);
 
-    // count_tokens is an Anthropic Messages sub-route; only Anthropic
-    // exposes it at `…/v1/messages/count_tokens`. Reject any other
-    // provider at the boundary with a 400 rather than dispatching to an
-    // upstream that would 404 (parallel to /v1/rerank's provider gate).
-    if model.provider.as_deref() != Some("anthropic") {
+    let mut last_err: Option<ProxyError> = None;
+    let mut any_anthropic = false;
+    for target in &attempt_models {
+        // count_tokens has no upstream equivalent for non-Anthropic
+        // providers; skip foreign targets in a mixed group rather than
+        // dispatching to an upstream that would 404.
+        if target.model.provider.as_deref() != Some("anthropic") {
+            continue;
+        }
+        any_anthropic = true;
+        match count_tokens_to_target(
+            state,
+            &snapshot,
+            body,
+            &target.model,
+            &target.id,
+            request_id,
+        )
+        .await
+        {
+            Ok(resp) => return Ok((resp, "anthropic".to_string())),
+            Err(e) => {
+                let retryable = matches!(
+                    &e,
+                    ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429)
+                );
+                last_err = Some(e);
+                if !retryable {
+                    break;
+                }
+            }
+        }
+    }
+
+    // No Anthropic target to serve count_tokens. Reject at the boundary
+    // with a 400 (parallel to /v1/rerank's provider gate) rather than
+    // dispatching to an upstream that would 404.
+    if !any_anthropic {
         return Err(ProxyError::InvalidRequest(format!(
             "model `{model_name}` is not an Anthropic provider; \
              /v1/messages/count_tokens requires an Anthropic-backed model"
         )));
     }
+    Err(last_err.unwrap_or(ProxyError::ProviderUnavailable))
+}
 
-    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+/// Dispatch one concrete Anthropic target's count_tokens passthrough to
+/// `{api_base}/v1/messages/count_tokens`. The caller has already
+/// confirmed `model.provider == anthropic`.
+async fn count_tokens_to_target(
+    state: &ProxyState,
+    snapshot: &aisix_core::AisixSnapshot,
+    body: &Value,
+    model: &aisix_core::Model,
+    model_id: &str,
+    request_id: &str,
+) -> Result<Response, ProxyError> {
+    let mut body = body.clone();
+    let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
     let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
@@ -182,11 +245,14 @@ async fn dispatch(
     // order matches §5: renames → constraints → defaults; each is a
     // no-op when its configured map is empty.
     if let Some(r) = pk_entry.value.request.as_ref() {
-        aisix_provider_openai::overrides::apply_param_renames(body, &r.param_renames);
+        aisix_provider_openai::overrides::apply_param_renames(&mut body, &r.param_renames);
         if let Some(constraints) = &r.param_constraints {
-            aisix_provider_openai::overrides::apply_param_constraints(body, constraints);
+            aisix_provider_openai::overrides::apply_param_constraints(&mut body, constraints);
         }
-        aisix_provider_openai::overrides::apply_default_body_fields(body, &r.default_body_fields);
+        aisix_provider_openai::overrides::apply_default_body_fields(
+            &mut body,
+            &r.default_body_fields,
+        );
     }
 
     // `build_v1_url` tolerates an api_base with or without `/v1` (the
@@ -233,13 +299,13 @@ async fn dispatch(
     let upstream_resp = client
         .post(&url)
         .headers(headers)
-        .json(body)
+        .json(&body)
         .send()
         .await
         .map_err(|e| {
             crate::cooldown::note_failure(
                 &state.runtime_status,
-                &model_entry.id,
+                model_id,
                 model.cooldown.as_ref(),
                 aisix_gateway::BridgeError::Transport(e.to_string()),
             )
@@ -272,15 +338,13 @@ async fn dispatch(
         );
         if let Some((ttl, reason)) = crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
         {
-            state
-                .runtime_status
-                .mark_cooldown(&model_entry.id, ttl, reason);
+            state.runtime_status.mark_cooldown(model_id, ttl, reason);
         }
         return Err(ProxyError::Bridge(err));
     }
 
-    state.health.record_success(&model_name);
-    state.runtime_status.mark_healthy(&model_entry.id);
+    state.health.record_success(&model.display_name);
+    state.runtime_status.mark_healthy(model_id);
 
     // Forward the `{"input_tokens": <int>}` response body verbatim — the
     // gateway adds nothing to the token-counting contract.
@@ -291,7 +355,7 @@ async fn dispatch(
         .map_err(|e| {
             crate::cooldown::note_failure(
                 &state.runtime_status,
-                &model_entry.id,
+                model_id,
                 model.cooldown.as_ref(),
                 aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
             )
@@ -313,7 +377,7 @@ async fn dispatch(
             .insert(HeaderName::from_static("x-aisix-request-id"), hv);
     }
 
-    Ok((resp, "anthropic".to_string()))
+    Ok(resp)
 }
 
 fn emit_access_log(

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -521,7 +521,7 @@ async fn anthropic_passthrough_dispatch(
     // that recovered via the Anthropic passthrough would stay in
     // `cooldown` on /admin/v1/models/status until its TTL naturally
     // expired (round-2 audit MEDIUM on PR #268).
-    state.health.record_success(model_name);
+    state.health.record_success(&model.display_name);
     state.runtime_status.mark_healthy(model_id);
 
     let provider_label = "anthropic".to_string();
@@ -866,7 +866,7 @@ async fn cross_provider_dispatch(
         }
         ProxyError::Bridge(err)
     })?;
-    state.health.record_success(model_name);
+    state.health.record_success(&model.display_name);
     state.runtime_status.mark_healthy(model_id);
 
     let metrics = AnthropicUsageMetrics {

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -243,23 +243,38 @@ async fn dispatch(
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
-    let model = &model_entry.value;
-    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    // Resolve the attempt list. For a Model Group (routing model) this
+    // walks `routing.targets` and health-filters them; for a direct
+    // model it's just the model itself. Shared with /v1/chat/completions
+    // so both endpoints dispatch Model Groups identically (#471).
+    let attempt_models = crate::routing::resolve_attempt_models(
+        &state.routing,
+        &state.runtime_status,
+        &snapshot,
+        &model_name,
+        &model_entry.id,
+        &model_entry.value,
+    )?;
 
-    // Cross-provider path: when the resolved Model points at a non-
-    // Anthropic upstream, parse the Anthropic-shape body into the
-    // gateway's internal ChatFormat, dispatch through the Hub, and
-    // re-encode the bridge's response as Anthropic JSON or SSE.
-    // The Anthropic-upstream branch below stays as a byte-for-byte
-    // passthrough to preserve features (cache_control, thinking
-    // blocks, …) the cross-provider path can't lossily round-trip.
-    if model.provider.as_deref() != Some("anthropic") {
-        return cross_provider_dispatch(
+    let is_stream = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let retry_on_429 = model_entry
+        .value
+        .routing
+        .as_ref()
+        .map(|r| r.retry_on_429_or_default())
+        .unwrap_or(false);
+
+    // Streaming attempts only the first target (no mid-stream fallback),
+    // matching /v1/chat/completions.
+    if is_stream {
+        return dispatch_to_target(
             state,
+            &snapshot,
             body,
-            model,
-            &model_entry.id,
-            &pk_entry.value,
+            &attempt_models[0],
             &model_name,
             request_id,
             started,
@@ -270,7 +285,116 @@ async fn dispatch(
         .await;
     }
 
-    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
+    // Non-streaming: walk targets, failing over to the next only on a
+    // retryable upstream failure. A 4xx / config error is returned
+    // as-is — retrying other targets won't help.
+    let n = attempt_models.len();
+    let mut last_err: Option<ProxyError> = None;
+    for (i, target) in attempt_models.iter().enumerate() {
+        match dispatch_to_target(
+            state,
+            &snapshot,
+            body,
+            target,
+            &model_name,
+            request_id,
+            started,
+            &auth.entry.id,
+            auth.key().team_id.clone(),
+            auth.key().user_id.clone(),
+        )
+        .await
+        {
+            Ok(outcome) => return Ok(outcome),
+            Err(e) => {
+                let retryable = matches!(
+                    &e,
+                    ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429)
+                );
+                last_err = Some(e);
+                if !(retryable && i + 1 < n) {
+                    break;
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap_or(ProxyError::ProviderUnavailable))
+}
+
+/// Dispatch one concrete (non-routing) target Model. Branches on the
+/// target's provider: Anthropic upstreams go through the byte-for-byte
+/// passthrough, everything else through the cross-provider translation.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_to_target(
+    state: &ProxyState,
+    snapshot: &aisix_core::AisixSnapshot,
+    body: &Value,
+    target: &crate::routing::AttemptModel,
+    model_name: &str,
+    request_id: &str,
+    started: Instant,
+    api_key_id: &str,
+    team_id: Option<String>,
+    user_id: Option<String>,
+) -> Result<DispatchOutcome, ProxyError> {
+    let model = &target.model;
+    let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
+
+    if model.provider.as_deref() != Some("anthropic") {
+        return cross_provider_dispatch(
+            state,
+            body,
+            model,
+            &target.id,
+            &pk_entry.value,
+            model_name,
+            request_id,
+            started,
+            api_key_id,
+            team_id,
+            user_id,
+        )
+        .await;
+    }
+
+    anthropic_passthrough_dispatch(
+        state,
+        body,
+        model,
+        &target.id,
+        &pk_entry.value,
+        &pk_entry.id,
+        model_name,
+        request_id,
+        started,
+        api_key_id,
+        team_id,
+        user_id,
+    )
+    .await
+}
+
+/// Anthropic-protocol input -> Anthropic upstream: byte-for-byte
+/// passthrough to `{api_base}/v1/messages`. Adds the `x-api-key` +
+/// `anthropic-version` headers, rewrites the `model` field to the
+/// upstream id, and streams the SSE response verbatim.
+#[allow(clippy::too_many_arguments)]
+async fn anthropic_passthrough_dispatch(
+    state: &ProxyState,
+    body: &Value,
+    model: &aisix_core::Model,
+    model_id: &str,
+    pk_value: &aisix_core::ProviderKey,
+    pk_id: &str,
+    model_name: &str,
+    request_id: &str,
+    started: Instant,
+    api_key_id: &str,
+    team_id: Option<String>,
+    user_id: Option<String>,
+) -> Result<DispatchOutcome, ProxyError> {
+    let mut body = body.clone();
+    let api_key = crate::dispatch::require_secret(pk_value, model)?;
 
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
@@ -290,19 +414,22 @@ async fn dispatch(
     //
     // Apply order matches §5: renames → constraints → defaults. Each
     // primitive is a no-op when its configured map is empty.
-    if let Some(r) = pk_entry.value.request.as_ref() {
-        aisix_provider_openai::overrides::apply_param_renames(body, &r.param_renames);
+    if let Some(r) = pk_value.request.as_ref() {
+        aisix_provider_openai::overrides::apply_param_renames(&mut body, &r.param_renames);
         if let Some(constraints) = &r.param_constraints {
-            aisix_provider_openai::overrides::apply_param_constraints(body, constraints);
+            aisix_provider_openai::overrides::apply_param_constraints(&mut body, constraints);
         }
-        aisix_provider_openai::overrides::apply_default_body_fields(body, &r.default_body_fields);
+        aisix_provider_openai::overrides::apply_default_body_fields(
+            &mut body,
+            &r.default_body_fields,
+        );
     }
 
     // Build the target URL. build_v1_url tolerates the rare case
     // where the customer mistakenly puts `/v1` in the Anthropic
     // api_base (the dashboard placeholder uses the OpenAI form, so
     // this is a copy-paste hazard).
-    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
+    let base = crate::dispatch::resolve_base_url(pk_value)?;
     let url = crate::dispatch::build_v1_url(&base, "/messages");
 
     // Check if the request wants streaming.
@@ -340,12 +467,12 @@ async fn dispatch(
         )))
     })?;
     headers.insert(HeaderName::from_static("x-aisix-request-id"), rid_hv);
-    if let Some(r) = pk_entry.value.request.as_ref() {
+    if let Some(r) = pk_value.request.as_ref() {
         aisix_provider_openai::overrides::apply_default_headers(&mut headers, &r.default_headers);
     }
 
     let client = crate::http_client::client();
-    let req_builder = client.post(&url).headers(headers).json(body);
+    let req_builder = client.post(&url).headers(headers).json(&body);
 
     let upstream_resp = req_builder
         .send()
@@ -353,7 +480,7 @@ async fn dispatch(
         .map_err(|e| {
             crate::cooldown::note_failure(
                 &state.runtime_status,
-                &model_entry.id,
+                model_id,
                 model.cooldown.as_ref(),
                 aisix_gateway::BridgeError::Transport(e.to_string()),
             )
@@ -383,9 +510,7 @@ async fn dispatch(
         // upstream. See `crate::cooldown` for the shared decision.
         if let Some((ttl, reason)) = crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
         {
-            state
-                .runtime_status
-                .mark_cooldown(&model_entry.id, ttl, reason);
+            state.runtime_status.mark_cooldown(model_id, ttl, reason);
         }
         return Err(ProxyError::Bridge(err));
     }
@@ -396,8 +521,8 @@ async fn dispatch(
     // that recovered via the Anthropic passthrough would stay in
     // `cooldown` on /admin/v1/models/status until its TTL naturally
     // expired (round-2 audit MEDIUM on PR #268).
-    state.health.record_success(&model_name);
-    state.runtime_status.mark_healthy(&model_entry.id);
+    state.health.record_success(model_name);
+    state.runtime_status.mark_healthy(model_id);
 
     let provider_label = "anthropic".to_string();
 
@@ -420,14 +545,14 @@ async fn dispatch(
         // CompleteOnDrop pattern as chat.rs::build_sse_stream).
         let state_c = state.clone();
         let request_id_c = request_id.to_string();
-        let model_id_c = model_entry.id.clone();
-        let api_key_id_c = auth.entry.id.clone();
+        let model_id_c = model_id.to_string();
+        let api_key_id_c = api_key_id.to_string();
         let provider_c = provider_label.clone();
-        let model_name_c = model_name.clone();
-        let provider_key_id_c = pk_entry.id.clone();
+        let model_name_c = model_name.to_string();
+        let provider_key_id_c = pk_id.to_string();
         let upstream_model_c = upstream_model.clone();
-        let team_id_c = auth.key().team_id.clone();
-        let user_id_c = auth.key().user_id.clone();
+        let team_id_c = team_id.clone();
+        let user_id_c = user_id.clone();
 
         let parsed_stream =
             build_anthropic_passthrough_stream(body_stream, started, move |usage| {
@@ -492,7 +617,7 @@ async fn dispatch(
         Ok(DispatchOutcome {
             response,
             provider_label,
-            provider_key_id: pk_entry.id.clone(),
+            provider_key_id: pk_id.to_string(),
             upstream_model: upstream_model.clone(),
             metrics: AnthropicUsageMetrics::default(),
             usage_handled_by_stream: true,
@@ -508,7 +633,7 @@ async fn dispatch(
             .map_err(|e| {
                 crate::cooldown::note_failure(
                     &state.runtime_status,
-                    &model_entry.id,
+                    model_id,
                     model.cooldown.as_ref(),
                     aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
                 )
@@ -522,14 +647,14 @@ async fn dispatch(
         if let Some(m) = json_body.get_mut("model") {
             // If the upstream echoes the model name, rewrite to the gateway name.
             if m.as_str().map(|s| s == upstream_model).unwrap_or(false) {
-                *m = Value::String(model_name.clone());
+                *m = Value::String(model_name.to_string());
             }
         }
 
         Ok(DispatchOutcome {
             response: Json(json_body).into_response(),
             provider_label,
-            provider_key_id: pk_entry.id.clone(),
+            provider_key_id: pk_id.to_string(),
             upstream_model,
             metrics,
             usage_handled_by_stream: false,

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -63,7 +63,7 @@ struct ResponseUsage {
 pub async fn responses(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
-    Json(mut body): Json<Value>,
+    Json(body): Json<Value>,
 ) -> Response {
     let started = Instant::now();
     let request_id = new_request_id();
@@ -75,7 +75,7 @@ pub async fn responses(
         .unwrap_or("")
         .to_string();
 
-    match dispatch(&state, &auth, &mut body, &request_id).await {
+    match dispatch(&state, &auth, &body, &request_id).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             let status = success.response.status().as_u16();
@@ -141,7 +141,7 @@ pub async fn responses(
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
-    body: &mut Value,
+    body: &Value,
     request_id: &str,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
     let snapshot = state.snapshot.load();
@@ -165,16 +165,103 @@ async fn dispatch(
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
-    let model = &model_entry.value;
+    // Resolve the attempt list (routing-aware). /v1/responses is
+    // OpenAI-only, so we attempt the group's OpenAI targets in order; a
+    // direct model resolves to itself (#471).
+    let attempt_models = crate::routing::resolve_attempt_models(
+        &state.routing,
+        &state.runtime_status,
+        &snapshot,
+        &model_name,
+        &model_entry.id,
+        &model_entry.value,
+    )?;
+    let retry_on_429 = model_entry
+        .value
+        .routing
+        .as_ref()
+        .map(|r| r.retry_on_429_or_default())
+        .unwrap_or(false);
 
-    // Responses API is only available for OpenAI.
-    if model.provider.as_deref() != Some("openai") {
-        return Err(ProxyError::InvalidRequest(format!(
+    let is_stream = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let not_openai = || {
+        ProxyError::InvalidRequest(format!(
             "model `{model_name}` is not an OpenAI provider; /v1/responses requires OpenAI"
-        )));
+        ))
+    };
+
+    // Streaming attempts the first eligible target only (no mid-stream
+    // fallback), matching /v1/chat/completions and /v1/messages.
+    if is_stream {
+        let target = attempt_models
+            .iter()
+            .find(|t| t.model.provider.as_deref() == Some("openai"))
+            .ok_or_else(not_openai)?;
+        return responses_to_target(
+            state,
+            &snapshot,
+            body,
+            &target.model,
+            &target.id,
+            request_id,
+        )
+        .await;
     }
 
-    let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
+    let mut last_err: Option<ProxyError> = None;
+    let mut any_openai = false;
+    for target in &attempt_models {
+        if target.model.provider.as_deref() != Some("openai") {
+            continue;
+        }
+        any_openai = true;
+        match responses_to_target(
+            state,
+            &snapshot,
+            body,
+            &target.model,
+            &target.id,
+            request_id,
+        )
+        .await
+        {
+            Ok(success) => return Ok(success),
+            Err(e) => {
+                let retryable = matches!(
+                    &e,
+                    ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429)
+                );
+                last_err = Some(e);
+                if !retryable {
+                    break;
+                }
+            }
+        }
+    }
+
+    if !any_openai {
+        return Err(not_openai());
+    }
+    Err(last_err.unwrap_or(ProxyError::ProviderUnavailable))
+}
+
+/// Dispatch one concrete OpenAI target's Responses-API passthrough to
+/// `{api_base}/v1/responses`. The caller has already confirmed
+/// `model.provider == openai`.
+async fn responses_to_target(
+    state: &ProxyState,
+    snapshot: &aisix_core::AisixSnapshot,
+    body: &Value,
+    model: &aisix_core::Model,
+    model_id: &str,
+    request_id: &str,
+) -> Result<ResponseDispatchSuccess, ProxyError> {
+    let mut body = body.clone();
+    let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
     let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
@@ -202,13 +289,13 @@ async fn dispatch(
         .header("authorization", format!("Bearer {api_key}"))
         .header("content-type", "application/json")
         .header("x-aisix-request-id", request_id)
-        .json(body)
+        .json(&body)
         .send()
         .await
         .map_err(|e| {
             crate::cooldown::note_failure(
                 &state.runtime_status,
-                &model_entry.id,
+                model_id,
                 model.cooldown.as_ref(),
                 aisix_gateway::BridgeError::Transport(e.to_string()),
             )
@@ -228,15 +315,13 @@ async fn dispatch(
         );
         if let Some((ttl, reason)) = crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
         {
-            state
-                .runtime_status
-                .mark_cooldown(&model_entry.id, ttl, reason);
+            state.runtime_status.mark_cooldown(model_id, ttl, reason);
         }
         return Err(ProxyError::Bridge(err));
     }
 
-    state.health.record_success(&model_name);
-    state.runtime_status.mark_healthy(&model_entry.id);
+    state.health.record_success(&model.display_name);
+    state.runtime_status.mark_healthy(model_id);
 
     let provider_label = "openai".to_string();
 
@@ -270,7 +355,7 @@ async fn dispatch(
             response,
             provider: provider_label,
             usage: None,
-            model_id: model_entry.id.to_string(),
+            model_id: model_id.to_string(),
         })
     } else {
         let json_body: Value = upstream_resp
@@ -279,7 +364,7 @@ async fn dispatch(
             .map_err(|e| {
                 crate::cooldown::note_failure(
                     &state.runtime_status,
-                    &model_entry.id,
+                    model_id,
                     model.cooldown.as_ref(),
                     aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
                 )
@@ -296,7 +381,7 @@ async fn dispatch(
             response: Json(json_body).into_response(),
             provider: provider_label,
             usage,
-            model_id: model_entry.id.to_string(),
+            model_id: model_id.to_string(),
         })
     }
 }

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -14,11 +14,23 @@
 //!   to `weight`, then walk forward on failure (weights only affect the
 //!   *first* target choice — once we're falling back, order is positional).
 
-use aisix_core::{Routing, RoutingStrategy, RoutingTarget};
+use aisix_core::{
+    AisixSnapshot, Model, OnAllFilteredPolicy, Routing, RoutingStrategy, RoutingTarget,
+};
 use aisix_gateway::BridgeError;
 use dashmap::DashMap;
 use rand::Rng;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use crate::error::ProxyError;
+
+/// Default Retry-After (in seconds) returned to the client when every
+/// candidate is background-unhealthy and no cooldown timer is available
+/// to derive a more precise hint. Operators tune per-model cooldown
+/// TTLs via `cooldown.default_seconds`; this is only the all-unhealthy
+/// fallback for the `on_all_filtered: fail` path.
+const FALLBACK_ALL_UNHEALTHY_RETRY_AFTER: Duration = Duration::from_secs(30);
 
 /// Whether a Bridge error is retryable at all, optionally treating 429
 /// as retryable. Non-429 4xx is the caller's mistake — retrying won't
@@ -136,6 +148,153 @@ fn weighted_pick(targets: &[RoutingTarget]) -> usize {
         }
     }
     targets.len() - 1
+}
+
+/// One concrete (non-routing) Model the dispatch loop will attempt, paired
+/// with its snapshot id so health/cooldown tracking can key on it.
+#[derive(Clone)]
+pub(crate) struct AttemptModel {
+    pub id: String,
+    pub model: Model,
+}
+
+/// Outcome of routing-candidate filtering. Lifts the "all candidates
+/// excluded" case out into a typed result so the dispatch loop can
+/// short-circuit to a 503 + Retry-After instead of sending traffic to
+/// a target we just confirmed is bad.
+pub(crate) enum FilterOutcome {
+    /// At least one candidate survived the filter. The returned vector
+    /// is the filtered attempt list, in the original strategy order
+    /// minus the excluded entries.
+    Selected(Vec<AttemptModel>),
+    /// Every candidate is currently background-unhealthy and the
+    /// routing model is configured with `on_all_filtered: fail`. The
+    /// caller should surface a 503 with the supplied Retry-After hint
+    /// (in seconds), if any.
+    AllUnhealthy { retry_after_secs: Option<u64> },
+}
+
+pub(crate) fn filter_attempt_models(
+    runtime_status: &crate::ModelRuntimeStatusTracker,
+    attempts: Vec<AttemptModel>,
+    policy: OnAllFilteredPolicy,
+) -> FilterOutcome {
+    let mut healthy = Vec::new();
+    let mut cooldown_only = Vec::new();
+    let mut unhealthy_count = 0usize;
+
+    for attempt in attempts.iter().cloned() {
+        let stale_after = attempt
+            .model
+            .background_model_check
+            .as_ref()
+            .map(|cfg| Duration::from_secs(cfg.stale_after_seconds));
+        let snapshot = runtime_status.status_with_stale(&attempt.id, stale_after);
+        match snapshot.status {
+            crate::RuntimeStatus::Unhealthy => unhealthy_count += 1,
+            crate::RuntimeStatus::Cooldown => cooldown_only.push(attempt),
+            crate::RuntimeStatus::Healthy | crate::RuntimeStatus::NotApplicable => {
+                healthy.push(attempt)
+            }
+        }
+    }
+
+    if !healthy.is_empty() {
+        return FilterOutcome::Selected(healthy);
+    }
+    // No healthy candidates — prefer cooldown over unhealthy when
+    // some non-unhealthy candidates exist. Sending to a target whose
+    // cooldown timer hasn't expired is still better than sending to
+    // a target that an active probe just confirmed is broken.
+    if unhealthy_count < attempts.len() && !cooldown_only.is_empty() {
+        let filtered: Vec<AttemptModel> = attempts
+            .into_iter()
+            .filter(|attempt| {
+                let stale_after = attempt
+                    .model
+                    .background_model_check
+                    .as_ref()
+                    .map(|cfg| Duration::from_secs(cfg.stale_after_seconds));
+                runtime_status.should_skip_for_routing(&attempt.id, stale_after)
+                    != crate::RuntimeStatus::Unhealthy
+            })
+            .collect();
+        return FilterOutcome::Selected(filtered);
+    }
+    // All candidates are excluded. Policy decides.
+    //
+    // Retry-After for the fail path is a coarse fallback (30s by
+    // default — see FALLBACK_ALL_UNHEALTHY_RETRY_AFTER). We could
+    // try to derive it from per-candidate cooldown timers, but the
+    // categorisation above routes cooldown candidates into
+    // `cooldown_only` (returned via the Selected branch above), so
+    // by construction every candidate that reaches here is in the
+    // background-unhealthy state and has no cooldown timer to read.
+    match policy {
+        OnAllFilteredPolicy::Fail => FilterOutcome::AllUnhealthy {
+            retry_after_secs: Some(FALLBACK_ALL_UNHEALTHY_RETRY_AFTER.as_secs()),
+        },
+        OnAllFilteredPolicy::OriginalOrder => FilterOutcome::Selected(attempts),
+    }
+}
+
+/// Resolve the ordered list of concrete Models a request will attempt.
+///
+/// For a routing model (Model Group), walk `routing.targets` per the
+/// configured strategy, resolve each target name to a Model in the
+/// snapshot, then apply the health/cooldown filter. For a direct
+/// (non-routing) model, the list is just the model itself.
+///
+/// Shared by `/v1/chat/completions` and `/v1/messages` so both endpoints
+/// dispatch Model Groups identically (ai-gateway#471).
+pub(crate) fn resolve_attempt_models(
+    routing_registry: &RoutingRegistry,
+    runtime_status: &crate::ModelRuntimeStatusTracker,
+    snapshot: &AisixSnapshot,
+    virtual_name: &str,
+    virtual_id: &str,
+    virtual_model: &Model,
+) -> Result<Vec<AttemptModel>, ProxyError> {
+    let Some(routing) = virtual_model.routing.as_ref() else {
+        return Ok(vec![AttemptModel {
+            id: virtual_id.to_string(),
+            model: virtual_model.clone(),
+        }]);
+    };
+
+    let names = routing_registry.pick_targets(virtual_name, routing);
+    if names.is_empty() {
+        return Err(ProxyError::InvalidRequest(
+            "routing model has no targets".into(),
+        ));
+    }
+    let mut resolved = Vec::with_capacity(names.len());
+    for name in &names {
+        let target_entry = snapshot.models.get_by_name(name).ok_or_else(|| {
+            ProxyError::InvalidRequest(format!(
+                "routing target {name:?} does not resolve to a Model"
+            ))
+        })?;
+        resolved.push(AttemptModel {
+            id: target_entry.id.clone(),
+            model: target_entry.value.clone(),
+        });
+    }
+    match filter_attempt_models(
+        runtime_status,
+        resolved,
+        routing.on_all_filtered_or_default(),
+    ) {
+        FilterOutcome::Selected(list) => Ok(list),
+        FilterOutcome::AllUnhealthy { retry_after_secs } => {
+            tracing::warn!(
+                virtual_model = %virtual_name,
+                retry_after_secs,
+                "all routing candidates are unavailable; failing fast",
+            );
+            Err(ProxyError::AllCandidatesUnavailable { retry_after_secs })
+        }
+    }
 }
 
 #[cfg(test)]
@@ -436,5 +595,120 @@ mod tests {
         ));
         assert!(is_retryable(&BridgeError::Config("bad key".into()), false));
         assert!(is_retryable(&BridgeError::StreamAborted, false));
+    }
+
+    // ── filter_attempt_models ─────────────────────────────────────
+    fn am(id: &str) -> AttemptModel {
+        let model: Model = serde_json::from_str(&format!(
+            r#"{{
+              "display_name": "{id}",
+              "provider": "openai",
+              "model_name": "gpt-4o-mini",
+              "provider_key_id": "pk-{id}"
+            }}"#
+        ))
+        .unwrap();
+        AttemptModel {
+            id: id.to_string(),
+            model,
+        }
+    }
+
+    #[test]
+    fn healthy_only_returns_all_healthy() {
+        let t = crate::ModelRuntimeStatusTracker::new();
+        let attempts = vec![am("a"), am("b")];
+        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+            FilterOutcome::Selected(list) => {
+                assert_eq!(list.len(), 2);
+            }
+            other => panic!(
+                "expected Selected, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn cooldown_skipped_when_healthy_present() {
+        let t = crate::ModelRuntimeStatusTracker::new();
+        t.mark_cooldown("a", Duration::from_secs(30), "retryable_failure");
+        let attempts = vec![am("a"), am("b")];
+        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+            FilterOutcome::Selected(list) => {
+                assert_eq!(list.len(), 1);
+                assert_eq!(list[0].id, "b");
+            }
+            _ => panic!("expected Selected"),
+        }
+    }
+
+    #[test]
+    fn all_unhealthy_fail_policy_returns_retry_after_hint() {
+        // H3 contract: every candidate background-unhealthy, no
+        // cooldown timer → return 503 + fallback Retry-After (30s
+        // default). The dispatch loop converts this to a
+        // ProxyError::AllCandidatesUnavailable.
+        let t = crate::ModelRuntimeStatusTracker::new();
+        t.mark_unhealthy("a", Some(503), "background_check_failed");
+        t.mark_unhealthy("b", Some(503), "background_check_failed");
+        let attempts = vec![am("a"), am("b")];
+        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+            FilterOutcome::AllUnhealthy { retry_after_secs } => {
+                assert_eq!(retry_after_secs, Some(30));
+            }
+            _ => panic!("expected AllUnhealthy"),
+        }
+    }
+
+    #[test]
+    fn one_cooldown_with_all_else_unhealthy_keeps_the_cooldown_candidate() {
+        // Mixed scenario: candidates a/b are background-unhealthy, c
+        // is in cooldown. The filter should pick c (cooldown beats
+        // unhealthy), not fail.
+        let t = crate::ModelRuntimeStatusTracker::new();
+        t.mark_unhealthy("a", Some(503), "background_check_failed");
+        t.mark_unhealthy("b", Some(503), "background_check_failed");
+        t.mark_cooldown("c", Duration::from_secs(30), "x");
+        let attempts = vec![am("a"), am("b"), am("c")];
+        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+            FilterOutcome::Selected(list) => {
+                assert_eq!(list.len(), 1);
+                assert_eq!(list[0].id, "c");
+            }
+            _ => panic!("expected Selected with cooldown candidate"),
+        }
+    }
+
+    #[test]
+    fn all_unhealthy_original_order_policy_returns_full_list() {
+        // Legacy opt-in: send to all candidates regardless.
+        let t = crate::ModelRuntimeStatusTracker::new();
+        t.mark_unhealthy("a", Some(503), "background_check_failed");
+        t.mark_unhealthy("b", Some(503), "background_check_failed");
+        let attempts = vec![am("a"), am("b")];
+        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::OriginalOrder) {
+            FilterOutcome::Selected(list) => {
+                assert_eq!(list.len(), 2);
+            }
+            _ => panic!("expected Selected under OriginalOrder policy"),
+        }
+    }
+
+    #[test]
+    fn cooldown_no_unhealthy_returns_cooldown_candidates() {
+        // No healthy, no unhealthy — all candidates have a cooldown
+        // timer set. Routing should still pick from them (better than
+        // erroring out when we don't have evidence anyone is *broken*).
+        let t = crate::ModelRuntimeStatusTracker::new();
+        t.mark_cooldown("a", Duration::from_secs(30), "x");
+        t.mark_cooldown("b", Duration::from_secs(30), "x");
+        let attempts = vec![am("a"), am("b")];
+        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+            FilterOutcome::Selected(list) => {
+                assert_eq!(list.len(), 2);
+            }
+            _ => panic!("expected Selected for cooldown-only"),
+        }
     }
 }

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -206,20 +206,16 @@ pub(crate) fn filter_attempt_models(
     // some non-unhealthy candidates exist. Sending to a target whose
     // cooldown timer hasn't expired is still better than sending to
     // a target that an active probe just confirmed is broken.
+    //
+    // Reuse the single status read from the classification loop above:
+    // with `healthy` empty here, the non-unhealthy candidates are
+    // exactly the `cooldown_only` ones. Re-reading runtime_status to
+    // re-filter would add a redundant per-candidate query and open a
+    // race window — a candidate flipping to unhealthy between the two
+    // reads could yield an empty `Selected`, which streaming callers
+    // turn into a panic by indexing `attempt_models[0]`.
     if unhealthy_count < attempts.len() && !cooldown_only.is_empty() {
-        let filtered: Vec<AttemptModel> = attempts
-            .into_iter()
-            .filter(|attempt| {
-                let stale_after = attempt
-                    .model
-                    .background_model_check
-                    .as_ref()
-                    .map(|cfg| Duration::from_secs(cfg.stale_after_seconds));
-                runtime_status.should_skip_for_routing(&attempt.id, stale_after)
-                    != crate::RuntimeStatus::Unhealthy
-            })
-            .collect();
-        return FilterOutcome::Selected(filtered);
+        return FilterOutcome::Selected(cooldown_only);
     }
     // All candidates are excluded. Policy decides.
     //

--- a/docs/configuration/routing-and-failover.md
+++ b/docs/configuration/routing-and-failover.md
@@ -10,7 +10,9 @@ This is the gateway's current virtual-model mechanism.
 
 Use it when you want to separate the caller contract from the individual upstream target that serves a given request.
 
-A routing alias works on both inbound protocols: `/v1/chat/completions` (OpenAI shape) and `/v1/messages` (Anthropic shape). Targets in one group may mix providers — e.g. an OpenAI target and an Anthropic target — and the gateway dispatches each target through the right path regardless of which endpoint the caller used. On `/v1/messages`, streaming requests attempt only the first target (no mid-stream fallback); non-streaming requests fail over across targets.
+A routing alias works across the proxy's passthrough endpoints: `/v1/chat/completions` (OpenAI shape), `/v1/messages` (Anthropic shape), `/v1/responses`, and `/v1/messages/count_tokens`. Targets in one group may mix providers — e.g. an OpenAI target and an Anthropic target — and the gateway dispatches each target through the right path regardless of which endpoint the caller used. Streaming requests attempt only the first target (no mid-stream fallback); non-streaming requests fail over across targets.
+
+`/v1/responses` and `/v1/messages/count_tokens` are provider-restricted (OpenAI-only and Anthropic-only respectively). When a group is used on one of these endpoints, only the targets whose provider matches the endpoint are attempted, in order; if the group has no matching target the request is rejected with a 400.
 
 ## Current Strategies
 

--- a/docs/configuration/routing-and-failover.md
+++ b/docs/configuration/routing-and-failover.md
@@ -10,6 +10,8 @@ This is the gateway's current virtual-model mechanism.
 
 Use it when you want to separate the caller contract from the individual upstream target that serves a given request.
 
+A routing alias works on both inbound protocols: `/v1/chat/completions` (OpenAI shape) and `/v1/messages` (Anthropic shape). Targets in one group may mix providers — e.g. an OpenAI target and an Anthropic target — and the gateway dispatches each target through the right path regardless of which endpoint the caller used. On `/v1/messages`, streaming requests attempt only the first target (no mid-stream fallback); non-streaming requests fail over across targets.
+
 ## Current Strategies
 
 - `failover`
@@ -161,7 +163,7 @@ The header applies to successful `/v1/chat/completions` responses. It is **absen
 - **Direct (non-routing) models.** The body's `response.model` already names the served model, so the header would be redundant — its presence is itself the routing signal.
 - **Cache hits.** A stored response is decoupled from whichever target produced it on the original miss; surfacing a stale name would lie. Operators inspecting routing must look at `x-aisix-cache` first.
 - **Error responses** (e.g. failover exhausted, every target unhealthy). No target served the request, so there is no name to report.
-- **Other endpoints.** The Anthropic-shape `/v1/messages` path is on a separate code path and does not currently emit this header.
+- **Other endpoints.** The Anthropic-shape `/v1/messages` path resolves routing groups (including failover) but is on a separate code path and does not currently emit this header.
 
 If a routing target's `display_name` contains bytes that are not valid HTTP header values (CR/LF or non-visible-ASCII), the header is omitted and the DP logs a `tracing::warn!` carrying the offending name. Rename the target with operator-side tools to restore the header.
 

--- a/tests/e2e/src/cases/messages-model-group-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-model-group-e2e.test.ts
@@ -71,7 +71,7 @@ type MessagesResult = {
   };
 };
 
-describe("model group via /v1/messages e2e (#471)", () => {
+describe("model group via passthrough endpoints e2e (#471)", () => {
   let app: SpawnedApp | undefined;
   let admin: AdminClient | undefined;
   let etcdReachable = false;
@@ -166,6 +166,37 @@ describe("model group via /v1/messages e2e (#471)", () => {
       }),
     });
     return { status: res.status, body: (await res.json()) as MessagesResult["body"] };
+  }
+
+  async function callCountTokens(
+    model: string,
+  ): Promise<{ status: number; body: { input_tokens?: number; error?: unknown } }> {
+    const res = await fetch(`${app?.proxyUrl}/v1/messages/count_tokens`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "count me" }],
+      }),
+    });
+    return { status: res.status, body: (await res.json()) as { input_tokens?: number } };
+  }
+
+  async function callResponses(
+    model: string,
+  ): Promise<{ status: number; body: { object?: string; error?: unknown } }> {
+    const res = await fetch(`${app?.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ model, input: "hello" }),
+    });
+    return { status: res.status, body: (await res.json()) as { object?: string } };
   }
 
   async function waitUntilGroupRoutable(virtual: string): Promise<void> {
@@ -303,5 +334,85 @@ describe("model group via /v1/messages e2e (#471)", () => {
     // Anthropic target which served the response.
     expect(openaiDown.receivedRequests.length - openaiBaseline).toBe(1);
     expect(anthropicGood.receivedRequests.length - anthropicBaseline).toBe(1);
+  });
+
+  test("Anthropic group is reachable via /v1/messages/count_tokens", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const anthropic = await startOpenAiUpstream({
+      nonStreamBody: { input_tokens: 42 },
+    });
+    upstreams.push(anthropic);
+
+    await createAnthropicModel("mg-ct-anthropic", anthropic);
+    await admin.createModel({
+      display_name: "mg-count-tokens",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "mg-ct-anthropic" }],
+        max_fallbacks: 0,
+      },
+    });
+
+    let result: { status: number; body: { input_tokens?: number } } | undefined;
+    await waitConfigPropagation(async () => {
+      result = await callCountTokens("mg-count-tokens");
+      return result.status === 200;
+    });
+
+    // Pre-fix this 400'd: a routing model has no provider, so the
+    // Anthropic-only gate rejected it before walking targets.
+    expect(result?.status).toBe(200);
+    expect(result?.body.input_tokens).toBe(42);
+  });
+
+  test("OpenAI group is reachable via /v1/responses", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const openai = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "resp_mg_01",
+        object: "response",
+        status: "completed",
+        model: "gpt-4o-mini",
+        output: [
+          {
+            id: "msg_mg_01",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "grouped response" }],
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 6, total_tokens: 11 },
+      },
+    });
+    upstreams.push(openai);
+
+    await createOpenAiModel("mg-resp-openai", openai);
+    await admin.createModel({
+      display_name: "mg-responses",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "mg-resp-openai" }],
+        max_fallbacks: 0,
+      },
+    });
+
+    let result: { status: number; body: { object?: string } } | undefined;
+    await waitConfigPropagation(async () => {
+      result = await callResponses("mg-responses");
+      return result.status === 200;
+    });
+
+    // Pre-fix this 400'd: a routing model has no provider, so the
+    // OpenAI-only gate rejected it before walking targets.
+    expect(result?.status).toBe(200);
+    expect(result?.body.object).toBe("response");
   });
 });

--- a/tests/e2e/src/cases/messages-model-group-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-model-group-e2e.test.ts
@@ -1,0 +1,307 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for ai-gateway#471: a Model Group (routing model) accessed via
+// /v1/messages used to 400 with
+//   model "<MG>" has no provider_key_id (routing models can't be dispatched directly)
+// because the Anthropic Messages handler dispatched the virtual model
+// directly instead of walking `routing.targets` like
+// /v1/chat/completions does.
+//
+// The customer's group mixed an Anthropic and an OpenAI provider, so
+// these tests exercise both per-target dispatch paths through
+// /v1/messages — Anthropic passthrough and cross-provider translation —
+// plus cross-protocol failover.
+//
+// The mock-upstream harness is path-agnostic: `startOpenAiUpstream`
+// doubles as the Anthropic mock when fed an Anthropic-shaped
+// `nonStreamBody`, and the Anthropic bridge appends `/v1/messages` to
+// the api_base on its own.
+
+const CALLER_PLAINTEXT = "sk-mg-messages-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function openAiChatBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+  };
+}
+
+function anthropicMessageBody(text: string) {
+  return {
+    id: `msg_${text}`,
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text }],
+    model: "claude-3-5-haiku-20241022",
+    stop_reason: "end_turn",
+    usage: { input_tokens: 5, output_tokens: 4 },
+  };
+}
+
+type MessagesResult = {
+  status: number;
+  body: {
+    type?: string;
+    content?: Array<{ type?: string; text?: string }>;
+    error?: { message?: string };
+  };
+};
+
+describe("model group via /v1/messages e2e (#471)", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  async function createOpenAiModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin client not initialized");
+    const pk = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-openai-mock",
+      // OpenAI bridge convention: host + /v1.
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+  }
+
+  async function createAnthropicModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin client not initialized");
+    const pk = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-ant-mock",
+      // Anthropic bridge appends /v1/messages, so point at the bare host.
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: pk.id,
+    });
+  }
+
+  // Warm a direct target so the routing health filter keeps it.
+  async function waitUntilModelResponds(model: string): Promise<void> {
+    await waitConfigPropagation(async () => {
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app?.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+      try {
+        const probe = await client.chat.completions.create({
+          model,
+          messages: [{ role: "user", content: `ready-${model}` }],
+        });
+        return probe.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  async function callMessages(model: string): Promise<MessagesResult> {
+    const res = await fetch(`${app?.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 64,
+        messages: [{ role: "user", content: "你是谁" }],
+      }),
+    });
+    return { status: res.status, body: (await res.json()) as MessagesResult["body"] };
+  }
+
+  async function waitUntilGroupRoutable(virtual: string): Promise<void> {
+    // Gate on the virtual record reaching the DP snapshot without
+    // sending traffic through it, so failover hit-counts below start clean.
+    await waitConfigPropagation(async () => {
+      try {
+        const models = await admin!.listModels();
+        return models.some((m) => m.display_name === virtual);
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  test("Anthropic target in a group is reachable via /v1/messages", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const anthropic = await startOpenAiUpstream({
+      nonStreamBody: anthropicMessageBody("claude-in-group"),
+    });
+    const openai = await startOpenAiUpstream({
+      nonStreamBody: openAiChatBody("gpt-in-group"),
+    });
+    upstreams.push(anthropic, openai);
+
+    await createAnthropicModel("mg-an-anthropic", anthropic);
+    await createOpenAiModel("mg-an-openai", openai);
+    await waitUntilModelResponds("mg-an-anthropic");
+    await waitUntilModelResponds("mg-an-openai");
+    await admin.createModel({
+      display_name: "mg-anthropic-first",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "mg-an-anthropic" },
+          { model: "mg-an-openai" },
+        ],
+        max_fallbacks: 1,
+      },
+    });
+
+    let result: MessagesResult | undefined;
+    await waitConfigPropagation(async () => {
+      result = await callMessages("mg-anthropic-first");
+      return result.status === 200;
+    });
+
+    // Pre-fix this 400'd with "has no provider_key_id".
+    expect(result?.status).toBe(200);
+    expect(result?.body.type).toBe("message");
+    expect(result?.body.content?.[0]?.text).toBe("claude-in-group");
+  });
+
+  test("OpenAI target in a group is reachable via /v1/messages (cross-provider)", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const openai = await startOpenAiUpstream({
+      nonStreamBody: openAiChatBody("gpt-served-via-messages"),
+    });
+    upstreams.push(openai);
+
+    await createOpenAiModel("mg-op-openai", openai);
+    await waitUntilModelResponds("mg-op-openai");
+    await admin.createModel({
+      display_name: "mg-openai-first",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "mg-op-openai" }],
+        max_fallbacks: 0,
+      },
+    });
+
+    let result: MessagesResult | undefined;
+    await waitConfigPropagation(async () => {
+      result = await callMessages("mg-openai-first");
+      return result.status === 200;
+    });
+
+    // Anthropic-in → OpenAI upstream → Anthropic-out to the caller.
+    expect(result?.status).toBe(200);
+    expect(result?.body.type).toBe("message");
+    expect(result?.body.content?.[0]?.text).toBe("gpt-served-via-messages");
+  });
+
+  test("cross-protocol failover: OpenAI target down falls over to Anthropic target", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const openaiDown = await startOpenAiUpstream({
+      status: 502,
+      errorBody: { error: { message: "openai target down", type: "server_error" } },
+    });
+    const anthropicGood = await startOpenAiUpstream({
+      nonStreamBody: anthropicMessageBody("failover-to-claude"),
+    });
+    upstreams.push(openaiDown, anthropicGood);
+
+    await createOpenAiModel("mg-fo-openai", openaiDown);
+    await createAnthropicModel("mg-fo-anthropic", anthropicGood);
+    // Only the healthy target can be probe-warmed; the 502 target is
+    // left unprobed so its cooldown doesn't exclude it from the attempt
+    // list before the measured call below.
+    await waitUntilModelResponds("mg-fo-anthropic");
+    await admin.createModel({
+      display_name: "mg-failover",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "mg-fo-openai" },
+          { model: "mg-fo-anthropic" },
+        ],
+        max_fallbacks: 1,
+      },
+    });
+    await waitUntilGroupRoutable("mg-failover");
+
+    const openaiBaseline = openaiDown.receivedRequests.length;
+    const anthropicBaseline = anthropicGood.receivedRequests.length;
+
+    const result = await callMessages("mg-failover");
+
+    expect(result.status).toBe(200);
+    expect(result.body.type).toBe("message");
+    expect(result.body.content?.[0]?.text).toBe("failover-to-claude");
+    // First target (OpenAI) attempted once, then failover to the
+    // Anthropic target which served the response.
+    expect(openaiDown.receivedRequests.length - openaiBaseline).toBe(1);
+    expect(anthropicGood.receivedRequests.length - anthropicBaseline).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

A Model Group (routing model) accessed through the Anthropic / OpenAI passthrough endpoints failed instead of dispatching:

- `/v1/messages` → `400 model "<MG>" has no provider_key_id (routing models can't be dispatched directly)`
- `/v1/responses` → `400 model "<MG>" is not an OpenAI provider`
- `/v1/messages/count_tokens` → `400 model "<MG>" is not an Anthropic provider`

All three resolved the requested Model and dispatched it directly (or applied a provider gate) without walking `routing.targets`. A routing model has no `provider`/`provider_key_id`, so it never reached target resolution. The same group worked on `/v1/chat/completions`, which already walks targets. Reported by a customer whose group mixed an Anthropic and an OpenAI provider.

## Fix

- Extract the routing-target resolution `chat.rs` already had (`pick_targets` + health/cooldown filter) into `routing::resolve_attempt_models`, shared by all handlers.
- **`/v1/messages`**: resolve the attempt list and dispatch each target by its provider — Anthropic passthrough or cross-provider translation. A group mixing Anthropic and OpenAI targets now serves correctly.
- **`/v1/responses`** (OpenAI-only) and **`/v1/messages/count_tokens`** (Anthropic-only): resolve the attempt list, then attempt the targets whose provider matches the endpoint, in order. A group with no matching-provider target still returns the endpoint's 400.
- Non-streaming requests fail over across matching targets on retryable upstream failures (`retry_on_429` honored); streaming attempts the first matching target only (matching chat completions).
- Health is recorded against the resolved target's `display_name` (the served target), not the group alias — the id-keyed runtime status was already correct.

## Behavior change

- Routing-model names now dispatch on `/v1/messages`, `/v1/responses`, and `/v1/messages/count_tokens` instead of returning 400. Direct (non-routing) models are unchanged — their dispatch paths and error messages are preserved.

## Tests

- New DP E2E (`messages-model-group-e2e.test.ts`): mixed-provider group over `/v1/messages` (Anthropic target, OpenAI target via cross-provider, cross-protocol failover), an Anthropic group over `/v1/messages/count_tokens`, and an OpenAI group over `/v1/responses`. Each case fails before the change (400) and passes after.
- Existing `aisix-proxy` unit tests (356) and the full DP e2e suite (60 files / 121 tests) pass.

## Docs

- `routing-and-failover.md`: routing aliases work across all four passthrough endpoints, including mixed-provider groups, the provider-restricted behavior of `/v1/responses` + `/v1/messages/count_tokens`, and the streaming-first-target caveat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model-group routing expanded: /v1/messages, /v1/chat, /v1/responses and token-count endpoints now resolve ordered attempt targets with consistent failover behavior (streaming uses primary only; non-streaming can fail over).
  * Anthropic targets support byte-for-byte passthrough; other providers use cross-provider translation.

* **Bug Fixes / Behavior**
  * Consistent request handling: handlers treat incoming bodies immutably and attribute health/usage to resolved targets.
  * Token-count now requires an Anthropic-backed target.

* **Documentation**
  * Clarified routing, failover, and header emission behavior for /v1/messages.

* **Tests**
  * Added end-to-end coverage for model-group routing and failover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->