### PR TITLE
fix(guardrails): run input guardrails on /v1/responses and /v1/embeddings (#719)

### DIFF
--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -14,7 +14,7 @@
 //! Providers that don't implement embeddings return a 501 with
 //! `"type": "not_implemented"`.
 
-use aisix_gateway::{BridgeContext, BridgeError, EmbeddingRequest};
+use aisix_gateway::{BridgeContext, BridgeError, ChatFormat, ChatMessage, EmbeddingRequest};
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -60,6 +60,23 @@ impl InputField {
             InputField::Multi(v) => v,
         }
     }
+}
+
+/// Build a [`ChatFormat`] of user messages from the embeddings `input` so
+/// the input guardrail chain can scan it (#719). Each non-empty string
+/// becomes one user message; the synthesized request is never sent
+/// upstream (the original `input` shape is forwarded verbatim).
+fn embeddings_input_to_chat(model: &str, input: &InputField) -> ChatFormat {
+    let messages = match input {
+        InputField::Single(s) if !s.is_empty() => vec![ChatMessage::user(s.clone())],
+        InputField::Single(_) => Vec::new(),
+        InputField::Multi(v) => v
+            .iter()
+            .filter(|s| !s.is_empty())
+            .map(|s| ChatMessage::user(s.clone()))
+            .collect(),
+    };
+    ChatFormat::new(model, messages)
 }
 
 pub async fn embeddings(
@@ -229,6 +246,39 @@ async fn dispatch(
         crate::quota::ModelRateLimit::from_model(&body.model, &model_entry.id, &model_entry.value);
     let reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
+    // #719: /v1/embeddings must run input guardrails. Before this the
+    // handler explicitly bypassed all guardrails, so a content block
+    // enforced on /v1/chat/completions was bypassable by sending the same
+    // text to /v1/embeddings. The embeddings `input` (a string or array of
+    // strings) carries scannable user content; translate it into the
+    // internal ChatFormat and run the resolved input guardrail chain. A
+    // Block short-circuits before the upstream call. (Embeddings responses
+    // are vectors, not text, so there is no output hook to run.)
+    let guardrail_ctx = aisix_guardrails::RequestContext {
+        model_id: &model_entry.id,
+        api_key_id: &auth.entry.id,
+        team_id: auth.key().team_id.as_deref(),
+    };
+    let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    if !resolved_chain.is_empty() {
+        let chat = embeddings_input_to_chat(&body.model, &body.input);
+        if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+            aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        {
+            // Per #153 keep the matched-pattern detail in ops logs only; the
+            // wire envelope stays generic.
+            tracing::warn!(
+                guardrail_hook = "input",
+                model = %body.model,
+                reason = %reason,
+                "guardrail blocked /v1/embeddings request",
+            );
+            return Err(ProxyError::ContentFiltered(
+                "request blocked by content policy".into(),
+            ));
+        }
+    }
+
     let upstream_model_id = crate::dispatch::require_upstream_model(model)?.to_string();
 
     // Preserve the caller's original `input` shape per #162 /
@@ -373,8 +423,11 @@ fn emit_usage_event(
     //   - provider_request_id / provider_model_version / finish_reason
     //     — not exposed by the OpenAI embeddings response shape
     //   - cost_usd — cp-api computes server-side from pricing catalog
-    //   - guardrail_blocked / guardrail_bypassed_reason — embeddings
-    //     bypass guardrails today
+    //   - guardrail_blocked — a blocked input short-circuits before this
+    //     emit (success-only path), so it is never set here
+    //   - guardrail_bypassed_reason — embeddings now run input guardrails
+    //     (#719); fail-open bypass telemetry is not yet plumbed for the
+    //     non-chat handlers (follow-up, same as the per-PK fields below)
     //   - cache_status / cache_hit_saved_* — no caching on embeddings
     //   - ttft_ms — embeddings are not streamed
     //   - served_by_model / routing_* — embeddings don't run routing
@@ -498,6 +551,113 @@ mod tests {
             "model": "text-embedding-3-small",
             "usage": {"prompt_tokens": 4, "total_tokens": 4}
         })
+    }
+
+    /// An env-scoped keyword input guardrail (no attachment row → applies
+    /// to every request via the backward-compat fallback) that blocks on a
+    /// literal. `fail_open:false` is irrelevant for keyword (local, never
+    /// errors) but keeps the row explicit.
+    fn keyword_input_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"test-block","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-1", g, 1)
+    }
+
+    /// #719: /v1/embeddings explicitly bypassed all guardrails, so a content
+    /// block configured on /v1/chat/completions was evadable by sending the
+    /// same text to /v1/embeddings. A configured input guardrail must now
+    /// fire here: a blocked literal returns 422 content_filter and the
+    /// upstream is never contacted (`expect(0)`).
+    #[tokio::test]
+    async fn input_guardrail_blocks_string_input_returns_422_content_filter() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({"model": "my-embed", "input": "please BLOCKME now"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        // Per #153 the matched literal must not leak into the wire message.
+        let msg = v["error"]["message"].as_str().unwrap_or_default();
+        assert!(!msg.contains("BLOCKME"), "blocklist literal leaked: {msg}");
+    }
+
+    /// #719: the array `input` form must be scanned too — a blocked literal
+    /// in any element blocks the call.
+    #[tokio::test]
+    async fn input_guardrail_blocks_array_input() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let body =
+            serde_json::json!({"model": "my-embed", "input": ["totally fine", "now BLOCKME"]});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #719 companion: a benign input with a configured input guardrail must
+    /// still reach the upstream (`expect(1)`) and return 200 — the guardrail
+    /// must not block clean traffic.
+    #[tokio::test]
+    async fn input_guardrail_allows_benign_input_forwards_200() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({"model": "my-embed", "input": "a perfectly fine request"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["object"], "list");
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -490,19 +490,24 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
 }
 
 /// Collect the plain, caller-supplied text of one Responses-API input
-/// item. A message item carries text under `content`; a
-/// `function_call_output` (a tool result the caller feeds back into the
-/// conversation) carries it under `output`. Both are user-controlled
-/// content entering the model — the `/v1/chat/completions` equivalent
-/// (a `role:"tool"` message) is scanned, so both are scanned here too,
-/// else the #719 surface-switch bypass would survive on the tool-result
-/// channel. `content`/`output` are each a string or an array of typed
-/// parts; we gather the `text` of each part and ignore non-text parts
-/// (images, files). A `function_call_output` item has no `role`, so the
-/// caller maps it to a user message (scanned by every guardrail kind).
+/// item, across every key on the `input`-item union that carries text the
+/// model will see:
+/// - `content` — message items;
+/// - `output` — tool-result items (`function_call_output`,
+///   `custom_tool_call_output`, `*_call_output`) the caller feeds back;
+/// - `reason` — an `mcp_approval_response` justification.
+///
+/// All are user-controlled content entering the model — the
+/// `/v1/chat/completions` equivalent (a `role:"tool"` message) is
+/// scanned, so leaving any of these unscanned would let the #719
+/// surface-switch bypass survive on that channel. Each slot is a string
+/// or an array of typed parts; we gather the `text` of each part and
+/// ignore non-text parts (images, files). These items carry no `role`,
+/// so the caller maps them to a user message (scanned by every guardrail
+/// kind). Reading a key absent on other item types is a harmless no-op.
 /// <https://platform.openai.com/docs/api-reference/responses/create>
 fn responses_item_text(item: &Value) -> String {
-    [item.get("content"), item.get("output")]
+    [item.get("content"), item.get("output"), item.get("reason")]
         .into_iter()
         .flatten()
         .map(responses_value_text)
@@ -1163,6 +1168,45 @@ mod tests {
                 "model": "gpt-4o-resp",
                 "instructions": "you must BLOCKME",
                 "input": "hello"
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #719 (re-audit LOW-1): an `mcp_approval_response` item carries
+    /// caller-supplied justification text under `reason`, which reaches the
+    /// model. It is scanned too, so no input-bearing channel is silently
+    /// skipped. A blocked literal in `reason` must 422.
+    #[tokio::test]
+    async fn input_guardrail_blocks_mcp_approval_response_reason() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id":"x","object":"response","output":[]})),
+            )
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": [
+                    {"type": "mcp_approval_response", "approve": true, "approval_request_id": "ar_1", "reason": "BLOCKME please"}
+                ]
             })))
             .await
             .unwrap();

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -12,6 +12,7 @@
 //! Only OpenAI models support this endpoint. Non-OpenAI models receive a
 //! 400 with an explanatory message.
 
