### PR TITLE
feat(obs): guardrail block + bypass metrics (#379)

### DIFF
--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -66,6 +66,9 @@ pub const M_USAGE_EVENT_DROPS_TOTAL: &str = "aisix_usage_event_drops_total";
 /// events — a remote-API guardrail's upstream was unreachable but `fail_open`
 /// let the request through — sliced by the bounded DP-internal `reason`
 /// (e.g. `bedrock_5xx` / `bedrock_timeout` / `bedrock_throttled`).
+///
+/// Scope: recorded for `/v1/chat/completions` only until #519 brings the
+/// `/v1/messages` path in — read these as chat-path, not gateway-wide.
 pub const M_GUARDRAIL_BLOCKS_TOTAL: &str = "aisix_guardrail_blocks_total";
 pub const M_GUARDRAIL_BYPASSES_TOTAL: &str = "aisix_guardrail_bypasses_total";
 /// Issue #408: counter for UsageEvents successfully enqueued onto the
@@ -811,9 +814,14 @@ mod tests {
             rendered.contains(&format!("{M_GUARDRAIL_BLOCKS_TOTAL} 1")),
             "want one block, got:\n{rendered}"
         );
-        // One bypass, sliced by the bounded reason.
-        assert!(rendered.contains(M_GUARDRAIL_BYPASSES_TOTAL));
-        assert!(rendered.contains("reason=\"bedrock_5xx\""));
+        // Exactly one bypass, sliced by the bounded reason — pinning the count
+        // proves the blocked + clean calls didn't touch the bypass counter.
+        assert!(
+            rendered.contains(&format!(
+                "{M_GUARDRAIL_BYPASSES_TOTAL}{{reason=\"bedrock_5xx\"}} 1"
+            )),
+            "want exactly one bedrock_5xx bypass, got:\n{rendered}"
+        );
     }
 
     #[test]

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -60,6 +60,14 @@ pub const M_BUDGET_RESET_SECONDS: &str = "aisix_budget_reset_seconds";
 pub const M_BUDGET_DETAILS_PRESENT: &str = "aisix_budget_details_present";
 pub const M_REDIS_FAILURES_TOTAL: &str = "aisix_redis_failures_total";
 pub const M_USAGE_EVENT_DROPS_TOTAL: &str = "aisix_usage_event_drops_total";
+/// Guardrail outcomes (#379 observability). `aisix_guardrail_blocks_total`
+/// counts requests a guardrail rejected (input or output hook; policy or
+/// fail-closed combined). `aisix_guardrail_bypasses_total` counts fail-open
+/// events — a remote-API guardrail's upstream was unreachable but `fail_open`
+/// let the request through — sliced by the bounded DP-internal `reason`
+/// (e.g. `bedrock_5xx` / `bedrock_timeout` / `bedrock_throttled`).
+pub const M_GUARDRAIL_BLOCKS_TOTAL: &str = "aisix_guardrail_blocks_total";
+pub const M_GUARDRAIL_BYPASSES_TOTAL: &str = "aisix_guardrail_bypasses_total";
 /// Issue #408: counter for UsageEvents successfully enqueued onto the
 /// `UsageSink` (i.e. handed off to the telemetry worker for delivery
 /// to cp-api + per-env OTLP exporters). Operators slice this by:
@@ -144,6 +152,25 @@ impl Metrics {
                 "status" => status.to_string(),
             )
             .record(duration.as_secs_f64());
+        });
+    }
+
+    /// Record one request's guardrail outcome. Called once per request from
+    /// the centralised telemetry emit, using the same data as the UsageEvent's
+    /// `guardrail_blocked` / `guardrail_bypassed_reason` fields. An empty
+    /// `bypass_reason` means no bypass occurred.
+    pub fn record_guardrail_outcome(&self, blocked: bool, bypass_reason: &str) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            if blocked {
+                metrics::counter!(M_GUARDRAIL_BLOCKS_TOTAL).increment(1);
+            }
+            if !bypass_reason.is_empty() {
+                metrics::counter!(
+                    M_GUARDRAIL_BYPASSES_TOTAL,
+                    "reason" => bypass_reason.to_string(),
+                )
+                .increment(1);
+            }
         });
     }
 
