### PR TITLE
feat(obs): pluggable observability-sink framework + Aliyun SLS exporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,33 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  sls-smoke:
+    name: aliyun sls smoke (real)
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+      # Real Aliyun SLS PutLogs validation — the v1 signature / lz4 block /
+      # protobuf a mock receiver cannot check. The test is `#[ignore]` +
+      # env-gated, so it only does real work when the SLS secrets are present;
+      # fork PRs (where GitHub withholds secrets) see empty vars and skip
+      # cleanly. NOTE: `AISIX_E2E_SLS_*` is read directly by the test — this is
+      # a `cargo test` process that never loads `Config`, so the `AISIX_`
+      # prefix is safe here (unlike the spawned binary in the e2e job, whose
+      # credentials must use the non-`AISIX_` `SLS_CRED_*` form).
+      - name: real-SLS smoke
+        env:
+          AISIX_E2E_SLS_AK_ID: ${{ secrets.ALI_SLS_AK_ID }}
+          AISIX_E2E_SLS_AK_SECRET: ${{ secrets.ALI_SLS_SK }}
+          AISIX_E2E_SLS_ENDPOINT: ap-southeast-3.log.aliyuncs.com
+          AISIX_E2E_SLS_PROJECT: aisix-e2e-obs
+          AISIX_E2E_SLS_LOGSTORE: request-events
+        run: cargo test -p aisix-obs --lib -- --ignored sls_smoke --nocapture
+
   coverage-gate:
     name: coverage >= 90%
     needs: [rust-unit, e2e]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,13 @@ name = "aisix-obs"
 version = "0.1.0"
 dependencies = [
  "aisix-core",
+ "aliyun-log-sdk-protobuf",
+ "aliyun-log-sdk-sign",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "http 1.4.0",
+ "lz4_flex",
  "metrics",
  "metrics-exporter-prometheus",
  "opentelemetry",
@@ -406,6 +410,35 @@ dependencies = [
  "uuid",
  "wiremock",
  "x509-parser",
+]
+
+[[package]]
+name = "aliyun-log-sdk-protobuf"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdcae66c6be087b827ddb61938cd752305f0ee15e75deb4ad98bf6b2fb69a067"
+dependencies = [
+ "getset",
+ "prost-build",
+ "quick-protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "aliyun-log-sdk-sign"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7706f485ba7c668a0a4f2cb27417fa7bc41bd43c60743079b482c76325dc0b"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "hmac-sha1",
+ "http 1.4.0",
+ "log",
+ "md5",
+ "string-builder",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2017,6 +2050,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
+]
+
+[[package]]
+name = "hmac-sha1"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b05da5b9e5d4720bfb691eebb2b9d42da3570745da71eac8a1f5bb7e59aab88"
+dependencies = [
+ "hmac 0.12.1",
+ "sha1",
 ]
 
 [[package]]
@@ -2728,6 +2783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +2805,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3274,6 +3344,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,6 +3439,15 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -4244,6 +4345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string-builder"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd10a070fb1f2796a288abec42695db4682a82b6f12ffacd60fb8d5ad3a4a12"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4866,6 +4973,12 @@ dependencies = [
  "thiserror 1.0.69",
  "utf-8",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ version = "0.1.0"
 dependencies = [
  "aisix-core",
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,14 @@ mime = "0.3"
 # Trusted-proxy CIDR matching for real-ip resolution (#492)
 ipnet = "2"
 
+# Aliyun SLS sink (aisix-obs): the official protobuf + signature sub-crates
+# ONLY — not the full `aliyun-log-rust-sdk`, which forces reqwest native-tls
+# (OpenSSL) + ~13 C/TLS crates. Transport is our own rustls reqwest, so these
+# stay pure-Rust with no OpenSSL.
+aliyun-log-sdk-protobuf = "0.1"
+aliyun-log-sdk-sign = "0.2"
+lz4_flex = "0.11"
+
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "gzip", "multipart"] }
 eventsource-stream = "0.2"

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -37,7 +37,9 @@ pub use guardrail::{
 pub use model::{
     Adapter, BackgroundModelCheck, CooldownConfig, Model, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
-pub use observability_exporter::{ExporterKind, ObservabilityExporter, OtlpHttpConfig};
+pub use observability_exporter::{
+    AliyunSlsConfig, ExporterKind, ObservabilityExporter, OtlpHttpConfig,
+};
 pub use provider_key::{
     ParamConstraints, ProviderKey, RequestOverrides, ResponseOverrides, StreamDoneMarker,
     TelemetryTags,

--- a/crates/aisix-core/src/models/observability_exporter.rs
+++ b/crates/aisix-core/src/models/observability_exporter.rs
@@ -10,9 +10,10 @@
 //! endpoint, which is the whole reason for DP-direct egress (sensitive
 //! prompt / response content stays on the data plane).
 //!
-//! MVP scope: `kind = "otlp_http"` only — covers Tempo / Loki / Jaeger
-//! / Honeycomb / Grafana Cloud / Langfuse-via-OTLP because all of them
-//! accept the OTLP/HTTP wire format.
+//! Kinds: `otlp_http` (Tempo / Loki / Jaeger / Honeycomb / Grafana Cloud /
+//! Langfuse-via-OTLP — anything speaking OTLP/HTTP) and `aliyun_sls`
+//! (Aliyun SLS PutLogs). Further targets (Datadog / S3 / …) land as
+//! additional kinds.
 //!
 //! Wire shape on kine — flat object with the kind-tagged config fields
 //! at top level, matching the `Guardrail` pattern in this crate:
@@ -33,10 +34,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::resource::Resource;
 
-/// Discriminated union of exporter back-ends. MVP ships only
-/// `otlp_http`; Helicone / Datadog / S3 land in follow-ups, each as a
-/// new variant whose serde tag matches the wire-side `kind`
-/// discriminator.
+/// Discriminated union of exporter back-ends. Ships `otlp_http` and
+/// `aliyun_sls`; Datadog / S3 / … land in follow-ups, each as a new
+/// variant whose serde tag matches the wire-side `kind` discriminator.
 ///
 /// `tag = "kind"` puts the variant tag inline with the inner struct's
 /// fields — same shape as `GuardrailKind` so the kine wire stays
@@ -45,6 +45,7 @@ use crate::resource::Resource;
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ExporterKind {
     OtlpHttp(OtlpHttpConfig),
+    AliyunSls(AliyunSlsConfig),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
@@ -62,6 +63,38 @@ pub struct OtlpHttpConfig {
     /// `provider_keys`. Field-level encryption arrives in Phase 2.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headers: BTreeMap<String, String>,
+}
+
+/// Aliyun SLS (Simple Log Service) PutLogs target. Unlike `otlp_http`,
+/// the AccessKey is **never** part of this config: it would otherwise
+/// sit in plaintext on the kine path, and SLS keys grant broad account
+/// access. Instead the config carries a [`credential_ref`] pointer that
+/// the customer-side DP resolves to the real key locally (env / mounted
+/// secret); API7's control plane stores only the reference. This is what
+/// lets the DP run in the customer's environment without API7 ever
+/// holding the plaintext key.
+///
+/// [`credential_ref`]: AliyunSlsConfig::credential_ref
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AliyunSlsConfig {
+    /// SLS region endpoint host with no scheme, e.g.
+    /// `ap-southeast-3.log.aliyuncs.com`. The request host the DP signs
+    /// and posts to is `<project>.<endpoint>`.
+    pub endpoint: String,
+
+    /// SLS project name (the `<project>` in the request host).
+    pub project: String,
+
+    /// SLS logstore that receives the request-event logs.
+    pub logstore: String,
+
+    /// Opaque pointer to the AccessKey credential, resolved locally by
+    /// the DP at delivery time. The plaintext AccessKey MUST NOT live in
+    /// etcd/kine — the control plane stores only this reference, never the
+    /// key itself. BYOK variants (customer KMS / uploaded key) resolve the
+    /// same reference through a different unwrap path in a later phase.
+    pub credential_ref: String,
 }
 
 /// Top-level `ObservabilityExporter` resource. `deny_unknown_fields`
@@ -140,6 +173,7 @@ mod tests {
                     Some("abc123"),
                 );
             }
+            other => panic!("expected otlp_http, got {other:?}"),
         }
     }
 
@@ -158,6 +192,7 @@ mod tests {
                 .unwrap();
         match &e.kind {
             ExporterKind::OtlpHttp(c) => assert!(c.headers.is_empty()),
+            other => panic!("expected otlp_http, got {other:?}"),
         }
     }
 
@@ -198,5 +233,58 @@ mod tests {
         assert_eq!(v["kind"], "otlp_http");
         assert_eq!(v["endpoint"], "https://api.honeycomb.io/v1/traces");
         assert!(v.get("otlp_http").is_none(), "kind block must not nest");
+    }
+
+    const VALID_SLS: &str = r#"{
+        "name": "sls-prod",
+        "enabled": true,
+        "kind": "aliyun_sls",
+        "endpoint": "ap-southeast-3.log.aliyuncs.com",
+        "project": "aisix-obs",
+        "logstore": "request-events",
+        "credential_ref": "sls-prod"
+    }"#;
+
+    #[test]
+    fn deserialises_aliyun_sls() {
+        let e: ObservabilityExporter = serde_json::from_str(VALID_SLS).unwrap();
+        assert_eq!(e.name, "sls-prod");
+        assert!(e.enabled);
+        match &e.kind {
+            ExporterKind::AliyunSls(c) => {
+                assert_eq!(c.endpoint, "ap-southeast-3.log.aliyuncs.com");
+                assert_eq!(c.project, "aisix-obs");
+                assert_eq!(c.logstore, "request-events");
+                assert_eq!(c.credential_ref, "sls-prod");
+            }
+            other => panic!("expected aliyun_sls, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn aliyun_sls_round_trips_flat() {
+        let e: ObservabilityExporter = serde_json::from_str(VALID_SLS).unwrap();
+        let v = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["kind"], "aliyun_sls");
+        assert_eq!(v["project"], "aisix-obs");
+        assert_eq!(v["credential_ref"], "sls-prod");
+        assert!(v.get("aliyun_sls").is_none(), "kind block must not nest");
+    }
+
+    #[test]
+    fn rejects_plaintext_credentials_in_config() {
+        // The AccessKey must NEVER be a config field — only a
+        // `credential_ref`. `deny_unknown_fields` on the inner config
+        // rejects any attempt to smuggle a plaintext key onto the kine path.
+        for key in ["access_key_secret", "access_key_id", "ak", "sk"] {
+            let json = format!(
+                r#"{{"name":"x","kind":"aliyun_sls","endpoint":"ap-southeast-3.log.aliyuncs.com","project":"p","logstore":"l","credential_ref":"r","{key}":"AKIASECRET"}}"#
+            );
+            let r: Result<ObservabilityExporter, _> = serde_json::from_str(&json);
+            assert!(
+                r.is_err(),
+                "plaintext credential field `{key}` must be rejected"
+            );
+        }
     }
 }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -585,11 +585,14 @@ fn cache_policy_schema() -> Value {
 }
 
 fn observability_exporter_schema() -> Value {
-    // MVP: single discriminator value `otlp_http` whose fields land
-    // flat at the top level (matches the Guardrail wire shape — see
-    // `models/observability_exporter.rs` doc comment). Phase 2 adds
-    // `helicone` / `datadog_logs` / `s3_ndjson` as additional
-    // discriminator values with their own `if`/`then` branches below.
+    // Discriminated by `kind`; each branch's fields land flat at the top
+    // level (matches the Guardrail wire shape — see
+    // `models/observability_exporter.rs`). `additionalProperties` only
+    // considers THIS object's `properties` (not those inside `allOf`/`then`),
+    // so every kind's fields are listed at the top level as the union;
+    // per-kind required-fields and the endpoint pattern live in the
+    // `if`/`then` branches. Phase 2 adds `datadog_logs` / `s3_ndjson` the
+    // same way.
     json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -598,25 +601,52 @@ fn observability_exporter_schema() -> Value {
         "properties": {
             "name":    { "type": "string", "minLength": 1, "maxLength": 120 },
             "enabled": { "type": "boolean" },
-            "kind":    { "type": "string", "enum": ["otlp_http"] },
-            // otlp_http branch — flat fields.
-            "endpoint": {
-                "type": "string",
-                // Reject http:// and any non-URL by anchoring on https://.
-                // Loopback bypass for e2e: allow http://mock-otlp:* /
-                // http://127.0.0.1 / http://localhost so the compose
-                // test can wire a fake receiver without TLS.
-                "pattern": "^https://.+|^http://(mock-otlp|otel-collector|127\\.0\\.0\\.1|localhost)(:[0-9]+)?(/.*)?$"
-            },
+            "kind":    { "type": "string", "enum": ["otlp_http", "aliyun_sls"] },
+            // Shared field; the per-kind pattern is enforced in the branches.
+            "endpoint": { "type": "string" },
+            // otlp_http field.
             "headers": {
                 "type": "object",
                 "additionalProperties": { "type": "string" }
-            }
+            },
+            // aliyun_sls fields. The AccessKey is NEVER here — only a
+            // `credential_ref` the DP resolves locally (no plaintext key on
+            // the kine path).
+            "project":        { "type": "string", "minLength": 1 },
+            "logstore":       { "type": "string", "minLength": 1 },
+            "credential_ref": { "type": "string", "minLength": 1 }
         },
         "allOf": [
             {
                 "if":   { "properties": { "kind": { "const": "otlp_http" } } },
-                "then": { "required": ["endpoint"] }
+                "then": {
+                    "required": ["endpoint"],
+                    "properties": {
+                        // Reject http:// and any non-URL by anchoring on
+                        // https://. Loopback bypass for e2e: allow
+                        // http://mock-otlp:* / otel-collector / 127.0.0.1 /
+                        // localhost so the compose test can wire a fake
+                        // receiver without TLS.
+                        "endpoint": {
+                            "pattern": "^https://.+|^http://(mock-otlp|otel-collector|127\\.0\\.0\\.1|localhost)(:[0-9]+)?(/.*)?$"
+                        }
+                    }
+                }
+            },
+            {
+                "if":   { "properties": { "kind": { "const": "aliyun_sls" } } },
+                "then": {
+                    "required": ["endpoint", "project", "logstore", "credential_ref"],
+                    "properties": {
+                        // A bare SLS region host (the sink prepends
+                        // https://<project>.). Loopback bypass for e2e: a
+                        // scheme-qualified mock-sls / 127.0.0.1 / localhost
+                        // the sink posts to directly.
+                        "endpoint": {
+                            "pattern": "^[a-z0-9][a-z0-9.-]*\\.aliyuncs\\.com$|^http://(mock-sls|127\\.0\\.0\\.1|localhost)(:[0-9]+)?$"
+                        }
+                    }
+                }
             }
         ]
     })
@@ -1291,6 +1321,97 @@ mod tests {
             "risk_level_threshold": "none"
         });
         assert!(validate_guardrail(&v).is_err());
