### PR TITLE
feat(guardrails): output guardrails on /v1/responses, streaming + non-streaming (#719)

### DIFF
--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -18,6 +18,7 @@ use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use futures::StreamExt;
 use serde_json::Value;
 use std::time::{Duration, Instant};
 
@@ -622,19 +623,47 @@ async fn responses_to_target(
         // verbatim or block with 422. Requests with no output-hook
         // guardrail keep the zero-copy verbatim passthrough below.
         if aisix_guardrails::Guardrail::runs_on_output(chain) {
-            let bytes = upstream_resp
-                .bytes()
-                .await
-                .map_err(|e| {
-                    crate::cooldown::note_failure(
-                        &state.runtime_status,
-                        model_id,
-                        model.cooldown.as_ref(),
-                        aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-                    )
-                })
-                .map_err(ProxyError::Bridge)?;
-            let out_text = responses_sse_output_text(&bytes);
+            // Hold the whole SSE response back to scan it, but cap the
+            // buffer so a huge (or malicious) upstream response can't OOM the
+            // gateway. Mirror the chat surface's secure BufferFull default
+            // (#466): read with a running byte count and fail closed if the
+            // response exceeds the cap — an output-hook guardrail must never
+            // release content it couldn't fully buffer to scan. The cap is
+            // taken from the chain's resolved streaming policy.
+            let max_buffer_bytes = match aisix_guardrails::Guardrail::stream_output_policy(chain) {
+                aisix_guardrails::StreamOutputPolicy::BufferFull {
+                    max_buffer_bytes, ..
+                } => max_buffer_bytes,
+                _ => aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES,
+            };
+            let stream = upstream_resp.bytes_stream();
+            futures::pin_mut!(stream);
+            let mut buf: Vec<u8> = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk
+                    .map_err(|e| {
+                        crate::cooldown::note_failure(
+                            &state.runtime_status,
+                            model_id,
+                            model.cooldown.as_ref(),
+                            aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
+                        )
+                    })
+                    .map_err(ProxyError::Bridge)?;
+                if buf.len() + chunk.len() > max_buffer_bytes {
+                    tracing::warn!(
+                        guardrail_hook = "output",
+                        model = %model.display_name,
+                        max_buffer_bytes,
+                        "streaming /v1/responses output exceeded buffer cap; failing closed",
+                    );
+                    return Err(ProxyError::ContentFiltered(
+                        "response blocked by content policy".into(),
+                    ));
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            let out_text = responses_sse_output_text(&buf);
             let synth = synth_chat_response(&upstream_model, out_text);
             if let aisix_guardrails::GuardrailVerdict::Block { reason } =
                 aisix_guardrails::Guardrail::check_output(chain, &synth).await
@@ -650,7 +679,7 @@ async fn responses_to_target(
                     "response blocked by content policy".into(),
                 ));
             }
-            let mut response = axum::response::Response::new(axum::body::Body::from(bytes));
+            let mut response = axum::response::Response::new(axum::body::Body::from(buf));
             apply_passthrough_headers(&mut response, &headers, request_id);
             return Ok(ResponseDispatchSuccess {
                 response,
@@ -1556,6 +1585,50 @@ mod tests {
             body.starts_with("event: ") || body.starts_with("data: "),
             "SSE shape preserved on release",
         );
+    }
+
+    /// #719 (audit HIGH-1): the streaming hold-back buffer is capped so a
+    /// huge (or malicious) upstream response can't OOM the gateway. A
+    /// response exceeding the BufferFull cap fails closed (422) rather than
+    /// being released unscanned — even when its content is otherwise clean.
+    #[tokio::test]
+    async fn output_guardrail_streaming_oversized_response_fails_closed() {
+        let upstream = MockServer::start().await;
+        // One delta larger than the 256 KiB default BufferFull cap.
+        let big = "x".repeat(300_000);
+        let sse =
+            format!("data: {{\"type\":\"response.output_text.delta\",\"delta\":\"{big}\"}}\n\ndata: [DONE]\n\n");
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "oversized streamed response must fail closed, not be released unscanned",
+        );
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -651,6 +651,12 @@ async fn responses_to_target(
                     })
                     .map_err(ProxyError::Bridge)?;
                 if buf.len() + chunk.len() > max_buffer_bytes {
+                    // Unlike chat's BufferFull, we always fail closed on
+                    // overflow regardless of `on_exceeded_fail_open`: an
+                    // output-hook guardrail must not release a response it
+                    // couldn't fully buffer to scan. No shipped guardrail
+                    // configures `BufferFull { on_exceeded_fail_open: true }`
+                    // on this surface today.
                     tracing::warn!(
                         guardrail_hook = "output",
                         model = %model.display_name,

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -12,7 +12,7 @@
 //! Only OpenAI models support this endpoint. Non-OpenAI models receive a
 //! 400 with an explanatory message.
 
-use aisix_gateway::{ChatFormat, ChatMessage};
+use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse, FinishReason, UsageStats};
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
@@ -324,6 +324,7 @@ async fn dispatch(
             &target.model,
             &target.id,
             request_id,
+            &resolved_chain,
         )
         .await
         {
@@ -381,6 +382,7 @@ async fn dispatch(
             &target.model,
             &target.id,
             request_id,
+            &resolved_chain,
         )
         .await
         {
@@ -541,6 +543,7 @@ async fn responses_to_target(
     model: &aisix_core::Model,
     model_id: &str,
     request_id: &str,
+    chain: &aisix_guardrails::GuardrailChain,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
     let mut body = body.clone();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
@@ -609,30 +612,63 @@ async fn responses_to_target(
 
     if is_stream {
         let headers = upstream_resp.headers().clone();
-        let body_stream = upstream_resp.bytes_stream();
 
+        // #719: when an output-hook guardrail is attached, the streaming
+        // response can't be forwarded token-by-token — a blocked phrase
+        // would already be on the wire before it scans clean, the same
+        // surface-switch bypass via `stream:true`. Mirror the chat
+        // surface's secure default (BufferFull): hold the whole SSE
+        // response, scan the assistant output text, then release the bytes
+        // verbatim or block with 422. Requests with no output-hook
+        // guardrail keep the zero-copy verbatim passthrough below.
+        if aisix_guardrails::Guardrail::runs_on_output(chain) {
+            let bytes = upstream_resp
+                .bytes()
+                .await
+                .map_err(|e| {
+                    crate::cooldown::note_failure(
+                        &state.runtime_status,
+                        model_id,
+                        model.cooldown.as_ref(),
+                        aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
+                    )
+                })
+                .map_err(ProxyError::Bridge)?;
+            let out_text = responses_sse_output_text(&bytes);
+            let synth = synth_chat_response(&upstream_model, out_text);
+            if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+                aisix_guardrails::Guardrail::check_output(chain, &synth).await
+            {
+                // Per #153 the matched-pattern detail stays in ops logs only.
+                tracing::warn!(
+                    guardrail_hook = "output",
+                    model = %model.display_name,
+                    reason = %reason,
+                    "guardrail blocked streaming /v1/responses response",
+                );
+                return Err(ProxyError::ContentFiltered(
+                    "response blocked by content policy".into(),
+                ));
+            }
+            let mut response = axum::response::Response::new(axum::body::Body::from(bytes));
+            apply_passthrough_headers(&mut response, &headers, request_id);
+            return Ok(ResponseDispatchSuccess {
+                response,
+                provider: provider_label,
+                usage: None,
+                model_id: model_id.to_string(),
+                routing: RoutingTelemetry::default(),
+            });
+        }
+
+        let body_stream = upstream_resp.bytes_stream();
         let mut response =
             axum::response::Response::new(axum::body::Body::from_stream(body_stream));
+        apply_passthrough_headers(&mut response, &headers, request_id);
 
-        if let Some(ct) = headers.get("content-type") {
-            if let Ok(hv) = HeaderValue::from_bytes(ct.as_bytes()) {
-                response
-                    .headers_mut()
-                    .insert(axum::http::header::CONTENT_TYPE, hv);
-            }
-        }
-
-        if let Ok(hv) = HeaderValue::from_str(request_id) {
-            response
-                .headers_mut()
-                .insert(HeaderName::from_static("x-aisix-request-id"), hv);
-        }
-
-        // Streaming path passes the upstream byte stream verbatim;
-        // the gateway doesn't parse SSE chunks here today, so we
-        // can't extract the usage block from `response.completed`
-        // without a stream wrapper. Emission for the streaming
-        // path is tracked as a #404 follow-up (see PR body).
+        // Verbatim passthrough (no output guardrail). The gateway doesn't
+        // parse SSE chunks here, so usage stays None — streaming usage
+        // emission is tracked as a #404 follow-up (see PR body).
         Ok(ResponseDispatchSuccess {
             response,
             provider: provider_label,
@@ -659,6 +695,32 @@ async fn responses_to_target(
         // `Json::into_response`) so the success struct can carry
         // typed counters rather than re-parsing JSON downstream.
         let usage = extract_response_usage(&json_body);
+
+        // #719: run the output guardrail chain on the assistant's text so a
+        // configured output block isn't bypassable by calling /v1/responses
+        // (the input half is enforced in `dispatch`). Only when an
+        // output-hook guardrail is attached; otherwise this is a no-op.
+        // NOTE: the provider has already billed for this response — an
+        // output block returns 422 and currently records a zero-token event
+        // rather than the billed tokens (telemetry refinement tracked as a
+        // follow-up, like the input-side #543).
+        if aisix_guardrails::Guardrail::runs_on_output(chain) {
+            let synth = synth_chat_response(&upstream_model, responses_output_text(&json_body));
+            if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+                aisix_guardrails::Guardrail::check_output(chain, &synth).await
+            {
+                // Per #153 the matched-pattern detail stays in ops logs only.
+                tracing::warn!(
+                    guardrail_hook = "output",
+                    model = %model.display_name,
+                    reason = %reason,
+                    "guardrail blocked /v1/responses response",
+                );
+                return Err(ProxyError::ContentFiltered(
+                    "response blocked by content policy".into(),
+                ));
+            }
+        }
 
         Ok(ResponseDispatchSuccess {
             response: Json(json_body).into_response(),
@@ -709,6 +771,106 @@ fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
         reasoning_tokens,
         cached_prompt_tokens,
     })
+}
+
+/// Collect the assistant's visible output text from a Responses-API
+/// response object for output-guardrail scanning (#719): the `text` of
+/// every `output_text` content part across all message items in
+/// `output[]`. Reasoning items and tool-call arguments are not included
+/// (reasoning is out of output-guardrail scope, matching the chat surface).
+/// <https://platform.openai.com/docs/api-reference/responses/object>
+fn responses_output_text(resp: &Value) -> String {
+    resp.get("output")
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|it| it.get("content").and_then(|c| c.as_array()))
+                .flatten()
+                .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                .filter(|t| !t.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default()
+}
+
+/// Collect the assistant's streamed output text from a buffered
+/// Responses-API SSE response (#719). Prefers the authoritative full output
+/// carried on the terminal `response.completed` event; falls back to
+/// concatenating `response.output_text.delta` chunks when no completed
+/// event is present (e.g. a truncated stream). The `type` field on each
+/// `data:` JSON line drives the dispatch.
+/// <https://platform.openai.com/docs/api-reference/responses-streaming>
+fn responses_sse_output_text(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let mut deltas = String::new();
+    for line in text.lines() {
+        let data = match line.strip_prefix("data:") {
+            Some(d) => d.trim(),
+            None => continue,
+        };
+        if data.is_empty() || data == "[DONE]" {
+            continue;
+        }
+        let json: Value = match serde_json::from_str(data) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        match json.get("type").and_then(|t| t.as_str()) {
+            Some("response.completed") => {
+                if let Some(resp) = json.get("response") {
+                    let full = responses_output_text(resp);
+                    if !full.is_empty() {
+                        return full;
+                    }
+                }
+            }
+            Some("response.output_text.delta") => {
+                if let Some(d) = json.get("delta").and_then(|d| d.as_str()) {
+                    deltas.push_str(d);
+                }
+            }
+            _ => {}
+        }
+    }
+    deltas
+}
+
+/// Build the minimal internal `ChatResponse` an output guardrail needs to
+/// scan: the assistant text in `message.content`. Only the text is read by
+/// `check_output` (via `guardrail_output_text`); the other fields are
+/// placeholders and never reach the client.
+fn synth_chat_response(model: &str, text: String) -> ChatResponse {
+    ChatResponse {
+        id: String::new(),
+        model: model.to_string(),
+        message: ChatMessage::assistant(text),
+        finish_reason: FinishReason::Stop,
+        usage: UsageStats::default(),
+    }
+}
+
+/// Copy the upstream `content-type` onto the client response and stamp the
+/// `x-aisix-request-id` header. Shared by the streaming verbatim-passthrough
+/// and buffered hold-back paths.
+fn apply_passthrough_headers(
+    response: &mut Response,
+    upstream_headers: &axum::http::HeaderMap,
+    request_id: &str,
+) {
+    if let Some(ct) = upstream_headers.get("content-type") {
+        if let Ok(hv) = HeaderValue::from_bytes(ct.as_bytes()) {
+            response
+                .headers_mut()
+                .insert(axum::http::header::CONTENT_TYPE, hv);
+        }
+    }
+    if let Ok(hv) = HeaderValue::from_str(request_id) {
+        response
+            .headers_mut()
+            .insert(HeaderName::from_static("x-aisix-request-id"), hv);
+    }
 }
 
 /// Issue #404: push one `UsageEvent` onto cp-api's telemetry sink
@@ -1215,6 +1377,185 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// An env-scoped keyword guardrail on the OUTPUT hook (no attachment →
+    /// applies to every request). `runs_on_output()` is true, so the
+    /// handler scans the assistant output.
+    fn keyword_output_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"test-out-block","enabled":true,"hook_point":"output","fail_open":false,"kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-out-1", g, 1)
+    }
+
+    /// #719: output guardrails must run on /v1/responses non-streaming
+    /// responses — a configured output block must not be bypassable by
+    /// switching surface. A blocked literal in the assistant output → 422.
+    /// The upstream IS contacted (`expect(1)`): output checks run on the
+    /// returned response, unlike the input check which short-circuits first.
+    #[tokio::test]
+    async fn output_guardrail_blocks_non_streaming_response() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp_x",
+                "object": "response",
+                "output": [{"type":"message","role":"assistant","content":[{"type":"output_text","text":"sure: BLOCKME here"}]}],
+                "usage": {"input_tokens": 5, "output_tokens": 4}
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        // The blocked model output must not be echoed back to the caller.
+        let msg = v["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            !msg.contains("BLOCKME"),
+            "model output leaked in error: {msg}"
+        );
+    }
+
+    /// #719 companion: a clean non-streaming response with an output
+    /// guardrail configured passes through unchanged → 200 with body.
+    #[tokio::test]
+    async fn output_guardrail_allows_clean_non_streaming_response() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp_ok",
+                "object": "response",
+                "output": [{"type":"message","role":"assistant","content":[{"type":"output_text","text":"a clean answer"}]}],
+                "usage": {"input_tokens": 5, "output_tokens": 3}
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["output"][0]["content"][0]["text"], "a clean answer");
+    }
+
+    /// #719: streaming /v1/responses must also enforce output guardrails —
+    /// else `stream:true` bypasses the output block. The blocked content is
+    /// held back (BufferFull): the client gets 422 and never the tokens.
+    #[tokio::test]
+    async fn output_guardrail_blocks_streaming_response_holds_back() {
+        let upstream = MockServer::start().await;
+        let sse = "event: response.output_text.delta\n\
+                   data: {\"type\":\"response.output_text.delta\",\"delta\":\"sure: BLOCKME\"}\n\n\
+                   event: response.completed\n\
+                   data: {\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"sure: BLOCKME\"}]}]}}\n\n\
+                   data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        // The held-back content must never reach the client.
+        assert!(
+            !String::from_utf8_lossy(&bytes).contains("BLOCKME"),
+            "streamed content leaked despite output block",
+        );
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #719 companion: a clean streaming response with an output guardrail
+    /// is scanned then released in full → 200 + the SSE body.
+    #[tokio::test]
+    async fn output_guardrail_allows_clean_streaming_response() {
+        let upstream = MockServer::start().await;
+        let sse = "event: response.output_text.delta\n\
+                   data: {\"type\":\"response.output_text.delta\",\"delta\":\"a clean answer\"}\n\n\
+                   data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let body = String::from_utf8_lossy(&bytes);
+        assert!(
+            body.contains("a clean answer"),
+            "clean SSE body must be released in full",
+        );
+        assert!(
+            body.starts_with("event: ") || body.starts_with("data: "),
+            "SSE shape preserved on release",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Completes #719 by adding **output** guardrails to `/v1/responses` — both non-streaming and streaming — so a configured output content/DLP block can't be bypassed by switching surface (PR #541 closed the input half). Stacked on #541 (base = `fix/issue-719-responses-guardrails`).

## Why both modes, together

Output coverage must be all-or-nothing: enforcing it only on the non-streaming path would make `stream:true` a *new* asymmetric bypass of the same class as #719. So both paths are handled in one change.

## How

The resolved guardrail chain (already built in `dispatch` for the input check) is threaded into `responses_to_target`. All output work is gated on `chain.runs_on_output()` — for a chain with no output-hook guardrail (the common case) behavior is **byte-for-byte unchanged**.

- **Non-streaming**: after the upstream 200, collect the assistant text from `output[].content[].text`, synthesize a minimal internal `ChatResponse`, run `check_output`; `Block` → `422 content_filter`. The clean path is untouched.
- **Streaming**: mirror the chat surface's secure default (**BufferFull**). When an output-hook guardrail is attached, buffer the whole upstream SSE response, extract the assistant text (authoritative `response.completed` output, falling back to concatenated `response.output_text.delta` chunks), scan, then either replay the buffered SSE bytes verbatim (`200`) or block (`422`) — the blocked tokens never reach the client. Without an output guardrail, the zero-copy verbatim passthrough is preserved.

Matched-pattern detail stays in ops logs only; the wire message is generic (#153).

## Reference / spec

- In-repo reference pattern: `chat.rs` output check (`check_output` on a synthesized response; streaming hold-back via the chain's `stream_output_policy`/`runs_on_output`, #466). This change applies the same model to the Responses surface.
- Responses object (`output[].content[].text`): <https://platform.openai.com/docs/api-reference/responses/object>. Streaming events (`response.output_text.delta`, `response.completed`): <https://platform.openai.com/docs/api-reference/responses-streaming>.

## Known limitations (follow-ups, not regressions)

- **Output-block billing**: the provider has already billed when an output block fires, but the 422 currently records a zero-token event rather than the billed upstream tokens (and doesn't set `guardrail_blocked`). Same class as the input-side telemetry gap #543; tracked there / in a follow-up. The *security* behavior (blocking) is correct.
- **Scan scope**: output scanning covers the visible assistant `output_text`. Tool-call arguments in `output[]` (function/computer calls) are not scanned on output yet — `output_text` covers the content-echo concern #719 demonstrates. Follow-up if needed.
- **Streaming usage**: the buffered path still reports `usage = None` (streaming usage extraction remains the deferred #404 work); this PR does not change that.

## Independent audit (CLAUDE.md §8) — findings + resolution

A fresh agent reviewed this PR cold. It verified the core contract: the streaming path fully buffers before any byte is sent (no leak), the 422 path returns no upstream bytes, `runs_on_output()` correctly gates so no-output-guardrail traffic stays on the verbatim/clean paths, an output block does **not** failover, and #153 holds.

- **HIGH-1 — unbounded streaming buffer (memory-DoS), divergence from chat's capped BufferFull: FIXED in code.** The streaming hold-back now reads the upstream with a running byte counter and **fails closed** once it exceeds the cap from the chain's resolved `stream_output_policy()` (`DEFAULT_STREAM_OUTPUT_BUFFER_BYTES` = 256 KiB by default) — memory is bounded per request, mirroring `chat.rs`'s secure default. New test `output_guardrail_streaming_oversized_response_fails_closed` proves a >256 KiB response → 422 (not released unscanned).
- **MEDIUM-1 — streaming block returns 422 here vs chat's 200 + in-band SSE `error` frame: JUSTIFIED (intentional).** Because the whole response is buffered before any status is sent, the Responses path can still return a real `422` — the stronger signal, and consistent with the non-streaming block (also 422). Chat emits 200 + an SSE `error` frame only because its bytes are already flushed. A 422 before any stream byte is standard HTTP a client must already handle. No code change.
- **LOW-1 — fail-open on an unparseable stream (no `response.completed`/no deltas → empty text → Allow → release): documented.** Consistent with the chat surface (which also releases on empty extracted text); the upstream — not the caller — controls the SSE shape, so it isn't attacker-forcible. Noted under limitations.
- **LOW-2 — tool-call arguments in `output[]` not scanned (asymmetric with chat's #448): follow-up filed (#546).**

Merge gate: HIGH-1 fixed; MEDIUM-1 justified; LOWs documented/filed. 

## Test plan

4 new wiremock tests:
- non-streaming: blocked output literal → `422 content_filter` (upstream `expect(1)` — output checks run post-response); clean output → `200` + body intact.
- streaming: blocked literal in the SSE → `422` and the held content (`BLOCKME`) never appears in the response body; clean SSE → `200` with the body released in full, SSE shape preserved.

The existing no-guardrail streaming passthrough test still passes (verbatim path unchanged). `cargo fmt` + `clippy` clean; full `aisix-proxy` lib suite green.

Refs #719, #379, #541, #543.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Output-level content filtering now enforced on all API responses
  * Streaming responses are buffered and scanned for policy compliance before delivery
  * Non-streaming responses checked for content violations
  * Oversized streaming responses are rejected when exceeding buffer limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->