### PR TITLE
fix(error): map upstream credential errors to 401, not 400 (#367 parity)

### DIFF
--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -156,14 +156,25 @@ pub enum BridgeError {
     #[error("bridge is misconfigured: {0}")]
     Config(String),
     /// Customer-fixable upstream config — the admin's ProviderKey/Model
-    /// is set up wrong (empty secret, missing api_base, missing
-    /// model_name) or the caller's request/key is malformed. Maps to
+    /// is set up wrong (missing api_base, missing model_name) or the
+    /// caller's request is malformed (e.g. split_system shape). Maps to
     /// 400, not 500: it's the caller's mistake, retrying won't help, and
     /// a 5xx wrongly tells SDKs/monitoring it's a server fault (#367).
     /// Contrast [`Config`], reserved for errors *we* cause
     /// (serialization, our generated request_id) which stays 500.
     #[error("invalid upstream configuration: {0}")]
     InvalidUpstreamConfig(String),
+    /// Customer-fixable upstream *credential* problem — the admin's
+    /// ProviderKey secret/credential is missing, empty, or malformed
+    /// (empty secret, api key with invalid HTTP-header bytes, unparseable
+    /// service-account / AAD / Bedrock credential JSON). Maps to 401
+    /// `authentication_error`, not 400: this is an auth-material problem,
+    /// and 401 matches LiteLLM's canonical mapping for the same providers
+    /// (Anthropic/OpenAI/Azure raise `AuthenticationError`). Non-retryable
+    /// (#367 follow-up). Distinct from [`InvalidUpstreamConfig`] (400),
+    /// which is request/routing shape, not credentials.
+    #[error("invalid upstream credentials: {0}")]
+    InvalidUpstreamCredentials(String),
     #[error("transport error: {0}")]
     Transport(String),
     #[error("upstream cancelled the response mid-stream")]
@@ -371,6 +382,7 @@ impl BridgeError {
             BridgeError::UpstreamDecode(_) => 502,
             BridgeError::Config(_) => 500,
             BridgeError::InvalidUpstreamConfig(_) => 400,
+            BridgeError::InvalidUpstreamCredentials(_) => 401,
             BridgeError::Transport(_) => 502,
             BridgeError::StreamAborted => 502,
         }
@@ -384,6 +396,7 @@ impl BridgeError {
             BridgeError::UpstreamDecode(_) => "upstream_decode_error",
             BridgeError::Config(_) => "config_error",
             BridgeError::InvalidUpstreamConfig(_) => "invalid_request_error",
+            BridgeError::InvalidUpstreamCredentials(_) => "authentication_error",
             BridgeError::Transport(_) => "transport_error",
             BridgeError::StreamAborted => "stream_aborted",
         }
@@ -556,12 +569,23 @@ mod tests {
 
     #[test]
     fn invalid_upstream_config_maps_to_400_invalid_request() {
-        // #367: customer-fixable config (empty secret, missing api_base,
-        // missing model_name, …) is a 400, not a 500 — retrying won't
-        // help and a 5xx wrongly reads as a server fault.
-        let e = BridgeError::InvalidUpstreamConfig("provider_key.secret is empty".into());
+        // #367: customer-fixable config (missing api_base, missing
+        // model_name, request-shape …) is a 400, not a 500 — retrying
+        // won't help and a 5xx wrongly reads as a server fault.
+        let e = BridgeError::InvalidUpstreamConfig("provider_key has no api_base".into());
         assert_eq!(e.http_status(), 400);
         assert_eq!(e.error_type(), "invalid_request_error");
+    }
+
+    #[test]
+    fn invalid_upstream_credentials_maps_to_401_authentication() {
+        // #367 follow-up: auth-material problems (empty/invalid secret,
+        // unparseable credential JSON) are a 401 authentication_error,
+        // not a 400 — they're a distinct class from request/routing shape
+        // and match LiteLLM's AuthenticationError mapping.
+        let e = BridgeError::InvalidUpstreamCredentials("provider_key.secret is empty".into());
+        assert_eq!(e.http_status(), 401);
+        assert_eq!(e.error_type(), "authentication_error");
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -148,7 +148,7 @@ fn resolve_base(ctx: &BridgeContext) -> Result<String, BridgeError> {
 fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
     let k = &ctx.provider_key.secret;
     if k.is_empty() {
-        return Err(BridgeError::InvalidUpstreamConfig(
+        return Err(BridgeError::InvalidUpstreamCredentials(
             "provider_key.secret is empty".into(),
         ));
     }
@@ -157,7 +157,7 @@ fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
     // the openai / azure bridges — otherwise reqwest's `.header()` fails
     // later with an opaque builder error (#367).
     if header::HeaderValue::from_str(k).is_err() {
-        return Err(BridgeError::InvalidUpstreamConfig(
+        return Err(BridgeError::InvalidUpstreamCredentials(
             "provider_key.secret contains invalid header characters".into(),
         ));
     }
@@ -542,7 +542,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_api_key_is_a_config_error() {
+    async fn missing_api_key_is_a_credentials_error() {
         let mut pk: ProviderKey =
             serde_json::from_str(r#"{"display_name":"empty","secret":"placeholder"}"#).unwrap();
         pk.secret.clear();
@@ -550,25 +550,29 @@ mod tests {
         let bridge = AnthropicBridge::new();
         let ctx = BridgeContext::new("req-1", sample_model(), Arc::new(pk));
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
-        assert!(matches!(err, BridgeError::InvalidUpstreamConfig(_)));
+        assert!(matches!(err, BridgeError::InvalidUpstreamCredentials(_)));
+        assert_eq!(err.http_status(), 401);
+        assert_eq!(err.error_type(), "authentication_error");
     }
 
     #[tokio::test]
-    async fn secret_with_control_chars_is_invalid_config() {
+    async fn secret_with_control_chars_is_credentials_error() {
         // A non-empty secret that can't be an x-api-key header value
-        // (control bytes) is customer-fixable config, not a 500 (#367).
+        // (control bytes) is a customer-fixable credential problem —
+        // a 401 authentication_error, not a 500 (#367 follow-up).
         let pk: ProviderKey =
             serde_json::from_str(r#"{"display_name":"bad","secret":"sk-live\n-injected"}"#)
                 .unwrap();
         let bridge = AnthropicBridge::new();
         let ctx = BridgeContext::new("req-1", sample_model(), Arc::new(pk));
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
-        match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+        match &err {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(msg.contains("invalid header characters"), "got {msg}");
             }
-            other => panic!("expected InvalidUpstreamConfig, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials, got {other:?}"),
         }
+        assert_eq!(err.http_status(), 401);
     }
 
     #[tokio::test]

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -394,14 +394,14 @@ impl AzureSecret {
     pub(crate) fn parse(secret: &str) -> Result<Self, BridgeError> {
         let trimmed = secret.trim();
         if trimmed.is_empty() {
-            return Err(BridgeError::InvalidUpstreamConfig(
+            return Err(BridgeError::InvalidUpstreamCredentials(
                 "provider_key.secret is empty".into(),
             ));
         }
         if trimmed.starts_with('{') {
             let creds: crate::aad_token_mint::AadCredentials = serde_json::from_str(trimmed)
                 .map_err(|_e| {
-                    BridgeError::InvalidUpstreamConfig(
+                    BridgeError::InvalidUpstreamCredentials(
                         "azure provider_key.secret looks JSON-shaped but failed to parse \
                          as AAD client_credentials \
                          {tenant_id, client_id, client_secret}"
@@ -602,7 +602,7 @@ fn build_request_headers(
     match (&auth.api_key, &auth.bearer_token) {
         (Some(key), None) => {
             let value = HeaderValue::from_str(key).map_err(|e| {
-                BridgeError::InvalidUpstreamConfig(format!(
+                BridgeError::InvalidUpstreamCredentials(format!(
                     "api key contains invalid header chars: {e}"
                 ))
             })?;
@@ -1332,7 +1332,8 @@ mod tests {
         // headers via the api-key value.
         let err = build_request_headers(&api_key_auth("legit\nx-evil: 1"), "req-1", false, None)
             .unwrap_err();
-        assert!(matches!(err, BridgeError::InvalidUpstreamConfig(_)));
+        assert!(matches!(err, BridgeError::InvalidUpstreamCredentials(_)));
+        assert_eq!(err.http_status(), 401);
     }
 
     #[test]
@@ -1369,11 +1370,12 @@ mod tests {
         let ctx = BridgeContext::new("req-1", sample_model(), pk);
         let req = ChatFormat::new("customer-facing-name", vec![ChatMessage::user("hi")]);
         let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        assert_eq!(err.http_status(), 401);
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(msg.contains("secret is empty"), "got {msg}");
             }
-            other => panic!("expected InvalidUpstreamConfig error, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }
     }
 
@@ -2043,19 +2045,21 @@ mod tests {
     #[test]
     fn azure_secret_rejects_empty_secret() {
         let err = AzureSecret::parse("   ").unwrap_err();
-        assert!(matches!(err, BridgeError::InvalidUpstreamConfig(_)));
+        assert!(matches!(err, BridgeError::InvalidUpstreamCredentials(_)));
+        assert_eq!(err.http_status(), 401);
     }
 
     #[test]
     fn azure_secret_rejects_json_missing_required_aad_fields() {
         let err = AzureSecret::parse(r#"{"tenant_id":"t"}"#).unwrap_err();
+        assert_eq!(err.http_status(), 401);
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 // Message must NOT echo raw secret bytes (audit-aware).
                 assert!(msg.contains("looks JSON-shaped"));
                 assert!(!msg.contains("tenant-uuid-aaa"));
             }
-            other => panic!("expected Config, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials, got {other:?}"),
         }
     }
 

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -306,7 +306,7 @@ impl BedrockSecret {
     /// generic shape errors.
     fn parse(secret: &str) -> Result<Self, BridgeError> {
         if secret.trim().is_empty() {
-            return Err(BridgeError::InvalidUpstreamConfig(
+            return Err(BridgeError::InvalidUpstreamCredentials(
                 "bedrock provider_key.secret is empty — \
                  expected JSON {access_key_id, secret_access_key, region, session_token?}"
                     .into(),
@@ -318,7 +318,7 @@ impl BedrockSecret {
             // "invalid character 'X' at position N" reveals what's
             // in the JSON). Generic shape hint is enough for the
             // operator who controls the registration.
-            BridgeError::InvalidUpstreamConfig(
+            BridgeError::InvalidUpstreamCredentials(
                 "bedrock provider_key.secret must be valid JSON: \
                  {access_key_id, secret_access_key, region, session_token?}"
                     .into(),
@@ -1455,8 +1455,9 @@ mod tests {
     #[test]
     fn bedrock_secret_rejects_empty() {
         let err = BedrockSecret::parse("").unwrap_err();
+        assert_eq!(err.http_status(), 401);
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(
                     msg.contains("secret is empty"),
                     "must mention empty secret; got {msg}"
@@ -1466,21 +1467,22 @@ mod tests {
                     "must hint at required JSON shape; got {msg}"
                 );
             }
-            other => panic!("expected InvalidUpstreamConfig error, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }
     }
 
     #[test]
     fn bedrock_secret_rejects_non_json() {
         let err = BedrockSecret::parse("AKIA-test").unwrap_err();
+        assert_eq!(err.http_status(), 401);
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(
                     msg.contains("must be valid JSON"),
                     "must mention JSON requirement; got {msg}"
                 );
             }
-            other => panic!("expected InvalidUpstreamConfig error, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }
     }
 
@@ -1492,7 +1494,7 @@ mod tests {
         let secret_with_distinctive_bytes = "X-DISTINCTIVE-LEAK-MARKER-Y";
         let err = BedrockSecret::parse(secret_with_distinctive_bytes).unwrap_err();
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(
                     !msg.contains("X-DISTINCTIVE-LEAK-MARKER-Y"),
                     "error must NOT echo raw secret bytes; got {msg}"
@@ -1502,7 +1504,7 @@ mod tests {
                     "error must NOT leak partial secret bytes; got {msg}"
                 );
             }
-            other => panic!("expected InvalidUpstreamConfig error, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }
     }
 
@@ -1515,7 +1517,7 @@ mod tests {
         // required).
         let json = r#"{"access_key_id":"AKIA","secret_access_key":"sk"}"#;
         let err = BedrockSecret::parse(json).unwrap_err();
-        assert!(matches!(err, BridgeError::InvalidUpstreamConfig(_)));
+        assert!(matches!(err, BridgeError::InvalidUpstreamCredentials(_)));
     }
 
     // ─── Pre-dispatch validation tests ─────────────────────────────────
@@ -1586,10 +1588,10 @@ mod tests {
         let req = ChatFormat::new("customer-facing", vec![ChatMessage::user("hi")]);
         let err = bridge.chat(&req, &ctx).await.unwrap_err();
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(msg.contains("must be valid JSON"));
             }
-            other => panic!("expected InvalidUpstreamConfig error, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }
     }
 
@@ -1603,11 +1605,12 @@ mod tests {
         );
         let req = ChatFormat::new("customer-facing", vec![ChatMessage::user("hi")]);
         let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        assert_eq!(err.http_status(), 401);
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(msg.contains("secret is empty"));
             }
-            other => panic!("expected InvalidUpstreamConfig error, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }
     }
 

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -201,7 +201,7 @@ fn normalize_canonical_openai(base: &str) -> String {
 fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
     let k = &ctx.provider_key.secret;
     if k.is_empty() {
-        return Err(BridgeError::InvalidUpstreamConfig(
+        return Err(BridgeError::InvalidUpstreamCredentials(
             "provider_key.secret is empty".into(),
         ));
     }
@@ -210,7 +210,7 @@ fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
     // endpoints build the `Bearer {key}` header inline rather than via
     // build_request_headers, so validating here covers them all (#367).
     if HeaderValue::from_str(k).is_err() {
-        return Err(BridgeError::InvalidUpstreamConfig(
+        return Err(BridgeError::InvalidUpstreamCredentials(
             "provider_key.secret contains invalid header characters".into(),
         ));
     }
@@ -343,7 +343,9 @@ fn build_request_headers(
 ) -> Result<HeaderMap, BridgeError> {
     let mut headers = HeaderMap::new();
     let auth = HeaderValue::from_str(&format!("Bearer {api_key_str}")).map_err(|e| {
-        BridgeError::InvalidUpstreamConfig(format!("api key contains invalid header chars: {e}"))
+        BridgeError::InvalidUpstreamCredentials(format!(
+            "api key contains invalid header chars: {e}"
+        ))
     })?;
     headers.insert(header::AUTHORIZATION, auth);
     headers.insert(
@@ -1074,10 +1076,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_api_key_is_a_config_error() {
+    async fn missing_api_key_is_a_credentials_error() {
         // Bridge's own guard: ProviderKey with an empty `secret` must
-        // surface a Config error rather than calling upstream with a
-        // bare bearer.
+        // surface a 401 authentication_error rather than calling
+        // upstream with a bare bearer (#367 follow-up).
         let mut pk: ProviderKey =
             serde_json::from_str(r#"{"display_name":"empty","secret":"placeholder"}"#).unwrap();
         pk.secret.clear();
@@ -1085,7 +1087,9 @@ mod tests {
         let bridge = OpenAiBridge::new();
         let ctx = BridgeContext::new("req-1", sample_model(), Arc::new(pk));
         let err = bridge.chat(&req(), &ctx).await.unwrap_err();
-        assert!(matches!(err, BridgeError::InvalidUpstreamConfig(_)));
+        assert!(matches!(err, BridgeError::InvalidUpstreamCredentials(_)));
+        assert_eq!(err.http_status(), 401);
+        assert_eq!(err.error_type(), "authentication_error");
     }
 
     #[tokio::test]

--- a/crates/aisix-provider-vertex/src/token_mint.rs
+++ b/crates/aisix-provider-vertex/src/token_mint.rs
@@ -76,25 +76,25 @@ impl ServiceAccountKey {
     /// the first mint will catch a malformed key with a clear message.
     pub fn validate(&self) -> Result<(), BridgeError> {
         if self.typ != "service_account" {
-            return Err(BridgeError::InvalidUpstreamConfig(format!(
+            return Err(BridgeError::InvalidUpstreamCredentials(format!(
                 "vertex service_account_json.type = {:?}, want \"service_account\"",
                 self.typ
             )));
         }
         if !self.private_key.starts_with("-----BEGIN") {
-            return Err(BridgeError::InvalidUpstreamConfig(
+            return Err(BridgeError::InvalidUpstreamCredentials(
                 "vertex service_account_json.private_key is not PEM-formatted \
                  (expected `-----BEGIN PRIVATE KEY-----` or `-----BEGIN RSA PRIVATE KEY-----`)"
                     .into(),
             ));
         }
         if self.client_email.is_empty() {
-            return Err(BridgeError::InvalidUpstreamConfig(
+            return Err(BridgeError::InvalidUpstreamCredentials(
                 "vertex service_account_json.client_email is empty".into(),
             ));
         }
         if self.token_uri.is_empty() {
-            return Err(BridgeError::InvalidUpstreamConfig(
+            return Err(BridgeError::InvalidUpstreamCredentials(
                 "vertex service_account_json.token_uri is empty".into(),
             ));
         }
@@ -449,11 +449,12 @@ mod tests {
         };
         let minter = TokenMinter::new(Client::new()).with_token_endpoint_override(server.uri());
         let err = minter.get_token(&sa).await.err().unwrap();
+        assert_eq!(err.http_status(), 401);
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(msg.contains("not PEM-formatted"));
             }
-            other => panic!("expected InvalidUpstreamConfig error, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }
     }
 
@@ -474,13 +475,14 @@ mod tests {
         };
         let minter = TokenMinter::new(Client::new()).with_token_endpoint_override(server.uri());
         let err = minter.get_token(&sa).await.err().unwrap();
+        assert_eq!(err.http_status(), 401);
         match err {
-            BridgeError::InvalidUpstreamConfig(msg) => {
+            BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(msg.contains("type"));
                 assert!(msg.contains("external_account"));
                 assert!(msg.contains("service_account"));
             }
-            other => panic!("expected InvalidUpstreamConfig error, got {other:?}"),
+            other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }
     }
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -93,6 +93,7 @@ fn routing_error_class(err: &BridgeError) -> &'static str {
         BridgeError::UpstreamDecode(_) => "upstream_decode",
         BridgeError::Config(_) => "config",
         BridgeError::InvalidUpstreamConfig(_) => "invalid_config",
+        BridgeError::InvalidUpstreamCredentials(_) => "invalid_credentials",
         BridgeError::Transport(_) => "transport",
         BridgeError::StreamAborted => "stream_aborted",
     }

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -44,9 +44,10 @@ pub fn is_retryable(err: &BridgeError, retry_on_429: bool) -> bool {
             }
             !(400..500).contains(status)
         }
-        // Customer-fixable config (#367) is the caller's mistake —
-        // retrying or failing over won't help, same as a non-429 4xx.
-        BridgeError::InvalidUpstreamConfig(_) => false,
+        // Customer-fixable config / credentials (#367) is the caller's
+        // mistake — retrying or failing over won't help, same as a
+        // non-429 4xx.
+        BridgeError::InvalidUpstreamConfig(_) | BridgeError::InvalidUpstreamCredentials(_) => false,
         BridgeError::Timeout { .. }
         | BridgeError::Transport(_)
         | BridgeError::UpstreamDecode(_)

--- a/tests/e2e/src/cases/invalid-upstream-credentials-401-e2e.test.ts
+++ b/tests/e2e/src/cases/invalid-upstream-credentials-401-e2e.test.ts
@@ -1,0 +1,113 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a customer-fixable upstream *credential* error must surface to
+// the client as a 401 authentication_error, not a 400 or 500
+// (#367 follow-up). This is the credential sibling of
+// invalid-upstream-config-400-e2e: there the misconfig is request/
+// routing shape (no api_base) → 400; here the ProviderKey has a valid
+// api_base but a secret that can't be a valid Authorization header
+// value (a newline-injected key), so the bridge can't build the auth
+// header and errors before dispatch. Auth-material problems map to 401
+// to match LiteLLM's AuthenticationError mapping, so SDKs that branch
+// on 401 to refresh credentials classify it right. (An empty secret is
+// the same error class but is rejected earlier by the admin schema's
+// min-length check, so this drives the post-admit header-bytes guard.)
+
+const CALLER_PLAINTEXT = "sk-invalid-cred-401";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("invalid upstream credentials maps to 401 e2e", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    // Valid api_base (routing shape is fine) but a secret that can't be
+    // an Authorization header value (embedded newline) — the openai
+    // bridge's api_key() guard rejects this before dispatch as a
+    // credential problem.
+    const pk = await admin.createProviderKey({
+      display_name: "invalid-cred-pk",
+      secret: "sk-live\n-injected",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "invalid-cred-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["invalid-cred-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("PK with an unusable secret surfaces as a 401 authentication_error", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "invalid-cred-model");
+    });
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
+        model: "invalid-cred-model",
+        messages: [{ role: "user", content: "hi" }],
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      throw new Error("unreachable: caught is not APIError");
+    }
+    // The load-bearing assertion: an unusable credential is a 401
+    // authentication_error, not a 400 or 500.
+    expect(caught.status).toBe(401);
+    expect((caught.error as { type?: string } | undefined)?.type).toBe(
+      "authentication_error",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

PR #500 (closing #367) mapped every customer-fixable upstream-config error to a single `400 invalid_request_error`. That flattened LiteLLM's 401-vs-400 distinction: for the same providers, LiteLLM raises `AuthenticationError` (**401**) for missing/invalid provider credentials (`anthropic/common_utils.py`, `exception_mapping_utils.py`), reserving 400 for request/routing shape. An empty/invalid provider secret surfacing as 400 is misleading to SDKs and operators expecting 401.

## Fix

New `BridgeError::InvalidUpstreamCredentials` variant → **401 / `authentication_error`** (non-retryable). The credential-validity construction sites move onto it across all bridges:
- empty `provider_key.secret`
- API key containing invalid HTTP-header bytes
- unparseable service-account / AAD / Bedrock credential JSON (the operator's secret blob is malformed)

Kept at **400 `invalid_request_error`** (request/routing shape, not credentials): missing `api_base` / api_base URL-shape, missing `model_name`, `split_system` validation. Internal faults (body serialization, our generated request_id, runtime token-mint/JWT-sign) stay `Config` → 500.

## Tests

Unit tests across gateway + all five provider bridges updated to assert `401` / `authentication_error` for the credential cases (was 400); the api_base/model_name/split_system tests still assert 400. New DP e2e `invalid-upstream-credentials-401-e2e.test.ts` drives the pre-dispatch credential path and asserts 401; `invalid-upstream-config-400-e2e.test.ts` (api_base-missing) stays 400.

## Known residual (separate, out of scope)

A few credential-shaped checks are currently `BridgeError::Config` → **500** rather than 400, so they're outside this 400→401 split: Vertex `VertexSecret::parse` (empty/both-neither secret), Azure AAD empty `client_secret`. For full cross-provider consistency these should also be 401, but that's a pre-existing 500→401 change on a different axis — flagging for a follow-up rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)