### PR TITLE
ci: resilient protoc install to fix flaky release-CDN 504s

### DIFF
--- a/.github/actions/setup-protoc/action.yml
+++ b/.github/actions/setup-protoc/action.yml
@@ -1,0 +1,43 @@
+name: setup-protoc
+description: >-
+  Install a pinned protoc, resilient to the GitHub release-asset 504s that flake
+  arduino/setup-protoc. The intermittent timeout is on the release-CDN *download*
+  (objects.githubusercontent.com), not the GitHub API lookup, so repo-token does
+  not help. Drop-in replacement that keeps the same pinned version and retries
+  the download hard before failing the job.
+inputs:
+  version:
+    description: protoc version to install (without the leading "v").
+    default: "23.4"
+runs:
+  using: composite
+  steps:
+    - name: install protoc ${{ inputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        url="https://github.com/protocolbuffers/protobuf/releases/download/v${{ inputs.version }}/protoc-${{ inputs.version }}-linux-x86_64.zip"
+        # curl's own --retry plus an outer loop: the release CDN 504s are
+        # intermittent, so retry hard (up to 5 outer x 5 inner) before failing.
+        for attempt in 1 2 3 4 5; do
+          echo "::group::protoc download attempt ${attempt}/5"
+          if curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 -o /tmp/protoc.zip "${url}"; then
+            echo "::endgroup::"
+            break
+          fi
+          echo "::endgroup::"
+          if [ "${attempt}" = 5 ]; then
+            echo "::error::protoc ${{ inputs.version }} download failed after 5 attempts (GitHub release CDN)"
+            exit 1
+          fi
+          sleep 15
+        done
+        # Install under $HOME (no sudo) and expose it to later steps via
+        # $GITHUB_PATH; pin $PROTOC for prost/tonic build scripts.
+        dest="${HOME}/.local/protoc-${{ inputs.version }}"
+        mkdir -p "${dest}"
+        unzip -o -q /tmp/protoc.zip -d "${dest}" 'bin/protoc' 'include/*'
+        echo "${dest}/bin" >> "${GITHUB_PATH}"
+        echo "PROTOC=${dest}/bin/protoc" >> "${GITHUB_ENV}"
+        # $GITHUB_PATH only affects *subsequent* steps, so verify by full path.
+        "${dest}/bin/protoc" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: arduino/setup-protoc@v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
@@ -34,9 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: arduino/setup-protoc@v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2
       - name: regenerate schemas
         run: cargo run -p aisix-core --bin dump-schema
@@ -93,9 +89,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
-      - uses: arduino/setup-protoc@v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2
       - name: install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -118,9 +112,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
-      - uses: arduino/setup-protoc@v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2
       - name: build
         run: cargo build -p aisix-server --bin aisix


### PR DESCRIPTION
## Problem

`arduino/setup-protoc@v3.0.0` flakes intermittently with

```
Error: Failed to download version v23.4: Unexpected HTTP response: 504
```

on `protoc-23.4-linux-x86_64.zip` from the GitHub **release CDN** (`objects.githubusercontent.com`). It hits whichever of the four protoc-needing jobs (`lint`, `schema drift`, `rust unit + coverage`, `build aisix (instrumented)`) loses the lottery, failing unrelated PRs. When `build aisix (instrumented)` is the loser, the dependent `e2e` + `coverage >= 90%` jobs are **skipped**, so a green-code PR shows red CI (this blocked #550 across three reruns).

`repo-token` is already set on all four steps — but it only authenticates the GitHub **API** release lookup, not the **asset download**, so it does not prevent the 504.

## Fix

A local composite action `.github/actions/setup-protoc` that downloads the **same pinned protoc 23.4** with hard retries (`curl --retry 5 --retry-all-errors` inside an outer 5× loop, 15 s backoff) and installs it under `$HOME` (no `sudo`), exposed to later steps via `$GITHUB_PATH`. Drop-in replacement at all four call sites (`−12/+4` in `ci.yml`).

- **Keeps protoc 23.4** — no risk of a distro `protoc` (e.g. the apt package on ubuntu-22.04 lacks proto3 `optional`) silently changing build behavior.
- **DRY** — one action / one version / one retry policy for all four jobs (previously four copies of the action block).
- **No `sudo`** — installs under `$HOME/.local`, pins `PROTOC` for prost/tonic build scripts.

## Validation

This PR modifies the workflow, so its **own** CI runs every job through the new install path — if they go green (incl. `build aisix (instrumented)` → `e2e`), the fix is proven against the real flake.

## Why not apt / a retry-action

- apt `protobuf-compiler` is the simplest "never touch the CDN" fix but changes the protoc version (version-dependent build risk) — rejected to stay zero-risk.
- A third-party retry-wrapper action adds a supply-chain dependency for what a ~14-line shell step does.

Integrity note: the asset is fetched over HTTPS from GitHub's official release CDN (TLS-authenticated), matching the integrity guarantee of the action it replaces (neither verifies a SHA-256). A pinned checksum can be added later if desired.
