### PR TITLE
fix(guardrails): scan tool-call args on /v1/responses output (#546)

### DIFF
--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -808,26 +808,46 @@ fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
     })
 }
 
-/// Collect the assistant's visible output text from a Responses-API
-/// response object for output-guardrail scanning (#719): the `text` of
-/// every `output_text` content part across all message items in
-/// `output[]`. Reasoning items and tool-call arguments are not included
-/// (reasoning is out of output-guardrail scope, matching the chat surface).
+/// Collect the assistant's output text from a Responses-API response object
+/// for output-guardrail scanning (#719/#546):
+/// - the `text` of every `output_text` content part of message items, and
+/// - the `name` + `arguments` (function calls) / `input` (custom tool calls)
+///   of tool-call items — these are **top-level** item fields, not under
+///   `content[]`, so without scanning them a blocked literal placed in a
+///   tool-call's arguments would bypass the output guardrail. The chat
+///   surface scans tool-call output too (`ChatResponse::guardrail_output_text`,
+///   the #448 fix); this keeps the surfaces symmetric.
+///
+/// Reasoning items are intentionally excluded (out of output-guardrail
+/// scope, matching the chat surface) — they carry `summary`, not `content`
+/// / `arguments`, so they're naturally skipped.
 /// <https://platform.openai.com/docs/api-reference/responses/object>
 fn responses_output_text(resp: &Value) -> String {
-    resp.get("output")
-        .and_then(|v| v.as_array())
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|it| it.get("content").and_then(|c| c.as_array()))
-                .flatten()
-                .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
-                .filter(|t| !t.is_empty())
-                .collect::<Vec<_>>()
-                .join("\n")
-        })
-        .unwrap_or_default()
+    let Some(items) = resp.get("output").and_then(|v| v.as_array()) else {
+        return String::new();
+    };
+    let mut parts: Vec<&str> = Vec::new();
+    for it in items {
+        if let Some(content) = it.get("content").and_then(|c| c.as_array()) {
+            parts.extend(
+                content
+                    .iter()
+                    .filter_map(|p| p.get("text").and_then(|t| t.as_str())),
+            );
+        }
+        // Tool-call items carry caller-visible model output under top-level
+        // `name`/`arguments` (function_call) or `name`/`input` (custom tool).
+        for key in ["name", "arguments", "input"] {
+            if let Some(s) = it.get(key).and_then(|v| v.as_str()) {
+                parts.push(s);
+            }
+        }
+    }
+    parts
+        .into_iter()
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Collect the assistant's streamed output text from a buffered
@@ -1633,6 +1653,95 @@ mod tests {
             "oversized streamed response must fail closed, not be released unscanned",
         );
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #546: output tool-call arguments must be scanned. A blocked literal in
+    /// a `function_call` item's `arguments` (a top-level item field, not under
+    /// `content[]`) must block the non-streaming response — else tool-call
+    /// output is an output-guardrail bypass.
+    #[tokio::test]
+    async fn output_guardrail_blocks_tool_call_arguments_non_streaming() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp_tc",
+                "object": "response",
+                "output": [{
+                    "type": "function_call",
+                    "name": "lookup",
+                    "arguments": "{\"q\":\"BLOCKME\"}"
+                }],
+                "usage": {"input_tokens": 5, "output_tokens": 4}
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #546: tool-call arguments are scanned on the streaming path too (via
+    /// the `response.completed` event), and held back — the args never reach
+    /// the client.
+    #[tokio::test]
+    async fn output_guardrail_blocks_tool_call_arguments_streaming() {
+        let upstream = MockServer::start().await;
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "response": {"output": [{
+                "type": "function_call",
+                "name": "lookup",
+                "arguments": "{\"q\":\"BLOCKME\"}"
+            }]}
+        });
+        let sse = format!("event: response.completed\ndata: {completed}\n\ndata: [DONE]\n\n");
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert!(
+            !String::from_utf8_lossy(&bytes).contains("BLOCKME"),
+            "tool-call arguments leaked despite output block",
+        );
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
     }

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -892,11 +892,19 @@ fn responses_sse_output_text(bytes: &[u8]) -> String {
                     deltas.push_str(d);
                 }
             }