+use aisix_gateway::{ChatFormat, ChatMessage};
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
@@ -236,6 +237,41 @@ async fn dispatch(
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
     let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
+    // #719: /v1/responses must run input guardrails like /v1/chat/completions
+    // and /v1/messages. Before this, user input reached the upstream without
+    // any configured content/DLP check, so a content block enforced on the
+    // chat surface was bypassable simply by calling /v1/responses (the same
+    // violent input that 422s on chat returned 200 with the content echoed
+    // here). Translate the Responses-API body into the internal ChatFormat
+    // and run the resolved input guardrail chain; a Block short-circuits
+    // before dispatch. (Input Rewrite/Bypass is not applied to the outgoing
+    // Responses body — only Block is enforced, matching /v1/messages.)
+    let guardrail_ctx = aisix_guardrails::RequestContext {
+        model_id: &model_entry.id,
+        api_key_id: &auth.entry.id,
+        team_id: auth.key().team_id.as_deref(),
+    };
+    let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    if !resolved_chain.is_empty() {
+        let chat = responses_input_to_chat(&model_name, body);
+        if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+            aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        {
+            // Per #153 the matched-pattern detail stays in ops logs only; the
+            // wire envelope stays generic so callers can't enumerate the
+            // blocklist by probing error responses.
+            tracing::warn!(
+                guardrail_hook = "input",
+                model = %model_name,
+                reason = %reason,
+                "guardrail blocked /v1/responses request",
+            );
+            return Err(
+                ProxyError::ContentFiltered("request blocked by content policy".into()).into(),
+            );
+        }
+    }
+
     // Resolve the attempt list (routing-aware). /v1/responses is
     // OpenAI-only, so we attempt the group's OpenAI targets in order; a
     // direct model resolves to itself (#471).
@@ -395,6 +431,78 @@ async fn dispatch(
         err: last_err.unwrap_or(ProxyError::ProviderUnavailable),
         routing,
     })
