### PR TITLE
fix(messages): output guardrails on /v1/messages, streaming + non-streaming (#448)

### DIFF
--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1051,6 +1051,11 @@ fn build_anthropic_sse_stream(
         // LiteLLM's streaming guardrail), so a blocked response is signalled
         // with a terminal `error` event rather than held back.
         let mut content_text = String::new();
+        // Also collect streamed tool-call fragments so tool-call output is
+        // scanned too (parity with the non-streaming path). Fragments are
+        // kept raw — the guardrail scans their serialized text, no need to
+        // reassemble by index.
+        let mut tool_call_fragments: Vec<serde_json::Value> = Vec::new();
         while let Some(item) = upstream.next().await {
             match item {
                 Ok(chunk) => {
@@ -1082,6 +1087,9 @@ fn build_anthropic_sse_stream(
                         if let Some(t) = chunk.delta.content.as_deref() {
                             content_text.push_str(t);
                         }
+                        if let Some(tcs) = chunk.delta.tool_calls.as_ref() {
+                            tool_call_fragments.extend(tcs.iter().cloned());
+                        }
                     }
                     for ev in encoder.next_events(&chunk) {
                         yield Ok::<_, std::io::Error>(bytes::Bytes::from(ev.to_sse_string()));
@@ -1105,11 +1113,21 @@ fn build_anthropic_sse_stream(
         // assistant text and, on a block, emit a terminal Anthropic
         // `error` event instead of completing the stream cleanly.
         if let Some(chain) = output_guardrail.as_ref() {
-            if !content_text.is_empty() {
+            if !content_text.is_empty() || !tool_call_fragments.is_empty() {
+                let mut message =
+                    aisix_gateway::ChatMessage::assistant(std::mem::take(&mut content_text));
+                if !tool_call_fragments.is_empty() {
+                    // guardrail_output_text() serializes extra["tool_calls"],
+                    // so streamed tool-call arguments are scanned too.
+                    message.extra.insert(
+                        "tool_calls".to_string(),
+                        serde_json::Value::Array(std::mem::take(&mut tool_call_fragments)),
+                    );
+                }
                 let synth = aisix_gateway::ChatResponse {
                     id: String::new(),
                     model: model_label.clone(),
-                    message: aisix_gateway::ChatMessage::assistant(std::mem::take(&mut content_text)),
+                    message,
                     finish_reason: aisix_gateway::FinishReason::Stop,
                     usage: aisix_gateway::UsageStats::new(0, 0),
                 };
@@ -1404,14 +1422,31 @@ fn update_anthropic_usage(
                 *first_token_seen = true;
                 acc.ttft_ms = started.elapsed().as_millis().min(u32::MAX as u128) as u32;
             }
-            // Accumulate assistant text for the end-of-stream output
-            // guardrail (#448). text_delta carries `delta.text`.
-            if let Some(t) = json
-                .get("delta")
-                .and_then(|d| d.get("text"))
-                .and_then(Value::as_str)
-            {
-                acc.response_text.push_str(t);
+            // Accumulate assistant output for the end-of-stream output
+            // guardrail (#448). text streams as `delta.text`; tool_use
+            // streams its name in `content_block.{name,input}` on
+            // content_block_start and its arguments as `delta.partial_json`
+            // on input_json_delta — scan all of it.
+            if let Some(delta) = json.get("delta") {
+                if let Some(t) = delta.get("text").and_then(Value::as_str) {
+                    acc.response_text.push('\n');
+                    acc.response_text.push_str(t);
+                }
+                if let Some(pj) = delta.get("partial_json").and_then(Value::as_str) {
+                    acc.response_text.push_str(pj);
+                }
+            }
+            if let Some(cb) = json.get("content_block") {
+                if let Some(name) = cb.get("name").and_then(Value::as_str) {
+                    acc.response_text.push('\n');
+                    acc.response_text.push_str(name);
+                }
+                if let Some(input) = cb.get("input") {
+                    if !input.is_null() {
+                        acc.response_text.push('\n');
+                        acc.response_text.push_str(&input.to_string());
+                    }
+                }
             }
         }
         Some("message_delta") => {

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -322,6 +322,7 @@ async fn dispatch(
             &auth.entry.id,
             auth.key().team_id.clone(),
             auth.key().user_id.clone(),
+            &resolved_chain,
         )
         .await;
     }
@@ -343,6 +344,7 @@ async fn dispatch(
             &auth.entry.id,
             auth.key().team_id.clone(),
             auth.key().user_id.clone(),
+            &resolved_chain,
         )
         .await
         {
@@ -377,6 +379,7 @@ async fn dispatch_to_target(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
+    resolved_chain: &aisix_guardrails::GuardrailChain,
 ) -> Result<DispatchOutcome, ProxyError> {
     let model = &target.model;
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
@@ -394,6 +397,7 @@ async fn dispatch_to_target(
             api_key_id,
             team_id,
             user_id,
+            resolved_chain,
         )
         .await;
     }
@@ -411,6 +415,7 @@ async fn dispatch_to_target(
         api_key_id,
         team_id,
         user_id,
+        resolved_chain,
     )
     .await
 }
@@ -433,6 +438,7 @@ async fn anthropic_passthrough_dispatch(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
+    resolved_chain: &aisix_guardrails::GuardrailChain,
 ) -> Result<DispatchOutcome, ProxyError> {
     let mut body = body.clone();
     let api_key = crate::dispatch::require_secret(pk_value, model)?;
@@ -683,6 +689,49 @@ async fn anthropic_passthrough_dispatch(
 
         let metrics = anthropic_metrics_from_response_json(&json_body);
 
+        // #448 (#22): run output guardrails on the passthrough response.
+        // The body is forwarded verbatim, so extract its text (content
+        // blocks + the raw content array, which covers tool_use args) into
+        // a synthetic ChatResponse for inspection before returning it.
+        if !resolved_chain.is_empty() {
+            if let Some(content) = json_body.get("content").and_then(|v| v.as_array()) {
+                let mut out_text = String::new();
+                for block in content {
+                    if let Some(t) = block.get("text").and_then(|v| v.as_str()) {
+                        if !out_text.is_empty() {
+                            out_text.push('\n');
+                        }
+                        out_text.push_str(t);
+                    }
+                }
+                if !out_text.is_empty() {
+                    out_text.push('\n');
+                }
+                out_text.push_str(&Value::Array(content.clone()).to_string());
+
+                let synth = aisix_gateway::ChatResponse {
+                    id: String::new(),
+                    model: model_name.to_string(),
+                    message: aisix_gateway::ChatMessage::assistant(out_text),
+                    finish_reason: aisix_gateway::FinishReason::Stop,
+                    usage: aisix_gateway::UsageStats::new(0, 0),
+                };
+                if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+                    aisix_guardrails::Guardrail::check_output(resolved_chain, &synth).await
+                {
+                    tracing::warn!(
+                        guardrail_hook = "output",
+                        model = %model_name,
+                        reason = %reason,
+                        "guardrail blocked /v1/messages passthrough response",
+                    );
+                    return Err(ProxyError::ContentFiltered(
+                        "response blocked by content policy".into(),
+                    ));
+                }
+            }
+        }
+
         // Restore the gateway-facing model name so callers see what they asked for.
         let mut json_body = json_body;
         if let Some(m) = json_body.get_mut("model") {
@@ -770,6 +819,7 @@ async fn cross_provider_dispatch(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
+    resolved_chain: &aisix_guardrails::GuardrailChain,
 ) -> Result<DispatchOutcome, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
     use aisix_provider_anthropic::{
@@ -909,6 +959,25 @@ async fn cross_provider_dispatch(
     })?;
     state.health.record_success(&model.display_name);
     state.runtime_status.mark_healthy(model_id);
+
+    // #448 (#22): run output guardrails on the cross-provider response
+    // before rendering it back as Anthropic JSON — the response is
+    // client-visible output just like /v1/chat/completions.
+    if !resolved_chain.is_empty() {
+        if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+            aisix_guardrails::Guardrail::check_output(resolved_chain, &resp).await
+        {
+            tracing::warn!(
+                guardrail_hook = "output",
+                model = %model_name,
+                reason = %reason,
+                "guardrail blocked /v1/messages response",
+            );
+            return Err(ProxyError::ContentFiltered(
+                "response blocked by content policy".into(),
+            ));
+        }
+    }
 
     let metrics = AnthropicUsageMetrics {
         prompt_tokens: resp.usage.prompt_tokens,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -255,11 +255,13 @@ async fn dispatch(
         api_key_id: &auth.entry.id,
         team_id: auth.key().team_id.as_deref(),
     };
-    let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    // Arc so the chain can be cloned into the streaming-response body
+    // (which outlives this handler) for end-of-stream output guardrails.
+    let resolved_chain = std::sync::Arc::new(state.guardrail_index.resolve(&guardrail_ctx));
     if !resolved_chain.is_empty() {
         if let Ok(chat) = aisix_provider_anthropic::parse_inbound_request(body) {
             if let aisix_guardrails::GuardrailVerdict::Block { reason } =
-                aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+                aisix_guardrails::Guardrail::check_input(resolved_chain.as_ref(), &chat).await
             {
                 tracing::warn!(
                     guardrail_hook = "input",
@@ -322,7 +324,7 @@ async fn dispatch(
             &auth.entry.id,
             auth.key().team_id.clone(),
             auth.key().user_id.clone(),
-            &resolved_chain,
+            resolved_chain.clone(),
         )
         .await;
     }
@@ -344,7 +346,7 @@ async fn dispatch(
             &auth.entry.id,
             auth.key().team_id.clone(),
             auth.key().user_id.clone(),
-            &resolved_chain,
+            resolved_chain.clone(),
         )
         .await
         {
@@ -379,7 +381,7 @@ async fn dispatch_to_target(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
-    resolved_chain: &aisix_guardrails::GuardrailChain,
+    resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let model = &target.model;
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
@@ -438,7 +440,7 @@ async fn anthropic_passthrough_dispatch(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
-    resolved_chain: &aisix_guardrails::GuardrailChain,
+    resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let mut body = body.clone();
     let api_key = crate::dispatch::require_secret(pk_value, model)?;
@@ -601,8 +603,17 @@ async fn anthropic_passthrough_dispatch(
         let team_id_c = team_id.clone();
         let user_id_c = user_id.clone();
 
-        let parsed_stream =
-            build_anthropic_passthrough_stream(body_stream, started, move |usage| {
+        let stream_guardrail = if resolved_chain.is_empty() {
+            None
+        } else {
+            Some(resolved_chain.clone())
+        };
+        let parsed_stream = build_anthropic_passthrough_stream(
+            body_stream,
+            started,
+            stream_guardrail,
+            model_name.to_string(),
+            move |usage| {
                 // Streaming responses that got this far are 200 — the
                 // !status.is_success() guard above returned early on
                 // upstream errors.
@@ -631,7 +642,8 @@ async fn anthropic_passthrough_dispatch(
                     started.elapsed(),
                     metrics,
                 );
-            });
+            },
+        );
 
         let mut response =
             axum::response::Response::new(axum::body::Body::from_stream(parsed_stream));
@@ -717,7 +729,7 @@ async fn anthropic_passthrough_dispatch(
                     usage: aisix_gateway::UsageStats::new(0, 0),
                 };
                 if let aisix_guardrails::GuardrailVerdict::Block { reason } =
-                    aisix_guardrails::Guardrail::check_output(resolved_chain, &synth).await
+                    aisix_guardrails::Guardrail::check_output(resolved_chain.as_ref(), &synth).await
                 {
                     tracing::warn!(
                         guardrail_hook = "output",
@@ -819,7 +831,7 @@ async fn cross_provider_dispatch(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
-    resolved_chain: &aisix_guardrails::GuardrailChain,
+    resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
 ) -> Result<DispatchOutcome, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
     use aisix_provider_anthropic::{
@@ -897,33 +909,45 @@ async fn cross_provider_dispatch(
         let team_id_for_telem = team_id;
         let user_id_for_telem = user_id;
         let started_for_telem = started;
-        let sse_body = build_anthropic_sse_stream(upstream, encoder, started, move |comp| {
-            let metrics = AnthropicUsageMetrics {
-                prompt_tokens: comp.prompt_tokens,
-                completion_tokens: comp.completion_tokens,
-                cache_creation_tokens: comp.cache_creation_tokens,
-                cache_read_tokens: comp.cache_read_tokens,
-                provider_request_id: comp.provider_request_id,
-                provider_model_version: comp.provider_model_version,
-                finish_reason: comp.finish_reason,
-                ttft_ms: comp.ttft_ms,
-            };
-            emit_anthropic_usage_event(
-                &state_for_telem,
-                &request_id_for_telem,
-                &model_id_for_telem,
-                &api_key_id_for_telem,
-                &provider_for_telem,
-                &model_for_telem,
-                &provider_key_id_for_telem,
-                &upstream_model_for_telem,
-                team_id_for_telem.as_deref(),
-                user_id_for_telem.as_deref(),
-                200,
-                started_for_telem.elapsed(),
-                metrics,
-            );
-        });
+        let stream_guardrail = if resolved_chain.is_empty() {
+            None
+        } else {
+            Some(resolved_chain.clone())
+        };
+        let sse_body = build_anthropic_sse_stream(
+            upstream,
+            encoder,
+            started,
+            stream_guardrail,
+            model_name.to_string(),
+            move |comp| {
+                let metrics = AnthropicUsageMetrics {
+                    prompt_tokens: comp.prompt_tokens,
+                    completion_tokens: comp.completion_tokens,
+                    cache_creation_tokens: comp.cache_creation_tokens,
+                    cache_read_tokens: comp.cache_read_tokens,
+                    provider_request_id: comp.provider_request_id,
+                    provider_model_version: comp.provider_model_version,
+                    finish_reason: comp.finish_reason,
+                    ttft_ms: comp.ttft_ms,
+                };
+                emit_anthropic_usage_event(
+                    &state_for_telem,
+                    &request_id_for_telem,
+                    &model_id_for_telem,
+                    &api_key_id_for_telem,
+                    &provider_for_telem,
+                    &model_for_telem,
+                    &provider_key_id_for_telem,
+                    &upstream_model_for_telem,
+                    team_id_for_telem.as_deref(),
+                    user_id_for_telem.as_deref(),
+                    200,
+                    started_for_telem.elapsed(),
+                    metrics,
+                );
+            },
+        );
 
         let mut response = axum::response::Response::new(sse_body);
         response.headers_mut().insert(
@@ -965,7 +989,7 @@ async fn cross_provider_dispatch(
     // client-visible output just like /v1/chat/completions.
     if !resolved_chain.is_empty() {
         if let aisix_guardrails::GuardrailVerdict::Block { reason } =
-            aisix_guardrails::Guardrail::check_output(resolved_chain, &resp).await
+            aisix_guardrails::Guardrail::check_output(resolved_chain.as_ref(), &resp).await
         {
             tracing::warn!(
                 guardrail_hook = "output",
@@ -1009,6 +1033,8 @@ fn build_anthropic_sse_stream(
     upstream: aisix_gateway::ChatChunkStream,
     encoder: aisix_provider_anthropic::AnthropicSseEncoder,
     started: Instant,
+    output_guardrail: Option<std::sync::Arc<aisix_guardrails::GuardrailChain>>,
+    model_label: String,
     on_complete: impl FnOnce(AnthropicStreamCompletion) + Send + 'static,
 ) -> axum::body::Body {
     use futures::StreamExt;
@@ -1020,6 +1046,11 @@ fn build_anthropic_sse_stream(
         };
         let mut upstream = upstream;
         let mut first_chunk_seen = false;
+        // Accumulate assistant text for the end-of-stream output guardrail
+        // (#448). Bytes are forwarded live (mirrors /v1/chat/completions and
+        // LiteLLM's streaming guardrail), so a blocked response is signalled
+        // with a terminal `error` event rather than held back.
+        let mut content_text = String::new();
         while let Some(item) = upstream.next().await {
             match item {
                 Ok(chunk) => {
@@ -1047,6 +1078,11 @@ fn build_anthropic_sse_stream(
                             comp.cache_creation_tokens.max(u.cache_creation_tokens);
                         comp.cache_read_tokens = comp.cache_read_tokens.max(u.cache_read_tokens);
                     }
+                    if output_guardrail.is_some() {
+                        if let Some(t) = chunk.delta.content.as_deref() {
+                            content_text.push_str(t);
+                        }
+                    }
                     for ev in encoder.next_events(&chunk) {
                         yield Ok::<_, std::io::Error>(bytes::Bytes::from(ev.to_sse_string()));
                     }
@@ -1060,6 +1096,33 @@ fn build_anthropic_sse_stream(
                         e.error_type(),
                         serde_json::to_string(&e.to_string()).unwrap_or_else(|_| "\"error\"".into()),
                     );
+                    yield Ok(bytes::Bytes::from(frame));
+                    return;
+                }
+            }
+        }
+        // End-of-stream output guardrail (#448): scan the accumulated
+        // assistant text and, on a block, emit a terminal Anthropic
+        // `error` event instead of completing the stream cleanly.
+        if let Some(chain) = output_guardrail.as_ref() {
+            if !content_text.is_empty() {
+                let synth = aisix_gateway::ChatResponse {
+                    id: String::new(),
+                    model: model_label.clone(),
+                    message: aisix_gateway::ChatMessage::assistant(std::mem::take(&mut content_text)),
+                    finish_reason: aisix_gateway::FinishReason::Stop,
+                    usage: aisix_gateway::UsageStats::new(0, 0),
+                };
+                if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+                    aisix_guardrails::Guardrail::check_output(chain.as_ref(), &synth).await
+                {
+                    tracing::warn!(
+                        guardrail_hook = "output",
+                        model = %model_label,
+                        reason = %reason,
+                        "guardrail blocked streaming /v1/messages response",
+                    );
+                    let frame = "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"content_filter\",\"message\":\"response blocked by content policy\"}}\n\n";
                     yield Ok(bytes::Bytes::from(frame));
                     return;
                 }
@@ -1290,6 +1353,9 @@ struct AnthropicStreamUsage {
     /// Count of upstream byte-chunks actually delivered to the client
     /// (read by the Drop guard for the #419 cost-leak gate).
     chunks_delivered: u32,
+    /// Assistant text accumulated from `content_block_delta` frames, for
+    /// the end-of-stream output guardrail (#448).
+    response_text: String,
 }
 
 /// Update the accumulator from one parsed SSE `data:` JSON object.
@@ -1337,6 +1403,15 @@ fn update_anthropic_usage(
             if !*first_token_seen {
                 *first_token_seen = true;
                 acc.ttft_ms = started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+            }
+            // Accumulate assistant text for the end-of-stream output
+            // guardrail (#448). text_delta carries `delta.text`.
+            if let Some(t) = json
+                .get("delta")
+                .and_then(|d| d.get("text"))
+                .and_then(Value::as_str)
+            {
+                acc.response_text.push_str(t);
             }
         }
         Some("message_delta") => {
@@ -1496,6 +1571,8 @@ impl<T> Stream for AnthropicDeliveryCounter<T> {
 fn build_anthropic_passthrough_stream<S, F>(
     upstream: S,
     started: Instant,
+    output_guardrail: Option<std::sync::Arc<aisix_guardrails::GuardrailChain>>,
+    model_label: String,
     on_complete: F,
 ) -> AnthropicDeliveryCounter<reqwest::Result<Bytes>>
 where
@@ -1551,6 +1628,34 @@ where
             // upstream error mid-stream is passed through; the
             // accumulator keeps whatever was captured before it).
             yield item;
+        }
+        // End-of-stream output guardrail (#448): scan the accumulated
+        // assistant text. On a block, emit a terminal Anthropic `error`
+        // event (bytes were already forwarded verbatim, mirroring the
+        // cross-provider path and LiteLLM's streaming guardrail).
+        if let Some(chain) = output_guardrail.as_ref() {
+            let text = std::mem::take(&mut guard.usage().response_text);
+            if !text.is_empty() {
+                let synth = aisix_gateway::ChatResponse {
+                    id: String::new(),
+                    model: model_label.clone(),
+                    message: aisix_gateway::ChatMessage::assistant(text),
+                    finish_reason: aisix_gateway::FinishReason::Stop,
+                    usage: aisix_gateway::UsageStats::new(0, 0),
+                };
+                if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+                    aisix_guardrails::Guardrail::check_output(chain.as_ref(), &synth).await
+                {
+                    tracing::warn!(
+                        guardrail_hook = "output",
+                        model = %model_label,
+                        reason = %reason,
+                        "guardrail blocked streaming /v1/messages passthrough response",
+                    );
+                    let frame = "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"content_filter\",\"message\":\"response blocked by content policy\"}}\n\n";
+                    yield Ok(Bytes::from(frame));
+                }
+            }
         }
         // guard drops here → on_complete fires (delivery-gated).
     };

--- a/tests/e2e/src/cases/messages-output-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-output-guardrail-e2e.test.ts
@@ -77,12 +77,19 @@ describe("/v1/messages output guardrail (#448)", () => {
       return;
     }
     // The mock always replies "mock reply", so once the output guardrail
-    // is live every /v1/messages call should be blocked.
-    await waitConfigPropagation(async () => (await messages("ready-probe")).status >= 400);
+    // is live every /v1/messages call is blocked. Gate specifically on the
+    // guardrail block (422), not any 4xx, so transient propagation errors
+    // don't satisfy the gate.
+    await waitConfigPropagation(async () => (await messages("ready-probe")).status === 422);
 
     const res = await messages("anything at all");
-    expect(res.status, "output guardrail must block the forbidden reply").toBeGreaterThanOrEqual(400);
-    const body = await res.text();
-    expect(body).toContain("content");
+    // ContentFiltered → 422; on the Anthropic /v1/messages envelope a 422
+    // maps to error.type "invalid_request_error" (not OpenAI's
+    // "content_filter") — see error.rs anthropic_error_type.
+    expect(res.status, "output guardrail must block the forbidden reply").toBe(422);
+    const json = (await res.json()) as { type?: string; error?: { type?: string; message?: string } };
+    expect(json.type).toBe("error");
+    expect(json.error?.type).toBe("invalid_request_error");
+    expect(json.error?.message ?? "").toContain("content policy");
   });
 });

--- a/tests/e2e/src/cases/messages-output-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-output-guardrail-e2e.test.ts
@@ -1,0 +1,88 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: non-streaming /v1/messages runs OUTPUT guardrails (#448 #22).
+// Pre-fix the /v1/messages response was returned without any output
+// check. Here a cross-provider /v1/messages request (Anthropic protocol →
+// OpenAI bridge) gets the mock's canned "mock reply"; an output guardrail
+// blocking the literal "reply" must reject the response rather than
+// return it.
+
+const CALLER = "sk-msgout-gr-caller";
+const HASH = createHash("sha256").update(CALLER).digest("hex");
+
+describe("/v1/messages output guardrail (#448)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    const pk = await admin.createProviderKey({
+      display_name: "msgout-gr-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    // OpenAI-provider model → /v1/messages takes the cross-provider path
+    // (Anthropic protocol translated to the OpenAI bridge).
+    await admin.createModel({
+      display_name: "msgout-gr",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({ key_hash: HASH, allowed_models: ["msgout-gr"] });
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: "msgout-gr-output-keyword",
+      enabled: true,
+      hook_point: "output",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: "reply" }],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  const messages = (content: string) =>
+    fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": CALLER },
+      body: JSON.stringify({
+        model: "msgout-gr",
+        max_tokens: 64,
+        messages: [{ role: "user", content }],
+      }),
+    });
+
+  test("a forbidden response is blocked on /v1/messages (non-streaming)", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    // The mock always replies "mock reply", so once the output guardrail
+    // is live every /v1/messages call should be blocked.
+    await waitConfigPropagation(async () => (await messages("ready-probe")).status >= 400);
+
+    const res = await messages("anything at all");
+    expect(res.status, "output guardrail must block the forbidden reply").toBeGreaterThanOrEqual(400);
+    const body = await res.text();
+    expect(body).toContain("content");
+  });
+});

--- a/tests/e2e/src/cases/messages-streaming-output-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-streaming-output-guardrail-e2e.test.ts
@@ -1,0 +1,102 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: STREAMING /v1/messages runs output guardrails at end-of-stream
+// (#448 #22). The Anthropic passthrough forwards bytes verbatim, so a
+// blocked response is signalled with a terminal `error` event (mirroring
+// /v1/chat/completions and LiteLLM's streaming guardrail). We stream
+// Anthropic SSE whose text_delta carries a forbidden token and require
+// the response to end with a content_filter error event.
+
+const CALLER = "sk-msgstream-gr-caller";
+const HASH = createHash("sha256").update(CALLER).digest("hex");
+const FORBIDDEN = "forbiddenstreamtoken";
+const STREAM_EVENTS = [
+  JSON.stringify({
+    type: "message_start",
+    message: { id: "msg_s", role: "assistant", content: [], model: "claude-3-5-haiku-20241022", stop_reason: null, usage: { input_tokens: 5, output_tokens: 1 } },
+  }),
+  JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+  JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `here is ${FORBIDDEN} in the stream` } }),
+  JSON.stringify({ type: "content_block_stop", index: 0 }),
+  JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 12 } }),
+  JSON.stringify({ type: "message_stop" }),
+];
+
+describe("streaming /v1/messages output guardrail (#448)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    upstream = await startOpenAiUpstream({ streamEvents: STREAM_EVENTS, eventDelayMs: 2 });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    const pk = await admin.createProviderKey({
+      display_name: "msgstream-gr-pk",
+      secret: "sk-anth-mock",
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "msgstream-gr",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({ key_hash: HASH, allowed_models: ["msgstream-gr"] });
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: "msgstream-gr-output-keyword",
+      enabled: true,
+      hook_point: "output",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: FORBIDDEN }],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  const stream = () =>
+    fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": CALLER },
+      body: JSON.stringify({
+        model: "msgstream-gr",
+        max_tokens: 64,
+        stream: true,
+        messages: [{ role: "user", content: "go" }],
+      }),
+    });
+
+  test("a forbidden streamed response ends with a content_filter error event", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    await waitConfigPropagation(async () => {
+      const r = await stream();
+      const b = await r.text();
+      return b.includes("content_filter");
+    });
+
+    const res = await stream();
+    expect(res.status).toBe(200); // stream starts 200; the block is in-band
+    const body = await res.text();
+    expect(body, "streamed content is forwarded verbatim").toContain(FORBIDDEN);
+    expect(body, "stream must end with a content_filter error event").toContain("content_filter");
+  });
+});

--- a/tests/e2e/src/cases/messages-streaming-toolcall-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-streaming-toolcall-guardrail-e2e.test.ts
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: streaming /v1/messages output guardrails also cover tool_use
+// payloads (#448 #22). Anthropic streams tool_use args as input_json_delta
+// (and the name in content_block_start), with no text_delta. The
+// passthrough end-of-stream guardrail must scan that too — a forbidden
+// token in the tool arguments must trigger a terminal content_filter
+// error, matching the non-streaming path.
+
+const CALLER = "sk-msgtool-gr-caller";
+const HASH = createHash("sha256").update(CALLER).digest("hex");
+const FORBIDDEN = "forbiddentoolarg";
+const STREAM_EVENTS = [
+  JSON.stringify({
+    type: "message_start",
+    message: { id: "msg_t", role: "assistant", content: [], model: "claude-3-5-haiku-20241022", stop_reason: null, usage: { input_tokens: 5, output_tokens: 1 } },
+  }),
+  JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "tu_1", name: "run_query", input: {} } }),
+  JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: `{"q":"${FORBIDDEN}"}` } }),
+  JSON.stringify({ type: "content_block_stop", index: 0 }),
+  JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 10 } }),
+  JSON.stringify({ type: "message_stop" }),
+];
+
+describe("streaming /v1/messages tool_use output guardrail (#448)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    upstream = await startOpenAiUpstream({ streamEvents: STREAM_EVENTS, eventDelayMs: 2 });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    const pk = await admin.createProviderKey({
+      display_name: "msgtool-gr-pk",
+      secret: "sk-anth-mock",
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "msgtool-gr",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({ key_hash: HASH, allowed_models: ["msgtool-gr"] });
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: "msgtool-gr-output-keyword",
+      enabled: true,
+      hook_point: "output",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: FORBIDDEN }],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  const stream = () =>
+    fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": CALLER },
+      body: JSON.stringify({ model: "msgtool-gr", max_tokens: 64, stream: true, messages: [{ role: "user", content: "go" }] }),
+    });
+
+  test("forbidden tool_use arguments in a stream trigger a content_filter error", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    await waitConfigPropagation(async () => (await stream().then((r) => r.text())).includes("content_filter"));
+
+    const body = await stream().then((r) => r.text());
+    expect(body, "tool_use arguments are forwarded verbatim").toContain(FORBIDDEN);
+    expect(body, "stream must end with a content_filter error event").toContain("content_filter");
+  });
+});


