### PR TITLE
fix(guardrails): scan content_blocks text (#465) + tolerate null Azure arrays (#470)

### DIFF
--- a/crates/aisix-guardrails/src/bedrock.rs
+++ b/crates/aisix-guardrails/src/bedrock.rs
@@ -340,7 +340,7 @@ impl Guardrail for BedrockGuardrail {
 fn collect_input_text(req: &ChatFormat) -> String {
     req.messages
         .iter()
-        .map(|m| m.content.as_str())
+        .map(crate::message_scan_text)
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("\n")

--- a/crates/aisix-guardrails/src/keyword.rs
+++ b/crates/aisix-guardrails/src/keyword.rs
@@ -105,7 +105,8 @@ impl Guardrail for KeywordBlocklist {
         let combined: String = req
             .messages
             .iter()
-            .map(|m| m.content.as_str())
+            .map(crate::message_scan_text)
+            .filter(|s| !s.is_empty())
             .collect::<Vec<_>>()
             .join("\n");
         match self.first_match(&combined) {
@@ -165,6 +166,23 @@ mod tests {
             .check_input(&req(&[("user", "say the FORBIDDEN word")]))
             .await;
         assert!(v.is_block());
+    }
+
+    #[tokio::test]
+    async fn matches_text_in_content_blocks_when_flat_content_empty() {
+        // #465: a message whose text lives only in content_blocks (empty
+        // top-level content — the round-trip shape) must still be
+        // scanned. Before the shared message_scan_text helper this
+        // bypassed moderation entirely.
+        let msg: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "user",
+            "content": "",
+            "content_blocks": [{"type": "text", "text": "the FORBIDDEN word"}]
+        }))
+        .unwrap();
+        let g = KeywordBlocklist::new(vec![KeywordRule::literal("Forbidden")]);
+        let v = g.check_input(&ChatFormat::new("m", vec![msg])).await;
+        assert!(v.is_block(), "content-block text must be scanned");
     }
 
     #[tokio::test]

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -32,8 +32,33 @@ mod prompt_shield;
 #[cfg(feature = "azure-content-safety")]
 mod text_moderation;
 
-use aisix_gateway::{ChatFormat, ChatResponse};
+use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse};
 use async_trait::async_trait;
+
+/// The text a guardrail should scan for one message.
+///
+/// Prefers the flat `content` string; when it's empty, falls back to
+/// concatenating the `text`-type entries of `content_blocks`. A caller
+/// that sends the OpenAI content-block shape
+/// (`content: [{ "type": "text", "text": "…" }]`) with an empty
+/// top-level string would otherwise bypass moderation entirely (#465).
+/// Non-text blocks (image/audio) are out of scope — multimodal
+/// moderation is a separate feature. Every guardrail's input/output
+/// collector goes through this so the families can't drift.
+pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
+    if !m.content.is_empty() {
+        return m.content.clone();
+    }
+    match m.content_blocks.as_ref() {
+        Some(blocks) => blocks
+            .iter()
+            .filter(|b| b.get("type").and_then(serde_json::Value::as_str) == Some("text"))
+            .filter_map(|b| b.get("text").and_then(serde_json::Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        None => String::new(),
+    }
+}
 
 #[cfg(feature = "bedrock")]
 pub use bedrock::BedrockGuardrail;
@@ -242,6 +267,44 @@ pub trait Guardrail: Send + Sync + 'static {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn message_scan_text_falls_back_to_content_blocks() {
+        // Flat content present → used verbatim.
+        let flat: ChatMessage =
+            serde_json::from_value(serde_json::json!({"role": "user", "content": "hello"}))
+                .unwrap();
+        assert_eq!(message_scan_text(&flat), "hello");
+
+        // The #465 bypass shape: empty top-level content with the text
+        // in an explicit content_blocks array (round-trip form). Must
+        // be scanned, not skipped.
+        let blocks_only: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "user",
+            "content": "",
+            "content_blocks": [
+                {"type": "text", "text": "first"},
+                {"type": "image_url", "image_url": {"url": "http://x"}},
+                {"type": "text", "text": "second"}
+            ]
+        }))
+        .unwrap();
+        assert_eq!(message_scan_text(&blocks_only), "first\nsecond");
+
+        // Empty content, only a non-text block → nothing to scan.
+        let image_only: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "user",
+            "content": "",
+            "content_blocks": [{"type": "image_url", "image_url": {"url": "http://x"}}]
+        }))
+        .unwrap();
+        assert_eq!(message_scan_text(&image_only), "");
+
+        // Empty content, no blocks → empty.
+        let empty: ChatMessage =
+            serde_json::from_value(serde_json::json!({"role": "user", "content": ""})).unwrap();
+        assert_eq!(message_scan_text(&empty), "");
+    }
 
     #[test]
     fn verdict_helpers() {

--- a/crates/aisix-guardrails/src/prompt_shield.rs
+++ b/crates/aisix-guardrails/src/prompt_shield.rs
@@ -301,7 +301,7 @@ impl Guardrail for PromptShieldGuardrail {
 fn collect_input_text(req: &ChatFormat) -> String {
     req.messages
         .iter()
-        .map(|m| m.content.as_str())
+        .map(crate::message_scan_text)
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("\n")

--- a/crates/aisix-guardrails/src/text_moderation.rs
+++ b/crates/aisix-guardrails/src/text_moderation.rs
@@ -282,9 +282,17 @@ struct AnalyzeRequest<'a> {
 
 #[derive(Deserialize)]
 struct AnalyzeResponse {
-    #[serde(rename = "categoriesAnalysis", default, deserialize_with = "null_as_empty")]
+    #[serde(
+        rename = "categoriesAnalysis",
+        default,
+        deserialize_with = "null_as_empty"
+    )]
     categories_analysis: Vec<CategoryAnalysis>,
-    #[serde(rename = "blocklistsMatch", default, deserialize_with = "null_as_empty")]
+    #[serde(
+        rename = "blocklistsMatch",
+        default,
+        deserialize_with = "null_as_empty"
+    )]
     blocklists_match: Vec<BlocklistMatch>,
 }
 

