### PR TITLE
fix(guardrails): input guardrails on /v1/completions, /v1/rerank, /v1/images, /v1/audio/speech (#545)

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -444,6 +444,16 @@ async fn multipart_dispatch(
 /// JSON passthrough for `/v1/audio/speech` — returns binary audio bytes.
 /// Returns `(response, provider_label, model_id)`; `model_id` lets the
 /// handler attribute a (zero-token) UsageEvent (#406).
+/// Build a [`ChatFormat`](aisix_gateway::ChatFormat) from the speech `input`
+/// text so the input guardrail chain can scan it (#545). Never sent upstream.
+fn speech_input_to_chat(model: &str, body: &Value) -> aisix_gateway::ChatFormat {
+    let messages = match body.get("input").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => vec![aisix_gateway::ChatMessage::user(s.to_string())],
+        _ => Vec::new(),
+    };
+    aisix_gateway::ChatFormat::new(model, messages)
+}
+
 async fn speech_dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
@@ -464,6 +474,36 @@ async fn speech_dispatch(
 
     if !auth.key().can_access(&model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
+    }
+
+    // #545: /v1/audio/speech must run input guardrails. Before this it
+    // forwarded the user `input` text (synthesized to audio) with no
+    // configured content/DLP check, so a block enforced on
+    // /v1/chat/completions was bypassable by switching surface. Run before
+    // the rate-limit reservation so a content-policy refusal doesn't burn an
+    // RPM slot. (Output is binary audio, not scannable text — no output hook.)
+    let guardrail_ctx = aisix_guardrails::RequestContext {
+        model_id: &model_entry.id,
+        api_key_id: &auth.entry.id,
+        team_id: auth.key().team_id.as_deref(),
+    };
+    let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    if !resolved_chain.is_empty() {
+        let chat = speech_input_to_chat(&model_name, &body);
+        if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+            aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        {
+            // Per #153 the matched-pattern detail stays in ops logs only.
+            tracing::warn!(
+                guardrail_hook = "input",
+                model = %model_name,
+                reason = %reason,
+                "guardrail blocked /v1/audio/speech request",
+            );
+            return Err(ProxyError::ContentFiltered(
+                "request blocked by content policy".into(),
+            ));
+        }
     }
 
     let model_rl =
@@ -744,6 +784,95 @@ mod tests {
         hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let handle = SnapshotHandle::new(snap);
         crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache())
+    }
+
+    fn keyword_input_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"t","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-1", g, 1)
+    }
+
+    fn speech_req(body: &str) -> Request<axum::body::Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/audio/speech")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    /// #545: a configured input guardrail must fire on /v1/audio/speech — a
+    /// blocked `input` returns 422 content_filter, upstream never contacted.
+    #[tokio::test]
+    async fn input_guardrail_blocks_speech_input_returns_422() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "audio/mpeg")
+                    .set_body_bytes(b"ID3".to_vec()),
+            )
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(tts_model("my-tts"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let resp = tower::ServiceExt::oneshot(
+            app,
+            speech_req(r#"{"model":"my-tts","input":"say BLOCKME aloud","voice":"alloy"}"#),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        assert!(!v["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("BLOCKME"));
+    }
+
+    /// #545 companion: benign input with a guardrail configured still forwards
+    /// (`expect(1)`) and returns the audio bytes.
+    #[tokio::test]
+    async fn input_guardrail_allows_benign_speech_input() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "audio/mpeg")
+                    .set_body_bytes(b"ID3\x03\x00".to_vec()),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(tts_model("my-tts"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let resp = tower::ServiceExt::oneshot(
+            app,
+            speech_req(r#"{"model":"my-tts","input":"Hello there","voice":"alloy"}"#),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -143,6 +143,27 @@ pub async fn completions(
     }
 }
 
+/// Build a [`ChatFormat`](aisix_gateway::ChatFormat) of user messages from
+/// the legacy completions `prompt` so the input guardrail chain can scan it
+/// (#545). `prompt` is a string, an array of strings, or an array of token
+/// ids / token-id arrays; only the string forms carry scannable text (token
+/// ids are integers — skipped). Never sent upstream.
+fn completions_input_to_chat(model: &str, body: &Value) -> aisix_gateway::ChatFormat {
+    let messages = match body.get("prompt") {
+        Some(Value::String(s)) if !s.is_empty() => {
+            vec![aisix_gateway::ChatMessage::user(s.clone())]
+        }
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|it| it.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| aisix_gateway::ChatMessage::user(s.to_string()))
+            .collect(),
+        _ => Vec::new(),
+    };
+    aisix_gateway::ChatFormat::new(model, messages)
+}
+
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
@@ -163,6 +184,36 @@ async fn dispatch(
 
     if !auth.key().can_access(model_name) {
         return Err(ProxyError::ModelForbidden(model_name.to_string()));
+    }
+
+    // #545: /v1/completions must run input guardrails. Before this it
+    // forwarded the user `prompt` to the upstream with no configured
+    // content/DLP check, so a block enforced on /v1/chat/completions was
+    // bypassable by switching surface. Run the check BEFORE the rate-limit
+    // reservation so a content-policy refusal doesn't burn an RPM slot
+    // (matching /v1/chat/completions).
+    let guardrail_ctx = aisix_guardrails::RequestContext {
+        model_id: &model_entry.id,
+        api_key_id: &auth.entry.id,
+        team_id: auth.key().team_id.as_deref(),
+    };
+    let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    if !resolved_chain.is_empty() {
+        let chat = completions_input_to_chat(model_name, &body);
+        if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+            aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        {
+            // Per #153 the matched-pattern detail stays in ops logs only.
+            tracing::warn!(
+                guardrail_hook = "input",
+                model = %model_name,
+                reason = %reason,
+                "guardrail blocked /v1/completions request",
+            );
+            return Err(ProxyError::ContentFiltered(
+                "request blocked by content policy".into(),
+            ));
+        }
     }
 
     let model_rl =
@@ -393,6 +444,84 @@ mod tests {
             .header("content-type", "application/json")
             .body(axum::body::Body::from(body.to_string()))
             .unwrap()
+    }
+
+    fn keyword_input_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"t","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-1", g, 1)
+    }
+
+    /// #545: a configured input guardrail must fire on /v1/completions — a
+    /// blocked `prompt` returns 422 content_filter and the upstream is never
+    /// contacted (`expect(0)`).
+    #[tokio::test]
+    async fn input_guardrail_blocks_prompt_returns_422() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"object":"text_completion"})),
+            )
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("instruct"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({"model": "instruct", "prompt": "please BLOCKME now"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        assert!(!v["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("BLOCKME"));
+    }
+
+    /// #545 companion: a benign prompt with a guardrail configured still
+    /// forwards (`expect(1)`) and returns 200.
+    #[tokio::test]
+    async fn input_guardrail_allows_benign_prompt_forwards_200() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "text_completion",
+                "choices": [{"text": "ok", "index": 0, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("instruct"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({"model": "instruct", "prompt": "a fine prompt"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["object"], "text_completion");
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -13,6 +13,13 @@
 //! (`/messages/count_tokens`), the absence of streaming, and the tiny
 //! `{"input_tokens": <int>}` response, which is forwarded verbatim.
 //!
+//! Guardrails: this surface is intentionally **exempt** from the input
+//! guardrail chain (#545). It is a pre-flight sizing call — no content
+//! reaches a model and the response is only an integer token count, never
+//! generated content — so there is nothing to moderate on either hook. The
+//! same `messages` payload is scanned when the caller issues the actual
+//! `/v1/messages` request, which runs input + output guardrails.
+//!
 //! Scope: Anthropic-backed models only. `count_tokens` has no upstream
 //! equivalent for OpenAI/Gemini/DeepSeek, so a non-Anthropic Model is
 //! rejected with a 400 at the gateway boundary (parallel to `/v1/rerank`

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -13,12 +13,16 @@
 //! (`/messages/count_tokens`), the absence of streaming, and the tiny
 //! `{"input_tokens": <int>}` response, which is forwarded verbatim.
 //!
-//! Guardrails: this surface is intentionally **exempt** from the input
-//! guardrail chain (#545). It is a pre-flight sizing call — no content
-//! reaches a model and the response is only an integer token count, never
-//! generated content — so there is nothing to moderate on either hook. The
-//! same `messages` payload is scanned when the caller issues the actual
-//! `/v1/messages` request, which runs input + output guardrails.
+//! Guardrails: this surface is intentionally **exempt** from the
+//! content-moderation guardrail chain (#545). It is a pre-flight sizing
+//! call — no content reaches a model and the response is only an integer
+//! token count, never generated content — so there is nothing for a
+//! content-moderation hook to moderate on either side, and the same
+//! `messages` payload is scanned when the caller issues the actual
+//! `/v1/messages` request. (A DLP/egress policy is a separate concern: the
+//! `messages` are forwarded to the provider's count endpoint here before the
+//! real call, so a DLP guardrail attached at env-scope would not see them —
+//! tracked in #555, out of scope for #545.)
 //!
 //! Scope: Anthropic-backed models only. `count_tokens` has no upstream
 //! equivalent for OpenAI/Gemini/DeepSeek, so a non-Anthropic Model is

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -127,6 +127,17 @@ pub async fn image_generations(
     }
 }
 
+/// Build a [`ChatFormat`](aisix_gateway::ChatFormat) from the image
+/// generation `prompt` so the input guardrail chain can scan it (#545).
+/// Never sent upstream.
+fn images_input_to_chat(model: &str, body: &Value) -> aisix_gateway::ChatFormat {
+    let messages = match body.get("prompt").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => vec![aisix_gateway::ChatMessage::user(s.to_string())],
+        _ => Vec::new(),
+    };
+    aisix_gateway::ChatFormat::new(model, messages)
+}
+
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
@@ -147,6 +158,36 @@ async fn dispatch(
 
     if !auth.key().can_access(model_name) {
         return Err(ProxyError::ModelForbidden(model_name.to_string()));
+    }
+
+    // #545: /v1/images/generations must run input guardrails. Before this it
+    // forwarded the user `prompt` with no configured content/DLP check, so a
+    // block enforced on /v1/chat/completions was bypassable by switching
+    // surface. Run before the rate-limit reservation so a content-policy
+    // refusal doesn't burn an RPM slot. (Output is an image, not scannable
+    // text, so there is no output hook.)
+    let guardrail_ctx = aisix_guardrails::RequestContext {
+        model_id: &model_entry.id,
+        api_key_id: &auth.entry.id,
+        team_id: auth.key().team_id.as_deref(),
+    };
+    let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    if !resolved_chain.is_empty() {
+        let chat = images_input_to_chat(model_name, &body);
+        if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+            aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        {
+            // Per #153 the matched-pattern detail stays in ops logs only.
+            tracing::warn!(
+                guardrail_hook = "input",
+                model = %model_name,
+                reason = %reason,
+                "guardrail blocked /v1/images/generations request",
+            );
+            return Err(ProxyError::ContentFiltered(
+                "request blocked by content policy".into(),
+            ));
+        }
     }
 
     let model_rl =
@@ -395,6 +436,76 @@ mod tests {
             "created": 1_700_000_000i64,
             "data": [{"url": "https://example.com/image.png"}]
         })
+    }
+
+    fn keyword_input_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"t","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-1", g, 1)
+    }
+
+    /// #545: a configured input guardrail must fire on /v1/images/generations
+    /// — a blocked `prompt` returns 422 content_filter, upstream never hit.
+    #[tokio::test]
+    async fn input_guardrail_blocks_prompt_returns_422() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("dalle"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({"model": "dalle", "prompt": "draw BLOCKME please"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        assert!(!v["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("BLOCKME"));
+    }
+
+    /// #545 companion: a benign prompt with a guardrail configured forwards
+    /// (`expect(1)`) and returns 200.
+    #[tokio::test]
+    async fn input_guardrail_allows_benign_prompt_forwards_200() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("dalle"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({"model": "dalle", "prompt": "a serene landscape"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(v["data"][0]["url"].is_string());
     }
 
     /// Issue #168 regression: only OpenAI's API has the documented

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -652,6 +652,10 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
+        assert!(!v["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("BLOCKME"));
     }
 
     /// #545: a blocked literal in `documents` (not the query) is also scanned.
@@ -684,6 +688,48 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
+        assert!(!v["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("BLOCKME"));
+    }
+
+    /// #545 companion: a benign query/documents with a guardrail configured
+    /// still dispatches to the upstream (`expect(1)`) and returns 200 — the
+    /// guardrail must not block clean rerank traffic.
+    #[tokio::test]
+    async fn input_guardrail_allows_benign_rerank_forwards_200() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/rerank"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "rr-ok",
+                "results": [{"index": 0, "relevance_score": 0.9}],
+                "meta": {"billed_units": {"search_units": 1}}
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        let pk_json = format!(
+            r#"{{"display_name":"cohere-up","secret":"sk-cohere-mock","api_base":"{}","provider":"cohere","adapter":"openai"}}"#,
+            upstream.uri()
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();
+        snap.provider_keys.insert(ResourceEntry::new(PK_ID, pk, 1));
+        snap.models.insert(cohere_model("rr"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "rr", "query": "a fine query", "documents": ["clean a", "clean b"]
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -131,6 +131,31 @@ pub async fn rerank(
     }
 }
 
+/// Build a [`ChatFormat`](aisix_gateway::ChatFormat) of user messages from
+/// the rerank `query` + `documents` so the input guardrail chain can scan
+/// them (#545). Documents may be plain strings or `{ "text": ... }`
+/// objects; both are collected. Never sent upstream.
+fn rerank_input_to_chat(model: &str, body: &Value) -> aisix_gateway::ChatFormat {
+    let mut messages = Vec::new();
+    if let Some(q) = body.get("query").and_then(|v| v.as_str()) {
+        if !q.is_empty() {
+            messages.push(aisix_gateway::ChatMessage::user(q.to_string()));
+        }
+    }
+    if let Some(docs) = body.get("documents").and_then(|v| v.as_array()) {
+        for d in docs {
+            let text = d
+                .as_str()
+                .or_else(|| d.get("text").and_then(|t| t.as_str()))
+                .unwrap_or("");
+            if !text.is_empty() {
+                messages.push(aisix_gateway::ChatMessage::user(text.to_string()));
+            }
+        }
+    }
+    aisix_gateway::ChatFormat::new(model, messages)
+}
+
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
@@ -152,6 +177,36 @@ async fn dispatch(
 
     if !auth.key().can_access(&model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
+    }
+
+    // #545: /v1/rerank must run input guardrails. Before this it forwarded
+    // the user `query` + `documents` with no configured content/DLP check,
+    // so a block enforced on /v1/chat/completions was bypassable by
+    // switching surface. Run before the rate-limit reservation so a
+    // content-policy refusal doesn't burn an RPM slot. (Output is reranked
+    // indices/scores, not generated text, so there is no output hook.)
+    let guardrail_ctx = aisix_guardrails::RequestContext {
+        model_id: &model_entry.id,
+        api_key_id: &auth.entry.id,
+        team_id: auth.key().team_id.as_deref(),
+    };
+    let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    if !resolved_chain.is_empty() {
+        let chat = rerank_input_to_chat(&model_name, &*body);
+        if let aisix_guardrails::GuardrailVerdict::Block { reason } =
+            aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        {
+            // Per #153 the matched-pattern detail stays in ops logs only.
+            tracing::warn!(
+                guardrail_hook = "input",
+                model = %model_name,
+                reason = %reason,
+                "guardrail blocked /v1/rerank request",
+            );
+            return Err(ProxyError::ContentFiltered(
+                "request blocked by content policy".into(),
+            ));
+        }
     }
 
     let model_rl =
@@ -469,6 +524,7 @@ mod tests {
     use aisix_core::{AisixSnapshot, ApiKey, Model, ProxyConfig};
     use aisix_gateway::Hub;
     use aisix_provider_openai::OpenAiBridge;
+    use axum::body::to_bytes;
     use axum::http::{Request, StatusCode};
     use std::sync::Arc;
     use tower::ServiceExt;
@@ -555,6 +611,79 @@ mod tests {
             .header("content-type", "application/json")
             .body(axum::body::Body::from(body.to_string()))
             .unwrap()
+    }
+
+    fn keyword_input_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"t","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-1", g, 1)
+    }
+
+    /// #545: a configured input guardrail must fire on /v1/rerank — a blocked
+    /// `query` returns 422 content_filter and the upstream is never contacted.
+    #[tokio::test]
+    async fn input_guardrail_blocks_query_returns_422() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/rerank"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"results": []})),
+            )
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(cohere_model("rr"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "rr", "query": "find BLOCKME", "documents": ["x", "y"]
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #545: a blocked literal in `documents` (not the query) is also scanned.
+    #[tokio::test]
+    async fn input_guardrail_blocks_document_returns_422() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/rerank"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"results": []})),
+            )
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(cohere_model("rr"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "rr", "query": "fine query", "documents": ["clean", "has BLOCKME inside"]
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Closes the **input** half of #545: four inbound surfaces carry user-controlled text but ran **no** guardrails, so a content/DLP block configured on `/v1/chat/completions` was bypassable by switching surface — the same content-safety bypass class as #719.

| Surface | Scanned field(s) | Output hook? |
|---|---|---|
| `/v1/completions` | `prompt` (string / array of strings; token-id arrays skipped) | text output → **follow-up** (see below) |
| `/v1/images/generations` | `prompt` | no (returns an image) |
| `/v1/rerank` | `query` + `documents` (strings or `{text}`) | no (returns scores) |
| `/v1/audio/speech` | `input` (text → TTS) | no (returns audio) |

`/v1/audio/speech` was **not** in the original #545 list — the independent audit surfaced it as a 4th surface in the same class.

## How

Per surface, mirroring the `/v1/embeddings` pattern: resolve the per-request chain (`RequestContext{model_id, api_key_id, team_id}`), synthesize a `ChatFormat` from the surface's text fields (scan-only, never sent upstream), run `check_input`; `Block` → `ProxyError::ContentFiltered` (422 `content_filter`). Matched-pattern detail stays in `tracing` only (#153) — the wire message is generic.

The check runs **before** `quota::enforce`, so a content-policy refusal doesn't burn a rate-limit slot (matching `/v1/chat/completions`, and avoiding the #542 ordering issue on these new surfaces from the start).

## Exemption (documented)

`/v1/messages/count_tokens` is intentionally **exempt**: it's a pre-flight sizing call that never reaches a model and returns only an integer token count — there's nothing to moderate on either hook, and the same `messages` payload is scanned on the actual `/v1/messages` request. Documented in `count_tokens.rs`.

## Follow-up (not in this PR)

`/v1/completions` also returns generated `choices[].text`, so it warrants an **output** guardrail too (the analog of the `/v1/responses` output work in #544). Out of scope here to keep the diff focused on the demonstrated input bypass; will file/track separately.

## Reference

In-repo reference pattern: `/v1/embeddings` (`embeddings.rs`) input check. Upstream field shapes: OpenAI [completions](https://platform.openai.com/docs/api-reference/completions/create), [images](https://platform.openai.com/docs/api-reference/images/create), [audio/speech](https://platform.openai.com/docs/api-reference/audio/createSpeech); rerank follows the Cohere/Jina `query`+`documents` shape.

## Test plan

Per-surface wiremock tests: blocked input → `422` + `error.type == content_filter` with the upstream **never contacted** (`expect(0)`); benign input still forwards (`expect(1)`) → `200`. `/v1/rerank` covers both the `query` and `documents` channels. The blocked literal must not leak into the wire message. `cargo fmt` + `clippy` clean; **401** `aisix-proxy` lib tests pass.

## Independent audit (CLAUDE.md §8) — findings + resolution

A fresh agent reviewed this PR cold and returned **MERGE**. It verified the core contract: each surface scans the right text, the check runs **before** `quota::enforce` (matching chat — no burned slot, no #542 issue), the forwarded body is unchanged, the no-guardrail path is a pure no-op, #153 holds, and the tests prove block (422 + `expect(0)`) and benign (`expect(1)` + 200).

- **MEDIUM-1 — count_tokens DLP/egress nuance (pre-existing): JUSTIFIED + doc softened + follow-up filed (#555).** The exemption is correct for *content moderation* (no model call, integer-only response). For a strict *DLP/egress* policy, the count endpoint forwards `messages` to the provider before the real `/v1/messages` call — a DLP-class gap, tracked in #555. Doc scoped to content moderation. Not introduced by this PR; not a blocker.
- **LOW-1 — rerank block tests now assert the literal isn't leaked** (#153 parity).
- **LOW-2 — added a benign-with-guardrail rerank test** (clean query/documents → forwards).
- **Deferred `/v1/completions` output guardrail** — filed as #554 (completions returns generated text, so it warrants an output hook like #544). Reasonable scope cut; the demonstrated bypass here is input-side.

Merge gate: no HIGH; the MEDIUM is justified + tracked; LOWs addressed.

Refs #545, #719, #554, #555.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Input content guardrails are now enforced across audio generation, text completions, image generation, and rerank endpoints. Requests with inappropriate content are blocked with a 422 response before reaching upstream providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->