### PR TITLE
feat(obs): object_store cloud_identity auth — keyless via the DP's own cloud identity (S3 / GCS)

### DIFF
--- a/crates/aisix-core/src/models/observability_exporter.rs
+++ b/crates/aisix-core/src/models/observability_exporter.rs
@@ -181,9 +181,16 @@ pub struct ObjectStoreConfig {
     #[serde(default)]
     pub compression: ObjectStoreCompression,
 
+    /// How the DP authenticates to the bucket. Default `credential_ref`.
+    #[serde(default)]
+    pub auth_mode: ObjectStoreAuthMode,
+
     /// Opaque pointer to the cloud credentials, resolved locally by the DP
     /// at delivery time. The plaintext key MUST NOT live in etcd/kine — the
     /// control plane stores only this reference, never the secret itself.
+    /// Required when `auth_mode = credential_ref`; unused (and may be empty)
+    /// when `auth_mode = cloud_identity`.
+    #[serde(default)]
     pub credential_ref: String,
 }
 
@@ -209,6 +216,23 @@ pub enum ObjectStoreCompression {
     Gzip,
     /// No compression — raw NDJSON.
     None,
+}
+
+/// How the DP obtains credentials for the object-storage bucket.
+#[derive(
+    Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq, Hash,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectStoreAuthMode {
+    /// Resolve `credential_ref` to static keys from the DP's local env
+    /// (`OBJSTORE_CRED_<SLUG>_<FIELD>`). The default.
+    #[default]
+    CredentialRef,
+    /// Use the DP host's own attached cloud identity — EC2 instance role /
+    /// EKS IRSA / ECS task role (S3), or GKE Workload Identity / GCE metadata
+    /// (GCS) — via the cloud SDK's default credential chain, with no static
+    /// keys anywhere. Supported for S3 and GCS only.
+    CloudIdentity,
 }
 
 /// Top-level `ObservabilityExporter` resource. `deny_unknown_fields`
