### PR TITLE
fix(openai): normalise OpenRouter non-stream message.reasoning → reasoning_content (#648)

### DIFF
--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -176,6 +176,17 @@ pub struct OpenAiResponseMessage {
     /// `choices[0].message.reasoning_content`.
     #[serde(default)]
     pub reasoning_content: Option<String>,
+    /// OpenRouter (and some other OpenAI-compatible aggregators) put a
+    /// reasoning model's chain-of-thought at `message.reasoning` —
+    /// NOT the DeepSeek-canonical `message.reasoning_content` (#648).
+    /// Captured here so `response_into_chat_response` can normalise it
+    /// into the canonical `reasoning_content` slot; without this, an
+    /// OpenRouter reasoning model that returns its whole answer as
+    /// reasoning surfaces empty `content` AND empty `reasoning_content`
+    /// to the customer. Default so non-OpenRouter upstreams (which omit
+    /// the field) parse unaffected.
+    #[serde(default)]
+    pub reasoning: Option<String>,
 }
 
 // `#[serde(default)]` at the container level so an upstream that omits
@@ -245,13 +256,24 @@ pub fn response_into_chat_response(mut raw: OpenAiResponse) -> ChatResponse {
             // streaming path's `delta.reasoning_content`. Skip empty
             // strings so a model that returns `""` doesn't add a noise
             // field.
-            if let Some(reasoning) = c.message.reasoning_content {
-                if !reasoning.is_empty() {
-                    extra.insert(
-                        "reasoning_content".to_string(),
-                        serde_json::Value::String(reasoning),
-                    );
-                }
+            //
+            // #648: normalise OpenRouter's `message.reasoning` into the same
+            // canonical `reasoning_content` slot. The DeepSeek-canonical
+            // `reasoning_content` takes precedence when present; otherwise we
+            // fall back to OpenRouter's `reasoning`. Without this an
+            // OpenRouter reasoning model that emits its whole answer as
+            // reasoning (empty `content`) reaches the customer with BOTH
+            // fields empty.
+            let reasoning_text = c
+                .message
+                .reasoning_content
+                .filter(|s| !s.is_empty())
+                .or(c.message.reasoning.filter(|s| !s.is_empty()));
+            if let Some(reasoning) = reasoning_text {
+                extra.insert(
+                    "reasoning_content".to_string(),
+                    serde_json::Value::String(reasoning),
+                );
             }
             (
                 ChatMessage {
@@ -750,6 +772,103 @@ mod tests {
         assert!(
             !out.message.extra.contains_key("reasoning_content"),
             "no reasoning_content field when upstream didn't send one",
+        );
+    }
+
+    /// #648: OpenRouter puts a reasoning model's chain-of-thought at
+    /// `message.reasoning` (not the DeepSeek-canonical
+    /// `message.reasoning_content`). The non-stream path must normalise it
+    /// into the canonical `reasoning_content` slot, so an OpenRouter
+    /// reasoning model that returns its whole answer as reasoning (empty
+    /// `content`) does NOT reach the customer with both fields empty.
+    #[test]
+    fn non_streaming_openrouter_reasoning_normalises_to_reasoning_content() {
+        let body = r#"{
+            "id": "gen-or",
+            "object": "chat.completion",
+            "model": "z-ai/glm-4.6",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning": "Step 1: parse. Step 2: answer. The capital is Paris."
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 230, "total_tokens": 241}
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        let reasoning = out
+            .message
+            .extra
+            .get("reasoning_content")
+            .expect("OpenRouter `message.reasoning` must normalise into canonical reasoning_content (#648)")
+            .as_str()
+            .unwrap();
+        assert_eq!(
+            reasoning,
+            "Step 1: parse. Step 2: answer. The capital is Paris."
+        );
+    }
+
+    /// #648: when an upstream sends BOTH the canonical `reasoning_content`
+    /// AND OpenRouter's `reasoning`, the canonical field wins (no
+    /// double-capture, no clobber).
+    #[test]
+    fn non_streaming_canonical_reasoning_content_takes_precedence_over_reasoning() {
+        let body = r#"{
+            "id": "gen-both",
+            "object": "chat.completion",
+            "model": "some-compat-model",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "ok",
+                    "reasoning_content": "canonical thoughts",
+                    "reasoning": "aggregator thoughts"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        let reasoning = out
+            .message
+            .extra
+            .get("reasoning_content")
+            .expect("reasoning_content must be present")
+            .as_str()
+            .unwrap();
+        assert_eq!(
+            reasoning, "canonical thoughts",
+            "canonical reasoning_content must win over OpenRouter `reasoning`",
+        );
+    }
+
+    /// #648: an empty `reasoning` (alongside empty/absent reasoning_content)
+    /// must NOT add a noise field — same skip-empty rule as #466.
+    #[test]
+    fn non_streaming_empty_reasoning_adds_no_extra_field() {
+        let body = r#"{
+            "id": "gen-empty",
+            "object": "chat.completion",
+            "model": "z-ai/glm-4.6",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi", "reasoning": ""},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert!(
+            !out.message.extra.contains_key("reasoning_content"),
+            "empty `reasoning` must not add a reasoning_content field",
         );
     }
 

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -849,6 +849,43 @@ mod tests {
         );
     }
 
+    /// #648: an EMPTY canonical `reasoning_content` ("") alongside a real
+    /// OpenRouter `reasoning` must fall through to `reasoning` — the empty
+    /// canonical must not be treated as "present and winning". This is the
+    /// one branch with real precedence logic (`.filter(!empty).or(...)`), so
+    /// it's the discriminating guard: it FAILS against the pre-fix
+    /// canonical-only code (which ignored `reasoning` entirely).
+    #[test]
+    fn non_streaming_empty_canonical_falls_through_to_openrouter_reasoning() {
+        let body = r#"{
+            "id": "gen-fallthrough",
+            "object": "chat.completion",
+            "model": "z-ai/glm-4.6",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_content": "",
+                    "reasoning": "real openrouter thoughts"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        }"#;
+        let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(
+            out.message
+                .extra
+                .get("reasoning_content")
+                .expect("empty canonical reasoning_content must fall through to OpenRouter `reasoning` (#648)")
+                .as_str()
+                .unwrap(),
+            "real openrouter thoughts",
+        );
+    }
+
     /// #648: an empty `reasoning` (alongside empty/absent reasoning_content)
     /// must NOT add a noise field — same skip-empty rule as #466.
     #[test]


### PR DESCRIPTION
## Summary

Fixes the **non-stream** half of the OpenRouter reasoning gap in AISIX-Cloud **#648**. OpenRouter (and some OpenAI-compatible aggregators) return a reasoning model's chain-of-thought at `message.reasoning` (string) — **not** the DeepSeek-canonical `message.reasoning_content`. `OpenAiResponseMessage` was a closed struct deserializing only `reasoning_content`, so `message.reasoning` was dropped at decode. A reasoning model that emits its whole answer as reasoning (e.g. `z-ai/glm-4.6` via OpenRouter) then reached the customer with **both** `content` AND `reasoning_content` empty.

**Evidence** (AISIX-Cloud real-chain e2e): the z-ai non-stream call returns `status=200, completion_tokens=230` — the upstream generated output — yet the customer saw empty `content`+`reasoning_content`. Consistent across runs; not model nondeterminism.

The **streaming** path already handles OpenRouter's `delta.reasoning` via the per-key `reasoning_field` override — but that lift is streaming/`delta`-only (`extract_reasoning_field` hard-rejects non-`delta` paths), so the non-stream response had no path to surface it.

## Change (auto-normalize — no per-key config required)
`crates/aisix-provider-openai/src/wire.rs`:
- Capture `message.reasoning` on `OpenAiResponseMessage` (was dropped at deserialize).
- In `response_into_chat_response`, lift it into the canonical `reasoning_content` `extra` slot **when the canonical `reasoning_content` is absent/empty**. DeepSeek-canonical `reasoning_content` takes precedence when both are present; an empty `reasoning` adds no noise field (same skip-empty rule as #466). Symmetric with the existing non-stream `reasoning_content` capture.

## Scope / blast radius (this is a global OpenAI-wire change, not OpenRouter-gated)
`OpenAiResponseMessage` is the **shared** OpenAI chat-completions response type for the whole workspace — it's also what `aisix-provider-azure-openai` and any future OpenAI-compatible bridge parse responses through (see the module doc on `pub` visibility). So this normalization is **not** keyed to OpenRouter: *any* upstream routed through the OpenAI wire that returns a non-empty `message.reasoning` (and no/empty `message.reasoning_content`) will now have it surfaced as canonical `reasoning_content`.

This is intended — `reasoning` is the de-facto field for OpenAI-compatible aggregators — and is safe because:
- it only **fills** the canonical slot when the canonical field is absent/empty (never overrides a real `reasoning_content`);
- it adds **no** field when `reasoning` is empty/absent (serde `default`), so OpenAI / Azure-OpenAI / DeepSeek-compat upstreams that never emit `reasoning` are byte-for-byte unaffected.

The blast radius is "OpenAI-compatible upstreams that emit `message.reasoning`", which today is OpenRouter-class aggregators; calling it out so reviewers don't read it as an OpenRouter-only branch.

## Test plan
- [x] 4 unit tests in `wire.rs`: (1) OpenRouter `reasoning`→canonical; (2) canonical-`reasoning_content`-wins precedence; (3) empty-`reasoning`-adds-no-field; (4) **empty-canonical-`reasoning_content`-falls-through-to-`reasoning`** — the discriminating guard exercising the real precedence logic (`reasoning_content.filter(!empty).or(reasoning)`). Verified tests (1) and (4) **FAIL** against the pre-fix canonical-only code and pass with the fix (genuine regression guards, not non-discriminating).
- [x] Existing 8 reasoning tests pass (no regression) — 12 reasoning tests green total.
- [x] `cargo clippy -p aisix-provider-openai` + `cargo fmt --check` clean.
- [x] Sibling crates that reuse these wire types (`aisix-provider-azure-openai`, `aisix-proxy`) build.
- [ ] CI green.

## Streaming parity (follow-up, out of scope here)
This PR makes the **non-stream** path auto-normalize with no operator config. Bringing the **streaming** path to the same no-config parity (default the `delta.reasoning` lift for the OpenRouter adapter so it works without a per-key `reasoning_field` override) is tracked in **#502**.

Closes the non-stream half of api7/AISIX-Cloud#648. Once this lands in the `:dev` image, the AISIX-Cloud `openrouter-longtail` real-chain z-ai non-stream leg goes green without the held-back workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for handling reasoning content in OpenAI API responses. Reasoning information is now properly captured and included in response data when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