### PR DESCRIPTION
Completes the output side of #448 #22, closing the last enforcement gap.

## Problem
`/v1/messages` returned the upstream response without any output guardrail check on either dispatch path (cross-provider + Anthropic passthrough), for both non-streaming and streaming. (Input guardrails + budget already landed earlier in #448.)

## Fix
Thread the resolved guardrail chain (as `Arc`) through the `/v1/messages` dispatch paths and run output guardrails:
- **Non-streaming** — cross-provider checks the bridge `ChatResponse`; passthrough extracts the response text (content blocks + raw `content` array, covering `tool_use`) into a synthetic `ChatResponse`.
- **Streaming** — both the cross-provider SSE-encoder path and the verbatim Anthropic byte-passthrough accumulate assistant text and run the guardrail at end-of-stream. Bytes are forwarded live (matching `/v1/chat/completions` and LiteLLM's streaming guardrail), so a block is signalled with a terminal Anthropic `error` (`content_filter`) event.

## Tests
- `messages-output-guardrail-e2e` — non-streaming cross-provider response blocked.
- `messages-streaming-output-guardrail-e2e` — streamed forbidden text → content forwarded, then a terminal `content_filter` error event.
- Existing `/v1/messages` round-trip + anthropic-streaming-usage e2e still pass (benign traffic unaffected).

## Standard-behavior (not changed)
`#6` count_tokens input guardrails, `#2/#13` reasoning_content output guardrails, and `#450 #24` remote-guardrail-vs-rate-limit ordering are accepted as standard behavior — LiteLLM has the same gaps.

Fixes #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Output guardrails for `/v1/messages` now enforced in both streaming and non-streaming modes across all provider types
  * Blocked responses return appropriate error responses, including terminal error frames for streaming

* **Tests**
  * Added E2E tests for output guardrail enforcement in both streaming and non-streaming scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->