### PR TITLE
fix(usage): emit with zero completion side instead of dropping the event (#429 parity)

### DIFF
--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -209,24 +209,30 @@ async fn dispatch(
 }
 
 /// Pull the usage counters out of a legacy /v1/completions response
-/// body. Returns `None` when:
+/// body. Returns `None` only when:
 ///   - The `usage` block is missing entirely (non-conformant edge), or
 ///   - `usage.prompt_tokens` is missing / non-numeric (malformed)
 ///
-/// Both cases skip UsageEvent emission rather than attributing a
-/// zero-everything noise row to the api_key. Per the OpenAI spec,
-/// `prompt_tokens` is required on every successful completion
-/// response — its absence is upstream-malformed, not a legitimate
-/// zero-spend reply. Wire shape:
+/// Those cases skip UsageEvent emission rather than attributing a
+/// zero-everything noise row to the api_key. The `prompt_tokens` gate
+/// distinguishes "no upstream usage at all" from a legitimate reply.
+///
+/// `completion_tokens`, by contrast, defaults to 0 when absent: a 200
+/// that reports a prompt side but omits the completion side is still a
+/// real billable call (the prompt was processed) and must be recorded.
+/// This matches LiteLLM, which coerces a missing completion side to 0
+/// and still logs/bills the event (`completion_tokens=response["usage"].
+/// get("completion_tokens", 0)` in convert_dict_to_response.py) — see
+/// #429 follow-up. Dropping the whole event would under-record more than
+/// the zeroed-completion it was meant to avoid. Wire shape:
 /// <https://platform.openai.com/docs/api-reference/completions/object>
 fn extract_completion_usage(body: &Value) -> Option<CompletionUsage> {
     let usage = body.get("usage")?;
-    // Both fields are required on a spec-compliant 200. Gate emit on
-    // each so a malformed reply (e.g. `usage: {prompt_tokens: 50}` with
-    // no completion side) is skipped rather than silently under-billed
-    // with a 0 (#429).
     let prompt_tokens = usage.get("prompt_tokens").and_then(|v| v.as_u64())? as u32;
-    let completion_tokens = usage.get("completion_tokens").and_then(|v| v.as_u64())? as u32;
+    let completion_tokens = usage
+        .get("completion_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
     Some(CompletionUsage {
         prompt_tokens,
         completion_tokens,
@@ -603,12 +609,14 @@ mod tests {
         }
     }
 
-    /// #429: a 200 whose `usage` carries `prompt_tokens` but omits the
-    /// required `completion_tokens` is malformed — emitting it would
-    /// silently under-bill the completion side with a 0. It must be
-    /// skipped, same as a wholly-empty usage block.
+    /// #429 (LiteLLM-parity follow-up): a 200 whose `usage` carries
+    /// `prompt_tokens` but omits `completion_tokens` is still a real
+    /// billable call — the prompt was processed. It MUST emit a
+    /// UsageEvent with `completion_tokens = 0` (matching LiteLLM's
+    /// `get("completion_tokens", 0)`), NOT be dropped. Only a fully
+    /// absent / prompt-less usage block skips (see the two tests below).
     #[tokio::test]
-    async fn skips_usage_event_when_completion_tokens_missing() {
+    async fn emits_with_zero_completion_when_completion_tokens_missing() {
         use aisix_obs::UsageSink;
 
         let upstream = MockServer::start().await;
@@ -643,14 +651,15 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        if let Ok(Some(ev)) = recv {
-            panic!(
-                "no UsageEvent should be emitted when completion_tokens is missing, \
-                 but got prompt_tokens={}",
-                ev.prompt_tokens,
-            );
-        }
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must still be emitted when only completion_tokens is missing")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.prompt_tokens, 50, "prompt side must be recorded");
+        assert_eq!(
+            event.completion_tokens, 0,
+            "missing completion_tokens must default to 0, not drop the event"
+        );
     }
 
     /// Issue #403 negative pinning: 4xx / 5xx responses must NOT

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -387,25 +387,28 @@ async fn responses_to_target(
 }
 
 /// Pull the usage counters out of a Responses-API non-streaming
-/// response body. Returns `None` when:
+/// response body. Returns `None` only when:
 ///   - The `usage` block is missing entirely, OR
 ///   - `usage.input_tokens` is missing / non-numeric
 ///
-/// Both cases skip UsageEvent emission rather than attributing a
-/// zero-everything noise row to the api_key. Per the OpenAI
-/// Responses API spec, `input_tokens` is required on every
-/// successful non-streaming 200 — its absence (e.g. `usage: {}`)
-/// is upstream-malformed, not a legitimate zero-spend reply.
-/// Audit MEDIUM-1 on this PR. Spec:
+/// Those cases skip UsageEvent emission rather than attributing a
+/// zero-everything noise row to the api_key. The `input_tokens` gate
+/// distinguishes "no upstream usage at all" from a legitimate reply.
+///
+/// `output_tokens`, by contrast, defaults to 0 when absent: a 200 that
+/// reports an input side but omits the output side is still a real
+/// billable call and must be recorded. This matches LiteLLM, which
+/// coerces a missing completion/output side to 0 and still logs/bills
+/// the event (#429 follow-up; mirrors the tolerant wire-layer decode of
+/// #474). Spec:
 /// <https://platform.openai.com/docs/api-reference/responses/object>
 fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
     let usage = body.get("usage")?;
-    // input_tokens and output_tokens are both required on a
-    // spec-compliant 200. Gate emit on each so a malformed reply
-    // missing the output side is skipped rather than under-billed with
-    // a 0 (#429, audit MEDIUM-1).
     let prompt_tokens = usage.get("input_tokens").and_then(|v| v.as_u64())? as u32;
-    let completion_tokens = usage.get("output_tokens").and_then(|v| v.as_u64())? as u32;
+    let completion_tokens = usage
+        .get("output_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
     let reasoning_tokens = usage
         .get("output_tokens_details")
         .and_then(|d| d.get("reasoning_tokens"))
@@ -1033,11 +1036,13 @@ mod tests {
         }
     }
 
-    /// #429: a 200 whose `usage` carries `input_tokens` but omits the
-    /// required `output_tokens` is malformed — emitting it would
-    /// under-bill the output side with a 0. It must be skipped.
+    /// #429 (LiteLLM-parity follow-up): a 200 whose `usage` carries
+    /// `input_tokens` but omits `output_tokens` is still a real billable
+    /// call. It MUST emit a UsageEvent with `completion_tokens = 0`
+    /// (matching LiteLLM's coerce-missing-to-0), NOT be dropped. Only a
+    /// fully absent / input-less usage block skips.
     #[tokio::test]
-    async fn skips_usage_event_when_output_tokens_missing() {
+    async fn emits_with_zero_output_when_output_tokens_missing() {
         use aisix_obs::UsageSink;
 
         let upstream = MockServer::start().await;
@@ -1075,13 +1080,14 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        if let Ok(Some(ev)) = recv {
-            panic!(
-                "no UsageEvent should be emitted when output_tokens is missing, \
-                 got prompt_tokens={}",
-                ev.prompt_tokens,
-            );
-        }
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must still be emitted when only output_tokens is missing")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.prompt_tokens, 17, "input side must be recorded");
+        assert_eq!(
+            event.completion_tokens, 0,
+            "missing output_tokens must default to 0, not drop the event"
+        );
     }
 }


### PR DESCRIPTION
## Problem

PR #495 (closing #429) made `extract_completion_usage` (`/v1/completions`) and `extract_response_usage` (`/v1/responses`) **require** `completion_tokens` / `output_tokens` — a 200 whose `usage` reports a prompt side but omits the completion side now emits **no** UsageEvent at all.

That diverges from LiteLLM, which coerces a missing completion/output side to 0 and **still logs/bills** the event (`litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py` → `get("completion_tokens", 0)`; `cost_calculator.py` bills the prompt side regardless). Dropping the whole event under-records *more* than the zeroed-completion row #429 was trying to avoid — a prompt-only 200 is a real, billable call.

It was also internally inconsistent with #474/#483, which deliberately made the wire-layer usage decode tolerant (missing field → 0). One layer tolerated, the other rejected the same reply.

## Fix

`completion_tokens` / `output_tokens` now default to 0 when absent. The `prompt_tokens` / `input_tokens` gate stays, so a fully absent or prompt-less `usage` block still skips (preserving the "no upstream usage at all" vs "real reply" distinction, and the 501-no-emit behavior which is gated separately by `upstream_called`).

## Tests

The two #495 regression tests are inverted: a `usage` with only `prompt_tokens` / `input_tokens` now asserts a UsageEvent IS emitted with `completion_tokens = 0` (was: asserts skip). The empty-usage-block and absent-usage-block tests still assert skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usage event tracking for `/v1/completions` and Responses API to properly record events when token count fields are absent, defaulting missing values to 0 instead of skipping the event entirely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->