### PR TITLE
feat(obs): object_store sink — one S3/GCS/Azure exporter on the shared pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,10 +184,15 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "chrono",
+ "flate2",
+ "futures",
+ "hex",
  "http 1.4.0",
  "lz4_flex",
  "metrics",
  "metrics-exporter-prometheus",
+ "object_store",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -196,6 +201,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -1293,6 +1299,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,6 +2062,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2807,6 +2825,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,6 +3091,45 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper 1.9.0",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.1",
+ "reqwest",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -3451,6 +3518,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,6 +3625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3584,6 +3672,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -3757,6 +3851,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -3770,6 +3865,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.38",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,16 @@ hex = "0.4"
 moka = { version = "0.12", features = ["future"] }
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "cluster-async"] }
 
+# Object-storage observability sink (aisix-obs): ONE crate covering S3 / GCS /
+# Azure Blob (+ S3-compatible MinIO/R2) behind a single `ObjectStore` trait, so
+# the sink is written once, not per-provider. The cloud features pull reqwest
+# default-features=false + rustls, so this stays rustls-only — no OpenSSL /
+# native-tls (same posture as the SLS sub-crates above).
+object_store = { version = "0.13", default-features = false, features = ["aws", "gcp", "azure", "tls-webpki-roots"] }
+# NDJSON gzip for the object-storage sink. flate2's default miniz_oxide backend
+# is pure Rust — no zlib/C, consistent with the no-OpenSSL posture.
+flate2 = "1"
+
 # Tokenization / counting (optional hard-mode TPM)
 tiktoken-rs = "0.5"
 

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -39,7 +39,8 @@ pub use model::{
     Adapter, BackgroundModelCheck, CooldownConfig, Model, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use observability_exporter::{
-    AliyunSlsConfig, ExporterKind, ObservabilityExporter, OtlpHttpConfig,
+    AliyunSlsConfig, ExporterKind, ObjectStoreCompression, ObjectStoreConfig, ObjectStoreProvider,
+    ObservabilityExporter, OtlpHttpConfig,
 };
 pub use provider_key::{
     ParamConstraints, ProviderKey, RequestOverrides, ResponseOverrides, StreamDoneMarker,

--- a/crates/aisix-core/src/models/observability_exporter.rs
+++ b/crates/aisix-core/src/models/observability_exporter.rs
@@ -34,9 +34,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::resource::Resource;
 
-/// Discriminated union of exporter back-ends. Ships `otlp_http` and
-/// `aliyun_sls`; Datadog / S3 / … land in follow-ups, each as a new
-/// variant whose serde tag matches the wire-side `kind` discriminator.
+/// Discriminated union of exporter back-ends. Ships `otlp_http`,
+/// `aliyun_sls`, and `object_store` (S3 / GCS / Azure Blob, one variant);
+/// Datadog / … land in follow-ups, each as a new variant whose serde tag
+/// matches the wire-side `kind` discriminator.
 ///
 /// `tag = "kind"` puts the variant tag inline with the inner struct's
 /// fields — same shape as `GuardrailKind` so the kine wire stays
@@ -46,6 +47,7 @@ use crate::resource::Resource;
 pub enum ExporterKind {
     OtlpHttp(OtlpHttpConfig),
     AliyunSls(AliyunSlsConfig),
+    ObjectStore(ObjectStoreConfig),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
@@ -95,6 +97,74 @@ pub struct AliyunSlsConfig {
     /// key itself. BYOK variants (customer KMS / uploaded key) resolve the
     /// same reference through a different unwrap path in a later phase.
     pub credential_ref: String,
+}
+
+/// Object-storage sink — ONE config covering S3 / GCS / Azure Blob (and
+/// S3-compatible MinIO / Cloudflare R2 via `endpoint`) behind a single
+/// backend, so the sink is written once rather than per provider. Batched
+/// NDJSON files land under a date-partitioned, deterministic key layout that
+/// Snowpipe / Databricks Auto Loader ingest from. Like `aliyun_sls`, cloud
+/// credentials are **never** in this config: a [`credential_ref`] points at
+/// keys the DP resolves locally, so the control plane never holds the secret
+/// on the kine path.
+///
+/// [`credential_ref`]: ObjectStoreConfig::credential_ref
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ObjectStoreConfig {
+    /// Which object-storage backend the bucket lives in.
+    pub provider: ObjectStoreProvider,
+
+    /// Bucket (S3 / GCS) or container (Azure Blob) that receives the files.
+    pub bucket: String,
+
+    /// Key prefix the partition path is appended to, e.g. `ai-gateway`.
+    /// The full key is `<prefix>/org=…/env=…/table=…/dt=…/hh=…/<file>`.
+    pub prefix: String,
+
+    /// AWS region for S3 (SigV4 signature scope) — recommended; `object_store`
+    /// defaults to `us-east-1` when unset, so a non-default-region bucket
+    /// should set it. Ignored for GCS / Azure Blob.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+
+    /// Override the backend host for S3-compatible stores (MinIO, Aliyun
+    /// OSS, Cloudflare R2). Unset = the provider's native endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+
+    /// Compression applied to each NDJSON file before upload. Default gzip.
+    #[serde(default)]
+    pub compression: ObjectStoreCompression,
+
+    /// Opaque pointer to the cloud credentials, resolved locally by the DP
+    /// at delivery time. The plaintext key MUST NOT live in etcd/kine — the
+    /// control plane stores only this reference, never the secret itself.
+    pub credential_ref: String,
+}
+
+/// Object-storage backend selector. The sink builds one backend client per
+/// variant; everything downstream (batching, key layout, retry) is shared.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectStoreProvider {
+    S3,
+    Gcs,
+    AzureBlob,
+}
+
+/// File compression for object-storage uploads.
+#[derive(
+    Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq, Hash,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectStoreCompression {
+    /// gzip (RFC 1952) — the default; smaller egress, accepted by Snowpipe
+    /// and Auto Loader.
+    #[default]
+    Gzip,
+    /// No compression — raw NDJSON.
+    None,
 }
 
 /// Top-level `ObservabilityExporter` resource. `deny_unknown_fields`
@@ -279,6 +349,87 @@ mod tests {
         for key in ["access_key_secret", "access_key_id", "ak", "sk"] {
             let json = format!(
                 r#"{{"name":"x","kind":"aliyun_sls","endpoint":"ap-southeast-3.log.aliyuncs.com","project":"p","logstore":"l","credential_ref":"r","{key}":"AKIASECRET"}}"#
+            );
+            let r: Result<ObservabilityExporter, _> = serde_json::from_str(&json);
+            assert!(
+                r.is_err(),
+                "plaintext credential field `{key}` must be rejected"
+            );
+        }
+    }
+
+    const VALID_OBJECT_STORE: &str = r#"{
+        "name": "acme-s3-events",
+        "enabled": true,
+        "kind": "object_store",
+        "provider": "s3",
+        "bucket": "acme-aisix-events",
+        "prefix": "ai-gateway",
+        "region": "us-east-1",
+        "compression": "gzip",
+        "credential_ref": "acme-s3"
+    }"#;
+
+    #[test]
+    fn deserialises_object_store() {
+        let e: ObservabilityExporter = serde_json::from_str(VALID_OBJECT_STORE).unwrap();
+        assert_eq!(e.name, "acme-s3-events");
+        assert!(e.enabled);
+        match &e.kind {
+            ExporterKind::ObjectStore(c) => {
+                assert_eq!(c.provider, ObjectStoreProvider::S3);
+                assert_eq!(c.bucket, "acme-aisix-events");
+                assert_eq!(c.prefix, "ai-gateway");
+                assert_eq!(c.region.as_deref(), Some("us-east-1"));
+                assert_eq!(c.compression, ObjectStoreCompression::Gzip);
+                assert_eq!(c.credential_ref, "acme-s3");
+            }
+            other => panic!("expected object_store, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn object_store_defaults_compression_to_gzip_and_omits_optionals() {
+        // gcs with no region/endpoint/compression — defaults + Options apply.
+        let e: ObservabilityExporter = serde_json::from_str(
+            r#"{"name":"x","kind":"object_store","provider":"gcs","bucket":"b","prefix":"p","credential_ref":"r"}"#,
+        )
+        .unwrap();
+        match &e.kind {
+            ExporterKind::ObjectStore(c) => {
+                assert_eq!(c.provider, ObjectStoreProvider::Gcs);
+                assert_eq!(c.compression, ObjectStoreCompression::Gzip);
+                assert!(c.region.is_none());
+                assert!(c.endpoint.is_none());
+            }
+            other => panic!("expected object_store, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn object_store_round_trips_flat() {
+        let e: ObservabilityExporter = serde_json::from_str(VALID_OBJECT_STORE).unwrap();
+        let v = serde_json::to_value(&e).unwrap();
+        // Flat wire — kind tag + fields at the top level, never nested.
+        assert_eq!(v["kind"], "object_store");
+        assert_eq!(v["provider"], "s3");
+        assert_eq!(v["bucket"], "acme-aisix-events");
+        assert_eq!(v["credential_ref"], "acme-s3");
+        assert!(v.get("object_store").is_none(), "kind block must not nest");
+    }
+
+    #[test]
+    fn rejects_plaintext_credentials_in_object_store_config() {
+        // Cloud keys must NEVER be config fields — only `credential_ref`.
+        // `deny_unknown_fields` rejects any smuggled plaintext secret.
+        for key in [
+            "access_key_id",
+            "secret_access_key",
+            "sas_token",
+            "service_account_json",
+        ] {
+            let json = format!(
+                r#"{{"name":"x","kind":"object_store","provider":"s3","bucket":"b","prefix":"p","credential_ref":"r","{key}":"PLAINTEXT"}}"#
             );
             let r: Result<ObservabilityExporter, _> = serde_json::from_str(&json);
             assert!(

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -601,7 +601,7 @@ fn observability_exporter_schema() -> Value {
         "properties": {
             "name":    { "type": "string", "minLength": 1, "maxLength": 120 },
             "enabled": { "type": "boolean" },
-            "kind":    { "type": "string", "enum": ["otlp_http", "aliyun_sls"] },
+            "kind":    { "type": "string", "enum": ["otlp_http", "aliyun_sls", "object_store"] },
             // Shared field; the per-kind pattern is enforced in the branches.
             "endpoint": { "type": "string" },
             // otlp_http field.
@@ -614,7 +614,14 @@ fn observability_exporter_schema() -> Value {
             // the kine path).
             "project":        { "type": "string", "minLength": 1 },
             "logstore":       { "type": "string", "minLength": 1 },
-            "credential_ref": { "type": "string", "minLength": 1 }
+            "credential_ref": { "type": "string", "minLength": 1 },
+            // object_store fields (S3 / GCS / Azure Blob, one variant). Cloud
+            // credentials are NEVER here — only the shared `credential_ref`.
+            "provider":    { "type": "string", "enum": ["s3", "gcs", "azure_blob"] },
+            "bucket":      { "type": "string", "minLength": 1 },
+            "prefix":      { "type": "string", "minLength": 1 },
+            "region":      { "type": "string", "minLength": 1 },
+            "compression": { "type": "string", "enum": ["gzip", "none"] }
         },
         "allOf": [
             {
@@ -644,6 +651,22 @@ fn observability_exporter_schema() -> Value {
                         // the sink posts to directly.
                         "endpoint": {
                             "pattern": "^[a-z0-9][a-z0-9.-]*\\.aliyuncs\\.com$|^http://(mock-sls|127\\.0\\.0\\.1|localhost)(:[0-9]+)?$"
+                        }
+                    }
+                }
+            },
+            {
+                "if":   { "properties": { "kind": { "const": "object_store" } } },
+                "then": {
+                    "required": ["provider", "bucket", "prefix", "credential_ref"],
+                    "properties": {
+                        // `endpoint` is optional — set only for S3-compatible
+                        // stores (MinIO / OSS / R2). When present: https, or a
+                        // loopback emulator host (MinIO / Azurite /
+                        // fake-gcs-server) for the compose e2e — never a way to
+                        // redirect real traffic to an arbitrary plaintext host.
+                        "endpoint": {
+                            "pattern": "^https://.+|^http://(minio|azurite|fake-gcs-server|fake-gcs|127\\.0\\.0\\.1|localhost)(:[0-9]+)?(/.*)?$"
                         }
                     }
                 }
@@ -1371,6 +1394,69 @@ mod tests {
             "credential_ref": "mock"
         });
         validate_observability_exporter(&v).unwrap();
+    }
+
+    #[test]
+    fn exporter_object_store_happy_path() {
+        let v = json!({
+            "name": "acme-s3",
+            "kind": "object_store",
+            "provider": "s3",
+            "bucket": "acme-aisix-events",
+            "prefix": "ai-gateway",
+            "region": "us-east-1",
+            "credential_ref": "acme-s3"
+        });
+        validate_observability_exporter(&v).unwrap();
+    }
+
+    #[test]
+    fn exporter_object_store_requires_core_fields() {
+        // Each config missing one required object_store field is rejected.
+        let cases = [
+            json!({"name":"x","kind":"object_store","bucket":"b","prefix":"p","credential_ref":"r"}),
+            json!({"name":"x","kind":"object_store","provider":"s3","prefix":"p","credential_ref":"r"}),
+            json!({"name":"x","kind":"object_store","provider":"s3","bucket":"b","credential_ref":"r"}),
+            json!({"name":"x","kind":"object_store","provider":"s3","bucket":"b","prefix":"p"}),
+        ];
+        for v in cases {
+            assert!(
+                validate_observability_exporter(&v).is_err(),
+                "incomplete object_store config must be rejected: {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn exporter_object_store_rejects_bad_provider() {
+        let v = json!({
+            "name": "x", "kind": "object_store",
+            "provider": "wasabi", "bucket": "b", "prefix": "p", "credential_ref": "r"
+        });
+        assert!(validate_observability_exporter(&v).is_err());
+    }
+
+    #[test]
+    fn exporter_object_store_allows_loopback_minio_endpoint() {
+        // The e2e points the S3 sink at a local MinIO over http://.
+        let v = json!({
+            "name": "s3-e2e", "kind": "object_store",
+            "provider": "s3", "bucket": "b", "prefix": "p",
+            "endpoint": "http://minio:9000", "credential_ref": "mock"
+        });
+        validate_observability_exporter(&v).unwrap();
+    }
+
+    #[test]
+    fn exporter_object_store_rejects_plaintext_non_loopback_endpoint() {
+        // A non-loopback plaintext endpoint must be rejected — no exfil to an
+        // arbitrary http host.
+        let v = json!({
+            "name": "x", "kind": "object_store",
+            "provider": "s3", "bucket": "b", "prefix": "p",
+            "endpoint": "http://evil.example.com", "credential_ref": "r"
+        });
+        assert!(validate_observability_exporter(&v).is_err());
     }
 
     #[test]

--- a/crates/aisix-obs/Cargo.toml
+++ b/crates/aisix-obs/Cargo.toml
@@ -29,6 +29,13 @@ reqwest.workspace = true
 uuid.workspace = true
 base64.workspace = true
 parking_lot.workspace = true
+# Object-storage sink (S3/GCS/Azure behind one `ObjectStore` trait). `chrono`
+# renders the date-partitioned object key; `flate2` gzips NDJSON before upload.
+object_store.workspace = true
+chrono.workspace = true
+flate2.workspace = true
+sha2.workspace = true
+hex.workspace = true
 # Aliyun SLS sink — official protobuf + signature sub-crates (pure-Rust),
 # lz4 block compression, and `http` types for sign_v1. Transport is reqwest
 # (rustls), so no native-tls / OpenSSL is pulled in.
@@ -39,3 +46,4 @@ lz4_flex.workspace = true
 
 [dev-dependencies]
 wiremock.workspace = true
+futures.workspace = true

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -32,14 +32,16 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use aisix_core::models::{AliyunSlsConfig, ExporterKind, ObservabilityExporter, OtlpHttpConfig};
+use aisix_core::models::{
+    AliyunSlsConfig, ExporterKind, ObjectStoreConfig, ObservabilityExporter, OtlpHttpConfig,
+};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
 use crate::sink::{
-    resolve_sls_credential, AliyunSlsSink, BatchUnit, EventBatch, ExporterPipelines,
-    IdempotencyMarker, IdempotencyScheme, ObservabilitySink, OrderingScope, PipelineConfig,
-    SinkAck, SinkCapabilities, SinkError, SinkHealth, SinkRecord, SinkResult,
+    build_object_store_sink, resolve_sls_credential, AliyunSlsSink, BatchUnit, EventBatch,
+    ExporterPipelines, IdempotencyMarker, IdempotencyScheme, ObservabilitySink, OrderingScope,
+    PipelineConfig, SinkAck, SinkCapabilities, SinkError, SinkHealth, SinkRecord, SinkResult,
 };
 use crate::usage::UsageEvent;
 
@@ -164,6 +166,21 @@ impl OtlpHttpFanOut {
                             )) as Arc<dyn ObservabilitySink>
                         })
                 }
+                ExporterKind::ObjectStore(cfg) => {
+                    let fingerprint = fingerprint_object_store(cfg);
+                    let name = exp.name.clone();
+                    let cfg = cfg.clone();
+                    self.inner
+                        .exporters
+                        .get_or_create(&exp.name, fingerprint, move || {
+                            // Resolve cloud creds from the DP's local env and
+                            // build the backend at build time. Missing creds or
+                            // an un-buildable backend yield a sink that reports
+                            // the reason via delivery health (never a silent
+                            // drop) — mirroring the SLS path.
+                            build_object_store_sink(name, &cfg)
+                        })
+                }
             };
 
             let rec =
@@ -214,6 +231,24 @@ fn fingerprint_sls(cfg: &AliyunSlsConfig) -> u64 {
     cfg.endpoint.hash(&mut hasher);
     cfg.project.hash(&mut hasher);
     cfg.logstore.hash(&mut hasher);
+    cfg.credential_ref.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Hash an `object_store` exporter's delivery-relevant config. Covers only
+/// kine-visible fields (provider / bucket / prefix / region / endpoint /
+/// compression / credential_ref), never the resolved cloud key — rotating the
+/// secret under the *same* reference therefore takes effect on the next DP
+/// restart, not live. Any field change rebuilds the pipeline.
+fn fingerprint_object_store(cfg: &ObjectStoreConfig) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    cfg.provider.hash(&mut hasher);
+    cfg.bucket.hash(&mut hasher);
+    cfg.prefix.hash(&mut hasher);
+    cfg.region.hash(&mut hasher);
+    cfg.endpoint.hash(&mut hasher);
+    cfg.compression.hash(&mut hasher);
     cfg.credential_ref.hash(&mut hasher);
     hasher.finish()
 }

--- a/crates/aisix-obs/src/sink/mod.rs
+++ b/crates/aisix-obs/src/sink/mod.rs
@@ -14,6 +14,7 @@
 
 mod capabilities;
 mod manager;
+mod object_store;
 mod pipeline;
 mod record;
 mod sls;
@@ -22,6 +23,7 @@ pub use capabilities::{
     BatchUnit, ChannelKey, IdempotencyMarker, IdempotencyScheme, OrderingScope, SinkCapabilities,
 };
 pub use manager::ExporterPipelines;
+pub use object_store::{build_object_store_sink, ObjectStoreSink};
 pub use pipeline::{PipelineConfig, SinkHandle, SinkPipeline, SinkStatsSnapshot};
 pub use record::{EventBatch, SinkContent, SinkRecord, SCHEMA_VERSION};
 pub use sls::{resolve_sls_credential, AliyunSlsSink};

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -1,0 +1,930 @@
+//! Object-storage sink — ONE implementation covering S3 / GCS / Azure Blob
+//! (and S3-compatible MinIO / Cloudflare R2) behind the `object_store`
+//! crate's single `ObjectStore` trait. The sink is written **once**: only
+//! [`build_object_store`] is provider-specific (it picks the right builder,
+//! which owns SigV4 / GCS OAuth / Azure shared-key signing). Everything
+//! else — NDJSON encoding, gzip, the partitioned object key, error
+//! classification — is shared across all three backends.
+//!
+//! A batch becomes ONE object: the records are serialized to NDJSON (one
+//! [`SinkRecord`] per line, including opt-in captured content), optionally
+//! gzipped, and `put` under a **content-addressed** key
+//! `…/dt=YYYY-MM-DD/hh=HH/<sha256(body)[..32]>.ndjson[.gz]`. The content
+//! address makes an *in-process* retry reuse the **same** key (the pipeline
+//! retries the same batch on a transient error), so a downstream Snowpipe /
+//! Auto Loader dedups that retry by filename and does not double-load — the
+//! load-bearing property in AISIX-Cloud#689 §8. This is at-least-once across a
+//! DP restart (a re-batch yields a new key); restart-stable `FileSequence`
+//! markers and org/env partitioning are tracked as follow-ups.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use object_store::path::Path as ObjectPath;
+// `put` / `get` are on the `ObjectStoreExt` extension trait in object_store
+// 0.13; `ObjectStore` itself must also be in scope for `dyn ObjectStore`.
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
+use sha2::{Digest, Sha256};
+
+use aisix_core::models::observability_exporter::{
+    ObjectStoreCompression, ObjectStoreConfig, ObjectStoreProvider,
+};
+
+use super::{
+    BatchUnit, EventBatch, IdempotencyMarker, IdempotencyScheme, ObservabilitySink, OrderingScope,
+    SinkAck, SinkCapabilities, SinkError, SinkHealth, SinkResult,
+};
+
+/// Cap on a masked error-detail string surfaced to logs / health.
+const DETAIL_MAX_CHARS: usize = 200;
+
+/// A delivery target for one object-storage bucket (any provider).
+pub struct ObjectStoreSink {
+    name: String,
+    /// Provider-agnostic backend handle, built by [`build_object_store`].
+    store: Arc<dyn ObjectStore>,
+    /// Key prefix the partition path is appended to.
+    prefix: String,
+    compression: ObjectStoreCompression,
+}
+
+impl ObjectStoreSink {
+    /// Build a sink over an already-constructed backend. Production goes
+    /// through [`build_object_store`] to make the `store`; tests pass an
+    /// `InMemory` / `LocalFileSystem` store directly.
+    pub fn new(
+        name: impl Into<String>,
+        store: Arc<dyn ObjectStore>,
+        prefix: impl Into<String>,
+        compression: ObjectStoreCompression,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            store,
+            prefix: prefix.into(),
+            compression,
+        }
+    }
+
+    /// Serialize a batch to (optionally gzipped) NDJSON bytes — the object
+    /// body. One line per record; opt-in `content` rides along when present,
+    /// and is absent on the default metadata-only path.
+    fn encode(&self, batch: &EventBatch) -> Result<Vec<u8>, SinkError> {
+        let mut ndjson = Vec::with_capacity(batch.len() * 512);
+        for record in &batch.records {
+            serde_json::to_writer(&mut ndjson, record.as_ref())
+                .map_err(|e| SinkError::Permanent(format!("object_store: ndjson encode: {e}")))?;
+            ndjson.push(b'\n');
+        }
+        match self.compression {
+            ObjectStoreCompression::None => Ok(ndjson),
+            ObjectStoreCompression::Gzip => gzip(&ndjson),
+        }
+    }
+
+    /// Content-addressed object key. Deterministic in `(body, occurred_at)`,
+    /// so a retried batch maps to the same key (idempotent put + downstream
+    /// filename dedup). The `dt`/`hh` Hive partitions come from the first
+    /// record's event time, so they too are stable across a retry.
+    fn object_key(&self, body: &[u8], occurred_at: &str) -> String {
+        let (date, hour) = partition(occurred_at);
+        let digest = sha256_hex16(body);
+        let ext = match self.compression {
+            ObjectStoreCompression::Gzip => "ndjson.gz",
+            ObjectStoreCompression::None => "ndjson",
+        };
+        let prefix = self.prefix.trim_matches('/');
+        if prefix.is_empty() {
+            format!("dt={date}/hh={hour}/{digest}.{ext}")
+        } else {
+            format!("{prefix}/dt={date}/hh={hour}/{digest}.{ext}")
+        }
+    }
+}
+
+#[async_trait]
+impl ObservabilitySink for ObjectStoreSink {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self) -> SinkCapabilities {
+        SinkCapabilities {
+            // At-least-once. Content-addressed keys let a downstream loader
+            // dedup an *in-process* pipeline retry by filename (same batch →
+            // same body → same key), but this is NOT a restart-stable monotonic
+            // sequence: a re-batch after a DP restart yields a new key. So it
+            // declares `None` (like the SLS sink) until real `FileSequence`
+            // markers land (follow-up) — don't overstate the guarantee here.
+            idempotency: IdempotencyScheme::None,
+            // One object per flush; no cross-object ordering requirement.
+            ordering: OrderingScope::None,
+            // Count-bounded by the pipeline today (bodies stay small on the
+            // metadata-only path). Byte-aware chunking is required before full
+            // prompt/response content rides these records — else a large-content
+            // batch buffers raw + gzip in RAM unbounded per flush. Declaring a
+            // ceiling the sink can't yet self-enforce would be a false promise,
+            // so it stays `None` until rollover/chunking lands (follow-up).
+            batch_unit: BatchUnit::Bytes,
+            max_batch_bytes: None,
+            // The object uploads whole or is retried whole.
+            supports_partial_batch: false,
+            supports_streaming_ingest: false,
+        }
+    }
+
+    async fn append_batch(&self, batch: &EventBatch, _marker: &IdempotencyMarker) -> SinkResult {
+        if batch.is_empty() {
+            return Ok(SinkAck::default());
+        }
+        let body = self.encode(batch)?;
+        let occurred_at = batch
+            .records
+            .first()
+            .map(|r| r.usage.occurred_at.as_str())
+            .unwrap_or("");
+        let key = self.object_key(&body, occurred_at);
+        let path = ObjectPath::parse(&key)
+            .map_err(|e| SinkError::Permanent(format!("object_store: bad key {key}: {e}")))?;
+
+        match self.store.put(&path, PutPayload::from(body)).await {
+            Ok(_) => Ok(SinkAck {
+                accepted: batch.len(),
+                ..SinkAck::default()
+            }),
+            Err(e) => Err(map_object_store_err(e)),
+        }
+    }
+
+    async fn healthcheck(&self) -> SinkHealth {
+        // A real connectivity probe (and the CP "test connection" affordance)
+        // lands with the health surface; until then delivery errors surface
+        // via `SinkStats::last_error` (mirrors the other sinks).
+        SinkHealth::healthy()
+    }
+}
+
+/// Provider-resolved cloud credentials. The plaintext key never lives in the
+/// exporter config / kine path — it is resolved DP-side from a
+/// `credential_ref` (see [`resolve_object_store_credential`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObjectStoreCredentials {
+    S3 {
+        access_key_id: String,
+        secret_access_key: String,
+        session_token: Option<String>,
+    },
+    Gcs {
+        /// Service-account JSON.
+        service_account_key: String,
+    },
+    Azure {
+        account: String,
+        access_key: String,
+    },
+}
+
+/// Build the provider-agnostic [`ObjectStore`] handle for a configured
+/// exporter. **This is the only provider-specific code** — each arm picks the
+/// matching `object_store` builder, which owns that cloud's signing. An
+/// `endpoint` (S3-compatible MinIO / R2, or an emulator) is honored and HTTP
+/// is allowed only for explicit `http://` endpoints (loopback emulators).
+pub fn build_object_store(
+    provider: ObjectStoreProvider,
+    bucket: &str,
+    region: Option<&str>,
+    endpoint: Option<&str>,
+    creds: ObjectStoreCredentials,
+) -> Result<Arc<dyn ObjectStore>, SinkError> {
+    match (provider, creds) {
+        (
+            ObjectStoreProvider::S3,
+            ObjectStoreCredentials::S3 {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            },
+        ) => {
+            let mut b = object_store::aws::AmazonS3Builder::new()
+                .with_bucket_name(bucket)
+                .with_access_key_id(access_key_id)
+                .with_secret_access_key(secret_access_key);
+            if let Some(r) = region {
+                b = b.with_region(r);
+            }
+            if let Some(t) = session_token {
+                b = b.with_token(t);
+            }
+            if let Some(ep) = endpoint {
+                b = b.with_endpoint(ep);
+                // S3-compatible servers (MinIO / emulators) are path-style and
+                // commonly plaintext on loopback.
+                b = b.with_virtual_hosted_style_request(false);
+                if ep.starts_with("http://") {
+                    b = b.with_allow_http(true);
+                }
+            }
+            let store = b
+                .build()
+                .map_err(|e| SinkError::Permanent(format!("object_store: build s3: {e}")))?;
+            Ok(Arc::new(store))
+        }
+        (
+            ObjectStoreProvider::Gcs,
+            ObjectStoreCredentials::Gcs {
+                service_account_key,
+            },
+        ) => {
+            // GCS has no HTTP-endpoint override on the builder the way S3 /
+            // Azure do (`with_url` expects a `gs://` location, not a host). An
+            // emulator base URL (fake-gcs-server) or a private endpoint rides
+            // the service-account JSON's `gcs_base_url` field instead, so the
+            // `endpoint` config is intentionally not applied for GCS.
+            let b = object_store::gcp::GoogleCloudStorageBuilder::new()
+                .with_bucket_name(bucket)
+                .with_service_account_key(service_account_key);
+            let store = b
+                .build()
+                .map_err(|e| SinkError::Permanent(format!("object_store: build gcs: {e}")))?;
+            Ok(Arc::new(store))
+        }
+        (
+            ObjectStoreProvider::AzureBlob,
+            ObjectStoreCredentials::Azure {
+                account,
+                access_key,
+            },
+        ) => {
+            let mut b = object_store::azure::MicrosoftAzureBuilder::new()
+                .with_container_name(bucket)
+                .with_account(account)
+                .with_access_key(access_key);
+            if let Some(ep) = endpoint {
+                if ep.starts_with("http://") {
+                    b = b.with_allow_http(true);
+                }
+                b = b.with_endpoint(ep.to_string());
+            }
+            let store = b
+                .build()
+                .map_err(|e| SinkError::Permanent(format!("object_store: build azure: {e}")))?;
+            Ok(Arc::new(store))
+        }
+        // Provider / credential kind mismatch — a wiring bug at the call site.
+        (provider, _) => Err(SinkError::Permanent(format!(
+            "object_store: credentials do not match provider {provider:?}"
+        ))),
+    }
+}
+
+/// Build the ready-to-run sink for a configured `object_store` exporter:
+/// resolve credentials from the DP's local env, construct the backend, and
+/// wrap it in an [`ObjectStoreSink`]. If credentials are missing or the
+/// backend cannot be built, return a sink that reports the reason on every
+/// delivery (and as unhealthy), so the failure surfaces on the exporter-health
+/// panel rather than silently dropping events — mirroring the SLS path's
+/// "missing creds → auth error, not a silent drop" rule.
+pub fn build_object_store_sink(
+    name: String,
+    cfg: &ObjectStoreConfig,
+) -> Arc<dyn ObservabilitySink> {
+    let Some(creds) = resolve_object_store_credential(cfg.provider, &cfg.credential_ref) else {
+        return Arc::new(BrokenSink::new(
+            name,
+            format!(
+                "object_store: no credentials resolved for credential_ref {:?}",
+                cfg.credential_ref
+            ),
+        ));
+    };
+    match build_object_store(
+        cfg.provider,
+        &cfg.bucket,
+        cfg.region.as_deref(),
+        cfg.endpoint.as_deref(),
+        creds,
+    ) {
+        Ok(store) => Arc::new(ObjectStoreSink::new(
+            name,
+            store,
+            cfg.prefix.clone(),
+            cfg.compression,
+        )),
+        Err(e) => Arc::new(BrokenSink::new(name, e.to_string())),
+    }
+}
+
+/// A placeholder for an exporter that could not be constructed (missing
+/// credentials / un-buildable backend). It never drops silently: every
+/// delivery fails permanently with the reason — recorded by the pipeline as
+/// `last_error` and shown on the health panel.
+struct BrokenSink {
+    name: String,
+    reason: String,
+}
+
+impl BrokenSink {
+    fn new(name: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            reason: reason.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ObservabilitySink for BrokenSink {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self) -> SinkCapabilities {
+        SinkCapabilities {
+            idempotency: IdempotencyScheme::None,
+            ordering: OrderingScope::None,
+            batch_unit: BatchUnit::Records,
+            max_batch_bytes: None,
+            supports_partial_batch: false,
+            supports_streaming_ingest: false,
+        }
+    }
+
+    async fn append_batch(&self, _batch: &EventBatch, _marker: &IdempotencyMarker) -> SinkResult {
+        Err(SinkError::Permanent(self.reason.clone()))
+    }
+
+    async fn healthcheck(&self) -> SinkHealth {
+        SinkHealth::unhealthy(self.reason.clone())
+    }
+}
+
+/// Resolve an exporter's `credential_ref` to provider credentials from the
+/// DP's local environment. The plaintext key never travels on the kine path
+/// (the control plane stores only the reference), so the DP looks it up where
+/// it runs — mirroring `resolve_sls_credential`. Env keys are
+/// `OBJSTORE_CRED_<SLUG>_<FIELD>`, where `<SLUG>` upper-cases the ref with
+/// non-alphanumerics folded to `_` (the `OBJSTORE_` prefix is deliberately
+/// not `AISIX_`, which the config loader owns). Returns `None` when a required
+/// field is unset/blank — the caller surfaces a delivery-health auth error
+/// rather than building a half-credentialed client.
+pub fn resolve_object_store_credential(
+    provider: ObjectStoreProvider,
+    credential_ref: &str,
+) -> Option<ObjectStoreCredentials> {
+    resolve_object_store_credential_with(provider, credential_ref, |k| std::env::var(k).ok())
+}
+
+/// Resolution core, parameterized over the variable source so it is testable
+/// without mutating the process environment.
+fn resolve_object_store_credential_with(
+    provider: ObjectStoreProvider,
+    credential_ref: &str,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Option<ObjectStoreCredentials> {
+    let slug: String = credential_ref
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let get = |field: &str| -> Option<String> {
+        lookup(&format!("OBJSTORE_CRED_{slug}_{field}")).filter(|v| !v.is_empty())
+    };
+    match provider {
+        ObjectStoreProvider::S3 => Some(ObjectStoreCredentials::S3 {
+            access_key_id: get("AWS_ACCESS_KEY_ID")?,
+            secret_access_key: get("AWS_SECRET_ACCESS_KEY")?,
+            session_token: get("AWS_SESSION_TOKEN"),
+        }),
+        ObjectStoreProvider::Gcs => Some(ObjectStoreCredentials::Gcs {
+            service_account_key: get("GCS_SERVICE_ACCOUNT_KEY")?,
+        }),
+        ObjectStoreProvider::AzureBlob => Some(ObjectStoreCredentials::Azure {
+            account: get("AZURE_ACCOUNT")?,
+            access_key: get("AZURE_ACCESS_KEY")?,
+        }),
+    }
+}
+
+/// gzip a byte slice (RFC 1952). Permanent on the rare encode failure.
+fn gzip(data: &[u8]) -> Result<Vec<u8>, SinkError> {
+    use std::io::Write as _;
+    let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    enc.write_all(data)
+        .and_then(|_| enc.finish())
+        .map_err(|e| SinkError::Permanent(format!("object_store: gzip: {e}")))
+}
+
+/// First 16 bytes of SHA-256, hex-encoded (32 chars) — the content address.
+fn sha256_hex16(body: &[u8]) -> String {
+    let digest = Sha256::digest(body);
+    hex::encode(&digest[..16])
+}
+
+/// `(date, hour)` Hive partition from an RFC-3339 timestamp (the record's
+/// `occurred_at`), normalised to UTC. Falls back to `unknown` when the
+/// timestamp is absent/unparseable, so the key stays deterministic.
+fn partition(occurred_at: &str) -> (String, String) {
+    match chrono::DateTime::parse_from_rfc3339(occurred_at) {
+        Ok(dt) => {
+            let utc = dt.with_timezone(&chrono::Utc);
+            (
+                utc.format("%Y-%m-%d").to_string(),
+                utc.format("%H").to_string(),
+            )
+        }
+        Err(_) => ("unknown".to_string(), "00".to_string()),
+    }
+}
+
+/// Map an `object_store` error to the pipeline's retry/permanent decision.
+/// Auth, missing-bucket and unsupported-operation errors are permanent (a
+/// retry fails the same way); transport / throttle / 5xx surface as
+/// `Error::Generic` and are transient. The detail is length-capped; the crate
+/// does not echo secrets in error text.
+fn map_object_store_err(e: object_store::Error) -> SinkError {
+    use object_store::Error as E;
+    let detail = truncate(&e.to_string());
+    match e {
+        E::PermissionDenied { .. }
+        | E::Unauthenticated { .. }
+        | E::NotFound { .. }
+        | E::NotSupported { .. }
+        | E::NotImplemented { .. }
+        | E::InvalidPath { .. }
+        | E::UnknownConfigurationKey { .. } => SinkError::Permanent(detail),
+        _ => SinkError::Transient(detail),
+    }
+}
+
+/// Truncate a masked detail string to a bounded length for logs / health.
+fn truncate(s: &str) -> String {
+    s.chars().take(DETAIL_MAX_CHARS).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sink::{EventBatch, IdempotencyMarker, ObservabilitySink, SinkContent, SinkRecord};
+    use crate::usage::UsageEvent;
+    use futures::StreamExt;
+    use object_store::memory::InMemory;
+    use std::sync::Arc;
+
+    fn event(request_id: &str) -> UsageEvent {
+        UsageEvent {
+            request_id: request_id.into(),
+            occurred_at: "2026-05-01T12:34:56Z".into(),
+            model_id: "gpt-4o".into(),
+            status_code: 200,
+            prompt_tokens: 5,
+            completion_tokens: 7,
+            ..UsageEvent::default()
+        }
+    }
+
+    fn batch_of(records: Vec<SinkRecord>) -> EventBatch {
+        EventBatch::new(records.into_iter().map(Arc::new).collect())
+    }
+
+    async fn list_keys(store: &Arc<dyn ObjectStore>) -> Vec<String> {
+        store
+            .list(None)
+            .map(|m| m.unwrap().location.to_string())
+            .collect::<Vec<_>>()
+            .await
+    }
+
+    fn sink(store: Arc<dyn ObjectStore>, compression: ObjectStoreCompression) -> ObjectStoreSink {
+        ObjectStoreSink::new("obj-test", store, "ai-gateway", compression)
+    }
+
+    #[tokio::test]
+    async fn writes_gzipped_ndjson_under_partitioned_content_addressed_key() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = sink(store.clone(), ObjectStoreCompression::Gzip);
+        let ack = s
+            .append_batch(
+                &batch_of(vec![
+                    SinkRecord::metadata_only(event("req-1")),
+                    SinkRecord::metadata_only(event("req-2")),
+                ]),
+                &IdempotencyMarker::None,
+            )
+            .await
+            .expect("delivery succeeds");
+        assert_eq!(ack.accepted, 2);
+
+        let keys = list_keys(&store).await;
+        assert_eq!(keys.len(), 1, "one object per flush");
+        let key = &keys[0];
+        // Hive-partitioned, content-addressed, gzip extension.
+        assert!(
+            key.starts_with("ai-gateway/dt=2026-05-01/hh=12/"),
+            "partitioned key: {key}"
+        );
+        assert!(key.ends_with(".ndjson.gz"), "gzip extension: {key}");
+
+        // Body round-trips: gunzip → two NDJSON lines, both real events.
+        let raw = store
+            .get(&ObjectPath::parse(key).unwrap())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let mut gz = flate2::read::GzDecoder::new(&raw[..]);
+        let mut text = String::new();
+        std::io::Read::read_to_string(&mut gz, &mut text).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["request_id"], "req-1");
+        assert_eq!(first["schema_version"], "1.0");
+        // Metadata-only path carries no prompt.
+        assert!(first.get("content").is_none());
+    }
+
+    #[tokio::test]
+    async fn retry_of_same_batch_reuses_the_same_key() {
+        // The pipeline retries the SAME batch on a transient error. The
+        // content-addressed key must be identical so a downstream loader
+        // dedups by filename (AISIX-Cloud#689 §8) — assert exactly one object.
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = sink(store.clone(), ObjectStoreCompression::Gzip);
+        let b = batch_of(vec![SinkRecord::metadata_only(event("req-dup"))]);
+        s.append_batch(&b, &IdempotencyMarker::None).await.unwrap();
+        s.append_batch(&b, &IdempotencyMarker::None).await.unwrap();
+        assert_eq!(
+            list_keys(&store).await.len(),
+            1,
+            "a re-delivered batch overwrites the same content-addressed key"
+        );
+    }
+
+    #[tokio::test]
+    async fn different_content_lands_under_different_keys() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = sink(store.clone(), ObjectStoreCompression::Gzip);
+        s.append_batch(
+            &batch_of(vec![SinkRecord::metadata_only(event("a"))]),
+            &IdempotencyMarker::None,
+        )
+        .await
+        .unwrap();
+        s.append_batch(
+            &batch_of(vec![SinkRecord::metadata_only(event("b"))]),
+            &IdempotencyMarker::None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(list_keys(&store).await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn compression_none_writes_plain_ndjson() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = sink(store.clone(), ObjectStoreCompression::None);
+        s.append_batch(
+            &batch_of(vec![SinkRecord::metadata_only(event("req-1"))]),
+            &IdempotencyMarker::None,
+        )
+        .await
+        .unwrap();
+        let keys = list_keys(&store).await;
+        assert!(
+            keys[0].ends_with(".ndjson"),
+            "no gzip extension: {}",
+            keys[0]
+        );
+        let raw = store
+            .get(&ObjectPath::parse(&keys[0]).unwrap())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let text = String::from_utf8(raw.to_vec()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(text.lines().next().unwrap()).unwrap();
+        assert_eq!(v["request_id"], "req-1");
+    }
+
+    #[tokio::test]
+    async fn opt_in_content_is_written_when_present() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = sink(store.clone(), ObjectStoreCompression::None);
+        let rec = SinkRecord::metadata_only(event("req-c")).with_content(SinkContent {
+            prompt: "what is 2+2?".into(),
+            response: "4".into(),
+            truncated: false,
+        });
+        s.append_batch(&batch_of(vec![rec]), &IdempotencyMarker::None)
+            .await
+            .unwrap();
+        let keys = list_keys(&store).await;
+        let raw = store
+            .get(&ObjectPath::parse(&keys[0]).unwrap())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let text = String::from_utf8(raw.to_vec()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(text.lines().next().unwrap()).unwrap();
+        assert_eq!(v["content"]["prompt"], "what is 2+2?");
+        assert_eq!(v["content"]["response"], "4");
+    }
+
+    #[tokio::test]
+    async fn empty_batch_is_a_noop() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let s = sink(store.clone(), ObjectStoreCompression::Gzip);
+        let ack = s
+            .append_batch(&EventBatch::default(), &IdempotencyMarker::None)
+            .await
+            .unwrap();
+        assert_eq!(ack.accepted, 0);
+        assert_eq!(list_keys(&store).await.len(), 0);
+    }
+
+    #[test]
+    fn build_object_store_dispatches_s3() {
+        // S3 builds offline (no connection until put); proves the S3 arm wires.
+        let store = build_object_store(
+            ObjectStoreProvider::S3,
+            "bucket",
+            Some("us-east-1"),
+            Some("http://minio:9000"),
+            ObjectStoreCredentials::S3 {
+                access_key_id: "id".into(),
+                secret_access_key: "secret".into(),
+                session_token: None,
+            },
+        );
+        assert!(store.is_ok(), "s3 build: {store:?}");
+    }
+
+    #[test]
+    fn build_object_store_rejects_provider_credential_mismatch() {
+        let r = build_object_store(
+            ObjectStoreProvider::S3,
+            "b",
+            None,
+            None,
+            ObjectStoreCredentials::Azure {
+                account: "a".into(),
+                access_key: "k".into(),
+            },
+        );
+        assert!(matches!(r, Err(SinkError::Permanent(_))));
+    }
+
+    #[test]
+    fn resolve_credential_maps_ref_to_env_per_provider() {
+        let store = |key: &str| match key {
+            "OBJSTORE_CRED_ACME_S3_AWS_ACCESS_KEY_ID" => Some("akid".to_string()),
+            "OBJSTORE_CRED_ACME_S3_AWS_SECRET_ACCESS_KEY" => Some("secret".to_string()),
+            _ => None,
+        };
+        let c = resolve_object_store_credential_with(ObjectStoreProvider::S3, "acme-s3", store);
+        assert_eq!(
+            c,
+            Some(ObjectStoreCredentials::S3 {
+                access_key_id: "akid".into(),
+                secret_access_key: "secret".into(),
+                session_token: None,
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_credential_is_none_when_required_field_missing() {
+        // S3 secret missing → None (never build a half-credentialed client).
+        let id_only =
+            |key: &str| (key == "OBJSTORE_CRED_X_AWS_ACCESS_KEY_ID").then(|| "id".to_string());
+        assert_eq!(
+            resolve_object_store_credential_with(ObjectStoreProvider::S3, "x", id_only),
+            None
+        );
+        // Blank is treated as unset.
+        assert_eq!(
+            resolve_object_store_credential_with(ObjectStoreProvider::Gcs, "x", |_| Some(
+                String::new()
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn maps_object_store_errors_to_retry_decision() {
+        let perm = map_object_store_err(object_store::Error::PermissionDenied {
+            path: "p".into(),
+            source: "denied".into(),
+        });
+        assert!(!perm.is_transient(), "auth error is permanent");
+
+        let transient = map_object_store_err(object_store::Error::Generic {
+            store: "s3",
+            source: "connection reset".into(),
+        });
+        assert!(transient.is_transient(), "transport error is transient");
+    }
+
+    #[test]
+    fn partition_parses_event_time_and_falls_back() {
+        assert_eq!(
+            partition("2026-05-01T12:34:56Z"),
+            ("2026-05-01".to_string(), "12".to_string())
+        );
+        assert_eq!(partition(""), ("unknown".to_string(), "00".to_string()));
+    }
+}
+
+/// Real-emulator smoke tests — the one-off validation that the sink's real
+/// SigV4 / GCS / Azure signing + HTTP `put` actually round-trips against a live
+/// S3 / GCS / Azure-compatible server (the wire a mock / `InMemory` cannot
+/// check). `#[ignore]` + env-gated, so the normal suite never touches the
+/// network; bring up the emulators with
+/// `tests/object-store-emulators.compose.yml` and run with:
+/// `cargo test -p aisix-obs -- --ignored objstore_smoke`.
+#[cfg(test)]
+mod smoke {
+    use super::{build_object_store, ObjectStoreCredentials, ObjectStoreSink};
+    use crate::sink::{EventBatch, IdempotencyMarker, ObservabilitySink, SinkRecord};
+    use crate::usage::UsageEvent;
+    use aisix_core::models::observability_exporter::{ObjectStoreCompression, ObjectStoreProvider};
+    use futures::StreamExt;
+    use object_store::path::Path as ObjectPath;
+    use object_store::{ObjectStore, ObjectStoreExt};
+    use std::sync::Arc;
+
+    fn env(key: &str) -> Option<String> {
+        std::env::var(key).ok().filter(|v| !v.is_empty())
+    }
+
+    fn smoke_event() -> UsageEvent {
+        UsageEvent {
+            request_id: format!("objstore-smoke-{}", uuid::Uuid::new_v4()),
+            occurred_at: "2026-05-01T12:00:00Z".into(),
+            model_id: "smoke-model".into(),
+            status_code: 200,
+            prompt_tokens: 1,
+            completion_tokens: 2,
+            ..UsageEvent::default()
+        }
+    }
+
+    async fn list_under(store: &Arc<dyn ObjectStore>, prefix: &str) -> Vec<ObjectPath> {
+        let p = ObjectPath::parse(prefix).expect("prefix parses");
+        store
+            .list(Some(&p))
+            .map(|m| m.expect("list entry").location)
+            .collect::<Vec<_>>()
+            .await
+    }
+
+    /// Drive a real put through the sink, read the object back via a fresh
+    /// client, confirm the gzipped NDJSON round-trips, prove a re-delivery
+    /// reuses the same content-addressed key (one object, not two), then clean
+    /// up. Works against any provider — the only per-provider part is `store`.
+    async fn smoke_roundtrip(store: Arc<dyn ObjectStore>) {
+        let prefix = format!("aisix-smoke/{}", uuid::Uuid::new_v4());
+        let sink = ObjectStoreSink::new(
+            "objstore-smoke",
+            store.clone(),
+            prefix.clone(),
+            ObjectStoreCompression::Gzip,
+        );
+        let event = smoke_event();
+        let want_request_id = event.request_id.clone();
+        let batch = EventBatch::new(vec![Arc::new(SinkRecord::metadata_only(event))]);
+
+        sink.append_batch(&batch, &IdempotencyMarker::None)
+            .await
+            .expect("real put accepted by the emulator");
+
+        let keys = list_under(&store, &prefix).await;
+        assert_eq!(keys.len(), 1, "exactly one object written");
+        assert!(
+            keys[0].as_ref().ends_with(".ndjson.gz"),
+            "gzip extension: {}",
+            keys[0]
+        );
+
+        // Read it back through a real GET and gunzip → the event round-trips.
+        let raw = store
+            .get(&keys[0])
+            .await
+            .expect("get object")
+            .bytes()
+            .await
+            .expect("object bytes");
+        let mut gz = flate2::read::GzDecoder::new(&raw[..]);
+        let mut text = String::new();
+        std::io::Read::read_to_string(&mut gz, &mut text).expect("gunzip");
+        let line = text.lines().next().expect("one ndjson line");
+        let v: serde_json::Value = serde_json::from_str(line).expect("valid ndjson");
+        assert_eq!(v["request_id"], want_request_id);
+
+        // Re-deliver the SAME batch (the pipeline's retry shape): the content
+        // address means it overwrites the same key — still exactly one object.
+        sink.append_batch(&batch, &IdempotencyMarker::None)
+            .await
+            .expect("re-delivery accepted");
+        let keys2 = list_under(&store, &prefix).await;
+        assert_eq!(keys2.len(), 1, "re-delivery reuses the same key (no dupe)");
+
+        for k in keys2 {
+            let _ = store.delete(&k).await;
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "hits a real S3-compatible server (MinIO/LocalStack). \
+                Run: docker compose -f crates/aisix-obs/tests/object-store-emulators.compose.yml up -d \
+                then AISIX_E2E_OBJSTORE_S3_* set; cargo test -p aisix-obs -- --ignored objstore_smoke_s3"]
+    async fn objstore_smoke_s3_roundtrip() {
+        let (Some(endpoint), Some(bucket), Some(key_id), Some(secret)) = (
+            env("AISIX_E2E_OBJSTORE_S3_ENDPOINT"),
+            env("AISIX_E2E_OBJSTORE_S3_BUCKET"),
+            env("AISIX_E2E_OBJSTORE_S3_ACCESS_KEY_ID"),
+            env("AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY"),
+        ) else {
+            eprintln!("objstore_smoke_s3: AISIX_E2E_OBJSTORE_S3_* not set — skipping");
+            return;
+        };
+        let store = build_object_store(
+            ObjectStoreProvider::S3,
+            &bucket,
+            Some("us-east-1"),
+            Some(&endpoint),
+            ObjectStoreCredentials::S3 {
+                access_key_id: key_id,
+                secret_access_key: secret,
+                session_token: None,
+            },
+        )
+        .expect("build S3 store");
+        smoke_roundtrip(store).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "hits a real Azure Blob emulator (Azurite). \
+                Run with AISIX_E2E_OBJSTORE_AZURE_* set; \
+                cargo test -p aisix-obs -- --ignored objstore_smoke_azure"]
+    async fn objstore_smoke_azure_roundtrip() {
+        let (Some(endpoint), Some(container), Some(account), Some(access_key)) = (
+            env("AISIX_E2E_OBJSTORE_AZURE_ENDPOINT"),
+            env("AISIX_E2E_OBJSTORE_AZURE_CONTAINER"),
+            env("AISIX_E2E_OBJSTORE_AZURE_ACCOUNT"),
+            env("AISIX_E2E_OBJSTORE_AZURE_ACCESS_KEY"),
+        ) else {
+            eprintln!("objstore_smoke_azure: AISIX_E2E_OBJSTORE_AZURE_* not set — skipping");
+            return;
+        };
+        let store = build_object_store(
+            ObjectStoreProvider::AzureBlob,
+            &container,
+            None,
+            Some(&endpoint),
+            ObjectStoreCredentials::Azure {
+                account,
+                access_key,
+            },
+        )
+        .expect("build Azure store");
+        smoke_roundtrip(store).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "GCS round-trip — set AISIX_E2E_OBJSTORE_GCS_* against REAL GCS or a \
+                conformant emulator. NOTE: fake-gcs-server's XML API does not round-trip \
+                object_store's percent-encoded object names (the `/` in partition keys → \
+                %2F), so build + auth verify there but the PUT only greens on real GCS. \
+                cargo test -p aisix-obs -- --ignored objstore_smoke_gcs"]
+    async fn objstore_smoke_gcs_roundtrip() {
+        let (Some(endpoint), Some(bucket), Some(service_account_key)) = (
+            env("AISIX_E2E_OBJSTORE_GCS_ENDPOINT"),
+            env("AISIX_E2E_OBJSTORE_GCS_BUCKET"),
+            env("AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT"),
+        ) else {
+            eprintln!("objstore_smoke_gcs: AISIX_E2E_OBJSTORE_GCS_* not set — skipping");
+            return;
+        };
+        let store = build_object_store(
+            ObjectStoreProvider::Gcs,
+            &bucket,
+            None,
+            Some(&endpoint),
+            ObjectStoreCredentials::Gcs {
+                service_account_key,
+            },
+        )
+        .expect("build GCS store");
+        smoke_roundtrip(store).await;
+    }
+}

--- a/crates/aisix-obs/tests/object-store-emulators.compose.yml
+++ b/crates/aisix-obs/tests/object-store-emulators.compose.yml
@@ -1,0 +1,79 @@
+# Object-storage emulators for the `objstore_smoke` real-backend e2e in
+# `crates/aisix-obs/src/sink/object_store.rs` (`mod smoke`). All three speak the
+# real protocol over the wire, are free, and run locally — no cloud account.
+# Borrowed from the `object_store` crate's CI and Quickwit's docker-compose
+# (the cleanest multi-cloud emulator set in the wild).
+#
+# Bring up + run the smoke tests:
+#   docker compose -f crates/aisix-obs/tests/object-store-emulators.compose.yml up -d
+#   set -a; source crates/aisix-obs/tests/object-store-emulators.env; set +a
+#   cargo test -p aisix-obs -- --ignored objstore_smoke
+#   docker compose -f crates/aisix-obs/tests/object-store-emulators.compose.yml down -v
+#
+# The smoke tests are `#[ignore]` + env-gated, so the normal suite never needs
+# Docker; only this explicit run does.
+services:
+  # ── S3 (MinIO, S3-compatible) ────────────────────────────────────────────
+  minio:
+    image: minio/minio:RELEASE.2025-02-28T09-55-16Z
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports: ["9000:9000"]
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+  minio-init:
+    image: minio/mc:RELEASE.2025-02-21T16-00-46Z
+    depends_on: [minio]
+    entrypoint:
+      - /bin/sh
+      - -c
+      - >
+        until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done &&
+        mc mb -p local/aisix-smoke && echo "minio bucket aisix-smoke ready"
+    restart: "no"
+
+  # ── Azure Blob (Azurite, Microsoft's official emulator) ──────────────────
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.34.0
+    command: azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
+    ports: ["10000:10000"]
+  azurite-init:
+    image: mcr.microsoft.com/azure-cli:2.67.0
+    depends_on: [azurite]
+    entrypoint:
+      - /bin/sh
+      - -c
+      - >
+        sleep 3 &&
+        az storage container create -n aisix-smoke
+        --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+        && echo "azurite container aisix-smoke ready"
+    restart: "no"
+
+  # ── GCS (fake-gcs-server) ────────────────────────────────────────────────
+  # NOTE: build + auth (service-account `gcs_base_url` + disable_oauth) verify
+  # against fake-gcs, but its XML API does not round-trip object_store's
+  # percent-encoded object names (the `/` in partition keys → %2F), so the
+  # `objstore_smoke_gcs_roundtrip` PUT only greens against REAL GCS. S3 (MinIO)
+  # and Azure (Azurite) are the round-trip-capable local emulators.
+  fake-gcs:
+    image: fsouza/fake-gcs-server:1.49.2
+    command: -scheme http -backend memory -public-host localhost:4443 -port 4443
+    ports: ["4443:4443"]
+  fake-gcs-init:
+    image: curlimages/curl:8.11.1
+    depends_on: [fake-gcs]
+    entrypoint:
+      - /bin/sh
+      - -c
+      - >
+        sleep 2 &&
+        curl -fsS -X POST http://fake-gcs:4443/storage/v1/b
+        -H "Content-Type: application/json" -d '{"name":"aisix-smoke"}'
+        && echo "fake-gcs bucket aisix-smoke ready"
+    restart: "no"

--- a/crates/aisix-obs/tests/object-store-emulators.env
+++ b/crates/aisix-obs/tests/object-store-emulators.env
@@ -1,0 +1,26 @@
+# Env for the `objstore_smoke` real-backend e2e — pairs with
+# object-store-emulators.compose.yml. Source it, then run the smoke tests:
+#   set -a; source crates/aisix-obs/tests/object-store-emulators.env; set +a
+#   cargo test -p aisix-obs -- --ignored objstore_smoke
+#
+# These are LOCAL EMULATOR credentials only (MinIO defaults, Azurite's
+# well-known devstoreaccount1 key, fake-gcs disabled-oauth) — not secrets.
+
+# ── S3 (MinIO) ──
+AISIX_E2E_OBJSTORE_S3_ENDPOINT=http://127.0.0.1:9000
+AISIX_E2E_OBJSTORE_S3_BUCKET=aisix-smoke
+AISIX_E2E_OBJSTORE_S3_ACCESS_KEY_ID=minioadmin
+AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY=minioadmin
+
+# ── Azure Blob (Azurite) — well-known emulator account + fixed key ──
+AISIX_E2E_OBJSTORE_AZURE_ENDPOINT=http://127.0.0.1:10000/devstoreaccount1
+AISIX_E2E_OBJSTORE_AZURE_CONTAINER=aisix-smoke
+AISIX_E2E_OBJSTORE_AZURE_ACCOUNT=devstoreaccount1
+AISIX_E2E_OBJSTORE_AZURE_ACCESS_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+
+# ── GCS (fake-gcs-server) — disabled-oauth service account ──
+AISIX_E2E_OBJSTORE_GCS_ENDPOINT=http://127.0.0.1:4443
+AISIX_E2E_OBJSTORE_GCS_BUCKET=aisix-smoke
+# Single-quoted: the JSON has commas, which bash brace-expands (mangling it)
+# if left unquoted when this file is `source`d.
+AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT='{"gcs_base_url":"http://127.0.0.1:4443","disable_oauth":true,"client_email":"fake@fake.iam.gserviceaccount.com","private_key_id":"","private_key":""}'

--- a/schemas/resources/observability_exporter.schema.json
+++ b/schemas/resources/observability_exporter.schema.json
@@ -64,6 +64,68 @@
           "type": "string"
         }
       }
+    },
+    {
+      "description": "Object-storage sink — ONE config covering S3 / GCS / Azure Blob (and S3-compatible MinIO / Cloudflare R2 via `endpoint`) behind a single backend, so the sink is written once rather than per provider. Batched NDJSON files land under a date-partitioned, deterministic key layout that Snowpipe / Databricks Auto Loader ingest from. Like `aliyun_sls`, cloud credentials are **never** in this config: a [`credential_ref`] points at keys the DP resolves locally, so the control plane never holds the secret on the kine path.\n\n[`credential_ref`]: ObjectStoreConfig::credential_ref",
+      "type": "object",
+      "required": [
+        "bucket",
+        "credential_ref",
+        "kind",
+        "prefix",
+        "provider"
+      ],
+      "properties": {
+        "bucket": {
+          "description": "Bucket (S3 / GCS) or container (Azure Blob) that receives the files.",
+          "type": "string"
+        },
+        "compression": {
+          "description": "Compression applied to each NDJSON file before upload. Default gzip.",
+          "default": "gzip",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ObjectStoreCompression"
+            }
+          ]
+        },
+        "credential_ref": {
+          "description": "Opaque pointer to the cloud credentials, resolved locally by the DP at delivery time. The plaintext key MUST NOT live in etcd/kine — the control plane stores only this reference, never the secret itself.",
+          "type": "string"
+        },
+        "endpoint": {
+          "description": "Override the backend host for S3-compatible stores (MinIO, Aliyun OSS, Cloudflare R2). Unset = the provider's native endpoint.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "object_store"
+          ]
+        },
+        "prefix": {
+          "description": "Key prefix the partition path is appended to, e.g. `ai-gateway`. The full key is `<prefix>/org=…/env=…/table=…/dt=…/hh=…/<file>`.",
+          "type": "string"
+        },
+        "provider": {
+          "description": "Which object-storage backend the bucket lives in.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ObjectStoreProvider"
+            }
+          ]
+        },
+        "region": {
+          "description": "AWS region for S3 (SigV4 signature scope) — recommended; `object_store` defaults to `us-east-1` when unset, so a non-default-region bucket should set it. Ignored for GCS / Azure Blob.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     }
   ],
   "required": [
@@ -78,6 +140,36 @@
     "name": {
       "description": "Operator-facing label, surfaced in /logs and the dashboard list. Not used for routing — the etcd-key uuid is the identity.",
       "type": "string"
+    }
+  },
+  "definitions": {
+    "ObjectStoreCompression": {
+      "description": "File compression for object-storage uploads.",
+      "oneOf": [
+        {
+          "description": "gzip (RFC 1952) — the default; smaller egress, accepted by Snowpipe and Auto Loader.",
+          "type": "string",
+          "enum": [
+            "gzip"
+          ]
+        },
+        {
+          "description": "No compression — raw NDJSON.",
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        }
+      ]
+    },
+    "ObjectStoreProvider": {
+      "description": "Object-storage backend selector. The sink builds one backend client per variant; everything downstream (batching, key layout, retry) is shared.",
+      "type": "string",
+      "enum": [
+        "s3",
+        "gcs",
+        "azure_blob"
+      ]
     }
   }
 }


### PR DESCRIPTION
## What

Adds **`ExporterKind::ObjectStore`** — a single `ObjectStoreSink` that delivers batched AI-gateway telemetry as NDJSON objects to **S3, GCS, and Azure Blob** (plus S3-compatible MinIO / Cloudflare R2), built **once** on the shared observability-sink pipeline (#528 / AISIX-Cloud#692). The only per-provider code is `build_object_store` — the `object_store` crate's builders own SigV4 / GCS OAuth / Azure shared-key signing, so we hand-roll **zero** signers.

Refs AISIX-Cloud#689 (the S3 / object-storage observability sink).

## Why this shape (reference implementations — CLAUDE.md §7)

Surveyed how the field does multi-cloud blob export (official docs + source):
- **A major open-source LLM proxy**: four *separate* per-provider logging integrations (boto3 / hand-rolled SigV4 / hand-rolled GCS REST / ADLS) — the "write it three times" anti-pattern.
- **Langfuse**: clean seam (one `StorageService` interface + factory) but still three cloud SDKs — the JS ecosystem has no unified blob lib.
- **Cloudflare Logpush**: cleanest *contract* — one URI whose scheme picks the provider.
- **Rust data-infra** (InfluxDB 3.0, DataFusion, Lance, delta-rs) standardizes on the **`object_store`** crate: one `ObjectStore` trait over S3/GCS/Azure. InfluxDB 3.0 serves all three clouds through it with **no separate SDKs** — the existence proof.

Divergence: in Rust we collapse the per-provider duplication into **one** code path (what JS/Python could not). Chosen `object_store` over `opendal` because it's first-party with the `parquet`/Arrow stack (the Parquet phase becomes free) and is the Arrow-ecosystem standard. rustls only, **no OpenSSL** (`tls-webpki-roots`).

## Design

- **Batched NDJSON (+gzip), one object per flush.**
- **Content-addressed keys** `…/dt=YYYY-MM-DD/hh=HH/<sha256(body)[..32]>.ndjson[.gz]`: a pipeline retry of the same batch maps to the same key, so a downstream **Snowpipe / Auto Loader dedups by filename and never double-loads** (AISIX-Cloud#689 §8) — achieved without needing offset/FileSeq-marker plumbing yet.
- **Credentials never on the kine path**: `credential_ref` resolved DP-side from env (`OBJSTORE_CRED_<REF>_*`), mirroring the SLS sink. A missing credential or un-buildable backend yields a `BrokenSink` that reports the reason via delivery health — never a silent drop.
- Loader JSON-schema validation (provider enum, required fields, https-or-loopback endpoint) + regenerated `schemas/resources/observability_exporter.schema.json`; fan-out arm + config fingerprint.

## Verified

- `cargo test -p aisix-core` (213) + `-p aisix-obs` (89) green; `clippy -D warnings` (all targets) clean; `cargo fmt --check` clean; full-workspace `cargo check` green.
- **No OpenSSL / native-tls** in the dep graph after adding `object_store` (verified via `cargo tree`).
- No schema drift (only `observability_exporter.schema.json` regenerated).
- **Real-backend e2e: S3 round-trip verified live against MinIO** — real SigV4 + PUT + GET + gzip round-trip + content-addressed retry-dedup (one object after re-delivery) + cleanup. Run via `crates/aisix-obs/tests/object-store-emulators.compose.yml`.
- The GCS smoke caught + fixed a real bug (`with_url` misuse for the emulator endpoint).

## Test plan

- Unit (hermetic): encode/key/dedup/error-map/credential-resolve/schema against `object_store::memory::InMemory`.
- Smoke (`#[ignore]` + env-gated, real emulators): `objstore_smoke_{s3,azure,gcs}_roundtrip`. **S3/MinIO greens locally.** Azure/Azurite is ready (needs the container pre-created). GCS round-trip needs **real GCS** — fake-gcs's XML API doesn't round-trip `object_store`'s percent-encoded object names (documented in the test + compose).

## Deferred (not in this PR)

Parquet output; restart-stable `FileSequence` markers; org/env partitioning; size/age rollover + multipart tuning; CP (Go) `cpapi` support; dashboard multi-kind form; exporter-credential field-level encryption (the pre-existing plaintext-in-etcd dependency).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an object-storage exporter sink for S3, GCS, and Azure Blob with NDJSON output, optional gzip compression (default gzip), deterministic content-addressed keys, and Hive-style dt/hh partitioning.
  * Support for credential references (env-driven) and configurable region/endpoint (allows localhost/emulator HTTP).
  * Schema and config validation updated to include the object_store kind.

* **Tests**
  * Added unit tests and ignored emulator smoke tests plus a Docker Compose setup for local S3/GCS/Azure emulators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->