### PR TITLE
fix(ratelimit): hold streaming concurrency until stream end (#450 #30)

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -830,11 +830,18 @@ async fn dispatch(
                 return Err(with_model(ProxyError::Bridge(err)).with_routing(routing));
             }
         };
-        // Drop the reservation now: concurrency releases on all layers.
-        // RPM was already counted by pre_commit. TPM is updated
-        // retroactively on stream-end by `add_tokens_post_stream`.
+        // Hold concurrency for the stream's full lifetime instead of
+        // releasing it at handler return. RPM was already counted by
+        // pre_commit; TPM is updated retroactively on stream-end by
+        // `add_tokens_post_stream`. The borrow-based reservation can't be
+        // carried into the stream, so convert it into an owned guard that
+        // releases the permit(s) on drop — i.e. when the stream completes
+        // or is cancelled (the guard is moved into the on_complete closure,
+        // which the CompleteOnDrop guard fires on both paths). Pre-fix the
+        // permit was released here, letting a key capped at N run far more
+        // than N simultaneous streams (#450).
         let post_stream_keys = reservation.keys();
-        drop(reservation);
+        let stream_concurrency_hold = reservation.into_stream_hold(Arc::clone(&state.limiter));
         // Capture everything the stream-completion callback needs so
         // it can fire `emit_usage_event` once the terminal SSE chunk
         // has yielded its `usage` block. Telemetry emission has to
@@ -987,6 +994,11 @@ async fn dispatch(
                     },
                     Duration::from_millis(u64::from(comp.ttft_ms)),
                 );
+                // Release the concurrency permit(s) now that the stream has
+                // completed (or was cancelled). on_complete is fired by the
+                // CompleteOnDrop guard on both paths, so the permit is held
+                // for the stream's full lifetime and never leaked (#450).
+                drop(stream_concurrency_hold);
             },
         );
         let response =

--- a/crates/aisix-ratelimit/src/lib.rs
+++ b/crates/aisix-ratelimit/src/lib.rs
@@ -20,5 +20,7 @@ mod window;
 
 pub use clock::{Clock, SystemClock, TestClock};
 pub use error::RateLimitError;
-pub use limiter::{Limiter, MultiReservation, RateLimitStatus, Reservation};
+pub use limiter::{
+    Limiter, MultiReservation, RateLimitStatus, Reservation, StreamConcurrencyGuard,
+};
 pub use window::{FixedWindowCounter, WindowCheck};