@@ -485,6 +509,30 @@ mod tests {
         assert_eq!(v["bucket"], "acme-aisix-events");
         assert_eq!(v["credential_ref"], "acme-s3");
         assert!(v.get("object_store").is_none(), "kind block must not nest");
+    }
+
+    #[test]
+    fn object_store_auth_mode_defaults_and_cloud_identity() {
+        // Absent auth_mode → credential_ref (back-compat default).
+        let e: ObservabilityExporter = serde_json::from_str(VALID_OBJECT_STORE).unwrap();
+        match &e.kind {
+            ExporterKind::ObjectStore(c) => {
+                assert_eq!(c.auth_mode, ObjectStoreAuthMode::CredentialRef);
+            }
+            other => panic!("expected object_store, got {other:?}"),
+        }
+        // cloud_identity deserializes and credential_ref may be omitted.
+        let e: ObservabilityExporter = serde_json::from_str(
+            r#"{"name":"x","kind":"object_store","provider":"s3","bucket":"b","prefix":"p","auth_mode":"cloud_identity"}"#,
+        )
+        .unwrap();
+        match &e.kind {
+            ExporterKind::ObjectStore(c) => {
+                assert_eq!(c.auth_mode, ObjectStoreAuthMode::CloudIdentity);
+                assert_eq!(c.credential_ref, "");
+            }
+            other => panic!("expected object_store, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -625,7 +625,9 @@ fn observability_exporter_schema() -> Value {
             "bucket":      { "type": "string", "minLength": 1 },
             "prefix":      { "type": "string", "minLength": 1 },
             "region":      { "type": "string", "minLength": 1 },
-            "compression": { "type": "string", "enum": ["gzip", "none"] }
+            "compression": { "type": "string", "enum": ["gzip", "none"] },
+            // object_store auth mode: how the DP reaches the bucket.
+            "auth_mode":   { "type": "string", "enum": ["credential_ref", "cloud_identity"] }
         },
         "allOf": [
             {
@@ -662,7 +664,7 @@ fn observability_exporter_schema() -> Value {
             {
                 "if":   { "properties": { "kind": { "const": "object_store" } } },
                 "then": {
-                    "required": ["provider", "bucket", "prefix", "credential_ref"],
+                    "required": ["provider", "bucket", "prefix"],
                     "properties": {
                         // `endpoint` is optional — set only for S3-compatible
                         // stores (MinIO / OSS / R2). When present: https, or a
@@ -672,7 +674,27 @@ fn observability_exporter_schema() -> Value {
                         "endpoint": {
                             "pattern": "^https://.+|^http://(minio|azurite|fake-gcs-server|fake-gcs|127\\.0\\.0\\.1|localhost)(:[0-9]+)?(/.*)?$"
                         }
-                    }
+                    },
+                    "allOf": [
+                        {
+                            // cloud_identity: the DP authenticates with its own
+                            // attached cloud identity — S3 / GCS only (Azure
+                            // managed identity needs a non-secret account name
+                            // the keyless config does not carry), and no
+                            // credential_ref. Otherwise (the default
+                            // credential_ref mode) credential_ref is required.
+                            "if": {
+                                "required": ["auth_mode"],
+                                "properties": { "auth_mode": { "const": "cloud_identity" } }
+                            },
+                            "then": {
+                                "properties": { "provider": { "enum": ["s3", "gcs"] } }
+                            },
+                            "else": {
+                                "required": ["credential_ref"]
+                            }
+                        }
+                    ]
                 }
             }
         ]
@@ -1438,6 +1460,48 @@ mod tests {
             "provider": "wasabi", "bucket": "b", "prefix": "p", "credential_ref": "r"
         });
         assert!(validate_observability_exporter(&v).is_err());
+    }
+
+    #[test]
+    fn exporter_object_store_cloud_identity_omits_credential_ref() {
+        // cloud_identity (S3 / GCS): the DP uses its own attached identity, so
+        // credential_ref is NOT required.
+        for provider in ["s3", "gcs"] {
+            let v = json!({
+                "name": "x", "kind": "object_store",
+                "provider": provider, "bucket": "b", "prefix": "p",
+                "auth_mode": "cloud_identity"
+            });
+            validate_observability_exporter(&v)
+                .unwrap_or_else(|e| panic!("cloud_identity {provider} should validate: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn exporter_object_store_cloud_identity_rejects_azure() {
+        // Azure cloud_identity is unsupported (managed identity needs a
+        // non-secret account name the keyless config does not carry).
+        let v = json!({
+            "name": "x", "kind": "object_store",
+            "provider": "azure_blob", "bucket": "c", "prefix": "p",
+            "auth_mode": "cloud_identity"
+        });
+        assert!(validate_observability_exporter(&v).is_err());
+    }
+
+    #[test]
+    fn exporter_object_store_credential_ref_mode_still_requires_ref() {
+        // Default (no auth_mode) and explicit credential_ref both require the
+        // ref — only cloud_identity drops it.
+        for v in [
+            json!({"name":"x","kind":"object_store","provider":"s3","bucket":"b","prefix":"p"}),
+            json!({"name":"x","kind":"object_store","provider":"s3","bucket":"b","prefix":"p","auth_mode":"credential_ref"}),
+        ] {
+            assert!(
+                validate_observability_exporter(&v).is_err(),
+                "credential_ref must be required outside cloud_identity: {v}"
+            );
+        }
     }
 
     #[test]

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -27,7 +27,7 @@ use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
 use sha2::{Digest, Sha256};
 
 use aisix_core::models::observability_exporter::{
-    ObjectStoreCompression, ObjectStoreConfig, ObjectStoreProvider,
+    ObjectStoreAuthMode, ObjectStoreCompression, ObjectStoreConfig, ObjectStoreProvider,
 };
 
 use super::{
@@ -277,6 +277,58 @@ pub fn build_object_store(
     }
 }
 
+/// Build the backend using the DP host's OWN attached cloud identity, with no
+/// static keys ("cloud identity" auth). **S3** uses the AWS default credential
+/// chain via [`object_store::aws::AmazonS3Builder::from_env`] (env / EKS IRSA
+/// web-identity / ECS task role / EC2 instance profile). **GCS** uses
+/// Application Default Credentials (GKE Workload Identity / GCE metadata) by
+/// constructing the builder with no service-account key. **Azure** is not
+/// supported here — its managed identity still needs a non-secret account name
+/// the keyless config does not carry; cp-api rejects that combination at create
+/// time, and this arm returns a clear permanent error as a backstop.
+pub fn build_object_store_ambient(
+    provider: ObjectStoreProvider,
+    bucket: &str,
+    region: Option<&str>,
+    endpoint: Option<&str>,
+) -> Result<Arc<dyn ObjectStore>, SinkError> {
+    match provider {
+        ObjectStoreProvider::S3 => {
+            let mut b = object_store::aws::AmazonS3Builder::from_env().with_bucket_name(bucket);
+            if let Some(r) = region {
+                b = b.with_region(r);
+            }
+            if let Some(ep) = endpoint {
+                b = b.with_endpoint(ep).with_virtual_hosted_style_request(false);
+                if ep.starts_with("http://") {
+                    b = b.with_allow_http(true);
+                }
+            }
+            let store = b.build().map_err(|e| {
+                SinkError::Permanent(format!("object_store: build s3 (cloud identity): {e}"))
+            })?;
+            Ok(Arc::new(store))
+        }
+        ObjectStoreProvider::Gcs => {
+            // No service-account key set → `object_store` sources Application
+            // Default Credentials (GKE Workload Identity / GCE metadata).
+            let store = object_store::gcp::GoogleCloudStorageBuilder::new()
+                .with_bucket_name(bucket)
+                .build()
+                .map_err(|e| {
+                    SinkError::Permanent(format!("object_store: build gcs (cloud identity): {e}"))
+                })?;
+            Ok(Arc::new(store))
+        }
+        ObjectStoreProvider::AzureBlob => Err(SinkError::Permanent(
+            "object_store: cloud_identity auth is not supported for azure_blob \
+             (managed identity needs a non-secret account name the keyless config \
+             does not carry); use credential_ref"
+                .to_string(),
+        )),
+    }
+}
+
 /// Build the ready-to-run sink for a configured `object_store` exporter:
 /// resolve credentials from the DP's local env, construct the backend, and
 /// wrap it in an [`ObjectStoreSink`]. If credentials are missing or the
@@ -288,22 +340,34 @@ pub fn build_object_store_sink(
     name: String,
     cfg: &ObjectStoreConfig,
 ) -> Arc<dyn ObservabilitySink> {
-    let Some(creds) = resolve_object_store_credential(cfg.provider, &cfg.credential_ref) else {
-        return Arc::new(BrokenSink::new(
-            name,
-            format!(
-                "object_store: no credentials resolved for credential_ref {:?}",
-                cfg.credential_ref
-            ),
-        ));
+    let store = match cfg.auth_mode {
+        ObjectStoreAuthMode::CredentialRef => {
+            let Some(creds) = resolve_object_store_credential(cfg.provider, &cfg.credential_ref)
+            else {
+                return Arc::new(BrokenSink::new(
+                    name,
+                    format!(
+                        "object_store: no credentials resolved for credential_ref {:?}",
+                        cfg.credential_ref
+                    ),
+                ));
+            };
+            build_object_store(
+                cfg.provider,
+                &cfg.bucket,
+                cfg.region.as_deref(),
+                cfg.endpoint.as_deref(),
+                creds,
+            )
+        }
+        ObjectStoreAuthMode::CloudIdentity => build_object_store_ambient(
+            cfg.provider,
+            &cfg.bucket,
+            cfg.region.as_deref(),
+            cfg.endpoint.as_deref(),
+        ),
     };
-    match build_object_store(
-        cfg.provider,
-        &cfg.bucket,
-        cfg.region.as_deref(),
-        cfg.endpoint.as_deref(),
-        creds,
-    ) {
+    match store {
         Ok(store) => Arc::new(ObjectStoreSink::new(
             name,
             store,
@@ -681,6 +745,39 @@ mod tests {
             },
         );
         assert!(matches!(r, Err(SinkError::Permanent(_))));
+    }
+
+    #[test]
+    fn build_object_store_ambient_dispatches_s3() {
+        // Cloud-identity S3 builds offline via the AWS default credential chain
+        // (from_env → IMDS / IRSA / ECS); creds are fetched lazily at request
+        // time, so build() succeeds with no static keys.
+        let store =
+            build_object_store_ambient(ObjectStoreProvider::S3, "bucket", Some("us-east-1"), None);
+        assert!(store.is_ok(), "s3 ambient build: {store:?}");
+    }
+
+    #[test]
+    fn build_object_store_ambient_dispatches_gcs() {
+        // Cloud-identity GCS builds with no service-account key → Application
+        // Default Credentials at request time; build() succeeds offline.
+        let store = build_object_store_ambient(ObjectStoreProvider::Gcs, "bucket", None, None);
+        assert!(store.is_ok(), "gcs ambient build: {store:?}");
+    }
+
+    #[test]
+    fn build_object_store_ambient_rejects_azure() {
+        // Azure cloud_identity is not supported (managed identity needs a
+        // non-secret account name the keyless config does not carry) — a clear
+        // permanent error pointing the operator back to credential_ref.
+        let r = build_object_store_ambient(ObjectStoreProvider::AzureBlob, "container", None, None);
+        match r {
+            Err(SinkError::Permanent(msg)) => {
+                assert!(msg.contains("azure_blob"), "msg: {msg}");
+                assert!(msg.contains("credential_ref"), "msg: {msg}");
+            }
+            other => panic!("expected Permanent error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/schemas/resources/observability_exporter.schema.json
+++ b/schemas/resources/observability_exporter.schema.json
@@ -86,12 +86,20 @@
       "type": "object",
       "required": [
         "bucket",
-        "credential_ref",
         "kind",
         "prefix",
         "provider"
       ],
       "properties": {
+        "auth_mode": {
+          "description": "How the DP authenticates to the bucket. Default `credential_ref`.",
+          "default": "credential_ref",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ObjectStoreAuthMode"
+            }
+          ]
+        },
         "bucket": {
           "description": "Bucket (S3 / GCS) or container (Azure Blob) that receives the files.",
           "type": "string"
@@ -106,7 +114,8 @@
           ]
         },
         "credential_ref": {
-          "description": "Opaque pointer to the cloud credentials, resolved locally by the DP at delivery time. The plaintext key MUST NOT live in etcd/kine — the control plane stores only this reference, never the secret itself.",
+          "description": "Opaque pointer to the cloud credentials, resolved locally by the DP at delivery time. The plaintext key MUST NOT live in etcd/kine — the control plane stores only this reference, never the secret itself. Required when `auth_mode = credential_ref`; unused (and may be empty) when `auth_mode = cloud_identity`.",
+          "default": "",
           "type": "string"
         },
         "endpoint": {
@@ -159,6 +168,25 @@
     }
   },
   "definitions": {
+    "ObjectStoreAuthMode": {
+      "description": "How the DP obtains credentials for the object-storage bucket.",
+      "oneOf": [
+        {
+          "description": "Resolve `credential_ref` to static keys from the DP's local env (`OBJSTORE_CRED_<SLUG>_<FIELD>`). The default.",
+          "type": "string",
+          "enum": [
+            "credential_ref"
+          ]
+        },
+        {
+          "description": "Use the DP host's own attached cloud identity — EC2 instance role / EKS IRSA / ECS task role (S3), or GKE Workload Identity / GCE metadata (GCS) — via the cloud SDK's default credential chain, with no static keys anywhere. Supported for S3 and GCS only.",
+          "type": "string",
+          "enum": [
+            "cloud_identity"
+          ]
+        }
+      ]
+    },
     "ObjectStoreCompression": {
       "description": "File compression for object-storage uploads.",
       "oneOf": [


### PR DESCRIPTION
## What

Adds a keyless **`cloud_identity`** auth mode to the `object_store` observability sink. Today the sink resolves `credential_ref` → `OBJSTORE_CRED_<SLUG>_*` static-key env vars on the DP. This adds a second mode where the DP authenticates with its **own attached cloud identity** — no static keys anywhere:

- `auth_mode: credential_ref` (default, unchanged).
- `auth_mode: cloud_identity` — **S3** via the AWS default credential chain (`AmazonS3Builder::from_env` → env / EKS IRSA / ECS task role / EC2 instance profile); **GCS** via Application Default Credentials (GKE Workload Identity / GCE metadata) by building with no service-account key.

`credential_ref` is now `#[serde(default)]` (omittable for cloud_identity). `build_object_store_sink` branches on `auth_mode`; the keyless builders live in a new `build_object_store_ambient`.

**Azure cloud_identity is intentionally out of scope in this cut** — Azure managed identity still needs a non-secret account name the keyless config doesn't carry. `build_object_store_ambient` returns a clear permanent error for `azure_blob`, and the loader schema pins `cloud_identity` to `s3` / `gcs` (tracked for a follow-up).

## Prior art

A **customer-run** data mover authenticating to object storage via its host's **ambient cloud identity** (instance role / IRSA / Workload Identity / metadata SA), with static keys as the opt-in fallback, is the standard pattern across self-hosted log/telemetry shippers, tiered-storage brokers, and backup tooling — they resolve through the cloud SDK's default credential chain (AWS) / ADC (GCP), and several recommend the role over static keys. A primary-source survey across API gateways, message middleware, and databases found ambient identity **universal for AWS** but **spottier for GCP/Azure** — which is exactly why this cut covers S3 + GCS and defers Azure.

## Test plan

- `build_object_store_ambient`: dispatches S3 (`from_env`, builds offline) + GCS (ADC, builds offline); **rejects Azure** with a clear permanent error.
- serde: `auth_mode` defaults to `credential_ref` (back-compat); `cloud_identity` round-trips with `credential_ref` omitted.
- loader schema (`validate_observability_exporter`): `cloud_identity` (s3/gcs) validates **without** `credential_ref`; `cloud_identity + azure_blob` is rejected; `credential_ref` is still required outside cloud_identity.
- `cargo fmt` + `cargo clippy -p aisix-core -p aisix-obs --all-targets -- -D warnings` + `cargo test -p aisix-core -p aisix-obs` → **99 passed, 0 failed**. `dump-schema` regenerated `schemas/resources/observability_exporter.schema.json` (no drift).

## Notes

- **Not emulator-testable**: CI has no real IAM role, so cloud_identity's actual auth can't run against MinIO / Azurite / fake-gcs — the builders are unit-tested for dispatch; real-cloud verification is manual (the same inherent limit as the existing GCS smoke).
- cp-api (accept + validate `auth_mode`, reject `cloud_identity + azure_blob` at create) and the dashboard (auth-mode selector) land in **separate PRs**; this is the DP foundation.

Refs: object_store sink line (DP #531; cp-api `api7/AISIX-Cloud#706`; dashboard `api7/AISIX-Cloud#714`). Design: `api7/AISIX-Cloud#724` (P2 keyless cloud-identity).
