### PR TITLE
chore: replace third-party gateway brand name with neutral wording in comments/docs

### DIFF
--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -12,7 +12,8 @@
 //!
 //! Newer AISIX-native series use `aisix_proxy_*` and `aisix_llm_*`
 //! names with bounded, DP-stable labels. They intentionally do not
-//! copy LiteLLM label names that the data plane does not have.
+//! copy label names from other LLM gateways that the data plane does
+//! not have.
 //!
 //! A single [`Metrics`] instance is held `Arc`'d inside `ObsState` and
 //! cloned into axum state. The exposition format is emitted via

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -283,8 +283,8 @@ where
 /// out the apply order: `param_renames` → `param_constraints` →
 /// `default_body_fields` (request side), `content_list_to_string`
 /// (response side flag, but it transforms the *request* body before
-/// send when the upstream only accepts string content per LiteLLM's
-/// convention). Anything not configured is a no-op.
+/// send when the upstream only accepts string content per the common
+/// gateway convention). Anything not configured is a no-op.
 fn prepare_outbound_body<T: serde::Serialize>(
     typed: &T,
     request: Option<&RequestOverrides>,
@@ -1335,7 +1335,7 @@ data: [DONE]\n\n";
     /// `param_renames` must rewrite the outbound body key. Build a
     /// request with `max_tokens=64`; configure rename
     /// `max_tokens → max_completion_tokens`; the bytes leaving the
-    /// bridge must carry the renamed key (LiteLLM source-wins).
+    /// bridge must carry the renamed key (source-wins convention).
     #[tokio::test]
     async fn chat_applies_param_renames_to_outbound_body() {
         use wiremock::matchers::body_partial_json;
@@ -1471,7 +1471,7 @@ data: [DONE]\n\n";
 
     /// `content_list_to_string=true` flattens the request body's
     /// `messages[*].content` array of text blocks into a string
-    /// before send (LiteLLM convention — applies to the request).
+    /// before send (common gateway convention — applies to the request).
     /// The outbound body must carry `content: "abc"`, not the array.
     #[tokio::test]
     async fn chat_content_list_to_string_flattens_text_blocks_in_outbound_body() {

--- a/crates/aisix-provider-openai/src/overrides.rs
+++ b/crates/aisix-provider-openai/src/overrides.rs
@@ -23,10 +23,9 @@
 //! stays here — it never serializes.
 //!
 //! Reference implementations consulted:
-//! - LiteLLM `convert_content_list_to_str` —
-//!   <https://github.com/BerriAI/litellm/blob/main/litellm/litellm_core_utils/prompt_templates/common_utils.py>
-//! - LiteLLM `convert_content_list_to_string` flag —
-//!   <https://github.com/BerriAI/litellm/blob/main/litellm/llms/openai_like/dynamic_config.py>
+//! - Established OpenAI-compatible gateways' content-block flattening
+//!   (`convert_content_list_to_str`-style) and the request-side
+//!   string-content config flag they expose.
 //! - DeepSeek reasoning shape (`delta.reasoning_content`) —
 //!   <https://api-docs.deepseek.com/guides/reasoning_model>
 //! - OpenAI SSE `data: [DONE]` terminator —
@@ -62,8 +61,8 @@ pub enum StreamDoneOutcome {
 ///
 /// **Collision semantics: source wins.** When both source and target
 /// are present in the body, the source value overwrites the target.
-/// Matches LiteLLM's convention across `databricks` / `openai_like` /
-/// `sambanova` / `dynamic_config` transformations — for the canonical
+/// Matches the established source-wins convention used by widely-deployed
+/// OpenAI-compatible gateways — for the canonical
 /// `max_completion_tokens → max_tokens` case the newer (source) value
 /// is what the caller intended; an accidentally-leftover deprecated
 /// `max_tokens` value should not shadow it.
@@ -215,8 +214,8 @@ pub fn apply_stream_done_marker_policy(
 /// entry's `content` is an array of `{type:"text", text:"..."}`
 /// blocks, replaces it with the concatenated text of those blocks.
 ///
-/// Matches LiteLLM's `convert_content_list_to_str`: text blocks are
-/// concatenated with no separator. Non-text blocks (image_url,
+/// Matches the common gateway `convert_content_list_to_str` behavior:
+/// text blocks are concatenated with no separator. Non-text blocks (image_url,
 /// audio, etc.) are skipped — same behavior as the reference — and
 /// if every block is non-text the field is left as-is, since
 /// flattening a vision payload to an empty string would silently
@@ -271,9 +270,9 @@ pub fn apply_content_list_to_string(body: &mut Value) {
 /// This intentionally does *not* mutate any other shape — the only
 /// guarantee is "after a successful call, the canonical
 /// `reasoning_content` slot reflects whatever the upstream put at
-/// `path`, when the upstream put a string there". Reference:
-/// LiteLLM normalizes vendor-specific reasoning fields onto
-/// `reasoning_content` in [`litellm/llms/ovhcloud/chat/transformation.py`](https://github.com/BerriAI/litellm/blob/main/litellm/llms/ovhcloud/chat/transformation.py).
+/// `path`, when the upstream put a string there". This mirrors the
+/// established ecosystem convention of normalizing vendor-specific
+/// reasoning fields onto the canonical `reasoning_content` slot.
 pub fn extract_reasoning_field(chunk: &mut Value, path: &str) {
     let segments: Vec<&str> = path.split('.').filter(|s| !s.is_empty()).collect();
     if segments.is_empty() {
@@ -405,8 +404,8 @@ mod tests {
 
     #[test]
     fn rename_source_wins_when_both_present() {
-        // Both source and target keys are present in the body. Per
-        // LiteLLM convention (source wins), the source's value should
+        // Both source and target keys are present in the body. Per the
+        // established source-wins convention, the source's value should
         // overwrite the target's pre-existing value — for the canonical
         // max_completion_tokens → max_tokens case, the newer source
         // value 100 wins over the deprecated target value 50.
@@ -660,8 +659,8 @@ mod tests {
 
     #[test]
     fn flattens_two_text_blocks() {
-        // Matches LiteLLM's convert_content_list_to_str: text fields
-        // are concatenated with no separator.
+        // Matches the common gateway convert_content_list_to_str behavior:
+        // text fields are concatenated with no separator.
         let mut body = json!({
             "messages": [{
                 "role": "user",

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -24,9 +24,9 @@
 //! - Anthropic Count Message Tokens API:
 //!   <https://platform.claude.com/docs/en/api/messages-count-tokens>
 //!   (`POST /v1/messages/count_tokens` → `{"input_tokens": <int>}`).
-//! - LiteLLM exposes the same route as a user-facing passthrough
-//!   (<https://docs.litellm.ai/docs/anthropic_count_tokens>) and had the
-//!   identical "route missing from the list" bug (BerriAI/litellm#15006).
+//! - Other OpenAI-compatible gateways expose the same route as a
+//!   user-facing passthrough and hit the identical "route missing from
+//!   the list" bug.
 
 use aisix_obs::{AccessLog, RequestOutcome};
 use axum::extract::rejection::JsonRejection;

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -38,7 +38,7 @@
 //!   taxonomy because the Anthropic SDK's `ErrorType` is a strict
 //!   literal — emitting `"upstream_error"` would silently break
 //!   customers branching on `e.body['error']['type']`. See
-//!   [`anthropic_kind_from_status`] for the LiteLLM-aligned mapping
+//!   [`anthropic_kind_from_status`] for the ecosystem-aligned mapping
 //!   table.
 //!
 //! `ProxyError` is the internal error taxonomy; it implements
@@ -376,10 +376,9 @@ struct AnthropicErrorBody {
 /// canonical strings on `error.type` are static-type violations for
 /// any customer doing `isinstance(e, anthropic.RateLimitError)` plus
 /// `e.body['error']['type'] == 'rate_limit_error'`. Per CLAUDE.md §7
-/// reference-implementation rule, this mapping mirrors LiteLLM's
-/// `anthropic_interface/exceptions/exception_mapping_utils.py`
-/// status-to-type table verbatim — divergence from the established
-/// ecosystem here would silently break Claude SDK users.
+/// reference-implementation rule, this mapping mirrors the established
+/// ecosystem's Anthropic status-to-type table verbatim — divergence from
+/// the established ecosystem here would silently break Claude SDK users.
 ///
 /// (The OpenAI envelope's inner `error.type` keeps the DP-stable
 /// strings per ai-gateway#327; that contract is unchanged on
@@ -408,7 +407,7 @@ impl ProxyError {
     /// Render this error as an Anthropic-shape `{type:"error", error:
     /// {type, message}}` HTTP response. Used by `/v1/messages` so the
     /// Anthropic SDK's envelope parser sees a shape the official
-    /// SDK + LiteLLM both treat as canonical.
+    /// SDK and the broader ecosystem both treat as canonical.
     ///
     /// **Inner `error.type` policy:** maps from the HTTP status code
     /// to the Anthropic SDK's `ErrorType` literal via

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1044,8 +1044,8 @@ fn build_anthropic_sse_stream(
         let mut first_chunk_seen = false;
         // Accumulate assistant text for the end-of-stream output guardrail
         // (#448). Bytes are forwarded live (mirrors /v1/chat/completions and
-        // LiteLLM's streaming guardrail), so a blocked response is signalled
-        // with a terminal `error` event rather than held back.
+        // the common streaming-guardrail pattern), so a blocked response is
+        // signalled with a terminal `error` event rather than held back.
         let mut content_text = String::new();
         // Also collect streamed tool-call fragments so tool-call output is
         // scanned too (parity with the non-streaming path). Fragments are
@@ -1663,7 +1663,7 @@ where
         // End-of-stream output guardrail (#448): scan the accumulated
         // assistant text. On a block, emit a terminal Anthropic `error`
         // event (bytes were already forwarded verbatim, mirroring the
-        // cross-provider path and LiteLLM's streaming guardrail).
+        // cross-provider path and the common streaming-guardrail pattern).
         if let Some(chain) = output_guardrail.as_ref() {
             let text = std::mem::take(&mut guard.usage().response_text);
             if !text.is_empty() {
@@ -2455,7 +2455,7 @@ data: [DONE]\n\n";
     /// customers branching on `e.body['error']['type']` against
     /// Anthropic-canonical strings stay portable. See
     /// `crate::error::anthropic_kind_from_status` for the
-    /// LiteLLM-aligned status→type mapping.
+    /// ecosystem-aligned status→type mapping.
     /// Strict envelope-shape helper used across every error-path
     /// test below — keeps regression coverage tight against a flip
     /// back to OpenAI shape (audit HIGH-2).

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -216,8 +216,9 @@ async fn dispatch(
     // provider's credentials through generic passthrough: pick the first
     // model of the provider the key is actually allowed to access.
     // Without this any valid key could reach any configured provider's
-    // upstream credentials (#449). Mirrors LiteLLM, which enforces the
-    // key's model access on passthrough when a target is identifiable.
+    // upstream credentials (#449). Mirrors the established gateway behavior,
+    // which enforces the key's model access on passthrough when a target is
+    // identifiable.
     let model_entry = all_models
         .into_iter()
         .find(|e| matches_provider(e) && auth.key().can_access(&e.value.display_name))

--- a/docs/configuration/byo-endpoint.md
+++ b/docs/configuration/byo-endpoint.md
@@ -17,7 +17,7 @@ A BYO endpoint uses the `openai` adapter family. The gateway sends a standard `P
 
 ## When to use this
 
-- Use this when you run an inference server that exposes the OpenAI chat-completions API (vLLM, SGLang, Ollama, LiteLLM-style proxies, or your own service).
+- Use this when you run an inference server that exposes the OpenAI chat-completions API (vLLM, SGLang, Ollama, other OpenAI-compatible proxies, or your own service).
 - Use this when you want a private or air-gapped model to share the gateway's auth, allowlist, rate limiting, and usage accounting.
 - Do not use this for AWS Bedrock, Google Vertex AI, or Azure OpenAI — those have native wire shapes and dedicated guides: [AWS Bedrock](../integration/upstream-bedrock.md), [Google Vertex AI](../integration/upstream-vertex.md), [Azure OpenAI](../integration/upstream-azure-openai.md).
 

--- a/docs/operations/metrics-and-logs.md
+++ b/docs/operations/metrics-and-logs.md
@@ -33,7 +33,7 @@ AISIX exposes native metric names with the `aisix_` prefix. Existing compatibili
 - `aisix_ratelimit_rejections_total`
 - `aisix_tokens_consumed_total`
 
-The Prometheus integration also emits LiteLLM-category equivalents under AISIX-native names:
+The Prometheus integration also emits common LLM-gateway-category equivalents under AISIX-native names:
 
 - usage and cost: `aisix_llm_input_tokens_total`, `aisix_llm_output_tokens_total`, `aisix_llm_total_tokens_total`, `aisix_llm_spend_micro_usd_total`
 - request volume and latency: `aisix_llm_requests_total`, `aisix_llm_request_duration_seconds`, `aisix_llm_time_to_first_token_seconds`

--- a/tests/e2e/src/cases/messages-streaming-output-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-streaming-output-guardrail-e2e.test.ts
@@ -13,7 +13,7 @@ import {
 // E2E: STREAMING /v1/messages runs output guardrails at end-of-stream
 // (#448 #22). The Anthropic passthrough forwards bytes verbatim, so a
 // blocked response is signalled with a terminal `error` event (mirroring
-// /v1/chat/completions and LiteLLM's streaming guardrail). We stream
+// /v1/chat/completions and the common streaming-guardrail pattern). We stream
 // Anthropic SSE whose text_delta carries a forbidden token and require
 // the response to end with a content_filter error event.
 


### PR DESCRIPTION
## Summary

A number of doc comments, inline comments, and two docs pages referenced a specific third-party OpenAI-compatible gateway **by brand name** as the reference implementation for various wire-shape and behavior decisions. This PR removes every such reference (case-insensitive, including the external source URLs that embedded the name) and replaces each with a **neutral description of the shared convention** it was documenting — so the engineering rationale is preserved without naming a third-party product.

## Why

Per project convention, that third-party brand name should not appear in shipped source, comments, or docs. The citations were useful as "this matches an established ecosystem convention" notes; the rewrite keeps that meaning while dropping the name.

## What changed (comments / doc-comments / markdown only — no code logic)

10 files, ~27 reference sites:

| File | Reference rewritten to |
|------|------------------------|
| `crates/aisix-obs/src/metrics.rs` | "label names from other LLM gateways" |
| `crates/aisix-provider-openai/src/overrides.rs` (×7) | "established source-wins convention", "common gateway `convert_content_list_to_str` behavior", "established ecosystem convention" for reasoning-field normalization; dropped two external source URLs |
| `crates/aisix-provider-openai/src/bridge.rs` (×3) | "common gateway convention", "source-wins convention" |
| `crates/aisix-proxy/src/count_tokens.rs` | "other OpenAI-compatible gateways"; dropped two external URLs |
| `crates/aisix-proxy/src/error.rs` (×3) | "ecosystem-aligned mapping", "the established ecosystem's Anthropic status-to-type table", "the broader ecosystem" |
| `crates/aisix-proxy/src/messages.rs` (×3) | "common streaming-guardrail pattern", "ecosystem-aligned status→type mapping" |
| `crates/aisix-proxy/src/passthrough.rs` | "established gateway behavior" |
| `docs/configuration/byo-endpoint.md` | "other OpenAI-compatible proxies" |
| `docs/operations/metrics-and-logs.md` | "common LLM-gateway-category equivalents" |
| `tests/e2e/src/cases/messages-streaming-output-guardrail-e2e.test.ts` | "common streaming-guardrail pattern" |

## Verification
- [x] Zero remaining occurrences of the brand name (case-insensitive, whole repo).
- [x] `cargo fmt --check` clean on the 3 touched crates.
- [x] `cargo clippy --all-targets` clean on the 3 touched crates (compiles test targets too).
- [x] Intra-doc links to real Rust items (e.g. `anthropic_kind_from_status`) left intact.
- [x] `rustdoc -D broken_intra_doc_links` emits a **byte-identical** error set to `origin/main` (pre-existing, unrelated; this PR adds none).
- [ ] CI green.

No behavior change — purely textual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comments and documentation across metrics, provider, proxy, and configuration modules to reference general OpenAI-compatible gateway patterns and ecosystem conventions instead of tool-specific references.
  * Clarified descriptions of metric naming, request/response handling, and guardrail behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->