### PR TITLE
fix(wire): preserve content:null on tool_calls responses instead of coercing to ""

### DIFF
--- a/crates/aisix-cache/src/key.rs
+++ b/crates/aisix-cache/src/key.rs
@@ -133,7 +133,7 @@ fn message_pair(m: &ChatMessage) -> (String, String) {
     // differences don't cause spurious cache misses.
     let content_repr = match m.content_blocks.as_ref() {
         Some(blocks) => canonical_json_string(&serde_json::Value::Array(blocks.clone())),
-        None => m.content.clone(),
+        None => m.content_str().to_string(),
     };
     (role_str(m.role).to_string(), content_repr)
 }

--- a/crates/aisix-cache/src/memory.rs
+++ b/crates/aisix-cache/src/memory.rs
@@ -135,7 +135,7 @@ mod tests {
         let cache = MemoryCache::with_defaults();
         cache.put("k1", sample_response()).await.unwrap();
         let got = cache.get("k1").await.unwrap().unwrap();
-        assert_eq!(got.message.content, "hi back");
+        assert_eq!(got.message.content_str(), "hi back");
         assert_eq!(got.usage.total_tokens, 5);
     }
 
@@ -164,10 +164,10 @@ mod tests {
         let cache = MemoryCache::with_defaults();
         cache.put("k", sample_response()).await.unwrap();
         let mut updated = sample_response();
-        updated.message.content = "second".into();
+        updated.message.content = Some("second".into());
         cache.put("k", updated).await.unwrap();
         let got = cache.get("k").await.unwrap().unwrap();
-        assert_eq!(got.message.content, "second");
+        assert_eq!(got.message.content_str(), "second");
     }
 
     /// Per-entry TTL: two keys inserted at the same time with

--- a/crates/aisix-cache/tests/redis_integration.rs
+++ b/crates/aisix-cache/tests/redis_integration.rs
@@ -41,7 +41,7 @@ async fn put_then_get_round_trips_against_real_redis() {
     let key = "fp-roundtrip";
     cache.put(key, sample("hello back")).await.unwrap();
     let got = cache.get(key).await.unwrap().expect("hit");
-    assert_eq!(got.message.content, "hello back");
+    assert_eq!(got.message.content_str(), "hello back");
     assert_eq!(got.usage.total_tokens, 8);
 }
 

--- a/crates/aisix-cache/tests/redis_integration.rs
+++ b/crates/aisix-cache/tests/redis_integration.rs
@@ -46,6 +46,43 @@ async fn put_then_get_round_trips_against_real_redis() {
 }
 
 #[tokio::test]
