### PR TITLE
docs: update `CLAUDE.md` for future doc update instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ AI Gateway public docs are maintained in the `api7/docs` repository under `docs/
 
 When asked to update AI Gateway docs:
 
-- Make content changes in `/Users/test/Desktop/api7/docs/docs/ai-gateway`.
-- Validate with the docs-site build or preview from `/Users/test/Desktop/api7/docs`.
+- Make content changes in the `api7/docs` repository under `docs/ai-gateway`.
+- Validate with the docs-site build or preview from the `api7/docs` repository.
 - Use this repository only to verify product behavior, generated schema/OpenAPI sources, or implementation details that the docs describe.
 
 ## 1. Think Before Coding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 Behavioral guidelines to reduce common LLM coding mistakes. Bias toward caution over speed; for trivial tasks, use judgment. Merge with project-specific instructions as needed.
 
+## AI Gateway Docs Ownership
+
+AI Gateway public docs are maintained in the `api7/docs` repository under `docs/ai-gateway`. Do not edit `docs/**` in this repository for public documentation updates unless the docs migration strategy changes explicitly.
+
+When asked to update AI Gateway docs:
+
+- Make content changes in `/Users/test/Desktop/api7/docs/docs/ai-gateway`.
+- Validate with the docs-site build or preview from `/Users/test/Desktop/api7/docs`.
+- Use this repository only to verify product behavior, generated schema/OpenAPI sources, or implementation details that the docs describe.
+- Do not delete the existing `docs/` content in this repository until the docs-site PR is polished, approved, and ready for the intentional cleanup step.
+
 ## 1. Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,13 @@ Behavioral guidelines to reduce common LLM coding mistakes. Bias toward caution 
 
 ## AI Gateway Docs Ownership
 
-AI Gateway public docs are maintained in the `api7/docs` repository under `docs/ai-gateway`. Do not edit `docs/**` in this repository for public documentation updates unless the docs migration strategy changes explicitly.
+AI Gateway public docs are maintained in the `api7/docs` repository under `docs/ai-gateway`.
 
 When asked to update AI Gateway docs:
 
 - Make content changes in `/Users/test/Desktop/api7/docs/docs/ai-gateway`.
 - Validate with the docs-site build or preview from `/Users/test/Desktop/api7/docs`.
 - Use this repository only to verify product behavior, generated schema/OpenAPI sources, or implementation details that the docs describe.
-- Do not delete the existing `docs/` content in this repository until the docs-site PR is polished, approved, and ready for the intentional cleanup step.
 
 ## 1. Think Before Coding
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ AI Gateway public docs are maintained in the `api7/docs` repository under `docs/
 
 When asked to update AI Gateway docs:
 
-- Make content changes in the `api7/docs` repository under `docs/ai-gateway`.
+- Make content changes in the `api7/docs` repository under the `docs/ai-gateway/*` path.
 - Validate with the docs-site build or preview from the `api7/docs` repository.
 - Use this repository only to verify product behavior, generated schema/OpenAPI sources, or implementation details that the docs describe.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Behavioral guidelines to reduce common LLM coding mistakes. Bias toward caution over speed; for trivial tasks, use judgment. Merge with project-specific instructions as needed.
 
-## AI Gateway Docs Ownership
+## AI Gateway Docs Update Strategy
 
 AI Gateway public docs are maintained in the `api7/docs` repository under `docs/ai-gateway`.
 


### PR DESCRIPTION
## Summary

- Updates agent instructions to state that public AI Gateway docs are maintained in `api7/docs/docs/ai-gateway`.
- Directs future docs-content edits, preview, and validation to the docs repository.
- Keeps this repository as the place to verify product behavior, generated schema/OpenAPI sources, and implementation details.

## Strategy

This reflects the new docs maintenance strategy only. It does not delete existing `docs/` content from this repository. That cleanup should happen later, after the `api7/docs` AI Gateway docs PR is polished and ready.

This PR will NOT be merged until the official doc release from `api7/docs` and docs are fully removed in this repo.