### PR TITLE
docs(admin): note managed data planes expose no standalone admin API (#476)

### DIFF
--- a/docs/configuration/admin-api.md
+++ b/docs/configuration/admin-api.md
@@ -6,6 +6,10 @@ sidebar_position: 31
 
 The AISIX AI Gateway admin API is the operator-facing surface for managing the gateway's dynamic configuration.
 
+:::note Standalone only
+The `admin/v1` examples on this page apply to self-hosted standalone AISIX. A [Cloud managed data plane](../quickstart/aisix-cloud-managed-dp.md) only exposes proxy APIs locally and does **not** bind the standalone admin listener — provider keys, models, and caller API keys are managed through the AISIX Cloud control plane instead.
+:::
+
 Use this API when you need to:
 
 - create and update models

--- a/docs/quickstart/first-model-first-key-first-request.md
+++ b/docs/quickstart/first-model-first-key-first-request.md
@@ -12,6 +12,10 @@ This guide shows how to move from a running self-hosted [gateway](../overview/gl
 
 Then you will verify that the new configuration is visible on the proxy surface.
 
+:::note Standalone only
+This guide uses the standalone `admin/v1` API on `127.0.0.1:3001`. A [Cloud managed data plane](aisix-cloud-managed-dp.md) only exposes proxy APIs locally and does **not** bind the standalone admin listener — create provider keys, models, and caller API keys through the AISIX Cloud control plane instead.
+:::
+
 ## Prerequisites
 
 - A running gateway from the [Self-Hosted Quickstart](self-hosted.md)


### PR DESCRIPTION
Closes #476

## Problem

Several docs use standalone admin API examples like `127.0.0.1:3001/admin/v1/*`. A user running a Cloud managed data plane locally may expect those to work against their DP, but a managed DP only exposes the proxy API — the standalone admin listener is not bound, and resources are managed through the Cloud control plane.

## Change

Add a "Standalone only" admonition to the two primary standalone-oriented docs:

- `docs/configuration/admin-api.md`
- `docs/quickstart/first-model-first-key-first-request.md`

Each note states the `admin/v1` examples are self-hosted-only and links to the managed DP quickstart. Docs-only change.