### PR TITLE
fix(openai): normalise OpenRouter delta.reasoning on the streaming path (#502)

### DIFF
--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -387,6 +387,15 @@ pub struct OpenAiStreamDelta {
     /// string lands here.
     #[serde(default)]
     pub reasoning_content: Option<String>,
+    /// OpenRouter (and some OpenAI-compatible aggregators) stream the
+    /// chain-of-thought at `delta.reasoning` — NOT the DeepSeek-canonical
+    /// `delta.reasoning_content` (#502, streaming parity with the
+    /// non-stream #648 fix). Normalised into the canonical
+    /// `reasoning_content` slot in [`stream_chunk_into_chat_chunk`] with no
+    /// per-key config required. Default so non-OpenRouter upstreams (which
+    /// omit the field) parse unaffected.
+    #[serde(default)]
+    pub reasoning: Option<String>,
 }
 
 pub fn stream_chunk_into_chat_chunk(mut raw: OpenAiStreamChunk) -> ChatChunk {
@@ -397,7 +406,15 @@ pub fn stream_chunk_into_chat_chunk(mut raw: OpenAiStreamChunk) -> ChatChunk {
                 role: c.delta.role.as_deref().map(role_from_str),
                 content: c.delta.content,
                 tool_calls: c.delta.tool_calls,
-                reasoning_content: c.delta.reasoning_content,
+                // #648 canonical precedence, mirrored on the streaming path
+                // (#502): DeepSeek-canonical `reasoning_content` wins; fall
+                // back to OpenRouter's `reasoning`. Skip empties so a model
+                // that streams `""` doesn't emit a noise field.
+                reasoning_content: c
+                    .delta
+                    .reasoning_content
+                    .filter(|s| !s.is_empty())
+                    .or(c.delta.reasoning.filter(|s| !s.is_empty())),
             },
             c.finish_reason
                 .as_deref()
@@ -1030,6 +1047,95 @@ mod tests {
         assert_eq!(tc.len(), 1);
         assert_eq!(tc[0]["id"], "call_abc");
         assert_eq!(tc[0]["function"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn stream_chunk_canonical_reasoning_content_propagates() {
+        let body = r#"{
+            "id": "cmpl-r",
+            "model": "deepseek-reasoner",
+            "choices": [{
+                "index": 0,
+                "delta": {"reasoning_content": "thinking..."},
+                "finish_reason": null
+            }]
+        }"#;
+        let raw: OpenAiStreamChunk = serde_json::from_str(body).unwrap();
+        let chunk = stream_chunk_into_chat_chunk(raw);
+        assert_eq!(
+            chunk.delta.reasoning_content.as_deref(),
+            Some("thinking...")
+        );
+    }
+
+    #[test]
+    fn stream_chunk_openrouter_reasoning_normalises_to_reasoning_content() {
+        // OpenRouter streams the chain-of-thought at `delta.reasoning`, with
+        // no per-key override configured. #502: it must surface in the
+        // canonical `delta.reasoning_content` slot, matching non-stream #648.
+        let body = r#"{
+            "id": "cmpl-or",
+            "model": "openrouter/some-reasoner",
+            "choices": [{
+                "index": 0,
+                "delta": {"reasoning": "let me reason about this"},
+                "finish_reason": null
+            }]
+        }"#;
+        let raw: OpenAiStreamChunk = serde_json::from_str(body).unwrap();
+        let chunk = stream_chunk_into_chat_chunk(raw);
+        assert_eq!(
+            chunk.delta.reasoning_content.as_deref(),
+            Some("let me reason about this")
+        );
+    }
+
+    #[test]
+    fn stream_chunk_canonical_reasoning_wins_over_openrouter_reasoning() {
+        let body = r#"{
+            "id": "cmpl-both",
+            "model": "x",
+            "choices": [{
+                "index": 0,
+                "delta": {"reasoning_content": "canonical", "reasoning": "fallback"},
+                "finish_reason": null
+            }]
+        }"#;
+        let raw: OpenAiStreamChunk = serde_json::from_str(body).unwrap();
+        let chunk = stream_chunk_into_chat_chunk(raw);
+        assert_eq!(chunk.delta.reasoning_content.as_deref(), Some("canonical"));
+    }
+
+    #[test]
+    fn stream_chunk_empty_canonical_falls_through_to_openrouter_reasoning() {
+        let body = r#"{
+            "id": "cmpl-empty",
+            "model": "x",
+            "choices": [{
+                "index": 0,
+                "delta": {"reasoning_content": "", "reasoning": "fallback"},
+                "finish_reason": null
+            }]
+        }"#;
+        let raw: OpenAiStreamChunk = serde_json::from_str(body).unwrap();
+        let chunk = stream_chunk_into_chat_chunk(raw);
+        assert_eq!(chunk.delta.reasoning_content.as_deref(), Some("fallback"));
+    }
+
+    #[test]
+    fn stream_chunk_without_reasoning_leaves_slot_empty() {
+        let body = r#"{
+            "id": "cmpl-none",
+            "model": "x",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "hi"},
+                "finish_reason": null
+            }]
+        }"#;
+        let raw: OpenAiStreamChunk = serde_json::from_str(body).unwrap();
+        let chunk = stream_chunk_into_chat_chunk(raw);
+        assert!(chunk.delta.reasoning_content.is_none());
     }
 
     #[test]

