### PR TITLE
fix(usage): require completion/output tokens before emitting UsageEvents (#429)

### DIFF
--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -222,13 +222,12 @@ async fn dispatch(
 /// <https://platform.openai.com/docs/api-reference/completions/object>
 fn extract_completion_usage(body: &Value) -> Option<CompletionUsage> {
     let usage = body.get("usage")?;
-    // Required field — gate emit on its presence so a malformed
-    // `usage: {}` upstream response doesn't generate a noise row.
+    // Both fields are required on a spec-compliant 200. Gate emit on
+    // each so a malformed reply (e.g. `usage: {prompt_tokens: 50}` with
+    // no completion side) is skipped rather than silently under-billed
+    // with a 0 (#429).
     let prompt_tokens = usage.get("prompt_tokens").and_then(|v| v.as_u64())? as u32;
-    let completion_tokens = usage
-        .get("completion_tokens")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
+    let completion_tokens = usage.get("completion_tokens").and_then(|v| v.as_u64())? as u32;
     Some(CompletionUsage {
         prompt_tokens,
         completion_tokens,
@@ -599,6 +598,56 @@ mod tests {
         if let Ok(Some(ev)) = recv {
             panic!(
                 "no UsageEvent should be emitted when upstream usage block is malformed, \
+                 but got prompt_tokens={}",
+                ev.prompt_tokens,
+            );
+        }
+    }
+
+    /// #429: a 200 whose `usage` carries `prompt_tokens` but omits the
+    /// required `completion_tokens` is malformed — emitting it would
+    /// silently under-bill the completion side with a 0. It must be
+    /// skipped, same as a wholly-empty usage block.
+    #[tokio::test]
+    async fn skips_usage_event_when_completion_tokens_missing() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        let upstream_body = serde_json::json!({
+            "id": "cmpl-up-1",
+            "object": "text_completion",
+            "choices": [],
+            "usage": { "prompt_tokens": 50 }  // missing completion_tokens
+        });
+        Mock::given(method("POST"))
+            .and(path("/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("instruct"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let body = serde_json::json!({"model": "instruct", "prompt": "x"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        if let Ok(Some(ev)) = recv {
+            panic!(
+                "no UsageEvent should be emitted when completion_tokens is missing, \
                  but got prompt_tokens={}",
                 ev.prompt_tokens,
             );

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -400,12 +400,12 @@ async fn responses_to_target(
 /// <https://platform.openai.com/docs/api-reference/responses/object>
 fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
     let usage = body.get("usage")?;
-    // Required field — gate emit on its presence (audit MEDIUM-1).
+    // input_tokens and output_tokens are both required on a
+    // spec-compliant 200. Gate emit on each so a malformed reply
+    // missing the output side is skipped rather than under-billed with
+    // a 0 (#429, audit MEDIUM-1).
     let prompt_tokens = usage.get("input_tokens").and_then(|v| v.as_u64())? as u32;
-    let completion_tokens = usage
-        .get("output_tokens")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
+    let completion_tokens = usage.get("output_tokens").and_then(|v| v.as_u64())? as u32;
     let reasoning_tokens = usage
         .get("output_tokens_details")
         .and_then(|d| d.get("reasoning_tokens"))
@@ -1027,6 +1027,58 @@ mod tests {
         if let Ok(Some(ev)) = recv {
             panic!(
                 "no UsageEvent should be emitted for malformed `usage: {{}}`, \
+                 got prompt_tokens={}",
+                ev.prompt_tokens,
+            );
+        }
+    }
+
+    /// #429: a 200 whose `usage` carries `input_tokens` but omits the
+    /// required `output_tokens` is malformed — emitting it would
+    /// under-bill the output side with a 0. It must be skipped.
+    #[tokio::test]
+    async fn skips_usage_event_when_output_tokens_missing() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        let upstream_body = serde_json::json!({
+            "id": "resp-abc",
+            "object": "response",
+            "output": [],
+            "usage": { "input_tokens": 17 }  // missing output_tokens
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": "hi"
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        if let Ok(Some(ev)) = recv {
+            panic!(
+                "no UsageEvent should be emitted when output_tokens is missing, \
                  got prompt_tokens={}",
                 ev.prompt_tokens,
             );


### PR DESCRIPTION
Closes #429.

### Problem
`extract_completion_usage` (`/v1/completions`) and `extract_response_usage` (`/v1/responses`) gated emit on the prompt side (`prompt_tokens` / `input_tokens`) but treated the completion side (`completion_tokens` / `output_tokens`) as optional with `unwrap_or(0)`. A non-conformant provider returning `{prompt_tokens: 50}` with no completion side would silently under-bill (emit a row with `completion_tokens = 0`) rather than skipping the malformed reply.

### Fix
Both fields are documented as required on every spec-compliant 200, so gate emit on each symmetrically (`...as_u64()?`). A reply missing either side now emits no event, matching the existing `usage: {}` behavior.

### Tests
Mirror regression tests on both endpoints: an upstream 200 whose `usage` carries only the prompt side emits no `UsageEvent`. They fail before this change (an event with a zeroed completion side is emitted) and pass after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where upstream responses with incomplete usage data would emit incorrect usage events with zero values. Usage data is now validated to ensure all required fields are present and numeric before metrics are recorded.

* **Tests**
  * Added test cases for Issue `#429` to verify proper validation of incomplete usage data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->