+    }
+
+    // ---- observability_exporter schema tests ----
+
+    #[test]
+    fn exporter_otlp_http_happy_path() {
+        let v = json!({
+            "name": "honeycomb",
+            "kind": "otlp_http",
+            "endpoint": "https://api.honeycomb.io/v1/traces",
+            "headers": { "x-honeycomb-team": "abc" }
+        });
+        validate_observability_exporter(&v).unwrap();
+    }
+
+    #[test]
+    fn exporter_otlp_http_rejects_plain_http_endpoint() {
+        let v = json!({
+            "name": "x",
+            "kind": "otlp_http",
+            "endpoint": "http://api.honeycomb.io/v1/traces"
+        });
+        assert!(validate_observability_exporter(&v).is_err());
+    }
+
+    #[test]
+    fn exporter_aliyun_sls_happy_path() {
+        let v = json!({
+            "name": "sls-prod",
+            "kind": "aliyun_sls",
+            "endpoint": "ap-southeast-3.log.aliyuncs.com",
+            "project": "aisix-obs",
+            "logstore": "request-events",
+            "credential_ref": "sls-prod"
+        });
+        validate_observability_exporter(&v).unwrap();
+    }
+
+    #[test]
+    fn exporter_aliyun_sls_allows_loopback_mock_endpoint() {
+        // The L2 e2e points the DP at a local mock SLS over http://.
+        let v = json!({
+            "name": "sls-e2e",
+            "kind": "aliyun_sls",
+            "endpoint": "http://mock-sls:9000",
+            "project": "p",
+            "logstore": "l",
+            "credential_ref": "mock"
+        });
+        validate_observability_exporter(&v).unwrap();
+    }
+
+    #[test]
+    fn exporter_aliyun_sls_requires_project_logstore_credential() {
+        for missing in ["project", "logstore", "credential_ref"] {
+            let mut v = json!({
+                "name": "x",
+                "kind": "aliyun_sls",
+                "endpoint": "ap-southeast-3.log.aliyuncs.com",
+                "project": "p",
+                "logstore": "l",
+                "credential_ref": "r"
+            });
+            v.as_object_mut().unwrap().remove(missing);
+            assert!(
+                validate_observability_exporter(&v).is_err(),
+                "missing `{missing}` must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn exporter_aliyun_sls_rejects_plaintext_credentials() {
+        // No AccessKey field is allowed at the schema layer either —
+        // `additionalProperties: false` rejects it before serde runs.
+        let v = json!({
+            "name": "x",
+            "kind": "aliyun_sls",
+            "endpoint": "ap-southeast-3.log.aliyuncs.com",
+            "project": "p",
+            "logstore": "l",
+            "credential_ref": "r",
+            "access_key_secret": "AKIASECRET"
+        });
+        assert!(validate_observability_exporter(&v).is_err());
+    }
+
+    #[test]
+    fn exporter_rejects_unknown_kind() {
+        let v = json!({ "name": "x", "kind": "splunk_hec", "endpoint": "https://x" });
+        assert!(validate_observability_exporter(&v).is_err());
     }
 
     // ---- rate_limit_policy schema tests ----

--- a/crates/aisix-obs/Cargo.toml
+++ b/crates/aisix-obs/Cargo.toml
@@ -22,6 +22,7 @@ metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
+async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true

--- a/crates/aisix-obs/Cargo.toml
+++ b/crates/aisix-obs/Cargo.toml
@@ -29,6 +29,13 @@ reqwest.workspace = true
 uuid.workspace = true
 base64.workspace = true
 parking_lot.workspace = true
+# Aliyun SLS sink — official protobuf + signature sub-crates (pure-Rust),
+# lz4 block compression, and `http` types for sign_v1. Transport is reqwest
+# (rustls), so no native-tls / OpenSSL is pulled in.
+http.workspace = true
+aliyun-log-sdk-protobuf.workspace = true
+aliyun-log-sdk-sign.workspace = true
+lz4_flex.workspace = true
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -9,6 +9,9 @@
 //!   requests/duration/rate-limits/tokens.
 //! - [`otlp::install_otlp_tracer`] — optional OTLP export handshake
 //!   (concrete pipeline wired in a follow-up PR).
+//! - [`sink`] — pluggable observability-sink framework: the
+//!   capability-typed [`sink::ObservabilitySink`] adapter contract
+//!   (AISIX-Cloud#692).
 
 #![deny(rust_2018_idioms)]
 
@@ -16,6 +19,7 @@ pub mod access_log;
 pub mod metrics;
 pub mod otlp;
 pub mod otlp_http_sink;
+pub mod sink;
 pub mod usage;
 
 use aisix_core::ObservabilityConfig;
@@ -28,6 +32,11 @@ pub use metrics::{
 };
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::OtlpHttpFanOut;
+pub use sink::{
+    BatchUnit, ChannelKey, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink,
+    OrderingScope, SinkAck, SinkCapabilities, SinkContent, SinkError, SinkHealth, SinkRecord,
+    SinkResult, SCHEMA_VERSION,
+};
 pub use usage::{RoutingAttemptEvent, UsageEvent, UsageSink};
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -31,7 +31,7 @@ pub use metrics::{
     RequestLabels, RequestOutcome, UsageLabels,
 };
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
-pub use otlp_http_sink::OtlpHttpFanOut;
+pub use otlp_http_sink::{OtlpHttpFanOut, OtlpSink};
 pub use sink::{
     BatchUnit, ChannelKey, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink,
     OrderingScope, PipelineConfig, SinkAck, SinkCapabilities, SinkContent, SinkError, SinkHandle,

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -33,9 +33,10 @@ pub use metrics::{
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::{OtlpHttpFanOut, OtlpSink};
 pub use sink::{
-    BatchUnit, ChannelKey, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink,
-    OrderingScope, PipelineConfig, SinkAck, SinkCapabilities, SinkContent, SinkError, SinkHandle,
-    SinkHealth, SinkPipeline, SinkRecord, SinkResult, SinkStatsSnapshot, SCHEMA_VERSION,
+    BatchUnit, ChannelKey, EventBatch, ExporterPipelines, IdempotencyMarker, IdempotencyScheme,
+    ObservabilitySink, OrderingScope, PipelineConfig, SinkAck, SinkCapabilities, SinkContent,
+    SinkError, SinkHandle, SinkHealth, SinkPipeline, SinkRecord, SinkResult, SinkStatsSnapshot,
+    SCHEMA_VERSION,
 };
 pub use usage::{RoutingAttemptEvent, UsageEvent, UsageSink};
 

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -34,8 +34,8 @@ pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::OtlpHttpFanOut;
 pub use sink::{
     BatchUnit, ChannelKey, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink,
-    OrderingScope, SinkAck, SinkCapabilities, SinkContent, SinkError, SinkHealth, SinkRecord,
-    SinkResult, SCHEMA_VERSION,
+    OrderingScope, PipelineConfig, SinkAck, SinkCapabilities, SinkContent, SinkError, SinkHandle,
+    SinkHealth, SinkPipeline, SinkRecord, SinkResult, SinkStatsSnapshot, SCHEMA_VERSION,
 };
 pub use usage::{RoutingAttemptEvent, UsageEvent, UsageSink};
 

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -33,10 +33,10 @@ pub use metrics::{
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::{OtlpHttpFanOut, OtlpSink};
 pub use sink::{
-    BatchUnit, ChannelKey, EventBatch, ExporterPipelines, IdempotencyMarker, IdempotencyScheme,
-    ObservabilitySink, OrderingScope, PipelineConfig, SinkAck, SinkCapabilities, SinkContent,
-    SinkError, SinkHandle, SinkHealth, SinkPipeline, SinkRecord, SinkResult, SinkStatsSnapshot,
-    SCHEMA_VERSION,
+    AliyunSlsSink, BatchUnit, ChannelKey, EventBatch, ExporterPipelines, IdempotencyMarker,
+    IdempotencyScheme, ObservabilitySink, OrderingScope, PipelineConfig, SinkAck, SinkCapabilities,
+    SinkContent, SinkError, SinkHandle, SinkHealth, SinkPipeline, SinkRecord, SinkResult,
+    SinkStatsSnapshot, SCHEMA_VERSION,
 };
 pub use usage::{RoutingAttemptEvent, UsageEvent, UsageSink};
 

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -32,14 +32,14 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use aisix_core::models::{ExporterKind, ObservabilityExporter};
+use aisix_core::models::{AliyunSlsConfig, ExporterKind, ObservabilityExporter, OtlpHttpConfig};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
 use crate::sink::{
-    BatchUnit, EventBatch, ExporterPipelines, IdempotencyMarker, IdempotencyScheme,
-    ObservabilitySink, OrderingScope, PipelineConfig, SinkAck, SinkCapabilities, SinkError,
-    SinkHealth, SinkRecord, SinkResult,
+    resolve_sls_credential, AliyunSlsSink, BatchUnit, EventBatch, ExporterPipelines,
+    IdempotencyMarker, IdempotencyScheme, ObservabilitySink, OrderingScope, PipelineConfig,
+    SinkAck, SinkCapabilities, SinkError, SinkHealth, SinkRecord, SinkResult,
 };
 use crate::usage::UsageEvent;
 
@@ -52,12 +52,19 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 /// to AISIX in their own analytics. Not a contract; informational.
 const USER_AGENT: &str = concat!("aisix-dp/", env!("CARGO_PKG_VERSION"));
 
-/// Fans usage events out to every configured `otlp_http` exporter, each via
-/// its own [`crate::sink::SinkPipeline`] (batched, retried, backpressured).
-/// Cheap clonable handle; the per-exporter pipelines and the shared
-/// `reqwest::Client` live behind an `Arc`. Pipelines start lazily on first
-/// sighting of an exporter (immediately consistent with the snapshot) and are
-/// GC'd by [`OtlpHttpFanOut::gc`] when an exporter leaves it.
+/// Fans usage events out to every configured observability exporter — any
+/// [`ExporterKind`], dispatched per kind to the matching
+/// [`crate::sink::ObservabilitySink`] — each via its own
+/// [`crate::sink::SinkPipeline`] (batched, retried, backpressured). Cheap
+/// clonable handle; the per-exporter pipelines and the shared `reqwest::Client`
+/// live behind an `Arc`. Pipelines start lazily on first sighting of an
+/// exporter (immediately consistent with the snapshot) and are GC'd by
+/// [`OtlpHttpFanOut::gc`] when an exporter leaves it.
+///
+/// NOTE: the type name is historical — it drove only `otlp_http` originally
+/// and now fans out all kinds. A rename to `ExporterFanOut` (plus the
+/// `ProxyState::otlp_fan_out` field) is a mechanical, behaviour-preserving
+/// follow-up kept out of this change to avoid churning every call site.
 #[derive(Clone)]
 pub struct OtlpHttpFanOut {
     inner: Arc<FanOutInner>,
@@ -66,7 +73,7 @@ pub struct OtlpHttpFanOut {
 struct FanOutInner {
     /// Per-exporter delivery pipelines (one batched worker each).
     exporters: ExporterPipelines,
-    /// Shared HTTP client handed to every `OtlpSink` (connection-pool reuse).
+    /// Shared HTTP client handed to every sink (connection-pool reuse).
     client: reqwest::Client,
 }
 
@@ -97,10 +104,11 @@ impl OtlpHttpFanOut {
         }
     }
 
-    /// Fan one event out to every enabled `otlp_http` exporter, enqueuing it
-    /// into that exporter's pipeline (lazily started on first sighting). The
-    /// pipeline owns batching / retry / backpressure; enqueue is non-blocking,
-    /// so this never blocks the request hot path. Empty list = cheap no-op.
+    /// Fan one event out to every enabled exporter, dispatched per kind and
+    /// enqueued into that exporter's pipeline (lazily started on first
+    /// sighting). The pipeline owns batching / retry / backpressure; enqueue is
+    /// non-blocking, so this never blocks the request hot path. Empty list =
+    /// cheap no-op.
     pub fn fan_out<'a, I>(&self, event: &UsageEvent, exporters: I)
     where
         I: IntoIterator<Item = &'a ObservabilityExporter>,
@@ -111,32 +119,52 @@ impl OtlpHttpFanOut {
             if !exp.enabled {
                 continue;
             }
-            // Single-variant enum today; the spelled-out pattern forces a
-            // compile error here when a new ExporterKind variant is added.
-            let ExporterKind::OtlpHttp(cfg) = &exp.kind;
 
-            // Fingerprint the delivery-relevant config so a dashboard edit
-            // (endpoint / headers) rebuilds the exporter's pipeline.
-            let fingerprint = {
-                use std::hash::{Hash, Hasher};
-                let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                cfg.endpoint.hash(&mut hasher);
-                cfg.headers.hash(&mut hasher);
-                hasher.finish()
-            };
-
+            // Dispatch on kind: each arm fingerprints its delivery-relevant
+            // config (so a dashboard edit rebuilds the pipeline) and lazily
+            // builds the matching sink. All kinds share one `ExporterPipelines`
+            // manager and the pooled client. A new `ExporterKind` variant
+            // makes this `match` non-exhaustive — a compile-time prompt to wire
+            // its sink here.
             let client = self.inner.client.clone();
-            let handle = self
-                .inner
-                .exporters
-                .get_or_create(&exp.name, fingerprint, move || {
-                    Arc::new(OtlpSink::new(
-                        exp.name.clone(),
-                        cfg.endpoint.clone(),
-                        cfg.headers.clone(),
-                        client,
-                    )) as Arc<dyn ObservabilitySink>
-                });
+            let handle = match &exp.kind {
+                ExporterKind::OtlpHttp(cfg) => {
+                    let fingerprint = fingerprint_otlp(cfg);
+                    let name = exp.name.clone();
+                    let endpoint = cfg.endpoint.clone();
+                    let headers = cfg.headers.clone();
+                    self.inner
+                        .exporters
+                        .get_or_create(&exp.name, fingerprint, move || {
+                            Arc::new(OtlpSink::new(name, endpoint, headers, client))
+                                as Arc<dyn ObservabilitySink>
+                        })
+                }
+                ExporterKind::AliyunSls(cfg) => {
+                    let fingerprint = fingerprint_sls(cfg);
+                    let name = exp.name.clone();
+                    let cfg = cfg.clone();
+                    self.inner
+                        .exporters
+                        .get_or_create(&exp.name, fingerprint, move || {
+                            // Resolve the AccessKey from the DP's local env at
+                            // build time (the key never rode the kine path).
+                            // Missing creds → empty key → SLS 401 surfaces as a
+                            // delivery-health auth error, not a silent drop.
+                            let (ak_id, ak_secret) =
+                                resolve_sls_credential(&cfg.credential_ref).unwrap_or_default();
+                            Arc::new(AliyunSlsSink::new(
+                                name,
+                                &cfg.endpoint,
+                                &cfg.project,
+                                &cfg.logstore,
+                                ak_id,
+                                ak_secret,
+                                client,
+                            )) as Arc<dyn ObservabilitySink>
+                        })
+                }
+            };
 
             let rec =
                 record.get_or_insert_with(|| Arc::new(SinkRecord::metadata_only(event.clone())));
@@ -145,8 +173,9 @@ impl OtlpHttpFanOut {
     }
 
     /// Stop pipelines for exporters no longer present in `live` (the current
-    /// snapshot's enabled `otlp_http` exporter names). Called periodically by
-    /// the server to GC pipelines for deleted / disabled exporters.
+    /// snapshot's enabled exporter names, across all kinds). Called
+    /// periodically by the server to GC pipelines for deleted / disabled
+    /// exporters.
     pub fn gc(&self, live: &std::collections::HashSet<String>) {
         self.inner.exporters.retain(live);
     }
@@ -161,6 +190,32 @@ impl Default for OtlpHttpFanOut {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Hash an `otlp_http` exporter's delivery-relevant config. A change to
+/// endpoint or headers yields a new fingerprint, so the manager rebuilds the
+/// exporter's pipeline against the edited target.
+fn fingerprint_otlp(cfg: &OtlpHttpConfig) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    cfg.endpoint.hash(&mut hasher);
+    cfg.headers.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Hash an `aliyun_sls` exporter's delivery-relevant config. The fingerprint
+/// covers only kine-visible fields (endpoint / project / logstore /
+/// credential_ref), never the resolved AccessKey — rotating the secret under
+/// the *same* reference therefore takes effect on the next DP restart, not
+/// live. A ref change does rebuild the pipeline.
+fn fingerprint_sls(cfg: &AliyunSlsConfig) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    cfg.endpoint.hash(&mut hasher);
+    cfg.project.hash(&mut hasher);
+    cfg.logstore.hash(&mut hasher);
+    cfg.credential_ref.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// An [`ObservabilitySink`] over the OTLP/HTTP-JSON traces protocol — the

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -1,53 +1,45 @@
-//! Per-env OTLP/HTTP exporter — emits one OTLP-shaped POST per chat
-//! request to each configured `ObservabilityExporter` (kind=otlp_http).
+//! Per-env OTLP/HTTP exporter — emits one OTLP-shaped span per chat request
+//! to each configured `ObservabilityExporter` (kind=otlp_http).
 //!
 //! ## Design
 //!
 //! cp-api projects every configured exporter onto kine at
-//! `/aisix/<env>/observability_exporters/<uuid>`. The DP loads them
-//! via the existing etcd watch into
-//! `AisixSnapshot::observability_exporters`. After every chat
-//! completion the proxy hot path hands the resulting `UsageEvent` plus
-//! the live snapshot's exporter list to [`fan_out`], which:
+//! `/aisix/<env>/observability_exporters/<uuid>`. The DP loads them via the
+//! existing etcd watch into `AisixSnapshot::observability_exporters`. After
+//! every chat completion the proxy hot path hands the resulting `UsageEvent`
+//! plus the live snapshot's exporter list to [`OtlpHttpFanOut::fan_out`],
+//! which:
 //!
 //! 1. Filters to enabled exporters with `kind = OtlpHttp`.
-//! 2. Builds one OTLP/HTTP-JSON span per exporter, encoded per
+//! 2. Resolves each exporter's [`crate::sink::SinkPipeline`] (lazily started
+//!    on first sighting, immediately consistent with the snapshot) and
+//!    enqueues one OTLP span record into it. The pipeline batches, retries
+//!    transient failures with backoff, and drops-with-metric under
+//!    backpressure — all off the request hot path. Spans are encoded per
 //!    OpenTelemetry's GenAI semantic conventions
 //!    (<https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md>).
-//! 3. Spawns a fire-and-forget tokio task per (event, exporter) pair
-//!    that POSTs the span. Failures get a `tracing::warn!` and are
-//!    dropped — observability MUST NOT block the request hot path.
 //!
-//! ## What's intentionally NOT in MVP
+//! ## What's intentionally NOT here yet
 //!
-//! - **No batching** — one HTTP POST per request per exporter. Phase 2
-//!   will move to a worker-task model with a bounded mpsc + 1s flush
-//!   interval once the patterns are exercised by real load.
-//! - **No retry / backoff** — best-effort fire-and-forget. If the
-//!   user's OTLP receiver is unreachable the span is lost. Phase 2
-//!   adds a tiny exponential-backoff wrapper.
-//! - **No gRPC** — `otlp_grpc` is a separate kind we'll add when a
-//!   user actually asks for it; the JSON-over-HTTP form works against
-//!   every receiver in the wild and avoids pulling in tonic on the
-//!   hot path.
-//! - **No content_mode redaction** — defaults to `metadata_only`
-//!   (no prompt/response bodies in the span). The MVP cannot leak
-//!   user content because it never accepts content fields in the
-//!   first place.
+//! - **No gRPC** — `otlp_grpc` is a separate kind we'll add when a user
+//!   actually asks for it; the JSON-over-HTTP form works against every
+//!   receiver in the wild and avoids pulling in tonic on the hot path.
+//! - **No content_mode redaction** — defaults to `metadata_only` (no
+//!   prompt/response bodies in the span). The record never carries content
+//!   fields, so it cannot leak.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use aisix_core::models::{ExporterKind, ObservabilityExporter};
 use async_trait::async_trait;
-use parking_lot::Mutex;
 use serde_json::{json, Value};
-use tokio::sync::Semaphore;
 
 use crate::sink::{
-    BatchUnit, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink, OrderingScope,
-    SinkAck, SinkCapabilities, SinkError, SinkHealth, SinkResult,
+    BatchUnit, EventBatch, ExporterPipelines, IdempotencyMarker, IdempotencyScheme,
+    ObservabilitySink, OrderingScope, PipelineConfig, SinkAck, SinkCapabilities, SinkError,
+    SinkHealth, SinkRecord, SinkResult,
 };
 use crate::usage::UsageEvent;
 
@@ -56,46 +48,36 @@ use crate::usage::UsageEvent;
 /// tasks for a wedged user receiver.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Maximum concurrent in-flight POSTs per exporter. Past this point we
-/// drop further events on the request hot path rather than queueing
-/// them — the queue would just grow unbounded behind a slow receiver,
-/// hold the per-event JSON body in memory, and eventually OOM the DP.
-/// 64 is generous enough that a healthy receiver never trips the cap
-/// (even at a sustained 100 RPS, a 200 ms p50 keeps in-flight under
-/// 20) but still bounds the worst case to ~64 × payload-size bytes.
-/// See issue #113.
-const MAX_INFLIGHT_PER_EXPORTER: usize = 64;
-
 /// `User-Agent` header so vendor receivers can attribute traces back
 /// to AISIX in their own analytics. Not a contract; informational.
 const USER_AGENT: &str = concat!("aisix-dp/", env!("CARGO_PKG_VERSION"));
 
-/// Cheap clonable handle the proxy hands to request handlers. Holds a
-/// reusable `reqwest::Client` so connection pools survive across
-/// requests — even with per-event POSTs the kept-alive socket
-/// amortises TLS for the common case where one DP exports to one
-/// vendor.
-///
-/// Per-exporter concurrency is bounded: a [`Semaphore`] with
-/// [`MAX_INFLIGHT_PER_EXPORTER`] permits is created lazily on first
-/// sighting of each exporter name. When the cap is hit, further events
-/// for that exporter are *dropped* on the hot path (logged at debug)
-/// rather than queued. This is intentional — the alternative is letting
-/// task count + memory grow unbounded behind a slow receiver, which
-/// caused real OOMs in production. See issue #113.
-#[derive(Debug, Clone)]
+/// Fans usage events out to every configured `otlp_http` exporter, each via
+/// its own [`crate::sink::SinkPipeline`] (batched, retried, backpressured).
+/// Cheap clonable handle; the per-exporter pipelines and the shared
+/// `reqwest::Client` live behind an `Arc`. Pipelines start lazily on first
+/// sighting of an exporter (immediately consistent with the snapshot) and are
+/// GC'd by [`OtlpHttpFanOut::gc`] when an exporter leaves it.
+#[derive(Clone)]
 pub struct OtlpHttpFanOut {
     inner: Arc<FanOutInner>,
 }
 
-#[derive(Debug)]
 struct FanOutInner {
+    /// Per-exporter delivery pipelines (one batched worker each).
+    exporters: ExporterPipelines,
+    /// Shared HTTP client handed to every `OtlpSink` (connection-pool reuse).
     client: reqwest::Client,
-    /// Per-exporter semaphores keyed by name. Created lazily; never
-    /// pruned (a Semaphore is small and the operator's exporter set
-    /// is bounded by configuration). The Mutex is parking_lot so
-    /// uncontended lookups are basically a single atomic load.
-    permits: Mutex<HashMap<String, Arc<Semaphore>>>,
+}
+
+/// Delivery tuning for otlp exporter pipelines. A short flush keeps a
+/// single-request span visible quickly (the old fan-out posted each event
+/// immediately); batching + retry + drop accounting come from the pipeline.
+fn exporter_pipeline_config() -> PipelineConfig {
+    PipelineConfig {
+        flush_interval: Duration::from_secs(1),
+        ..PipelineConfig::default()
+    }
 }
 
 impl OtlpHttpFanOut {
@@ -109,102 +91,69 @@ impl OtlpHttpFanOut {
             .expect("reqwest::Client default config is valid");
         Self {
             inner: Arc::new(FanOutInner {
+                exporters: ExporterPipelines::new(exporter_pipeline_config()),
                 client,
-                permits: Mutex::new(HashMap::new()),
             }),
         }
     }
 
-    /// Look up (or lazily insert) the per-exporter permit semaphore.
-    /// Returning `Arc<Semaphore>` lets the spawned task hold the permit
-    /// past `fan_out`'s lifetime — the permit drops with the task.
-    fn permits_for(&self, exporter_name: &str) -> Arc<Semaphore> {
-        let mut guard = self.inner.permits.lock();
-        if let Some(sem) = guard.get(exporter_name) {
-            return Arc::clone(sem);
-        }
-        let sem = Arc::new(Semaphore::new(MAX_INFLIGHT_PER_EXPORTER));
-        guard.insert(exporter_name.to_string(), Arc::clone(&sem));
-        sem
-    }
-
-    /// Test-only: how many in-flight slots are currently held for
-    /// `exporter_name`. Used by tests to assert the bounded-fan-out
-    /// invariant. Returns 0 if the exporter has never been seen.
-    #[doc(hidden)]
-    pub fn in_flight_for(&self, exporter_name: &str) -> usize {
-        let guard = self.inner.permits.lock();
-        match guard.get(exporter_name) {
-            Some(sem) => MAX_INFLIGHT_PER_EXPORTER.saturating_sub(sem.available_permits()),
-            None => 0,
-        }
-    }
-
-    /// Fan out one event to every enabled `otlp_http` exporter in the
-    /// supplied list. Returns immediately — the actual POSTs run on
-    /// detached tokio tasks and never block the caller.
-    ///
-    /// Per-exporter concurrency is capped at
-    /// [`MAX_INFLIGHT_PER_EXPORTER`]. Past the cap, further events for
-    /// that exporter are dropped (logged at `debug`) — the alternative
-    /// is unbounded queueing behind a slow / down receiver, which OOMs
-    /// the DP. See issue #113.
-    ///
-    /// The `exporters` slice is what the proxy's snapshot lookup
-    /// returns. Empty slice = no-op (the common case for envs that
-    /// haven't configured any exporters yet, so this is the cheap
-    /// path).
+    /// Fan one event out to every enabled `otlp_http` exporter, enqueuing it
+    /// into that exporter's pipeline (lazily started on first sighting). The
+    /// pipeline owns batching / retry / backpressure; enqueue is non-blocking,
+    /// so this never blocks the request hot path. Empty list = cheap no-op.
     pub fn fan_out<'a, I>(&self, event: &UsageEvent, exporters: I)
     where
         I: IntoIterator<Item = &'a ObservabilityExporter>,
     {
+        // Build the record once, and only if there is at least one exporter.
+        let mut record: Option<Arc<SinkRecord>> = None;
         for exp in exporters {
             if !exp.enabled {
                 continue;
             }
-            // Single-variant enum today; the `let ExporterKind::OtlpHttp`
-            // pattern is exhaustive but deliberately written with the
-            // type tag spelled out so adding a new variant in Phase 2
-            // forces a compile error here.
+            // Single-variant enum today; the spelled-out pattern forces a
+            // compile error here when a new ExporterKind variant is added.
             let ExporterKind::OtlpHttp(cfg) = &exp.kind;
 
-            // Try to claim a permit BEFORE building the payload — if
-            // we're at the cap, drop early so we don't even pay the
-            // JSON-serialisation cost.
-            let sem = self.permits_for(&exp.name);
-            let permit = match sem.try_acquire_owned() {
-                Ok(p) => p,
-                Err(_) => {
-                    tracing::debug!(
-                        exporter = %exp.name,
-                        cap = MAX_INFLIGHT_PER_EXPORTER,
-                        "otlp_http fan-out: exporter at concurrency cap; dropping span",
-                    );
-                    continue;
-                }
+            // Fingerprint the delivery-relevant config so a dashboard edit
+            // (endpoint / headers) rebuilds the exporter's pipeline.
+            let fingerprint = {
+                use std::hash::{Hash, Hasher};
+                let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                cfg.endpoint.hash(&mut hasher);
+                cfg.headers.hash(&mut hasher);
+                hasher.finish()
             };
 
-            // Build the wire body once per exporter (cheap — small
-            // JSON) so the spawned task only owns the bytes.
-            let body = build_otlp_traces_payload(event, &exp.name);
-            let endpoint = cfg.endpoint.clone();
-            let headers = cfg.headers.clone();
             let client = self.inner.client.clone();
-            let exporter_name = exp.name.clone();
+            let handle = self
+                .inner
+                .exporters
+                .get_or_create(&exp.name, fingerprint, move || {
+                    Arc::new(OtlpSink::new(
+                        exp.name.clone(),
+                        cfg.endpoint.clone(),
+                        cfg.headers.clone(),
+                        client,
+                    )) as Arc<dyn ObservabilitySink>
+                });
 
-            tokio::spawn(async move {
-                // Permit released when the task ends. `_permit` keeps
-                // it alive across the await point.
-                let _permit = permit;
-                if let Err(err) = post_one(client, endpoint, headers, body).await {
-                    tracing::warn!(
-                        exporter = %exporter_name,
-                        error = %err,
-                        "otlp_http exporter POST failed; span dropped",
-                    );
-                }
-            });
+            let rec =
+                record.get_or_insert_with(|| Arc::new(SinkRecord::metadata_only(event.clone())));
+            handle.try_enqueue(Arc::clone(rec));
         }
+    }
+
+    /// Stop pipelines for exporters no longer present in `live` (the current
+    /// snapshot's enabled `otlp_http` exporter names). Called periodically by
+    /// the server to GC pipelines for deleted / disabled exporters.
+    pub fn gc(&self, live: &std::collections::HashSet<String>) {
+        self.inner.exporters.retain(live);
+    }
+
+    /// Drain every exporter pipeline at graceful shutdown.
+    pub async fn shutdown(&self) {
+        self.inner.exporters.shutdown().await;
     }
 }
 
@@ -325,33 +274,6 @@ impl ObservabilitySink for OtlpSink {
         // `SinkStats::last_error`.
         SinkHealth::healthy()
     }
-}
-
-async fn post_one(
-    client: reqwest::Client,
-    endpoint: String,
-    headers: BTreeMap<String, String>,
-    body: Value,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let mut req = client
-        .post(&endpoint)
-        .header("Content-Type", "application/json")
-        .body(serde_json::to_vec(&body)?);
-    for (k, v) in headers {
-        req = req.header(k, v);
-    }
-    let resp = req.send().await?;
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(format!(
-            "HTTP {}: {}",
-            status,
-            body.chars().take(200).collect::<String>()
-        )
-        .into());
-    }
-    Ok(())
 }
 
 /// Build the single OTLP span object for one usage event. Attribute names
@@ -475,7 +397,10 @@ fn otlp_export_request(spans: Vec<Value>) -> Value {
     })
 }
 
-/// One event -> one-span export request (used by the per-event fan-out).
+/// One event -> one-span export request. Test-only helper for the payload
+/// assertions; production paths build spans via [`build_otlp_span`] and batch
+/// them through [`otlp_export_request`] inside [`OtlpSink`].
+#[cfg(test)]
 fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
     otlp_export_request(vec![build_otlp_span(event, exporter_name)])
 }
@@ -861,104 +786,40 @@ mod tests {
         f.fan_out(&sample_event(), std::iter::once(&exp));
     }
 
-    // ---- regression coverage for issue #113 -------------------------
-    // Pre-fix, fan_out spawned one detached tokio::spawn per (event,
-    // exporter) with no concurrency cap. A slow / down OTLP receiver
-    // would let task count + per-task payload memory grow unbounded
-    // until OOM. The fix bounds in-flight POSTs per exporter to
-    // MAX_INFLIGHT_PER_EXPORTER via a Semaphore; past the cap, events
-    // are dropped on the request hot path rather than queued.
-
-    /// A receiver that hangs forever — simulates a wedged OTLP backend.
-    /// We point exporters at it to wedge the spawned tasks past the
-    /// cap so we can observe the bound.
-    fn wedged_endpoint(server: &wiremock::MockServer) -> ObservabilityExporter {
-        // wiremock without registering any Mock returns 404 — that's
-        // fast (not the wedged behaviour we want). Instead point at a
-        // path that has a long delay registered.
-        let exp_json = serde_json::json!({
-            "name": "wedged-exporter",
+    #[tokio::test]
+    async fn fan_out_delivers_a_span_to_a_real_receiver() {
+        // The new fan-out enqueues into a per-exporter pipeline (1s flush);
+        // a single request's span lands at the receiver after the flush.
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/v1/traces"))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        let exp: ObservabilityExporter = serde_json::from_value(serde_json::json!({
+            "name": "real-otlp",
             "enabled": true,
             "kind": "otlp_http",
             "endpoint": format!("{}/v1/traces", server.uri()),
             "headers": {}
-        });
-        serde_json::from_value(exp_json).unwrap()
-    }
+        }))
+        .unwrap();
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn fan_out_caps_in_flight_when_exporter_is_slow() {
-        use std::time::Duration;
-        use wiremock::matchers::{method, path};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
-
-        let server = MockServer::start().await;
-        // Each POST hangs for 5 minutes; production REQUEST_TIMEOUT
-        // is 5s so in steady state these all time out, but for the
-        // test window we drive the cap deterministically.
-        Mock::given(method("POST"))
-            .and(path("/v1/traces"))
-            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(300)))
-            .mount(&server)
-            .await;
-
-        let exp = wedged_endpoint(&server);
         let f = OtlpHttpFanOut::new();
-        // Push more events than the cap; tasks block on the wedged
-        // receiver, so in_flight must saturate at MAX_INFLIGHT_PER_EXPORTER
-        // and further calls must be dropped at the hot path.
-        let pushes = MAX_INFLIGHT_PER_EXPORTER + 50;
-        for _ in 0..pushes {
-            f.fan_out(&sample_event(), std::iter::once(&exp));
-        }
-        // Yield so spawned tasks get a chance to acquire their
-        // permits before we sample. Multi-thread runtime + a couple
-        // of yields is plenty for try_acquire to settle.
-        for _ in 0..5 {
-            tokio::task::yield_now().await;
-        }
-        let inflight = f.in_flight_for(&exp.name);
-        assert_eq!(
-            inflight, MAX_INFLIGHT_PER_EXPORTER,
-            "in-flight should saturate exactly at the cap; got {inflight}",
-        );
-        // Pre-fix (no cap), inflight would equal `pushes` here —
-        // i.e. ~114, growing unboundedly. The assertion above pins
-        // the bound.
-    }
+        f.fan_out(&sample_event(), std::iter::once(&exp));
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn fan_out_recovers_after_permits_release() {
-        use wiremock::matchers::{method, path};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
-
-        let server = MockServer::start().await;
-        // Fast 200 — every permit released quickly.
-        Mock::given(method("POST"))
-            .and(path("/v1/traces"))
-            .respond_with(ResponseTemplate::new(200))
-            .mount(&server)
-            .await;
-
-        let exp = wedged_endpoint(&server);
-        let f = OtlpHttpFanOut::new();
-        // Drive a burst that exceeds the cap; under fast-receiver
-        // conditions the permits cycle through quickly.
-        for _ in 0..(MAX_INFLIGHT_PER_EXPORTER * 2) {
-            f.fan_out(&sample_event(), std::iter::once(&exp));
+        // Poll for the batched POST (flush_interval is 1s).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if !server.received_requests().await.unwrap().is_empty() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "no OTLP POST within 5s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
-        // Generous wait — wiremock + reqwest + tokio handshake is
-        // hundreds of ms in CI. The point: in-flight should drop back
-        // to (close to) zero after the burst clears.
-        for _ in 0..50 {
-            tokio::task::yield_now().await;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-        let inflight = f.in_flight_for(&exp.name);
-        assert!(
-            inflight < MAX_INFLIGHT_PER_EXPORTER,
-            "permits should release as POSTs complete; in_flight stuck at {inflight}",
-        );
+        f.shutdown().await;
     }
 }

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -40,10 +40,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aisix_core::models::{ExporterKind, ObservabilityExporter};
+use async_trait::async_trait;
 use parking_lot::Mutex;
 use serde_json::{json, Value};
 use tokio::sync::Semaphore;
 
+use crate::sink::{
+    BatchUnit, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink, OrderingScope,
+    SinkAck, SinkCapabilities, SinkError, SinkHealth, SinkResult,
+};
 use crate::usage::UsageEvent;
 
 /// Wall-clock duration of an OTLP/HTTP POST before we abandon it.
@@ -209,6 +214,119 @@ impl Default for OtlpHttpFanOut {
     }
 }
 