-            Some("response.function_call_arguments.delta") => {
-                // Concatenate WITHOUT a separator — these are pieces of one
-                // call's `arguments` string; a separator would split a literal
-                // that streamed across two deltas (e.g. "BLOCK"+"ME") and miss
-                // the match.
+            // Tool-call argument deltas across all tool kinds — function calls,
+            // MCP tool calls, and custom tools each stream their args/input via
+            // their own event, not output_text.delta. On a terminal `response`
+            // object these are already covered by responses_output_text; this
+            // matters only when the stream aborts before any terminal object.
+            // Concatenate WITHOUT a separator — these are pieces of one call's
+            // string; a separator would split a literal that streamed across
+            // two deltas (e.g. "BLOCK"+"ME") and miss the match.
+            Some(
+                "response.function_call_arguments.delta"
+                | "response.mcp_call_arguments.delta"
+                | "response.custom_tool_call_input.delta",
+            ) => {
                 if let Some(d) = json.get("delta").and_then(|d| d.as_str()) {
                     deltas.push_str(d);
                 }
@@ -1854,6 +1862,45 @@ mod tests {
             !String::from_utf8_lossy(&bytes).contains("BLOCK"),
             "streamed tool-call args leaked with no terminal event",
         );
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #546 (re-audit): MCP tool-call argument deltas stream via their own
+    /// event too; a no-terminal stream of `response.mcp_call_arguments.delta`
+    /// carrying a blocked literal must still be scanned and held back.
+    #[tokio::test]
+    async fn output_guardrail_blocks_mcp_tool_call_delta_without_terminal() {
+        let upstream = MockServer::start().await;
+        let d = serde_json::json!({"type":"response.mcp_call_arguments.delta","delta":"{\"q\":\"BLOCKME\"}"});
+        let sse =
+            format!("event: response.mcp_call_arguments.delta\ndata: {d}\n\ndata: [DONE]\n\n");
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert!(!String::from_utf8_lossy(&bytes).contains("BLOCKME"));
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
     }

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -851,10 +851,16 @@ fn responses_output_text(resp: &Value) -> String {
 }
 
 /// Collect the assistant's streamed output text from a buffered
-/// Responses-API SSE response (#719). Prefers the authoritative full output
-/// carried on the terminal `response.completed` event; falls back to
-/// concatenating `response.output_text.delta` chunks when no completed
-/// event is present (e.g. a truncated stream). The `type` field on each
+/// Responses-API SSE response (#719/#546). Prefers the authoritative full
+/// output carried on a terminal `response` event — `response.completed`,
+/// **and also `response.incomplete` / `response.failed`**, which carry the
+/// same full `output[]` (incl. tool-call items) and fire routinely (e.g.
+/// `max_output_tokens` truncation). Falls back to concatenating the streamed
+/// deltas when no terminal `response` object is present (truncated/aborted):
+/// both `response.output_text.delta` (assistant text) and
+/// `response.function_call_arguments.delta` (tool-call args stream via their
+/// own event, NOT output_text) — otherwise blocked tool-call args would leak
+/// on a stream that never reaches a terminal object. The `type` field on each
 /// `data:` JSON line drives the dispatch.
 /// <https://platform.openai.com/docs/api-reference/responses-streaming>
 fn responses_sse_output_text(bytes: &[u8]) -> String {
@@ -873,7 +879,7 @@ fn responses_sse_output_text(bytes: &[u8]) -> String {
             Err(_) => continue,
         };
         match json.get("type").and_then(|t| t.as_str()) {
-            Some("response.completed") => {
+            Some("response.completed" | "response.incomplete" | "response.failed") => {
                 if let Some(resp) = json.get("response") {
                     let full = responses_output_text(resp);
                     if !full.is_empty() {
@@ -882,6 +888,15 @@ fn responses_sse_output_text(bytes: &[u8]) -> String {
                 }
             }
             Some("response.output_text.delta") => {
+                if let Some(d) = json.get("delta").and_then(|d| d.as_str()) {
+                    deltas.push_str(d);
+                }
+            }
+            Some("response.function_call_arguments.delta") => {
+                // Concatenate WITHOUT a separator — these are pieces of one
+                // call's `arguments` string; a separator would split a literal
+                // that streamed across two deltas (e.g. "BLOCK"+"ME") and miss
+                // the match.
                 if let Some(d) = json.get("delta").and_then(|d| d.as_str()) {
                     deltas.push_str(d);
                 }
@@ -1741,6 +1756,103 @@ mod tests {
         assert!(
             !String::from_utf8_lossy(&bytes).contains("BLOCKME"),
             "tool-call arguments leaked despite output block",
+        );
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #546 (audit HIGH): tool-call args on a `response.incomplete` terminal
+    /// (fires routinely on `max_output_tokens` truncation — it carries the
+    /// full `output[]`) must also be scanned and held back, not only
+    /// `response.completed`. Same for `response.failed`.
+    #[tokio::test]
+    async fn output_guardrail_blocks_tool_call_on_incomplete_terminal() {
+        let upstream = MockServer::start().await;
+        let incomplete = serde_json::json!({
+            "type": "response.incomplete",
+            "response": {"output": [{
+                "type": "function_call",
+                "name": "lookup",
+                "arguments": "{\"q\":\"BLOCKME\"}"
+            }]}
+        });
+        let sse = format!("event: response.incomplete\ndata: {incomplete}\n\ndata: [DONE]\n\n");
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert!(
+            !String::from_utf8_lossy(&bytes).contains("BLOCKME"),
+            "tool-call args leaked on response.incomplete terminal",
+        );
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #546 (audit HIGH): a stream that ends WITHOUT a terminal `response`
+    /// object but streamed tool-call argument deltas must still be scanned —
+    /// args arrive via `response.function_call_arguments.delta`, not
+    /// `output_text.delta`. The literal is split across two deltas to pin
+    /// that they reassemble without a separator.
+    #[tokio::test]
+    async fn output_guardrail_blocks_tool_call_delta_without_terminal() {
+        let upstream = MockServer::start().await;
+        let d1 = serde_json::json!({"type":"response.function_call_arguments.delta","delta":"{\"q\":\"BLOCK"});
+        let d2 =
+            serde_json::json!({"type":"response.function_call_arguments.delta","delta":"ME\"}"});
+        let sse = format!(
+            "event: response.function_call_arguments.delta\ndata: {d1}\n\n\
+             event: response.function_call_arguments.delta\ndata: {d2}\n\ndata: [DONE]\n\n"
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert!(
+            !String::from_utf8_lossy(&bytes).contains("BLOCK"),
+            "streamed tool-call args leaked with no terminal event",
         );
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");


### PR DESCRIPTION
## What
The `/v1/responses` output guardrail (added in #544) scanned only `output_text`. A `function_call`/`custom_tool_call` item carries model output under **top-level** `name`/`arguments`/`input` — **not** under `content[]` — so a blocked literal in tool-call arguments **bypassed** the output guardrail. The chat surface already scans tool-call output (`ChatResponse::guardrail_output_text`, the #448 fix); this restores parity.

## How
- **Non-streaming + the `response.completed` path**: `responses_output_text` now also collects each `output[]` item's `name` + `arguments` (function calls) + `input` (custom tool calls), in addition to message `content[].text`.
- **Streaming terminals**: `responses_sse_output_text` now matches `response.completed` **and** `response.incomplete` / `response.failed` — all three carry the full `output[]` (incl. tool-call items), and incomplete/failed fire routinely (e.g. `max_output_tokens` truncation).
- **Truncated streams (no terminal object)**: also accumulate `response.function_call_arguments.delta` (tool-call args stream via their own event, not `output_text.delta`), concatenated without a separator so a literal split across deltas still reassembles.

Reasoning items stay excluded (they carry `summary`, not `content`/`arguments`). Corrected the doc-comment that falsely claimed tool-call args were out of scope.

## Independent audit (CLAUDE.md §8) — findings + resolution
The first audit found a **HIGH**: the streaming fix initially only matched `response.completed`, so tool-call args still leaked (200) on `response.incomplete`/`response.failed` terminals and on truncated streams — the exact bypass class this PR exists to close, triggered by an ordinary `max_output_tokens` completion. **Fixed in code** (commit `0909f5d`): match incomplete/failed terminals + accumulate `function_call_arguments.delta`. Two gating tests added (they fail before the fix, pass after). Verified clean: non-streaming bypass closed, `arguments` scanned as a raw string (substring match hits the literal), reasoning excluded, no over-scan of message items, #153 redaction intact, buffer-cap still fails closed.

## Test plan
`function_call` with a blocked literal in `arguments` → 422 `content_filter`: non-streaming; streaming via `response.completed`; streaming via `response.incomplete` terminal; and a delta-only stream with the literal split across two `function_call_arguments.delta` events (no terminal). All hold the args back (never in the response body). fmt + clippy clean; output-guardrail suite green.

## Related
The **chat.rs streaming** `tool_calls` leak (same #448 class on the chat surface — streaming buffers only `delta.content`, not `delta.tool_calls`; pre-existing) is fixed in a separate PR. Refs #546, #719, #448.
