### PR TITLE
fix(managed): pin HTTP/1.1 on the dp-manager mTLS REST clients

### DIFF
--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -283,6 +283,18 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
         .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")))
         .identity(identity)
         .add_root_certificate(ca)
+        // Pin HTTP/1.1 for the dp-manager REST calls. dp-manager
+        // multiplexes gRPC (kine/etcd, HTTP/2) and the REST surface
+        // (/dp/*) on one TLS port via cmux, which routes by the
+        // negotiated ALPN protocol. When the observability cloud-sink
+        // crates pulled reqwest's `http2` feature into the workspace
+        // (Cargo feature unification), this client began advertising `h2`
+        // in ALPN, so cmux handed these REST requests to the gRPC handler
+        // and every POST failed with "error sending request". Forcing
+        // http/1.1 keeps ALPN at `http/1.1` so cmux routes to the REST
+        // mux. The etcd/gRPC client is a separate tonic h2 connection and
+        // is unaffected.
+        .http1_only()
         .use_rustls_tls();
     // Operator-supplied extra root (e2e / on-prem). Covers the dp-
     // manager server cert when it's signed by a CA distinct from the

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -244,6 +244,12 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
         .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")))
         .identity(identity)
         .add_root_certificate(ca)
+        // Pin HTTP/1.1 — see heartbeat::build_client. dp-manager cmux
+        // routes one TLS port to gRPC (h2) vs REST (http1) by ALPN; once
+        // the cloud-sink crates pulled reqwest's `http2` feature into the
+        // workspace, this telemetry client advertised `h2` and cmux
+        // misrouted the /dp/telemetry POSTs to the gRPC handler.
+        .http1_only()
         .use_rustls_tls();
     // Mirror heartbeat::build_client — pick up the operator-supplied
     // extra trust root (managed.cp_ca_cert_file) when set.


### PR DESCRIPTION
## Problem

In managed mode the DP talks to dp-manager over a single mTLS port (`:7944`) that **cmux**-multiplexes two protocols: gRPC (kine/etcd, HTTP/2) and the REST surface (`/dp/heartbeat`, `/dp/budget_check`, `/dp/telemetry`). cmux dispatches each connection by its negotiated **ALPN** protocol.

Since the observability cloud-sink work (object_store + Aliyun SLS), `Cargo.lock` pulls reqwest's `http2` feature into the workspace, and Cargo **feature unification** turns it on for *every* reqwest client — including the DP→dp-manager mTLS REST clients. Those clients then started advertising `h2` in ALPN, so cmux handed their REST POSTs to the **gRPC** handler and every request failed with `error sending request`. The DP then fail-closes budget checks (`429 budget_exceeded`) and drops heartbeats/telemetry. The etcd/gRPC client is a separate tonic h2 connection, so it kept working — which is why the symptom is "gRPC up, REST down" on the same port.

## Fix

Pin the two DP→dp-manager mTLS clients to HTTP/1.1 with `.http1_only()` (`crates/aisix-server/src/heartbeat.rs` — also used by the budget client — and `crates/aisix-server/src/telemetry.rs`). ALPN then offers only `http/1.1`, so cmux routes them to the REST mux. No behavior change to the etcd/gRPC path.

## Testing

The regression is exercised by the control-plane e2e (`AISIX-Cloud` `e2e-go`, the `TestGuardrail*` suite), which boots a real DP from the `:dev` image against a real dp-manager: it fails (DP never serves; `429 budget_exceeded`) with the buggy image and passes with this fix. Verified locally by building the fixed image and running `TestGuardrailAliyunBlocksAndWireShape` — fails before, passes after (2.8s vs a 3-min timeout). A pure DP-side unit test isn't practical here (the behavior is ALPN negotiation against a cmux server); the cross-repo e2e is the guard.

Unblocks the per-attempt telemetry CP PR (api7/AISIX-Cloud#710), whose `e2e-go` is currently red solely due to this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heartbeat and telemetry POST request delivery failures. Ensured correct HTTP protocol configuration to prevent request routing issues and improve system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->