+/// An [`ObservabilitySink`] over the OTLP/HTTP-JSON traces protocol — the
+/// same wire shape as [`OtlpHttpFanOut`], but driven by the shared
+/// [`crate::sink::SinkPipeline`] (batched, retried, backpressured) rather
+/// than a per-event fire-and-forget spawn. One instance per configured
+/// `otlp_http` exporter.
+pub struct OtlpSink {
+    name: String,
+    endpoint: String,
+    headers: BTreeMap<String, String>,
+    client: reqwest::Client,
+}
+
+impl OtlpSink {
+    /// Build a sink for one exporter. The `client` is shared across sinks so
+    /// connection pools and TLS sessions are reused.
+    pub fn new(
+        name: impl Into<String>,
+        endpoint: impl Into<String>,
+        headers: BTreeMap<String, String>,
+        client: reqwest::Client,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            endpoint: endpoint.into(),
+            headers,
+            client,
+        }
+    }
+}
+
+#[async_trait]
+impl ObservabilitySink for OtlpSink {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self) -> SinkCapabilities {
+        SinkCapabilities {
+            idempotency: IdempotencyScheme::None,
+            ordering: OrderingScope::None,
+            batch_unit: BatchUnit::Records,
+            // OTLP spans are small and receivers accept large payloads; the
+            // sink does not split by bytes, so no pipeline-enforced ceiling.
+            max_batch_bytes: None,
+            supports_partial_batch: false,
+            supports_streaming_ingest: false,
+        }
+    }
+
+    async fn append_batch(&self, batch: &EventBatch, _marker: &IdempotencyMarker) -> SinkResult {
+        if batch.is_empty() {
+            return Ok(SinkAck::default());
+        }
+        // One export request carrying every record's span — one POST, one
+        // atomic retry unit (vs. the per-event fan-out's N spawns).
+        let spans: Vec<Value> = batch
+            .records
+            .iter()
+            .map(|record| build_otlp_span(&record.usage, &self.name))
+            .collect();
+        let body = otlp_export_request(spans);
+        let bytes = serde_json::to_vec(&body)
+            .map_err(|e| SinkError::Permanent(format!("otlp encode: {e}")))?;
+
+        let mut req = self
+            .client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .body(bytes);
+        for (key, value) in &self.headers {
+            req = req.header(key, value);
+        }
+
+        match req.send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    return Ok(SinkAck {
+                        accepted: batch.len(),
+                        ..SinkAck::default()
+                    });
+                }
+                let text = resp.text().await.unwrap_or_default();
+                let detail = format!(
+                    "HTTP {}: {}",
+                    status,
+                    text.chars().take(200).collect::<String>()
+                );
+                // 5xx / 408 / 429 are worth retrying; other 4xx are
+                // config/auth/payload errors that will fail identically.
+                if status.is_server_error()
+                    || status == reqwest::StatusCode::REQUEST_TIMEOUT
+                    || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+                {
+                    Err(SinkError::Transient(detail))
+                } else {
+                    Err(SinkError::Permanent(detail))
+                }
+            }
+            // Connect / DNS / timeout — transient by nature.
+            Err(e) => Err(SinkError::Transient(format!("POST {}: {e}", self.endpoint))),
+        }
+    }
+
+    async fn healthcheck(&self) -> SinkHealth {
+        // A real connectivity probe (and the control-plane "test connection"
+        // affordance) lands with the health/metrics surface; until then a
+        // sink reports healthy and its delivery errors surface via
+        // `SinkStats::last_error`.
+        SinkHealth::healthy()
+    }
+}
+
 async fn post_one(
     client: reqwest::Client,
     endpoint: String,
@@ -236,9 +354,8 @@ async fn post_one(
     Ok(())
 }
 
-/// Build an OTLP/HTTP-JSON `ExportTraceServiceRequest` payload with
-/// one span representing this chat completion. Attribute names match
-/// the OpenTelemetry GenAI semantic conventions:
+/// Build the single OTLP span object for one usage event. Attribute names
+/// match the OpenTelemetry GenAI semantic conventions:
 /// <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md>.
 ///
 /// Per-attribute encoding:
@@ -246,7 +363,7 @@ async fn post_one(
 ///   `{"intValue": "..."}` (string-encoded int per OTLP/JSON spec).
 /// - Trace ID + span ID are random 16-byte / 8-byte hex values.
 /// - Timestamps are nanos-since-epoch, OTLP's required unit.
-fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
+fn build_otlp_span(event: &UsageEvent, exporter_name: &str) -> Value {
     let trace_id = random_trace_id();
     let span_id = random_span_id();
 
@@ -258,8 +375,6 @@ fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
     // Latency landed in milliseconds; widen + multiply.
     let latency_nanos = (event.latency_ms as u128).saturating_mul(1_000_000);
     let start_unix_nano = end_unix_nano.saturating_sub(latency_nanos);
-
-    let span_name = "chat.completions";
 
     // Status: OK (1) for 2xx, ERROR (2) otherwise.
     let status_code = if (200..300).contains(&event.status_code) {
@@ -332,6 +447,20 @@ fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
     }
 
     json!({
+        "traceId": trace_id,
+        "spanId":  span_id,
+        "name":    "chat.completions",
+        "kind":    3, // SPAN_KIND_CLIENT (DP → upstream LLM)
+        "startTimeUnixNano": start_unix_nano.to_string(),
+        "endTimeUnixNano":   end_unix_nano.to_string(),
+        "attributes": attributes,
+        "status": { "code": status_code },
+    })
+}
+
+/// Wrap one or more spans into an OTLP/HTTP-JSON `ExportTraceServiceRequest`.
+fn otlp_export_request(spans: Vec<Value>) -> Value {
+    json!({
         "resourceSpans": [{
             "resource": {
                 "attributes": [
@@ -340,19 +469,15 @@ fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
             },
             "scopeSpans": [{
                 "scope": { "name": "aisix-obs.otlp_http_sink" },
-                "spans": [{
-                    "traceId": trace_id,
-                    "spanId":  span_id,
-                    "name":    span_name,
-                    "kind":    3, // SPAN_KIND_CLIENT (DP → upstream LLM)
-                    "startTimeUnixNano": start_unix_nano.to_string(),
-                    "endTimeUnixNano":   end_unix_nano.to_string(),
-                    "attributes": attributes,
-                    "status": { "code": status_code },
-                }],
+                "spans": spans,
             }],
         }],
     })
+}
+
+/// One event -> one-span export request (used by the per-event fan-out).
+fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
+    otlp_export_request(vec![build_otlp_span(event, exporter_name)])
 }
 
 fn attr_string(key: &str, value: &str) -> Value {
@@ -591,6 +716,80 @@ mod tests {
             body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["status"]["code"],
             2
         );
+    }
+
+    fn otlp_test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap()
+    }
+
+    fn batch_of(n: usize) -> EventBatch {
+        let records = (0..n)
+            .map(|_| Arc::new(crate::sink::SinkRecord::metadata_only(sample_event())))
+            .collect();
+        EventBatch::new(records)
+    }
+
+    #[tokio::test]
+    async fn otlp_sink_posts_one_request_with_all_spans() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/v1/traces"))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        let sink = OtlpSink::new(
+            "test-exp",
+            format!("{}/v1/traces", server.uri()),
+            BTreeMap::new(),
+            otlp_test_client(),
+        );
+
+        let ack = sink
+            .append_batch(&batch_of(3), &IdempotencyMarker::None)
+            .await
+            .expect("2xx delivers the batch");
+        assert_eq!(ack.accepted, 3);
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1, "one batched request, not three spawns");
+        let body: Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        let spans = body["resourceSpans"][0]["scopeSpans"][0]["spans"]
+            .as_array()
+            .unwrap();
+        assert_eq!(spans.len(), 3, "all three spans in one export request");
+    }
+
+    #[tokio::test]
+    async fn otlp_sink_classifies_5xx_as_transient() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let sink = OtlpSink::new("e", server.uri(), BTreeMap::new(), otlp_test_client());
+        let err = sink
+            .append_batch(&batch_of(1), &IdempotencyMarker::None)
+            .await
+            .unwrap_err();
+        assert!(err.is_transient(), "5xx must be retryable: {err}");
+    }
+
+    #[tokio::test]
+    async fn otlp_sink_classifies_4xx_as_permanent() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(400))
+            .mount(&server)
+            .await;
+        let sink = OtlpSink::new("e", server.uri(), BTreeMap::new(), otlp_test_client());
+        let err = sink
+            .append_batch(&batch_of(1), &IdempotencyMarker::None)
+            .await
+            .unwrap_err();
+        assert!(!err.is_transient(), "4xx must be permanent: {err}");
     }
 
     #[test]

--- a/crates/aisix-obs/src/sink/capabilities.rs
+++ b/crates/aisix-obs/src/sink/capabilities.rs
@@ -1,0 +1,134 @@
+//! Capability descriptors for observability sinks.
+//!
+//! Each [`super::ObservabilitySink`] declares a [`SinkCapabilities`] so the
+//! shared delivery pipeline (and control-plane validation) can adapt to the
+//! sink's wire contract. At-least-once HTTP posts, stable-filename object
+//! writes, and offset-token exactly-once streaming differ in how a batch is
+//! sized, ordered, deduplicated and retried — the capability matrix makes
+//! those differences data, not a fork in the pipeline.
+
+use serde::{Deserialize, Serialize};
+
+/// How a sink deduplicates re-delivered data after a producer restart.
+///
+/// The producer owns the marker; the sink interprets it. See
+/// [`IdempotencyMarker`] for the matching runtime value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdempotencyScheme {
+    /// Snowpipe-Streaming-style channel-scoped offset token: the sink
+    /// commits a monotonic offset and resumes after the last committed one.
+    SnowpipeOffsetToken,
+    /// Object-store-style stable, monotonic file name: a retried upload
+    /// reuses the same key so downstream (e.g. Snowpipe) dedups by filename.
+    FileSequence {
+        /// Template for the object key, e.g. `{dp_node}-{worker}-{seq}.ndjson`.
+        filename_template: String,
+    },
+    /// No server-side dedup. Delivery is at-least-once; a stable per-record
+    /// sequence field lets a downstream system dedup if it chooses to.
+    None,
+}
+
+/// The runtime value matching an [`IdempotencyScheme`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdempotencyMarker {
+    /// Monotonic offset for [`IdempotencyScheme::SnowpipeOffsetToken`].
+    OffsetToken(u64),
+    /// File sequence number for [`IdempotencyScheme::FileSequence`].
+    FileSeq(u64),
+    /// No marker — at-least-once delivery.
+    None,
+}
+
+/// Ordering guarantee the sink relies on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OrderingScope {
+    /// Records must be delivered in order within a channel (warehouse stream).
+    PerChannel,
+    /// No cross-record ordering requirement (independent HTTP posts).
+    None,
+}
+
+/// What unit the pipeline uses to bound a batch handed to this sink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BatchUnit {
+    /// Bound by record count.
+    Records,
+    /// Bound by encoded byte size.
+    Bytes,
+    /// Bound by whichever limit is hit first.
+    Both,
+}
+
+/// Identifies one ordered delivery channel for a sink.
+///
+/// Stable across DP restarts so offset-token / file-sequence resume works —
+/// keyed by a control-plane-persisted node id, never an ephemeral
+/// IP/hostname. At-least-once sinks (every `http_batch` target) never key
+/// by channel and can ignore it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChannelKey {
+    pub org_id: String,
+    pub env_id: String,
+    pub worker_idx: u32,
+    /// CP-persisted DP node id, reused across pod restarts.
+    pub dp_node_uid: String,
+    /// Sink-specific destination (logstore / table / bucket-prefix).
+    pub target: String,
+}
+
+/// Static description of how a sink wants to be driven by the shared pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SinkCapabilities {
+    /// Dedup/replay scheme the sink implements.
+    pub idempotency: IdempotencyScheme,
+    /// Ordering the sink relies on.
+    pub ordering: OrderingScope,
+    /// How the pipeline sizes a batch for this sink.
+    pub batch_unit: BatchUnit,
+    /// Hard ceiling on a single batch's encoded size, in bytes. The pipeline
+    /// never hands the sink a batch larger than this. `None` means the sink
+    /// self-limits (no pipeline-enforced byte ceiling).
+    pub max_batch_bytes: Option<u64>,
+    /// True when the sink can accept part of a batch and report which records
+    /// failed (e.g. Elasticsearch `_bulk`), so the pipeline retries only the
+    /// failed tail. False = whole-batch all-or-nothing.
+    pub supports_partial_batch: bool,
+    /// True when the sink ingests row-by-row with its own commit protocol
+    /// (e.g. Snowpipe Streaming) rather than discrete request/response posts.
+    pub supports_streaming_ingest: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn at_least_once_capabilities_are_constructible() {
+        // The shape an `http_batch` sink (e.g. Aliyun SLS) declares.
+        let caps = SinkCapabilities {
+            idempotency: IdempotencyScheme::None,
+            ordering: OrderingScope::None,
+            batch_unit: BatchUnit::Both,
+            max_batch_bytes: Some(10 * 1024 * 1024),
+            supports_partial_batch: false,
+            supports_streaming_ingest: false,
+        };
+        assert_eq!(caps.idempotency, IdempotencyScheme::None);
+        assert!(!caps.supports_streaming_ingest);
+    }
+
+    #[test]
+    fn idempotency_scheme_and_marker_pair_up() {
+        let scheme = IdempotencyScheme::FileSequence {
+            filename_template: "{dp_node}-{worker}-{seq}.ndjson".into(),
+        };
+        // round-trips through serde so the CP can persist it
+        let json = serde_json::to_string(&scheme).unwrap();
+        let back: IdempotencyScheme = serde_json::from_str(&json).unwrap();
+        assert_eq!(scheme, back);
+
+        let marker = IdempotencyMarker::FileSeq(42);
+        assert_ne!(marker, IdempotencyMarker::None);
+    }
+}

--- a/crates/aisix-obs/src/sink/manager.rs
+++ b/crates/aisix-obs/src/sink/manager.rs
@@ -1,14 +1,20 @@
 //! Per-exporter pipeline manager.
 //!
-//! Owns one [`SinkPipeline`] per configured exporter and keeps the running
-//! set reconciled against the desired set (the etcd snapshot's exporters).
-//! The request hot path enqueues a record into every running pipeline; a
-//! reconcile loop (driven by snapshot version changes) starts pipelines for
-//! new exporters, stops removed ones, and rebuilds reconfigured ones.
+//! Owns one [`SinkPipeline`] per configured exporter. The request hot path
+//! resolves an exporter's pipeline with [`ExporterPipelines::get_or_create`]
+//! — lazily starting it on first sighting, and rebuilding it when the
+//! exporter's config changes — then enqueues into the returned handle. A
+//! periodic [`ExporterPipelines::retain`] stops pipelines for exporters that
+//! left the snapshot.
 //!
-//! Shared by every pipeline-backed sink family (`otlp`, `http_batch`, …) —
-//! the manager is sink-agnostic: the caller supplies a `build` closure that
-//! turns one desired spec into an [`ObservabilitySink`].
+//! Lazy-on-first-sighting mirrors the previous `OtlpHttpFanOut` permit map:
+//! it is immediately consistent with the snapshot (a just-added exporter
+//! receives the very next request), avoiding the reconcile-loop race where a
+//! newly-added exporter would miss requests until the next poll.
+//!
+//! Sink-agnostic — the caller supplies a `build` closure mapping an exporter
+//! to an [`ObservabilitySink`], so the manager is shared by every
+//! pipeline-backed sink family (`otlp`, `http_batch`, …).
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -17,17 +23,16 @@ use parking_lot::Mutex;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-use super::{
-    ObservabilitySink, PipelineConfig, SinkHandle, SinkPipeline, SinkRecord, SinkStatsSnapshot,
-};
+use super::{ObservabilitySink, PipelineConfig, SinkHandle, SinkPipeline, SinkStatsSnapshot};
 
 /// One running pipeline plus the bookkeeping needed to stop/rebuild it.
 struct Running {
-    /// Hash of the exporter's delivery-relevant config. A change rebuilds
-    /// the pipeline (old stops, new starts).
+    /// Hash of the exporter's delivery-relevant config. A change rebuilds the
+    /// pipeline (old stops, new starts).
     fingerprint: u64,
     handle: SinkHandle,
     cancel: watch::Sender<bool>,
+    /// Detached worker; awaited only on graceful [`ExporterPipelines::shutdown`].
     worker: JoinHandle<()>,
 }
 