@@ -770,6 +797,23 @@ mod tests {
         let rendered = m.render();
         assert!(rendered.contains(M_RATELIMIT_REJECTIONS));
         assert!(rendered.contains("scope=\"requests\""));
+    }
+
+    #[test]
+    fn guardrail_outcome_counters_increment() {
+        let m = Metrics::new(false);
+        m.record_guardrail_outcome(true, ""); // blocked, no bypass
+        m.record_guardrail_outcome(false, "bedrock_5xx"); // fail-open bypass
+        m.record_guardrail_outcome(false, ""); // clean request → records nothing
+        let rendered = m.render();
+        // Exactly one block (the clean call must not increment it).
+        assert!(
+            rendered.contains(&format!("{M_GUARDRAIL_BLOCKS_TOTAL} 1")),
+            "want one block, got:\n{rendered}"
+        );
+        // One bypass, sliced by the bounded reason.
+        assert!(rendered.contains(M_GUARDRAIL_BYPASSES_TOTAL));
+        assert!(rendered.contains("reason=\"bedrock_5xx\""));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1657,6 +1657,12 @@ fn emit_usage_event(
     // `aisix_usage_events_emitted_total` (#408). Keep `&'static str`
     // so prometheus cardinality stays bounded.
     state.usage_sink.try_emit("chat", event.clone());
+    // Guardrail outcome counters (#379). Recorded here — the one place every
+    // chat path (success / error / streaming / cache-hit) funnels through —
+    // from the same guardrail fields the UsageEvent carries.
+    state
+        .metrics
+        .record_guardrail_outcome(guardrail_blocked, &event.guardrail_bypassed_reason);
     // Per-env OTLP/HTTP fan-out. The snapshot's exporter table is
     // empty for envs that haven't configured any, so this is a cheap
     // no-op on the common path. Spawned tasks own the POST work and


### PR DESCRIPTION
## What

First slice of guardrail observability (#379): two Prometheus counters in `aisix-obs`.

- `aisix_guardrail_blocks_total` — requests a guardrail rejected (input or output hook; policy and fail-closed combined).
- `aisix_guardrail_bypasses_total{reason}` — **fail-open** events: a remote-API guardrail's upstream was unreachable but `fail_open` let the request through. Sliced by the bounded DP-internal `reason` (`bedrock_5xx` / `bedrock_timeout` / `bedrock_throttled` — same values the UsageEvent's `guardrail_bypassed_reason` already carries, so cardinality stays bounded).

## Where it's recorded (one point, not scattered)

`emit_usage_event` in chat.rs is the centralized telemetry funnel — its own doc says "success / error / streaming / cache-hit paths share one event construction." It already has `guardrail_blocked` + `bypass_reason` in scope, so `record_guardrail_outcome` is called there, once per request. This avoids instrumenting the ~15 individual `GuardrailVerdict::Block/Bypass` sites (which would risk miss/double-count) and reuses the exact data the telemetry already finalized.

## Prior art

Exposing block / policy-enforcement counters (and a fail-open signal) is standard guardrail observability across mainstream gateways; this follows the existing `aisix_*` metric naming + the bounded-label discipline already documented in `metrics.rs`. Referenced generically.

## Scope + follow-ups

Scoped to `/v1/chat/completions`:
- The `/v1/messages` (anthropic) handler runs guardrails too but has a pre-existing telemetry gap (its UsageEvent doesn't carry `guardrail_blocked`), so the counters undercount there — **#519**, folds into the applied-guardrails (#379 "A") telemetry-threading.
- A distinct `aisix_guardrail_fail_close_total` (error-block vs policy-block) needs a verdict-level error signal the DP doesn't expose today — **#520**. The fail-OPEN half is covered here by `bypasses_total`.

The original task also mentioned an Alertmanager rule; AISIX-Cloud has no monitoring config dir, so the alert rule is deferred (the metrics are the prerequisite; rule placement is a separate infra decision).

## Tests

Unit test asserts `aisix_guardrail_blocks_total 1` (so a clean request records nothing) + the `reason="bedrock_5xx"` bypass label. `cargo fmt` / `cargo test -p aisix-obs` / `cargo clippy -p aisix-obs -p aisix-proxy` green; `aisix-proxy` builds with the new emit call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added observability metrics to track guardrail outcomes, capturing blocked content counts and bypass events with reasons.
  * Integrated guardrail outcome recording into chat telemetry emissions for enhanced monitoring.

* **Tests**
  * Extended unit tests to verify guardrail outcome counters for blocked calls, bypasses with reasons, and no-ops for empty reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->