### PR TITLE
fix(quota): run input guardrails before the rate-limit reservation (#542)

### DIFF
--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -242,10 +242,6 @@ async fn dispatch(
     let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
-    let model_rl =
-        crate::quota::ModelRateLimit::from_model(&body.model, &model_entry.id, &model_entry.value);
-    let reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
-
     // #719: /v1/embeddings must run input guardrails. Before this the
     // handler explicitly bypassed all guardrails, so a content block
     // enforced on /v1/chat/completions was bypassable by sending the same
@@ -254,6 +250,9 @@ async fn dispatch(
     // internal ChatFormat and run the resolved input guardrail chain. A
     // Block short-circuits before the upstream call. (Embeddings responses
     // are vectors, not text, so there is no output hook to run.)
+    //
+    // #542: run this BEFORE the rate-limit reservation so a content-policy
+    // block doesn't burn an RPM slot (matching /v1/chat/completions).
     let guardrail_ctx = aisix_guardrails::RequestContext {
         model_id: &model_entry.id,
         api_key_id: &auth.entry.id,
@@ -278,6 +277,10 @@ async fn dispatch(
             ));
         }
     }
+
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&body.model, &model_entry.id, &model_entry.value);
+    let reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     let upstream_model_id = crate::dispatch::require_upstream_model(model)?.to_string();
 

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -369,17 +369,16 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(model_name.clone()).into());
     }
 
-    let model_rl =
-        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
-
-    // #448 (#22): /v1/messages must run input guardrails + the budget
-    // pre-check like /v1/chat/completions — previously prompts reached the
-    // upstream without any content/DLP check. Translate the Anthropic-
-    // shaped body into the internal ChatFormat and run the resolved input
-    // guardrail chain; a Block short-circuits before dispatch. (Input
-    // Rewrite/Bypass on this endpoint is not yet applied to the outgoing
-    // Anthropic body — only Block is enforced here.)
+    // #448 (#22): /v1/messages must run input guardrails like
+    // /v1/chat/completions — previously prompts reached the upstream without
+    // any content/DLP check. Translate the Anthropic-shaped body into the
+    // internal ChatFormat and run the resolved input guardrail chain; a Block
+    // short-circuits before dispatch. (Input Rewrite/Bypass on this endpoint
+    // is not yet applied to the outgoing Anthropic body — only Block is
+    // enforced here.)
+    //
+    // #542: run this BEFORE the rate-limit reservation so a content-policy
+    // block doesn't burn an RPM slot (matching /v1/chat/completions).
     let guardrail_ctx = aisix_guardrails::RequestContext {
         model_id: &model_entry.id,
         api_key_id: &auth.entry.id,
@@ -410,6 +409,10 @@ async fn dispatch(
             }
         }
     }
+
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     // Budget pre-check via cp-api (mirrors /v1/chat/completions).
     let budget_decision = state.budgets.check(&auth.entry.id).await;

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -234,10 +234,6 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(model_name.clone()).into());
     }
 
-    let model_rl =
-        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
-
     // #719: /v1/responses must run input guardrails like /v1/chat/completions
     // and /v1/messages. Before this, user input reached the upstream without
     // any configured content/DLP check, so a content block enforced on the
@@ -247,6 +243,9 @@ async fn dispatch(
     // and run the resolved input guardrail chain; a Block short-circuits
     // before dispatch. (Input Rewrite/Bypass is not applied to the outgoing
     // Responses body — only Block is enforced, matching /v1/messages.)
+    //
+    // #542: run this BEFORE the rate-limit reservation so a content-policy
+    // block doesn't burn an RPM slot (matching /v1/chat/completions).
     let guardrail_ctx = aisix_guardrails::RequestContext {
         model_id: &model_entry.id,
         api_key_id: &auth.entry.id,
@@ -272,6 +271,10 @@ async fn dispatch(
             );
         }
     }
+
+    let model_rl =
+        crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
+    let _reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
 
     // Resolve the attempt list (routing-aware). /v1/responses is
     // OpenAI-only, so we attempt the group's OpenAI targets in order; a
@@ -1903,6 +1906,59 @@ mod tests {
         assert!(!String::from_utf8_lossy(&bytes).contains("BLOCKME"));
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// #542: a guardrail-blocked request must NOT consume a rate-limit slot.
+    /// With RPM=1 and a blocking guardrail, a blocked request followed by a
+    /// benign one — the benign request must still succeed (the block didn't
+    /// burn the only slot). Pre-fix (guardrail ran after `quota::enforce`) the
+    /// block reserved+burned the slot, so the benign request got 429.
+    #[tokio::test]
+    async fn blocked_request_does_not_consume_rate_limit_slot() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id":"resp_ok","object":"response",
+                "output":[{"type":"message","content":[{"type":"output_text","text":"hi"}]}],
+                "usage":{"input_tokens":1,"output_tokens":1}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        // API key capped at RPM=1.
+        let apikey: ApiKey = serde_json::from_str(
+            r#"{"key_hash":"8b6712790a2089c67aa97a2d80022df18cc65c7814350e33baebe79aab508891","allowed_models":["*"],"rate_limit":{"rpm":1}}"#,
+        )
+        .unwrap();
+        snap.apikeys.insert(ResourceEntry::new("k-1", apikey, 1));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        let app = build_app(snap);
+
+        // Blocked by the guardrail — must NOT reserve the single RPM slot.
+        let blocked = app
+            .clone()
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"BLOCKME"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(blocked.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        // Benign request — the slot must still be available.
+        let ok = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hello"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            ok.status(),
+            StatusCode::OK,
+            "a guardrail block must not burn the RPM slot (#542)",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
A guardrail-blocked request burned an RPM/RPD/RPS/RPH slot. `/v1/messages`, `/v1/responses`, `/v1/embeddings` ran `check_input` **after** `crate::quota::enforce`, and `Reservation::drop` only releases the concurrency permit — it never refunds the request counter. So a content-policy refusal counted against the caller's quota. `/v1/chat/completions` already runs guardrails **before** the reservation precisely to avoid this (its own code comment says so).

## How
Hoist the resolve-chain + `check_input` block above `quota::enforce` on all three surfaces. (messages was pre-existing; responses + embeddings inherited the ordering from #541/#544.) The budget pre-check ordering is unchanged. Deliberately **not** fixed via a `Reservation::drop` refund — that would also refund slots on upstream 5xx/timeouts, a separate policy decision affecting every surface.

## Test plan
`blocked_request_does_not_consume_rate_limit_slot`: API key capped at RPM=1, a blocking guardrail; a blocked request (422) followed by a benign one — the benign request still returns **200** (pre-fix it got **429** because the block burned the only slot). The existing per-surface input-block tests still pass (the guardrail blocks correctly in its new position). fmt + clippy clean; 408 `aisix-proxy` lib tests pass.

Surfaced by the independent pre-fix audit of the #719 follow-up batch. Refs #542, #719.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Requests blocked by input guardrails and content policies are now evaluated before rate-limit reservation. This prevents blocked requests from consuming your quota, allowing a higher proportion of your rate limit to serve legitimate requests.

* **Tests**
  * Added test to verify that content-blocked requests do not consume rate limit slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->