### PR TITLE
fix: harden upstream-error handling — forward 429 Retry-After + UTF-8-safe truncation (#144, #420)

### DIFF
--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -318,19 +318,7 @@ async fn count_tokens_to_target(
         let status_u16 = status.as_u16();
         let retry_after = aisix_gateway::parse_retry_after(upstream_resp.headers());
         let message = upstream_resp.text().await.unwrap_or_default();
-        let truncated = if message.len() > 1024 {
-            // Truncate on a UTF-8 char boundary — slicing at the raw byte
-            // index 1024 panics when it splits a multibyte codepoint,
-            // which a non-ASCII upstream error body can trigger on this
-            // error path.
-            let end = (0..=1024)
-                .rev()
-                .find(|&i| message.is_char_boundary(i))
-                .unwrap_or(0);
-            format!("{}…", &message[..end])
-        } else {
-            message
-        };
+        let truncated = crate::util::truncate_on_char_boundary(&message, 1024);
         let err = aisix_gateway::BridgeError::upstream_status_with_retry_after(
             status_u16,
             truncated,

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -243,6 +243,15 @@ impl ProxyError {
             // body carries (prd-09b §5.8 retry_after_seconds), so the
             // header and body agree — SDKs back off on the header.
             ProxyError::BudgetExceeded(r) => r.retry_after_seconds,
+            // Forward an upstream 429's Retry-After hint so SDK clients
+            // back off on the provider's actual cool-down instead of a
+            // default. The hint is parsed into `UpstreamStatus.retry_after`
+            // by the bridge; only 429 carries a meaningful value.
+            ProxyError::Bridge(BridgeError::UpstreamStatus {
+                status: 429,
+                retry_after: Some(d),
+                ..
+            }) => Some(d.as_secs()),
             _ => None,
         }
     }
@@ -505,6 +514,37 @@ mod tests {
         let wrapped = ProxyError::Bridge(bridge_err);
         assert_eq!(wrapped.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(wrapped.kind(), "upstream_error");
+    }
+
+    #[test]
+    fn upstream_429_forwards_retry_after_hint() {
+        // An upstream 429 carrying a parsed Retry-After must surface
+        // through retry_after_secs so the response writer emits the
+        // header SDKs back off on (#144).
+        let wrapped = ProxyError::Bridge(BridgeError::upstream_status_with_retry_after(
+            429,
+            "rate limited",
+            Some(std::time::Duration::from_secs(30)),
+        ));
+        assert_eq!(wrapped.retry_after_secs(), Some(30));
+    }
+
+    #[test]
+    fn upstream_429_without_hint_has_no_retry_after() {
+        let wrapped = ProxyError::Bridge(BridgeError::upstream_status(429, "rate limited"));
+        assert_eq!(wrapped.retry_after_secs(), None);
+    }
+
+    #[test]
+    fn non_429_upstream_does_not_forward_retry_after() {
+        // Only 429 carries a meaningful hint; a stray Retry-After on a
+        // 5xx must not leak to the client.
+        let wrapped = ProxyError::Bridge(BridgeError::upstream_status_with_retry_after(
+            503,
+            "unavailable",
+            Some(std::time::Duration::from_secs(30)),
+        ));
+        assert_eq!(wrapped.retry_after_secs(), None);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -49,6 +49,7 @@ mod rerank;
 mod responses;
 mod routing;
 mod state;
+mod util;
 
 pub use auth::AuthenticatedKey;
 pub use error::{ErrorEnvelope, ProxyError};

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -542,11 +542,7 @@ async fn anthropic_passthrough_dispatch(
         let status_u16 = status.as_u16();
         let retry_after = aisix_gateway::parse_retry_after(upstream_resp.headers());
         let message = upstream_resp.text().await.unwrap_or_default();
-        let truncated = if message.len() > 1024 {
-            format!("{}…", &message[..1024])
-        } else {
-            message
-        };
+        let truncated = crate::util::truncate_on_char_boundary(&message, 1024);
         let err = aisix_gateway::BridgeError::upstream_status_with_retry_after(
             status_u16,
             truncated,

--- a/crates/aisix-proxy/src/util.rs
+++ b/crates/aisix-proxy/src/util.rs
@@ -1,0 +1,52 @@
+//! Small shared helpers for the proxy layer.
+
+/// Truncate `s` to at most `max_bytes` bytes, rounding down to a UTF-8
+/// char boundary, and append an ellipsis when truncation occurred.
+///
+/// Slicing a `String`/`str` at a fixed byte offset (`&s[..n]`) panics
+/// when the offset splits a multibyte codepoint. A non-ASCII upstream
+/// error body can trigger that on the error-handling path (issue #420),
+/// so every site that truncates an upstream error body for a log line
+/// or error envelope must go through this helper rather than a raw
+/// byte slice.
+pub(crate) fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let end = (0..=max_bytes)
+        .rev()
+        .find(|&i| s.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("{}…", &s[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_string_is_returned_unchanged() {
+        assert_eq!(truncate_on_char_boundary("hello", 1024), "hello");
+    }
+
+    #[test]
+    fn ascii_over_limit_truncates_and_appends_ellipsis() {
+        let s = "a".repeat(2000);
+        assert_eq!(
+            truncate_on_char_boundary(&s, 1024),
+            format!("{}…", "a".repeat(1024))
+        );
+    }
+
+    #[test]
+    fn multibyte_body_does_not_panic_and_rounds_down_to_boundary() {
+        // '€' is 3 bytes; 1024 is not a multiple of 3, so a raw
+        // `&s[..1024]` slice would split a codepoint and panic. The
+        // helper must round down to byte 1023 (341 whole '€').
+        let s = "€".repeat(1000); // 3000 bytes
+        let out = truncate_on_char_boundary(&s, 1024);
+        let kept = out.strip_suffix('…').expect("ellipsis appended");
+        assert_eq!(kept, "€".repeat(341)); // 341 * 3 = 1023 bytes
+        assert!(kept.len() <= 1024);
+    }
+}

--- a/tests/e2e/src/cases/upstream-retry-after-passthrough-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-retry-after-passthrough-e2e.test.ts
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: when an upstream provider returns 429 with a `Retry-After`
+// header, the gateway must forward BOTH the 429 status AND the
+// `Retry-After` value to the client, so SDKs back off on the provider's
+// actual cool-down instead of a default (#144). Before the fix the
+// gateway forwarded the 429 but dropped the header.
+
+const CALLER_PLAINTEXT = "sk-retry-after-passthrough";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("upstream 429 Retry-After passthrough e2e", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // Every upstream reply is a 429 carrying `Retry-After: 30`. The
+    // readiness probe below uses the proxy's model list (not the
+    // upstream), so only the chat call actually hits this 429.
+    upstream = await startOpenAiUpstream({
+      status: 429,
+      responseHeaders: { "retry-after": "30" },
+      errorBody: { error: { message: "slow down", type: "rate_limit_error" } },
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "retry-after-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "retry-after-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["retry-after-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("forwards the upstream Retry-After header on a 429 passthrough", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "retry-after-model");
+    });
+
+    // maxRetries=0 so the SDK surfaces the first 429 instead of
+    // silently retrying around it.
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
+        model: "retry-after-model",
+        messages: [{ role: "user", content: "hi" }],
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      throw new Error("unreachable: caught is not APIError");
+    }
+    expect(caught.status).toBe(429);
+    // The load-bearing assertion: the upstream's Retry-After must reach
+    // the client verbatim. OpenAI Node SDK 4.x lowercases header lookups.
+    expect(caught.headers?.["retry-after"]).toBe("30");
+  });
+});


### PR DESCRIPTION
Two related hardening fixes on the upstream-error path. Closes #144 and #420.

### #144 — forward upstream 429 `Retry-After`
When an upstream returns `429` with a `Retry-After` header, the gateway forwarded the `429` status but dropped the header, so SDK clients backed off on a default instead of the provider's actual cool-down. The bridge already parses the header into `UpstreamStatus.retry_after`; it just wasn't surfaced. `ProxyError::retry_after_secs` now returns it for the `Bridge` 429 arm (and only 429 — a stray hint on a 5xx is ignored).

### #420 — UTF-8 truncation panic
The `/v1/messages` upstream-error path truncated the body with a raw byte slice `&message[..1024]`, which panics when a non-ASCII error body lands byte 1024 mid-codepoint. `count_tokens.rs` already had a char-boundary-safe version; that logic is now extracted into a shared `util::truncate_on_char_boundary` helper and both sites route through it so the family can't drift again. (`rerank.rs` was already safe via `chars().take()`.)

### Behavior change
A 429 passthrough now carries `Retry-After` to the client. No change to non-429 statuses or to successful responses.

### Tests
- `#144`: unit tests on `retry_after_secs` (429 with/without hint, non-429 ignored) **plus** an e2e (`upstream-retry-after-passthrough-e2e`) that mocks an upstream 429 + `Retry-After: 30` and asserts the client sees `retry-after: 30`. Verified it fails before the fix (header absent) and passes after.
- `#420`: unit tests on the shared helper (ASCII over-limit, multibyte rounds down to a char boundary without panicking, short strings unchanged). The pure-string truncation is exercised at the helper level, its appropriate layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed rate-limit response handling. The gateway now correctly forwards `Retry-After` headers from upstream API providers alongside 429 errors, enabling client applications to implement proper retry and backoff strategies based on upstream guidance.

* **Tests**
  * Added end-to-end test coverage for upstream rate-limit header passthrough functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->