### PR TITLE
fix(guardrails): scan tool-call args on chat.rs streaming output (#558)

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2419,9 +2419,24 @@ where
                                     aisix_gateway::ChatResponse {
                                         id: comp.provider_request_id.clone(),
                                         model: comp.provider_model_version.clone(),
-                                        message: aisix_gateway::ChatMessage::assistant(
-                                            window_buf.clone(),
-                                        ),
+                                        // Fold tool-call text into the window
+                                        // scan (#558) so a blocked tool-call
+                                        // arg is caught BEFORE this window's
+                                        // held events (which include the
+                                        // tool-call chunks) are released —
+                                        // otherwise Window mode would leak
+                                        // tool-call args ahead of the
+                                        // end-of-stream check.
+                                        message: aisix_gateway::ChatMessage::assistant({
+                                            let w = window_buf.clone();
+                                            match tool_calls_buf.as_deref() {
+                                                Some(tc) if !tc.is_empty() && !w.is_empty() => {
+                                                    format!("{w}\n{tc}")
+                                                }
+                                                Some(tc) if !tc.is_empty() => tc.to_string(),
+                                                _ => w,
+                                            }
+                                        }),
                                         finish_reason: aisix_gateway::FinishReason::Stop,
                                         usage: aisix_gateway::UsageStats::new(
                                             comp.prompt_tokens,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2233,6 +2233,18 @@ where
         } else {
             None
         };
+        // #448 parity for streaming: accumulate tool-call text (function name +
+        // arguments) so the end-of-stream output check scans tool calls too.
+        // The chat non-streaming path (`guardrail_output_text`) and /v1/messages
+        // streaming already scan tool calls, but chat streaming buffered only
+        // `delta.content` — a blocked literal in tool-call `arguments` leaked.
+        // Bounded to the same cap as the hold-back buffer so a huge tool-call
+        // stream can't grow it without limit. Allocated only with a guardrail.
+        let mut tool_calls_buf = if output_guardrail.is_some() {
+            Some(String::new())
+        } else {
+            None
+        };
         // P2 (#379) / #466: streamed-output policy folded over the output-hook
         // guardrails. EndOfStreamCheck (reached only when no output-hook
         // guardrail is present) leaves the live-forward path below byte-for-byte
@@ -2311,6 +2323,27 @@ where
                         if let Some(cap) = content_cap {
                             if comp.response_text.len() < cap as usize {
                                 comp.response_text.push_str(text);
+                            }
+                        }
+                    }
+                    // #448 streaming parity: collect tool-call name + arguments
+                    // for the output guardrail. `delta.tool_calls` streams as
+                    // partial JSON objects; concatenate their text WITHOUT a
+                    // separator so a literal split across deltas reassembles.
+                    if let (Some(tcs), Some(buf)) =
+                        (chunk.delta.tool_calls.as_ref(), tool_calls_buf.as_mut())
+                    {
+                        for tc in tcs {
+                            if buf.len() >= aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES {
+                                break;
+                            }
+                            if let Some(f) = tc.get("function") {
+                                if let Some(n) = f.get("name").and_then(|v| v.as_str()) {
+                                    buf.push_str(n);
+                                }
+                                if let Some(a) = f.get("arguments").and_then(|v| v.as_str()) {
+                                    buf.push_str(a);
+                                }
                             }
                         }
                     }
@@ -2507,9 +2540,20 @@ where
                 // or — for BufferFull — the whole response), then release
                 // the held events if it scans clean.
                 if let Some(ctx) = output_guardrail.as_ref() {
-                    let final_text = match &stream_policy {
+                    let content_part = match &stream_policy {
                         aisix_guardrails::StreamOutputPolicy::Window { .. } => window_buf.clone(),
                         _ => content_buffer.clone().unwrap_or_default(),
+                    };
+                    // Scan content + tool-call text together (#448 streaming
+                    // parity) so blocked content in tool-call arguments can't
+                    // leak. Joined with a newline; either part may be empty.
+                    let tc_part = tool_calls_buf.as_deref().unwrap_or("");
+                    let final_text = if tc_part.is_empty() {
+                        content_part
+                    } else if content_part.is_empty() {
+                        tc_part.to_string()
+                    } else {
+                        format!("{content_part}\n{tc_part}")
                     };
                     let blocked = if final_text.is_empty() {
                         false
@@ -2564,10 +2608,19 @@ where
             } else if let (Some(content), Some(ctx)) =
                 (content_buffer.as_ref(), output_guardrail.as_ref())
             {
+                // EndOfStreamCheck: scan content + tool-call text (#448 parity).
+                let tc_part = tool_calls_buf.as_deref().unwrap_or("");
+                let scan_text = if tc_part.is_empty() {
+                    content.clone()
+                } else if content.is_empty() {
+                    tc_part.to_string()
+                } else {
+                    format!("{content}\n{tc_part}")
+                };
                 let synthesized = aisix_gateway::ChatResponse {
                     id: guard.comp().provider_request_id.clone(),
                     model: guard.comp().provider_model_version.clone(),
-                    message: aisix_gateway::ChatMessage::assistant(content.clone()),
+                    message: aisix_gateway::ChatMessage::assistant(scan_text),
                     finish_reason: aisix_gateway::FinishReason::Stop,
                     usage: aisix_gateway::UsageStats::new(
                         guard.comp().prompt_tokens,

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1976,6 +1976,84 @@ data: [DONE]\n\n";
         );
     }
 
+    /// #448 parity (streaming): the chat streaming output guardrail buffered
+    /// only `delta.content`, so a blocked literal in a tool-call's `arguments`
+    /// leaked (chat non-streaming + /v1/messages streaming already scan tool
+    /// calls). With the fix, tool-call name + arguments are scanned at
+    /// end-of-stream; a blocked literal blocks the stream (error frame) and is
+    /// held back (never on the wire) under the default BufferFull policy.
+    #[tokio::test]
+    async fn streaming_output_guardrail_blocks_tool_call_arguments() {
+        let upstream = MockServer::start().await;
+        let c1 = serde_json::json!({"id":"up-1","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]});
+        // Tool-call delta carrying the forbidden literal in `arguments` — the
+        // pre-fix path never scanned this.
+        let c2 = serde_json::json!({"id":"up-1","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"secret-string\"}"}}]},"finish_reason":null}]});
+        let c3 = serde_json::json!({"id":"up-1","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]});
+        let sse = format!("data: {c1}\n\ndata: {c2}\n\ndata: {c3}\n\ndata: [DONE]\n\n");
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub);
+        seed_guardrail(
+            &state.snapshot,
+            "g-stream-tc",
+            r#"{"name":"stream-tc-guard","kind":"keyword","hook_point":"output","patterns":[{"kind":"literal","value":"secret-string"}]}"#,
+        );
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut body_stream = resp.into_body().into_data_stream();
+        let mut wire = Vec::new();
+        while let Some(chunk) = body_stream.next().await {
+            wire.extend_from_slice(chunk.unwrap().as_ref());
+        }
+        let wire_str = String::from_utf8(wire).expect("SSE bytes are utf8");
+
+        assert!(
+            !wire_str.contains("secret-string"),
+            "tool-call arguments leaked despite output block; got:\n{wire_str}"
+        );
+        assert!(
+            wire_str.contains("event: error"),
+            "blocked stream must emit `event: error`; got:\n{wire_str}"
+        );
+        let idx = wire_str
+            .find("event: error\n")
+            .expect("error event present");
+        let data_line = wire_str[idx..]
+            .lines()
+            .find(|l| l.starts_with("data: "))
+            .expect("error event followed by a data line");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&data_line["data: ".len()..]).expect("valid error envelope");
+        assert_eq!(parsed["error"]["type"], "content_filter");
+    }
+
     /// P2 (#379): like the keyword guardrail above (which now holds back by
     /// default, #466), `azure_content_safety_text_moderation` keeps offending
     /// content off the wire — here via the configurable `Window` policy


