### PR TITLE
fix(guardrails): hold streamed output back by default so output guardrails can't leak (#466)

### DIFF
--- a/crates/aisix-guardrails/src/aliyun.rs
+++ b/crates/aisix-guardrails/src/aliyun.rs
@@ -402,6 +402,15 @@ impl Guardrail for AliyunTextModerationGuardrail {
         "aliyun_text_moderation"
     }
 
+    /// Its streamed-output hold-back policy applies only when it inspects
+    /// output (#466); an input-only attachment must not buffer the response.
+    fn runs_on_output(&self) -> bool {
+        matches!(
+            self.hook_point,
+            GuardrailHookPoint::Output | GuardrailHookPoint::Both
+        )
+    }
+
     fn stream_output_policy(&self) -> StreamOutputPolicy {
         match self.stream_processing_mode.as_str() {
             "buffer_full" => StreamOutputPolicy::BufferFull {

--- a/crates/aisix-guardrails/src/bedrock.rs
+++ b/crates/aisix-guardrails/src/bedrock.rs
@@ -295,6 +295,15 @@ impl BedrockFailure {
 
 #[async_trait]
 impl Guardrail for BedrockGuardrail {
+    /// Its streamed-output hold-back policy applies only when it inspects
+    /// output (#466); an input-only attachment must not buffer the response.
+    fn runs_on_output(&self) -> bool {
+        matches!(
+            self.hook_point,
+            GuardrailHookPoint::Output | GuardrailHookPoint::Both
+        )
+    }
+
     fn name(&self) -> &'static str {
         // Static name keeps metric cardinality bounded; the row's
         // own name is logged via tracing fields when we hit a

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 
 use crate::index::{GuardrailIndex, RequestContext, ScopeKind};
 use crate::keyword::{KeywordBlocklist, KeywordRule};
-use crate::{Guardrail, GuardrailChain, GuardrailVerdict};
+use crate::{Guardrail, GuardrailChain, GuardrailVerdict, StreamOutputPolicy};
 
 /// Build a chain from a snapshot's `guardrails` table.
 ///
@@ -296,6 +296,20 @@ impl Guardrail for LiveGuardrailChain {
 
     async fn check_output(&self, resp: &ChatResponse) -> GuardrailVerdict {
         self.current().check_output(resp).await
+    }
+
+    /// Delegate streamed-output gating to the live inner chain so this exported
+    /// wrapper can't silently diverge from `GuardrailChain`'s hold-back
+    /// semantics if it is ever used directly as a streaming chain (#466).
+    /// Without these it would inherit the trait defaults (`BufferFull` +
+    /// `runs_on_output() == true`) and always hold back, ignoring its inner
+    /// members' hooks.
+    fn stream_output_policy(&self) -> StreamOutputPolicy {
+        self.current().stream_output_policy()
+    }
+
+    fn runs_on_output(&self) -> bool {
+        self.current().runs_on_output()
     }
 }
 

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -286,9 +286,9 @@ mod tests {
         // #466 regression: the trait default stream policy is now BufferFull
         // (secure-by-default), but a chain whose only member is input-only must
         // NOT buffer the response stream — it never inspects output.
-        let input_only = GuardrailChain::new(vec![Arc::new(KeywordBlocklist::input_only(
-            vec![KeywordRule::literal("x")],
-        ))]);
+        let input_only = GuardrailChain::new(vec![Arc::new(KeywordBlocklist::input_only(vec![
+            KeywordRule::literal("x"),
+        ]))]);
         assert!(!input_only.runs_on_output());
         assert!(
             !input_only.stream_output_policy().holds_back(),
@@ -308,8 +308,12 @@ mod tests {
         // A mixed chain (input-only + output) still holds back because of the
         // output member; the input-only member is skipped, not the driver.
         let mixed = GuardrailChain::new(vec![
-            Arc::new(KeywordBlocklist::input_only(vec![KeywordRule::literal("x")])),
-            Arc::new(KeywordBlocklist::output_only(vec![KeywordRule::literal("y")])),
+            Arc::new(KeywordBlocklist::input_only(vec![KeywordRule::literal(
+                "x",
+            )])),
+            Arc::new(KeywordBlocklist::output_only(vec![KeywordRule::literal(
+                "y",
+            )])),
         ]);
         assert!(mixed.runs_on_output());
         assert!(mixed.stream_output_policy().holds_back());

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -56,17 +56,25 @@ impl Guardrail for GuardrailChain {
         self.guardrails.is_empty()
     }
 
-    /// The strictest streamed-output policy across the chain's members.
-    /// If any member wants hold-back, the whole stream holds back and
-    /// the full chain's `check_output` runs on the held content.
+    /// The strictest streamed-output policy across the chain's
+    /// **output-hook** members. Only guardrails that actually inspect the
+    /// output influence hold-back; an input-only member must not force the
+    /// response to buffer (#466). If any output member wants hold-back, the
+    /// whole stream holds back and the full chain's `check_output` runs on
+    /// the held content.
     fn stream_output_policy(&self) -> StreamOutputPolicy {
         self.guardrails
             .iter()
+            .filter(|g| g.runs_on_output())
             .map(|g| g.stream_output_policy())
             .fold(
                 StreamOutputPolicy::EndOfStreamCheck,
                 StreamOutputPolicy::stricter,
             )
+    }
+
+    fn runs_on_output(&self) -> bool {
+        self.guardrails.iter().any(|g| g.runs_on_output())
     }
 
     async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
@@ -271,5 +279,44 @@ mod tests {
         } else {
             panic!("expected Block");
         }
+    }
+
+    #[test]
+    fn input_only_member_does_not_force_streamed_output_holdback() {
+        // #466 regression: the trait default stream policy is now BufferFull
+        // (secure-by-default), but a chain whose only member is input-only must
+        // NOT buffer the response stream — it never inspects output.
+        let input_only = GuardrailChain::new(vec![Arc::new(KeywordBlocklist::input_only(
+            vec![KeywordRule::literal("x")],
+        ))]);
+        assert!(!input_only.runs_on_output());
+        assert!(
+            !input_only.stream_output_policy().holds_back(),
+            "input-only chain must fold to a non-holding policy"
+        );
+
+        // An output guardrail folds to the default hold-back policy.
+        let output = GuardrailChain::new(vec![Arc::new(KeywordBlocklist::output_only(vec![
+            KeywordRule::literal("x"),
+        ]))]);
+        assert!(output.runs_on_output());
+        assert!(
+            output.stream_output_policy().holds_back(),
+            "output chain must fold to a holding policy"
+        );
+
+        // A mixed chain (input-only + output) still holds back because of the
+        // output member; the input-only member is skipped, not the driver.
+        let mixed = GuardrailChain::new(vec![
+            Arc::new(KeywordBlocklist::input_only(vec![KeywordRule::literal("x")])),
+            Arc::new(KeywordBlocklist::output_only(vec![KeywordRule::literal("y")])),
+        ]);
+        assert!(mixed.runs_on_output());
+        assert!(mixed.stream_output_policy().holds_back());
+
+        // Empty chain → nothing runs on output, no hold-back.
+        let empty = GuardrailChain::new(vec![]);
+        assert!(!empty.runs_on_output());
+        assert!(!empty.stream_output_policy().holds_back());
     }
 }

--- a/crates/aisix-guardrails/src/keyword.rs
+++ b/crates/aisix-guardrails/src/keyword.rs
@@ -95,6 +95,12 @@ impl Guardrail for KeywordBlocklist {
         "keyword_blocklist"
     }
 
+    /// Only force streamed-output hold-back when this blocklist actually
+    /// checks output (#466). An input-only keyword guard must not buffer.
+    fn runs_on_output(&self) -> bool {
+        self.check_output_enabled
+    }
+
     async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
         if !self.check_input_enabled {
             return GuardrailVerdict::Allow;

--- a/crates/aisix-guardrails/src/length.rs
+++ b/crates/aisix-guardrails/src/length.rs
@@ -51,6 +51,13 @@ impl Guardrail for MaxContentLength {
         "max_content_length"
     }
 
+    /// Only inspects output when an output cap is set; otherwise `check_output`
+    /// is a guaranteed `Allow`, so it must not force streamed-output hold-back
+    /// (#466). Mirrors the `max_output_chars` gate in `check_output`.
+    fn runs_on_output(&self) -> bool {
+        self.max_output_chars.is_some()
+    }
+
     async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
         let Some(cap) = self.max_input_chars else {
             return GuardrailVerdict::Allow;

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -345,7 +345,10 @@ mod tests {
         // inherits a hold-back default, so an output-blocking guardrail can't
         // live-forward streamed content before its check (secure-by-default).
         let p = DefaultPolicyGuardrail.stream_output_policy();
-        assert!(p.holds_back(), "default streamed-output policy must hold back");
+        assert!(
+            p.holds_back(),
+            "default streamed-output policy must hold back"
+        );
         assert!(matches!(
             p,
             StreamOutputPolicy::BufferFull {

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -277,6 +277,17 @@ pub trait Guardrail: Send + Sync + 'static {
             on_exceeded_fail_open: false,
         }
     }
+
+    /// Whether this guardrail actually inspects the OUTPUT hook. Drives
+    /// whether its `stream_output_policy` participates in the streamed-output
+    /// hold-back fold (#466): an input-only guardrail must NOT force output
+    /// buffering — it never looks at the response, so holding the stream back
+    /// for it is pure latency with no security benefit. Default: `true`
+    /// (assume output-relevant, secure-leaning); input-only impls override
+    /// to gate on their hook.
+    fn runs_on_output(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -234,6 +234,11 @@ impl StreamOutputPolicy {
     }
 }
 
+/// Default whole-response hold-back cap for output guardrails that don't
+/// configure their own streaming policy (keyword, prompt shield, bedrock).
+/// Matches the Azure text-moderation buffer-mode default.
+pub const DEFAULT_STREAM_OUTPUT_BUFFER_BYTES: usize = 262_144;
+
 /// Pluggable content-policy hook. Production wires `Arc<dyn Guardrail>`
 /// in `ProxyState`; tests construct in-memory chains directly.
 #[async_trait]
@@ -261,10 +266,16 @@ pub trait Guardrail: Send + Sync + 'static {
     }
 
     /// How this guardrail wants streamed OUTPUT moderated. Default:
-    /// [`StreamOutputPolicy::EndOfStreamCheck`] (no hold-back, pre-P2
-    /// behavior). Hold-back guardrails (Azure text moderation) override.
+    /// hold the whole response back ([`StreamOutputPolicy::BufferFull`],
+    /// fail-closed) so an output-blocking guardrail can't leak content
+    /// onto the wire before its check runs (#466 — secure-by-default).
+    /// Guardrails that want partial streaming (Azure text moderation)
+    /// override with `Window`.
     fn stream_output_policy(&self) -> StreamOutputPolicy {
-        StreamOutputPolicy::EndOfStreamCheck
+        StreamOutputPolicy::BufferFull {
+            max_buffer_bytes: DEFAULT_STREAM_OUTPUT_BUFFER_BYTES,
+            on_exceeded_fail_open: false,
+        }
     }
 }
 
@@ -308,6 +319,29 @@ mod tests {
         let empty: ChatMessage =
             serde_json::from_value(serde_json::json!({"role": "user", "content": ""})).unwrap();
         assert_eq!(message_scan_text(&empty), "");
+    }
+
+    struct DefaultPolicyGuardrail;
+    impl Guardrail for DefaultPolicyGuardrail {
+        fn name(&self) -> &'static str {
+            "default-policy"
+        }
+    }
+
+    #[test]
+    fn default_stream_output_policy_holds_back() {
+        // #466: a guardrail that doesn't override stream_output_policy
+        // inherits a hold-back default, so an output-blocking guardrail can't
+        // live-forward streamed content before its check (secure-by-default).
+        let p = DefaultPolicyGuardrail.stream_output_policy();
+        assert!(p.holds_back(), "default streamed-output policy must hold back");
+        assert!(matches!(
+            p,
+            StreamOutputPolicy::BufferFull {
+                on_exceeded_fail_open: false,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/aisix-guardrails/src/prompt_shield.rs
+++ b/crates/aisix-guardrails/src/prompt_shield.rs
@@ -260,6 +260,16 @@ struct AttackAnalysis {
 
 #[async_trait]
 impl Guardrail for PromptShieldGuardrail {
+    /// Its streamed-output hold-back policy applies only when it inspects
+    /// output (#466); prompt shield is normally input-only, so it must not
+    /// buffer the response unless attached on the output hook.
+    fn runs_on_output(&self) -> bool {
+        matches!(
+            self.hook_point,
+            GuardrailHookPoint::Output | GuardrailHookPoint::Both
+        )
+    }
+
     fn name(&self) -> &'static str {
         // Static name keeps metric cardinality bounded; the row's own
         // name is surfaced via tracing fields on failure paths.

--- a/crates/aisix-guardrails/src/text_moderation.rs
+++ b/crates/aisix-guardrails/src/text_moderation.rs
@@ -331,6 +331,15 @@ impl Guardrail for TextModerationGuardrail {
         "azure_content_safety_text_moderation"
     }
 
+    /// Its streamed-output hold-back policy applies only when it inspects
+    /// output (#466); an input-only attachment must not buffer the response.
+    fn runs_on_output(&self) -> bool {
+        matches!(
+            self.hook_point,
+            GuardrailHookPoint::Output | GuardrailHookPoint::Both
+        )
+    }
+
     fn stream_output_policy(&self) -> StreamOutputPolicy {
         match self.stream_processing_mode.as_str() {
             "buffer_full" => StreamOutputPolicy::BufferFull {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1992,10 +1992,11 @@ where
         } else {
             None
         };
-        // P2 (#379): per-guardrail streamed-output policy. EndOfStreamCheck
-        // (default / no guardrail) leaves the live-forward path below
-        // byte-for-byte unchanged. Window / BufferFull hold content back
-        // until it scans clean.
+        // P2 (#379) / #466: streamed-output policy folded over the output-hook
+        // guardrails. EndOfStreamCheck (reached only when no output-hook
+        // guardrail is present) leaves the live-forward path below byte-for-byte
+        // unchanged. Window / BufferFull hold content back until it scans clean
+        // (BufferFull is now the secure default for output-blocking guardrails).
         let stream_policy = output_guardrail
             .as_ref()
             .map(|ctx| ctx.chain.stream_output_policy())

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1847,32 +1847,24 @@ data: <not valid json>\n\n";
         );
     }
 
-    /// Issue #204: streaming responses MUST run output guardrails at
-    /// end-of-stream (buffer-then-check). Pre-fix the streaming path
-    /// skipped output guardrails entirely — a `kind: "keyword"`
-    /// deny-list could be trivially bypassed by setting `stream:
-    /// true`. This test pins:
+    /// Issue #204: streaming responses MUST run output guardrails — pre-fix
+    /// the streaming path skipped them, so a `kind: "keyword"` deny-list was
+    /// bypassable by setting `stream: true`.
+    ///
+    /// Issue #466: output guardrails must also HOLD content back while
+    /// streaming. `keyword` now inherits the default hold-back policy
+    /// ([`StreamOutputPolicy::BufferFull`], fail-closed), so a blocked
+    /// streaming response NEVER puts the forbidden content on the wire.
+    /// This test pins:
     ///
     ///   - 200 OK + SSE wire shape (the request itself is well-formed)
     ///   - upstream IS hit (output guardrails run AFTER the upstream call)
-    ///   - the response wire bytes contain an SSE `event: error` frame
-    ///     with the OpenAI envelope shape
-    ///   - the wire bytes contain NO terminal `[DONE]` (per docs §5
-    ///     pattern: a guardrail block is an abnormal termination)
-    ///   - the matched literal does NOT appear anywhere in the
-    ///     wire bytes that follow the error frame (the redaction
-    ///     mirrors #153's non-streaming contract)
-    ///
-    /// Note: the pre-emitted `data: ...` chunks DO contain "secret"
-    /// (the assistant's content reaching the caller's iterator
-    /// before the buffer-then-check completes). That's the
-    /// fundamental trade-off the issue's fix-shape discussion calls
-    /// out for buffer-then-check; preventing prefix bytes from
-    /// reaching the wire would require holding ALL chunks server-
-    /// side until the check fires, which negates streaming's
-    /// latency-to-first-token benefit. The buffer-then-check
-    /// guarantee is "no `[DONE]` and an error event signals the
-    /// block" — what we assert here.
+    ///   - an SSE `event: error` frame with the OpenAI `content_filter` envelope
+    ///   - NO terminal `[DONE]` (a guardrail block is an abnormal termination)
+    ///   - the matched literal "secret-string" does NOT appear ANYWHERE on
+    ///     the wire — the hold-back means the offending content is never
+    ///     emitted (the #466 fix; previously the live-forwarded chunks
+    ///     leaked it before the end-of-stream check).
     #[tokio::test]
     async fn streaming_output_guardrail_blocks_with_sse_error_event_and_no_done() {
         let upstream = MockServer::start().await;
@@ -1928,6 +1920,14 @@ data: [DONE]\n\n";
         }
         let wire_str = String::from_utf8(wire).expect("SSE bytes are utf8");
 
+        // #466: the default hold-back policy means the forbidden content is
+        // never forwarded — the matched literal appears NOWHERE on the wire
+        // (pre-fix the live-forwarded chunks leaked it before the check).
+        assert!(
+            !wire_str.contains("secret-string"),
+            "hold-back guardrail leaked the matched content onto the wire; got:\n{wire_str}"
+        );
+
         // Per docs §5 abnormal-termination contract (the guardrail
         // block is the streaming-equivalent of an abnormal close):
         // NO `[DONE]` after the error event. SDK consumers that key
@@ -1973,9 +1973,10 @@ data: [DONE]\n\n";
         );
     }
 
-    /// P2 (#379): unlike the keyword guardrail above (EndOfStreamCheck,
-    /// which leaks pre-emitted chunks), `azure_content_safety_text_moderation`
-    /// uses a hold-back streaming policy — a blocked streaming response
+    /// P2 (#379): like the keyword guardrail above (which now holds back by
+    /// default, #466), `azure_content_safety_text_moderation` keeps offending
+    /// content off the wire — here via the configurable `Window` policy
+    /// rather than the default `BufferFull`. A blocked streaming response
     /// NEVER puts the offending content on the wire.
     #[tokio::test]
     async fn streaming_text_moderation_blocks_and_holds_content_back_no_leak() {


### PR DESCRIPTION
Closes #466.

## Problem
For **streaming** responses, output guardrails using the trait-default `stream_output_policy` (`EndOfStreamCheck`) `yield` each content chunk **live**, and `check_output` runs only at end-of-stream — so on `Block` the `content_filter` frame arrives **after** the forbidden content is already on the wire. This affects `kind=keyword` and any output-hook guardrail not overriding the policy (`bedrock`, and `prompt_shield` if attached on output) — a real streaming output-moderation bypass (non-streaming output blocks correctly).

## Fix (secure-by-default)
Change the trait default `Guardrail::stream_output_policy()` from `EndOfStreamCheck` (live-forward) to **`BufferFull { max_buffer_bytes: DEFAULT_STREAM_OUTPUT_BUFFER_BYTES, on_exceeded_fail_open: false }`** — hold the whole response back, scan, then release-all-or-block. So an output-blocking guardrail can never leak content before its check.

- `build_sse_stream` is **policy-driven** (it reads the resolved **output** chain's folded `stream_output_policy().holds_back()`), so no streaming-path change — just the policy these kinds report.
- `text_moderation` keeps its configurable `Window` override (partial streaming).

## Hold-back is gated on the output hook
`GuardrailChain::stream_output_policy()` folds the policy across its members. The fold must skip members that don't inspect output, otherwise an **input-only** guardrail (prompt shield, or a keyword guard with output-check disabled) would force the response stream to buffer for a check it never runs — pure latency, and contradicting the claim that input-only guardrails are unaffected.

Added `Guardrail::runs_on_output()` (default `true`) and the chain fold now filters on it:
- `keyword` -> `self.check_output_enabled`
- `text_moderation` / `aliyun` / `bedrock` / `prompt_shield` -> `hook_point` is `Output | Both`
- `MaxContentLength` -> `max_output_chars.is_some()`; the exported `LiveGuardrailChain` wrapper delegates to its inner chain — so every `Guardrail` impl reports its output hook consistently (the latter two are off the production streaming path; included for consistency / defense-in-depth per the audit).

A chain folds to a hold-back policy only when at least one output-hook member wants it; an empty chain and an input-only-only chain both fold to `EndOfStreamCheck` (no buffering). Pinned by `input_only_member_does_not_force_streamed_output_holdback`.

## Trade-off
Output streaming now **buffers while an output guardrail is active on the output hook** (higher TTFT, no token-by-token). That's the price of output moderation actually working; operators who want partial streaming can use a per-guardrail policy (as `text_moderation` already has). Chosen per discussion on #466.

## Known limitation (follow-up #513)
The `BufferFull` cap counts `content_buffer` (text) bytes, not the full held `pending` event bytes (tool-call / reasoning / framing). Making `BufferFull` the default widens that pre-existing under-count to every default output guardrail. It is bounded in practice by the model's max output tokens and is a soft memory-amplification concern, **not** a content leak. The fix (count held wire bytes) is a semantic change to `max_buffer_bytes` plus a default re-tuning, so it is tracked separately in #513 rather than bundled into this security-default change.

## Tests
- `streaming_output_guardrail_blocks_with_sse_error_event_and_no_done` (keyword on output, upstream emits `leak: secret-string`) now asserts the matched literal appears **NOWHERE** on the wire — previously its doc-comment accepted the leak as a "known trade-off". The existing `event: error` / `content_filter` / no-`[DONE]` / redacted-message assertions still hold.
- `default_stream_output_policy_holds_back` unit test pins the secure-by-default contract.
- `input_only_member_does_not_force_streamed_output_holdback` pins the output-hook gate (input-only -> no hold-back; output -> hold-back; mixed -> hold-back; empty -> no hold-back).
- Full `aisix-guardrails` + `aisix-proxy` suites green (367 proxy tests; all `streaming_text_moderation_*` unaffected); clippy `-D warnings` and rustfmt clean. No generated-schema impact (runtime trait method, not a config field).
