### PR TITLE
fix(metrics): bound endpoint/model labels against cardinality DoS (#451)

### DIFF
--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -133,10 +133,44 @@ async fn record_in_flight_request(
     request: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    let endpoint = request.uri().path().to_string();
-    let inbound_protocol = inbound_protocol_for_endpoint(&endpoint).to_string();
-    let _guard = InFlightGuard::new(state.metrics.clone(), endpoint, inbound_protocol);
+    // Normalize to a bounded route template BEFORE using the path as a
+    // metric label. This middleware runs before authentication and before
+    // route matching, so the raw `request.uri().path()` is fully
+    // attacker-controlled — the `/passthrough/:provider/*rest` wildcard
+    // suffix (or any 404 path) would otherwise let an unauthenticated
+    // caller mint unbounded Prometheus time series (#451).
+    let endpoint = normalize_endpoint_label(request.uri().path());
+    let inbound_protocol = inbound_protocol_for_endpoint(endpoint).to_string();
+    let _guard = InFlightGuard::new(
+        state.metrics.clone(),
+        endpoint.to_string(),
+        inbound_protocol,
+    );
     next.run(request).await
+}
+
+/// Collapse a raw request path to a fixed route template so metric labels
+/// stay bounded regardless of caller-supplied path segments. Keep this
+/// allowlist in sync with the routes registered in `build_router`; any
+/// unrecognized path (including unmatched 404s) maps to `"other"`.
+fn normalize_endpoint_label(path: &str) -> &'static str {
+    match path {
+        "/livez" => "/livez",
+        "/v1/models" => "/v1/models",
+        "/v1/chat/completions" => "/v1/chat/completions",
+        "/v1/completions" => "/v1/completions",
+        "/v1/embeddings" => "/v1/embeddings",
+        "/v1/images/generations" => "/v1/images/generations",
+        "/v1/messages" => "/v1/messages",
+        "/v1/messages/count_tokens" => "/v1/messages/count_tokens",
+        "/v1/rerank" => "/v1/rerank",
+        "/v1/responses" => "/v1/responses",
+        "/v1/audio/transcriptions" => "/v1/audio/transcriptions",
+        "/v1/audio/translations" => "/v1/audio/translations",
+        "/v1/audio/speech" => "/v1/audio/speech",
+        _ if path.starts_with("/passthrough/") => "/passthrough/:provider/*rest",
+        _ => "other",
+    }
 }
 
 fn inbound_protocol_for_endpoint(endpoint: &str) -> &'static str {