--- a/tests/e2e/src/cases/openrouter-stream-reasoning-e2e.test.ts
+++ b/tests/e2e/src/cases/openrouter-stream-reasoning-e2e.test.ts
@@ -1,0 +1,169 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: OpenRouter `delta.reasoning` normalization on the *streaming*
+// /v1/chat/completions path (#502, streaming parity with non-stream #648).
+//
+// OpenRouter (and some OpenAI-compatible aggregators) stream a reasoning
+// model's chain-of-thought at `delta.reasoning`, NOT the DeepSeek-canonical
+// `delta.reasoning_content`. The non-stream half (#648/#501) already
+// normalizes `message.reasoning` → `reasoning_content`; before #502 the
+// streaming delta type had no `reasoning` field, so with no per-key
+// override an OpenRouter reasoning model dropped its whole reasoning trace
+// on the streaming path. We assert the gateway surfaces it in the canonical
+// `delta.reasoning_content` slot with no operator configuration.
+//
+// References:
+// - Issue: api7/ai-gateway#502 (follow-up to #501 / api7/AISIX-Cloud#648)
+
+const CALLER_PLAINTEXT = "sk-or-stream-reasoning-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const REASONING_A = "Let me think. ";
+const REASONING_B = "6 * 7 = 42.";
+const FINAL_ANSWER = "The answer is 42.";
+
+function chunk(delta: Record<string, unknown>, finish: string | null = null) {
+  return JSON.stringify({
+    id: "cmpl-or-stream",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "openrouter/some-reasoner",
+    choices: [{ index: 0, delta, finish_reason: finish }],
+  });
+}
+
+describe("openrouter delta.reasoning normalization on streaming /v1/chat/completions (#502)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // OpenRouter-style streaming: reasoning text arrives on `delta.reasoning`,
+    // the final answer on `delta.content`. No `reasoning_content` anywhere.
+    upstream = await startOpenAiUpstream({
+      streamEvents: [
+        chunk({ role: "assistant" }),
+        chunk({ reasoning: REASONING_A }),
+        chunk({ reasoning: REASONING_B }),
+        chunk({ content: FINAL_ANSWER }),
+        chunk({}, "stop"),
+        "[DONE]",
+      ],
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // OpenRouter dispatches through the OpenAI-compat family bridge.
+    const pk = await admin.createProviderKey({
+      display_name: "or-stream-reasoning-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+      provider: "openrouter",
+      adapter: "openai",
+    });
+    await admin.createModel({
+      display_name: "or-reasoner",
+      provider: "openrouter",
+      model_name: "some-reasoner",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["or-reasoner"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("streaming deltas surface delta.reasoning_content from upstream delta.reasoning (#502)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          },
+          body: JSON.stringify({
+            model: "or-reasoner",
+            stream: true,
+            messages: [{ role: "user", content: "probe" }],
+          }),
+        });
+        // Drain so the next request isn't blocked on a dangling stream.
+        await r.text();
+        return r.ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      },
+      body: JSON.stringify({
+        model: "or-reasoner",
+        stream: true,
+        messages: [{ role: "user", content: "What is 6 times 7?" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const reasoningParts: string[] = [];
+    const contentParts: string[] = [];
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const payload = trimmed.slice("data:".length).trim();
+      if (payload === "[DONE]" || payload === "") continue;
+      const evt = JSON.parse(payload) as {
+        choices?: { delta?: Record<string, unknown> }[];
+      };
+      const delta = evt.choices?.[0]?.delta ?? {};
+      if (typeof delta.reasoning_content === "string") {
+        reasoningParts.push(delta.reasoning_content);
+      }
+      // The upstream's raw `reasoning` field must NOT leak through verbatim;
+      // it should be normalized to `reasoning_content`.
+      expect(
+        delta.reasoning,
+        `raw delta.reasoning leaked: ${JSON.stringify(delta)}`,
+      ).toBeUndefined();
+      if (typeof delta.content === "string") contentParts.push(delta.content);
+    }
+
+    expect(reasoningParts.join(""), `stream:\n${text}`).toBe(
+      REASONING_A + REASONING_B,
+    );
+    expect(contentParts.join("")).toBe(FINAL_ANSWER);
+  });
+});


### PR DESCRIPTION
## Problem

#501 (api7/AISIX-Cloud#648) normalises OpenRouter's `message.reasoning` into the canonical `reasoning_content` slot on the **non-streaming** path. The **streaming** path was not at parity: `OpenAiStreamDelta` had no `reasoning` field, so unless an operator configured a per-key `reasoning_field` override, an OpenRouter reasoning model dropped its entire chain-of-thought when streaming. A reasoning model that emits its answer as reasoning would stream empty `content` and empty `reasoning_content` to the caller.

## Fix

- Add `reasoning: Option<String>` to `OpenAiStreamDelta`.
- In `stream_chunk_into_chat_chunk`, normalise it into `reasoning_content` with the same canonical precedence as the non-stream #648 fix: DeepSeek-canonical `reasoning_content` wins, fall back to OpenRouter's `reasoning`, skip empty strings so a `""` doesn't emit a noise field.

No per-key configuration required. Non-OpenRouter upstreams omit the field and are unaffected. Azure-OpenAI reuses the shared `stream_chunk_into_chat_chunk` / `OpenAiStreamChunk` types, so it inherits the fix.

## Tests

- Unit (`wire.rs`): canonical-propagates, OpenRouter-`reasoning`→`reasoning_content`, canonical-wins-over-reasoning, empty-canonical-falls-through, no-reasoning-leaves-empty.
- E2E (`tests/e2e/src/cases/openrouter-stream-reasoning-e2e.test.ts`): a mock upstream streams `delta.reasoning` (no `reasoning_content`, no per-key override); asserts the gateway surfaces `delta.reasoning_content` across chunks and never leaks raw `delta.reasoning`. Fails before, passes after.

Fixes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)