@@ -38,9 +43,8 @@ pub struct ExporterPipelines {
 }
 
 impl ExporterPipelines {
-    /// Build an empty manager. Pipelines appear on the first [`reconcile`].
-    ///
-    /// [`reconcile`]: ExporterPipelines::reconcile
+    /// Build an empty manager. Pipelines start on first
+    /// [`get_or_create`](Self::get_or_create).
     pub fn new(cfg: PipelineConfig) -> Self {
         Self {
             running: Mutex::new(HashMap::new()),
@@ -53,79 +57,63 @@ impl ExporterPipelines {
         self.running.lock().len()
     }
 
-    /// True when no pipeline is running (no exporters configured).
+    /// True when no pipeline is running.
     pub fn is_empty(&self) -> bool {
         self.running.lock().is_empty()
     }
 
-    /// Enqueue `record` into every running pipeline (fan-out). Non-blocking:
-    /// a full queue drops the record on that pipeline (counted there). Cheap
-    /// — the record is `Arc`-shared, so each pipeline gets a pointer clone.
-    pub fn enqueue_to_all(&self, record: &Arc<SinkRecord>) {
-        let running = self.running.lock();
-        for pipeline in running.values() {
-            pipeline.handle.try_enqueue(Arc::clone(record));
+    /// Resolve the pipeline handle for exporter `key`, lazily starting it via
+    /// `build` on first sighting — or rebuilding it (stop old, start new) when
+    /// `fingerprint` changed (the exporter's config was updated). `build` runs
+    /// only when a (re)start is needed; an unchanged exporter just returns its
+    /// existing handle. The returned handle is cheap to clone and enqueue into.
+    pub fn get_or_create(
+        &self,
+        key: &str,
+        fingerprint: u64,
+        build: impl FnOnce() -> Arc<dyn ObservabilitySink>,
+    ) -> SinkHandle {
+        let mut running = self.running.lock();
+        if let Some(existing) = running.get(key) {
+            if existing.fingerprint == fingerprint {
+                return existing.handle.clone();
+            }
+            // Config changed — stop the stale pipeline, then rebuild below.
+            if let Some(old) = running.remove(key) {
+                let _ = old.cancel.send(true);
+                tracing::info!(exporter = %key, "rebuilding reconfigured exporter pipeline");
+            }
         }
+        let sink = build();
+        let (handle, pipeline) = SinkPipeline::new(sink, self.cfg.clone());
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let worker = tokio::spawn(pipeline.run(cancel_rx));
+        running.insert(
+            key.to_string(),
+            Running {
+                fingerprint,
+                handle: handle.clone(),
+                cancel: cancel_tx,
+                worker,
+            },
+        );
+        handle
     }
 
-    /// Reconcile the running pipelines against `desired`:
-    /// - start a pipeline for every desired key that isn't running;
-    /// - stop pipelines whose key is no longer desired;
-    /// - rebuild a pipeline whose `fingerprint` changed (stop old, start new).
-    ///
-    /// `build` is invoked only for new or changed exporters, so unchanged
-    /// pipelines keep running untouched. Stopped pipelines drain their queue
-    /// and exit on their own (cancel signal); they are not aborted.
-    pub fn reconcile<T>(
-        &self,
-        desired: &[T],
-        key: impl Fn(&T) -> String,
-        fingerprint: impl Fn(&T) -> u64,
-        build: impl Fn(&T) -> Arc<dyn ObservabilitySink>,
-    ) {
+    /// Stop pipelines whose exporter key is not in `live`. Stopped pipelines
+    /// drain their queue and exit on their own (cancel signal); they are not
+    /// aborted. Called periodically to GC exporters that left the snapshot.
+    pub fn retain(&self, live: &HashSet<String>) {
         let mut running = self.running.lock();
-
-        // Stop pipelines whose exporter disappeared.
-        let desired_keys: HashSet<String> = desired.iter().map(&key).collect();
-        running.retain(|name, pipeline| {
-            if desired_keys.contains(name) {
+        running.retain(|key, pipeline| {
+            if live.contains(key) {
                 true
             } else {
                 let _ = pipeline.cancel.send(true);
-                tracing::info!(exporter = %name, "stopping removed exporter pipeline");
+                tracing::info!(exporter = %key, "stopping removed exporter pipeline");
                 false
             }
         });
-
-        // Start new / rebuild changed.
-        for spec in desired {
-            let name = key(spec);
-            let fp = fingerprint(spec);
-            match running.get(&name) {
-                Some(existing) if existing.fingerprint == fp => continue,
-                Some(_) => {
-                    if let Some(old) = running.remove(&name) {
-                        let _ = old.cancel.send(true);
-                        tracing::info!(exporter = %name, "rebuilding reconfigured exporter pipeline");
-                    }
-                }
-                None => {}
-            }
-
-            let sink = build(spec);
-            let (handle, pipeline) = SinkPipeline::new(sink, self.cfg.clone());
-            let (cancel_tx, cancel_rx) = watch::channel(false);
-            let worker = tokio::spawn(pipeline.run(cancel_rx));
-            running.insert(
-                name,
-                Running {
-                    fingerprint: fp,
-                    handle,
-                    cancel: cancel_tx,
-                    worker,
-                },
-            );
-        }
     }
 
     /// Per-exporter delivery stats, keyed by exporter name (health/dashboard).
@@ -133,7 +121,7 @@ impl ExporterPipelines {
         self.running
             .lock()
             .iter()
-            .map(|(name, pipeline)| (name.clone(), pipeline.handle.stats()))
+            .map(|(key, pipeline)| (key.clone(), pipeline.handle.stats()))
             .collect()
     }
 
@@ -160,8 +148,7 @@ mod tests {
     use crate::usage::UsageEvent;
     use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
-    /// A sink that adds each delivered batch's size to a shared counter, so
-    /// tests can assert total fan-out delivery without tracking each sink.
+    /// A sink that adds each delivered batch's size to a shared counter.
     struct CountingSink {
         delivered: Arc<AtomicUsize>,
     }
@@ -197,12 +184,6 @@ mod tests {
         }
     }
 
-    /// A desired exporter spec for the test reconcile calls.
-    struct Spec {
-        name: &'static str,
-        fp: u64,
-    }
-
     fn rec() -> Arc<SinkRecord> {
         Arc::new(SinkRecord::metadata_only(UsageEvent::default()))
     }
@@ -217,142 +198,66 @@ mod tests {
         ExporterPipelines::new(cfg)
     }
 
-    #[tokio::test]
-    async fn reconcile_starts_a_pipeline_per_exporter() {
-        let mgr = manager();
-        let delivered = Arc::new(AtomicUsize::new(0));
-        let d = Arc::clone(&delivered);
-        mgr.reconcile(
-            &[Spec { name: "a", fp: 1 }, Spec { name: "b", fp: 1 }],
-            |s| s.name.to_string(),
-            |s| s.fp,
-            move |_| {
-                Arc::new(CountingSink {
-                    delivered: Arc::clone(&d),
-                }) as Arc<dyn ObservabilitySink>
-            },
-        );
-        assert_eq!(mgr.len(), 2);
-        assert!(!mgr.is_empty());
+    /// A `build` closure that counts invocations and shares a delivery counter.
+    fn counting(
+        builds: &Arc<AtomicU32>,
+        delivered: &Arc<AtomicUsize>,
+    ) -> impl FnOnce() -> Arc<dyn ObservabilitySink> {
+        let builds = Arc::clone(builds);
+        let delivered = Arc::clone(delivered);
+        move || {
+            builds.fetch_add(1, Ordering::Relaxed);
+            Arc::new(CountingSink { delivered }) as Arc<dyn ObservabilitySink>
+        }
     }
 
     #[tokio::test]
-    async fn enqueue_fans_out_to_every_pipeline() {
-        let mgr = manager();
-        let delivered = Arc::new(AtomicUsize::new(0));
-        let d = Arc::clone(&delivered);
-        mgr.reconcile(
-            &[Spec { name: "a", fp: 1 }, Spec { name: "b", fp: 1 }],
-            |s| s.name.to_string(),
-            |s| s.fp,
-            move |_| {
-                Arc::new(CountingSink {
-                    delivered: Arc::clone(&d),
-                }) as Arc<dyn ObservabilitySink>
-            },
-        );
-        mgr.enqueue_to_all(&rec());
-        mgr.shutdown().await; // drains both pipelines
-
-        assert_eq!(
-            delivered.load(Ordering::Relaxed),
-            2,
-            "one record to each of two sinks"
-        );
-    }
-
-    #[tokio::test]
-    async fn reconcile_stops_removed_exporters() {
-        let mgr = manager();
-        let d = Arc::new(AtomicUsize::new(0));
-        let build = |d: Arc<AtomicUsize>| {
-            move |_: &Spec| {
-                Arc::new(CountingSink {
-                    delivered: Arc::clone(&d),
-                }) as Arc<dyn ObservabilitySink>
-            }
-        };
-        mgr.reconcile(
-            &[Spec { name: "a", fp: 1 }, Spec { name: "b", fp: 1 }],
-            |s| s.name.to_string(),
-            |s| s.fp,
-            build(Arc::clone(&d)),
-        );
-        assert_eq!(mgr.len(), 2);
-
-        mgr.reconcile(
-            &[Spec { name: "a", fp: 1 }],
-            |s| s.name.to_string(),
-            |s| s.fp,
-            build(Arc::clone(&d)),
-        );
-        assert_eq!(mgr.len(), 1, "exporter b's pipeline was stopped");
-    }
-
-    #[tokio::test]
-    async fn reconcile_is_idempotent_for_unchanged_exporters() {
+    async fn get_or_create_starts_once_and_reuses() {
         let mgr = manager();
         let builds = Arc::new(AtomicU32::new(0));
-        let d = Arc::new(AtomicUsize::new(0));
-        let make = |builds: Arc<AtomicU32>, d: Arc<AtomicUsize>| {
-            move |_: &Spec| {
-                builds.fetch_add(1, Ordering::Relaxed);
-                Arc::new(CountingSink {
-                    delivered: Arc::clone(&d),
-                }) as Arc<dyn ObservabilitySink>
-            }
-        };
-        let specs = [Spec { name: "a", fp: 1 }];
-        mgr.reconcile(
-            &specs,
-            |s| s.name.to_string(),
-            |s| s.fp,
-            make(Arc::clone(&builds), Arc::clone(&d)),
-        );
-        mgr.reconcile(
-            &specs,
-            |s| s.name.to_string(),
-            |s| s.fp,
-            make(Arc::clone(&builds), Arc::clone(&d)),
-        );
+        let delivered = Arc::new(AtomicUsize::new(0));
+        let h1 = mgr.get_or_create("a", 1, counting(&builds, &delivered));
+        let h2 = mgr.get_or_create("a", 1, counting(&builds, &delivered));
         assert_eq!(
             builds.load(Ordering::Relaxed),
             1,
-            "unchanged exporter is not rebuilt"
+            "second call reuses the pipeline"
         );
         assert_eq!(mgr.len(), 1);
+
+        // Both handles point at the same pipeline.
+        h1.try_enqueue(rec());
+        h2.try_enqueue(rec());
+        mgr.shutdown().await;
+        assert_eq!(delivered.load(Ordering::Relaxed), 2);
     }
 
     #[tokio::test]
-    async fn reconcile_rebuilds_on_fingerprint_change() {
+    async fn get_or_create_rebuilds_on_fingerprint_change() {
         let mgr = manager();
         let builds = Arc::new(AtomicU32::new(0));
-        let d = Arc::new(AtomicUsize::new(0));
-        let make = |builds: Arc<AtomicU32>, d: Arc<AtomicUsize>| {
-            move |_: &Spec| {
-                builds.fetch_add(1, Ordering::Relaxed);
-                Arc::new(CountingSink {
-                    delivered: Arc::clone(&d),
-                }) as Arc<dyn ObservabilitySink>
-            }
-        };
-        mgr.reconcile(
-            &[Spec { name: "a", fp: 1 }],
-            |s| s.name.to_string(),
-            |s| s.fp,
-            make(Arc::clone(&builds), Arc::clone(&d)),
-        );
-        mgr.reconcile(
-            &[Spec { name: "a", fp: 2 }],
-            |s| s.name.to_string(),
-            |s| s.fp,
-            make(Arc::clone(&builds), Arc::clone(&d)),
-        );
+        let delivered = Arc::new(AtomicUsize::new(0));
+        mgr.get_or_create("a", 1, counting(&builds, &delivered));
+        mgr.get_or_create("a", 2, counting(&builds, &delivered));
         assert_eq!(
             builds.load(Ordering::Relaxed),
             2,
             "config change rebuilds the pipeline"
         );
         assert_eq!(mgr.len(), 1, "still exactly one pipeline for exporter a");
+    }
+
+    #[tokio::test]
+    async fn retain_stops_absent_exporters() {
+        let mgr = manager();
+        let builds = Arc::new(AtomicU32::new(0));
+        let delivered = Arc::new(AtomicUsize::new(0));
+        mgr.get_or_create("a", 1, counting(&builds, &delivered));
+        mgr.get_or_create("b", 1, counting(&builds, &delivered));
+        assert_eq!(mgr.len(), 2);
+
+        let live: HashSet<String> = ["a".to_string()].into_iter().collect();
+        mgr.retain(&live);
+        assert_eq!(mgr.len(), 1, "exporter b's pipeline was stopped");
     }
 }

--- a/crates/aisix-obs/src/sink/manager.rs
+++ b/crates/aisix-obs/src/sink/manager.rs
@@ -1,0 +1,358 @@
+//! Per-exporter pipeline manager.
+//!
+//! Owns one [`SinkPipeline`] per configured exporter and keeps the running
+//! set reconciled against the desired set (the etcd snapshot's exporters).
+//! The request hot path enqueues a record into every running pipeline; a
+//! reconcile loop (driven by snapshot version changes) starts pipelines for
+//! new exporters, stops removed ones, and rebuilds reconfigured ones.
+//!
+//! Shared by every pipeline-backed sink family (`otlp`, `http_batch`, …) —
+//! the manager is sink-agnostic: the caller supplies a `build` closure that
+//! turns one desired spec into an [`ObservabilitySink`].
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use super::{
+    ObservabilitySink, PipelineConfig, SinkHandle, SinkPipeline, SinkRecord, SinkStatsSnapshot,
+};
+
+/// One running pipeline plus the bookkeeping needed to stop/rebuild it.
+struct Running {
+    /// Hash of the exporter's delivery-relevant config. A change rebuilds
+    /// the pipeline (old stops, new starts).
+    fingerprint: u64,
+    handle: SinkHandle,
+    cancel: watch::Sender<bool>,
+    worker: JoinHandle<()>,
+}
+
+/// Manages the live set of per-exporter pipelines.
+pub struct ExporterPipelines {
+    running: Mutex<HashMap<String, Running>>,
+    cfg: PipelineConfig,
+}
+
+impl ExporterPipelines {
+    /// Build an empty manager. Pipelines appear on the first [`reconcile`].
+    ///
+    /// [`reconcile`]: ExporterPipelines::reconcile
+    pub fn new(cfg: PipelineConfig) -> Self {
+        Self {
+            running: Mutex::new(HashMap::new()),
+            cfg,
+        }
+    }
+
+    /// Number of running pipelines.
+    pub fn len(&self) -> usize {
+        self.running.lock().len()
+    }
+
+    /// True when no pipeline is running (no exporters configured).
+    pub fn is_empty(&self) -> bool {
+        self.running.lock().is_empty()
+    }
+
+    /// Enqueue `record` into every running pipeline (fan-out). Non-blocking:
+    /// a full queue drops the record on that pipeline (counted there). Cheap
+    /// — the record is `Arc`-shared, so each pipeline gets a pointer clone.
+    pub fn enqueue_to_all(&self, record: &Arc<SinkRecord>) {
+        let running = self.running.lock();
+        for pipeline in running.values() {
+            pipeline.handle.try_enqueue(Arc::clone(record));
+        }
+    }
+
+    /// Reconcile the running pipelines against `desired`:
+    /// - start a pipeline for every desired key that isn't running;
+    /// - stop pipelines whose key is no longer desired;
+    /// - rebuild a pipeline whose `fingerprint` changed (stop old, start new).
+    ///
+    /// `build` is invoked only for new or changed exporters, so unchanged
+    /// pipelines keep running untouched. Stopped pipelines drain their queue
+    /// and exit on their own (cancel signal); they are not aborted.
+    pub fn reconcile<T>(
+        &self,
+        desired: &[T],
+        key: impl Fn(&T) -> String,
+        fingerprint: impl Fn(&T) -> u64,
+        build: impl Fn(&T) -> Arc<dyn ObservabilitySink>,
+    ) {
+        let mut running = self.running.lock();
+
+        // Stop pipelines whose exporter disappeared.
+        let desired_keys: HashSet<String> = desired.iter().map(&key).collect();
+        running.retain(|name, pipeline| {
+            if desired_keys.contains(name) {
+                true
+            } else {
+                let _ = pipeline.cancel.send(true);
+                tracing::info!(exporter = %name, "stopping removed exporter pipeline");
+                false
+            }
+        });
+
+        // Start new / rebuild changed.
+        for spec in desired {
+            let name = key(spec);
+            let fp = fingerprint(spec);
+            match running.get(&name) {
+                Some(existing) if existing.fingerprint == fp => continue,
+                Some(_) => {
+                    if let Some(old) = running.remove(&name) {
+                        let _ = old.cancel.send(true);
+                        tracing::info!(exporter = %name, "rebuilding reconfigured exporter pipeline");
+                    }
+                }
+                None => {}
+            }
+
+            let sink = build(spec);
+            let (handle, pipeline) = SinkPipeline::new(sink, self.cfg.clone());
+            let (cancel_tx, cancel_rx) = watch::channel(false);
+            let worker = tokio::spawn(pipeline.run(cancel_rx));
+            running.insert(
+                name,
+                Running {
+                    fingerprint: fp,
+                    handle,
+                    cancel: cancel_tx,
+                    worker,
+                },
+            );
+        }
+    }
+
+    /// Per-exporter delivery stats, keyed by exporter name (health/dashboard).
+    pub fn stats(&self) -> HashMap<String, SinkStatsSnapshot> {
+        self.running
+            .lock()
+            .iter()
+            .map(|(name, pipeline)| (name.clone(), pipeline.handle.stats()))
+            .collect()
+    }
+
+    /// Stop every pipeline and await its worker (graceful shutdown). Each
+    /// pipeline performs a final drain before exiting.
+    pub async fn shutdown(&self) {
+        let pipelines: Vec<Running> = self.running.lock().drain().map(|(_, p)| p).collect();
+        for pipeline in &pipelines {
+            let _ = pipeline.cancel.send(true);
+        }
+        for pipeline in pipelines {
+            let _ = pipeline.worker.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sink::{
+        BatchUnit, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink,
+        OrderingScope, SinkAck, SinkCapabilities, SinkHealth, SinkRecord, SinkResult,
+    };
+    use crate::usage::UsageEvent;
+    use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+    /// A sink that adds each delivered batch's size to a shared counter, so
+    /// tests can assert total fan-out delivery without tracking each sink.
+    struct CountingSink {
+        delivered: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl ObservabilitySink for CountingSink {
+        fn name(&self) -> &str {
+            "counting"
+        }
+        fn capabilities(&self) -> SinkCapabilities {
+            SinkCapabilities {
+                idempotency: IdempotencyScheme::None,
+                ordering: OrderingScope::None,
+                batch_unit: BatchUnit::Records,
+                max_batch_bytes: None,
+                supports_partial_batch: false,
+                supports_streaming_ingest: false,
+            }
+        }
+        async fn append_batch(
+            &self,
+            batch: &EventBatch,
+            _marker: &IdempotencyMarker,
+        ) -> SinkResult {
+            self.delivered.fetch_add(batch.len(), Ordering::Relaxed);
+            Ok(SinkAck {
+                accepted: batch.len(),
+                ..SinkAck::default()
+            })
+        }
+        async fn healthcheck(&self) -> SinkHealth {
+            SinkHealth::healthy()
+        }
+    }
+
+    /// A desired exporter spec for the test reconcile calls.
+    struct Spec {
+        name: &'static str,
+        fp: u64,
+    }
+
+    fn rec() -> Arc<SinkRecord> {
+        Arc::new(SinkRecord::metadata_only(UsageEvent::default()))
+    }
+
+    fn manager() -> ExporterPipelines {
+        // Long flush interval so the only flush is the shutdown drain —
+        // keeps delivery assertions deterministic.
+        let cfg = PipelineConfig {
+            flush_interval: std::time::Duration::from_secs(60),
+            ..PipelineConfig::default()
+        };
+        ExporterPipelines::new(cfg)
+    }
+
+    #[tokio::test]
+    async fn reconcile_starts_a_pipeline_per_exporter() {
+        let mgr = manager();
+        let delivered = Arc::new(AtomicUsize::new(0));
+        let d = Arc::clone(&delivered);
+        mgr.reconcile(
+            &[Spec { name: "a", fp: 1 }, Spec { name: "b", fp: 1 }],
+            |s| s.name.to_string(),
+            |s| s.fp,
+            move |_| {
+                Arc::new(CountingSink {
+                    delivered: Arc::clone(&d),
+                }) as Arc<dyn ObservabilitySink>
+            },
+        );
+        assert_eq!(mgr.len(), 2);
+        assert!(!mgr.is_empty());
+    }
+
+    #[tokio::test]
+    async fn enqueue_fans_out_to_every_pipeline() {
+        let mgr = manager();
+        let delivered = Arc::new(AtomicUsize::new(0));
+        let d = Arc::clone(&delivered);
+        mgr.reconcile(
+            &[Spec { name: "a", fp: 1 }, Spec { name: "b", fp: 1 }],
+            |s| s.name.to_string(),
+            |s| s.fp,
+            move |_| {
+                Arc::new(CountingSink {
+                    delivered: Arc::clone(&d),
+                }) as Arc<dyn ObservabilitySink>
+            },
+        );
+        mgr.enqueue_to_all(&rec());
+        mgr.shutdown().await; // drains both pipelines
+
+        assert_eq!(
+            delivered.load(Ordering::Relaxed),
+            2,
+            "one record to each of two sinks"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_stops_removed_exporters() {
+        let mgr = manager();
+        let d = Arc::new(AtomicUsize::new(0));
+        let build = |d: Arc<AtomicUsize>| {
+            move |_: &Spec| {
+                Arc::new(CountingSink {
+                    delivered: Arc::clone(&d),
+                }) as Arc<dyn ObservabilitySink>
+            }
+        };
+        mgr.reconcile(
+            &[Spec { name: "a", fp: 1 }, Spec { name: "b", fp: 1 }],
+            |s| s.name.to_string(),
+            |s| s.fp,
+            build(Arc::clone(&d)),
+        );
+        assert_eq!(mgr.len(), 2);
+
+        mgr.reconcile(
+            &[Spec { name: "a", fp: 1 }],
+            |s| s.name.to_string(),
+            |s| s.fp,
+            build(Arc::clone(&d)),
+        );
+        assert_eq!(mgr.len(), 1, "exporter b's pipeline was stopped");
+    }
+
+    #[tokio::test]
+    async fn reconcile_is_idempotent_for_unchanged_exporters() {
+        let mgr = manager();
+        let builds = Arc::new(AtomicU32::new(0));
+        let d = Arc::new(AtomicUsize::new(0));
+        let make = |builds: Arc<AtomicU32>, d: Arc<AtomicUsize>| {
+            move |_: &Spec| {
+                builds.fetch_add(1, Ordering::Relaxed);
+                Arc::new(CountingSink {
+                    delivered: Arc::clone(&d),
+                }) as Arc<dyn ObservabilitySink>
+            }
+        };
+        let specs = [Spec { name: "a", fp: 1 }];
+        mgr.reconcile(
+            &specs,
+            |s| s.name.to_string(),
+            |s| s.fp,
+            make(Arc::clone(&builds), Arc::clone(&d)),
+        );
+        mgr.reconcile(
+            &specs,
+            |s| s.name.to_string(),
+            |s| s.fp,
+            make(Arc::clone(&builds), Arc::clone(&d)),
+        );
+        assert_eq!(
+            builds.load(Ordering::Relaxed),
+            1,
+            "unchanged exporter is not rebuilt"
+        );
+        assert_eq!(mgr.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reconcile_rebuilds_on_fingerprint_change() {
+        let mgr = manager();
+        let builds = Arc::new(AtomicU32::new(0));
+        let d = Arc::new(AtomicUsize::new(0));
+        let make = |builds: Arc<AtomicU32>, d: Arc<AtomicUsize>| {
+            move |_: &Spec| {
+                builds.fetch_add(1, Ordering::Relaxed);
+                Arc::new(CountingSink {
+                    delivered: Arc::clone(&d),
+                }) as Arc<dyn ObservabilitySink>
+            }
+        };
+        mgr.reconcile(
+            &[Spec { name: "a", fp: 1 }],
+            |s| s.name.to_string(),
+            |s| s.fp,
+            make(Arc::clone(&builds), Arc::clone(&d)),
+        );
+        mgr.reconcile(
+            &[Spec { name: "a", fp: 2 }],
+            |s| s.name.to_string(),
+            |s| s.fp,
+            make(Arc::clone(&builds), Arc::clone(&d)),
+        );
+        assert_eq!(
+            builds.load(Ordering::Relaxed),
+            2,
+            "config change rebuilds the pipeline"
+        );
+        assert_eq!(mgr.len(), 1, "still exactly one pipeline for exporter a");
+    }
+}

--- a/crates/aisix-obs/src/sink/mod.rs
+++ b/crates/aisix-obs/src/sink/mod.rs
@@ -1,0 +1,207 @@
+//! Pluggable observability-sink framework — the capability-typed adapter
+//! contract that the shared delivery pipeline drives.
+//!
+//! One implementation per sink *family* (`http_batch`, `object_store`,
+//! `warehouse_stream`, `otlp`); per-vendor behaviour (Aliyun SLS, Datadog,
+//! …) is configuration plus pluggable encoder/signer traits, not a new
+//! sink. The shared pipeline owns batching, retry/backoff, backpressure and
+//! per-sink delivery state; a sink only encodes a batch and reports the
+//! outcome.
+//!
+//! This module is the framework foundation (AISIX-Cloud#692, phase F1): the
+//! trait + capability matrix + idempotency types. The shared pipeline (F2)
+//! and the concrete sinks (SLS, …) build on it.
+
+mod capabilities;
+mod record;
+
+pub use capabilities::{
+    BatchUnit, ChannelKey, IdempotencyMarker, IdempotencyScheme, OrderingScope, SinkCapabilities,
+};
+pub use record::{EventBatch, SinkContent, SinkRecord, SCHEMA_VERSION};
+
+use async_trait::async_trait;
+
+/// Health snapshot a sink reports for the circuit-breaker and the dashboard.
+#[derive(Debug, Clone)]
+pub struct SinkHealth {
+    pub healthy: bool,
+    /// Masked, human-readable reason when unhealthy. Never contains secrets.
+    pub detail: Option<String>,
+}
+
+impl SinkHealth {
+    pub fn healthy() -> Self {
+        Self {
+            healthy: true,
+            detail: None,
+        }
+    }
+
+    pub fn unhealthy(detail: impl Into<String>) -> Self {
+        Self {
+            healthy: false,
+            detail: Some(detail.into()),
+        }
+    }
+}
+
+/// Acknowledgement returned by a successful (possibly partial) delivery.
+#[derive(Debug, Clone, Default)]
+pub struct SinkAck {
+    /// Number of records the sink accepted on this call.
+    pub accepted: usize,
+    /// For partial-success sinks, the index of the first record that failed
+    /// — the pipeline retries from there. `None` = whole batch accepted.
+    pub first_failed: Option<usize>,
+    /// The idempotency marker now durably committed, if any (offset-token /
+    /// file-sequence sinks). `None` for at-least-once sinks.
+    pub committed: Option<IdempotencyMarker>,
+}
+
+/// Why a delivery failed. Drives the pipeline's retry/backoff/drop logic.
+#[derive(Debug, thiserror::Error)]
+pub enum SinkError {
+    /// Transient — worth retrying with backoff (network, timeout, 5xx,
+    /// throttle/429).
+    #[error("transient sink error: {0}")]
+    Transient(String),
+    /// Permanent for this batch — retrying it unchanged will fail again
+    /// (auth/403, malformed payload, oversize). The pipeline stops hammering
+    /// and surfaces a masked health error instead.
+    #[error("permanent sink error: {0}")]
+    Permanent(String),
+}
+
+impl SinkError {
+    /// Whether the pipeline should retry this batch with backoff.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, SinkError::Transient(_))
+    }
+}
+
+/// Result of one [`ObservabilitySink::append_batch`] call.
+pub type SinkResult = Result<SinkAck, SinkError>;
+
+/// A pluggable delivery target for observability events.
+///
+/// Implementors are held as `Arc<dyn ObservabilitySink>` and driven by the
+/// shared pipeline. The trait is deliberately small: encode-and-deliver one
+/// batch, plus the hooks streaming sinks need (committed-marker resume) and
+/// everyone needs (health). HTTP/object-store sinks get sensible defaults so
+/// they stay simple.
+#[async_trait]
+pub trait ObservabilitySink: Send + Sync + 'static {
+    /// Stable name used in logs/metrics labels and health reporting.
+    fn name(&self) -> &str;
+
+    /// How this sink wants to be driven (idempotency, ordering, batch
+    /// sizing, partial-success).
+    fn capabilities(&self) -> SinkCapabilities;
+
+    /// Deliver one batch. The pipeline retains ownership of `batch` and
+    /// retries on [`SinkError::Transient`]; `marker` is the idempotency
+    /// marker for this batch (or [`IdempotencyMarker::None`] for
+    /// at-least-once sinks).
+    async fn append_batch(&self, batch: &EventBatch, marker: &IdempotencyMarker) -> SinkResult;
+
+    /// On startup, the last marker this channel durably committed, so the
+    /// pipeline can resume after a restart. Defaults to `None` —
+    /// at-least-once sinks (every `http_batch` / `object_store` target)
+    /// don't track one.
+    async fn last_committed_marker(&self, _channel: &ChannelKey) -> Option<IdempotencyMarker> {
+        None
+    }
+
+    /// Cheap liveness/connectivity probe for the circuit-breaker and the
+    /// control-plane "test connection" affordance.
+    async fn healthcheck(&self) -> SinkHealth;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::usage::UsageEvent;
+    use std::sync::Arc;
+
+    /// A trivial at-least-once sink that records what it was handed —
+    /// proves the trait is object-safe (`Arc<dyn ObservabilitySink>`) and
+    /// usable with the default `last_committed_marker`.
+    struct CountingSink {
+        accepted: parking_lot::Mutex<usize>,
+    }
+
+    #[async_trait]
+    impl ObservabilitySink for CountingSink {
+        fn name(&self) -> &str {
+            "counting"
+        }
+
+        fn capabilities(&self) -> SinkCapabilities {
+            SinkCapabilities {
+                idempotency: IdempotencyScheme::None,
+                ordering: OrderingScope::None,
+                batch_unit: BatchUnit::Both,
+                max_batch_bytes: Some(10 * 1024 * 1024),
+                supports_partial_batch: false,
+                supports_streaming_ingest: false,
+            }
+        }
+
+        async fn append_batch(
+            &self,
+            batch: &EventBatch,
+            _marker: &IdempotencyMarker,
+        ) -> SinkResult {
+            *self.accepted.lock() += batch.len();
+            Ok(SinkAck {
+                accepted: batch.len(),
+                ..SinkAck::default()
+            })
+        }
+
+        async fn healthcheck(&self) -> SinkHealth {
+            SinkHealth::healthy()
+        }
+    }
+
+    #[tokio::test]
+    async fn dyn_sink_accepts_a_batch_and_defaults_marker_to_none() {
+        let sink: Arc<dyn ObservabilitySink> = Arc::new(CountingSink {
+            accepted: parking_lot::Mutex::new(0),
+        });
+        let batch = EventBatch::new(vec![Arc::new(SinkRecord::metadata_only(
+            UsageEvent::default(),
+        ))]);
+
+        let ack = sink
+            .append_batch(&batch, &IdempotencyMarker::None)
+            .await
+            .expect("delivery succeeds");
+        assert_eq!(ack.accepted, 1);
+
+        let channel = ChannelKey {
+            org_id: "o".into(),
+            env_id: "e".into(),
+            worker_idx: 0,
+            dp_node_uid: "node-1".into(),
+            target: "request-events".into(),
+        };
+        assert_eq!(sink.last_committed_marker(&channel).await, None);
+        assert!(sink.healthcheck().await.healthy);
+    }
+
+    #[test]
+    fn sink_error_transience_drives_retry() {
+        assert!(SinkError::Transient("429".into()).is_transient());
+        assert!(!SinkError::Permanent("403".into()).is_transient());
+    }
+
+    #[test]
+    fn health_helpers_round_trip() {
+        assert!(SinkHealth::healthy().healthy);
+        let bad = SinkHealth::unhealthy("endpoint unreachable");
+        assert!(!bad.healthy);
+        assert_eq!(bad.detail.as_deref(), Some("endpoint unreachable"));
+    }
+}

--- a/crates/aisix-obs/src/sink/mod.rs
+++ b/crates/aisix-obs/src/sink/mod.rs
@@ -13,12 +13,14 @@
 //! and the concrete sinks (SLS, …) build on it.
 
 mod capabilities;
+mod manager;
 mod pipeline;
 mod record;
 
 pub use capabilities::{
     BatchUnit, ChannelKey, IdempotencyMarker, IdempotencyScheme, OrderingScope, SinkCapabilities,
 };
+pub use manager::ExporterPipelines;
 pub use pipeline::{PipelineConfig, SinkHandle, SinkPipeline, SinkStatsSnapshot};
 pub use record::{EventBatch, SinkContent, SinkRecord, SCHEMA_VERSION};
 

--- a/crates/aisix-obs/src/sink/mod.rs
+++ b/crates/aisix-obs/src/sink/mod.rs
@@ -16,6 +16,7 @@ mod capabilities;
 mod manager;
 mod pipeline;
 mod record;
+mod sls;
 
 pub use capabilities::{
     BatchUnit, ChannelKey, IdempotencyMarker, IdempotencyScheme, OrderingScope, SinkCapabilities,
@@ -23,6 +24,7 @@ pub use capabilities::{
 pub use manager::ExporterPipelines;
 pub use pipeline::{PipelineConfig, SinkHandle, SinkPipeline, SinkStatsSnapshot};
 pub use record::{EventBatch, SinkContent, SinkRecord, SCHEMA_VERSION};
+pub use sls::{resolve_sls_credential, AliyunSlsSink};
 
 use async_trait::async_trait;
 

--- a/crates/aisix-obs/src/sink/mod.rs
+++ b/crates/aisix-obs/src/sink/mod.rs
@@ -13,11 +13,13 @@
 //! and the concrete sinks (SLS, …) build on it.
 
 mod capabilities;
+mod pipeline;
 mod record;
 
 pub use capabilities::{
     BatchUnit, ChannelKey, IdempotencyMarker, IdempotencyScheme, OrderingScope, SinkCapabilities,
 };
+pub use pipeline::{PipelineConfig, SinkHandle, SinkPipeline, SinkStatsSnapshot};
 pub use record::{EventBatch, SinkContent, SinkRecord, SCHEMA_VERSION};
 
 use async_trait::async_trait;

--- a/crates/aisix-obs/src/sink/pipeline.rs
+++ b/crates/aisix-obs/src/sink/pipeline.rs
@@ -1,0 +1,560 @@
+//! The shared, per-sink delivery pipeline.
+//!
+//! Generalises the proven `aisix-server` telemetry worker (bounded mpsc →
+//! batch → flush) into a reusable component every sink runs behind, and adds
+//! what telemetry deliberately skipped: retry with exponential backoff and
+//! drop-with-metric backpressure. One pipeline per sink, so a slow or down
+//! sink can never stall another or the request hot path.
+//!
+//! Division of labour: the pipeline owns *flow control* — a bounded queue,
+//! count/time batching, retry/backoff and drop accounting. The sink owns
+//! *wire encoding*, including chunking a batch down to its own per-request
+//! byte limit inside `append_batch` (only the sink knows the encoded size).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use tokio::sync::{mpsc, watch};
+
+use super::{EventBatch, IdempotencyMarker, ObservabilitySink, SinkError, SinkRecord};
+
+/// Tuning for a [`SinkPipeline`]. Defaults mirror the telemetry worker
+/// (100-record batches, 5s flush, 1024-deep queue) plus a bounded retry.
+#[derive(Debug, Clone)]
+pub struct PipelineConfig {
+    /// Bound on the producer→worker queue. When full, `try_enqueue` drops
+    /// the record (counted) rather than blocking the request hot path.
+    pub queue_capacity: usize,
+    /// Flush once this many records have buffered.
+    pub max_batch: usize,
+    /// Flush whatever is buffered at least this often.
+    pub flush_interval: Duration,
+    /// Max retry attempts for a [`SinkError::Transient`] batch before it is
+    /// dropped (counted). `0` = no retry.
+    pub max_retries: u32,
+    /// First retry delay; doubles each attempt up to `max_backoff`.
+    pub base_backoff: Duration,
+    /// Ceiling on the exponential backoff delay.
+    pub max_backoff: Duration,
+}
+
+impl Default for PipelineConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: 1024,
+            max_batch: 100,
+            flush_interval: Duration::from_secs(5),
+            max_retries: 4,
+            base_backoff: Duration::from_millis(200),
+            max_backoff: Duration::from_secs(5),
+        }
+    }
+}
+
+/// Live delivery counters for one sink, shared between the producer handle
+/// and the worker. Cheap atomics; read via [`SinkStats::snapshot`].
+#[derive(Debug, Default)]
+pub struct SinkStats {
+    sent: AtomicU64,
+    dropped: AtomicU64,
+    retries: AtomicU64,
+    failed_batches: AtomicU64,
+    last_error: Mutex<Option<String>>,
+}
+
+/// A point-in-time read of [`SinkStats`] for health / dashboard surfaces.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct SinkStatsSnapshot {
+    /// Records the sink confirmed it accepted.
+    pub sent: u64,
+    /// Records dropped — queue-full backpressure plus retry-exhausted /
+    /// permanent failures.
+    pub dropped: u64,
+    /// Retry attempts made across all batches.
+    pub retries: u64,
+    /// Batches given up on after retries (or a permanent error).
+    pub failed_batches: u64,
+    /// Masked excerpt of the most recent delivery error, if any.
+    pub last_error: Option<String>,
+}
+
+impl SinkStats {
+    fn add_sent(&self, n: u64) {
+        self.sent.fetch_add(n, Ordering::Relaxed);
+    }
+    fn add_dropped(&self, n: u64) {
+        self.dropped.fetch_add(n, Ordering::Relaxed);
+    }
+    fn add_retries(&self, n: u64) {
+        self.retries.fetch_add(n, Ordering::Relaxed);
+    }
+    fn add_failed_batch(&self) {
+        self.failed_batches.fetch_add(1, Ordering::Relaxed);
+    }
+    fn set_error(&self, detail: String) {
+        *self.last_error.lock() = Some(detail);
+    }
+    fn clear_error(&self) {
+        *self.last_error.lock() = None;
+    }
+
+    /// Read the current counters.
+    pub fn snapshot(&self) -> SinkStatsSnapshot {
+        SinkStatsSnapshot {
+            sent: self.sent.load(Ordering::Relaxed),
+            dropped: self.dropped.load(Ordering::Relaxed),
+            retries: self.retries.load(Ordering::Relaxed),
+            failed_batches: self.failed_batches.load(Ordering::Relaxed),
+            last_error: self.last_error.lock().clone(),
+        }
+    }
+}
+
+/// Cheap, clonable producer handle the request hot path uses to enqueue
+/// records. Cloning shares the same queue and stats.
+#[derive(Clone)]
+pub struct SinkHandle {
+    name: Arc<str>,
+    tx: mpsc::Sender<Arc<SinkRecord>>,
+    stats: Arc<SinkStats>,
+}
+
+impl SinkHandle {
+    /// Non-blocking enqueue. Returns `false` (and counts a drop) when the
+    /// bounded queue is full or the worker has stopped — never blocks the
+    /// request hot path.
+    pub fn try_enqueue(&self, record: Arc<SinkRecord>) -> bool {
+        match self.tx.try_send(record) {
+            Ok(()) => true,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.stats.add_dropped(1);
+                tracing::debug!(sink = %self.name, "sink queue full; record dropped");
+                false
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.stats.add_dropped(1);
+                false
+            }
+        }
+    }
+
+    /// Snapshot of this sink's delivery counters.
+    pub fn stats(&self) -> SinkStatsSnapshot {
+        self.stats.snapshot()
+    }
+
+    /// Stable sink name (logs / metrics labels).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// The per-sink worker: drains the queue, batches, and delivers with
+/// retry/backoff. Build with [`SinkPipeline::new`]; the caller spawns
+/// [`SinkPipeline::run`].
+pub struct SinkPipeline {
+    sink: Arc<dyn ObservabilitySink>,
+    cfg: PipelineConfig,
+    rx: mpsc::Receiver<Arc<SinkRecord>>,
+    stats: Arc<SinkStats>,
+}
+
+impl SinkPipeline {
+    /// Build a pipeline for one sink. Returns the producer handle and the
+    /// worker; spawn `worker.run(cancel)` on the runtime.
+    pub fn new(
+        sink: Arc<dyn ObservabilitySink>,
+        cfg: PipelineConfig,
+    ) -> (SinkHandle, SinkPipeline) {
+        let (tx, rx) = mpsc::channel(cfg.queue_capacity);
+        let stats = Arc::new(SinkStats::default());
+        let handle = SinkHandle {
+            name: Arc::from(sink.name()),
+            tx,
+            stats: Arc::clone(&stats),
+        };
+        let worker = SinkPipeline {
+            sink,
+            cfg,
+            rx,
+            stats,
+        };
+        (handle, worker)
+    }
+
+    /// Drain → batch → deliver until the channel closes or `cancel` flips
+    /// true. Performs one final flush on shutdown. Delivery failures are
+    /// counted and logged, never propagated.
+    pub async fn run(mut self, mut cancel: watch::Receiver<bool>) {
+        let mut ticker = tokio::time::interval(self.cfg.flush_interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut buffer: Vec<Arc<SinkRecord>> = Vec::with_capacity(self.cfg.max_batch);
+
+        tracing::info!(
+            sink = %self.sink.name(),
+            max_batch = self.cfg.max_batch,
+            flush_interval_secs = self.cfg.flush_interval.as_secs(),
+            max_retries = self.cfg.max_retries,
+            "sink pipeline started",
+        );
+
+        loop {
+            tokio::select! {
+                maybe = self.rx.recv() => match maybe {
+                    Some(record) => {
+                        buffer.push(record);
+                        if buffer.len() >= self.cfg.max_batch {
+                            self.flush(&mut buffer).await;
+                        }
+                    }
+                    None => {
+                        self.flush(&mut buffer).await;
+                        tracing::info!(sink = %self.sink.name(), "sink pipeline: channel closed, exiting");
+                        return;
+                    }
+                },
+                _ = ticker.tick() => {
+                    self.flush(&mut buffer).await;
+                }
+                _ = cancel.changed() => {
+                    if *cancel.borrow() {
+                        while let Ok(record) = self.rx.try_recv() {
+                            buffer.push(record);
+                        }
+                        self.flush(&mut buffer).await;
+                        tracing::info!(sink = %self.sink.name(), "sink pipeline shutting down");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Take the buffer and deliver it as one batch (with retry). No-op when
+    /// empty.
+    async fn flush(&self, buffer: &mut Vec<Arc<SinkRecord>>) {
+        if buffer.is_empty() {
+            return;
+        }
+        let records = std::mem::take(buffer);
+        buffer.reserve(self.cfg.max_batch);
+        let count = records.len();
+        let batch = EventBatch::new(records);
+        self.deliver(&batch, count).await;
+    }
+
+    /// Deliver one batch, retrying transient failures with exponential
+    /// backoff. At-least-once: a retried batch may re-send already-accepted
+    /// records (the marker is `None` for the at-least-once sinks this phase
+    /// serves; offset-token sinks set their own marker later).
+    async fn deliver(&self, batch: &EventBatch, count: usize) {
+        let marker = IdempotencyMarker::None;
+        let mut attempt: u32 = 0;
+        loop {
+            match self.sink.append_batch(batch, &marker).await {
+                Ok(ack) => {
+                    self.stats.add_sent(ack.accepted as u64);
+                    self.stats.clear_error();
+                    return;
+                }
+                Err(err) => {
+                    let detail = masked(&err);
+                    if err.is_transient() && attempt < self.cfg.max_retries {
+                        attempt += 1;
+                        self.stats.add_retries(1);
+                        let delay = backoff(self.cfg.base_backoff, self.cfg.max_backoff, attempt);
+                        tracing::warn!(
+                            sink = %self.sink.name(),
+                            attempt,
+                            delay_ms = delay.as_millis() as u64,
+                            error = %detail,
+                            "sink delivery failed; retrying",
+                        );
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    self.stats.add_failed_batch();
+                    self.stats.add_dropped(count as u64);
+                    self.stats.set_error(detail.clone());
+                    tracing::warn!(
+                        sink = %self.sink.name(),
+                        dropped = count,
+                        transient = err.is_transient(),
+                        error = %detail,
+                        "sink delivery dropped after retries",
+                    );
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Exponential backoff: `base * 2^(attempt - 1)`, capped at `cap`.
+fn backoff(base: Duration, cap: Duration, attempt: u32) -> Duration {
+    let factor = 2u32.saturating_pow(attempt.saturating_sub(1));
+    base.checked_mul(factor).unwrap_or(cap).min(cap)
+}
+
+/// Trim a sink error to a bounded, log-safe excerpt. The sink is responsible
+/// for not embedding secrets in its error text; this only caps length so a
+/// verbose upstream body can't flood the logs.
+fn masked(err: &SinkError) -> String {
+    err.to_string().chars().take(200).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{backoff, PipelineConfig, SinkPipeline};
+    use crate::sink::{
+        BatchUnit, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink,
+        OrderingScope, SinkAck, SinkCapabilities, SinkError, SinkHealth, SinkRecord, SinkResult,
+    };
+    use crate::usage::UsageEvent;
+    use parking_lot::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::watch;
+
+    enum Mode {
+        Ok,
+        /// Fail with a transient error this many times, then succeed.
+        TransientThenOk(AtomicU32),
+        AlwaysTransient,
+        Permanent,
+    }
+
+    /// A configurable sink that records the batch sizes it was handed.
+    struct FakeSink {
+        mode: Mode,
+        batch_sizes: Mutex<Vec<usize>>,
+    }
+
+    impl FakeSink {
+        fn new(mode: Mode) -> Arc<Self> {
+            Arc::new(Self {
+                mode,
+                batch_sizes: Mutex::new(Vec::new()),
+            })
+        }
+        fn delivered(&self) -> usize {
+            self.batch_sizes.lock().iter().sum()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObservabilitySink for FakeSink {
+        fn name(&self) -> &str {
+            "fake"
+        }
+
+        fn capabilities(&self) -> SinkCapabilities {
+            SinkCapabilities {
+                idempotency: IdempotencyScheme::None,
+                ordering: OrderingScope::None,
+                batch_unit: BatchUnit::Records,
+                max_batch_bytes: None,
+                supports_partial_batch: false,
+                supports_streaming_ingest: false,
+            }
+        }
+
+        async fn append_batch(
+            &self,
+            batch: &EventBatch,
+            _marker: &IdempotencyMarker,
+        ) -> SinkResult {
+            match &self.mode {
+                Mode::Ok => {
+                    self.batch_sizes.lock().push(batch.len());
+                    Ok(SinkAck {
+                        accepted: batch.len(),
+                        ..SinkAck::default()
+                    })
+                }
+                Mode::TransientThenOk(remaining) => {
+                    if remaining.load(Ordering::Relaxed) > 0 {
+                        remaining.fetch_sub(1, Ordering::Relaxed);
+                        Err(SinkError::Transient("temporary".into()))
+                    } else {
+                        self.batch_sizes.lock().push(batch.len());
+                        Ok(SinkAck {
+                            accepted: batch.len(),
+                            ..SinkAck::default()
+                        })
+                    }
+                }
+                Mode::AlwaysTransient => Err(SinkError::Transient("always failing".into())),
+                Mode::Permanent => Err(SinkError::Permanent("bad credentials".into())),
+            }
+        }
+
+        async fn healthcheck(&self) -> SinkHealth {
+            SinkHealth::healthy()
+        }
+    }
+
+    fn rec(i: u32) -> Arc<SinkRecord> {
+        Arc::new(SinkRecord::metadata_only(UsageEvent {
+            request_id: format!("req-{i}"),
+            ..UsageEvent::default()
+        }))
+    }
+
+    /// Fast config: no time-based flush (60s), tiny backoff so retry tests
+    /// finish quickly.
+    fn cfg() -> PipelineConfig {
+        PipelineConfig {
+            queue_capacity: 1024,
+            max_batch: 100,
+            flush_interval: Duration::from_secs(60),
+            max_retries: 4,
+            base_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(5),
+        }
+    }
+
+    async fn wait_for(f: impl Fn() -> bool, within: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + within;
+        while tokio::time::Instant::now() < deadline {
+            if f() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        f()
+    }
+
+    #[tokio::test]
+    async fn delivers_all_records_when_channel_closes() {
+        let sink = FakeSink::new(Mode::Ok);
+        let (handle, worker) = SinkPipeline::new(sink.clone(), cfg());
+        for i in 0..5 {
+            assert!(handle.try_enqueue(rec(i)));
+        }
+        // Closing the channel makes the worker drain + final-flush, then exit.
+        drop(handle);
+        let (_keep_alive, cancel) = watch::channel(false);
+        worker.run(cancel).await;
+
+        assert_eq!(sink.delivered(), 5);
+    }
+
+    #[tokio::test]
+    async fn flushes_at_the_batch_ceiling() {
+        let sink = FakeSink::new(Mode::Ok);
+        let mut c = cfg();
+        c.max_batch = 2;
+        let (handle, worker) = SinkPipeline::new(sink.clone(), c);
+        for i in 0..5 {
+            assert!(handle.try_enqueue(rec(i)));
+        }
+        drop(handle);
+        let (_keep_alive, cancel) = watch::channel(false);
+        worker.run(cancel).await;
+
+        // Two count-flushes of 2, then a final drain flush of 1.
+        assert_eq!(*sink.batch_sizes.lock(), vec![2, 2, 1]);
+    }
+
+    #[tokio::test]
+    async fn retries_transient_then_succeeds() {
+        let sink = FakeSink::new(Mode::TransientThenOk(AtomicU32::new(2)));
+        let (handle, worker) = SinkPipeline::new(sink.clone(), cfg());
+        assert!(handle.try_enqueue(rec(0)));
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let jh = tokio::spawn(worker.run(cancel_rx));
+        cancel_tx.send(true).unwrap();
+        jh.await.unwrap();
+
+        let s = handle.stats();
+        assert_eq!(s.retries, 2, "two transient failures retried");
+        assert_eq!(s.sent, 1, "record eventually delivered");
+        assert_eq!(s.dropped, 0);
+        assert_eq!(sink.delivered(), 1);
+    }
+
+    #[tokio::test]
+    async fn drops_with_metric_after_exhausting_retries() {
+        let sink = FakeSink::new(Mode::AlwaysTransient);
+        let mut c = cfg();
+        c.max_retries = 2;
+        let (handle, worker) = SinkPipeline::new(sink.clone(), c);
+        assert!(handle.try_enqueue(rec(0)));
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let jh = tokio::spawn(worker.run(cancel_rx));
+        cancel_tx.send(true).unwrap();
+        jh.await.unwrap();
+
+        let s = handle.stats();
+        assert_eq!(s.retries, 2, "retried up to the cap");
+        assert_eq!(s.dropped, 1, "record dropped and counted");
+        assert_eq!(s.failed_batches, 1);
+        assert_eq!(s.sent, 0);
+        assert!(
+            s.last_error.is_some(),
+            "last error recorded for the dashboard"
+        );
+    }
+
+    #[tokio::test]
+    async fn drops_permanent_error_without_retry() {
+        let sink = FakeSink::new(Mode::Permanent);
+        let (handle, worker) = SinkPipeline::new(sink.clone(), cfg());
+        assert!(handle.try_enqueue(rec(0)));
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let jh = tokio::spawn(worker.run(cancel_rx));
+        cancel_tx.send(true).unwrap();
+        jh.await.unwrap();
+
+        let s = handle.stats();
+        assert_eq!(s.retries, 0, "permanent errors are not retried");
+        assert_eq!(s.dropped, 1);
+        assert_eq!(s.sent, 0);
+    }
+
+    #[tokio::test]
+    async fn queue_full_drops_without_blocking() {
+        // No worker draining — the bounded queue fills and over-capacity
+        // enqueues are dropped, never blocking the caller.
+        let sink = FakeSink::new(Mode::Ok);
+        let mut c = cfg();
+        c.queue_capacity = 2;
+        let (handle, _worker) = SinkPipeline::new(sink, c);
+
+        assert!(handle.try_enqueue(rec(0)));
+        assert!(handle.try_enqueue(rec(1)));
+        assert!(!handle.try_enqueue(rec(2)), "third enqueue is dropped");
+        assert_eq!(handle.stats().dropped, 1);
+    }
+
+    #[tokio::test]
+    async fn age_flush_delivers_a_partial_batch() {
+        let sink = FakeSink::new(Mode::Ok);
+        let mut c = cfg();
+        c.flush_interval = Duration::from_millis(20);
+        let (handle, worker) = SinkPipeline::new(sink.clone(), c);
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let jh = tokio::spawn(worker.run(cancel_rx));
+
+        assert!(handle.try_enqueue(rec(0)));
+        let flushed = wait_for(|| handle.stats().sent == 1, Duration::from_secs(2)).await;
+        assert!(flushed, "a sub-ceiling record flushes on the age timer");
+
+        cancel_tx.send(true).unwrap();
+        jh.await.unwrap();
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_and_caps() {
+        let base = Duration::from_millis(100);
+        let cap = Duration::from_secs(1);
+        assert_eq!(backoff(base, cap, 1), Duration::from_millis(100));
+        assert_eq!(backoff(base, cap, 2), Duration::from_millis(200));
+        assert_eq!(backoff(base, cap, 3), Duration::from_millis(400));
+        assert_eq!(backoff(base, cap, 10), cap, "capped at max_backoff");
+    }
+}

--- a/crates/aisix-obs/src/sink/record.rs
+++ b/crates/aisix-obs/src/sink/record.rs
@@ -1,0 +1,128 @@
+//! The canonical event a sink delivers, plus the batch wrapper.
+//!
+//! A [`SinkRecord`] wraps the existing per-request [`UsageEvent`] (the
+//! canonical metadata, already mirrored to cp-api) and adds optional,
+//! opt-in [`SinkContent`]. Reusing `UsageEvent` keeps the metadata schema
+//! single-sourced; content lives in a separate field so the default
+//! metadata-only path can never carry a prompt.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::usage::UsageEvent;
+
+/// Current canonical event schema version, emitted on every [`SinkRecord`]
+/// so downstream consumers can evolve safely.
+pub const SCHEMA_VERSION: &str = "1.0";
+
+/// Captured request/response content.
+///
+/// Populated ONLY when an exporter opts into full-content capture
+/// (`content_mode = full`); absent by default so the metadata path cannot
+/// leak prompts. Size caps / truncation are applied before this is built.
+#[derive(Debug, Clone, Serialize)]
+pub struct SinkContent {
+    /// The request prompt — serialized chat messages (JSON) or raw text.
+    pub prompt: String,
+    /// The assembled response text (full, post-stream).
+    pub response: String,
+    /// True when either field was truncated to a configured size cap.
+    pub truncated: bool,
+}
+
+/// One canonical observability event handed to sinks.
+///
+/// Sink body-encoders read fields off `usage` (and optionally `content`) to
+/// build their wire payload.
+#[derive(Debug, Clone, Serialize)]
+pub struct SinkRecord {
+    /// Canonical schema version. See [`SCHEMA_VERSION`].
+    pub schema_version: &'static str,
+    /// The per-request metadata (flattened into the record on the wire).
+    #[serde(flatten)]
+    pub usage: UsageEvent,
+    /// Opt-in captured content; omitted entirely under `metadata_only`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<SinkContent>,
+}
+
+impl SinkRecord {
+    /// Build a metadata-only record (no content captured).
+    pub fn metadata_only(usage: UsageEvent) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            usage,
+            content: None,
+        }
+    }
+
+    /// Attach captured content (`content_mode = full`).
+    pub fn with_content(mut self, content: SinkContent) -> Self {
+        self.content = Some(content);
+        self
+    }
+}
+
+/// A batch of records the pipeline hands to a sink in one delivery.
+///
+/// Records are `Arc`-shared so the same record can fan out to several sinks
+/// without copying the payload.
+#[derive(Debug, Clone, Default)]
+pub struct EventBatch {
+    pub records: Vec<Arc<SinkRecord>>,
+}
+
+impl EventBatch {
+    pub fn new(records: Vec<Arc<SinkRecord>>) -> Self {
+        Self { records }
+    }
+
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_only_record_omits_content() {
+        let rec = SinkRecord::metadata_only(UsageEvent {
+            request_id: "req-1".into(),
+            ..UsageEvent::default()
+        });
+        let json = serde_json::to_value(&rec).unwrap();
+        assert_eq!(json["schema_version"], "1.0");
+        // content key is absent, and metadata is flattened (no `usage` nesting)
+        assert!(json.get("content").is_none());
+        assert_eq!(json["request_id"], "req-1");
+    }
+
+    #[test]
+    fn full_content_record_carries_prompt_and_response() {
+        let rec = SinkRecord::metadata_only(UsageEvent::default()).with_content(SinkContent {
+            prompt: "hi".into(),
+            response: "hello".into(),
+            truncated: false,
+        });
+        let json = serde_json::to_value(&rec).unwrap();
+        assert_eq!(json["content"]["prompt"], "hi");
+        assert_eq!(json["content"]["response"], "hello");
+    }
+
+    #[test]
+    fn batch_len_tracks_records() {
+        let batch = EventBatch::new(vec![Arc::new(SinkRecord::metadata_only(
+            UsageEvent::default(),
+        ))]);
+        assert_eq!(batch.len(), 1);
+        assert!(!batch.is_empty());
+        assert!(EventBatch::default().is_empty());
+    }
+}

--- a/crates/aisix-obs/src/sink/sls.rs
+++ b/crates/aisix-obs/src/sink/sls.rs
@@ -34,12 +34,6 @@ const X_LOG_BODYRAWSIZE: HeaderName = HeaderName::from_static("x-log-bodyrawsize
 /// compresses, so the value is constant.
 const X_LOG_COMPRESSTYPE: HeaderName = HeaderName::from_static("x-log-compresstype");
 
-/// Conservative ceiling on a single PutLogs body, comfortably under SLS's
-/// documented per-request limit. The shared pipeline never hands the sink a
-/// batch larger than this; an oversize body would otherwise come back as a
-/// permanent 400.
-const SLS_MAX_REQUEST_BYTES: u64 = 3 * 1024 * 1024;
-
 /// Cap on a masked error-detail string surfaced to logs / health.
 const DETAIL_MAX_CHARS: usize = 200;
 
@@ -118,8 +112,16 @@ impl ObservabilitySink for AliyunSlsSink {
             idempotency: IdempotencyScheme::None,
             // Independent posts; SLS does not require cross-record ordering.
             ordering: OrderingScope::None,
-            batch_unit: BatchUnit::Both,
-            max_batch_bytes: Some(SLS_MAX_REQUEST_BYTES),
+            // Count-bounded today (parity with OtlpSink). SLS does cap the
+            // PutLogs body (low single-digit MB), but byte-aware chunking is
+            // only needed once full prompt/response content rides these
+            // records; on the metadata-only path the pipeline's per-batch
+            // record cap keeps bodies far under the limit. Declaring a byte
+            // ceiling the sink does not yet self-enforce would be a false
+            // promise (and a silent-drop bug under content) — so it stays
+            // `None` until the chunking lands. Tracked in #529.
+            batch_unit: BatchUnit::Records,
+            max_batch_bytes: None,
             // PutLogs accepts or rejects the whole LogGroup.
             supports_partial_batch: false,
             supports_streaming_ingest: false,

--- a/crates/aisix-obs/src/sink/sls.rs
+++ b/crates/aisix-obs/src/sink/sls.rs
@@ -1,0 +1,950 @@
+//! Aliyun SLS (Simple Log Service) sink — the `http_batch` family's first
+//! concrete vendor (AISIX-Cloud#687, the pre-sales deliverable on
+//! ai-gateway#432).
+//!
+//! A batch becomes one SLS **PutLogs** request: every [`SinkRecord`] maps to
+//! one protobuf `Log` (the canonical usage metadata flattened into key/value
+//! contents, plus opt-in captured prompt/response), the `LogGroup` is
+//! lz4-block compressed, signed with SLS signature v1 (HMAC-SHA1), and POSTed
+//! to `/logstores/<logstore>/shards/lb` over the crate's shared rustls client.
+//!
+//! Wire details are taken from the official Aliyun SLS sub-crates
+//! (`aliyun-log-sdk-protobuf`, `aliyun-log-sdk-sign`) rather than re-derived.
+//! In particular the signer sets `Date` / `Content-MD5` / `Content-Length` /
+//! `x-log-apiversion` / `x-log-signaturemethod` / `Authorization` itself and
+//! signs over *every* `x-log-*` header, so `Content-Type` plus
+//! `x-log-bodyrawsize` and `x-log-compresstype` are populated before the call.
+
+use aliyun_log_sdk_protobuf::{Log, LogGroup};
+use aliyun_log_sdk_sign::{sign_v1, QueryParams};
+use async_trait::async_trait;
+use http::header::CONTENT_TYPE;
+use http::{HeaderMap, HeaderName, HeaderValue, Method};
+use serde::Deserialize;
+
+use super::{
+    BatchUnit, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink, OrderingScope,
+    SinkAck, SinkCapabilities, SinkError, SinkHealth, SinkRecord, SinkResult,
+};
+
+/// `x-log-bodyrawsize`: the *uncompressed* protobuf size. SLS uses it to size
+/// the lz4 decompression buffer (the block format carries no length itself).
+const X_LOG_BODYRAWSIZE: HeaderName = HeaderName::from_static("x-log-bodyrawsize");
+/// `x-log-compresstype`: the body compression. This sink always lz4-block-
+/// compresses, so the value is constant.
+const X_LOG_COMPRESSTYPE: HeaderName = HeaderName::from_static("x-log-compresstype");
+
+/// Conservative ceiling on a single PutLogs body, comfortably under SLS's
+/// documented per-request limit. The shared pipeline never hands the sink a
+/// batch larger than this; an oversize body would otherwise come back as a
+/// permanent 400.
+const SLS_MAX_REQUEST_BYTES: u64 = 3 * 1024 * 1024;
+
+/// Cap on a masked error-detail string surfaced to logs / health.
+const DETAIL_MAX_CHARS: usize = 200;
+
+/// A delivery target for one Aliyun SLS logstore.
+pub struct AliyunSlsSink {
+    name: String,
+    /// Full POST target — `https://<project>.<endpoint>/logstores/<ls>/shards/lb`.
+    endpoint_url: String,
+    /// The request path used for the SLS signature (no scheme/host/query).
+    path: String,
+    access_key_id: String,
+    access_key_secret: String,
+    client: reqwest::Client,
+}
+
+impl AliyunSlsSink {
+    /// Build a sink for one `<project>/<logstore>` in an SLS region.
+    ///
+    /// `endpoint` is the bare region host, e.g.
+    /// `ap-southeast-3.log.aliyuncs.com`; the request host is
+    /// `<project>.<endpoint>`. An endpoint that already carries a scheme
+    /// (the e2e's `http://mock-sls:9000`) is used verbatim so a local mock
+    /// needs no `<project>.` DNS or TLS. The `client` is shared across sinks
+    /// so connection pools and TLS sessions are reused.
+    pub fn new(
+        name: impl Into<String>,
+        endpoint: &str,
+        project: &str,
+        logstore: &str,
+        access_key_id: impl Into<String>,
+        access_key_secret: impl Into<String>,
+        client: reqwest::Client,
+    ) -> Self {
+        Self::from_base_url(
+            name,
+            base_url_for(endpoint, project),
+            logstore,
+            access_key_id,
+            access_key_secret,
+            client,
+        )
+    }
+
+    /// Construct from an explicit `scheme://host[:port]` base. Production goes
+    /// through [`AliyunSlsSink::new`]; tests point this at a mock server.
+    fn from_base_url(
+        name: impl Into<String>,
+        base_url: impl Into<String>,
+        logstore: &str,
+        access_key_id: impl Into<String>,
+        access_key_secret: impl Into<String>,
+        client: reqwest::Client,
+    ) -> Self {
+        let path = format!("/logstores/{logstore}/shards/lb");
+        let endpoint_url = format!("{}{}", base_url.into(), path);
+        Self {
+            name: name.into(),
+            endpoint_url,
+            path,
+            access_key_id: access_key_id.into(),
+            access_key_secret: access_key_secret.into(),
+            client,
+        }
+    }
+}
+
+#[async_trait]
+impl ObservabilitySink for AliyunSlsSink {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self) -> SinkCapabilities {
+        SinkCapabilities {
+            // SLS PutLogs is at-least-once: no server-side dedup token.
+            idempotency: IdempotencyScheme::None,
+            // Independent posts; SLS does not require cross-record ordering.
+            ordering: OrderingScope::None,
+            batch_unit: BatchUnit::Both,
+            max_batch_bytes: Some(SLS_MAX_REQUEST_BYTES),
+            // PutLogs accepts or rejects the whole LogGroup.
+            supports_partial_batch: false,
+            supports_streaming_ingest: false,
+        }
+    }
+
+    async fn append_batch(&self, batch: &EventBatch, _marker: &IdempotencyMarker) -> SinkResult {
+        if batch.is_empty() {
+            return Ok(SinkAck::default());
+        }
+
+        // 1. One protobuf `Log` per record → a single `LogGroup`.
+        let mut group = LogGroup::new();
+        for record in &batch.records {
+            group.add_log(to_log(record)?);
+        }
+        let raw = group
+            .encode()
+            .map_err(|e| SinkError::Permanent(format!("sls: protobuf encode: {e}")))?;
+        let raw_size = raw.len();
+
+        // 2. lz4 *block* compression (bare block; the size lives in the header).
+        let compressed = lz4_flex::block::compress(&raw);
+
+        // 3. Headers SLS signs over. The signer adds Date / Content-MD5 /
+        //    Content-Length / apiversion / signaturemethod / Authorization and
+        //    signs every `x-log-*`, so these three are set beforehand.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/x-protobuf"),
+        );
+        headers.insert(X_LOG_BODYRAWSIZE, HeaderValue::from(raw_size as u64));
+        headers.insert(X_LOG_COMPRESSTYPE, HeaderValue::from_static("lz4"));
+        sign_v1(
+            &self.access_key_id,
+            &self.access_key_secret,
+            None,
+            Method::POST,
+            &self.path,
+            &mut headers,
+            QueryParams::empty(),
+            Some(&compressed),
+        )
+        .map_err(|e| SinkError::Permanent(format!("sls: sign request: {e}")))?;
+
+        // 4. Deliver. The exact `compressed` bytes were signed (Content-MD5).
+        let resp = match self
+            .client
+            .post(&self.endpoint_url)
+            .headers(headers)
+            .body(compressed)
+            .send()
+            .await
+        {
+            Ok(resp) => resp,
+            // Connect / DNS / timeout — transient by nature.
+            Err(e) => {
+                return Err(SinkError::Transient(format!(
+                    "sls: POST {}: {e}",
+                    self.endpoint_url
+                )))
+            }
+        };
+
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(SinkAck {
+                accepted: batch.len(),
+                ..SinkAck::default()
+            });
+        }
+
+        let body = resp.text().await.unwrap_or_default();
+        let (error_code, detail) = parse_sls_error(status, &body);
+        // 5xx / 408 / 429 are always worth retrying; SLS also signals back-
+        // pressure (quota / busy / clock skew) on a 4xx with a code whose plain
+        // meaning is transient, so promote those rather than drop a log batch.
+        if status.is_server_error()
+            || status == reqwest::StatusCode::REQUEST_TIMEOUT
+            || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+            || is_transient_error_code(&error_code)
+        {
+            Err(SinkError::Transient(detail))
+        } else {
+            Err(SinkError::Permanent(detail))
+        }
+    }
+
+    async fn healthcheck(&self) -> SinkHealth {
+        // A real connectivity probe (and the control-plane "test connection"
+        // affordance) lands with the health/metrics surface; until then a sink
+        // reports healthy and its delivery errors surface via
+        // `SinkStats::last_error`. (Mirrors `OtlpSink`.)
+        SinkHealth::healthy()
+    }
+}
+
+/// Map one canonical record to an SLS protobuf `Log`.
+///
+/// Metadata is produced by *serializing* [`crate::usage::UsageEvent`] rather
+/// than hand-listing its 30-plus fields: that single-sources the schema and
+/// inherits the exact `skip_serializing_if` emptiness rules the cp-api wire
+/// already uses (empty strings / zero counters are omitted). The SLS log time
+/// is ingest time (now); the event's own `occurred_at` is preserved as a
+/// content field.
+fn to_log(record: &SinkRecord) -> Result<Log, SinkError> {
+    let mut log = Log::from_unixtime(now_unix_secs());
+    log.add_content_kv("schema_version", record.schema_version);
+
+    let usage = serde_json::to_value(&record.usage)
+        .map_err(|e| SinkError::Permanent(format!("sls: serialize usage: {e}")))?;
+    if let serde_json::Value::Object(fields) = usage {
+        for (key, value) in fields {
+            if let Some(rendered) = render_scalar(&value) {
+                log.add_content_kv(key, rendered);
+            }
+        }
+    }
+
+    // Opt-in captured content as flat, queryable fields (the SLS customer case
+    // wants prompt / response columns, not a nested blob). Absent on the
+    // default metadata-only path, so prompts never leak there.
+    if let Some(content) = &record.content {
+        log.add_content_kv("prompt", content.prompt.as_str());
+        log.add_content_kv("response", content.response.as_str());
+        if content.truncated {
+            log.add_content_kv("content_truncated", "true");
+        }
+    }
+
+    Ok(log)
+}
+
+/// Render a JSON scalar as an SLS content value; `None` skips the field.
+///
+/// Empty strings are skipped so the SLS log omits blank columns uniformly:
+/// most optional `UsageEvent` fields already drop out via
+/// `skip_serializing_if`, but a few (`model_id`, `api_key_id`) carry only
+/// `#[serde(default)]` and would otherwise serialize as `""`. Numeric `0` and
+/// `false` are kept — a zero token count or status code is real data.
+fn render_scalar(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(s) if s.is_empty() => None,
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        // Nested fields (e.g. routing_attempts) round-trip as compact JSON in
+        // a single content value.
+        other => Some(other.to_string()),
+    }
+}
+
+/// The SLS JSON error envelope — `{"errorCode": ..., "errorMessage": ...}`.
+#[derive(Deserialize)]
+struct SlsErrorBody {
+    #[serde(rename = "errorCode", default)]
+    error_code: String,
+    #[serde(rename = "errorMessage", default)]
+    error_message: String,
+}
+
+/// Parse the SLS error body into `(errorCode, masked detail)`, falling back to
+/// the raw (truncated) body when it isn't the JSON envelope. The detail never
+/// contains the access key — SLS error messages echo neither id nor secret.
+fn parse_sls_error(status: reqwest::StatusCode, body: &str) -> (String, String) {
+    if let Ok(parsed) = serde_json::from_str::<SlsErrorBody>(body) {
+        if !parsed.error_code.is_empty() {
+            let detail = truncate(&format!(
+                "HTTP {status}: {} {}",
+                parsed.error_code, parsed.error_message
+            ));
+            return (parsed.error_code, detail);
+        }
+    }
+    (String::new(), truncate(&format!("HTTP {status}: {body}")))
+}
+
+/// Whether an SLS `errorCode` means "retry with backoff", keyed on the plain
+/// semantics of the code string. SLS returns throttling / overload / clock
+/// skew on a 4xx in some configurations, which a status-only check would
+/// mis-classify as permanent and silently drop a log batch. See the SLS error
+/// code reference:
+/// <https://www.alibabacloud.com/help/en/sls/developer-reference/api-error-codes>.
+fn is_transient_error_code(code: &str) -> bool {
+    const TRANSIENT_TOKENS: [&str; 6] = [
+        "QuotaExceed",          // Write/Read/ShardWriteQuotaExceed — throttle
+        "Busy",                 // ServerBusy — transient overload
+        "InternalServerError",  // server-side, retryable
+        "Unavailable",          // ServiceUnavailable
+        "RequestTimeExpired",   // stale Date — a fresh re-sign on retry fixes it
+        "RequestTimeTooSkewed", // clock skew — likewise
+    ];
+    TRANSIENT_TOKENS.iter().any(|token| code.contains(token))
+}
+
+/// Truncate a masked detail string to a bounded length for logs / health.
+fn truncate(s: &str) -> String {
+    s.chars().take(DETAIL_MAX_CHARS).collect()
+}
+
+/// Compute the base URL (`scheme://host[:port]`) the sink posts to.
+///
+/// A bare SLS region host becomes `https://<project>.<host>` — the real
+/// PutLogs target. An endpoint that already carries a scheme (the e2e's
+/// `http://mock-sls:9000`) is used verbatim, so a local mock receiver needs
+/// no `<project>.` DNS or TLS. The exporter schema only admits a
+/// scheme-qualified endpoint for vetted loopback hosts, so this branch can't
+/// be used to redirect real traffic.
+fn base_url_for(endpoint: &str, project: &str) -> String {
+    let endpoint = endpoint.trim().trim_end_matches('/');
+    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        endpoint.to_string()
+    } else {
+        format!("https://{project}.{endpoint}")
+    }
+}
+
+/// Resolve an exporter's `credential_ref` to `(access_key_id,
+/// access_key_secret)` from the DP's local environment.
+///
+/// The AccessKey never travels on the kine path (the control plane stores
+/// only the reference), so the DP looks it up where it actually runs. The
+/// reference is upper-cased with non-alphanumerics folded to `_`, then read
+/// from `SLS_CRED_<REF>_AK_ID` / `SLS_CRED_<REF>_AK_SECRET`. The prefix is
+/// deliberately NOT `AISIX_`: that namespace is owned by the config loader
+/// (`Environment::with_prefix("AISIX")`), so an `AISIX_`-named secret would be
+/// reinterpreted as a config override. Returns `None` when either half is
+/// unset or blank — the caller then lets the misconfiguration surface as a
+/// delivery-health auth error rather than signing with an empty key. BYOK
+/// variants (customer KMS / uploaded key) plug in here as alternative
+/// resolution paths keyed off the same reference.
+pub fn resolve_sls_credential(credential_ref: &str) -> Option<(String, String)> {
+    resolve_sls_credential_with(credential_ref, |key| std::env::var(key).ok())
+}
+
+/// Reference-resolution core, parameterized over the variable source so it is
+/// testable without mutating the process environment.
+fn resolve_sls_credential_with(
+    credential_ref: &str,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Option<(String, String)> {
+    let slug: String = credential_ref
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let id = lookup(&format!("SLS_CRED_{slug}_AK_ID"))?;
+    let secret = lookup(&format!("SLS_CRED_{slug}_AK_SECRET"))?;
+    if id.is_empty() || secret.is_empty() {
+        return None;
+    }
+    Some((id, secret))
+}
+
+/// Unix seconds (UTC) for the SLS log time. SLS expects a `u32` (valid until
+/// 2106); falls back to 0 only if the clock predates the epoch.
+fn now_unix_secs() -> u32 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as u32)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        base_url_for, is_transient_error_code, parse_sls_error, resolve_sls_credential_with,
+        AliyunSlsSink,
+    };
+    use crate::sink::{EventBatch, IdempotencyMarker, ObservabilitySink, SinkContent, SinkRecord};
+    use crate::usage::UsageEvent;
+    use aliyun_log_sdk_protobuf::LogGroupList;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const LOGSTORE: &str = "request-events";
+    const POST_PATH: &str = "/logstores/request-events/shards/lb";
+
+    /// Wrap a bare `LogGroup` message as the single element of a `LogGroupList`
+    /// (protobuf field #1, length-delimited) so the SDK decoder reads it back.
+    fn wrap_as_log_group_list(group: &[u8]) -> Vec<u8> {
+        let mut out = vec![0x0A]; // tag: field 1, wire type 2 (length-delimited)
+        let mut len = group.len();
+        loop {
+            let mut byte = (len & 0x7F) as u8;
+            len >>= 7;
+            if len != 0 {
+                byte |= 0x80; // continuation bit
+            }
+            out.push(byte);
+            if len == 0 {
+                break;
+            }
+        }
+        out.extend_from_slice(group);
+        out
+    }
+
+    /// Decode the request body a mock server captured back into the flat
+    /// key→value content map of its single log (lz4-decompress using the
+    /// raw-size header, then protobuf-decode).
+    fn decode_single_log(req: &wiremock::Request) -> HashMap<String, String> {
+        let raw_size: usize = req
+            .headers
+            .get("x-log-bodyrawsize")
+            .expect("x-log-bodyrawsize header")
+            .to_str()
+            .unwrap()
+            .parse()
+            .expect("raw size is a number");
+        let raw = lz4_flex::block::decompress(&req.body, raw_size).expect("lz4 decompress");
+        let list = LogGroupList::decode(&wrap_as_log_group_list(&raw)).expect("protobuf decode");
+        let groups = list.log_groups();
+        assert_eq!(groups.len(), 1, "exactly one LogGroup");
+        let logs = groups[0].logs();
+        assert_eq!(logs.len(), 1, "exactly one Log");
+        logs[0]
+            .contents()
+            .iter()
+            .map(|c| (c.key().clone(), c.value().clone()))
+            .collect()
+    }
+
+    fn sink_for(server: &MockServer) -> AliyunSlsSink {
+        AliyunSlsSink::from_base_url(
+            "sls-test",
+            server.uri(),
+            LOGSTORE,
+            "test-akid",
+            "test-secret",
+            reqwest::Client::new(),
+        )
+    }
+
+    fn batch_of(records: Vec<SinkRecord>) -> EventBatch {
+        EventBatch::new(records.into_iter().map(Arc::new).collect())
+    }
+
+    #[tokio::test]
+    async fn appends_batch_posts_signed_lz4_protobuf() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(POST_PATH))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let sink = sink_for(&server);
+        let event = UsageEvent {
+            request_id: "req-42".into(),
+            occurred_at: "2026-05-01T12:00:00Z".into(),
+            model_id: "gpt-4o".into(),
+            status_code: 200,
+            prompt_tokens: 5,
+            completion_tokens: 7,
+            latency_ms: 123,
+            ..UsageEvent::default()
+        };
+        let ack = sink
+            .append_batch(
+                &batch_of(vec![SinkRecord::metadata_only(event)]),
+                &IdempotencyMarker::None,
+            )
+            .await
+            .expect("delivery succeeds");
+        assert_eq!(ack.accepted, 1);
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let req = &requests[0];
+
+        // Wire shape: signed PutLogs over lz4 protobuf.
+        assert_eq!(req.method.as_str(), "POST");
+        assert_eq!(req.url.path(), POST_PATH);
+        assert_eq!(
+            req.headers.get("content-type").unwrap().to_str().unwrap(),
+            "application/x-protobuf"
+        );
+        assert_eq!(
+            req.headers
+                .get("x-log-compresstype")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "lz4"
+        );
+        assert_eq!(
+            req.headers
+                .get("x-log-apiversion")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "0.6.0"
+        );
+        let auth = req.headers.get("authorization").unwrap().to_str().unwrap();
+        assert!(
+            auth.starts_with("LOG test-akid:"),
+            "signature carries the access-key id, not the secret: {auth}"
+        );
+        assert!(
+            !auth.contains("test-secret"),
+            "secret must never be on the wire"
+        );
+        assert!(req.headers.contains_key("date"));
+        assert!(req.headers.contains_key("content-md5"));
+
+        // Body round-trips: the mapped fields land as flat contents.
+        let contents = decode_single_log(req);
+        assert_eq!(
+            contents.get("schema_version").map(String::as_str),
+            Some("1.0")
+        );
+        assert_eq!(
+            contents.get("request_id").map(String::as_str),
+            Some("req-42")
+        );
+        assert_eq!(
+            contents.get("occurred_at").map(String::as_str),
+            Some("2026-05-01T12:00:00Z")
+        );
+        assert_eq!(contents.get("model_id").map(String::as_str), Some("gpt-4o"));
+        assert_eq!(contents.get("status_code").map(String::as_str), Some("200"));
+        assert_eq!(contents.get("prompt_tokens").map(String::as_str), Some("5"));
+        assert_eq!(
+            contents.get("completion_tokens").map(String::as_str),
+            Some("7")
+        );
+        assert_eq!(contents.get("latency_ms").map(String::as_str), Some("123"));
+        // Empty metadata is omitted uniformly: `api_key_id` (serde `default`
+        // only, would serialize as "") and `finish_reason` (`skip_serializing_if`)
+        // both drop out, so the SLS log carries no blank columns.
+        assert!(!contents.contains_key("api_key_id"));
+        assert!(!contents.contains_key("finish_reason"));
+        // Metadata-only path never carries a prompt.
+        assert!(!contents.contains_key("prompt"));
+    }
+
+    #[tokio::test]
+    async fn full_content_record_emits_prompt_and_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(POST_PATH))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let sink = sink_for(&server);
+        let record = SinkRecord::metadata_only(UsageEvent {
+            request_id: "req-content".into(),
+            status_code: 200,
+            ..UsageEvent::default()
+        })
+        .with_content(SinkContent {
+            prompt: "what is 2+2?".into(),
+            response: "4".into(),
+            truncated: true,
+        });
+        sink.append_batch(&batch_of(vec![record]), &IdempotencyMarker::None)
+            .await
+            .expect("delivery succeeds");
+
+        let requests = server.received_requests().await.unwrap();
+        let contents = decode_single_log(&requests[0]);
+        assert_eq!(
+            contents.get("prompt").map(String::as_str),
+            Some("what is 2+2?")
+        );
+        assert_eq!(contents.get("response").map(String::as_str), Some("4"));
+        assert_eq!(
+            contents.get("content_truncated").map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[tokio::test]
+    async fn server_error_is_transient() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(POST_PATH))
+            .respond_with(ResponseTemplate::new(500).set_body_string(
+                r#"{"errorCode":"InternalServerError","errorMessage":"try again"}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let err = sink_for(&server)
+            .append_batch(
+                &batch_of(vec![SinkRecord::metadata_only(UsageEvent::default())]),
+                &IdempotencyMarker::None,
+            )
+            .await
+            .expect_err("5xx fails");
+        assert!(err.is_transient(), "5xx must be retried: {err}");
+    }
+
+    #[tokio::test]
+    async fn auth_error_is_permanent() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(POST_PATH))
+            .respond_with(ResponseTemplate::new(403).set_body_string(
+                r#"{"errorCode":"SignatureNotMatch","errorMessage":"signature mismatch"}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let err = sink_for(&server)
+            .append_batch(
+                &batch_of(vec![SinkRecord::metadata_only(UsageEvent::default())]),
+                &IdempotencyMarker::None,
+            )
+            .await
+            .expect_err("bad signature fails");
+        assert!(!err.is_transient(), "auth error must not be retried: {err}");
+    }
+
+    #[tokio::test]
+    async fn quota_exceeded_on_4xx_is_transient() {
+        // SLS signals shard write throttling with a 4xx + a quota code; a log
+        // sink must back off and retry, not drop the batch.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(POST_PATH))
+            .respond_with(ResponseTemplate::new(403).set_body_string(
+                r#"{"errorCode":"WriteQuotaExceed","errorMessage":"shard write quota exceeded"}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let err = sink_for(&server)
+            .append_batch(
+                &batch_of(vec![SinkRecord::metadata_only(UsageEvent::default())]),
+                &IdempotencyMarker::None,
+            )
+            .await
+            .expect_err("quota exceeded fails this attempt");
+        assert!(
+            err.is_transient(),
+            "quota-exceed on a 4xx must be retried: {err}"
+        );
+    }
+
+    #[test]
+    fn transient_error_codes_are_recognised() {
+        for code in [
+            "WriteQuotaExceed",
+            "ShardWriteQuotaExceed",
+            "ReadQuotaExceed",
+            "ServerBusy",
+            "InternalServerError",
+            "ServiceUnavailable",
+            "RequestTimeExpired",
+            "RequestTimeTooSkewed",
+        ] {
+            assert!(is_transient_error_code(code), "{code} should be transient");
+        }
+        for code in [
+            "SignatureNotMatch",
+            "Unauthorized",
+            "ParameterInvalid",
+            "PostBodyInvalid",
+            "LogStoreNotExist",
+            "",
+        ] {
+            assert!(!is_transient_error_code(code), "{code} should be permanent");
+        }
+    }
+
+    #[test]
+    fn parse_sls_error_extracts_code_and_masks_body() {
+        let (code, detail) = parse_sls_error(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"{"errorCode":"SignatureNotMatch","errorMessage":"bad sig"}"#,
+        );
+        assert_eq!(code, "SignatureNotMatch");
+        assert!(detail.contains("SignatureNotMatch"));
+        assert!(detail.contains("403"));
+
+        // Non-envelope body falls back to the raw (truncated) text.
+        let (code, detail) = parse_sls_error(reqwest::StatusCode::BAD_GATEWAY, "<html>502</html>");
+        assert_eq!(code, "");
+        assert!(detail.contains("502"));
+    }
+
+    #[test]
+    fn base_url_prepends_project_for_a_region_host() {
+        assert_eq!(
+            base_url_for("ap-southeast-3.log.aliyuncs.com", "aisix-obs"),
+            "https://aisix-obs.ap-southeast-3.log.aliyuncs.com"
+        );
+        // Trailing slash trimmed.
+        assert_eq!(
+            base_url_for("cn-hangzhou.log.aliyuncs.com/", "p"),
+            "https://p.cn-hangzhou.log.aliyuncs.com"
+        );
+    }
+
+    #[test]
+    fn base_url_uses_a_scheme_qualified_endpoint_verbatim() {
+        // A loopback mock is posted to directly — no `<project>.` prefix.
+        assert_eq!(
+            base_url_for("http://mock-sls:9000", "aisix-obs"),
+            "http://mock-sls:9000"
+        );
+    }
+
+    #[test]
+    fn resolve_credential_maps_reference_to_env_keys() {
+        // The ref folds to an upper `_`-joined slug; both halves come from
+        // `SLS_CRED_<SLUG>_AK_{ID,SECRET}`.
+        let store = |key: &str| match key {
+            "SLS_CRED_SLS_PROD_AK_ID" => Some("akid-123".to_string()),
+            "SLS_CRED_SLS_PROD_AK_SECRET" => Some("secret-456".to_string()),
+            _ => None,
+        };
+        assert_eq!(
+            resolve_sls_credential_with("sls-prod", store),
+            Some(("akid-123".to_string(), "secret-456".to_string()))
+        );
+        // Case-insensitive: `SLS.Prod` folds to the same slug.
+        assert_eq!(
+            resolve_sls_credential_with("SLS.Prod", store),
+            Some(("akid-123".to_string(), "secret-456".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_credential_is_none_when_unset_or_blank() {
+        // Neither half present.
+        assert_eq!(resolve_sls_credential_with("missing", |_| None), None);
+        // Id present, secret missing → still None (never sign half-credentialed).
+        let id_only = |key: &str| (key == "SLS_CRED_X_AK_ID").then(|| "id".to_string());
+        assert_eq!(resolve_sls_credential_with("x", id_only), None);
+        // Blank value is treated as unset.
+        assert_eq!(
+            resolve_sls_credential_with("x", |_| Some(String::new())),
+            None
+        );
+    }
+}
+
+/// Real-SLS smoke test — the one-off validation that Aliyun actually accepts
+/// our signed PutLogs (the signature / lz4 / protobuf a mock receiver cannot
+/// check). `#[ignore]` + env-gated, so the normal suite never touches the
+/// network; run against real SLS with the creds present via
+/// `cargo test -p aisix-obs -- --ignored sls_smoke`.
+#[cfg(test)]
+mod smoke {
+    use super::{base_url_for, now_unix_secs, AliyunSlsSink};
+    use crate::sink::{EventBatch, IdempotencyMarker, ObservabilitySink, SinkError, SinkRecord};
+    use crate::usage::UsageEvent;
+    use aliyun_log_sdk_sign::{sign_v1, QueryParams};
+    use http::header::CONTENT_TYPE;
+    use http::{HeaderMap, HeaderValue, Method};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn env(key: &str) -> Option<String> {
+        std::env::var(key).ok().filter(|v| !v.is_empty())
+    }
+
+    #[tokio::test]
+    #[ignore = "hits real Aliyun SLS; needs AISIX_E2E_SLS_* creds. \
+                Run: cargo test -p aisix-obs -- --ignored sls_smoke"]
+    async fn sls_smoke_putlogs_and_readback() {
+        // Env-gate so `--ignored` is safe without creds (CI injects them).
+        let (Some(ak_id), Some(ak_secret), Some(endpoint), Some(project), Some(logstore)) = (
+            env("AISIX_E2E_SLS_AK_ID"),
+            env("AISIX_E2E_SLS_AK_SECRET"),
+            env("AISIX_E2E_SLS_ENDPOINT"),
+            env("AISIX_E2E_SLS_PROJECT"),
+            env("AISIX_E2E_SLS_LOGSTORE"),
+        ) else {
+            eprintln!("sls_smoke: AISIX_E2E_SLS_* not set — skipping real-SLS smoke");
+            return;
+        };
+
+        let client = reqwest::Client::new();
+        let marker = format!("smoke-{}", uuid::Uuid::new_v4());
+
+        // ── 1. PutLogs through the real sink path (the hard assertion). ──
+        // A 2xx here means Aliyun accepted our v1 signature, lz4 block, and
+        // protobuf LogGroup — exactly what a mock receiver cannot validate.
+        let sink = AliyunSlsSink::new(
+            "smoke",
+            &endpoint,
+            &project,
+            &logstore,
+            ak_id.clone(),
+            ak_secret.clone(),
+            client.clone(),
+        );
+        let event = UsageEvent {
+            request_id: marker.clone(),
+            occurred_at: "2026-01-01T00:00:00Z".into(),
+            model_id: "smoke-model".into(),
+            status_code: 200,
+            prompt_tokens: 1,
+            completion_tokens: 2,
+            latency_ms: 7,
+            ..UsageEvent::default()
+        };
+        let batch = EventBatch::new(vec![Arc::new(SinkRecord::metadata_only(event))]);
+        // A Permanent error (bad signature / auth / payload) is a real
+        // regression — fail fast. A Transient one (network / 5xx) is retried a
+        // few times so an SLS blip doesn't flake the CI gate.
+        let mut transient: Option<SinkError> = None;
+        for attempt in 0..3 {
+            match sink.append_batch(&batch, &IdempotencyMarker::None).await {
+                Ok(_) => {
+                    transient = None;
+                    break;
+                }
+                Err(e @ SinkError::Permanent(_)) => {
+                    panic!("real SLS rejected the signed PutLogs (permanent): {e}")
+                }
+                Err(e) => {
+                    eprintln!("sls_smoke: PutLogs attempt {attempt} transient: {e}");
+                    transient = Some(e);
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+            }
+        }
+        if let Some(e) = transient {
+            panic!("real SLS PutLogs failed after retries (transient): {e}");
+        }
+        eprintln!("sls_smoke: PutLogs accepted by real SLS (request_id={marker})");
+
+        // ── 2. GetLogs readback (best-effort confirmation). ──
+        // Whether the event is queryable depends on the logstore having an
+        // index and SLS's indexing lag, so a miss is reported, not asserted —
+        // the PutLogs 2xx above is the real signal. The diagnostics make the
+        // first real run debuggable so this can later be hardened to assert.
+        let base_url = base_url_for(&endpoint, &project);
+        match readback(&client, &base_url, &logstore, &ak_id, &ak_secret, &marker).await {
+            Ok(true) => eprintln!("sls_smoke: readback found request_id={marker}"),
+            Ok(false) => eprintln!(
+                "sls_smoke: readback did NOT find request_id={marker} within timeout \
+                 (logstore index / indexing lag?) — PutLogs still succeeded"
+            ),
+            Err(e) => eprintln!("sls_smoke: readback error: {e} — PutLogs still succeeded"),
+        }
+    }
+
+    /// Poll GetLogs (`POST /logstores/<ls>/logs`, signed like PutLogs) for the
+    /// marker request_id. Returns `Ok(true)` once found, `Ok(false)` after the
+    /// poll budget, `Err` on a transport/encode failure.
+    async fn readback(
+        client: &reqwest::Client,
+        base_url: &str,
+        logstore: &str,
+        ak_id: &str,
+        ak_secret: &str,
+        marker: &str,
+    ) -> Result<bool, String> {
+        let path = format!("/logstores/{logstore}/logs");
+        let url = format!("{base_url}{path}");
+        let now = now_unix_secs() as i64;
+        for attempt in 0..20 {
+            let body = serde_json::json!({
+                "from": now - 600,
+                "to": now + 120,
+                "query": format!("request_id: \"{marker}\""),
+                "line": 100,
+                "offset": 0,
+                "reverse": true,
+            });
+            let body_bytes = serde_json::to_vec(&body).map_err(|e| e.to_string())?;
+            let mut headers = HeaderMap::new();
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+            sign_v1(
+                ak_id,
+                ak_secret,
+                None,
+                Method::POST,
+                &path,
+                &mut headers,
+                QueryParams::empty(),
+                Some(&body_bytes),
+            )
+            .map_err(|e| format!("sign: {e}"))?;
+            let resp = client
+                .post(&url)
+                .headers(headers)
+                .body(body_bytes)
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                eprintln!(
+                    "sls_smoke: GetLogs attempt {attempt}: HTTP {status}: {}",
+                    text.chars().take(200).collect::<String>()
+                );
+            } else if response_contains(&text, marker) {
+                return Ok(true);
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        }
+        Ok(false)
+    }
+
+    /// True if any returned log's `request_id` equals `marker`. Tolerates both
+    /// the `{ "data": [...] }` envelope and a bare `[...]` array.
+    fn response_contains(text: &str, marker: &str) -> bool {
+        #[derive(serde::Deserialize)]
+        struct Envelope {
+            data: Vec<HashMap<String, String>>,
+        }
+        let logs: Vec<HashMap<String, String>> = serde_json::from_str::<Envelope>(text)
+            .map(|e| e.data)
+            .or_else(|_| serde_json::from_str::<Vec<HashMap<String, String>>>(text))
+            .unwrap_or_default();
+        logs.iter()
+            .any(|log| log.get("request_id").map(String::as_str) == Some(marker))
+    }
+}

--- a/schemas/resources/observability_exporter.schema.json
+++ b/schemas/resources/observability_exporter.schema.json
@@ -29,6 +29,41 @@
           ]
         }
       }
+    },
+    {
+      "description": "Aliyun SLS (Simple Log Service) PutLogs target. Unlike `otlp_http`, the AccessKey is **never** part of this config: it would otherwise sit in plaintext on the kine path, and SLS keys grant broad account access. Instead the config carries a [`credential_ref`] pointer that the customer-side DP resolves to the real key locally (env / mounted secret); API7's control plane stores only the reference. This is what lets the DP run in the customer's environment without API7 ever holding the plaintext key.\n\n[`credential_ref`]: AliyunSlsConfig::credential_ref",
+      "type": "object",
+      "required": [
+        "credential_ref",
+        "endpoint",
+        "kind",
+        "logstore",
+        "project"
+      ],
+      "properties": {
+        "credential_ref": {
+          "description": "Opaque pointer to the AccessKey credential, resolved locally by the DP at delivery time. The plaintext AccessKey MUST NOT live in etcd/kine — the control plane stores only this reference, never the key itself. BYOK variants (customer KMS / uploaded key) resolve the same reference through a different unwrap path in a later phase.",
+          "type": "string"
+        },
+        "endpoint": {
+          "description": "SLS region endpoint host with no scheme, e.g. `ap-southeast-3.log.aliyuncs.com`. The request host the DP signs and posts to is `<project>.<endpoint>`.",
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "aliyun_sls"
+          ]
+        },
+        "logstore": {
+          "description": "SLS logstore that receives the request-event logs.",
+          "type": "string"
+        },
+        "project": {
+          "description": "SLS project name (the `<project>` in the request host).",
+          "type": "string"
+        }
+      }
     }
   ],
   "required": [

--- a/tests/e2e/src/cases/aliyun-sls-exporter-e2e.test.ts
+++ b/tests/e2e/src/cases/aliyun-sls-exporter-e2e.test.ts
@@ -1,0 +1,225 @@
+import { createHash } from "node:crypto";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// L2 mock e2e (AISIX-Cloud#687): a dashboard-configured `aliyun_sls`
+// exporter makes the real DP deliver request events to SLS over a signed
+// PutLogs call. We stand up a mock SLS receiver, register the exporter, drive
+// one chat, and assert the DP POSTed a correctly-shaped, signed lz4-protobuf
+// PutLogs to the configured logstore.
+//
+// Scope boundary (deliberate): the mock cannot validate the SLS signature or
+// decode the lz4+protobuf body, so this test pins the WIRING and wire SHAPE —
+// path, the SLS headers, the lz4 framing, and that the Authorization carries
+// the AccessKey the DP resolved from its environment (proving the
+// credential_ref → env path, not a key on the kine config). The body's field
+// mapping is covered by the Rust round-trip unit test (`sink::sls::tests`),
+// and that a real Aliyun endpoint actually accepts the signed request is
+// covered by the one-off real-SLS smoke (`sls_smoke`, env-gated).
+
+const CALLER_PLAINTEXT = "sk-sls-exporter-caller-PLAINTEXT";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+const PROVIDER_SECRET = "sk-mock-sls-exporter";
+
+// The exporter's credential_ref; the DP resolves it from the env vars the
+// harness injects (SLS_CRED_<REF>_AK_{ID,SECRET}, ref upper-cased).
+const CREDENTIAL_REF = "mock";
+const MOCK_AK_ID = "mock-akid";
+const MOCK_AK_SECRET = "mock-secret";
+const SLS_PROJECT = "aisix-e2e-obs";
+const SLS_LOGSTORE = "request-events";
+const PUTLOGS_PATH = `/logstores/${SLS_LOGSTORE}/shards/lb`;
+
+interface CapturedPutLogs {
+  method: string;
+  path: string;
+  headers: IncomingMessage["headers"];
+  bodyLen: number;
+}
+
+interface MockSls {
+  /** Base URL the exporter points at (no `<project>.` prefix; sink uses it verbatim). */
+  url: string;
+  requests: CapturedPutLogs[];
+  close(): Promise<void>;
+}
+
+async function startMockSls(): Promise<MockSls> {
+  const requests: CapturedPutLogs[] = [];
+  const server: Server = createServer((req, res) => {
+    // Only the byte count matters here (lz4+protobuf decoding lives in the
+    // Rust round-trip test), so accumulate length instead of the bytes.
+    let bodyLen = 0;
+    req.on("data", (c: Buffer) => {
+      bodyLen += c.length;
+    });
+    req.on("end", () => {
+      requests.push({
+        method: req.method ?? "",
+        path: (req.url ?? "").split("?")[0],
+        headers: req.headers,
+        bodyLen,
+      });
+      // SLS PutLogs returns 200 with an empty body on success.
+      res.statusCode = 200;
+      res.end();
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${port}`,
+    requests,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+async function seedRouting(admin: AdminClient, upstream: OpenAiUpstream) {
+  const pk = await admin.createProviderKey({
+    display_name: "sls-exporter-pk",
+    secret: PROVIDER_SECRET,
+    api_base: `${upstream.baseUrl}/v1`,
+  });
+  await admin.createModel({
+    display_name: "sls-exporter-model",
+    provider: "openai",
+    model_name: "gpt-4o-mini",
+    provider_key_id: pk.id,
+  });
+  await admin.createApiKey({
+    key_hash: CALLER_KEY_HASH,
+    allowed_models: ["sls-exporter-model"],
+  });
+}
+
+async function chat(app: SpawnedApp): Promise<Response> {
+  return fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "sls-exporter-model",
+      messages: [{ role: "user", content: "hello sls" }],
+    }),
+  });
+}
+
+async function waitForPutLogs(
+  sls: MockSls,
+  timeoutMs = 10_000,
+): Promise<CapturedPutLogs> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hit = sls.requests.find((r) => r.path === PUTLOGS_PATH);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`no PutLogs to ${PUTLOGS_PATH} recorded within ${timeoutMs}ms`);
+}
+
+function headerValue(
+  headers: IncomingMessage["headers"],
+  name: string,
+): string {
+  const v = headers[name];
+  return Array.isArray(v) ? (v[0] ?? "") : (v ?? "");
+}
+
+describe("aliyun_sls exporter e2e (#687): DP delivers a signed PutLogs to SLS", () => {
+  let etcdReachable = false;
+  let upstream: OpenAiUpstream | undefined;
+  let sls: MockSls | undefined;
+  const apps: SpawnedApp[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    upstream = await startOpenAiUpstream();
+    sls = await startMockSls();
+  });
+
+  afterAll(async () => {
+    await Promise.all(apps.map((a) => a.exit()));
+    await upstream?.close();
+    await sls?.close();
+  });
+
+  test(
+    "a configured aliyun_sls exporter posts a signed lz4-protobuf PutLogs per chat",
+    async (ctx) => {
+      if (!etcdReachable || !upstream || !sls) {
+        ctx.skip();
+        return;
+      }
+      const app = await spawnApp({
+        // The AccessKey rides the DP's own env, never the kine config.
+        extraEnv: {
+          [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: MOCK_AK_ID,
+          [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: MOCK_AK_SECRET,
+        },
+      });
+      apps.push(app);
+      const admin = new AdminClient(app.adminUrl, app.adminKey);
+      await admin.createObservabilityExporter({
+        name: "mock-sls",
+        enabled: true,
+        kind: "aliyun_sls",
+        endpoint: sls.url,
+        project: SLS_PROJECT,
+        logstore: SLS_LOGSTORE,
+        credential_ref: CREDENTIAL_REF,
+      });
+      await seedRouting(admin, upstream);
+
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await chat(app);
+          await r.text();
+          return r.status === 200;
+        } catch {
+          return false;
+        }
+      });
+
+      const res = await chat(app);
+      expect(res.status).toBe(200);
+      await res.text();
+
+      const put = await waitForPutLogs(sls);
+
+      // Correct logstore + verb.
+      expect(put.method).toBe("POST");
+      expect(put.path).toBe(PUTLOGS_PATH);
+      // SLS PutLogs wire shape: protobuf body, lz4 block compression, API ver.
+      expect(headerValue(put.headers, "content-type")).toBe("application/x-protobuf");
+      expect(headerValue(put.headers, "x-log-compresstype")).toBe("lz4");
+      expect(headerValue(put.headers, "x-log-apiversion")).toBe("0.6.0");
+      // Uncompressed size present and non-trivial (a real LogGroup was built).
+      expect(Number(headerValue(put.headers, "x-log-bodyrawsize"))).toBeGreaterThan(0);
+      expect(put.bodyLen).toBeGreaterThan(0);
+      // Signature carries the AccessKey id the DP resolved from its env —
+      // proves credential_ref → env resolution wired into signing, and that
+      // the secret never appears on the wire.
+      const auth = headerValue(put.headers, "authorization");
+      expect(auth.startsWith(`LOG ${MOCK_AK_ID}:`)).toBe(true);
+      expect(auth.includes(MOCK_AK_SECRET)).toBe(false);
+    },
+    60_000,
+  );
+});

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -28,6 +28,14 @@ export interface AppOverrides {
     recursive?: boolean;
     header?: string;
   };
+  /**
+   * Extra environment variables for the spawned binary, applied AFTER the
+   * `AISIX_*` strip. Use for non-config secrets the DP reads from its own
+   * environment rather than from the kine config — e.g.
+   * `SLS_CRED_<REF>_AK_ID` / `_AK_SECRET` for an `aliyun_sls` exporter, whose
+   * AccessKey deliberately never travels on the config path.
+   */
+  extraEnv?: Record<string, string>;
 }
 
 export interface SpawnedApp {
@@ -113,6 +121,12 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
   childEnv.all_proxy = "";
   childEnv.NO_PROXY = "127.0.0.1,localhost";
   childEnv.no_proxy = "127.0.0.1,localhost";
+
+  // Non-config secrets the DP reads straight from its environment (e.g.
+  // SLS AccessKeys). Applied last so they survive the AISIX_* strip above.
+  for (const [k, v] of Object.entries(overrides.extraEnv ?? {})) {
+    childEnv[k] = v;
+  }
 
   const child = spawn(BIN_PATH, ["--config", cfgPath], {
     stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

Introduces a pluggable observability-sink framework and lands its first real vendor — **Aliyun SLS** — so the DP can ship per-request telemetry (and, later, full prompt/response) to customer log/analytics backends without a bespoke connector per vendor.

Driven by the pre-sales requirement on api7/AISIX-Cloud#687 (customer wants AI Gateway logs in Aliyun SLS) and the generic-integration design in api7/AISIX-Cloud#692.

### Framework (one implementation per *family*, not per vendor)
- `ObservabilitySink` trait + `SinkCapabilities` matrix (idempotency / ordering / batch-unit / partial-batch / streaming) so the shared pipeline adapts to a sink's wire contract as **data, not a fork**.
- `SinkPipeline` — bounded mpsc → batch → retry/backoff → drop-with-metric, one per exporter.
- `ExporterPipelines` manager — lazy `get_or_create` (immediate consistency) + `retain` GC.
- The existing OTLP/HTTP fan-out is migrated onto this pipeline (`OtlpSink`), behaviour-preserving (the `usage-client-source` e2e is the regression gate).

### Aliyun SLS exporter
- `AliyunSlsSink` (http_batch family): one protobuf `LogGroup` per batch → lz4 **block** compression → SLS signature **v1 (HMAC-SHA1)** → `POST /logstores/<ls>/shards/lb`. Built on the official `aliyun-log-sdk-protobuf` / `aliyun-log-sdk-sign` sub-crates over the existing **rustls** reqwest — **no OpenSSL / native-tls** is pulled in.
- `ExporterKind::AliyunSls` carries a **`credential_ref`, never the AccessKey** — the plaintext key never rides the kine path. The DP resolves the ref from its local env (`SLS_CRED_<REF>_AK_{ID,SECRET}`, deliberately **not** the `AISIX_` prefix the config loader claims). BYOK variants slot into the same resolution point later.
- `fan_out` generalized to dispatch per kind over one shared `ExporterPipelines` + client; **all 7 proxy call sites unchanged**.

## Key design decisions
- **No plaintext credentials in etcd** — `credential_ref` + local env resolution; `rejects_plaintext_credentials_in_config` pins it at the serde + schema layers.
- **Field mapping serializes `UsageEvent`** (single-sources the schema + its `skip_serializing_if` rules) rather than hand-listing 35 fields; opt-in prompt/response land as flat fields, absent on the default metadata-only path so prompts cannot leak.
- **Error classification** mirrors `OtlpSink` (5xx/408/429 → transient) **plus** SLS `errorCode`-aware promotion, so a 4xx quota/busy/clock-skew is retried, not dropped (a log sink must not drop under throttling).
- Endpoint handling: a bare region host → `https://<project>.<host>`; a scheme-qualified loopback (the e2e mock) is used verbatim.

## Test plan
- **Unit**: `aisix-core` 204 passed, `aisix-obs` 75 passed (sink encode/sign/lz4 round-trip decode, error classification incl. quota→transient, credential resolver, schema validators). clippy `-D warnings` clean; `schemas/` regenerated (schema-drift gate).
- **L2 mock e2e** (`aliyun-sls-exporter-e2e`): a dashboard-configured `aliyun_sls` exporter makes the **real `aisix` binary** post a signed lz4-protobuf PutLogs to a mock SLS receiver on a real chat — asserts logstore path, SLS headers, lz4 framing, and that `Authorization` carries the **env-resolved** AccessKey id (secret never on the wire). ✅ passing.
- **OTLP regression gate** (`usage-client-source-e2e`): ✅ 2/2 — confirms the per-kind dispatch generalization preserved the OTLP path.
- **Real-SLS smoke** (`sls_smoke`, `#[ignore]` + env-gated): validates the v1 signature / lz4 / protobuf against the **live** SLS endpoint (the thing a mock cannot check). Runs in the new `sls-smoke` CI job with the SLS secrets injected; fork PRs skip cleanly. PutLogs→2xx is the hard assertion (Permanent error fails fast, Transient retries); GetLogs readback is best-effort with diagnostics pending its first real run.

## Deliberately out of scope (follow-ups)
- **Content capture** (full prompt/response into SLS — the customer's primary ask): the sink already emits content when a record carries it; the hot-path capture + size-cap + per-exporter gating is the next milestone. Current fan-out is metadata-only (parity with OTLP).
- **CP-side `aliyun_sls` support** (AISIX-Cloud / Go) — the DP accepts the kind via admin API + kine now; the dashboard/CP flow is separate per #687 ("DP first, then CP").
- Type rename `OtlpHttpFanOut → ExporterFanOut` and wiring the fan-out GC/shutdown loop — mechanical follow-ups kept out to avoid churn.
- 4 pre-existing `tsc --noEmit` errors in unrelated e2e files tracked in #527 (not touched here; my additions typecheck clean).

Refs: api7/AISIX-Cloud#687, api7/AISIX-Cloud#692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Aliyun SLS as an observability exporter backend with secure credential references and pluggable sink support.
  * Introduced resilient delivery pipelines with batching, retry, backpressure, and per-sink health/stats.

* **Tests**
  * Added CI smoke test and end-to-end test validating Aliyun SLS export behavior and headers.

* **Chores**
  * Updated CI to run the new SLS verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->