### PR TITLE
feat(server): serve HTTPS when proxy.tls / admin.tls is configured (#473)

### DIFF
--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -474,11 +474,14 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         let admin_router = aisix_admin::build_router(admin_state);
 
         let admin_addr: std::net::SocketAddr = cfg.admin.addr.parse()?;
-        let admin_listener = tokio::net::TcpListener::bind(admin_addr).await?;
-        tracing::info!(admin = %admin_addr, "aisix admin listening");
-        let admin_serve = axum::serve(admin_listener, admin_router)
-            .with_graceful_shutdown(shutdown_signal(cancel_rx.clone(), "admin"));
-        Some(tokio::spawn(async move { admin_serve.await }))
+        let admin_tls = cfg.admin.tls.clone();
+        Some(tokio::spawn(serve_http(
+            admin_addr,
+            admin_router,
+            admin_tls,
+            cancel_rx.clone(),
+            "admin",
+        )))
     } else {
         // Drop unused shared components so the compiler can see they
         // don't escape managed mode. The health tracker exists on
@@ -490,18 +493,22 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
 
     // Step 9: bind + serve the proxy (always). Admin is handled above.
     let proxy_addr: std::net::SocketAddr = cfg.proxy.addr.parse()?;
-    let proxy_listener = tokio::net::TcpListener::bind(proxy_addr).await?;
-    tracing::info!(proxy = %proxy_addr, "aisix proxy listening");
-
-    let proxy_serve = axum::serve(proxy_listener, proxy_router)
-        .with_graceful_shutdown(shutdown_signal(cancel_rx.clone(), "proxy"));
+    let proxy_tls = cfg.proxy.tls.clone();
+    let proxy_serve = serve_http(
+        proxy_addr,
+        proxy_router,
+        proxy_tls,
+        cancel_rx.clone(),
+        "proxy",
+    );
 
     // Step 10: shutdown coordinator. Whichever of (signal, proxy, admin)
     // completes first triggers the rest.
     let signal_task = tokio::spawn(wait_for_signal(cancel_tx.clone(), livez_state));
 
-    let proxy_res = proxy_serve.await;
-    proxy_res.map_err(|e| anyhow::anyhow!("proxy serve error: {e}"))?;
+    proxy_serve
+        .await
+        .map_err(|e| anyhow::anyhow!("proxy serve error: {e}"))?;
     if let Some(handle) = admin_serve_handle {
         match handle.await {
             Ok(Ok(())) => {}
@@ -835,6 +842,57 @@ fn background_check_interval(snapshot: &aisix_core::AisixSnapshot) -> std::time:
 /// Completes when the process receives SIGINT or SIGTERM (best-effort on
 /// Windows — Ctrl+C only) OR when another part of the system has already
 /// flipped the cancel channel.
+/// Serve `router` on `addr`, choosing HTTPS when `tls` is configured and
+/// plain HTTP otherwise. Both variants honour the shared `cancel` watch for
+/// graceful shutdown so the proxy/admin surfaces stop in lockstep with the
+/// rest of the process. Wired for #473: `proxy.tls` / `admin.tls` were
+/// parsed but never reached the listener, so the documented config silently
+/// served plain HTTP.
+async fn serve_http(
+    addr: std::net::SocketAddr,
+    router: axum::Router,
+    tls: Option<aisix_core::TlsConfig>,
+    cancel: watch::Receiver<bool>,
+    label: &'static str,
+) -> anyhow::Result<()> {
+    match tls {
+        None => {
+            let listener = tokio::net::TcpListener::bind(addr).await?;
+            tracing::info!(%addr, label, "aisix listening (http)");
+            axum::serve(listener, router)
+                .with_graceful_shutdown(shutdown_signal(cancel, label))
+                .await?;
+            Ok(())
+        }
+        Some(tls) => {
+            let tls_config =
+                axum_server::tls_rustls::RustlsConfig::from_pem_file(&tls.cert_file, &tls.key_file)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "{label}.tls: failed to load cert_file={:?} / key_file={:?}: {e}",
+                            tls.cert_file,
+                            tls.key_file
+                        )
+                    })?;
+            let handle = axum_server::Handle::new();
+            tokio::spawn({
+                let handle = handle.clone();
+                async move {
+                    shutdown_signal(cancel, label).await;
+                    handle.graceful_shutdown(Some(std::time::Duration::from_secs(10)));
+                }
+            });
+            tracing::info!(%addr, label, "aisix listening (https)");
+            axum_server::bind_rustls(addr, tls_config)
+                .handle(handle)
+                .serve(router.into_make_service())
+                .await?;
+            Ok(())
+        }
+    }
+}
+
 async fn shutdown_signal(mut cancel: watch::Receiver<bool>, label: &'static str) {
     loop {
         if *cancel.borrow() {

--- a/tests/e2e/src/cases/listener-tls-e2e.test.ts
+++ b/tests/e2e/src/cases/listener-tls-e2e.test.ts
@@ -1,0 +1,163 @@
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { stringify as yamlStringify } from "yaml";
+import { Agent, request } from "undici";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { EtcdClient, pickFreePorts } from "../harness/index.js";
+
+// E2E: `proxy.tls` / `admin.tls` actually serve HTTPS.
+//
+// Pins issue #473: both TLS config blocks were parsed into the config
+// structs but never wired into the Axum listeners, so the ports kept
+// serving plain HTTP while the docs claimed TLS. This spec configures a
+// self-signed cert on both listeners and asserts:
+//   1. HTTPS works on the proxy listener (`/livez`).
+//   2. HTTPS works on the admin listener (`/metrics`, unauthenticated).
+//   3. A plain-HTTP request to the TLS proxy port does NOT succeed.
+
+const BIN_PATH =
+  process.env.AISIX_BIN ??
+  join(process.cwd(), "..", "..", "target", "debug", "aisix");
+
+const insecureAgent = new Agent({ connect: { rejectUnauthorized: false } });
+
+async function waitForHttpsReady(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await request(url, { dispatcher: insecureAgent });
+      res.body.dump();
+      if (res.statusCode === 200) return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`timed out waiting for ${url}: ${String(lastErr)}`);
+}
+
+describe("listener TLS (#473)", () => {
+  let child: ChildProcess | undefined;
+  let dir: string | undefined;
+  let proxyPort = 0;
+  let adminPort = 0;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    dir = await mkdtemp(join(tmpdir(), "aisix-tls-e2e-"));
+    const certFile = join(dir, "server.crt");
+    const keyFile = join(dir, "server.key");
+    // Self-signed cert valid for 127.0.0.1.
+    execFileSync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048",
+      "-keyout", keyFile, "-out", certFile,
+      "-days", "1", "-nodes",
+      "-subj", "/CN=127.0.0.1",
+      "-addext", "subjectAltName=IP:127.0.0.1",
+    ]);
+
+    [proxyPort, adminPort] = await pickFreePorts(2);
+    const adminKey = `admin-${randomUUID()}`;
+    const cfg = {
+      etcd: {
+        endpoints: [process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379"],
+        prefix: `/aisix-e2e-tls-${randomUUID()}`,
+        dial_timeout_ms: 5000,
+        request_timeout_ms: 5000,
+      },
+      proxy: {
+        addr: `127.0.0.1:${proxyPort}`,
+        request_body_limit_bytes: 10485760,
+        tls: { cert_file: certFile, key_file: keyFile },
+      },
+      admin: {
+        addr: `127.0.0.1:${adminPort}`,
+        admin_keys: [adminKey],
+        tls: { cert_file: certFile, key_file: keyFile },
+      },
+      observability: {
+        service_name: "aisix-e2e-tls",
+        log_level: "warn",
+        access_log: false,
+        metrics: { prometheus: { enabled: true, path: "/metrics" } },
+      },
+      cache: { backend: "memory" },
+    };
+    const cfgPath = join(dir, "config.yaml");
+    await writeFile(cfgPath, yamlStringify(cfg), "utf8");
+
+    const childEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && !k.startsWith("AISIX_")) childEnv[k] = v;
+    }
+    childEnv.RUST_LOG = process.env.RUST_LOG ?? "warn";
+    childEnv.NO_PROXY = "127.0.0.1,localhost";
+    childEnv.no_proxy = "127.0.0.1,localhost";
+
+    child = spawn(BIN_PATH, ["--config", cfgPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: childEnv,
+    });
+    let buf = "";
+    child.stderr?.on("data", (c: Buffer) => (buf += c.toString("utf8")));
+    child.stdout?.on("data", (c: Buffer) => (buf += c.toString("utf8")));
+
+    try {
+      await waitForHttpsReady(`https://127.0.0.1:${proxyPort}/livez`, 15_000);
+    } catch (err) {
+      throw new Error(`${String(err)}\n--- aisix output ---\n${buf}`);
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    if (child) {
+      child.kill("SIGTERM");
+      await new Promise((r) => setTimeout(r, 500));
+      child.kill("SIGKILL");
+    }
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  test("proxy listener serves HTTPS", async (ctx) => {
+    if (!etcdReachable) return ctx.skip();
+    const res = await request(`https://127.0.0.1:${proxyPort}/livez`, {
+      dispatcher: insecureAgent,
+    });
+    res.body.dump();
+    expect(res.statusCode).toBe(200);
+  });
+
+  test("admin listener serves HTTPS", async (ctx) => {
+    if (!etcdReachable) return ctx.skip();
+    const res = await request(`https://127.0.0.1:${adminPort}/metrics`, {
+      dispatcher: insecureAgent,
+    });
+    res.body.dump();
+    expect(res.statusCode).toBe(200);
+  });
+
+  test("plain HTTP to the TLS proxy port does not succeed", async (ctx) => {
+    if (!etcdReachable) return ctx.skip();
+    // A plain-HTTP request hitting a TLS listener must not yield a 200.
+    let ok = false;
+    try {
+      const res = await request(`http://127.0.0.1:${proxyPort}/livez`, {
+        dispatcher: insecureAgent,
+        headersTimeout: 2000,
+        bodyTimeout: 2000,
+      });
+      res.body.dump();
+      ok = res.statusCode === 200;
+    } catch {
+      ok = false;
+    }
+    expect(ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #473

## Problem

`docs/operations/tls-and-mtls.md` documents `proxy.tls` and `admin.tls` as listener TLS, but setting them does not make the ports serve HTTPS. The fields are parsed into `ProxyConfig`/`AdminConfig` but the listeners are bound with a plain `tokio::net::TcpListener` + `axum::serve` and never wrapped in a TLS acceptor — so the config is silently ignored and the ports stay on plain HTTP.

## Fix

Add a `serve_http` helper in `aisix-server` that:

- when a `tls` block is present, binds with `axum_server::bind_rustls(addr, RustlsConfig::from_pem_file(cert_file, key_file))` to serve HTTPS;
- otherwise keeps the existing plain `axum::serve` path.

Both the proxy and admin listeners route through this helper. Graceful shutdown is preserved for both paths: the plain path uses the existing `with_graceful_shutdown(shutdown_signal(...))`, and the TLS path bridges the same cancel-watch into `axum_server::Handle::graceful_shutdown`.

No new dependencies: `axum-server` with `tls-rustls` was already declared, and the aws-lc-rs rustls crypto provider is already installed at startup (used by etcd TLS).

## Behavior change

With `proxy.tls` / `admin.tls` set, the corresponding ports now serve HTTPS. Without them, behavior is unchanged (plain HTTP).

## Tests

DP e2e `listener-tls-e2e.test.ts`: starts aisix with a self-signed cert on both listeners and asserts HTTPS succeeds on the proxy (`/livez`) and admin (`/metrics`) ports, and that a plain-HTTP request to the TLS proxy port does not return 200.