### PR TITLE
feat(obs): per-attempt UsageEvent emission for Model-Group routing (#655)

### DIFF
--- a/crates/aisix-obs/src/access_log.rs
+++ b/crates/aisix-obs/src/access_log.rs
@@ -20,10 +20,15 @@ pub struct AccessLog<'a> {
     pub completion_tokens: Option<u64>,
     pub total_tokens: Option<u64>,
     pub request_id: &'a str,
+    /// Routing target that ultimately served the request (the winning
+    /// attempt's display name). `None` for direct models / cache hits.
     pub served_by_model: Option<&'a str>,
+    /// Total upstream attempts made (initial + retries + fallbacks).
     pub routing_attempt_count: Option<u32>,
+    /// How many attempts moved to a different target. Per #655 the
+    /// per-attempt detail lives in telemetry (per-attempt UsageEvents),
+    /// not in this one-line-per-request access log.
     pub routing_fallback_count: Option<u32>,
-    pub routing_attempts: Option<&'a str>,
 }
 
 impl AccessLog<'_> {
@@ -47,7 +52,6 @@ impl AccessLog<'_> {
             served_by_model = self.served_by_model,
             routing_attempt_count = self.routing_attempt_count,
             routing_fallback_count = self.routing_fallback_count,
-            routing_attempts = self.routing_attempts,
             "proxy request completed",
         );
     }
@@ -112,7 +116,6 @@ mod tests {
                 served_by_model: Some("fallback-target"),
                 routing_attempt_count: Some(2),
                 routing_fallback_count: Some(1),
-                routing_attempts: Some(r#"[{"model":"primary","success":false},{"model":"fallback-target","success":true}]"#),
             }
             .emit();
         });
@@ -131,7 +134,6 @@ mod tests {
         );
         assert!(out.contains("routing_attempt_count=2"));
         assert!(out.contains("routing_fallback_count=1"));
-        assert!(out.contains("routing_attempts="));
     }
 
     #[test]