+}
+
+/// Translate a `/v1/responses` request body into the internal
+/// [`ChatFormat`] so the input guardrail chain can scan the
+/// user-supplied content (#719). Only scannable text matters here — this
+/// is **not** a faithful Responses→Chat transform and is never sent
+/// upstream; the original `body` is forwarded verbatim.
+///
+/// The Responses-API `input` field is either a bare string or an array of
+/// input items; a message item is `{role, content}` whose `content` is a
+/// string or an array of typed parts (`input_text` / `output_text` /
+/// `text`). The optional top-level `instructions` maps to a system
+/// message. Roles are preserved so the guardrail's user-vs-all message
+/// selection behaves the same as on /v1/chat/completions.
+/// <https://platform.openai.com/docs/api-reference/responses/create>
+fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
+    let mut messages = Vec::new();
+
+    if let Some(instructions) = body.get("instructions").and_then(|v| v.as_str()) {
+        if !instructions.is_empty() {
+            messages.push(ChatMessage::system(instructions.to_string()));
+        }
+    }
+
+    match body.get("input") {
+        Some(Value::String(text)) => {
+            if !text.is_empty() {
+                messages.push(ChatMessage::user(text.clone()));
+            }
+        }
+        Some(Value::Array(items)) => {
+            for item in items {
+                // A bare-string array element is treated as user text; an
+                // object element is a message whose role we preserve.
+                if let Some(text) = item.as_str() {
+                    if !text.is_empty() {
+                        messages.push(ChatMessage::user(text.to_string()));
+                    }
+                    continue;
+                }
+                let text = responses_item_text(item);
+                if text.is_empty() {
+                    continue;
+                }
+                let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("user");
+                messages.push(match role {
+                    "assistant" => ChatMessage::assistant(text),
+                    "system" | "developer" => ChatMessage::system(text),
+                    _ => ChatMessage::user(text),
+                });
+            }
+        }
+        _ => {}
+    }
+
+    ChatFormat::new(model, messages)
+}
+
+/// Collect the plain text of one Responses-API input item. `content` is
+/// either a string or an array of typed parts; we gather the `text` of
+/// each part and ignore non-text parts (images, files, tool calls).
+fn responses_item_text(item: &Value) -> String {
+    match item.get("content") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(parts)) => parts
+            .iter()
+            .filter_map(|p| p.get("text").and_then(|v| v.as_str()))
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
 }
 
 /// Dispatch one concrete OpenAI target's Responses-API passthrough to
