### PR TITLE
fix(openai): tolerate usage objects missing token fields (#474)

### DIFF
--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -400,7 +400,11 @@ pub enum AnthropicResponseBlock {
     Other,
 }
 
+// `#[serde(default)]` at the container level so a response missing any
+// token counter deserializes to 0 rather than failing the whole body
+// decode (same bug class as OpenAI usage, #474).
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct AnthropicUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -178,7 +178,12 @@ pub struct OpenAiResponseMessage {
     pub reasoning_content: Option<String>,
 }
 
+// `#[serde(default)]` at the container level so an upstream that omits
+// any token counter (OpenAI-compatible providers vary on which fields
+// they return) deserializes to 0 instead of failing the whole response
+// body decode with `502 upstream_decode_error` (#474).
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct OpenAiUsage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
@@ -437,8 +442,12 @@ pub(crate) struct OpenAiEmbeddingObject {
     pub embedding: EmbeddingVector,
 }
 
-/// Usage block from OpenAI's embeddings response.
+/// Usage block from OpenAI's embeddings response. `#[serde(default)]`
+/// so a provider that returns only `total_tokens` (e.g. Jina) — or omits
+/// usage fields entirely — still deserializes instead of failing with
+/// `502 upstream_decode_error` (#474).
 #[derive(Debug, Default, Deserialize)]
+#[serde(default)]
 pub(crate) struct OpenAiEmbedUsage {
     pub prompt_tokens: u32,
     pub total_tokens: u32,
@@ -988,6 +997,51 @@ mod tests {
                 panic!("float request must deserialize as EmbeddingVector::Float")
             }
         }
+    }
+
+    #[test]
+    fn embeddings_response_tolerates_missing_prompt_tokens_474() {
+        // Jina's /v1/embeddings returns `usage.total_tokens` only,
+        // omitting `prompt_tokens`. Pre-#474 the required field made the
+        // whole body fail to deserialize -> `502 upstream_decode_error`.
+        let body = r#"{
+            "object": "list",
+            "model": "jina-embeddings-v5-text-small",
+            "data": [{
+                "index": 0,
+                "object": "embedding",
+                "embedding": [0.1]
+            }],
+            "usage": { "total_tokens": 6 }
+        }"#;
+        let raw: OpenAiEmbedResponse =
+            serde_json::from_str(body).expect("embeddings without prompt_tokens must deserialize");
+        let resp = embed_response_into(raw);
+        assert_eq!(resp.usage.prompt_tokens, 0);
+        assert_eq!(resp.usage.total_tokens, 6);
+    }
+
+    #[test]
+    fn chat_response_tolerates_partial_usage_474() {
+        // Same bug class as embeddings: a chat usage object missing some
+        // counters must not fail the response decode.
+        let body = r#"{
+            "id": "x",
+            "object": "chat.completion",
+            "model": "gpt-4o",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop"
+            }],
+            "usage": { "total_tokens": 3 }
+        }"#;
+        let raw: OpenAiResponse =
+            serde_json::from_str(body).expect("chat with partial usage must deserialize");
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.usage.prompt_tokens, 0);
+        assert_eq!(out.usage.completion_tokens, 0);
+        assert_eq!(out.usage.total_tokens, 3);
     }
 
     #[test]

--- a/tests/e2e/src/cases/embeddings-missing-prompt-tokens-e2e.test.ts
+++ b/tests/e2e/src/cases/embeddings-missing-prompt-tokens-e2e.test.ts
@@ -1,0 +1,138 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: OpenAI client → OpenAI-compatible upstream — `/v1/embeddings`
+// tolerates a usage block that omits `prompt_tokens`.
+//
+// Pins issue #474: Jina's OpenAI-compatible `/v1/embeddings` returns
+// `usage.total_tokens` only, omitting `prompt_tokens`. The gateway's
+// `OpenAiEmbedUsage` declared `prompt_tokens` as a required field, so
+// serde rejected the body and the gateway surfaced
+// `502 upstream_decode_error` even though the upstream returned 200.
+//
+// What this spec proves: an embeddings response whose `usage` has only
+// `total_tokens` returns 200 to the SDK with the vectors intact.
+
+const CALLER_PLAINTEXT = "sk-openai-embed-missing-pt-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const FLOAT_VECTOR = [0.1, -0.2, 0.3];
+
+// Jina-shape response: `usage` carries `total_tokens` only.
+const JINA_SHAPE_RESPONSE = {
+  object: "list",
+  model: "jina-embeddings-v5-text-small",
+  data: [{ index: 0, object: "embedding", embedding: FLOAT_VECTOR }],
+  usage: { total_tokens: 6 },
+};
+
+describe("OpenAI /v1/embeddings tolerates missing usage.prompt_tokens (#474)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      scriptedResponses: [
+        // Readiness probe via chat — consumes scripted step 0.
+        {
+          nonStreamBody: {
+            id: "chatcmpl-ready",
+            object: "chat.completion",
+            created: 0,
+            model: "jina-embeddings-v5-text-small",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "ready" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          },
+        },
+        // Embeddings call — usage without prompt_tokens.
+        { nonStreamBody: JINA_SHAPE_RESPONSE },
+      ],
+      nonStreamBody: JINA_SHAPE_RESPONSE,
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "jina-embed-pk",
+      secret: "sk-jina-mock",
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "jina-embed",
+      provider: "openai",
+      model_name: "jina-embeddings-v5-text-small",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["jina-embed"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("usage with only total_tokens → 200, not 502", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.chat.completions.create({
+          model: "jina-embed",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+
+    // Pre-#474 this threw a 502 upstream_decode_error.
+    const resp = await client.embeddings.create({
+      model: "jina-embed",
+      input: ["hello", "world"],
+      encoding_format: "float",
+    });
+
+    expect(resp.data).toHaveLength(1);
+    expect(resp.data[0]?.object).toBe("embedding");
+    expect(Array.isArray(resp.data[0]?.embedding)).toBe(true);
+    expect(resp.usage.total_tokens).toBe(6);
+    // prompt_tokens was absent upstream → surfaces as 0, not an error.
+    expect(resp.usage.prompt_tokens).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #474

## Problem

OpenAI-compatible `/v1/embeddings` (and chat) responses whose `usage` block omits a token counter fail to deserialize and surface `502 upstream_decode_error`, even though the upstream returned 200. Concretely, Jina's `/v1/embeddings` returns `usage.total_tokens` only (no `prompt_tokens`), and `OpenAiEmbedUsage` declared `prompt_tokens` as a required field, so serde rejected the whole body.

`#[derive(Default)]` alone does not help here — serde still errors on a present-but-incomplete `usage` object unless `#[serde(default)]` is set.

## Fix

Add container-level `#[serde(default)]` to the upstream usage structs so any missing counter decodes to `0` instead of failing the response decode:

- `OpenAiEmbedUsage` and `OpenAiUsage` (`aisix-provider-openai`) — also covers azure-openai/deepseek which reuse these wire types.
- `AnthropicUsage` (`aisix-provider-anthropic`) — same bug class on `input_tokens`/`output_tokens`.

Gemini's `GeminiUsageMetadata` already defaulted all fields; Bedrock uses AWS SDK types — no change.

## Behavior change

An embeddings/chat response with a partial `usage` object now returns 200 with the missing counters reported as 0, instead of 502.

## Tests

- Unit: `wire.rs` deserialization tests for a Jina-shape embeddings `usage` (`total_tokens` only) and a partial chat `usage`.
- DP e2e: `embeddings-missing-prompt-tokens-e2e.test.ts` sends a Jina-shape embeddings response through a mock upstream; fails before the fix (502), passes after (200).