### PR TITLE
fix(etcd): enforce delimiter boundary on config key prefix (#452)

### DIFF
--- a/crates/aisix-etcd/src/key.rs
+++ b/crates/aisix-etcd/src/key.rs
@@ -36,7 +36,19 @@ pub fn parse<'a>(prefix: &str, key: &'a str) -> Result<ResourceKey<'a>, KeyError
             key: key.to_string(),
             prefix: prefix.to_string(),
         })?;
-    let rest = rest.trim_start_matches('/');
+    // Enforce a delimiter boundary after the prefix: the next character must
+    // be `/`. Without this, `strip_prefix` byte-matching would treat an
+    // adjacent key such as `/aisixmodels/x` as if it lived under `/aisix/`,
+    // letting a writer outside the configured namespace inject models or API
+    // keys. An exact-prefix match (`rest == ""`) falls through to the
+    // MissingSuffix check below.
+    if !rest.is_empty() && !rest.starts_with('/') {
+        return Err(KeyError::PrefixMismatch {
+            key: key.to_string(),
+            prefix: prefix.to_string(),
+        });
+    }
+    let rest = rest.strip_prefix('/').unwrap_or(rest);
 
     let (kind, id) = rest
         .split_once('/')
@@ -77,6 +89,31 @@ mod tests {
     fn prefix_mismatch_is_detected() {
         let err = parse("/aisix", "/other/models/a").unwrap_err();
         assert!(matches!(err, KeyError::PrefixMismatch { .. }));
+    }
+
+    #[test]
+    fn adjacent_prefix_without_delimiter_is_rejected() {
+        // `/aisixmodels/...` byte-starts with `/aisix` but is NOT a child of
+        // the `/aisix/` namespace — it must not be parsed as config.
+        for key in [
+            "/aisixmodels/models/m-1",
+            "/aisixapikeys/api_keys/k-1",
+            "/aisix-extra/models/m-1",
+            "/aisixfoo/bar/baz",
+        ] {
+            let err = parse("/aisix", key).unwrap_err();
+            assert!(
+                matches!(err, KeyError::PrefixMismatch { .. }),
+                "expected PrefixMismatch for {key:?}, got {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn child_of_namespace_is_accepted() {
+        let k = parse("/aisix", "/aisix/models/m-1").unwrap();
+        assert_eq!(k.kind, "models");
+        assert_eq!(k.id, "m-1");
     }
 
     #[test]


### PR DESCRIPTION
## Problem
The etcd config key parser (`crates/aisix-etcd/src/key.rs`) stripped the configured prefix with a raw byte match (`strip_prefix` + `trim_start_matches('/')`). A key like `/aisixmodels/models/x` byte-starts with `/aisix` and was therefore parsed as a child of the `/aisix/` namespace. A writer with etcd access outside `/aisix/` — but under an adjacent prefix that its RBAC range permits — could inject models or API keys into the gateway config.

## Fix
After stripping the prefix, require the next character to be the `/` delimiter. Adjacent keys that merely byte-start with the prefix (`/aisixmodels`, `/aisix-extra`, …) are now rejected as `PrefixMismatch`. An exact-prefix match still falls through to `MissingSuffix`.

## Behavior change
- `/aisix/models/x` → accepted (unchanged)
- `/aisixmodels/x`, `/aisixapikeys/x`, `/aisix-extra/...` → rejected (was: silently accepted)

## Tests
Added unit tests covering accepted children and rejected adjacent prefixes; existing key-parser tests still pass.

Fixes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced key validation logic to correctly reject malformed keys with invalid prefix formatting
  * Improved path normalization during key processing to ensure consistent handling

* **Tests**
  * Expanded test coverage with new test suite validating proper rejection of improperly formatted keys and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->