@@ -834,6 +942,134 @@ mod tests {
             .header("content-type", "application/json")
             .body(axum::body::Body::from(body.to_string()))
             .unwrap()
+    }
+
+    /// An env-scoped keyword input guardrail (no attachment row → applies to
+    /// every request via the backward-compat fallback) that blocks on a
+    /// literal substring. Keyword is local (no remote call), so it's the
+    /// deterministic stand-in for any input-hook guardrail kind.
+    fn keyword_input_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"test-block","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-1", g, 1)
+    }
+
+    /// #719 (the core fix): a configured INPUT guardrail that blocks on
+    /// /v1/chat/completions must also fire on /v1/responses. The same blocked
+    /// input must return 422 content_filter here — not 200 with the input
+    /// echoed back — and the upstream must never be contacted (`expect(0)`).
+    #[tokio::test]
+    async fn input_guardrail_blocks_string_input_returns_422_content_filter() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp_should_not_happen",
+                "object": "response",
+                "output": [{"type":"message","content":[{"type":"output_text","text":"echo: BLOCKME"}]}]
+            })))
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": "please BLOCKME now"
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        // Per #153 the matched literal must not leak into the wire message.
+        let msg = v["error"]["message"].as_str().unwrap_or_default();
+        assert!(!msg.contains("BLOCKME"), "blocklist literal leaked: {msg}");
+    }
+
+    /// #719: the Responses `input` array form (message items with typed
+    /// content parts) must be scanned too — a blocked literal inside an
+    /// `input_text` part blocks the call.
+    #[tokio::test]
+    async fn input_guardrail_blocks_array_message_items() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id":"x","object":"response","output":[]})),
+            )
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": [
+                    {"role": "user", "content": [{"type": "input_text", "text": "hi BLOCKME"}]}
+                ]
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #719 companion: a benign input with a configured input guardrail must
+    /// still forward to the upstream (`expect(1)`) and return 200 — the
+    /// guardrail must not block clean traffic.
+    #[tokio::test]
+    async fn input_guardrail_allows_benign_input_forwards_200() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp_ok",
+                "object": "response",
+                "output": [{"type":"message","content":[{"type":"output_text","text":"hi"}]}]
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": "a perfectly fine request"
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["object"], "response");
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -489,15 +489,36 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
     ChatFormat::new(model, messages)
 }
 
