### PR TITLE
test(usage): backfill 501-no-emit coverage for embeddings + images (#456)

### DIFF
--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -890,6 +890,69 @@ mod tests {
         );
     }
 
+    /// Issue #456 (#226 family): the 501 NotImplemented path (provider
+    /// doesn't support embeddings) must NOT emit a UsageEvent — no
+    /// upstream call happened, so there's nothing to attribute. Mirrors
+    /// the canonical `completions.rs::provider_lacking_complete_returns_501_without_emit`.
+    /// Triggers the path by routing /v1/embeddings at an Anthropic-backed
+    /// model; `AnthropicBridge` doesn't override `Bridge::embed()` so the
+    /// trait default returns `BridgeError::Config(...)` → 501. Without this
+    /// test, a regression flipping `upstream_called: false` → `true` (or
+    /// `usage: None` → `Some(zero)`) on the 501 branch would silently emit
+    /// a bogus zero event.
+    #[tokio::test]
+    async fn provider_lacking_embed_returns_501_without_emit_issue_456() {
+        use aisix_obs::UsageSink;
+        use aisix_provider_anthropic::AnthropicBridge;
+
+        const ANTHROPIC_PK_ID: &str = "22222222-2222-2222-2222-222222222222";
+
+        let anthropic_pk_json = r#"{"display_name":"anthropic-up","secret":"sk-ant-test","provider":"anthropic","adapter":"anthropic"}"#;
+        let anthropic_pk: aisix_core::ProviderKey =
+            serde_json::from_str(anthropic_pk_json).unwrap();
+        let anthropic_pk_entry = ResourceEntry::new(ANTHROPIC_PK_ID, anthropic_pk, 1);
+
+        let anthropic_model_json = format!(
+            r#"{{"display_name":"claude-embed","provider":"anthropic","model_name":"claude-3-haiku-20240307","provider_key_id":"{ANTHROPIC_PK_ID}"}}"#
+        );
+        let anthropic_model: Model = serde_json::from_str(&anthropic_model_json).unwrap();
+        let anthropic_model_entry = ResourceEntry::new("m-anthropic", anthropic_model, 1);
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys.insert(anthropic_pk_entry);
+        snap.models.insert(anthropic_model_entry);
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let body = serde_json::json!({"model": "claude-embed", "input": "hello"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_IMPLEMENTED,
+            "Anthropic-backed /v1/embeddings must surface as 501 \
+             (default Bridge::embed returns BridgeError::Config)",
+        );
+
+        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        if let Ok(Some(ev)) = recv {
+            panic!(
+                "501 NotImplemented must not emit UsageEvent, \
+                 got prompt_tokens={}, status_code={}",
+                ev.prompt_tokens, ev.status_code,
+            );
+        }
+    }
+
     /// Issue #226 audit M1: a 200 response with upstream-reported
     /// `prompt_tokens = 0` MUST still emit a UsageEvent. Pre-fix the
     /// handler gated emission on `prompt_tokens > 0`, conflating

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -614,4 +614,90 @@ mod tests {
         assert_eq!(event.model_id, "m-1");
         assert_eq!(event.inbound_protocol, "openai");
     }
+
+    /// Issue #456 (#226 family): the 501 NotImplemented path (resolved
+    /// bridge doesn't support image generation) must NOT emit a
+    /// UsageEvent — no upstream call happened. Mirrors
+    /// `completions.rs::provider_lacking_complete_returns_501_without_emit`
+    /// and the embeddings sibling. Unlike those, /v1/images/generations
+    /// rejects non-OpenAI providers with 400 *before* dispatch (see
+    /// `non_openai_provider_returns_400_invalid_request`) and the real
+    /// `OpenAiBridge` overrides `generate_image`, so the only way to reach
+    /// the 501 default is an openai-provider Model whose resolved bridge
+    /// leaves `Bridge::generate_image` at the trait default. We register a
+    /// minimal stub under the "openai" key to exercise exactly that.
+    #[tokio::test]
+    async fn resolved_bridge_lacking_generate_image_returns_501_without_emit_issue_456() {
+        use aisix_gateway::{
+            Bridge, BridgeContext, BridgeError, ChatChunkStream, ChatFormat, ChatMessage,
+            ChatResponse, FinishReason, UsageStats,
+        };
+        use aisix_obs::UsageSink;
+
+        // Minimal openai-family bridge that satisfies the required chat
+        // methods but leaves `generate_image` at the 501 trait default.
+        struct NoImageBridge;
+
+        #[async_trait::async_trait]
+        impl Bridge for NoImageBridge {
+            fn name(&self) -> &'static str {
+                "no-image"
+            }
+
+            async fn chat(
+                &self,
+                req: &ChatFormat,
+                _ctx: &BridgeContext,
+            ) -> Result<ChatResponse, BridgeError> {
+                Ok(ChatResponse {
+                    id: "stub".into(),
+                    model: req.model.clone(),
+                    message: ChatMessage::assistant("stub"),
+                    finish_reason: FinishReason::Stop,
+                    usage: UsageStats::new(0, 0),
+                })
+            }
+
+            async fn chat_stream(
+                &self,
+                _req: &ChatFormat,
+                _ctx: &BridgeContext,
+            ) -> Result<ChatChunkStream, BridgeError> {
+                Ok(Box::pin(futures::stream::iter(Vec::new())))
+            }
+        }
+
+        let snap = new_snap("https://api.openai.com");
+        snap.models.insert(model_entry("stub-image"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(NoImageBridge));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let body = serde_json::json!({"model": "stub-image", "prompt": "a cat", "n": 1});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_IMPLEMENTED,
+            "a bridge without generate_image must surface /v1/images/generations as 501 \
+             (default Bridge::generate_image returns BridgeError::Config)",
+        );
+
+        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        if let Ok(Some(ev)) = recv {
+            panic!(
+                "501 NotImplemented must not emit UsageEvent, \
+                 got prompt_tokens={}, status_code={}",
+                ev.prompt_tokens, ev.status_code,
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The #226 UsageEvent family establishes that a `501 NotImplemented` response — where the provider doesn't support the endpoint and no upstream call is made — must NOT emit a UsageEvent (it would be a bogus zero-token event attributed to a call that never happened). `completions.rs` pins this via `provider_lacking_complete_returns_501_without_emit`, but the `embeddings` and `images` handlers, which share the same `upstream_called` emit gate, had no equivalent negative test.

## Changes (test-only)

- **embeddings** (`provider_lacking_embed_returns_501_without_emit_issue_456`): routes an Anthropic-backed model through `/v1/embeddings`; the default `Bridge::embed` returns a 501-mapped `BridgeError::Config`. Asserts 501 + empty `UsageSink`.
- **images** (`resolved_bridge_lacking_generate_image_returns_501_without_emit_issue_456`): `/v1/images/generations` rejects non-OpenAI providers with 400 *before* dispatch, and the real `OpenAiBridge` overrides `generate_image`, so the only way to reach the 501 default is an openai-provider model whose resolved bridge leaves `generate_image` at the trait default — exercised with a minimal stub bridge registered under the `"openai"` key. Asserts 501 + empty `UsageSink`.

## Scope note

`audio`/`rerank`/`responses` have no default-capability 501 branch (they don't fall through to a "does not support" trait default), so there is no analogous no-emit case for them — confirmed by grep. `completions` already covered.

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)