+async fn put_then_get_preserves_null_content_through_cache() {
+    // #395: a tool_calls response carries `message.content == None`. The
+    // cache persists `ChatResponse` as JSON; this proves `None`
+    // survives the store→load round-trip as `None` (not coerced to
+    // `Some("")`), so a cache hit serves the same `content: null` the
+    // upstream returned.
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: CACHE_TEST_REDIS_URL not set");
+        return;
+    };
+
+    let cache = RedisCache::connect(&url)
+        .await
+        .expect("redis connect")
+        .with_prefix(format!("aisix:test:{}", uuid_like()));
+
+    let message: ChatMessage =
+        serde_json::from_str(r#"{"role":"assistant","content":null}"#).unwrap();
+    assert!(message.content.is_none());
+    let resp = ChatResponse {
+        id: "cmpl-null-1".into(),
+        model: "openai/gpt-4o".into(),
+        message,
+        finish_reason: FinishReason::ToolCalls,
+        usage: UsageStats::new(3, 5),
+    };
+
+    let key = "fp-null-content";
+    cache.put(key, resp).await.unwrap();
+    let got = cache.get(key).await.unwrap().expect("hit");
+    assert!(
+        got.message.content.is_none(),
+        "null content must round-trip as None, not Some(\"\")"
+    );
+}
+
+#[tokio::test]
 async fn ttl_eviction_drops_entry_after_window() {
     let Some(url) = redis_url() else {
         eprintln!("skipping: CACHE_TEST_REDIS_URL not set");

--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -62,7 +62,15 @@ pub enum Role {
 #[serde(from = "ChatMessageRaw")]
 pub struct ChatMessage {
     pub role: Role,
-    pub content: String,
+    /// Assistant/text content. `Option<String>` (not `String`) so the
+    /// OpenAI `string | null` shape round-trips faithfully: a `tool_calls`
+    /// response upstream returns `content: null` and we must surface
+    /// exactly `null` to the SDK caller, not `""` (#395). On the request
+    /// path callers always send a string; `None` only arises on the
+    /// response-projection path (or an inbound `content: null` from a
+    /// history-replay assistant message).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
     /// Raw content-block array when the caller sent
     /// `content: [{type, ...}, ...]`. `None` for the bare-string and
     /// `null` content shapes. Bridges that support content blocks
@@ -134,20 +142,21 @@ impl From<ChatMessageRaw> for ChatMessage {
 
 /// Split a wire-form `content` value into the gateway's
 /// `(extracted_text, raw_blocks)` representation:
-///   * String → (string, None)
-///   * null → ("", None) — OpenAI's assistant-with-tool_calls history
-///     shape per <https://platform.openai.com/docs/api-reference/chat/create>
-///   * Array → (concatenated text from `{type:"text", text}` blocks,
-///     Some(raw array)) — vision / multimodal input. Non-text blocks
-///     (e.g. `image_url`) are skipped on the text-extraction path but
-///     preserved verbatim in the raw array for forwarding.
-///   * Anything else → ("", None) — defensive default; unexpected
-///     shapes don't fail the request, they degrade to an empty text
+///   * String → (Some(string), None)
+///   * null → (None, None) — OpenAI's assistant-with-tool_calls history
+///     shape per <https://platform.openai.com/docs/api-reference/chat/create>.
+///     Preserved as `None` so it round-trips back to `null` (#395).
+///   * Array → (Some(concatenated text from `{type:"text", text}`
+///     blocks), Some(raw array)) — vision / multimodal input. Non-text
+///     blocks (e.g. `image_url`) are skipped on the text-extraction path
+///     but preserved verbatim in the raw array for forwarding.
+///   * Anything else → (None, None) — defensive default; unexpected
+///     shapes don't fail the request, they degrade to absent text
 ///     so the bridge can still dispatch.
-fn split_content(v: Value) -> (String, Option<Vec<Value>>) {
+fn split_content(v: Value) -> (Option<String>, Option<Vec<Value>>) {
     match v {
-        Value::String(s) => (s, None),
-        Value::Null => (String::new(), None),
+        Value::String(s) => (Some(s), None),
+        Value::Null => (None, None),
         Value::Array(blocks) => {
             let text = blocks
                 .iter()
@@ -161,9 +170,9 @@ fn split_content(v: Value) -> (String, Option<Vec<Value>>) {
                 })
                 .collect::<Vec<_>>()
                 .join("");
-            (text, Some(blocks))
+            (Some(text), Some(blocks))
         }
-        _ => (String::new(), None),
+        _ => (None, None),
     }
 }
 
@@ -171,7 +180,7 @@ impl ChatMessage {
     pub fn system(content: impl Into<String>) -> Self {
         Self {
             role: Role::System,
-            content: content.into(),
+            content: Some(content.into()),
             content_blocks: None,
             name: None,
             tool_call_id: None,
@@ -182,7 +191,7 @@ impl ChatMessage {
     pub fn user(content: impl Into<String>) -> Self {
         Self {
             role: Role::User,
-            content: content.into(),
+            content: Some(content.into()),
             content_blocks: None,
             name: None,
             tool_call_id: None,
@@ -193,12 +202,19 @@ impl ChatMessage {
     pub fn assistant(content: impl Into<String>) -> Self {
         Self {
             role: Role::Assistant,
-            content: content.into(),
+            content: Some(content.into()),
             content_blocks: None,
             name: None,
             tool_call_id: None,
             extra: serde_json::Map::new(),
         }
+    }
+
+    /// The text content as a `&str`, treating absent (`null`) content as
+    /// `""`. Use this for bridges/guardrails that need a plain string and
+    /// for which the string-vs-null distinction is irrelevant.
+    pub fn content_str(&self) -> &str {
+        self.content.as_deref().unwrap_or("")
     }
 }
 
@@ -357,7 +373,7 @@ impl ChatResponse {
     /// Reasoning/thinking content is intentionally NOT included — it is
     /// left out of output-guardrail scope by design.
     pub fn guardrail_output_text(&self) -> String {
-        let mut out = self.message.content.clone();
+        let mut out = self.message.content.clone().unwrap_or_default();
         if let Some(tool_calls) = self.message.extra.get("tool_calls") {
             if !tool_calls.is_null() {
                 if !out.is_empty() {
@@ -542,15 +558,18 @@ mod tests {
     #[test]
     fn content_accepts_string() {
         let m: ChatMessage = serde_json::from_str(r#"{"role": "user", "content": "hi"}"#).unwrap();
-        assert_eq!(m.content, "hi");
+        assert_eq!(m.content.as_deref(), Some("hi"));
         assert!(m.content_blocks.is_none());
     }
 
     #[test]
-    fn content_accepts_null_collapsing_to_empty_string() {
+    fn content_null_preserved_as_none() {
+        // #395: `content: null` (OpenAI's assistant-with-tool_calls shape)
+        // is preserved as `None` so it round-trips back to JSON `null`,
+        // not `""`.
         let m: ChatMessage =
             serde_json::from_str(r#"{"role": "assistant", "content": null}"#).unwrap();
-        assert_eq!(m.content, "");
+        assert_eq!(m.content, None);
         assert!(m.content_blocks.is_none());
     }
 
@@ -569,7 +588,7 @@ mod tests {
         )
         .unwrap();
         // Concatenated text from text blocks (non-text blocks skipped).
-        assert_eq!(m.content, "What's in this image?");
+        assert_eq!(m.content.as_deref(), Some("What's in this image?"));
         // Raw blocks preserved verbatim for forwarding.
         let blocks = m.content_blocks.expect("blocks should be Some");
         assert_eq!(blocks.len(), 2);
@@ -589,7 +608,9 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert_eq!(m.content, "");
+        // An array of only non-text blocks yields empty-but-present text
+        // (the array form is never `null`); blocks are preserved.
+        assert_eq!(m.content.as_deref(), Some(""));
         assert!(m.content_blocks.is_some());
     }
 
@@ -605,7 +626,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert_eq!(m.content, "line one\nline two");
+        assert_eq!(m.content.as_deref(), Some("line one\nline two"));
     }
 
     #[test]
@@ -706,7 +727,7 @@ mod tests {
         }"#;
         let m: ChatMessage = serde_json::from_str(json).expect("must accept tool_calls");
         assert_eq!(m.role, Role::Assistant);
-        assert_eq!(m.content, ""); // null collapses to empty string
+        assert_eq!(m.content, None); // null preserved as None (#395)
         assert!(m.extra.contains_key("tool_calls"));
     }
 
@@ -740,11 +761,13 @@ mod tests {
     #[test]
     fn chat_message_accepts_null_content() {
         // The OpenAI assistant-with-tool_calls shape uses content: null;
-        // we collapse to "" so downstream Bridges that don't accept null
-        // (Anthropic, Gemini) still get a string.
+        // we preserve it as `None` (#395) so it round-trips to JSON null.
+        // Bridges that can't accept null (Anthropic, Gemini) read
+        // `content_str()` which maps `None → ""`.
         let json = r#"{"role": "assistant", "content": null}"#;
         let m: ChatMessage = serde_json::from_str(json).expect("must accept null content");
-        assert_eq!(m.content, "");
+        assert_eq!(m.content, None);
+        assert_eq!(m.content_str(), "");
     }
 
     #[test]

--- a/crates/aisix-gateway/src/hub.rs
+++ b/crates/aisix-gateway/src/hub.rs
@@ -178,7 +178,7 @@ mod tests {
         let req = ChatFormat::new("t", vec![ChatMessage::user("hi")]);
 
         let resp = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(resp.message.content, "stubbed");
+        assert_eq!(resp.message.content_str(), "stubbed");
         assert_eq!(resp.finish_reason, FinishReason::Stop);
     }
 

--- a/crates/aisix-guardrails/src/length.rs
+++ b/crates/aisix-guardrails/src/length.rs
@@ -62,10 +62,14 @@ impl Guardrail for MaxContentLength {
         let Some(cap) = self.max_input_chars else {
             return GuardrailVerdict::Allow;
         };
+        // Use the shared scan-text normaliser so text carried only in
+        // `content_blocks` (the typed-block shape) is counted too —
+        // otherwise a blocks-only message could evade the length cap
+        // while the rest of the guardrail stack still scans it.
         let total: usize = req
             .messages
             .iter()
-            .map(|m| m.content_str().chars().count())
+            .map(|m| crate::message_scan_text(m).chars().count())
             .sum();
         if total > cap {
             return GuardrailVerdict::Block {
@@ -79,7 +83,7 @@ impl Guardrail for MaxContentLength {
         let Some(cap) = self.max_output_chars else {
             return GuardrailVerdict::Allow;
         };
-        let len = resp.message.content_str().chars().count();
+        let len = crate::message_scan_text(&resp.message).chars().count();
         if len > cap {
             return GuardrailVerdict::Block {
                 reason: format!("output exceeds {cap} chars (was {len})"),
@@ -157,6 +161,23 @@ mod tests {
         let g = MaxContentLength::output_only(100);
         let v = g.check_output(&resp("ok")).await;
         assert_eq!(v, GuardrailVerdict::Allow);
+    }
+
+    #[tokio::test]
+    async fn input_counts_text_in_content_blocks() {
+        // A message whose text lives ONLY in the typed-block array
+        // (`content: [{type:"text", text}]`, bare `content` empty) must
+        // still be counted, or the length cap can be evaded while the
+        // rest of the guardrail stack scans the same text.
+        let blocks_only: ChatMessage = serde_json::from_str(
+            r#"{"role":"user","content":[{"type":"text","text":"1234567890"}]}"#,
+        )
+        .unwrap();
+        let g = MaxContentLength::input_only(5);
+        let v = g
+            .check_input(&ChatFormat::new("m", vec![blocks_only]))
+            .await;
+        assert!(v.is_block(), "blocks-only text must count toward the cap");
     }
 
     #[tokio::test]

--- a/crates/aisix-guardrails/src/length.rs
+++ b/crates/aisix-guardrails/src/length.rs
@@ -62,7 +62,11 @@ impl Guardrail for MaxContentLength {
         let Some(cap) = self.max_input_chars else {
             return GuardrailVerdict::Allow;
         };
-        let total: usize = req.messages.iter().map(|m| m.content.chars().count()).sum();
+        let total: usize = req
+            .messages
+            .iter()
+            .map(|m| m.content_str().chars().count())
+            .sum();
         if total > cap {
             return GuardrailVerdict::Block {
                 reason: format!("input exceeds {cap} chars (was {total})"),
@@ -75,7 +79,7 @@ impl Guardrail for MaxContentLength {
         let Some(cap) = self.max_output_chars else {
             return GuardrailVerdict::Allow;
         };
-        let len = resp.message.content.chars().count();
+        let len = resp.message.content_str().chars().count();
         if len > cap {
             return GuardrailVerdict::Block {
                 reason: format!("output exceeds {cap} chars (was {len})"),

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -48,8 +48,9 @@ use async_trait::async_trait;
 /// moderation is a separate feature. Every guardrail's input/output
 /// collector goes through this so the families can't drift.
 pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
-    if !m.content.is_empty() {
-        return m.content.clone();
+    let content = m.content_str();
+    if !content.is_empty() {
+        return content.to_string();
     }
     match m.content_blocks.as_ref() {
         Some(blocks) => blocks

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -423,7 +423,7 @@ mod tests {
 
         assert_eq!(resp.id, "msg_01");
         assert_eq!(resp.message.role, Role::Assistant);
-        assert_eq!(resp.message.content, "hello back");
+        assert_eq!(resp.message.content_str(), "hello back");
         assert_eq!(resp.finish_reason, FinishReason::Stop);
         assert_eq!(resp.usage.prompt_tokens, 2);
         assert_eq!(resp.usage.completion_tokens, 3);
@@ -589,7 +589,7 @@ mod tests {
             "my-claude",
             vec![ChatMessage {
                 role: Role::Tool,
-                content: "tool output".into(),
+                content: Some("tool output".into()),
                 content_blocks: None,
                 name: None,
                 tool_call_id: None,

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -142,18 +142,18 @@ pub fn split_system<'a>(
                     // System messages interleaved with user/assistant
                     // turns don't map cleanly; append as a user turn to
                     // preserve semantics without silently dropping them.
-                    messages.push(AnthropicMessage::text("user", &m.content));
+                    messages.push(AnthropicMessage::text("user", m.content_str()));
                 } else {
-                    system_parts.push(&m.content);
+                    system_parts.push(m.content_str());
                 }
             }
             Role::User => {
                 seen_non_system = true;
-                messages.push(AnthropicMessage::text("user", &m.content));
+                messages.push(AnthropicMessage::text("user", m.content_str()));
             }
             Role::Assistant => {
                 seen_non_system = true;
-                messages.push(AnthropicMessage::text("assistant", &m.content));
+                messages.push(AnthropicMessage::text("assistant", m.content_str()));
             }
             Role::Tool => {
                 seen_non_system = true;
@@ -161,7 +161,7 @@ pub fn split_system<'a>(
                     .tool_call_id
                     .as_deref()
                     .ok_or(TranslateError::MissingToolCallId)?;
-                messages.push(AnthropicMessage::tool_result(tool_use_id, &m.content));
+                messages.push(AnthropicMessage::tool_result(tool_use_id, m.content_str()));
             }
         }
     }
@@ -427,6 +427,10 @@ pub fn response_into_chat_response(raw: AnthropicResponse) -> ChatResponse {
         })
         .collect::<Vec<_>>()
         .join("");
+    // #395: when an Anthropic upstream returns only `tool_use` blocks
+    // (no text), surface `content: null` on the OpenAI shape rather than
+    // `""` — same wire-shape parity fix as the OpenAI passthrough.
+    let content = if text.is_empty() { None } else { Some(text) };
 
     // Translate Anthropic `tool_use` content blocks into OpenAI's
     // `message.tool_calls` shape so OpenAI-SDK callers see a
@@ -499,7 +503,7 @@ pub fn response_into_chat_response(raw: AnthropicResponse) -> ChatResponse {
         model: raw.model,
         message: ChatMessage {
             role: Role::Assistant,
-            content: text,
+            content,
             content_blocks: None,
             name: None,
             tool_call_id: None,
@@ -820,8 +824,8 @@ pub fn chat_response_into_anthropic_json(
 
     let mut content: Vec<serde_json::Value> = Vec::new();
 
-    if !resp.message.content.is_empty() {
-        content.push(serde_json::json!({"type": "text", "text": resp.message.content}));
+    if let Some(text) = resp.message.content.as_deref().filter(|s| !s.is_empty()) {
+        content.push(serde_json::json!({"type": "text", "text": text}));
     }
 
     // Translate OpenAI-shape tool_calls from message.extra into
@@ -1263,7 +1267,7 @@ mod tests {
             "claude",
             vec![ChatMessage {
                 role: Role::Tool,
-                content: "x".into(),
+                content: Some("x".into()),
                 content_blocks: None,
                 name: None,
                 tool_call_id: None,
@@ -1289,7 +1293,7 @@ mod tests {
                 // (skipping the assistant turn for brevity in test setup)
                 ChatMessage {
                     role: Role::Tool,
-                    content: "72F, sunny".into(),
+                    content: Some("72F, sunny".into()),
                     content_blocks: None,
                     name: None,
                     tool_call_id: Some("toolu_abc".into()),
@@ -1349,9 +1353,9 @@ mod tests {
 
         // stop_reason "tool_use" → finish_reason ToolCalls.
         assert_eq!(out.finish_reason, FinishReason::ToolCalls);
-        // Text content is empty when only tool_use blocks were
-        // emitted (no text blocks present).
-        assert_eq!(out.message.content, "");
+        // #395: when only tool_use blocks are emitted (no text), the
+        // OpenAI-shape content is `null`, not `""`.
+        assert_eq!(out.message.content, None);
 
         // tool_calls translation lives in `message.extra` so the
         // proxy renderer flattens it onto the wire as a top-level
@@ -1398,7 +1402,7 @@ mod tests {
         }"#;
         let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
         let out = response_into_chat_response(raw);
-        assert_eq!(out.message.content, "Let me check the weather.");
+        assert_eq!(out.message.content_str(), "Let me check the weather.");
         assert!(out.message.extra.get("tool_calls").is_some());
     }
 
@@ -1644,7 +1648,7 @@ mod tests {
         let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
         let out = response_into_chat_response(raw);
         assert_eq!(out.id, "msg_01A");
-        assert_eq!(out.message.content, "hello");
+        assert_eq!(out.message.content_str(), "hello");
         assert_eq!(out.finish_reason, FinishReason::Stop);
         assert_eq!(out.usage.total_tokens, 5);
     }
@@ -1708,7 +1712,7 @@ mod tests {
         }"#;
         let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
         let out = response_into_chat_response(raw);
-        assert_eq!(out.message.content, "done");
+        assert_eq!(out.message.content_str(), "done");
     }
 
     #[test]
@@ -1813,7 +1817,7 @@ mod tests {
         assert_eq!(chat.model, "claude-sonnet-4-5");
         assert_eq!(chat.messages.len(), 1);
         assert_eq!(chat.messages[0].role, Role::User);
-        assert_eq!(chat.messages[0].content, "hi");
+        assert_eq!(chat.messages[0].content_str(), "hi");
         assert_eq!(chat.max_tokens, Some(100));
     }
 
@@ -1827,7 +1831,7 @@ mod tests {
         let chat = parse_inbound_request(&body).unwrap();
         assert_eq!(chat.messages.len(), 2);
         assert_eq!(chat.messages[0].role, Role::System);
-        assert_eq!(chat.messages[0].content, "you are helpful");
+        assert_eq!(chat.messages[0].content_str(), "you are helpful");
         assert_eq!(chat.messages[1].role, Role::User);
     }
 
@@ -1843,7 +1847,7 @@ mod tests {
         });
         let chat = parse_inbound_request(&body).unwrap();
         assert_eq!(chat.messages[0].role, Role::System);
-        assert_eq!(chat.messages[0].content, "line1\nline2");
+        assert_eq!(chat.messages[0].content_str(), "line1\nline2");
     }
 
     #[test]
@@ -1861,7 +1865,7 @@ mod tests {
         });
         let chat = parse_inbound_request(&body).unwrap();
         // Image block silently skipped; text concatenates.
-        assert_eq!(chat.messages[0].content, "hello world");
+        assert_eq!(chat.messages[0].content_str(), "hello world");
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -418,19 +418,25 @@ pub struct AnthropicUsage {
 }
 
 pub fn response_into_chat_response(raw: AnthropicResponse) -> ChatResponse {
+    let mut saw_text_block = false;
     let text = raw
         .content
         .iter()
         .filter_map(|b| match b {
-            AnthropicResponseBlock::Text { text } => Some(text.as_str()),
+            AnthropicResponseBlock::Text { text } => {
+                saw_text_block = true;
+                Some(text.as_str())
+            }
             _ => None,
         })
         .collect::<Vec<_>>()
         .join("");
     // #395: when an Anthropic upstream returns only `tool_use` blocks
-    // (no text), surface `content: null` on the OpenAI shape rather than
-    // `""` — same wire-shape parity fix as the OpenAI passthrough.
-    let content = if text.is_empty() { None } else { Some(text) };
+    // (no text block at all), surface `content: null` on the OpenAI
+    // shape rather than `""` — same wire-shape parity fix as the OpenAI
+    // passthrough. An explicit empty text block (`text: ""`) is distinct
+    // and preserved as `Some("")`.
+    let content = saw_text_block.then_some(text);
 
     // Translate Anthropic `tool_use` content blocks into OpenAI's
     // `message.tool_calls` shape so OpenAI-SDK callers see a
@@ -1404,6 +1410,26 @@ mod tests {
         let out = response_into_chat_response(raw);
         assert_eq!(out.message.content_str(), "Let me check the weather.");
         assert!(out.message.extra.get("tool_calls").is_some());
+    }
+
+    #[test]
+    fn explicit_empty_text_block_stays_empty_string_not_null() {
+        // #395 refinement: distinguish "no text block at all" (→ null)
+        // from an explicit empty text block (→ ""). A response carrying
+        // a `{"type":"text","text":""}` block must surface `Some("")`,
+        // not `None`.
+        let body = r#"{
+            "id": "msg_empty_text_01",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-5-sonnet-20241022",
+            "content": [{"type": "text", "text": ""}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 3, "output_tokens": 0}
+        }"#;
+        let raw: AnthropicResponse = serde_json::from_str(body).unwrap();
+        let out = response_into_chat_response(raw);
+        assert_eq!(out.message.content, Some(String::new()));
     }
 
     #[test]

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -1463,7 +1463,7 @@ mod tests {
         let ctx = canonical_test_ctx();
         let req = ChatFormat::new("my-azure-gpt4", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "hi from azure");
+        assert_eq!(chat.message.content_str(), "hi from azure");
 
         // Audit M3: assert `Authorization` is absent on the wire (not
         // just absent from the helper's output).
@@ -1562,7 +1562,7 @@ mod tests {
         let ctx = canonical_test_ctx();
         let req = ChatFormat::new("my-azure-gpt4", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "filtered ok");
+        assert_eq!(chat.message.content_str(), "filtered ok");
         assert_eq!(chat.usage.total_tokens, 7);
     }
 
@@ -2113,7 +2113,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-azure-gpt4", vec![ChatMessage::user("hi")]);
         let resp = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(resp.message.content, "hello via aad");
+        assert_eq!(resp.message.content_str(), "hello via aad");
 
         let headers = captured_headers
             .lock()

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -910,8 +910,9 @@ fn build_converse_inputs(
     for msg in &req.messages {
         match msg.role {
             Role::System => {
-                if !msg.content.is_empty() {
-                    systems.push(SystemContentBlock::Text(msg.content.clone()));
+                let content = msg.content_str();
+                if !content.is_empty() {
+                    systems.push(SystemContentBlock::Text(content.to_string()));
                 }
             }
             Role::User | Role::Assistant => {
@@ -922,7 +923,7 @@ fn build_converse_inputs(
                 };
                 let m = BedrockMessage::builder()
                     .role(role)
-                    .content(ContentBlock::Text(msg.content.clone()))
+                    .content(ContentBlock::Text(msg.content_str().to_string()))
                     .build()
                     .map_err(|e| {
                         BridgeError::Config(format!("bedrock converse: build message: {e}"))
@@ -1749,7 +1750,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "hello from bedrock");
+        assert_eq!(chat.message.content_str(), "hello from bedrock");
         assert_eq!(chat.usage.total_tokens, 9);
     }
 
@@ -1883,7 +1884,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "calling tool");
+        assert_eq!(chat.message.content_str(), "calling tool");
         // Tool calls translated into OpenAI shape via the reused
         // anthropic crate's converter.
         let tool_calls = chat
@@ -2070,7 +2071,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "cross-region ok");
+        assert_eq!(chat.message.content_str(), "cross-region ok");
     }
 
     /// Audit M6: cross-region dispatch coverage was only `us.`; the
@@ -2104,7 +2105,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "us-gov ok");
+        assert_eq!(chat.message.content_str(), "us-gov ok");
     }
 
     #[tokio::test]
@@ -2132,7 +2133,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "global ok");
+        assert_eq!(chat.message.content_str(), "global ok");
     }
 
     // Removed `chat_publisher_not_implemented_error_includes_model_id_and_publisher_name`
@@ -2274,7 +2275,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-llama", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "hello from converse");
+        assert_eq!(chat.message.content_str(), "hello from converse");
         assert_eq!(chat.usage.prompt_tokens, 7);
         assert_eq!(chat.usage.completion_tokens, 3);
         assert_eq!(chat.usage.total_tokens, 10);
@@ -2306,7 +2307,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-nova", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "hello from converse");
+        assert_eq!(chat.message.content_str(), "hello from converse");
     }
 
     #[tokio::test]

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -781,7 +781,7 @@ mod tests {
 
         assert_eq!(resp.id, "cmpl-1");
         assert_eq!(resp.message.role, Role::Assistant);
-        assert_eq!(resp.message.content, "hello back");
+        assert_eq!(resp.message.content_str(), "hello back");
         assert_eq!(resp.finish_reason, FinishReason::Stop);
         assert_eq!(resp.usage.total_tokens, 4);
     }

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -116,7 +116,7 @@ pub fn messages_from(req: &ChatFormat) -> Vec<OpenAiMessage<'_>> {
             // string. See `ChatMessage::content_blocks` doc.
             content: match m.content_blocks.as_deref() {
                 Some(blocks) => OpenAiContent::Blocks(blocks),
-                None => OpenAiContent::Text(&m.content),
+                None => OpenAiContent::Text(m.content_str()),
             },
             name: m.name.as_deref(),
             tool_call_id: m.tool_call_id.as_deref(),
@@ -278,7 +278,11 @@ pub fn response_into_chat_response(mut raw: OpenAiResponse) -> ChatResponse {
             (
                 ChatMessage {
                     role: role_from_str(&c.message.role),
-                    content: c.message.content.unwrap_or_default(),
+                    // #395: carry the upstream `string | null` through
+                    // verbatim. A tool_calls response returns
+                    // `content: null`; collapsing it to `""` here is the
+                    // divergence we're fixing.
+                    content: c.message.content,
                     content_blocks: None,
                     name: None,
                     tool_call_id: None,
@@ -573,7 +577,7 @@ mod tests {
         assert_eq!(out.id, "cmpl-1");
         assert_eq!(out.model, "gpt-4o");
         assert_eq!(out.message.role, Role::Assistant);
-        assert_eq!(out.message.content, "hi there");
+        assert_eq!(out.message.content_str(), "hi there");
         assert_eq!(out.finish_reason, FinishReason::Stop);
         assert_eq!(out.usage.total_tokens, 6);
         // No cache / reasoning details on this minimal response →
@@ -606,6 +610,9 @@ mod tests {
         let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
         let out = response_into_chat_response(raw);
         assert_eq!(out.finish_reason, FinishReason::ToolCalls);
+        // #395: upstream `content: null` must be carried through as
+        // `None`, not collapsed to `Some("")`.
+        assert_eq!(out.message.content, None);
         let tc = out
             .message
             .extra
@@ -719,7 +726,7 @@ mod tests {
         }"#;
         let raw: OpenAiResponse = serde_json::from_str(body).unwrap();
         let out = response_into_chat_response(raw);
-        assert_eq!(out.message.content, "The answer is 42.");
+        assert_eq!(out.message.content_str(), "The answer is 42.");
         let reasoning = out
             .message
             .extra

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -1680,17 +1680,17 @@ fn build_gemini_request(req: &ChatFormat) -> GeminiGenerateContentRequest {
     let mut contents: Vec<GeminiContent> = Vec::new();
     for m in &req.messages {
         match m.role {
-            Role::System => system_parts.push(m.content.clone()),
+            Role::System => system_parts.push(m.content_str().to_string()),
             Role::User | Role::Tool => contents.push(GeminiContent {
                 role: "user",
                 parts: vec![GeminiPart {
-                    text: m.content.clone(),
+                    text: m.content_str().to_string(),
                 }],
             }),
             Role::Assistant => contents.push(GeminiContent {
                 role: "model",
                 parts: vec![GeminiPart {
-                    text: m.content.clone(),
+                    text: m.content_str().to_string(),
                 }],
             }),
         }
@@ -2469,7 +2469,7 @@ mod tests {
         )
         .unwrap();
         let chat = gemini_response_into_chat_response(raw, "gemini-1.5-pro");
-        assert_eq!(chat.message.content, "hello");
+        assert_eq!(chat.message.content_str(), "hello");
         assert_eq!(chat.message.role, Role::Assistant);
         assert_eq!(chat.finish_reason, FinishReason::Stop);
         assert_eq!(chat.usage.total_tokens, 6);
@@ -2724,7 +2724,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "hello from gemini");
+        assert_eq!(chat.message.content_str(), "hello from gemini");
         assert_eq!(chat.usage.total_tokens, 6);
     }
 
@@ -2777,7 +2777,7 @@ mod tests {
         let chat = bridge.chat(&req, &ctx).await.unwrap();
 
         // Customer-visible response decoded from the Anthropic envelope.
-        assert_eq!(chat.message.content, "hello from claude on vertex");
+        assert_eq!(chat.message.content_str(), "hello from claude on vertex");
         assert_eq!(chat.usage.total_tokens, 8);
 
         // Wire-shape: Anthropic Messages body with the Vertex
@@ -3010,7 +3010,7 @@ mod tests {
         let chat = bridge.chat(&req, &ctx).await.unwrap();
 
         // Customer-visible response decoded from the OpenAI envelope.
-        assert_eq!(chat.message.content, "hello from llama on vertex");
+        assert_eq!(chat.message.content_str(), "hello from llama on vertex");
         assert_eq!(chat.usage.total_tokens, 9);
 
         // Wire-shape: OpenAI chat body with the model id IN the body
@@ -3187,7 +3187,7 @@ mod tests {
 
         // Response decoded from the OpenAI envelope (shared responder).
         assert_eq!(chat.usage.total_tokens, 9);
-        assert!(!chat.message.content.is_empty());
+        assert!(!chat.message.content_str().is_empty());
 
         // Wire-shape: the model id is kept in the OpenAI body (it rides in
         // BOTH the URL — pinned by the matcher above — and the body).
@@ -3414,7 +3414,7 @@ mod tests {
         );
         let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
-        assert_eq!(chat.message.content, "hello from gemini");
+        assert_eq!(chat.message.content_str(), "hello from gemini");
     }
 
     /// Same as above but exercises the trailing-slash trim — a
@@ -3445,7 +3445,7 @@ mod tests {
         let chat = bridge.chat(&req, &ctx).await.unwrap();
         // Body shape unaffected — the assertion is the wiremock's
         // `expect(1)` on the exact path (no `//` doubling).
-        assert_eq!(chat.message.content, "hello from gemini");
+        assert_eq!(chat.message.content_str(), "hello from gemini");
     }
 
     #[tokio::test]
@@ -3883,7 +3883,7 @@ mod tests {
         let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
         assert_eq!(chat.finish_reason, FinishReason::Length);
-        assert_eq!(chat.message.content, "truncated...");
+        assert_eq!(chat.message.content_str(), "truncated...");
     }
 
     // ─── Streaming (:streamGenerateContent?alt=sse) ─────────────────

--- a/crates/aisix-proxy/src/render.rs
+++ b/crates/aisix-proxy/src/render.rs
@@ -50,7 +50,14 @@ pub struct NonStreamChoice {
 #[derive(Debug, Serialize)]
 pub struct RenderedMessage {
     pub role: &'static str,
-    pub content: String,
+    /// `Option<String>` — NOT `#[serde(skip_serializing_if)]`. OpenAI
+    /// emits an explicit `"content": null` on a `tool_calls` response
+    /// (the assistant chose to call a tool, there is no text reply), so
+    /// `None` MUST serialize as JSON `null`, not be omitted (#395).
+    /// Contrast the streaming `RenderedDelta.content`, which correctly
+    /// uses `skip_serializing_if` because OpenAI omits `delta.content`
+    /// on tool-call chunks.
+    pub content: Option<String>,
     /// Forward-compatible bag for OpenAI message-level fields the
     /// gateway doesn't model directly on `ChatMessage` (e.g.
     /// `tool_calls` for cross-provider tool-use translation,
@@ -339,6 +346,54 @@ mod tests {
         );
         assert!(json["usage"].get("completion_tokens_details").is_none());
         assert!(json["usage"].get("prompt_cache_hit_tokens").is_none());
+    }
+
+    /// #395: a tool_calls response carries `content: null` from the
+    /// upstream. The renderer MUST emit an explicit JSON `null` (the
+    /// OpenAI documented shape) — not `""` and not an omitted field.
+    #[test]
+    fn render_response_emits_explicit_null_content_on_tool_calls() {
+        let mut extra = serde_json::Map::new();
+        extra.insert(
+            "tool_calls".into(),
+            serde_json::json!([{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{}"}
+            }]),
+        );
+        let message = ChatMessage {
+            role: Role::Assistant,
+            content: None,
+            content_blocks: None,
+            name: None,
+            tool_call_id: None,
+            extra,
+        };
+        let r = ChatResponse {
+            id: "cmpl-1".into(),
+            model: "m".into(),
+            message,
+            finish_reason: FinishReason::ToolCalls,
+            usage: UsageStats::new(3, 2),
+        };
+        let out = render_response(0, r, "m");
+
+        // Serialized JSON must contain `"content":null`, not `""` and
+        // not an omitted key.
+        let raw = serde_json::to_string(&out).unwrap();
+        assert!(
+            raw.contains("\"content\":null"),
+            "tool_calls content must serialize as explicit null: {raw}"
+        );
+        assert!(!raw.contains("\"content\":\"\""));
+
+        let json = serde_json::to_value(&out).unwrap();
+        let msg = &json["choices"][0]["message"];
+        assert!(msg.get("content").is_some(), "content key must be present");
+        assert!(msg["content"].is_null());
+        assert_eq!(msg["tool_calls"][0]["id"], "call_1");
+        assert_eq!(json["choices"][0]["finish_reason"], "tool_calls");
     }
 
     /// Issue #542 (OpenAI half): when the gateway has a non-zero

--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -189,3 +189,108 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
     expect(messagesReq!.headers["anthropic-version"]).toBeDefined();
   });
 });
+
+// E2E (#395): an Anthropic upstream that returns ONLY a `tool_use` block
+// (no text block) must surface `choices[0].message.content === null` on
+// the OpenAI shape — not `""`. The text-block join produced `""` before
+// the fix; we now map empty/absent text to `null` to match OpenAI's
+// documented `string | null` shape and LiteLLM's behaviour.
+const TOOL_CALLER_PLAINTEXT = "sk-an-e2e-toolnull-caller";
+const TOOL_CALLER_KEY_HASH = createHash("sha256")
+  .update(TOOL_CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("anthropic upstream e2e: tool_use-only response surfaces content:null (#395)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_toolonly_01",
+        type: "message",
+        role: "assistant",
+        // Only a tool_use block, no text block — the bug-class case.
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_abc",
+            name: "get_weather",
+            input: { location: "SF" },
+          },
+        ],
+        model: "claude-3-5-haiku-20241022",
+        stop_reason: "tool_use",
+        usage: { input_tokens: 7, output_tokens: 3 },
+      },
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "an-e2e-toolnull-pk",
+      provider: "anthropic",
+      adapter: "anthropic",
+      secret: "sk-ant-mock",
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "an-e2e-toolnull",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: TOOL_CALLER_KEY_HASH,
+      allowed_models: ["an-e2e-toolnull"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("tool_use-only Anthropic response → content is exactly null on OpenAI shape", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: TOOL_CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.chat.completions.create({
+          model: "an-e2e-toolnull",
+          messages: [{ role: "user", content: "ready-probe" }],
+        });
+        return r.choices[0]?.message.role === "assistant";
+      } catch {
+        return false;
+      }
+    });
+
+    const completion = await client.chat.completions.create({
+      model: "an-e2e-toolnull",
+      messages: [{ role: "user", content: "weather in SF?" }],
+    });
+
+    expect(completion.choices[0]?.finish_reason).toBe("tool_calls");
+    // The tool_use block translates to OpenAI tool_calls.
+    expect(completion.choices[0]?.message.tool_calls?.[0]?.function.name).toBe(
+      "get_weather",
+    );
+    // The fix: content must be exactly null, not "".
+    expect(completion.choices[0]?.message.content).toBeNull();
+  });
+});

--- a/tests/e2e/src/cases/openai-tools-roundtrip-e2e.test.ts
+++ b/tests/e2e/src/cases/openai-tools-roundtrip-e2e.test.ts
@@ -306,12 +306,11 @@ describe("OpenAI tools round-trip (#220 + #202)", () => {
 
     expect(completion.choices[0]?.finish_reason).toBe("tool_calls");
     // OpenAI's `message.content` is documented as `string | null`
-    // (<https://platform.openai.com/docs/api-reference/chat/object>);
-    // when tool_calls fires, both `null` and `""` are valid no-text
-    // signals and the SDK treats them identically. The gateway
-    // currently surfaces an empty string here — a minor wire-shape
-    // divergence tracked separately; not the #220 contract.
-    expect(completion.choices[0]?.message.content).toBeFalsy();
+    // (<https://platform.openai.com/docs/api-reference/chat/object>).
+    // On a tool_calls response the upstream returns `content: null` to
+    // signal "the assistant chose to call a tool, no text reply"; the
+    // gateway must surface exactly `null`, not `""` (#395).
+    expect(completion.choices[0]?.message.content).toBeNull();
   });
 
   test("streaming: delta.tool_calls fragments survive upstream → gateway → caller (#202)", async (ctx) => {


### PR DESCRIPTION
## Problem

On a non-streaming `/v1/chat/completions` response where the upstream returns `message.content: null` together with `tool_calls` (`finish_reason: "tool_calls"`), the gateway surfaced `content: ""` instead of `null`.

OpenAI documents `message.content` as `string | null`, and `null` is the correct value on a tool_calls response (it signals "the assistant chose to call a tool, there is no text reply"). LiteLLM preserves `null`, so the `""` coercion was a real wire-shape divergence. It bites strict-equality tooling (`content is None` / `content === null`) and muddles the upstream's intent.

## Fix

Carry the `Option<String>` through end to end:

- `OpenAiResponseMessage.content` was already `Option<String>`; stop calling `unwrap_or_default()` in `response_into_chat_response`.
- `ChatMessage.content` becomes `Option<String>` (`null` -> `None`, round-trips back to JSON `null`). Constructors wrap in `Some`; readers go through a new `content_str()` helper that maps `None -> ""`. The request path is unchanged (`None -> ""` when building upstream messages), so existing request tests/behaviour are unaffected.
- `RenderedMessage.content` becomes `Option<String>` **without** `skip_serializing_if`, so `None` serializes as an explicit JSON `null` (never omitted) — matching OpenAI. The streaming `RenderedDelta.content` path is left untouched; it correctly omits `content` on tool-call chunks.

## Bug class (cross-provider)

The same divergence applies across the family that surfaces tool calls:

- **Anthropic** (cross-provider): a response with only `tool_use` blocks (no text) now maps empty/absent text to `None`, surfacing `content: null` on the OpenAI shape instead of `""`.
- **Azure** reuses the OpenAI wire path (`response_into_chat_response`) and is fixed transitively.
- **Bedrock / Vertex** were adapted to the new `Option` type. They don't translate provider tool-use into OpenAI `tool_calls` today, so the null-vs-`""` path isn't reachable there; left as-is.

## Tests

- DP e2e `openai-tools-roundtrip` tightened from `toBeFalsy()` to `toBeNull()` — fails before the fix (gateway sent `""`), passes after.
- New DP e2e: an Anthropic upstream returning a `tool_use`-only response, routed via `/v1/chat/completions`, asserts `choices[0].message.content === null`.
- Rust unit tests: OpenAI wire keeps `None` on a `content: null` tool_calls response; the renderer serializes `"content":null` (not `""`, not omitted) for a tool_calls message.

Fixes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed message content representation to properly preserve `null` values in tool-call responses, ensuring OpenAI-compatible behavior where responses with only tool calls (no text) now correctly return `content: null` instead of empty strings.

* **Tests**
  * Added end-to-end tests verifying proper null content handling for tool-only responses from upstream providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->