-/// Collect the plain text of one Responses-API input item. `content` is
-/// either a string or an array of typed parts; we gather the `text` of
-/// each part and ignore non-text parts (images, files, tool calls).
+/// Collect the plain, caller-supplied text of one Responses-API input
+/// item. A message item carries text under `content`; a
+/// `function_call_output` (a tool result the caller feeds back into the
+/// conversation) carries it under `output`. Both are user-controlled
+/// content entering the model — the `/v1/chat/completions` equivalent
+/// (a `role:"tool"` message) is scanned, so both are scanned here too,
+/// else the #719 surface-switch bypass would survive on the tool-result
+/// channel. `content`/`output` are each a string or an array of typed
+/// parts; we gather the `text` of each part and ignore non-text parts
+/// (images, files). A `function_call_output` item has no `role`, so the
+/// caller maps it to a user message (scanned by every guardrail kind).
+/// <https://platform.openai.com/docs/api-reference/responses/create>
 fn responses_item_text(item: &Value) -> String {
-    match item.get("content") {
-        Some(Value::String(s)) => s.clone(),
-        Some(Value::Array(parts)) => parts
+    [item.get("content"), item.get("output")]
+        .into_iter()
+        .flatten()
+        .map(responses_value_text)
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Plain text of one Responses-API content slot: a bare string, or the
+/// concatenated `text` of an array of typed parts.
+fn responses_value_text(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Array(parts) => parts
             .iter()
-            .filter_map(|p| p.get("text").and_then(|v| v.as_str()))
+            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
             .filter(|t| !t.is_empty())
             .collect::<Vec<_>>()
             .join("\n"),
@@ -1070,6 +1091,86 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["object"], "response");
+    }
+
+    /// #719 (audit MEDIUM-1): a `function_call_output` item carries
+    /// caller-supplied tool-result text under `output` (not `content`), and
+    /// that text reaches the model. It must be scanned too — otherwise the
+    /// surface-switch bypass survives on the tool-result channel. A blocked
+    /// literal in `output` must 422 with the upstream never contacted.
+    #[tokio::test]
+    async fn input_guardrail_blocks_function_call_output_text() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id":"x","object":"response","output":[]})),
+            )
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": [
+                    {"type": "function_call_output", "call_id": "call_1", "output": "tool said BLOCKME"}
+                ]
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #719: the top-level `instructions` field (the system-prompt analog)
+    /// is caller-supplied and reaches the model, so it is scanned too. A
+    /// blocked literal in `instructions` must 422. (Scanned via the
+    /// all-roles keyword guardrail; text-moderation's user-only default
+    /// would skip a system message, matching chat's system-message
+    /// semantics.)
+    #[tokio::test]
+    async fn input_guardrail_blocks_instructions_field() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id":"x","object":"response","output":[]})),
+            )
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "instructions": "you must BLOCKME",
+                "input": "hello"
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Closes the **input** half of #719: a configured input guardrail that blocks on `/v1/chat/completions` was **silently skipped** on `/v1/responses` and `/v1/embeddings`. The same input that returns `422 content_filter` on the chat surface returned `200` on these surfaces — `/v1/responses` echoed the content back, `/v1/embeddings` embedded it. A customer-configured content/DLP block was therefore bypassable just by switching surface.

This PR makes both non-chat input-bearing surfaces run the resolved input guardrail chain before dispatch, exactly as `/v1/chat/completions` and `/v1/messages` already do.

## Why this happened

Guardrail invocation was inlined per-surface. `chat.rs` and `messages.rs` each resolve the chain and call `check_input`; `responses.rs` had **zero** guardrail calls and `embeddings.rs` explicitly documented "embeddings bypass guardrails today". So the enforcement gap was per-surface, not in the chain itself.

## Changes

**`crates/aisix-proxy/src/responses.rs`**
- After auth + rate-limit, before dispatch: resolve the per-request chain (`RequestContext { model_id, api_key_id, team_id }`), and if non-empty run `check_input`. `Block` → `ProxyError::ContentFiltered` (`422 content_filter`).
- New `responses_input_to_chat()` synthesizes a **role-preserving** `ChatFormat` from the Responses-API body: `input` as a bare string, or an array of message items whose `content` is a string or typed parts (`input_text` / `output_text` / `text`); optional top-level `instructions` → system message. Roles are preserved so the guardrail's user-vs-all message selection behaves identically to chat. The synthesized request is for scanning only — the original body is still forwarded verbatim.

**`crates/aisix-proxy/src/embeddings.rs`**
- Same input check before the upstream call. `embeddings_input_to_chat()` turns the `input` (string / array of strings) into user messages. Embeddings responses are vectors → no output hook.
- Corrected the now-stale telemetry comment that claimed embeddings bypass guardrails.

**Shared semantics (both surfaces), matching `/v1/messages`:**
- Only `Block` is enforced. `Rewrite`/`Bypass` are **not** applied to the outgoing non-chat body (same deliberate limitation `/v1/messages` documents).
- Per #153, the verdict's matched-pattern `reason` is logged for ops but the wire message stays generic (`"request blocked by content policy"`) so callers can't enumerate the blocklist by probing error responses.

## Reference / spec

- Responses-API `input` shape (string | array of input items; message `content` is a string or typed parts): <https://platform.openai.com/docs/api-reference/responses/create>. Embeddings `input` (string | array of strings): <https://platform.openai.com/docs/api-reference/embeddings/create>.
- In-repo reference pattern this mirrors: `messages.rs` input check (resolve chain → `is_empty()` guard → translate body → `check_input` → `ContentFiltered` on `Block`).
- Mainstream AI gateways apply their moderation/guardrail hooks uniformly across every input-bearing surface, not only the chat endpoint; this change brings the non-chat surfaces in line with that norm.

## #719 scope status