### PR DESCRIPTION
## What
On `/v1/chat/completions` **streaming**, the output guardrail buffered only `delta.content` for the end-of-stream `check_output`; `delta.tool_calls` was never accumulated. So a blocked literal in a streamed tool-call's `function.arguments` bypassed the output guardrail. This is asymmetric: chat **non-streaming** scans tool-call output (`ChatResponse::guardrail_output_text`, the #448 fix), and `/v1/messages` **streaming** scans them too — only chat streaming leaked. Surfaced by the independent pre-fix audit of the #719 follow-up batch.

## How
Accumulate tool-call `name` + `arguments` from `chunk.delta.tool_calls` across the stream (bounded to `DEFAULT_STREAM_OUTPUT_BUFFER_BYTES`; concatenated **without** a separator so a literal split across deltas reassembles), and merge them into the scanned text at both end-of-stream check sites (the hold-back BufferFull/Window path and the EndOfStreamCheck path). Under the default **BufferFull** policy the tool-call chunks are already held in `pending` (line ~2399), so a block holds them back — they never reach the wire.

## Test plan
A streamed `tool_call` delta carrying a blocked literal in `arguments` blocks the stream (`event: error` with `error.type: content_filter`) and the args **never** appear on the wire (held back). Mirrors the existing `streaming_output_guardrail_blocks_with_sse_error_event_and_no_done` test. fmt + clippy clean; 403 `aisix-proxy` lib tests pass.

Closes #558. Refs #719, #546, #448.