### PR TITLE
docs(metrics): clarify empty /metrics before traffic and managed DP exposure (#478)

### DIFF
--- a/docs/operations/metrics-and-logs.md
+++ b/docs/operations/metrics-and-logs.md
@@ -16,6 +16,16 @@ This endpoint is unauthenticated by design on the private admin listener.
 
 Treat `/metrics` as infrastructure-facing, not as a public diagnostics surface.
 
+:::note `/metrics` is empty before the first request
+Metric families are registered lazily on first observation — the gateway does not pre-register `# HELP` / `# TYPE` lines at startup. Immediately after boot, `GET /metrics` returns an empty body. This is expected, not a misconfigured endpoint. To smoke-test, send one model request and then re-check `/metrics`; you should now see series such as `aisix_requests_total` and `aisix_tokens_consumed_total`.
+:::
+
+### Managed Data Plane Metrics
+
+The `/metrics` endpoint lives on the **admin listener**, which a Cloud managed data plane does not bind. So a managed DP does **not** expose `/metrics` for local scraping.
+
+To get metrics off a managed data plane into your own Prometheus/OTLP stack, configure an OTLP exporter through the AISIX Cloud control plane (the same `otlp_http` exporter resource described below). The data plane fans metrics/telemetry out to the configured collector rather than waiting to be scraped. Self-hosted standalone deployments keep using local `/metrics` scraping as usual.
+
 AISIX exposes native metric names with the `aisix_` prefix. Existing compatibility series remain:
 
 - `aisix_requests_total`


### PR DESCRIPTION
Closes #478

## Problem

`docs/operations/metrics-and-logs.md` doesn't explain two behaviors that make `/metrics` look broken:

1. Immediately after boot, `GET /metrics` returns an empty body.
2. It's unclear how to scrape metrics from a Cloud managed data plane.

## Findings (verified against code)

- The Prometheus integration (`metrics-exporter-prometheus`) registers families lazily on first observation; there are no `describe_*` pre-registration calls, so `/metrics` is empty until the first sample is recorded.
- `/metrics` is served on the admin listener, which managed mode does not bind — so a managed DP exposes no local `/metrics`. Metrics instead leave the DP via OTLP exporters configured through the control plane.

## Change

- Add a note that `/metrics` is empty before the first request (lazy registration) with a smoke-test flow.
- Add a "Managed Data Plane Metrics" subsection explaining managed DPs aren't scraped locally and that metrics flow through an OTLP exporter configured in the Cloud control plane.

Docs-only change.