@@ -288,6 +322,29 @@ async fn livez(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn endpoint_label_is_bounded_for_arbitrary_paths() {
+        // Known routes pass through unchanged.
+        assert_eq!(
+            normalize_endpoint_label("/v1/chat/completions"),
+            "/v1/chat/completions"
+        );
+        assert_eq!(normalize_endpoint_label("/v1/messages"), "/v1/messages");
+        // Passthrough collapses regardless of provider/suffix — this is the
+        // unbounded-cardinality vector from #451.
+        assert_eq!(
+            normalize_endpoint_label("/passthrough/openai/anything/unique-123"),
+            "/passthrough/:provider/*rest"
+        );
+        assert_eq!(
+            normalize_endpoint_label("/passthrough/openai/other-unique-456"),
+            "/passthrough/:provider/*rest"
+        );
+        // Arbitrary unauthenticated paths bucket to a single label.
+        assert_eq!(normalize_endpoint_label("/random/x"), "other");
+        assert_eq!(normalize_endpoint_label("/random/y"), "other");
+    }
 
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -35,6 +35,11 @@ use crate::error::ProxyError;
 use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
+/// Bounded `model` metric label for passthrough requests. The wildcard
+/// `*rest` suffix is caller-controlled and must never be used directly as
+/// a label (unbounded Prometheus cardinality — #451).
+const PASSTHROUGH_MODEL_LABEL: &str = "passthrough";
+
 /// Headers that the passthrough endpoint ALWAYS strips before
 /// forwarding to upstream, regardless of customer configuration.
 ///
@@ -150,7 +155,11 @@ pub async fn passthrough(
             );
             state.metrics.record_request(
                 &provider_label,
-                &rest,
+                // The raw `rest` wildcard is caller-controlled; using it as
+                // the `model` label would create unbounded metric
+                // cardinality. Passthrough has no resolved model, so record
+                // a fixed sentinel (#451).
+                PASSTHROUGH_MODEL_LABEL,
                 status,
                 RequestOutcome::from_status(status),
                 elapsed,
@@ -171,7 +180,7 @@ pub async fn passthrough(
             );
             state.metrics.record_request(
                 &provider,
-                &rest,
+                PASSTHROUGH_MODEL_LABEL,
                 status,
                 RequestOutcome::from_status(status),
                 elapsed,

--- a/tests/e2e/src/cases/metric-cardinality-passthrough-e2e.test.ts
+++ b/tests/e2e/src/cases/metric-cardinality-passthrough-e2e.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { EtcdClient, spawnApp, type SpawnedApp } from "../harness/index.js";
+
+// E2E: unauthenticated passthrough paths must NOT mint unbounded metric
+// series (#451). The in-flight middleware runs before auth and before
+// route matching; pre-fix it used the raw request path as the `endpoint`
+// label, so each unique /passthrough/<provider>/<unique> path created a
+// new Prometheus time series — an unauthenticated cardinality DoS.
+//
+// We fire many unique unauthenticated passthrough paths, then scrape
+// /metrics and assert the endpoint label is collapsed to the route
+// template (no unique suffix leaks into a label).
+
+describe("metric label cardinality for passthrough (#451)", () => {
+  let app: SpawnedApp | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    app = await spawnApp();
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+  });
+
+  test("unique unauthenticated passthrough paths collapse to one label", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // No Authorization header — these are unauthenticated requests.
+    for (let i = 0; i < 25; i++) {
+      await fetch(`${app.proxyUrl}/passthrough/openai/unique-path-${i}/sub-${i}`, {
+        method: "POST",
+        body: "{}",
+      }).catch(() => {});
+    }
+
+    const scrape = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+    const inFlightLines = scrape
+      .split("\n")
+      .filter((l) => l.startsWith("aisix_proxy_in_flight_requests{"));
+
+    // No raw unique suffix may appear in any label.
+    const leaked = inFlightLines.filter((l) => l.includes("unique-path-"));
+    expect(leaked, `raw paths leaked into metric labels:\n${leaked.join("\n")}`).toHaveLength(0);
+
+    // The passthrough route template is the single bounded label used.
+    const passthroughLabels = new Set(
+      inFlightLines
+        .map((l) => l.match(/endpoint="([^"]*)"/)?.[1])
+        .filter((e): e is string => !!e && e.includes("passthrough")),
+    );
+    expect(passthroughLabels.size).toBeLessThanOrEqual(1);
+    if (passthroughLabels.size === 1) {
+      expect([...passthroughLabels][0]).toBe("/passthrough/:provider/*rest");
+    }
+  });
+});


### PR DESCRIPTION
## Problem
The in-flight metrics middleware runs **before authentication and before route matching** and used the raw `request.uri().path()` as the `endpoint` Prometheus label. An unauthenticated caller could therefore mint unbounded time series by varying the path — e.g. the `/passthrough/:provider/*rest` wildcard suffix, or arbitrary 404 paths. The passthrough handler additionally used the caller-controlled `*rest` wildcard as the `model` label.

## Fix
- Normalize the `endpoint` label to a fixed route template before recording (`normalize_endpoint_label`); any unrecognized path (including unmatched 404s) buckets to `"other"`. Passthrough collapses to `/passthrough/:provider/*rest`.
- Record a fixed `"passthrough"` sentinel for the passthrough `model` label instead of the raw suffix.

## Tests
- Unit: `endpoint_label_is_bounded_for_arbitrary_paths`.
- E2E: `metric-cardinality-passthrough-e2e.test.ts` fires 25 unique unauthenticated passthrough paths and asserts no raw suffix leaks into a label and the passthrough endpoint collapses to a single template. Existing `prometheus-metrics-e2e` still passes (known routes are unchanged).

Fixes #451