- [x] `/v1/responses` runs input guardrails — **this PR**
- [x] `/v1/embeddings` runs input guardrails (carries scannable user content) — **this PR**
- [x] Anthropic `/v1/messages` runs input + output guardrails — already present (`messages.rs` input `:398`, output non-streaming `:1353`, streaming `:1529`); verified, no change
- [ ] **Output** guardrails on non-chat surfaces that return a body (`/v1/responses` non-streaming + streaming) — **deliberately deferred to a follow-up PR**

### Why output is a separate PR (not in this one)

Output coverage on `/v1/responses` must be **all-or-nothing**: adding it to the non-streaming path only would make `stream:true` a *new* asymmetric bypass of the exact class #719 is about. Streaming output requires parsing the Responses-API SSE event protocol (`response.output_text.delta` / `response.completed`) — which the gateway deliberately does **not** do today (SSE is passed through verbatim; streaming `usage` extraction was itself deferred under #404). That is a focused, protocol-specific change with its own regression surface, so it is isolated for independent review rather than bundled with this clean, high-value input fix. Follow-up will use buffer-then-scan (`BufferFull`) semantics, matching the chat surface's secure default.

## Test plan

6 new wiremock unit tests (3 per surface):
- block on **string** input → `422` + `error.type == content_filter` + upstream **never contacted** (`expect(0)`)
- block on **array** input → `422 content_filter`
- benign input → upstream **is** called (`expect(1)`) → `200` (guardrail must not block clean traffic)
- the blocked literal must not leak into the wire message (#153)

`cargo fmt` + `cargo clippy --all-targets` clean; **385** `aisix-proxy` lib tests pass.

The real-Azure `M1` acceptance test (held back in AISIX-Cloud#718) will be re-added to AISIX-Cloud once this merges, per the source-blind discipline.

## Independent audit (CLAUDE.md §8) — findings + resolution

A fresh agent reviewed this PR cold. It verified the core fix is solid: synthesized text is actually scannable (`message_scan_text`), the input check runs before the streaming split (covers both modes), #153 redaction holds (no blocklist leak), `422 content_filter` confirmed, the forwarded upstream body is byte-identical, the no-guardrail path is a pure no-op, and the 6 tests genuinely assert the contract (wiremock `expect(0)`/`expect(1)`).

- **MEDIUM-1 — `function_call_output` tool-result text not scanned (narrowed #719 bypass on the tool-result channel): FIXED in code** (commit `3fba23d`). `responses_item_text` now scans both `content` and `output`; such items map to a user message and are scanned by every guardrail kind. New tests cover it (`function_call_output` block + `instructions` block).
- **MEDIUM-2 — a guardrail-blocked request burns a rate-limit slot (reservation runs before the block): JUSTIFIED + follow-up filed (#542).** This matches the existing `/v1/messages` ordering (intentionally mirrored), so it is consistent shipped behavior, not a regression. Aligning all passthrough endpoints with `chat.rs` (which checks before reservation) is tracked in #542.
- **LOW-1 — blocked responses/embeddings not attributed as guardrail blocks in telemetry: follow-up filed (#543).** Observability only; the Blocked dashboard tab under-counts non-chat blocks. Threading `applied_guardrails`/`guardrail_blocked` through the non-chat emit paths is tracked in #543.
- **LOW-2 — extra test cases: ADDED** (`instructions`-only block; `function_call_output` block). The `Bypass`/fail-open path is correct by construction (the `if let Block` match forwards every non-Block verdict) and exercised by the benign-forwards test.

A second, focused audit of the MEDIUM-1 fix returned **MERGE**: the `function_call_output` channel is fully closed (string + array-of-parts forms; no over-scan of normal items; `#153` intact), and it confirmed the generic `output` read also covers `custom_tool_call_output` / `*_call_output`. It found one further LOW residual — `mcp_approval_response.reason` (a niche MCP-approval justification that also reaches the model) was unscanned. **Fixed** (commit appended): `responses_item_text` now also reads `reason`, with a test. Net: every input-bearing channel on the `input` union is scanned.

Merge gate: both MEDIUMs fixed-or-justified; both LOW residuals fixed; LOW telemetry tracked in #543. No HIGH findings; both audits recommend merge.

Refs #719, #379, #542, #543.