@@ -160,7 +162,6 @@ mod tests {
                 served_by_model: None,
                 routing_attempt_count: None,
                 routing_fallback_count: None,
-                routing_attempts: None,
             }
             .emit();
         });

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -28,7 +28,7 @@ pub use metrics::{
 };
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::OtlpHttpFanOut;
-pub use usage::{RoutingAttemptEvent, UsageEvent, UsageSink};
+pub use usage::{UsageEvent, UsageSink};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ObsError {

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -315,6 +315,23 @@ fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
     if event.ttft_ms > 0 {
         attributes.push(attr_int("aisix.ttft_ms", event.ttft_ms as i64));
     }
+    // Per-attempt telemetry (#655). `request_id` is the trace/group key; a
+    // failover request emits one span per attempt sharing it, ordered by
+    // `aisix.attempt_index`. The OTLP encoder is an explicit allowlist, so
+    // these are added here alongside the wire fields.
+    attributes.push(attr_int("aisix.attempt_index", event.attempt_index as i64));
+    if !event.attempt_kind.is_empty() {
+        attributes.push(attr_string("aisix.attempt_kind", &event.attempt_kind));
+    }
+    if !event.attempt_model.is_empty() {
+        attributes.push(attr_string("aisix.attempt_model", &event.attempt_model));
+    }
+    if !event.error_class.is_empty() {
+        attributes.push(attr_string("aisix.error_class", &event.error_class));
+    }
+    if !event.error_message.is_empty() {
+        attributes.push(attr_string("aisix.error_message", &event.error_message));
+    }
     // Downstream client attribution (#492). Custom attrs so exporters
     // can slice by source IP / client type; the OTLP encoder is an
     // explicit allowlist, so new UsageEvent fields must be added here.
@@ -548,6 +565,54 @@ mod tests {
         assert!(keys.contains(&"aisix.model_id"));
         assert!(keys.contains(&"aisix.exporter_name"));
         assert!(keys.contains(&"aisix.request_id"));
+    }
+
+    #[test]
+    fn payload_carries_per_attempt_attributes() {
+        // A failed fallback attempt (#655): zero tokens, error info, target.
+        let mut ev = sample_event();
+        ev.attempt_index = 1;
+        ev.attempt_kind = "fallback".into();
+        ev.attempt_model = "secondary".into();
+        ev.error_class = "upstream_status".into();
+        ev.error_message = "upstream returned 502".into();
+        let body = build_otlp_traces_payload(&ev, "test-exp");
+        let attrs = body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+            .as_array()
+            .unwrap();
+        let find = |k: &str| attrs.iter().find(|a| a["key"] == k);
+        assert_eq!(find("aisix.attempt_index").unwrap()["value"]["intValue"], "1");
+        assert_eq!(
+            find("aisix.attempt_kind").unwrap()["value"]["stringValue"],
+            "fallback"
+        );
+        assert_eq!(
+            find("aisix.attempt_model").unwrap()["value"]["stringValue"],
+            "secondary"
+        );
+        assert_eq!(
+            find("aisix.error_class").unwrap()["value"]["stringValue"],
+            "upstream_status"
+        );
+        assert_eq!(
+            find("aisix.error_message").unwrap()["value"]["stringValue"],
+            "upstream returned 502"
+        );
+
+        // A direct (non-routing) success omits the routing-only attrs but
+        // still carries attempt_index=0.
+        let plain = build_otlp_traces_payload(&sample_event(), "test-exp");
+        let plain_attrs = plain["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+            .as_array()
+            .unwrap();
+        let keys: Vec<&str> = plain_attrs
+            .iter()
+            .map(|a| a["key"].as_str().unwrap())
+            .collect();
+        assert!(keys.contains(&"aisix.attempt_index"));
+        assert!(!keys.contains(&"aisix.attempt_kind"));
+        assert!(!keys.contains(&"aisix.attempt_model"));
+        assert!(!keys.contains(&"aisix.error_class"));
     }
 
     #[test]

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -29,20 +29,6 @@
 
 use serde::Serialize;
 
-/// One upstream attempt made while serving a routing-model request.
-/// This intentionally carries only low-sensitivity operational fields:
-/// target name, per-target attempt index, status/error class, and outcome.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct RoutingAttemptEvent {
-    pub model: String,
-    pub attempt: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub status: Option<u16>,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub error: String,
-    pub success: bool,
-}
-
 /// One usage event. Emitted at end-of-request (success / upstream error /
 /// guardrail block) per chat completion. Field shape pinned to the
 /// cp-api wire (snake_case via serde).
@@ -202,25 +188,46 @@ pub struct UsageEvent {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub inbound_protocol: String,
 
-    /// Display name of the routing target that ultimately served the
-    /// request. Empty for direct-model requests, cache hits, and routing
-    /// requests where every candidate failed.
+    // ─── Per-attempt telemetry (#655) ───
+    //
+    // Each UsageEvent now represents ONE upstream attempt. A request
+    // that fails over emits multiple events sharing `request_id` (the
+    // grouping/trace key); they are ordered by `attempt_index`. This
+    // mirrors LiteLLM's per-call logging model — `status_code`,
+    // `latency_ms`, and `ttft_ms` are scoped to THIS attempt, so the
+    // user-perceived total is reconstructed by summing the attempts of
+    // one `request_id`. Direct (non-routing) requests emit a single
+    // event with attempt_index=0, attempt_kind="initial".
+    /// 0-based index of this attempt within the request. Together with
+    /// `request_id` it uniquely identifies one attempt.
+    #[serde(default)]
+    pub attempt_index: u32,
+
+    /// What kind of attempt this is: `"initial"` (first try of the
+    /// first target), `"retry"` (same target, after a retryable
+    /// failure), or `"fallback"` (a different target than the previous
+    /// attempt). Defaults to `"initial"`.
     #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub served_by_model: String,
+    pub attempt_kind: String,
 
-    /// Number of upstream attempts made for a routing-model request.
-    /// Zero means routing did not run or no upstream attempt was made.
-    #[serde(default, skip_serializing_if = "is_zero_u32")]
-    pub routing_attempt_count: u32,
+    /// Display name of the routing target this attempt actually used —
+    /// the target that served (success) or failed (failure). Empty for
+    /// direct-model requests and cache hits, where `model_id` already
+    /// identifies the single model. Replaces the old `served_by_model`,
+    /// which only carried the winning target.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub attempt_model: String,
 
-    /// Number of times routing moved from one target model to another.
-    #[serde(default, skip_serializing_if = "is_zero_u32")]
-    pub routing_fallback_count: u32,
+    /// Error class for a FAILED attempt — a bounded, low-sensitivity
+    /// label (e.g. `"upstream_status"`, `"timeout"`, `"transport"`).
+    /// Empty on the successful attempt.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub error_class: String,
 
-    /// Per-attempt routing trace for debugging failover. Omitted for
-    /// direct-model requests and cache hits.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub routing_attempts: Vec<RoutingAttemptEvent>,
+    /// Short human-readable error message for a FAILED attempt
+    /// (length-capped). Empty on the successful attempt.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub error_message: String,
 
     // ─── ProviderKey telemetry attribution (#302 M17 / AISIX-Cloud#436) ───
     //
@@ -823,43 +830,48 @@ mod tests {
     }
 
     #[test]
-    fn routing_fields_serialise_only_when_present() {
-        let ev = UsageEvent {
+    fn per_attempt_fields_serialise_only_when_present() {
+        // A failed fallback attempt: zero tokens, error info, target name.
+        let failed = UsageEvent {
             request_id: "req-routing".into(),
-            served_by_model: "secondary".into(),
-            routing_attempt_count: 3,
-            routing_fallback_count: 1,
-            routing_attempts: vec![
-                RoutingAttemptEvent {
-                    model: "primary".into(),
-                    attempt: 1,
-                    status: Some(502),
-                    error: "upstream_status".into(),
-                    success: false,
-                },
-                RoutingAttemptEvent {
-                    model: "secondary".into(),
-                    attempt: 1,
-                    status: Some(200),
-                    error: String::new(),
-                    success: true,
-                },
-            ],
+            attempt_index: 0,
+            attempt_kind: "initial".into(),
+            attempt_model: "primary".into(),
+            status_code: 502,
+            error_class: "upstream_status".into(),
+            error_message: "upstream returned 502".into(),
+            latency_ms: 2000,
             ..Default::default()
         };
-        let json = serde_json::to_string(&ev).unwrap();
-        assert!(json.contains(r#""served_by_model":"secondary""#));
-        assert!(json.contains(r#""routing_attempt_count":3"#));
-        assert!(json.contains(r#""routing_fallback_count":1"#));
-        assert!(json.contains(r#""routing_attempts""#));
-        assert!(json.contains(r#""model":"primary""#));
-        assert!(json.contains(r#""error":"upstream_status""#));
+        let json = serde_json::to_string(&failed).unwrap();
+        assert!(json.contains(r#""attempt_index":0"#));
+        assert!(json.contains(r#""attempt_kind":"initial""#));
+        assert!(json.contains(r#""attempt_model":"primary""#));
+        assert!(json.contains(r#""error_class":"upstream_status""#));
+        assert!(json.contains(r#""error_message":"upstream returned 502""#));
 
+        // A winning fallback attempt of the same request shares request_id.
+        let won = UsageEvent {
+            request_id: "req-routing".into(),
+            attempt_index: 1,
+            attempt_kind: "fallback".into(),
+            attempt_model: "secondary".into(),
+            status_code: 200,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&won).unwrap();
+        assert!(json.contains(r#""attempt_kind":"fallback""#));
+        assert!(json.contains(r#""attempt_model":"secondary""#));
+        // No error fields on the winner.
+        assert!(!json.contains("error_class"));
+        assert!(!json.contains("error_message"));
+
+        // A direct (non-routing) request omits the routing-only fields.
         let empty = serde_json::to_string(&UsageEvent::default()).unwrap();
-        assert!(!empty.contains("served_by_model"));
-        assert!(!empty.contains("routing_attempt_count"));
-        assert!(!empty.contains("routing_fallback_count"));
-        assert!(!empty.contains("routing_attempts"));
+        assert!(!empty.contains("attempt_kind"));
+        assert!(!empty.contains("attempt_model"));
+        assert!(!empty.contains("error_class"));
+        assert!(!empty.contains("error_message"));
     }
 
     fn sample_event(id: &str) -> UsageEvent {

--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -12,7 +12,11 @@
 //! `/v1/messages`, and `/v1/responses` cannot drift apart on how they
 //! classify and emit attempts.
 
+use std::time::Instant;
+
 use aisix_gateway::BridgeError;
+
+use crate::error::ProxyError;
 
 /// One recorded upstream attempt. See module docs.
 #[derive(Clone)]
@@ -153,4 +157,23 @@ pub(crate) fn attempt_error_message(err: &BridgeError) -> String {
         .filter(|c| !c.is_control())
         .take(256)
         .collect()
+}
+
+/// Bounded error class + short message for a per-attempt record, derived
+/// from a `ProxyError`. Bridge errors carry the upstream-mapped class +
+/// message; everything else uses the DP-stable `ProxyError::kind`. Shared
+/// by the `/v1/messages` and `/v1/responses` dispatch loops.
+pub(crate) fn attempt_error_from_proxy(err: &ProxyError) -> (String, String) {
+    match err {
+        ProxyError::Bridge(be) => (
+            routing_error_class(be).to_string(),
+            attempt_error_message(be),
+        ),
+        other => (other.kind().to_string(), String::new()),
+    }
+}
+
+/// Milliseconds elapsed since `started`, saturating at `u32::MAX`.
+pub(crate) fn ms_since(started: Instant) -> u32 {
+    started.elapsed().as_millis().min(u32::MAX as u128) as u32
 }

--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -1,0 +1,156 @@
+//! Per-attempt routing telemetry shared by the Model-Group dispatch
+//! endpoints (#655).
+//!
+//! Each upstream attempt — the initial try, a same-target retry, or a
+//! fallback to a different target — becomes its own `UsageEvent`. Failed
+//! attempts carry zero tokens + error info; the winning attempt carries
+//! the real tokens/cost. All attempts of one request share `request_id`
+//! (the trace/group key) and are ordered by `index`. This mirrors
+//! LiteLLM's per-call logging model.
+//!
+//! The type lives in its own module so `/v1/chat/completions`,
+//! `/v1/messages`, and `/v1/responses` cannot drift apart on how they
+//! classify and emit attempts.
+
+use aisix_gateway::BridgeError;
+
+/// One recorded upstream attempt. See module docs.
+#[derive(Clone)]
+pub(crate) struct AttemptRecord {
+    /// 0-based attempt index within the request.
+    pub index: u32,
+    /// `"initial"` (first try of the first target), `"retry"` (same
+    /// target after a retryable failure), or `"fallback"` (a different
+    /// target than the previous attempt).
+    pub kind: &'static str,
+    /// Routing target display name. Empty for direct (non-routing)
+    /// models, where `model_id` already identifies the single model.
+    pub target_model: String,
+    /// Resolved ProviderKey UUID for this attempt's target — feeds the
+    /// per-PK attribution tags on the emitted event. Empty when unknown.
+    pub provider_key_id: String,
+    /// This attempt's status (mapped upstream status / timeout on
+    /// failure, 200 on success).
+    pub status: u16,
+    pub success: bool,
+    /// Bounded error class (`routing_error_class`); empty on success.
+    pub error_class: String,
+    /// Short error message (length-capped); empty on success.
+    pub error_message: String,
+    /// This attempt's own wall-clock duration in ms.
+    pub latency_ms: u32,
+}
+
+/// Per-attempt telemetry accumulated while serving one request. Direct
+/// (non-routing) models record a single attempt with `target_model`
+/// empty; routing groups record one entry per try.
+#[derive(Clone, Default)]
+pub(crate) struct RoutingTelemetry {
+    pub attempts: Vec<AttemptRecord>,
+    /// Display name of the most recently attempted target — drives the
+    /// initial/retry/fallback classification in [`Self::begin_attempt`].
+    last_target: Option<String>,
+}
+
+impl RoutingTelemetry {
+    /// Build a telemetry log holding a single already-classified attempt
+    /// (the streaming path, which only ever tries the first target).
+    pub fn single(rec: AttemptRecord) -> Self {
+        let last_target = Some(rec.target_model.clone());
+        Self {
+            attempts: vec![rec],
+            last_target,
+        }
+    }
+
+    /// Classify the next attempt against `display_name` and advance the
+    /// last-target tracker. Returns `(index, kind)` to stamp onto the
+    /// `AttemptRecord` the caller pushes once the attempt resolves. Call
+    /// once per attempt, before dispatch.
+    pub fn begin_attempt(&mut self, display_name: &str) -> (u32, &'static str) {
+        let index = self.attempts.len() as u32;
+        let kind = if self.attempts.is_empty() {
+            "initial"
+        } else if self.last_target.as_deref() != Some(display_name) {
+            "fallback"
+        } else {
+            "retry"
+        };
+        self.last_target = Some(display_name.to_string());
+        (index, kind)
+    }
+
+    pub fn attempt_count(&self) -> u32 {
+        self.attempts.len() as u32
+    }
+
+    /// Number of attempts that moved to a different target than the
+    /// previous one. Drives the access log's `routing_fallback_count`.
+    pub fn fallback_count(&self) -> u32 {
+        self.attempts
+            .iter()
+            .filter(|a| a.kind == "fallback")
+            .count() as u32
+    }
+
+    /// The winning (successful) attempt, if any. None for all-failed and
+    /// pre-dispatch-error requests.
+    pub fn winner(&self) -> Option<&AttemptRecord> {
+        self.attempts.iter().rfind(|a| a.success)
+    }
+}
+
+/// Winning-attempt / failed-attempt classification stamped onto an
+/// emitted `UsageEvent` (#655). Used by the `/v1/messages` and
+/// `/v1/responses` emit helpers, which (unlike chat's `UsageExtras`)
+/// carry the attempt fields as a small standalone bundle.
+#[derive(Default, Clone)]
+pub(crate) struct AttemptInfo {
+    pub index: u32,
+    /// `"initial"` / `"retry"` / `"fallback"`. Empty → wire default
+    /// `"initial"`.
+    pub kind: String,
+    /// Routing target display name; empty for direct models.
+    pub model: String,
+    /// Bounded error class for a failed attempt; empty on success.
+    pub error_class: String,
+    /// Short error message for a failed attempt; empty on success.
+    pub error_message: String,
+}
+
+impl AttemptInfo {
+    pub fn from_record(rec: &AttemptRecord) -> Self {
+        Self {
+            index: rec.index,
+            kind: rec.kind.to_string(),
+            model: rec.target_model.clone(),
+            error_class: rec.error_class.clone(),
+            error_message: rec.error_message.clone(),
+        }
+    }
+}
+
+/// Bounded, low-sensitivity error class for the per-attempt `error_class`
+/// telemetry field (#655).
+pub(crate) fn routing_error_class(err: &BridgeError) -> &'static str {
+    match err {
+        BridgeError::Timeout { .. } => "timeout",
+        BridgeError::UpstreamStatus { .. } => "upstream_status",
+        BridgeError::UpstreamDecode(_) => "upstream_decode",
+        BridgeError::Config(_) => "config",
+        BridgeError::InvalidUpstreamConfig(_) => "invalid_config",
+        BridgeError::InvalidUpstreamCredentials(_) => "invalid_credentials",
+        BridgeError::Transport(_) => "transport",
+        BridgeError::StreamAborted => "stream_aborted",
+    }
+}
+
+/// Short, control-char-stripped error string for the per-attempt
+/// `error_message` telemetry field (#655). Capped like `sanitize_tag`.
+pub(crate) fn attempt_error_message(err: &BridgeError) -> String {
+    err.to_string()
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(256)
+        .collect()
+}

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -659,7 +659,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -33,6 +33,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use crate::attempt::{attempt_error_message, routing_error_class, AttemptRecord, RoutingTelemetry};
 use crate::auth::AuthenticatedKey;
 use crate::client_ip::ClientContext;
 use crate::error::ProxyError;
@@ -44,65 +45,6 @@ use crate::state::ProxyState;
 /// Header set on every non-streaming response indicating whether the
 /// response came from the cache (`hit`) or the upstream (`miss`).
 pub const CACHE_HEADER: &str = "x-aisix-cache";
-
-/// One recorded upstream attempt (#655). Each attempt becomes its own
-/// per-attempt `UsageEvent`: failed attempts carry zero tokens + error
-/// info, the winning attempt carries the real tokens/cost. All attempts
-/// of one request share `request_id` and are ordered by `index`.
-#[derive(Clone)]
-struct AttemptRecord {
-    /// 0-based attempt index within the request.
-    index: u32,
-    /// `"initial"` (first try of the first target), `"retry"` (same
-    /// target after a retryable failure), or `"fallback"` (a different
-    /// target than the previous attempt).
-    kind: &'static str,
-    /// Routing target display name. Empty for direct (non-routing)
-    /// models, where `model_id` already identifies the single model.
-    target_model: String,
-    /// Resolved ProviderKey UUID for this attempt's target — feeds the
-    /// per-PK attribution tags on the emitted event. Empty when unknown.
-    provider_key_id: String,
-    /// This attempt's status (502/timeout-mapped/… on failure, 200 on
-    /// success).
-    status: u16,
-    success: bool,
-    /// Bounded error class (`routing_error_class`); empty on success.
-    error_class: String,
-    /// Short error message (length-capped); empty on success.
-    error_message: String,
-    /// This attempt's own wall-clock duration in ms.
-    latency_ms: u32,
-}
-
-/// Per-attempt telemetry accumulated while serving one request. Direct
-/// (non-routing) models record a single attempt with `target_model`
-/// empty; routing groups record one entry per try.
-#[derive(Clone, Default)]
-struct RoutingTelemetry {
-    attempts: Vec<AttemptRecord>,
-}
-
-impl RoutingTelemetry {
-    fn attempt_count(&self) -> u32 {
-        self.attempts.len() as u32
-    }
-
-    /// Number of attempts that moved to a different target than the
-    /// previous one. Drives the access log's `routing_fallback_count`.
-    fn fallback_count(&self) -> u32 {
-        self.attempts
-            .iter()
-            .filter(|a| a.kind == "fallback")
-            .count() as u32
-    }
-
-    /// The winning (successful) attempt, if any. None for all-failed and
-    /// pre-dispatch-error requests.
-    fn winner(&self) -> Option<&AttemptRecord> {
-        self.attempts.iter().rfind(|a| a.success)
-    }
-}
 
 struct DispatchFailure {
     model_id: Option<String>,
@@ -125,29 +67,6 @@ impl DispatchFailure {
         self.routing = routing;
         self
     }
-}
-
-fn routing_error_class(err: &BridgeError) -> &'static str {
-    match err {
-        BridgeError::Timeout { .. } => "timeout",
-        BridgeError::UpstreamStatus { .. } => "upstream_status",
-        BridgeError::UpstreamDecode(_) => "upstream_decode",
-        BridgeError::Config(_) => "config",
-        BridgeError::InvalidUpstreamConfig(_) => "invalid_config",
-        BridgeError::InvalidUpstreamCredentials(_) => "invalid_credentials",
-        BridgeError::Transport(_) => "transport",
-        BridgeError::StreamAborted => "stream_aborted",
-    }
-}
-
-/// Short, control-char-stripped error string for the per-attempt
-/// `error_message` telemetry field (#655). Capped like `sanitize_tag`.
-fn attempt_error_message(err: &BridgeError) -> String {
-    err.to_string()
-        .chars()
-        .filter(|c| !c.is_control())
-        .take(256)
-        .collect()
 }
 
 // Per-attempt cooldown decision lives in `crate::cooldown` so every
@@ -877,19 +796,17 @@ async fn dispatch(
                 // Streaming attempts only the first target (#655): a single
                 // failed AttemptRecord, emitted by the Err-arm fan-out.
                 let routing = if virtual_entry.value.routing.is_some() {
-                    RoutingTelemetry {
-                        attempts: vec![AttemptRecord {
-                            index: 0,
-                            kind: "initial",
-                            target_model: model.display_name.clone(),
-                            provider_key_id: pk_entry.id.clone(),
-                            status: err.http_status(),
-                            success: false,
-                            error_class: routing_error_class(&err).to_string(),
-                            error_message: attempt_error_message(&err),
-                            latency_ms: attempt_latency_ms,
-                        }],
-                    }
+                    RoutingTelemetry::single(AttemptRecord {
+                        index: 0,
+                        kind: "initial",
+                        target_model: model.display_name.clone(),
+                        provider_key_id: pk_entry.id.clone(),
+                        status: err.http_status(),
+                        success: false,
+                        error_class: routing_error_class(&err).to_string(),
+                        error_message: attempt_error_message(&err),
+                        latency_ms: attempt_latency_ms,
+                    })
                 } else {
                     RoutingTelemetry::default()
                 };
@@ -940,19 +857,17 @@ async fn dispatch(
         // Streaming attempts only the first target (#655): a single
         // winning AttemptRecord drives the access log served-by + counts.
         let stream_routing = if virtual_entry.value.routing.is_some() {
-            RoutingTelemetry {
-                attempts: vec![AttemptRecord {
-                    index: 0,
-                    kind: "initial",
-                    target_model: model.display_name.clone(),
-                    provider_key_id: pk_entry.id.clone(),
-                    status: 200,
-                    success: true,
-                    error_class: String::new(),
-                    error_message: String::new(),
-                    latency_ms: 0,
-                }],
-            }
+            RoutingTelemetry::single(AttemptRecord {
+                index: 0,
+                kind: "initial",
+                target_model: model.display_name.clone(),
+                provider_key_id: pk_entry.id.clone(),
+                status: 200,
+                success: true,
+                error_class: String::new(),
+                error_message: String::new(),
+                latency_ms: 0,
+            })
         } else {
             RoutingTelemetry::default()
         };
@@ -1317,7 +1232,6 @@ async fn dispatch(
         .unwrap_or(false);
     let is_routing_request = virtual_entry.value.routing.is_some();
     let mut routing = RoutingTelemetry::default();
-    let mut last_attempted_target: Option<String> = None;
 
     for attempt in &attempt_models {
         let model = &attempt.model;
@@ -1354,15 +1268,7 @@ async fn dispatch(
             // Per-attempt telemetry kind (#655): the first attempt overall
             // is "initial"; a different target than the previous attempt is
             // a "fallback"; the same target again is a "retry".
-            let attempt_index = routing.attempts.len() as u32;
-            let kind = if routing.attempts.is_empty() {
-                "initial"
-            } else if last_attempted_target.as_deref() != Some(model.display_name.as_str()) {
-                "fallback"
-            } else {
-                "retry"
-            };
-            last_attempted_target = Some(model.display_name.clone());
+            let (attempt_index, kind) = routing.begin_attempt(&model.display_name);
             // Routing target name only for routing groups; a direct model
             // leaves it empty since `model_id` already identifies it.
             let target_model = if is_routing_request {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -20,8 +20,7 @@ use aisix_cache::CacheKey;
 use aisix_gateway::{BridgeContext, BridgeError, ChatFormat};
 use aisix_guardrails::GuardrailVerdict;
 use aisix_obs::{
-    AccessLog, LlmUsage, Metrics, RequestLabels, RequestOutcome, RoutingAttemptEvent, UsageEvent,
-    UsageLabels,
+    AccessLog, LlmUsage, Metrics, RequestLabels, RequestOutcome, UsageEvent, UsageLabels,
 };
 use axum::extract::State;
 use axum::http::HeaderValue;
@@ -46,21 +45,62 @@ use crate::state::ProxyState;
 /// response came from the cache (`hit`) or the upstream (`miss`).
 pub const CACHE_HEADER: &str = "x-aisix-cache";
 
+/// One recorded upstream attempt (#655). Each attempt becomes its own
+/// per-attempt `UsageEvent`: failed attempts carry zero tokens + error
+/// info, the winning attempt carries the real tokens/cost. All attempts
+/// of one request share `request_id` and are ordered by `index`.
+#[derive(Clone)]
+struct AttemptRecord {
+    /// 0-based attempt index within the request.
+    index: u32,
+    /// `"initial"` (first try of the first target), `"retry"` (same
+    /// target after a retryable failure), or `"fallback"` (a different
+    /// target than the previous attempt).
+    kind: &'static str,
+    /// Routing target display name. Empty for direct (non-routing)
+    /// models, where `model_id` already identifies the single model.
+    target_model: String,
+    /// Resolved ProviderKey UUID for this attempt's target — feeds the
+    /// per-PK attribution tags on the emitted event. Empty when unknown.
+    provider_key_id: String,
+    /// This attempt's status (502/timeout-mapped/… on failure, 200 on
+    /// success).
+    status: u16,
+    success: bool,
+    /// Bounded error class (`routing_error_class`); empty on success.
+    error_class: String,
+    /// Short error message (length-capped); empty on success.
+    error_message: String,
+    /// This attempt's own wall-clock duration in ms.
+    latency_ms: u32,
+}
+
+/// Per-attempt telemetry accumulated while serving one request. Direct
+/// (non-routing) models record a single attempt with `target_model`
+/// empty; routing groups record one entry per try.
 #[derive(Clone, Default)]
 struct RoutingTelemetry {
-    served_by_model: String,
-    attempt_count: u32,
-    fallback_count: u32,
-    attempts: Vec<RoutingAttemptEvent>,
+    attempts: Vec<AttemptRecord>,
 }
 
 impl RoutingTelemetry {
-    fn attempts_json(&self) -> Option<String> {
-        if self.attempts.is_empty() {
-            None
-        } else {
-            serde_json::to_string(&self.attempts).ok()
-        }
+    fn attempt_count(&self) -> u32 {
+        self.attempts.len() as u32
+    }
+
+    /// Number of attempts that moved to a different target than the
+    /// previous one. Drives the access log's `routing_fallback_count`.
+    fn fallback_count(&self) -> u32 {
+        self.attempts
+            .iter()
+            .filter(|a| a.kind == "fallback")
+            .count() as u32
+    }
+
+    /// The winning (successful) attempt, if any. None for all-failed and
+    /// pre-dispatch-error requests.
+    fn winner(&self) -> Option<&AttemptRecord> {
+        self.attempts.iter().rfind(|a| a.success)
     }
 }
 
@@ -100,11 +140,14 @@ fn routing_error_class(err: &BridgeError) -> &'static str {
     }
 }
 
-fn routing_error_status(err: &BridgeError) -> Option<u16> {
-    match err {
-        BridgeError::UpstreamStatus { status, .. } => Some(*status),
-        _ => None,
-    }
+/// Short, control-char-stripped error string for the per-attempt
+/// `error_message` telemetry field (#655). Capped like `sanitize_tag`.
+fn attempt_error_message(err: &BridgeError) -> String {
+    err.to_string()
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(256)
+        .collect()
 }
 
 // Per-attempt cooldown decision lives in `crate::cooldown` so every
@@ -178,7 +221,6 @@ pub async fn chat_completions(
                 &success,
                 elapsed,
             );
-            let routing_attempts_json = success.routing.attempts_json();
             emit_access_log(
                 method,
                 path,
@@ -192,22 +234,42 @@ pub async fn chat_completions(
                 success.total_tokens,
                 &request_id,
                 &success.routing,
-                routing_attempts_json.as_deref(),
             );
-            // The streaming path wires telemetry into the SSE stream's
-            // on_complete callback (it has to wait for the terminal
-            // chunk to read the upstream's `usage` block). Calling
-            // `emit_usage_event` here for streaming would double-emit
-            // — once with all-zero tokens at handler return, then
-            // again with the real values at stream end.
+            // Per #655: emit a zero-token event for each failed attempt
+            // that preceded the winner (non-streaming fallover). No-op for
+            // direct-model success, cache hits, and the single-attempt
+            // streaming path.
+            emit_failed_attempts(
+                &state,
+                &request_id,
+                &success.model_id,
+                &api_key_id,
+                &client,
+                &success.routing,
+            );
+            // The streaming path wires the WINNER's telemetry into the SSE
+            // stream's on_complete callback (it has to wait for the
+            // terminal chunk to read the upstream's `usage` block). Calling
+            // `emit_usage_event` here for streaming would double-emit — once
+            // with all-zero tokens at handler return, then again with the
+            // real values at stream end.
             if !success.telemetry_handled_by_stream {
+                // Winning-attempt metadata (#655). Direct models / cache
+                // hits have no recorded attempt → defaults (index 0,
+                // "initial", empty target). `latency_ms` is scoped to the
+                // winning attempt itself; the access log above carries the
+                // user-perceived total.
+                let winner = success.routing.winner();
+                let winner_latency = winner
+                    .map(|w| Duration::from_millis(u64::from(w.latency_ms)))
+                    .unwrap_or(elapsed);
                 emit_usage_event(
                     &state,
                     &request_id,
                     &success.model_id,
                     &api_key_id,
                     status,
-                    elapsed,
+                    winner_latency,
                     success.prompt_tokens.unwrap_or(0) as u32,
                     success.completion_tokens.unwrap_or(0) as u32,
                     UsageExtras {
@@ -223,7 +285,11 @@ pub async fn chat_completions(
                         cache_hit_saved_input_tokens: success.cache_hit_saved_input_tokens,
                         cache_hit_saved_output_tokens: success.cache_hit_saved_output_tokens,
                         ttft_ms: 0,
-                        routing: success.routing.clone(),
+                        attempt_index: winner.map(|w| w.index).unwrap_or(0),
+                        attempt_kind: winner.map(|w| w.kind).unwrap_or("initial").to_string(),
+                        attempt_model: winner.map(|w| w.target_model.clone()).unwrap_or_default(),
+                        error_class: String::new(),
+                        error_message: String::new(),
                         provider_key_id: success.provider_key_id.clone(),
                     },
                     success.cost_usd,
@@ -304,7 +370,14 @@ pub async fn chat_completions(
                 ),
                 None => (None, None, None),
             };
-            let routing_attempts_json = routing.attempts_json();
+            // Routing telemetry lives on the charge for an output-blocked
+            // request (the upstream succeeded, then the output guardrail
+            // blocked it); otherwise on the failure itself.
+            let routing = charge
+                .as_ref()
+                .map(|c| c.routing.clone())
+                .filter(|r| !r.attempts.is_empty())
+                .unwrap_or(routing);
             emit_access_log(
                 method,
                 path,
@@ -318,68 +391,96 @@ pub async fn chat_completions(
                 al_total,
                 &request_id,
                 &routing,
-                routing_attempts_json.as_deref(),
             );
-            // Telemetry for the failure path. `resolved_model_id` is
-            // populated by `dispatch` once the request's `req.model`
-            // has been resolved against the snapshot — so a guardrail
-            // / budget / rate-limit / bridge error after that point
-            // still records which model the request targeted. Errors
-            // before resolution (empty messages, ModelNotFound) keep
-            // an empty string. ContentFiltered (guardrail) is recorded
-            // with the dedicated `guardrail_blocked` flag so the
-            // dashboard can surface it on the Blocked tab.
+            // `resolved_model_id` is populated by `dispatch` once
+            // `req.model` resolves against the snapshot, so a guardrail /
+            // budget / rate-limit / bridge error after that point still
+            // records which model the request targeted. ContentFiltered
+            // (guardrail) sets `guardrail_blocked` for the Blocked tab.
             let guardrail_blocked = matches!(err, ProxyError::ContentFiltered(_));
-            // For output-content-filter blocks the upstream WAS called
-            // and the provider already billed for `prompt_tokens` +
-            // `completion_tokens`. The captured `charge` carries those
-            // counts forward so the customer's `usage_events` row
-            // reflects the bill. For all other error paths charge is
-            // None and tokens stay at 0 — those errors never reached
-            // the upstream.
-            let (prompt_tokens, completion_tokens, extras) = match charge {
-                Some(c) => (
-                    c.prompt_tokens,
-                    c.completion_tokens,
-                    UsageExtras {
-                        cached_prompt_tokens: c.cached_prompt_tokens,
-                        reasoning_tokens: c.reasoning_tokens,
-                        cache_creation_tokens: c.cache_creation_tokens,
-                        cache_read_tokens: c.cache_read_tokens,
-                        provider_request_id: c.provider_request_id,
-                        provider_model_version: c.provider_model_version,
-                        finish_reason: c.finish_reason,
-                        bypass_reason: c.bypass_reason,
-                        cache_status: c.cache_status.as_str().to_string(),
-                        cache_hit_saved_input_tokens: 0,
-                        cache_hit_saved_output_tokens: 0,
-                        ttft_ms: 0,
-                        routing: c.routing,
-                        provider_key_id: c.provider_key_id,
-                    },
-                ),
-                None => {
-                    let extras = UsageExtras {
-                        routing,
-                        ..UsageExtras::default()
-                    };
-                    (0, 0, extras)
-                }
-            };
-            emit_usage_event(
+            let model_id_str = resolved_model_id.as_deref().unwrap_or("");
+            // Per #655: emit one zero-token event for each FAILED attempt.
+            emit_failed_attempts(
                 &state,
                 &request_id,
-                resolved_model_id.as_deref().unwrap_or(""),
+                model_id_str,
                 &api_key_id,
-                status,
-                elapsed,
-                prompt_tokens,
-                completion_tokens,
-                extras,
-                /* cost_usd */ 0.0,
-                guardrail_blocked,
                 &client,
+                &routing,
             );
+            // Terminal event:
+            //  - output-blocked (charge present): the WINNING attempt was
+            //    billed by the upstream then blocked — emit it with the
+            //    charge tokens + guardrail_blocked + winner metadata.
+            //  - all-targets-failed (charge None, attempts present): every
+            //    attempt was already emitted above — nothing more.
+            //  - pre-dispatch error (charge None, no attempts): emit a
+            //    single terminal event (attempt 0, "initial").
+            match charge {
+                Some(c) => {
+                    let winner = routing.winner();
+                    emit_usage_event(
+                        &state,
+                        &request_id,
+                        model_id_str,
+                        &api_key_id,
+                        status,
+                        elapsed,
+                        c.prompt_tokens,
+                        c.completion_tokens,
+                        UsageExtras {
+                            cached_prompt_tokens: c.cached_prompt_tokens,
+                            reasoning_tokens: c.reasoning_tokens,
+                            cache_creation_tokens: c.cache_creation_tokens,
+                            cache_read_tokens: c.cache_read_tokens,
+                            provider_request_id: c.provider_request_id,
+                            provider_model_version: c.provider_model_version,
+                            finish_reason: c.finish_reason,
+                            bypass_reason: c.bypass_reason,
+                            cache_status: c.cache_status.as_str().to_string(),
+                            cache_hit_saved_input_tokens: 0,
+                            cache_hit_saved_output_tokens: 0,
+                            ttft_ms: 0,
+                            attempt_index: winner.map(|w| w.index).unwrap_or(0),
+                            attempt_kind: winner.map(|w| w.kind).unwrap_or("initial").to_string(),
+                            attempt_model: winner
+                                .map(|w| w.target_model.clone())
+                                .unwrap_or_default(),
+                            error_class: String::new(),
+                            error_message: String::new(),
+                            provider_key_id: c.provider_key_id,
+                        },
+                        /* cost_usd */ 0.0,
+                        guardrail_blocked,
+                        &client,
+                    );
+                }
+                None if routing.attempts.is_empty() => {
+                    emit_usage_event(
+                        &state,
+                        &request_id,
+                        model_id_str,
+                        &api_key_id,
+                        status,
+                        elapsed,
+                        /* prompt_tokens */ 0,
+                        /* completion_tokens */ 0,
+                        UsageExtras {
+                            attempt_kind: "initial".to_string(),
+                            // Bounded ProxyError class so the dashboard can
+                            // show why the request never reached an upstream.
+                            error_class: err.kind().to_string(),
+                            ..UsageExtras::default()
+                        },
+                        /* cost_usd */ 0.0,
+                        guardrail_blocked,
+                        &client,
+                    );
+                }
+                None => {
+                    // All attempts failed; each was emitted above.
+                }
+            }
             err.into_response()
         }
     }
@@ -765,20 +866,28 @@ async fn dispatch(
         let model_arc = Arc::new(model.clone());
         let pk_arc = Arc::new(pk_entry.value.clone());
         let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+        let stream_attempt_started = Instant::now();
         let upstream = match bridge.chat_stream(req, &ctx).await {
             Ok(upstream) => upstream,
             Err(err) => {
+                let attempt_latency_ms = stream_attempt_started
+                    .elapsed()
+                    .as_millis()
+                    .min(u32::MAX as u128) as u32;
+                // Streaming attempts only the first target (#655): a single
+                // failed AttemptRecord, emitted by the Err-arm fan-out.
                 let routing = if virtual_entry.value.routing.is_some() {
                     RoutingTelemetry {
-                        served_by_model: String::new(),
-                        attempt_count: 1,
-                        fallback_count: 0,
-                        attempts: vec![RoutingAttemptEvent {
-                            model: model.display_name.clone(),
-                            attempt: 1,
-                            status: routing_error_status(&err),
-                            error: routing_error_class(&err).to_string(),
+                        attempts: vec![AttemptRecord {
+                            index: 0,
+                            kind: "initial",
+                            target_model: model.display_name.clone(),
+                            provider_key_id: pk_entry.id.clone(),
+                            status: err.http_status(),
                             success: false,
+                            error_class: routing_error_class(&err).to_string(),
+                            error_message: attempt_error_message(&err),
+                            latency_ms: attempt_latency_ms,
                         }],
                     }
                 } else {
@@ -828,23 +937,31 @@ async fn dispatch(
         // Downstream client attribution (#492) moved into the on_complete
         // closure so streamed responses log the same IP/UA as non-streaming.
         let client_for_telem = client.clone();
+        // Streaming attempts only the first target (#655): a single
+        // winning AttemptRecord drives the access log served-by + counts.
         let stream_routing = if virtual_entry.value.routing.is_some() {
             RoutingTelemetry {
-                served_by_model: model.display_name.clone(),
-                attempt_count: 1,
-                fallback_count: 0,
-                attempts: vec![RoutingAttemptEvent {
-                    model: model.display_name.clone(),
-                    attempt: 1,
-                    status: Some(200),
-                    error: String::new(),
+                attempts: vec![AttemptRecord {
+                    index: 0,
+                    kind: "initial",
+                    target_model: model.display_name.clone(),
+                    provider_key_id: pk_entry.id.clone(),
+                    status: 200,
                     success: true,
+                    error_class: String::new(),
+                    error_message: String::new(),
+                    latency_ms: 0,
                 }],
             }
         } else {
             RoutingTelemetry::default()
         };
-        let stream_routing_for_telem = stream_routing.clone();
+        // Per-attempt target name for the on_complete winner event.
+        let attempt_model_for_telem = if virtual_entry.value.routing.is_some() {
+            model.display_name.clone()
+        } else {
+            String::new()
+        };
         // Per #204: pass the resolved guardrail chain so the streaming
         // path can run output guardrails at end-of-stream
         // (buffer-then-check). Mirrors the non-streaming
@@ -915,7 +1032,13 @@ async fn dispatch(
                         cache_hit_saved_input_tokens: 0,
                         cache_hit_saved_output_tokens: 0,
                         ttft_ms: comp.ttft_ms,
-                        routing: stream_routing_for_telem.clone(),
+                        // Streaming is single-attempt (#655): the winner is
+                        // always the initial attempt of the first target.
+                        attempt_index: 0,
+                        attempt_kind: "initial".to_string(),
+                        attempt_model: attempt_model_for_telem.clone(),
+                        error_class: String::new(),
+                        error_message: String::new(),
                         provider_key_id: provider_key_id_for_telem.clone(),
                     },
                     /* cost_usd */ 0.0,
@@ -1228,16 +1351,31 @@ async fn dispatch(
         let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
 
         for attempt_idx in 0..=retries {
-            if is_routing_request {
-                if let Some(prev) = last_attempted_target.as_deref() {
-                    if prev != model.display_name {
-                        routing.fallback_count += 1;
-                    }
-                }
-                last_attempted_target = Some(model.display_name.clone());
-                routing.attempt_count += 1;
-            }
-            match bridge.chat(req, &ctx).await {
+            // Per-attempt telemetry kind (#655): the first attempt overall
+            // is "initial"; a different target than the previous attempt is
+            // a "fallback"; the same target again is a "retry".
+            let attempt_index = routing.attempts.len() as u32;
+            let kind = if routing.attempts.is_empty() {
+                "initial"
+            } else if last_attempted_target.as_deref() != Some(model.display_name.as_str()) {
+                "fallback"
+            } else {
+                "retry"
+            };
+            last_attempted_target = Some(model.display_name.clone());
+            // Routing target name only for routing groups; a direct model
+            // leaves it empty since `model_id` already identifies it.
+            let target_model = if is_routing_request {
+                model.display_name.clone()
+            } else {
+                String::new()
+            };
+
+            let attempt_started = Instant::now();
+            let result = bridge.chat(req, &ctx).await;
+            let attempt_latency_ms =
+                attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+            match result {
                 Ok(resp) => {
                     state.health.record_success(&model.display_name);
                     state.runtime_status.mark_healthy(&attempt.id);
@@ -1246,29 +1384,32 @@ async fn dispatch(
                     chosen_upstream_model =
                         Some(model.upstream_model().unwrap_or("unknown").to_string());
                     chosen_target_display_name = Some(model.display_name.clone());
-                    if is_routing_request {
-                        routing.served_by_model = model.display_name.clone();
-                        routing.attempts.push(RoutingAttemptEvent {
-                            model: model.display_name.clone(),
-                            attempt: (attempt_idx + 1) as u32,
-                            status: Some(200),
-                            error: String::new(),
-                            success: true,
-                        });
-                    }
+                    routing.attempts.push(AttemptRecord {
+                        index: attempt_index,
+                        kind,
+                        target_model,
+                        provider_key_id: pk_entry.id.clone(),
+                        status: 200,
+                        success: true,
+                        error_class: String::new(),
+                        error_message: String::new(),
+                        latency_ms: attempt_latency_ms,
+                    });
                     upstream = Some(resp);
                     break;
                 }
                 Err(err) => {
-                    if is_routing_request {
-                        routing.attempts.push(RoutingAttemptEvent {
-                            model: model.display_name.clone(),
-                            attempt: (attempt_idx + 1) as u32,
-                            status: routing_error_status(&err),
-                            error: routing_error_class(&err).to_string(),
-                            success: false,
-                        });
-                    }
+                    routing.attempts.push(AttemptRecord {
+                        index: attempt_index,
+                        kind,
+                        target_model,
+                        provider_key_id: pk_entry.id.clone(),
+                        status: err.http_status(),
+                        success: false,
+                        error_class: routing_error_class(&err).to_string(),
+                        error_message: attempt_error_message(&err),
+                        latency_ms: attempt_latency_ms,
+                    });
                     let retryable = is_retryable(&err, retry_on_429);
                     tracing::warn!(
                         target_model = %model.display_name,
@@ -1631,10 +1772,11 @@ fn emit_usage_event(
         // /v1/rerank don't emit UsageEvents today; when they do they
         // also pass `"openai"` here.
         inbound_protocol: "openai".to_string(),
-        served_by_model: extras.routing.served_by_model,
-        routing_attempt_count: extras.routing.attempt_count,
-        routing_fallback_count: extras.routing.fallback_count,
-        routing_attempts: extras.routing.attempts,
+        attempt_index: extras.attempt_index,
+        attempt_kind: extras.attempt_kind,
+        attempt_model: extras.attempt_model,
+        error_class: extras.error_class,
+        error_message: extras.error_message,
         // Per-PK telemetry attribution (#302 M17 / AISIX-Cloud#436).
         // Source struct is `aisix_core::TelemetryTags`; the wire
         // shape is flat strings + a bool, with skip_serializing_if
@@ -1728,7 +1870,18 @@ struct UsageExtras {
     cache_hit_saved_input_tokens: u32,
     cache_hit_saved_output_tokens: u32,
     ttft_ms: u32,
-    routing: RoutingTelemetry,
+    // ─── Per-attempt telemetry (#655) ───
+    /// 0-based attempt index within the request.
+    attempt_index: u32,
+    /// `"initial"` / `"retry"` / `"fallback"`. Empty defaults to
+    /// `"initial"` on the wire.
+    attempt_kind: String,
+    /// Routing target display name for this attempt; empty for direct.
+    attempt_model: String,
+    /// Bounded error class for a failed attempt; empty on success.
+    error_class: String,
+    /// Short error message for a failed attempt; empty on success.
+    error_message: String,
     /// UUID of the resolved ProviderKey. Used at emit time to look up
     /// `telemetry_tags` from the snapshot and populate UsageEvent's
     /// per-PK attribution fields (`provider_kind` / `provider_featured`
@@ -1738,6 +1891,46 @@ struct UsageExtras {
     /// emit events land in cp-api with the tag columns NULL.
     /// See AISIX-Cloud#436 / #302 M17.
     provider_key_id: String,
+}
+
+/// Emit one zero-token `UsageEvent` per FAILED attempt of a request
+/// (#655). The winning attempt (and pre-dispatch errors) are emitted
+/// separately by the caller. No-op when there are no failed attempts
+/// (direct-model success / pre-dispatch error). Each event shares the
+/// request's `request_id` (the trace key) and carries this attempt's
+/// status / error / latency.
+fn emit_failed_attempts(
+    state: &ProxyState,
+    request_id: &str,
+    model_id: &str,
+    api_key_id: &str,
+    client: &ClientContext,
+    routing: &RoutingTelemetry,
+) {
+    for rec in routing.attempts.iter().filter(|a| !a.success) {
+        emit_usage_event(
+            state,
+            request_id,
+            model_id,
+            api_key_id,
+            rec.status,
+            Duration::from_millis(u64::from(rec.latency_ms)),
+            /* prompt_tokens */ 0,
+            /* completion_tokens */ 0,
+            UsageExtras {
+                attempt_index: rec.index,
+                attempt_kind: rec.kind.to_string(),
+                attempt_model: rec.target_model.clone(),
+                error_class: rec.error_class.clone(),
+                error_message: rec.error_message.clone(),
+                provider_key_id: rec.provider_key_id.clone(),
+                ..UsageExtras::default()
+            },
+            /* cost_usd */ 0.0,
+            /* guardrail_blocked */ false,
+            client,
+        );
+    }
 }
 
 fn record_error(metrics: &Metrics, err: &ProxyError, model: &str, status: u16, elapsed: Duration) {
@@ -1763,8 +1956,11 @@ fn emit_access_log(
     total_tokens: Option<u64>,
     request_id: &str,
     routing: &RoutingTelemetry,
-    routing_attempts: Option<&str>,
 ) {
+    // Per #655 the access log stays ONE line per request (the transport
+    // plane), carrying user-perceived `latency` + the final status plus a
+    // routing summary. The per-attempt detail lives in telemetry only.
+    let served_by = routing.winner().map(|w| w.target_model.as_str());
     AccessLog {
         method,
         path,
@@ -1777,22 +1973,15 @@ fn emit_access_log(
         completion_tokens,
         total_tokens,
         request_id,
-        served_by_model: if routing.served_by_model.is_empty() {
-            None
-        } else {
-            Some(routing.served_by_model.as_str())
+        served_by_model: served_by.filter(|s| !s.is_empty()),
+        routing_attempt_count: match routing.attempt_count() {
+            0 => None,
+            n => Some(n),
         },
-        routing_attempt_count: if routing.attempt_count == 0 {
-            None
-        } else {
-            Some(routing.attempt_count)
+        routing_fallback_count: match routing.fallback_count() {
+            0 => None,
+            n => Some(n),
         },
-        routing_fallback_count: if routing.fallback_count == 0 {
-            None
-        } else {
-            Some(routing.fallback_count)
-        },
-        routing_attempts,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -313,7 +313,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -391,7 +391,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -327,7 +327,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -294,7 +294,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -3321,24 +3321,48 @@ data: [DONE]\n\n";
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["choices"][0]["message"]["content"], "after retries");
 
-        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
-            .await
-            .expect("usage event was never emitted")
-            .expect("sender dropped");
-        assert_eq!(event.served_by_model, "secondary");
-        assert_eq!(event.routing_attempt_count, 3);
-        assert_eq!(event.routing_fallback_count, 1);
-        assert_eq!(event.routing_attempts.len(), 3);
-        assert_eq!(event.routing_attempts[0].model, "primary");
-        assert_eq!(event.routing_attempts[0].attempt, 1);
-        assert_eq!(event.routing_attempts[0].status, Some(502));
-        assert!(!event.routing_attempts[0].success);
-        assert_eq!(event.routing_attempts[1].model, "primary");
-        assert_eq!(event.routing_attempts[1].attempt, 2);
-        assert_eq!(event.routing_attempts[2].model, "secondary");
-        assert_eq!(event.routing_attempts[2].attempt, 1);
-        assert_eq!(event.routing_attempts[2].status, Some(200));
-        assert!(event.routing_attempts[2].success);
+        // Per #655 each upstream attempt emits its own UsageEvent, all
+        // sharing `request_id`. Here: primary fails (initial), primary
+        // fails again (retry), secondary succeeds (fallback) — 3 events.
+        let mut events = Vec::new();
+        for _ in 0..3 {
+            let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+                .await
+                .expect("usage event was never emitted")
+                .expect("sender dropped");
+            events.push(ev);
+        }
+        events.sort_by_key(|e| e.attempt_index);
+        let rid = events[0].request_id.clone();
+        assert!(
+            !rid.is_empty() && events.iter().all(|e| e.request_id == rid),
+            "all attempts share the request_id (trace key)"
+        );
+
+        // initial attempt on `primary` failed with the upstream's 502
+        assert_eq!(events[0].attempt_index, 0);
+        assert_eq!(events[0].attempt_kind, "initial");
+        assert_eq!(events[0].attempt_model, "primary");
+        assert_eq!(events[0].status_code, 502);
+        assert_eq!(events[0].error_class, "upstream_status");
+        assert_eq!(events[0].prompt_tokens, 0);
+        assert_eq!(events[0].completion_tokens, 0);
+
+        // retry on the SAME target, also failed
+        assert_eq!(events[1].attempt_index, 1);
+        assert_eq!(events[1].attempt_kind, "retry");
+        assert_eq!(events[1].attempt_model, "primary");
+        assert_eq!(events[1].status_code, 502);
+        assert!(!events[1].error_class.is_empty());
+
+        // fallback to `secondary` succeeded and carries the real tokens
+        assert_eq!(events[2].attempt_index, 2);
+        assert_eq!(events[2].attempt_kind, "fallback");
+        assert_eq!(events[2].attempt_model, "secondary");
+        assert_eq!(events[2].status_code, 200);
+        assert_eq!(events[2].error_class, "");
+        assert_eq!(events[2].prompt_tokens, 1);
+        assert_eq!(events[2].completion_tokens, 1);
     }
 
     #[tokio::test]
@@ -3389,19 +3413,31 @@ data: [DONE]\n\n";
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
 
+        // Streaming attempts only the first target (#655): the single
+        // failed initial attempt is emitted as one per-attempt event.
         let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
             .await
             .expect("usage event was never emitted")
             .expect("sender dropped");
-        assert_eq!(event.served_by_model, "");
-        assert_eq!(event.routing_attempt_count, 1);
-        assert_eq!(event.routing_fallback_count, 0);
-        assert_eq!(event.routing_attempts.len(), 1);
-        assert_eq!(event.routing_attempts[0].model, "primary");
-        assert_eq!(event.routing_attempts[0].attempt, 1);
-        assert_eq!(event.routing_attempts[0].status, Some(502));
-        assert_eq!(event.routing_attempts[0].error, "upstream_status");
-        assert!(!event.routing_attempts[0].success);
+        assert_eq!(event.attempt_index, 0);
+        assert_eq!(event.attempt_kind, "initial");
+        assert_eq!(event.attempt_model, "primary");
+        assert_eq!(event.status_code, 502);
+        assert_eq!(event.error_class, "upstream_status");
+        assert_eq!(event.prompt_tokens, 0);
+        // No further events for this single-attempt request.
+        if let Ok(Some(extra)) =
+            tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await
+        {
+            panic!(
+                "unexpected 2nd event: idx={} kind={} model={} status={} err={}",
+                extra.attempt_index,
+                extra.attempt_kind,
+                extra.attempt_model,
+                extra.status_code,
+                extra.error_class
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -24,6 +24,7 @@
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
+mod attempt;
 mod audio;
 mod auth;
 pub mod background;
@@ -3438,6 +3439,235 @@ data: [DONE]\n\n";
                 extra.error_class
             );
         }
+    }
+
+    #[tokio::test]
+    async fn messages_routing_emits_per_attempt_events() {
+        // Per #655 the /v1/messages family must emit one UsageEvent per
+        // upstream attempt, just like /v1/chat/completions. A Model Group
+        // whose primary 502s and secondary succeeds emits 2 events sharing
+        // request_id, tagged inbound_protocol="anthropic".
+        use aisix_obs::UsageSink;
+
+        let bad_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("upstream down"))
+            .expect(1)
+            .mount(&bad_upstream)
+            .await;
+
+        let good_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-good",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "fallback worked"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1)
+            .mount(&good_upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-bad", &bad_upstream.uri()));
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-good", &good_upstream.uri()));
+        snap.models
+            .insert(model_entry_with_id("m-bad", "primary", "pk-bad"));
+        snap.models
+            .insert(model_entry_with_id("m-good", "secondary", "pk-good"));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary", "secondary"],
+            None,
+            None,
+            None,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_router(build_state(snap, hub).with_usage_sink(UsageSink::new(tx)));
+        let body = serde_json::json!({
+            "model": "smart",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/messages")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let mut events = Vec::new();
+        for _ in 0..2 {
+            let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+                .await
+                .expect("usage event was never emitted")
+                .expect("sender dropped");
+            events.push(ev);
+        }
+        events.sort_by_key(|e| e.attempt_index);
+        let rid = events[0].request_id.clone();
+        assert!(
+            !rid.is_empty() && events.iter().all(|e| e.request_id == rid),
+            "all attempts share the request_id (trace key)"
+        );
+        assert!(
+            events.iter().all(|e| e.inbound_protocol == "anthropic"),
+            "/v1/messages tags inbound_protocol=anthropic on every attempt"
+        );
+
+        // initial attempt on `primary` failed with the upstream's 502
+        assert_eq!(events[0].attempt_index, 0);
+        assert_eq!(events[0].attempt_kind, "initial");
+        assert_eq!(events[0].attempt_model, "primary");
+        assert_eq!(events[0].status_code, 502);
+        assert_eq!(events[0].error_class, "upstream_status");
+        assert_eq!(events[0].prompt_tokens, 0);
+        assert_eq!(events[0].completion_tokens, 0);
+
+        // fallback to `secondary` succeeded with real tokens
+        assert_eq!(events[1].attempt_index, 1);
+        assert_eq!(events[1].attempt_kind, "fallback");
+        assert_eq!(events[1].attempt_model, "secondary");
+        assert_eq!(events[1].status_code, 200);
+        assert_eq!(events[1].error_class, "");
+        assert_eq!(events[1].prompt_tokens, 1);
+        assert_eq!(events[1].completion_tokens, 1);
+    }
+
+    #[tokio::test]
+    async fn responses_routing_emits_per_attempt_events() {
+        // Per #655 the /v1/responses family must emit one UsageEvent per
+        // upstream attempt. A Model Group whose primary 502s and secondary
+        // succeeds emits 2 events sharing request_id, inbound_protocol="openai".
+        use aisix_obs::UsageSink;
+
+        let bad_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("upstream down"))
+            .expect(1)
+            .mount(&bad_upstream)
+            .await;
+
+        let good_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp-good",
+                "object": "response",
+                "output": [],
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            })))
+            .expect(1)
+            .mount(&good_upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-bad", &bad_upstream.uri()));
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-good", &good_upstream.uri()));
+        snap.models
+            .insert(model_entry_with_id("m-bad", "primary", "pk-bad"));
+        snap.models
+            .insert(model_entry_with_id("m-good", "secondary", "pk-good"));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary", "secondary"],
+            None,
+            None,
+            None,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_router(build_state(snap, hub).with_usage_sink(UsageSink::new(tx)));
+        let body = serde_json::json!({
+            "model": "smart",
+            "input": "hi"
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(&bytes)
+        );
+
+        let mut events = Vec::new();
+        for _ in 0..2 {
+            let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+                .await
+                .expect("usage event was never emitted")
+                .expect("sender dropped");
+            events.push(ev);
+        }
+        events.sort_by_key(|e| e.attempt_index);
+        let rid = events[0].request_id.clone();
+        assert!(
+            !rid.is_empty() && events.iter().all(|e| e.request_id == rid),
+            "all attempts share the request_id (trace key)"
+        );
+        assert!(
+            events.iter().all(|e| e.inbound_protocol == "openai"),
+            "/v1/responses tags inbound_protocol=openai on every attempt"
+        );
+
+        // initial attempt on `primary` failed with the upstream's 502
+        assert_eq!(events[0].attempt_index, 0);
+        assert_eq!(events[0].attempt_kind, "initial");
+        assert_eq!(events[0].attempt_model, "primary");
+        assert_eq!(events[0].status_code, 502);
+        assert_eq!(events[0].error_class, "upstream_status");
+        assert_eq!(events[0].prompt_tokens, 0);
+
+        // fallback to `secondary` succeeded with real tokens
+        assert_eq!(events[1].attempt_index, 1);
+        assert_eq!(events[1].attempt_kind, "fallback");
+        assert_eq!(events[1].attempt_model, "secondary");
+        assert_eq!(events[1].status_code, 200);
+        assert_eq!(events[1].error_class, "");
+        assert_eq!(events[1].prompt_tokens, 1);
+        assert_eq!(events[1].completion_tokens, 1);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1739,7 +1739,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -48,6 +48,9 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
+use crate::attempt::{
+    attempt_error_message, routing_error_class, AttemptInfo, AttemptRecord, RoutingTelemetry,
+};
 use crate::auth::AuthenticatedKey;
 use crate::chat::sanitize_tag;
 use crate::client_ip::ClientContext;
@@ -116,6 +119,7 @@ pub async fn messages(
             upstream_model,
             metrics,
             usage_handled_by_stream,
+            routing,
         }) => {
             let elapsed = started.elapsed();
             let status = response.status().as_u16();
@@ -126,6 +130,7 @@ pub async fn messages(
                 status,
                 elapsed,
                 &request_id,
+                &routing,
             );
             state.metrics.record_request(
                 &provider_label,
@@ -150,7 +155,31 @@ pub async fn messages(
             };
             state.metrics.record_proxy_request(labels, elapsed);
             state.metrics.record_llm_request(labels, elapsed);
+            // Per #655: one zero-token UsageEvent per failed attempt that
+            // preceded the winner (non-streaming failover). No-op for a
+            // first-try success and for the single-attempt streaming path.
+            emit_failed_attempts_anthropic(
+                &state,
+                &request_id,
+                &model_id,
+                &api_key_id,
+                &provider_label,
+                &model_name,
+                &upstream_model,
+                auth.key().team_id.as_deref(),
+                auth.key().user_id.as_deref(),
+                &client,
+                &routing,
+            );
             if !usage_handled_by_stream {
+                // Winning-attempt classification (#655). Direct models have
+                // no recorded attempt → AttemptInfo defaults (index 0,
+                // "initial", empty target). The streaming path emits the
+                // winner from its Drop guard, so it is skipped here.
+                let attempt = routing
+                    .winner()
+                    .map(AttemptInfo::from_record)
+                    .unwrap_or_default();
                 emit_anthropic_usage_event(
                     &state,
                     &request_id,
@@ -166,11 +195,12 @@ pub async fn messages(
                     elapsed,
                     metrics,
                     &client,
+                    attempt,
                 );
             }
             response
         }
-        Err(err) => {
+        Err(MessagesDispatchError { err, routing }) => {
             let status = err.status().as_u16();
             let elapsed = started.elapsed();
             emit_access_log(
@@ -180,6 +210,7 @@ pub async fn messages(
                 status,
                 elapsed,
                 &request_id,
+                &routing,
             );
             state.metrics.record_request(
                 "unknown",
@@ -188,11 +219,9 @@ pub async fn messages(
                 RequestOutcome::from_status(status),
                 elapsed,
             );
-            // Emit a token-less UsageEvent so the dashboard's Logs tab
-            // surfaces the failed Anthropic-SDK request alongside its
-            // openai-shape siblings. status_code carries the failure
-            // class; tokens stay zero.
-            emit_anthropic_usage_event(
+            // Per #655: emit one zero-token UsageEvent per FAILED attempt so
+            // the dashboard's Logs tab surfaces each failed upstream try.
+            emit_failed_attempts_anthropic(
                 &state,
                 &request_id,
                 &model_id,
@@ -200,14 +229,38 @@ pub async fn messages(
                 "unknown",
                 &model_name,
                 "unknown",
-                "unknown",
                 auth.key().team_id.as_deref(),
                 auth.key().user_id.as_deref(),
-                status,
-                elapsed,
-                AnthropicUsageMetrics::default(),
                 &client,
+                &routing,
             );
+            // Pre-dispatch failure (model-not-found, auth, budget, guardrail
+            // block before any upstream attempt) records no attempts — emit a
+            // single terminal event carrying the failure class. When attempts
+            // were recorded, each was already emitted above.
+            if routing.attempts.is_empty() {
+                emit_anthropic_usage_event(
+                    &state,
+                    &request_id,
+                    &model_id,
+                    &api_key_id,
+                    "unknown",
+                    &model_name,
+                    "unknown",
+                    "unknown",
+                    auth.key().team_id.as_deref(),
+                    auth.key().user_id.as_deref(),
+                    status,
+                    elapsed,
+                    AnthropicUsageMetrics::default(),
+                    &client,
+                    AttemptInfo {
+                        kind: "initial".to_string(),
+                        error_class: err.kind().to_string(),
+                        ..Default::default()
+                    },
+                );
+            }
             // /v1/messages must return Anthropic-shape error envelope
             // `{type:"error", error:{type, message}}` so Claude SDKs
             // can parse it — closes #336. The DP-stable taxonomy
@@ -218,6 +271,44 @@ pub async fn messages(
     }
 }
 
+/// Emit one zero-token `UsageEvent` per FAILED attempt of a `/v1/messages`
+/// request (#655). The winner / pre-dispatch event is emitted separately.
+/// No-op when there are no failed attempts. Each event shares `request_id`.
+#[allow(clippy::too_many_arguments)]
+fn emit_failed_attempts_anthropic(
+    state: &ProxyState,
+    request_id: &str,
+    model_id: &str,
+    api_key_id: &str,
+    provider: &str,
+    model: &str,
+    upstream_model: &str,
+    team_id: Option<&str>,
+    user_id: Option<&str>,
+    client: &ClientContext,
+    routing: &RoutingTelemetry,
+) {
+    for rec in routing.attempts.iter().filter(|a| !a.success) {
+        emit_anthropic_usage_event(
+            state,
+            request_id,
+            model_id,
+            api_key_id,
+            provider,
+            model,
+            &rec.provider_key_id,
+            upstream_model,
+            team_id,
+            user_id,
+            rec.status,
+            Duration::from_millis(u64::from(rec.latency_ms)),
+            AnthropicUsageMetrics::default(),
+            client,
+            AttemptInfo::from_record(rec),
+        );
+    }
+}
+
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
@@ -225,7 +316,7 @@ async fn dispatch(
     request_id: &str,
     started: Instant,
     client: &ClientContext,
-) -> Result<DispatchOutcome, ProxyError> {
+) -> Result<DispatchOutcome, MessagesDispatchError> {
     let snapshot = state.snapshot.load();
 
     // Extract and resolve model.
@@ -241,7 +332,7 @@ async fn dispatch(
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
     if !auth.key().can_access(&model_name) {
-        return Err(ProxyError::ModelForbidden(model_name.clone()));
+        return Err(ProxyError::ModelForbidden(model_name.clone()).into());
     }
 
     let model_rl =
@@ -276,7 +367,8 @@ async fn dispatch(
                 );
                 return Err(ProxyError::ContentFiltered(
                     "request blocked by content policy".into(),
-                ));
+                )
+                .into());
             }
         }
     }
@@ -284,11 +376,12 @@ async fn dispatch(
     // Budget pre-check via cp-api (mirrors /v1/chat/completions).
     let budget_decision = state.budgets.check(&auth.entry.id).await;
     if !budget_decision.allowed {
-        return Err(ProxyError::BudgetExceeded(Box::new(
-            budget_decision.reason.unwrap_or_else(|| {
+        return Err(
+            ProxyError::BudgetExceeded(Box::new(budget_decision.reason.unwrap_or_else(|| {
                 crate::budget::BudgetReason::message_only(auth.entry.id.clone())
-            }),
-        )));
+            })))
+            .into(),
+        );
     }
 
     // Resolve the attempt list. For a Model Group (routing model) this
@@ -314,15 +407,33 @@ async fn dispatch(
         .as_ref()
         .map(|r| r.retry_on_429_or_default())
         .unwrap_or(false);
+    // Routing target names only matter on the telemetry for a real Model
+    // Group; a direct model leaves `attempt_model` empty (its `model_id`
+    // already identifies it), matching chat.rs.
+    let is_routing_request = model_entry.value.routing.is_some();
+    let mut routing = RoutingTelemetry::default();
 
     // Streaming attempts only the first target (no mid-stream fallback),
-    // matching /v1/chat/completions.
+    // matching /v1/chat/completions. The winning UsageEvent is emitted by
+    // the stream's Drop guard; a connect failure records a single failed
+    // attempt the handler emits.
     if is_stream {
-        return dispatch_to_target(
+        let target = &attempt_models[0];
+        let (idx, kind) = routing.begin_attempt(&target.model.display_name);
+        let target_model = if is_routing_request {
+            target.model.display_name.clone()
+        } else {
+            String::new()
+        };
+        let pk_id = crate::dispatch::resolve_provider_key(&snapshot, &target.model)
+            .map(|e| e.id.clone())
+            .unwrap_or_default();
+        let attempt_started = Instant::now();
+        return match dispatch_to_target(
             state,
             &snapshot,
             body,
-            &attempt_models[0],
+            target,
             &model_name,
             request_id,
             started,
@@ -331,16 +442,65 @@ async fn dispatch(
             auth.key().user_id.clone(),
             resolved_chain.clone(),
             client,
+            AttemptInfo {
+                index: idx,
+                kind: kind.to_string(),
+                model: target_model.clone(),
+                ..Default::default()
+            },
         )
-        .await;
+        .await
+        {
+            Ok(mut outcome) => {
+                routing.attempts.push(AttemptRecord {
+                    index: idx,
+                    kind,
+                    target_model,
+                    provider_key_id: outcome.provider_key_id.clone(),
+                    status: 200,
+                    success: true,
+                    error_class: String::new(),
+                    error_message: String::new(),
+                    latency_ms: ms_since(attempt_started),
+                });
+                outcome.routing = routing;
+                Ok(outcome)
+            }
+            Err(e) => {
+                let (error_class, error_message) = attempt_error_from_proxy(&e);
+                routing.attempts.push(AttemptRecord {
+                    index: idx,
+                    kind,
+                    target_model,
+                    provider_key_id: pk_id,
+                    status: e.status().as_u16(),
+                    success: false,
+                    error_class,
+                    error_message,
+                    latency_ms: ms_since(attempt_started),
+                });
+                Err(MessagesDispatchError { err: e, routing })
+            }
+        };
     }
 
     // Non-streaming: walk targets, failing over to the next only on a
     // retryable upstream failure. A 4xx / config error is returned
-    // as-is — retrying other targets won't help.
+    // as-is — retrying other targets won't help. Each target attempt
+    // becomes its own per-attempt record (#655).
     let n = attempt_models.len();
     let mut last_err: Option<ProxyError> = None;
     for (i, target) in attempt_models.iter().enumerate() {
+        let (idx, kind) = routing.begin_attempt(&target.model.display_name);
+        let target_model = if is_routing_request {
+            target.model.display_name.clone()
+        } else {
+            String::new()
+        };
+        let pk_id = crate::dispatch::resolve_provider_key(&snapshot, &target.model)
+            .map(|e| e.id.clone())
+            .unwrap_or_default();
+        let attempt_started = Instant::now();
         match dispatch_to_target(
             state,
             &snapshot,
@@ -354,15 +514,47 @@ async fn dispatch(
             auth.key().user_id.clone(),
             resolved_chain.clone(),
             client,
+            AttemptInfo {
+                index: idx,
+                kind: kind.to_string(),
+                model: target_model.clone(),
+                ..Default::default()
+            },
         )
         .await
         {
-            Ok(outcome) => return Ok(outcome),
+            Ok(mut outcome) => {
+                routing.attempts.push(AttemptRecord {
+                    index: idx,
+                    kind,
+                    target_model,
+                    provider_key_id: outcome.provider_key_id.clone(),
+                    status: 200,
+                    success: true,
+                    error_class: String::new(),
+                    error_message: String::new(),
+                    latency_ms: ms_since(attempt_started),
+                });
+                outcome.routing = routing;
+                return Ok(outcome);
+            }
             Err(e) => {
                 let retryable = matches!(
                     &e,
                     ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429)
                 );
+                let (error_class, error_message) = attempt_error_from_proxy(&e);
+                routing.attempts.push(AttemptRecord {
+                    index: idx,
+                    kind,
+                    target_model,
+                    provider_key_id: pk_id,
+                    status: e.status().as_u16(),
+                    success: false,
+                    error_class,
+                    error_message,
+                    latency_ms: ms_since(attempt_started),
+                });
                 last_err = Some(e);
                 if !(retryable && i + 1 < n) {
                     break;
@@ -370,7 +562,15 @@ async fn dispatch(
             }
         }
     }
-    Err(last_err.unwrap_or(ProxyError::ProviderUnavailable))
+    Err(MessagesDispatchError {
+        err: last_err.unwrap_or(ProxyError::ProviderUnavailable),
+        routing,
+    })
+}
+
+/// Milliseconds elapsed since `started`, saturating at `u32::MAX`.
+fn ms_since(started: Instant) -> u32 {
+    started.elapsed().as_millis().min(u32::MAX as u128) as u32
 }
 
 /// Dispatch one concrete (non-routing) target Model. Branches on the
@@ -390,6 +590,10 @@ async fn dispatch_to_target(
     user_id: Option<String>,
     resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
     client: &ClientContext,
+    // Winning-attempt classification (#655) — used by the streaming paths
+    // whose Drop guard owns the UsageEvent emit. Non-streaming paths emit
+    // from the handler and ignore it.
+    attempt: AttemptInfo,
 ) -> Result<DispatchOutcome, ProxyError> {
     let model = &target.model;
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
@@ -409,6 +613,7 @@ async fn dispatch_to_target(
             user_id,
             resolved_chain,
             client,
+            attempt,
         )
         .await;
     }
@@ -428,6 +633,7 @@ async fn dispatch_to_target(
         user_id,
         resolved_chain,
         client,
+        attempt,
     )
     .await
 }
@@ -452,6 +658,7 @@ async fn anthropic_passthrough_dispatch(
     user_id: Option<String>,
     resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
     client_ctx: &ClientContext,
+    attempt: AttemptInfo,
 ) -> Result<DispatchOutcome, ProxyError> {
     let mut body = body.clone();
     let api_key = crate::dispatch::require_secret(pk_value, model)?;
@@ -611,6 +818,8 @@ async fn anthropic_passthrough_dispatch(
         let user_id_c = user_id.clone();
         // #492: log the same client IP/UA on streamed responses.
         let client_ctx_c = client_ctx.clone();
+        // Winning-attempt classification (#655) for the stream-end emit.
+        let attempt_c = attempt.clone();
 
         let stream_guardrail = if resolved_chain.is_empty() {
             None
@@ -651,6 +860,7 @@ async fn anthropic_passthrough_dispatch(
                     started.elapsed(),
                     metrics,
                     &client_ctx_c,
+                    attempt_c.clone(),
                 );
             },
         );
@@ -690,6 +900,7 @@ async fn anthropic_passthrough_dispatch(
             upstream_model: upstream_model.clone(),
             metrics: AnthropicUsageMetrics::default(),
             usage_handled_by_stream: true,
+            routing: RoutingTelemetry::default(),
         })
     } else {
         // Non-streaming: deserialise and re-serialise as JSON. Decode
@@ -770,6 +981,7 @@ async fn anthropic_passthrough_dispatch(
             upstream_model,
             metrics,
             usage_handled_by_stream: false,
+            routing: RoutingTelemetry::default(),
         })
     }
 }
@@ -843,6 +1055,7 @@ async fn cross_provider_dispatch(
     user_id: Option<String>,
     resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
     client: &ClientContext,
+    attempt: AttemptInfo,
 ) -> Result<DispatchOutcome, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
     use aisix_provider_anthropic::{
@@ -921,6 +1134,8 @@ async fn cross_provider_dispatch(
         let started_for_telem = started;
         // #492: log the same client IP/UA on streamed responses.
         let client_for_telem = client.clone();
+        // Winning-attempt classification (#655) for the stream-end emit.
+        let attempt_for_telem = attempt.clone();
         let stream_guardrail = if resolved_chain.is_empty() {
             None
         } else {
@@ -958,6 +1173,7 @@ async fn cross_provider_dispatch(
                     started_for_telem.elapsed(),
                     metrics,
                     &client_for_telem,
+                    attempt_for_telem.clone(),
                 );
             },
         );
@@ -983,6 +1199,7 @@ async fn cross_provider_dispatch(
             upstream_model,
             metrics: AnthropicUsageMetrics::default(),
             usage_handled_by_stream: true,
+            routing: RoutingTelemetry::default(),
         });
     }
 
@@ -1034,6 +1251,7 @@ async fn cross_provider_dispatch(
         upstream_model,
         metrics,
         usage_handled_by_stream: false,
+        routing: RoutingTelemetry::default(),
     })
 }
 
@@ -1223,6 +1441,49 @@ struct DispatchOutcome {
     upstream_model: String,
     metrics: AnthropicUsageMetrics,
     usage_handled_by_stream: bool,
+    /// Per-attempt routing telemetry (#655). Carries every attempt that
+    /// preceded the winner plus the winning attempt itself, so the
+    /// handler can emit one `UsageEvent` per attempt sharing `request_id`.
+    routing: RoutingTelemetry,
+}
+
+/// Dispatch error carrying the per-attempt telemetry accumulated before
+/// the request ultimately failed (#655). Mirrors `chat::DispatchFailure`.
+struct MessagesDispatchError {
+    err: ProxyError,
+    routing: RoutingTelemetry,
+}
+
+impl MessagesDispatchError {
+    /// Pre-dispatch failure (model-not-found, auth, budget, guardrail
+    /// block before any upstream attempt): no recorded attempts.
+    fn pre_dispatch(err: ProxyError) -> Self {
+        Self {
+            err,
+            routing: RoutingTelemetry::default(),
+        }
+    }
+}
+
+impl From<ProxyError> for MessagesDispatchError {
+    /// Every `?` in `dispatch`'s pre-attempt prelude converts here — those
+    /// errors fire before any upstream attempt, so they carry no routing.
+    fn from(err: ProxyError) -> Self {
+        Self::pre_dispatch(err)
+    }
+}
+
+/// Bounded error class + short message for a per-attempt record, derived
+/// from a `ProxyError`. Bridge errors carry the upstream-mapped class +
+/// message; everything else uses the DP-stable `ProxyError::kind`.
+fn attempt_error_from_proxy(err: &ProxyError) -> (String, String) {
+    match err {
+        ProxyError::Bridge(be) => (
+            routing_error_class(be).to_string(),
+            attempt_error_message(be),
+        ),
+        other => (other.kind().to_string(), String::new()),
+    }
 }
 
 /// Bundle of optional fields a UsageEvent emit-call wants when the
@@ -1265,6 +1526,7 @@ fn emit_anthropic_usage_event(
     elapsed: Duration,
     metrics: AnthropicUsageMetrics,
     client: &ClientContext,
+    attempt: AttemptInfo,
 ) {
     // Per-PK telemetry attribution (#302 M17 / AISIX-Cloud#436).
     // Same shape as chat.rs's emit_usage_event — look up the
@@ -1296,6 +1558,11 @@ fn emit_anthropic_usage_event(
         finish_reason: metrics.finish_reason,
         ttft_ms: metrics.ttft_ms,
         inbound_protocol: "anthropic".to_string(),
+        attempt_index: attempt.index,
+        attempt_kind: attempt.kind,
+        attempt_model: attempt.model,
+        error_class: attempt.error_class,
+        error_message: attempt.error_message,
         provider_kind: sanitize_tag(tags.kind.unwrap_or_default()),
         provider_featured: tags.featured,
         branded_provider: sanitize_tag(tags.branded_provider.unwrap_or_default()),
@@ -1723,7 +1990,15 @@ fn emit_access_log(
     status: u16,
     latency: Duration,
     request_id: &str,
+    routing: &RoutingTelemetry,
 ) {
+    // Per #655 the access log stays ONE line per request, carrying the
+    // user-perceived `latency` + final status plus a routing summary; the
+    // per-attempt detail lives in telemetry.
+    let served_by = routing
+        .winner()
+        .map(|w| w.target_model.as_str())
+        .filter(|s| !s.is_empty());
     AccessLog {
         method: "POST",
         path: "/v1/messages",
@@ -1736,9 +2011,15 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
-        served_by_model: None,
-        routing_attempt_count: None,
-        routing_fallback_count: None,
+        served_by_model: served_by,
+        routing_attempt_count: match routing.attempt_count() {
+            0 => None,
+            n => Some(n),
+        },
+        routing_fallback_count: match routing.fallback_count() {
+            0 => None,
+            n => Some(n),
+        },
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -53,7 +53,7 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use crate::attempt::{
-    attempt_error_message, routing_error_class, AttemptInfo, AttemptRecord, RoutingTelemetry,
+    attempt_error_from_proxy, ms_since, AttemptInfo, AttemptRecord, RoutingTelemetry,
 };
 use crate::auth::AuthenticatedKey;
 use crate::chat::sanitize_tag;
@@ -604,11 +604,6 @@ async fn dispatch(
         err: last_err.unwrap_or(ProxyError::ProviderUnavailable),
         routing,
     })
-}
-
-/// Milliseconds elapsed since `started`, saturating at `u32::MAX`.
-fn ms_since(started: Instant) -> u32 {
-    started.elapsed().as_millis().min(u32::MAX as u128) as u32
 }
 
 /// Dispatch one concrete (non-routing) target Model. Branches on the
@@ -1648,19 +1643,6 @@ impl From<ProxyError> for MessagesDispatchError {
     /// errors fire before any upstream attempt, so they carry no routing.
     fn from(err: ProxyError) -> Self {
         Self::pre_dispatch(err)
-    }
-}
-
-/// Bounded error class + short message for a per-attempt record, derived
-/// from a `ProxyError`. Bridge errors carry the upstream-mapped class +
-/// message; everything else uses the DP-stable `ProxyError::kind`.
-fn attempt_error_from_proxy(err: &ProxyError) -> (String, String) {
-    match err {
-        ProxyError::Bridge(be) => (
-            routing_error_class(be).to_string(),
-            attempt_error_message(be),
-        ),
-        other => (other.kind().to_string(), String::new()),
     }
 }
 

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -451,7 +451,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -458,7 +458,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -506,7 +506,6 @@ fn emit_access_log(
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
-        routing_attempts: None,
     }
     .emit();
 }

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -21,7 +21,7 @@ use serde_json::Value;
 use std::time::{Duration, Instant};
 
 use crate::attempt::{
-    attempt_error_message, routing_error_class, AttemptInfo, AttemptRecord, RoutingTelemetry,
+    attempt_error_from_proxy, ms_since, AttemptInfo, AttemptRecord, RoutingTelemetry,
 };
 use crate::auth::AuthenticatedKey;
 use crate::client_ip::ClientContext;
@@ -65,24 +65,6 @@ impl From<ProxyError> for ResponsesDispatchError {
             routing: RoutingTelemetry::default(),
         }
     }
-}
-
-/// Bounded error class + short message for a per-attempt record, derived
-/// from a `ProxyError`. Bridge errors carry the upstream-mapped class +
-/// message; everything else uses the DP-stable `ProxyError::kind`.
-fn attempt_error_from_proxy(err: &ProxyError) -> (String, String) {
-    match err {
-        ProxyError::Bridge(be) => (
-            routing_error_class(be).to_string(),
-            attempt_error_message(be),
-        ),
-        other => (other.kind().to_string(), String::new()),
-    }
-}
-
-/// Milliseconds elapsed since `started`, saturating at `u32::MAX`.
-fn ms_since(started: Instant) -> u32 {
-    started.elapsed().as_millis().min(u32::MAX as u128) as u32
 }
 
 /// Subset of the OpenAI Responses-API `usage` block the gateway

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -20,6 +20,9 @@ use axum::Json;
 use serde_json::Value;
 use std::time::{Duration, Instant};
 
+use crate::attempt::{
+    attempt_error_message, routing_error_class, AttemptInfo, AttemptRecord, RoutingTelemetry,
+};
 use crate::auth::AuthenticatedKey;
 use crate::client_ip::ClientContext;
 use crate::error::ProxyError;
@@ -41,6 +44,45 @@ struct ResponseDispatchSuccess {
     /// UUID of the resolved Model row — needed for UsageEvent
     /// `model_id` field. Always present on success.
     model_id: String,
+    /// Per-attempt routing telemetry (#655): the failed attempts that
+    /// preceded the winner plus the winning attempt itself.
+    routing: RoutingTelemetry,
+}
+
+/// Dispatch error carrying the per-attempt telemetry accumulated before
+/// the request ultimately failed (#655). Mirrors `chat::DispatchFailure`.
+struct ResponsesDispatchError {
+    err: ProxyError,
+    routing: RoutingTelemetry,
+}
+
+impl From<ProxyError> for ResponsesDispatchError {
+    /// Pre-attempt `?` failures (model-not-found, auth, budget) carry no
+    /// recorded attempts.
+    fn from(err: ProxyError) -> Self {
+        Self {
+            err,
+            routing: RoutingTelemetry::default(),
+        }
+    }
+}
+
+/// Bounded error class + short message for a per-attempt record, derived
+/// from a `ProxyError`. Bridge errors carry the upstream-mapped class +
+/// message; everything else uses the DP-stable `ProxyError::kind`.
+fn attempt_error_from_proxy(err: &ProxyError) -> (String, String) {
+    match err {
+        ProxyError::Bridge(be) => (
+            routing_error_class(be).to_string(),
+            attempt_error_message(be),
+        ),
+        other => (other.kind().to_string(), String::new()),
+    }
+}
+
+/// Milliseconds elapsed since `started`, saturating at `u32::MAX`.
+fn ms_since(started: Instant) -> u32 {
+    started.elapsed().as_millis().min(u32::MAX as u128) as u32
 }
 
 /// Subset of the OpenAI Responses-API `usage` block the gateway
@@ -88,6 +130,7 @@ pub async fn responses(
                 status,
                 elapsed,
                 &request_id,
+                &success.routing,
             );
             state.metrics.record_request(
                 &success.provider,
@@ -95,6 +138,16 @@ pub async fn responses(
                 status,
                 RequestOutcome::from_status(status),
                 elapsed,
+            );
+            // Per #655: one zero-token UsageEvent per failed attempt that
+            // preceded the winner (non-streaming failover).
+            emit_failed_attempts(
+                &state,
+                &request_id,
+                &success.model_id,
+                &api_key_id,
+                &client,
+                &success.routing,
             );
             // Issue #404: emit UsageEvent so cp-api's budget ledger
             // and customer-facing /logs analytics see /v1/responses
@@ -105,6 +158,13 @@ pub async fn responses(
             // emission requires SSE byte-stream interception and is
             // tracked as a follow-up.
             if let Some(usage) = success.usage {
+                // Winning-attempt classification (#655). Direct models
+                // have no recorded attempt → AttemptInfo defaults.
+                let attempt = success
+                    .routing
+                    .winner()
+                    .map(AttemptInfo::from_record)
+                    .unwrap_or_default();
                 emit_usage_event(
                     &state,
                     &request_id,
@@ -114,11 +174,12 @@ pub async fn responses(
                     elapsed,
                     &usage,
                     &client,
+                    attempt,
                 );
             }
             success.response
         }
-        Err(err) => {
+        Err(ResponsesDispatchError { err, routing }) => {
             let status = err.status().as_u16();
             let elapsed = started.elapsed();
             emit_access_log(
@@ -128,6 +189,7 @@ pub async fn responses(
                 status,
                 elapsed,
                 &request_id,
+                &routing,
             );
             state.metrics.record_request(
                 "unknown",
@@ -136,6 +198,30 @@ pub async fn responses(
                 RequestOutcome::from_status(status),
                 elapsed,
             );
+            // Per #655: emit one zero-token UsageEvent per FAILED attempt so
+            // the dashboard's Logs tab surfaces each failed upstream try.
+            // `model_id` is empty on pre-dispatch failures (model never
+            // resolved); the request_id still groups the rows.
+            emit_failed_attempts(&state, &request_id, "", &api_key_id, &client, &routing);
+            // Pre-dispatch failure (model-not-found, auth, budget) records no
+            // attempts — emit a single terminal event carrying the failure
+            // class. When attempts were recorded, each was already emitted.
+            if routing.attempts.is_empty() {
+                emit_zero_token_event(
+                    &state,
+                    &request_id,
+                    "",
+                    &api_key_id,
+                    status,
+                    elapsed,
+                    &client,
+                    AttemptInfo {
+                        kind: "initial".to_string(),
+                        error_class: err.kind().to_string(),
+                        ..Default::default()
+                    },
+                );
+            }
             err.into_response()
         }
     }
@@ -146,7 +232,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: &Value,
     request_id: &str,
-) -> Result<ResponseDispatchSuccess, ProxyError> {
+) -> Result<ResponseDispatchSuccess, ResponsesDispatchError> {
     let snapshot = state.snapshot.load();
 
     let model_name = body
@@ -161,7 +247,7 @@ async fn dispatch(
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
     if !auth.key().can_access(&model_name) {
-        return Err(ProxyError::ModelForbidden(model_name.clone()));
+        return Err(ProxyError::ModelForbidden(model_name.clone()).into());
     }
 
     let model_rl =
@@ -185,6 +271,8 @@ async fn dispatch(
         .as_ref()
         .map(|r| r.retry_on_429_or_default())
         .unwrap_or(false);
+    let is_routing_request = model_entry.value.routing.is_some();
+    let mut routing = RoutingTelemetry::default();
 
     let is_stream = body
         .get("stream")
@@ -204,7 +292,14 @@ async fn dispatch(
             .iter()
             .find(|t| t.model.provider.as_deref() == Some("openai"))
             .ok_or_else(not_openai)?;
-        return responses_to_target(
+        let (idx, kind) = routing.begin_attempt(&target.model.display_name);
+        let target_model = if is_routing_request {
+            target.model.display_name.clone()
+        } else {
+            String::new()
+        };
+        let attempt_started = Instant::now();
+        return match responses_to_target(
             state,
             &snapshot,
             body,
@@ -212,7 +307,39 @@ async fn dispatch(
             &target.id,
             request_id,
         )
-        .await;
+        .await
+        {
+            Ok(mut success) => {
+                routing.attempts.push(AttemptRecord {
+                    index: idx,
+                    kind,
+                    target_model,
+                    provider_key_id: String::new(),
+                    status: success.response.status().as_u16(),
+                    success: true,
+                    error_class: String::new(),
+                    error_message: String::new(),
+                    latency_ms: ms_since(attempt_started),
+                });
+                success.routing = routing;
+                Ok(success)
+            }
+            Err(e) => {
+                let (error_class, error_message) = attempt_error_from_proxy(&e);
+                routing.attempts.push(AttemptRecord {
+                    index: idx,
+                    kind,
+                    target_model,
+                    provider_key_id: String::new(),
+                    status: e.status().as_u16(),
+                    success: false,
+                    error_class,
+                    error_message,
+                    latency_ms: ms_since(attempt_started),
+                });
+                Err(ResponsesDispatchError { err: e, routing })
+            }
+        };
     }
 
     let mut last_err: Option<ProxyError> = None;
@@ -222,6 +349,13 @@ async fn dispatch(
             continue;
         }
         any_openai = true;
+        let (idx, kind) = routing.begin_attempt(&target.model.display_name);
+        let target_model = if is_routing_request {
+            target.model.display_name.clone()
+        } else {
+            String::new()
+        };
+        let attempt_started = Instant::now();
         match responses_to_target(
             state,
             &snapshot,
@@ -232,12 +366,38 @@ async fn dispatch(
         )
         .await
         {
-            Ok(success) => return Ok(success),
+            Ok(mut success) => {
+                routing.attempts.push(AttemptRecord {
+                    index: idx,
+                    kind,
+                    target_model,
+                    provider_key_id: String::new(),
+                    status: success.response.status().as_u16(),
+                    success: true,
+                    error_class: String::new(),
+                    error_message: String::new(),
+                    latency_ms: ms_since(attempt_started),
+                });
+                success.routing = routing;
+                return Ok(success);
+            }
             Err(e) => {
                 let retryable = matches!(
                     &e,
                     ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429)
                 );
+                let (error_class, error_message) = attempt_error_from_proxy(&e);
+                routing.attempts.push(AttemptRecord {
+                    index: idx,
+                    kind,
+                    target_model,
+                    provider_key_id: String::new(),
+                    status: e.status().as_u16(),
+                    success: false,
+                    error_class,
+                    error_message,
+                    latency_ms: ms_since(attempt_started),
+                });
                 last_err = Some(e);
                 if !retryable {
                     break;
@@ -247,9 +407,12 @@ async fn dispatch(
     }
 
     if !any_openai {
-        return Err(not_openai());
+        return Err(not_openai().into());
     }
-    Err(last_err.unwrap_or(ProxyError::ProviderUnavailable))
+    Err(ResponsesDispatchError {
+        err: last_err.unwrap_or(ProxyError::ProviderUnavailable),
+        routing,
+    })
 }
 
 /// Dispatch one concrete OpenAI target's Responses-API passthrough to
@@ -359,6 +522,7 @@ async fn responses_to_target(
             provider: provider_label,
             usage: None,
             model_id: model_id.to_string(),
+            routing: RoutingTelemetry::default(),
         })
     } else {
         let json_body: Value = upstream_resp
@@ -385,6 +549,7 @@ async fn responses_to_target(
             provider: provider_label,
             usage,
             model_id: model_id.to_string(),
+            routing: RoutingTelemetry::default(),
         })
     }
 }
@@ -458,6 +623,7 @@ fn emit_usage_event(
     elapsed: Duration,
     usage: &ResponseUsage,
     client: &ClientContext,
+    attempt: AttemptInfo,
 ) {
     let event = UsageEvent {
         request_id: request_id.to_string(),
@@ -471,6 +637,11 @@ fn emit_usage_event(
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),
+        attempt_index: attempt.index,
+        attempt_kind: attempt.kind,
+        attempt_model: attempt.model,
+        error_class: attempt.error_class,
+        error_message: attempt.error_message,
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         ..Default::default()
@@ -483,6 +654,68 @@ fn emit_usage_event(
         .fan_out(&event, exporters.iter().map(|e| &e.value));
 }
 
+/// Emit a zero-token `UsageEvent` for a failed / pre-dispatch attempt
+/// (#655). Tokens stay 0; `status_code` + `error_*` carry the failure.
+#[allow(clippy::too_many_arguments)]
+fn emit_zero_token_event(
+    state: &ProxyState,
+    request_id: &str,
+    model_id: &str,
+    api_key_id: &str,
+    status_code: u16,
+    elapsed: Duration,
+    client: &ClientContext,
+    attempt: AttemptInfo,
+) {
+    let event = UsageEvent {
+        request_id: request_id.to_string(),
+        occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        model_id: model_id.to_string(),
+        api_key_id: api_key_id.to_string(),
+        latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
+        status_code,
+        inbound_protocol: "openai".to_string(),
+        attempt_index: attempt.index,
+        attempt_kind: attempt.kind,
+        attempt_model: attempt.model,
+        error_class: attempt.error_class,
+        error_message: attempt.error_message,
+        client_source_ip: client.source_ip.clone(),
+        client_user_agent: client.user_agent.clone(),
+        ..Default::default()
+    };
+    state.usage_sink.try_emit("responses", event.clone());
+    let snap = state.snapshot.load();
+    let exporters = snap.observability_exporters.entries();
+    state
+        .otlp_fan_out
+        .fan_out(&event, exporters.iter().map(|e| &e.value));
+}
+
+/// Emit one zero-token `UsageEvent` per FAILED attempt of a `/v1/responses`
+/// request (#655). The winner / terminal event is emitted separately.
+fn emit_failed_attempts(
+    state: &ProxyState,
+    request_id: &str,
+    model_id: &str,
+    api_key_id: &str,
+    client: &ClientContext,
+    routing: &RoutingTelemetry,
+) {
+    for rec in routing.attempts.iter().filter(|a| !a.success) {
+        emit_zero_token_event(
+            state,
+            request_id,
+            model_id,
+            api_key_id,
+            rec.status,
+            Duration::from_millis(u64::from(rec.latency_ms)),
+            client,
+            AttemptInfo::from_record(rec),
+        );
+    }
+}
+
 fn emit_access_log(
     model: &str,
     provider: &str,
@@ -490,7 +723,14 @@ fn emit_access_log(
     status: u16,
     elapsed: Duration,
     request_id: &str,
+    routing: &RoutingTelemetry,
 ) {
+    // Per #655 the access log stays ONE line per request, carrying the
+    // user-perceived `latency` + final status plus a routing summary.
+    let served_by = routing
+        .winner()
+        .map(|w| w.target_model.as_str())
+        .filter(|s| !s.is_empty());
     AccessLog {
         method: "POST",
         path: "/v1/responses",
@@ -503,9 +743,15 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
-        served_by_model: None,
-        routing_attempt_count: None,
-        routing_fallback_count: None,
+        served_by_model: served_by,
+        routing_attempt_count: match routing.attempt_count() {
+            0 => None,
+            n => Some(n),
+        },
+        routing_fallback_count: match routing.fallback_count() {
+            0 => None,
+            n => Some(n),
+        },
     }
     .emit();
 }
@@ -943,12 +1189,14 @@ mod tests {
         }
     }
 
-    /// Issue #404 negative pinning: 5xx responses must NOT emit
-    /// a UsageEvent. Audit MEDIUM-2 on this PR — without negative
-    /// pinning, a future regression that moved `emit_usage_event`
-    /// into the error branch would silently ship.
+    /// Per #655: a 5xx upstream now emits ONE zero-token UsageEvent for the
+    /// failed attempt, so the dashboard's Logs tab surfaces the failure
+    /// alongside its siblings. (Pre-#655 the responses handler dropped the
+    /// event on the error path — the failed request was invisible.) The
+    /// event carries the mapped status (502), zero tokens, an error class,
+    /// and the initial-attempt classification.
     #[tokio::test]
-    async fn upstream_5xx_does_not_emit_usage_event() {
+    async fn upstream_5xx_emits_zero_token_failed_attempt_event() {
         use aisix_obs::UsageSink;
 
         let upstream = MockServer::start().await;
@@ -981,10 +1229,26 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
 
         let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        if let Ok(Some(ev)) = recv {
+        let ev = recv
+            .expect("a failed-attempt UsageEvent must be emitted within the timeout")
+            .expect("the usage sink channel must not be closed");
+        assert_eq!(ev.status_code, 502, "failed attempt records the mapped 502");
+        assert_eq!(ev.prompt_tokens, 0, "failed attempt has zero tokens");
+        assert_eq!(ev.completion_tokens, 0, "failed attempt has zero tokens");
+        assert_eq!(ev.attempt_index, 0, "single direct-model attempt");
+        assert_eq!(ev.attempt_kind, "initial");
+        assert_eq!(
+            ev.error_class, "upstream_status",
+            "500 upstream maps to an upstream_status error class",
+        );
+        // Exactly one event — a direct model has no further attempts and no
+        // separate terminal event (the attempt itself is terminal).
+        let extra = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
+        if let Ok(Some(ev)) = extra {
             panic!(
-                "5xx must not emit UsageEvent, got status_code={}",
-                ev.status_code,
+                "expected exactly one event for a single failed attempt, got a second: \
+                 attempt_index={} status_code={}",
+                ev.attempt_index, ev.status_code,
             );
         }
     }

--- a/tests/e2e/src/cases/per-attempt-telemetry-e2e.test.ts
+++ b/tests/e2e/src/cases/per-attempt-telemetry-e2e.test.ts
@@ -1,0 +1,247 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E (#655): the DP emits one UsageEvent per upstream attempt — the
+// initial try, each retry, and each fallback — all sharing the request's
+// `request_id` (the trace/group key). A Model Group whose primary fails
+// and secondary succeeds must therefore emit TWO telemetry records: a
+// failed `initial` attempt on the primary and a successful `fallback`
+// attempt on the secondary.
+//
+// Usage telemetry has no cp-api receiver in DP e2e, so we observe the
+// emitted field VALUES through the per-env OTLP/HTTP fan-out: register a
+// mock OTLP receiver as an `observability_exporter`, drive one failover
+// request, and assert two spans carrying the per-attempt attributes
+// (`aisix.attempt_index` / `aisix.attempt_kind` / `aisix.attempt_model`
+// / `aisix.error_class`) share the same `aisix.request_id`.
+
+const CALLER_PLAINTEXT = "sk-per-attempt-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+interface OtlpReceiver {
+  url: string;
+  /** All span attribute maps recorded across every posted batch. */
+  spanAttrs: Array<Record<string, string>>;
+  close(): Promise<void>;
+}
+
+async function startOtlpReceiver(): Promise<OtlpReceiver> {
+  const spanAttrs: Array<Record<string, string>> = [];
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(raw);
+        for (const rs of body.resourceSpans ?? []) {
+          for (const ss of rs.scopeSpans ?? []) {
+            for (const span of ss.spans ?? []) {
+              const attrs: Record<string, string> = {};
+              for (const a of span.attributes ?? []) {
+                const v = a.value ?? {};
+                attrs[a.key] =
+                  v.stringValue ?? String(v.intValue ?? v.boolValue ?? "");
+              }
+              spanAttrs.push(attrs);
+            }
+          }
+        }
+      } catch {
+        // ignore malformed bodies — assertions fail on missing spans
+      }
+      res.statusCode = 200;
+      res.end("{}");
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${port}/v1/traces`,
+    spanAttrs,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+async function waitForAttempts(
+  recv: OtlpReceiver,
+  requestId: string,
+  count: number,
+  timeoutMs = 10_000,
+): Promise<Array<Record<string, string>>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hits = recv.spanAttrs.filter(
+      (a) => a["aisix.request_id"] === requestId,
+    );
+    if (hits.length >= count) return hits;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(
+    `expected ${count} attempt spans for request_id=${requestId}, ` +
+      `saw ${recv.spanAttrs.filter((a) => a["aisix.request_id"] === requestId).length}`,
+  );
+}
+
+describe("per-attempt telemetry e2e (#655): one UsageEvent per upstream attempt", () => {
+  let etcdReachable = false;
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let otlp: OtlpReceiver | undefined;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    otlp = await startOtlpReceiver();
+    await admin.createObservabilityExporter({
+      name: "per-attempt-otlp",
+      enabled: true,
+      kind: "otlp_http",
+      endpoint: otlp.url,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+    await otlp?.close();
+  });
+
+  async function createOpenAiModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin client not initialized");
+    const providerKey = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: providerKey.id,
+    });
+  }
+
+  test("a failover request emits a failed initial + successful fallback attempt sharing request_id", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    const primary = await startOpenAiUpstream({
+      status: 502,
+      errorBody: { error: { message: "primary down", type: "server_error" } },
+    });
+    const secondary = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-per-attempt-fallback",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "fallback worked" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+      },
+    });
+    upstreams.push(primary, secondary);
+
+    await createOpenAiModel("attempt-primary", primary);
+    await createOpenAiModel("attempt-secondary", secondary);
+    await admin.createModel({
+      display_name: "attempt-virtual",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "attempt-primary" }, { model: "attempt-secondary" }],
+        retries: 0,
+        max_fallbacks: 1,
+      },
+    });
+
+    // Gate on admin-snapshot presence rather than probing the virtual —
+    // probing would warm the primary's cooldown (every retryable upstream
+    // failure cools the failing direct target) and the measured request
+    // would then skip the primary entirely.
+    await waitConfigPropagation(async () => {
+      try {
+        const models = await admin!.listModels();
+        return models.some((m) => m.display_name === "attempt-virtual");
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "attempt-virtual",
+        messages: [{ role: "user", content: "fail over please" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const requestId = res.headers.get("x-aisix-call-id");
+    expect(requestId).toBeTruthy();
+    await res.text();
+
+    // Exactly the primary (initial) then the secondary (fallback).
+    expect(primary.receivedRequests.length).toBe(1);
+    expect(secondary.receivedRequests.length).toBe(1);
+
+    const attempts = await waitForAttempts(otlp, requestId!, 2);
+    attempts.sort(
+      (a, b) =>
+        Number(a["aisix.attempt_index"]) - Number(b["aisix.attempt_index"]),
+    );
+
+    // Attempt 0: failed initial try on the primary.
+    expect(attempts[0]["aisix.attempt_index"]).toBe("0");
+    expect(attempts[0]["aisix.attempt_kind"]).toBe("initial");
+    expect(attempts[0]["aisix.attempt_model"]).toBe("attempt-primary");
+    expect(attempts[0]["aisix.error_class"]).toBe("upstream_status");
+    expect(attempts[0]["http.response.status_code"]).toBe("502");
+    expect(attempts[0]["gen_ai.usage.input_tokens"]).toBe("0");
+
+    // Attempt 1: successful fallback on the secondary with real tokens.
+    expect(attempts[1]["aisix.attempt_index"]).toBe("1");
+    expect(attempts[1]["aisix.attempt_kind"]).toBe("fallback");
+    expect(attempts[1]["aisix.attempt_model"]).toBe("attempt-secondary");
+    expect(attempts[1]["aisix.error_class"]).toBeUndefined();
+    expect(attempts[1]["http.response.status_code"]).toBe("200");
+    expect(attempts[1]["gen_ai.usage.input_tokens"]).toBe("3");
+    expect(attempts[1]["gen_ai.usage.output_tokens"]).toBe("4");
+  });
+});


### PR DESCRIPTION
## Problem

A Model-Group request that retries or fails over made multiple upstream attempts, but the DP emitted a single aggregated `UsageEvent` per request — the per-attempt detail (which target was tried, why it failed, how long it took) was flattened into a `routing_attempts` JSON blob and `ttft_ms`/`latency_ms` covered only the winning call. This diverges from how LiteLLM logs routing (one log record per call, linked by a trace id) and makes per-attempt latency/error analysis impossible downstream.

## What changed

Each upstream attempt — the initial try, each same-target retry, and each fallback — now emits its own `UsageEvent`, all sharing the request's `request_id` (the trace/group key) and ordered by a new `attempt_index`. Failed attempts carry zero tokens plus a bounded `error_class`/`error_message`; the winning attempt carries the real tokens/cost. `status_code`/`latency_ms`/`ttft_ms` are scoped to the attempt.

- New `attempt` module holds the shared `AttemptRecord`/`RoutingTelemetry`/`AttemptInfo` types and the error-class helpers, so `/v1/chat/completions`, `/v1/messages`, and `/v1/responses` classify and emit attempts identically and can't drift.
- All three Model-Group endpoints emit per-attempt events; the `/v1/responses` error path previously emitted nothing and now surfaces failed attempts.
- The one-line-per-request access log is unchanged (it keeps a served-by + attempt/fallback summary); per-attempt detail lives only in telemetry, matching LiteLLM's transport-log vs. structured-log split.
- The OTLP span exports the per-attempt attributes (`aisix.attempt_index`/`_kind`/`_model`/`error_class`/`error_message`).

New `UsageEvent` fields: `attempt_index`, `attempt_kind` (`initial`/`retry`/`fallback`), `attempt_model`, `error_class`, `error_message`. Removed: `served_by_model`, `routing_attempt_count`, `routing_fallback_count`, `routing_attempts` (and the `RoutingAttemptEvent` type).

## Compatibility

Breaking wire-shape change paired with the cp-api ingestion change (api7/AISIX-Cloud#655). Per the project's cross-plane policy this DP change lands first so a new `dev` image is available; the brief window where the not-yet-updated cp-api can't parse the new shape is acceptable and not worked around.

## Tests

- Per-attempt fallback integration tests for the chat, messages, and responses families (failed initial + successful fallback share one `request_id`, with the right per-attempt fields).
- OTLP unit test for the new span attributes.
- DP standalone E2E (`tests/e2e/per-attempt-telemetry-e2e`) drives a primary-502 → secondary-200 Model Group and asserts two attempt spans sharing the request id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emit per-upstream-attempt telemetry for routing/failover: each attempt reports index, kind (initial/retry/fallback), target model, error classification/message, and latency. OTLP spans now include attempt-level attributes. Access logs now surface served model plus attempt and fallback counts.

* **Tests**
  * Added E2E and unit tests validating per-attempt telemetry, OTLP span attributes, and updated access-log/usage emission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->