--- a/crates/aisix-ratelimit/src/limiter.rs
+++ b/crates/aisix-ratelimit/src/limiter.rs
@@ -356,6 +356,69 @@ impl<'a, C: Clock> MultiReservation<'a, C> {
     pub fn keys(&self) -> Vec<String> {
         self.reservations.iter().map(|r| r.key.clone()).collect()
     }
+
+    /// Convert into an owned [`StreamConcurrencyGuard`] for the streaming
+    /// path. The per-layer concurrency permits stay held — they are NOT
+    /// released here — and are released only when the returned guard drops,
+    /// i.e. at stream completion or cancellation. Token accounting still
+    /// happens via [`Limiter::add_tokens_post_stream`].
+    ///
+    /// A borrow-based reservation can't outlive the request handler, so the
+    /// pre-fix streaming path dropped it at handler return; that released
+    /// the concurrency permit before the stream finished, letting a key
+    /// capped at N run many more than N simultaneous streams (#450).
+    pub fn into_stream_hold(mut self, limiter: Arc<Limiter<C>>) -> StreamConcurrencyGuard<C> {
+        let keys = self.keys();
+        // Defuse each reservation's Drop so it doesn't release the permit
+        // now; the returned guard owns release from here on.
+        for r in &mut self.reservations {
+            r.committed = true;
+        }
+        StreamConcurrencyGuard {
+            limiter,
+            keys,
+            released: false,
+        }
+    }
+}
+
+/// Owned concurrency hold for the streaming path. Holds an `Arc<Limiter>`
+/// and the reserved keys, and releases the concurrency permit(s) on drop —
+/// i.e. when the stream completes or is cancelled — instead of at handler
+/// return. See [`MultiReservation::into_stream_hold`].
+pub struct StreamConcurrencyGuard<C: Clock = SystemClock> {
+    limiter: Arc<Limiter<C>>,
+    keys: Vec<String>,
+    released: bool,
+}
+
+impl<C: Clock> StreamConcurrencyGuard<C> {
+    fn release_now(&mut self) {
+        if self.released {
+            return;
+        }
+        self.released = true;
+        for key in &self.keys {
+            let state = self.limiter.state_for(key);
+            let mut s = state.lock();
+            s.in_flight = s.in_flight.saturating_sub(1);
+        }
+    }
+}
+
+impl<C: Clock> std::fmt::Debug for StreamConcurrencyGuard<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamConcurrencyGuard")
+            .field("keys", &self.keys)
+            .field("released", &self.released)
+            .finish()
+    }
+}
+
+impl<C: Clock> Drop for StreamConcurrencyGuard<C> {
+    fn drop(&mut self) {
+        self.release_now();
+    }
 }
 
 impl<'a, C: Clock> std::fmt::Debug for MultiReservation<'a, C> {
@@ -757,6 +820,29 @@ mod tests {
 
         assert!(limiter.pre_commit("k1", &l).is_ok());
         assert!(limiter.pre_commit("k2", &l).is_ok());
+    }
+
+    #[test]
+    fn stream_hold_keeps_concurrency_until_guard_drop() {
+        // #450: a streaming request must keep its concurrency permit for the
+        // stream's full lifetime, not release it at handler return.
+        let clock = TestClock::new(100);
+        let limiter = std::sync::Arc::new(Limiter::with_clock(clock.clone()));
+        let l = limits(None, None, Some(1));
+
+        let r = limiter.pre_commit("k", &l).unwrap();
+        let hold = MultiReservation::new(vec![r]).into_stream_hold(std::sync::Arc::clone(&limiter));
+
+        // Permit is still held while the stream runs — a second concurrent
+        // request is rejected.
+        assert!(matches!(
+            limiter.pre_commit("k", &l).unwrap_err(),
+            RateLimitError::Concurrency
+        ));
+
+        // Stream completes/cancels → guard drops → permit released.
+        drop(hold);
+        assert!(limiter.pre_commit("k", &l).is_ok());
     }
 
     #[test]

--- a/crates/aisix-ratelimit/src/limiter.rs
+++ b/crates/aisix-ratelimit/src/limiter.rs
@@ -367,6 +367,13 @@ impl<'a, C: Clock> MultiReservation<'a, C> {
     /// pre-fix streaming path dropped it at handler return; that released
     /// the concurrency permit before the stream finished, letting a key
     /// capped at N run many more than N simultaneous streams (#450).
+    ///
+    /// `limiter` MUST be the same [`Limiter`] this reservation was acquired
+    /// against (in the proxy there is exactly one, behind `state.limiter`);
+    /// the guard decrements `in_flight` on it at drop. A borrow can't be
+    /// upgraded to an `Arc`, so the caller supplies the owned handle.
+    #[must_use = "dropping the returned guard immediately releases the concurrency \
+                  permit, recreating the early-release bug this fixes"]
     pub fn into_stream_hold(mut self, limiter: Arc<Limiter<C>>) -> StreamConcurrencyGuard<C> {
         let keys = self.keys();
         // Defuse each reservation's Drop so it doesn't release the permit


### PR DESCRIPTION
Part of #450 (finding #30).

## Problem
The streaming chat path (`/v1/chat/completions`) released its concurrency reservation at handler return — before the SSE stream finished (`chat.rs` previously did `drop(reservation)` right after `chat_stream`). A key capped at N concurrent requests could therefore run far more than N simultaneous streams. The borrow-based `MultiReservation` can't be carried into a stream that outlives the handler, so it was simply dropped. (TPM was already reconciled at stream end via `add_tokens_post_stream` from an earlier fix; concurrency was not.)

## Fix
Add an owned `StreamConcurrencyGuard` and `MultiReservation::into_stream_hold()` (in `aisix-ratelimit`) that keeps the per-layer concurrency permits held and releases them on drop. The guard is moved into the `on_complete` closure, which the `CompleteOnDrop` guard fires on **both** normal completion and mid-stream cancellation — so the permit is held for the stream's full lifetime and never leaked.

## Scope / deferred siblings
`/v1/messages` and `/v1/completions` bind their reservation for handler scope only and share the same early-release pattern on their streaming paths. Correct reservation handling for those lands when they're routed through the shared policy pipeline in #22 (called out per the repo's whole-bug-class guideline).

## Tests
- Unit: `stream_hold_keeps_concurrency_until_guard_drop` in `limiter.rs` — a 2nd concurrent request is rejected while the hold is alive and admitted after it drops.
- A streaming-concurrency E2E is omitted as timing-dependent/flaky; the deterministic limiter semantics are covered by the unit test (per the hard-to-simulate-concurrency test exception).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where concurrent streaming requests could exceed rate-limit concurrency caps. Concurrency limits are now properly maintained for the entire duration of a stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->