### PR TITLE
fix(bedrock): cross-region prefix coverage (#412) + SDK error detail on guardrail failure (#106)

### DIFF
--- a/crates/aisix-guardrails/src/bedrock.rs
+++ b/crates/aisix-guardrails/src/bedrock.rs
@@ -207,11 +207,13 @@ impl BedrockGuardrail {
     }
 
     fn handle_failure(&self, failure: BedrockFailure) -> GuardrailVerdict {
-        let reason = failure.bypass_tag();
+        let (reason, error_detail, error_source) = failure.log_fields();
         tracing::warn!(
             row = %self.row_name,
             guardrail_id = %self.guardrail_id,
-            failure = ?failure,
+            failure_tag = reason,
+            error = error_detail,
+            source = error_source,
             fail_open = self.fail_open,
             "bedrock ApplyGuardrail call failed",
         );
@@ -230,12 +232,21 @@ impl BedrockGuardrail {
 /// Failure cause buckets that map onto `guardrail_bypassed_reason`
 /// telemetry tags. `Other` collapses every long-tail SDK error onto
 /// `bedrock_5xx` so an unrecognised AWS error doesn't leak its
-/// internal shape into our wire schema.
+/// internal shape into our wire schema — but it carries the original
+/// SDK error detail for the failure log line so operators can tell a
+/// network blip from an auth/validation error (#106).
 #[derive(Debug)]
 enum BedrockFailure {
     Timeout,
     Throttled,
-    Other,
+    Other {
+        /// Human-readable detail for logs: the modeled service error
+        /// (carries the exception code, e.g. AccessDeniedException) or
+        /// the dispatch/transport error Display.
+        detail: String,
+        /// The underlying cause (hyper/rustls/sigv4) when present.
+        source: Option<String>,
+    },
 }
 
 impl BedrockFailure {
@@ -245,15 +256,39 @@ impl BedrockFailure {
             if matches!(svc.err(), ApplyGuardrailError::ThrottlingException(_)) {
                 return Self::Throttled;
             }
+            // Surface the modeled service error — its Debug carries the
+            // exception code (AccessDeniedException, ValidationException,
+            // …) so the failure log is greppable.
+            return Self::Other {
+                detail: format!("{:?}", svc.err()),
+                source: std::error::Error::source(&err).map(|s| s.to_string()),
+            };
         }
-        Self::Other
+        // Dispatch / response / construction / timeout: the SdkError
+        // Display names the variant; source() reaches the underlying
+        // hyper/rustls/sigv4 error.
+        Self::Other {
+            detail: err.to_string(),
+            source: std::error::Error::source(&err).map(|s| s.to_string()),
+        }
     }
 
     fn bypass_tag(&self) -> &'static str {
         match self {
             Self::Timeout => "bedrock_timeout",
             Self::Throttled => "bedrock_throttled",
-            Self::Other => "bedrock_5xx",
+            Self::Other { .. } => "bedrock_5xx",
+        }
+    }
+
+    /// Fields for the failure log line: the wire-stable tag plus, for
+    /// `Other`, the captured SDK error detail and underlying source.
+    fn log_fields(&self) -> (&'static str, Option<&str>, Option<&str>) {
+        match self {
+            Self::Other { detail, source } => {
+                (self.bypass_tag(), Some(detail.as_str()), source.as_deref())
+            }
+            _ => (self.bypass_tag(), None, None),
         }
     }
 }
@@ -337,7 +372,35 @@ mod tests {
     fn bypass_tags_match_wire_contract() {
         assert_eq!(BedrockFailure::Timeout.bypass_tag(), "bedrock_timeout");
         assert_eq!(BedrockFailure::Throttled.bypass_tag(), "bedrock_throttled");
-        assert_eq!(BedrockFailure::Other.bypass_tag(), "bedrock_5xx");
+        assert_eq!(
+            BedrockFailure::Other {
+                detail: "x".into(),
+                source: None,
+            }
+            .bypass_tag(),
+            "bedrock_5xx",
+        );
+    }
+
+    /// #106: the `Other` bucket keeps the wire-stable `bedrock_5xx`
+    /// tag but surfaces the captured SDK error detail + source so the
+    /// failure log line is greppable. The non-`Other` buckets carry no
+    /// extra detail.
+    #[test]
+    fn other_failure_log_fields_carry_detail_and_source() {
+        let f = BedrockFailure::Other {
+            detail: "AccessDeniedException(...)".into(),
+            source: Some("dispatch failure: connection refused".into()),
+        };
+        let (tag, detail, source) = f.log_fields();
+        assert_eq!(tag, "bedrock_5xx");
+        assert_eq!(detail, Some("AccessDeniedException(...)"));
+        assert_eq!(source, Some("dispatch failure: connection refused"));
+
+        let (tag, detail, source) = BedrockFailure::Timeout.log_fields();
+        assert_eq!(tag, "bedrock_timeout");
+        assert_eq!(detail, None);
+        assert_eq!(source, None);
     }
 
     /// `handle_failure` is the integration point between the SDK
@@ -375,7 +438,10 @@ mod tests {
     #[tokio::test]
     async fn other_5xx_with_fail_open_true_tags_5xx() {
         let g = build_test(true);
-        let v = g.handle_failure(BedrockFailure::Other);
+        let v = g.handle_failure(BedrockFailure::Other {
+            detail: "AccessDeniedException(...)".into(),
+            source: None,
+        });
         match v {
             GuardrailVerdict::Bypass { reason } => assert_eq!(reason, "bedrock_5xx"),
             other => panic!("expected Bypass, got {other:?}"),

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -199,8 +199,9 @@ const KNOWN_PUBLISHER_TAGS: &[&str] = &[
 
 impl BedrockPublisher {
     /// Resolve the publisher from the Bedrock model id, tolerating
-    /// cross-region inference profile prefixes (`us.`, `eu.`,
-    /// `apac.`, `global.`, `us-gov.`).
+    /// cross-region inference profile prefixes (`us.`, `eu.`, `apac.`,
+    /// `global.`, `us-gov.`, `au.`, `ca.`, `jp.`, …) — see
+    /// [`strip_region_prefix`] for the exact rule.
     pub fn from_model_id(model_id: &str) -> Option<Self> {
         let stripped = strip_region_prefix(model_id);
         let (publisher_tag, _rest) = stripped.split_once('.')?;
@@ -244,8 +245,15 @@ impl BedrockPublisher {
 
 /// Strip a leading cross-region inference profile prefix.
 ///
-/// Recognized prefixes (per AWS catalog as of 2026-05):
-/// `us.`, `eu.`, `apac.`, `global.`, `us-gov.`.
+/// Rather than hardcode AWS's region list (which grows over time),
+/// this strips any leading 2–7 char `[a-z0-9-]` token that is
+/// immediately followed by a known publisher tag. That covers every
+/// documented cross-region prefix without a code change when AWS adds
+/// a new region: `us.`, `eu.`, `apac.`, `global.`, `us-gov.`, `au.`
+/// (Australia), `ca.` (Canada), `jp.` (Japan), … The publisher-tag
+/// gate means a token that isn't a real prefix (no known publisher
+/// after it) is left untouched, so a plain `anthropic.claude-…` id is
+/// never mangled.
 fn strip_region_prefix(model_id: &str) -> &str {
     let Some((maybe_region, rest)) = model_id.split_once('.') else {
         return model_id;
@@ -1360,6 +1368,24 @@ mod tests {
         assert_eq!(
             BedrockPublisher::from_model_id("us-gov.anthropic.claude-3-5-sonnet-20241022-v2:0"),
             Some(BedrockPublisher::Anthropic),
+        );
+    }
+
+    #[test]
+    fn publisher_strips_au_ca_jp_cross_region_prefixes() {
+        // #412: Australia/Canada/Japan cross-region inference profiles
+        // must resolve to their publisher, same as us./eu./apac.
+        assert_eq!(
+            BedrockPublisher::from_model_id("au.meta.llama3-1-70b-instruct-v1:0"),
+            Some(BedrockPublisher::Meta),
+        );
+        assert_eq!(
+            BedrockPublisher::from_model_id("ca.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            Some(BedrockPublisher::Anthropic),
+        );
+        assert_eq!(
+            BedrockPublisher::from_model_id("jp.amazon.nova-pro-v1:0"),
+            Some(BedrockPublisher::AmazonNova),
         );
     }
 


### PR DESCRIPTION
Two bedrock fixes. Closes #412 and #106.

### #412 — cross-region inference profile prefixes (au/ca/jp)
Investigation showed `strip_region_prefix` is already forward-compatible: it strips any short `[a-z0-9-]` token that precedes a known publisher tag, so `au.`/`ca.`/`jp.` profiles **already dispatch** (the reported "publisher-unknown error" wasn't reproducible). The real gaps were the stale docstrings (claimed only 5 prefixes) and missing test coverage. This corrects the docstrings to describe the actual rule and adds a test pinning `au.meta` / `ca.anthropic` / `jp.amazon.nova`. **No behavior change** — chose to document+pin the existing forward-compatible behavior rather than tighten to a fixed allowlist (which would reject any future AWS region prefix until a code change).

### #106 — surface SDK error detail on guardrail failure
`BedrockFailure::Other` collapsed every non-throttle SDK error into a bare `failure=Other` log, leaving operators blind on Bedrock outages. `Other` now carries the modeled service error detail (Debug includes the exception code, e.g. `AccessDeniedException`/`ValidationException`) plus the underlying `source` (hyper/rustls/sigv4), logged as structured `error`/`source` fields. The wire-stable `bedrock_5xx` bypass tag is unchanged, so `guardrail_bypassed_reason` dashboards are unaffected.

### Tests
- #412: unit test pinning au/ca/jp (and the existing us/eu/apac/global/us-gov tests still pass).
- #106: unit test on `log_fields` (Other carries detail+source, non-Other carries none); the existing `apply_5xx_*` wiremock tests exercise `from_sdk` → `Other` → `handle_failure` end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error logging for Bedrock failures to capture more detailed error information and sources.

* **Documentation**
  * Improved documentation for cross-region inference profile handling in the Bedrock provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->