--- a/crates/aisix-guardrails/src/text_moderation.rs
+++ b/crates/aisix-guardrails/src/text_moderation.rs
@@ -236,7 +236,7 @@ impl TextModerationGuardrail {
         req.messages
             .iter()
             .filter(|m| all || m.role == Role::User)
-            .map(|m| m.content.as_str())
+            .map(crate::message_scan_text)
             .filter(|s| !s.is_empty())
             .collect::<Vec<_>>()
             .join("\n")
@@ -282,10 +282,25 @@ struct AnalyzeRequest<'a> {
 
 #[derive(Deserialize)]
 struct AnalyzeResponse {
-    #[serde(rename = "categoriesAnalysis", default)]
+    #[serde(rename = "categoriesAnalysis", default, deserialize_with = "null_as_empty")]
     categories_analysis: Vec<CategoryAnalysis>,
-    #[serde(rename = "blocklistsMatch", default)]
+    #[serde(rename = "blocklistsMatch", default, deserialize_with = "null_as_empty")]
     blocklists_match: Vec<BlocklistMatch>,
+}
+
+/// Deserialize an array field that may arrive as JSON `null` (or be
+/// absent) into an empty `Vec`. `#[serde(default)]` alone only covers
+/// an *absent* field; a field present as `null` fails with "invalid
+/// type: null, expected a sequence", which previously fail-closed the
+/// whole request as an Azure `ServerError`. Conformant Azure always
+/// sends `[]`, but a non-conformant upstream/proxy can send `null`
+/// (#470).
+fn null_as_empty<'de, D, T>(d: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(d)?.unwrap_or_default())
 }
 
 #[derive(Deserialize)]
@@ -407,6 +422,32 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
+
+    #[test]
+    fn analyze_response_tolerates_null_and_absent_arrays() {
+        // #470: a non-conformant upstream may send the arrays as JSON
+        // `null`; that must deserialize to empty, not fail-closed.
+        let from_null: AnalyzeResponse =
+            serde_json::from_value(json!({ "categoriesAnalysis": null, "blocklistsMatch": null }))
+                .expect("null arrays must deserialize to empty");
+        assert!(from_null.categories_analysis.is_empty());
+        assert!(from_null.blocklists_match.is_empty());
+
+        // Absent fields (today's path) still work.
+        let from_absent: AnalyzeResponse =
+            serde_json::from_value(json!({})).expect("absent arrays default to empty");
+        assert!(from_absent.categories_analysis.is_empty());
+        assert!(from_absent.blocklists_match.is_empty());
+
+        // Conformant Azure (`[]` + populated) is unaffected.
+        let from_conformant: AnalyzeResponse = serde_json::from_value(json!({
+            "categoriesAnalysis": [{ "category": "Hate", "severity": 4 }],
+            "blocklistsMatch": []
+        }))
+        .expect("conformant body must deserialize");
+        assert_eq!(from_conformant.categories_analysis.len(), 1);
+        assert!(from_conformant.blocklists_match.is_empty());
+    }
 
     fn cfg(endpoint: &str) -> AzureContentSafetyTextModerationConfig {
         // Mirrors what cp-api projects after applying its defaults.


### PR DESCRIPTION
Two guardrail input-path fixes. Closes #465 and #470.

### #465 — content_blocks text bypassed moderation
Every text-scanning guardrail (`keyword`, `azure_content_safety` Prompt Shield, `azure_content_safety_text_moderation`, and the bedrock dispatcher) read only the flat `ChatMessage.content`. A message carrying its text in the structured `content_blocks` array with an empty top-level `content` (the round-trip shape) was scanned as empty → moderation bypassed.

Fix: a shared `crate::message_scan_text(m)` helper that uses `content` when present and otherwise concatenates the `text`-type entries of `content_blocks`. All four collectors now route through it, so the family can't drift again. Non-text blocks (image/audio) are out of scope — multimodal moderation is a separate feature.

### #470 — Azure null arrays fail-closed
`AnalyzeResponse.categoriesAnalysis`/`blocklistsMatch` were non-optional `Vec` with only `#[serde(default)]`, which covers an *absent* field but not one present as JSON `null`. A non-conformant upstream/proxy sending `null` failed deserialization and fail-closed-blocked **every** request as an Azure `ServerError`. Added a `null_as_empty` deserializer mapping `null`/absent → empty `Vec`. Conformant Azure (`[]`) is unaffected.

### Tests
- #465: `message_scan_text` unit test (flat / blocks-only / image-only / empty) + a keyword e2e proving a content-block-only message with a banned word is now blocked (was allowed before).
- #470: `AnalyzeResponse` deserialization test across `null`, absent, and conformant (`[]` + populated) bodies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guardrail checks across keyword filtering, text moderation, and prompt shield now comprehensively scan all message content areas, closing potential bypass vectors.
  * Improved error handling for null or missing data in moderation service responses.

* **Tests**
  * Added tests for comprehensive content scanning and null value handling in moderation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->