### PR TITLE
feat: timeout-triggered fallback (timeout + stream_timeout)

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -267,7 +267,11 @@ mod tests {
     }
 
     async fn body_json(resp: axum::http::Response<Body>) -> Value {
-        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        // 1 MiB cap: the merged `/admin/openapi.json` embeds every resource
+        // schema and is ~60 KB and growing, so the old 64 KB cap raced the
+        // spec size (#554 pushed it over on CI). Generous headroom for a
+        // self-generated, in-memory body.
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         serde_json::from_slice(&bytes).unwrap()
     }
 
@@ -294,7 +298,7 @@ mod tests {
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
-        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         let body = String::from_utf8(bytes.to_vec()).unwrap();
         assert!(body.contains("/admin/openapi.json"));
     }
@@ -336,7 +340,7 @@ mod tests {
             "unexpected content-type: {ct}"
         );
 
-        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         let body = String::from_utf8(bytes.to_vec()).unwrap();
         assert!(body.contains("aisix_requests_total"));
         assert!(body.contains("provider=\"openai\""));
@@ -441,7 +445,7 @@ mod tests {
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
-        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         assert_eq!(std::str::from_utf8(&bytes).unwrap(), "ok");
     }
 
@@ -468,7 +472,7 @@ mod tests {
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         let text = std::str::from_utf8(&bytes).unwrap();
         assert!(text.contains("livez check failed"));
     }
@@ -1051,7 +1055,7 @@ mod tests {
     #[tokio::test]
     async fn openapi_apikey_schema_excludes_max_budget_usd() {
         let resp = openapi::openapi_json().await;
-        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         let parsed: serde_json::Value =
             serde_json::from_slice(&bytes).expect("OPENAPI_JSON must parse");
         let props = &parsed["components"]["schemas"]["ApiKey"]["properties"];

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -245,20 +245,23 @@ pub struct Model {
     pub provider_key_id: Option<String>,
 
     /// Non-streaming request timeout in ms — the end-to-end budget for a
-    /// `stream:false` upstream call. 0 or absent = no timeout. On a
+    /// `stream:false` upstream call. `0` or absent = no timeout. On a
     /// routing model's target, an elapsed timeout fails over to the next
-    /// target (the timeout error is retryable). Mirrors LiteLLM's
+    /// target (the timeout error is retryable). For `stream:true` requests
+    /// it is also the fallback streaming budget when `stream_timeout` is
+    /// unset (see [`Model::stream_timeout_effective`]). Mirrors LiteLLM's
     /// `timeout`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
 
     /// Streaming read timeout in ms — the maximum gap the gateway waits
     /// for the next upstream chunk on a `stream:true` call, applied to the
-    /// first chunk and to every inter-chunk gap. 0 or absent = no timeout.
-    /// A *first-chunk* timeout fails over to the next target (before any
-    /// bytes reach the client); a *mid-stream* timeout terminates the
-    /// stream like any other upstream error. Mirrors LiteLLM's
-    /// `stream_timeout`.
+    /// first chunk and to every inter-chunk gap. `0` = no timeout; when
+    /// absent, streaming falls back to `timeout` (see
+    /// [`Model::stream_timeout_effective`]). A *first-chunk* timeout fails
+    /// over to the next target (before any bytes reach the client); a
+    /// *mid-stream* timeout terminates the stream like any other upstream
+    /// error. Mirrors LiteLLM's `stream_timeout`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_timeout: Option<u64>,
 
@@ -417,6 +420,24 @@ mod tests {
         .unwrap();
         assert_eq!(zero.request_timeout(), None);
         assert_eq!(zero.stream_read_timeout(), None);
+
+        // stream_timeout_effective cascade: prefer stream_timeout when set.
+        assert_eq!(
+            m.stream_timeout_effective(),
+            Some(std::time::Duration::from_millis(2_500))
+        );
+        // Falls back to `timeout` when stream_timeout is absent.
+        let timeout_only: Model = serde_json::from_str(
+            r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","timeout":5000}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            timeout_only.stream_timeout_effective(),
+            Some(std::time::Duration::from_millis(5_000))
+        );
+        // None when neither is set, and when both are the 0 sentinel.
+        assert_eq!(none.stream_timeout_effective(), None);
+        assert_eq!(zero.stream_timeout_effective(), None);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -244,9 +244,23 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_key_id: Option<String>,
 
-    /// Request timeout in ms. 0 or absent = no timeout.
+    /// Non-streaming request timeout in ms — the end-to-end budget for a
+    /// `stream:false` upstream call. 0 or absent = no timeout. On a
+    /// routing model's target, an elapsed timeout fails over to the next
+    /// target (the timeout error is retryable). Mirrors LiteLLM's
+    /// `timeout`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
+
+    /// Streaming read timeout in ms — the maximum gap the gateway waits
+    /// for the next upstream chunk on a `stream:true` call, applied to the
+    /// first chunk and to every inter-chunk gap. 0 or absent = no timeout.
+    /// A *first-chunk* timeout fails over to the next target (before any
+    /// bytes reach the client); a *mid-stream* timeout terminates the
+    /// stream like any other upstream error. Mirrors LiteLLM's
+    /// `stream_timeout`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_timeout: Option<u64>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<RateLimit>,
@@ -291,6 +305,35 @@ impl Model {
     pub fn upstream_model(&self) -> Option<&str> {
         self.model_name.as_deref()
     }
+
+    /// Non-streaming request deadline derived from `timeout`. Folds the
+    /// `0`/absent "no timeout" sentinel into `None` so callers can apply
+    /// it unconditionally with `if let Some(d) = ...`.
+    pub fn request_timeout(&self) -> Option<std::time::Duration> {
+        self.timeout
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis)
+    }
+
+    /// Streaming per-chunk read deadline derived from `stream_timeout`.
+    /// Same `0`/absent → `None` folding as [`Model::request_timeout`].
+    pub fn stream_read_timeout(&self) -> Option<std::time::Duration> {
+        self.stream_timeout
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis)
+    }
+
+    /// Effective deadline for a streaming request: `stream_timeout` when
+    /// set, otherwise the non-streaming `timeout`. Mirrors LiteLLM's
+    /// `Router._get_timeout`, which uses `stream_timeout` for stream calls
+    /// and falls back to the general `timeout`. Applied both to the connect
+    /// phase and as the per-chunk read timeout. `None` = no streaming
+    /// timeout. Note: a model that sets only a small `timeout` therefore
+    /// also gets that value as its streaming read timeout.
+    pub fn stream_timeout_effective(&self) -> Option<std::time::Duration> {
+        self.stream_read_timeout()
+            .or_else(|| self.request_timeout())
+    }
 }
 
 impl Resource for Model {
@@ -334,6 +377,46 @@ mod tests {
         );
         assert_eq!(m.timeout, Some(30_000));
         assert_eq!(m.rate_limit.as_ref().unwrap().rpm, Some(100));
+    }
+
+    #[test]
+    fn deserialises_stream_timeout_and_helpers_fold_zero() {
+        let m: Model = serde_json::from_str(
+            r#"{
+              "display_name": "my-gpt4",
+              "provider": "openai",
+              "model_name": "gpt-4o",
+              "provider_key_id": "pk-1",
+              "timeout": 30000,
+              "stream_timeout": 2500
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(m.stream_timeout, Some(2_500));
+        assert_eq!(
+            m.request_timeout(),
+            Some(std::time::Duration::from_millis(30_000))
+        );
+        assert_eq!(
+            m.stream_read_timeout(),
+            Some(std::time::Duration::from_millis(2_500))
+        );
+
+        // Absent → None.
+        let none: Model = serde_json::from_str(
+            r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1"}"#,
+        )
+        .unwrap();
+        assert_eq!(none.request_timeout(), None);
+        assert_eq!(none.stream_read_timeout(), None);
+
+        // Explicit 0 is the "no timeout" sentinel → None.
+        let zero: Model = serde_json::from_str(
+            r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","timeout":0,"stream_timeout":0}"#,
+        )
+        .unwrap();
+        assert_eq!(zero.request_timeout(), None);
+        assert_eq!(zero.stream_read_timeout(), None);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -256,10 +256,12 @@ pub struct Model {
 
     /// Streaming read timeout in ms — the maximum gap the gateway waits
     /// for the next upstream chunk on a `stream:true` call, applied to the
-    /// first chunk and to every inter-chunk gap. `0` = no timeout; when
-    /// absent, streaming falls back to `timeout` (see
-    /// [`Model::stream_timeout_effective`]). A *first-chunk* timeout fails
-    /// over to the next target (before any bytes reach the client); a
+    /// first chunk and to every inter-chunk gap. A positive value bounds
+    /// each chunk wait; `0` or absent means "no streaming-specific
+    /// override", so the effective streaming budget falls back to `timeout`
+    /// (see [`Model::stream_timeout_effective`]) — set `timeout` to `0` too
+    /// to disable streaming timeouts entirely. A *first-chunk* timeout
+    /// fails over to the next target (before any bytes reach the client); a
     /// *mid-stream* timeout terminates the stream like any other upstream
     /// error. Mirrors LiteLLM's `stream_timeout`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -326,13 +328,17 @@ impl Model {
             .map(std::time::Duration::from_millis)
     }
 
-    /// Effective deadline for a streaming request: `stream_timeout` when
-    /// set, otherwise the non-streaming `timeout`. Mirrors LiteLLM's
-    /// `Router._get_timeout`, which uses `stream_timeout` for stream calls
-    /// and falls back to the general `timeout`. Applied both to the connect
-    /// phase and as the per-chunk read timeout. `None` = no streaming
-    /// timeout. Note: a model that sets only a small `timeout` therefore
-    /// also gets that value as its streaming read timeout.
+    /// Effective deadline for a streaming request: a positive
+    /// `stream_timeout`, otherwise the non-streaming `timeout`. Mirrors
+    /// LiteLLM's `Router._get_timeout`, which uses `stream_timeout` for
+    /// stream calls and falls back to the general `timeout`. Applied to the
+    /// connect phase, the per-chunk read timeout, and the first-chunk
+    /// failover gate. Because `stream_read_timeout()` folds `0` to `None`,
+    /// `stream_timeout: 0` is treated the same as absent — it falls back to
+    /// `timeout` rather than disabling the streaming timeout. `None` (both
+    /// unset or `0`) = no streaming timeout. Note: a model that sets only a
+    /// small `timeout` therefore also gets that value as its streaming
+    /// budget.
     pub fn stream_timeout_effective(&self) -> Option<std::time::Duration> {
         self.stream_read_timeout()
             .or_else(|| self.request_timeout())
@@ -438,6 +444,18 @@ mod tests {
         // None when neither is set, and when both are the 0 sentinel.
         assert_eq!(none.stream_timeout_effective(), None);
         assert_eq!(zero.stream_timeout_effective(), None);
+
+        // Explicit `stream_timeout: 0` folds to absent → falls back to
+        // `timeout` (matches LiteLLM's falsy 0), not "disable streaming".
+        let stream_zero_timeout_set: Model = serde_json::from_str(
+            r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","timeout":5000,"stream_timeout":0}"#,
+        )
+        .unwrap();
+        assert_eq!(stream_zero_timeout_set.stream_read_timeout(), None);
+        assert_eq!(
+            stream_zero_timeout_set.stream_timeout_effective(),
+            Some(std::time::Duration::from_millis(5_000))
+        );
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -134,6 +134,7 @@ fn model_schema() -> Value {
             "model_name":      { "type": "string", "minLength": 1 },
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },
+            "stream_timeout":  { "type": "integer", "minimum": 0 },
             "rate_limit":      { "$ref": "#/$defs/rate_limit" },
             "routing": {
                 "type": "object",

--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -57,16 +57,6 @@ pub(crate) struct RoutingTelemetry {
 }
 
 impl RoutingTelemetry {
-    /// Build a telemetry log holding a single already-classified attempt
-    /// (the streaming path, which only ever tries the first target).
-    pub fn single(rec: AttemptRecord) -> Self {
-        let last_target = Some(rec.target_model.clone());
-        Self {
-            attempts: vec![rec],
-            last_target,
-        }
-    }
-
     /// Classify the next attempt against `display_name` and advance the
     /// last-target tracker. Returns `(index, kind)` to stamp onto the
     /// `AttemptRecord` the caller pushes once the attempt resolves. Call

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -897,24 +897,46 @@ async fn dispatch(
                 ctx = ctx.with_deadline(d);
             }
             let attempt_started = Instant::now();
-            let outcome: Result<
-                (aisix_gateway::ChatChunkStream, aisix_gateway::ChatChunk),
-                BridgeError,
-            > = match bridge.chat_stream(req, &ctx).await {
+            // Connect, then — only when a `stream_timeout` is configured —
+            // peek the first chunk so a slow or erroring first token fails
+            // over before the 200 is committed. Without a stream timeout
+            // there is nothing to gate on, so the stream is committed
+            // directly (a first-chunk error then surfaces in-band, exactly
+            // like the pre-#554 behavior). The read-timeout wrapper is a
+            // no-op when `stream_read_timeout()` is None.
+            let attempt_stream: Result<aisix_gateway::ChatChunkStream, BridgeError> = match bridge
+                .chat_stream(req, &ctx)
+                .await
+            {
                 Err(e) => Err(e),
                 Ok(up) => {
-                    let mut up =
+                    let up =
                         crate::stream_timeout::with_read_timeout(up, model.stream_read_timeout());
-                    match up.next().await {
-                        Some(Ok(chunk)) => Ok((up, chunk)),
-                        Some(Err(e)) => Err(e),
-                        None => Err(BridgeError::StreamAborted),
+                    if model.stream_read_timeout().is_some() {
+                        let mut up = up;
+                        match up.next().await {
+                            // Re-prepend the peeked chunk so the SSE pump
+                            // sees the whole stream (and records TTFT on
+                            // the first content chunk); the wrapper keeps
+                            // enforcing the read timeout on the rest.
+                            Some(Ok(chunk)) => Ok(Box::pin(
+                                futures::stream::once(std::future::ready(Ok::<_, BridgeError>(
+                                    chunk,
+                                )))
+                                .chain(up),
+                            )
+                                as aisix_gateway::ChatChunkStream),
+                            Some(Err(e)) => Err(e),
+                            None => Err(BridgeError::StreamAborted),
+                        }
+                    } else {
+                        Ok(up)
                     }
                 }
             };
             let latency_ms = attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
-            match outcome {
-                Ok((rest, chunk)) => {
+            match attempt_stream {
+                Ok(upstream) => {
                     state.health.record_success(&model.display_name);
                     state.runtime_status.mark_healthy(&attempt.id);
                     stream_routing.attempts.push(AttemptRecord {
@@ -928,14 +950,6 @@ async fn dispatch(
                         error_message: String::new(),
                         latency_ms,
                     });
-                    // Re-prepend the peeked first chunk so `build_sse_stream`
-                    // sees the whole stream (and still records TTFT on the
-                    // first content chunk). `rest` keeps enforcing the
-                    // per-chunk read timeout on everything after it.
-                    let upstream: aisix_gateway::ChatChunkStream = Box::pin(
-                        futures::stream::once(std::future::ready(Ok::<_, BridgeError>(chunk)))
-                            .chain(rest),
-                    );
                     won = Some(StreamWin {
                         model: model.clone(),
                         provider_lc: provider.to_ascii_lowercase(),

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -897,43 +897,45 @@ async fn dispatch(
                 ctx = ctx.with_deadline(d);
             }
             let attempt_started = Instant::now();
-            // Connect, then — only when a `stream_timeout` is configured —
+            // Effective streaming budget: `stream_timeout`, falling back to
+            // `timeout`. Used for the connect deadline (above) AND the
+            // per-chunk read timeout + first-chunk peek here, so the budget
+            // is applied consistently.
+            let stream_budget = model.stream_timeout_effective();
+            // Connect, then — only when a streaming budget is configured —
             // peek the first chunk so a slow or erroring first token fails
-            // over before the 200 is committed. Without a stream timeout
-            // there is nothing to gate on, so the stream is committed
-            // directly (a first-chunk error then surfaces in-band, exactly
-            // like the pre-#554 behavior). The read-timeout wrapper is a
-            // no-op when `stream_read_timeout()` is None.
-            let attempt_stream: Result<aisix_gateway::ChatChunkStream, BridgeError> = match bridge
-                .chat_stream(req, &ctx)
-                .await
-            {
-                Err(e) => Err(e),
-                Ok(up) => {
-                    let up =
-                        crate::stream_timeout::with_read_timeout(up, model.stream_read_timeout());
-                    if model.stream_read_timeout().is_some() {
-                        let mut up = up;
-                        match up.next().await {
-                            // Re-prepend the peeked chunk so the SSE pump
-                            // sees the whole stream (and records TTFT on
-                            // the first content chunk); the wrapper keeps
-                            // enforcing the read timeout on the rest.
-                            Some(Ok(chunk)) => Ok(Box::pin(
-                                futures::stream::once(std::future::ready(Ok::<_, BridgeError>(
-                                    chunk,
-                                )))
-                                .chain(up),
-                            )
-                                as aisix_gateway::ChatChunkStream),
-                            Some(Err(e)) => Err(e),
-                            None => Err(BridgeError::StreamAborted),
+            // over before the 200 is committed. Without a budget there is
+            // nothing to gate on, so the stream is committed directly (a
+            // first-chunk error then surfaces in-band, exactly like the
+            // pre-#554 behavior). The read-timeout wrapper is a no-op when
+            // the budget is None.
+            let attempt_stream: Result<aisix_gateway::ChatChunkStream, BridgeError> =
+                match bridge.chat_stream(req, &ctx).await {
+                    Err(e) => Err(e),
+                    Ok(up) => {
+                        let up = crate::stream_timeout::with_read_timeout(up, stream_budget);
+                        if stream_budget.is_some() {
+                            let mut up = up;
+                            match up.next().await {
+                                // Re-prepend the peeked chunk so the SSE pump
+                                // sees the whole stream (and records TTFT on
+                                // the first content chunk); the wrapper keeps
+                                // enforcing the read timeout on the rest.
+                                Some(Ok(chunk)) => Ok(Box::pin(
+                                    futures::stream::once(std::future::ready(
+                                        Ok::<_, BridgeError>(chunk),
+                                    ))
+                                    .chain(up),
+                                )
+                                    as aisix_gateway::ChatChunkStream),
+                                Some(Err(e)) => Err(e),
+                                None => Err(BridgeError::StreamAborted),
+                            }
+                        } else {
+                            Ok(up)
                         }
-                    } else {
-                        Ok(up)
                     }
-                }
-            };
+                };
             let latency_ms = attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
             match attempt_stream {
                 Ok(upstream) => {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -832,47 +832,170 @@ async fn dispatch(
 
     let now = created_ts();
 
-    // Streaming path: only attempt the first target. Streaming fallback
-    // is genuinely hard (we'd have to buffer the stream to detect
-    // failure mid-flight) and not worth the complexity for V1.
+    // Streaming path (#554): walk the target list with first-chunk
+    // fallback. For each target we connect, then peek the first stream
+    // chunk under the per-chunk read timeout (`stream_timeout`, falling
+    // back to `timeout`). A first-chunk failure — connect error, an error
+    // chunk, an empty stream, or a read timeout — fails over to the next
+    // target before any bytes reach the client, exactly like the
+    // non-streaming loop. The peeked chunk is re-prepended so the SSE pump
+    // sees the full stream; the wrapper keeps enforcing the read timeout on
+    // the remaining chunks, so a mid-stream stall terminates the response
+    // (no fallback once the 200 is committed).
     if req.is_streaming() {
-        let model = &attempt_models[0].model;
-        let provider = crate::dispatch::require_provider(model).map_err(with_model)?;
-        let pk_entry =
-            crate::dispatch::resolve_provider_key(&snapshot, model).map_err(with_model)?;
-        let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
-            .ok_or_else(|| with_model(ProxyError::ProviderUnavailable))?;
-        let model_arc = Arc::new(model.clone());
-        let pk_arc = Arc::new(pk_entry.value.clone());
-        let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
-        let stream_attempt_started = Instant::now();
-        let upstream = match bridge.chat_stream(req, &ctx).await {
-            Ok(upstream) => upstream,
-            Err(err) => {
-                let attempt_latency_ms = stream_attempt_started
-                    .elapsed()
-                    .as_millis()
-                    .min(u32::MAX as u128) as u32;
-                // Streaming attempts only the first target (#655): a single
-                // failed AttemptRecord, emitted by the Err-arm fan-out.
-                let routing = if virtual_entry.value.routing.is_some() {
-                    RoutingTelemetry::single(AttemptRecord {
-                        index: 0,
-                        kind: "initial",
-                        target_model: model.display_name.clone(),
+        let retry_on_429 = virtual_entry
+            .value
+            .routing
+            .as_ref()
+            .map(|r| r.retry_on_429_or_default())
+            .unwrap_or(false);
+        let is_routing_request = virtual_entry.value.routing.is_some();
+        let mut stream_routing = RoutingTelemetry::default();
+        let mut last_err: Option<BridgeError> = None;
+
+        struct StreamWin {
+            model: aisix_core::Model,
+            provider_lc: String,
+            pk_id: String,
+            upstream: aisix_gateway::ChatChunkStream,
+            idx: u32,
+            kind: &'static str,
+        }
+        let mut won: Option<StreamWin> = None;
+
+        'targets: for attempt in &attempt_models {
+            let model = &attempt.model;
+            let Ok(provider) = crate::dispatch::require_provider(model) else {
+                last_err = Some(BridgeError::Config("model has no provider".into()));
+                continue 'targets;
+            };
+            let Ok(pk_entry) = crate::dispatch::resolve_provider_key(&snapshot, model) else {
+                last_err = Some(BridgeError::Config(
+                    "model references unknown provider_key_id".into(),
+                ));
+                continue 'targets;
+            };
+            let Some(bridge) = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value) else {
+                last_err = Some(BridgeError::Config(
+                    "no bridge registered for provider_key".into(),
+                ));
+                continue 'targets;
+            };
+            let (idx, kind) = stream_routing.begin_attempt(&model.display_name);
+            let target_model = if is_routing_request {
+                model.display_name.clone()
+            } else {
+                String::new()
+            };
+            let model_arc = Arc::new(model.clone());
+            let pk_arc = Arc::new(pk_entry.value.clone());
+            // Streaming deadline (#554): bound the connect by the effective
+            // stream timeout; the read-timeout wrapper below enforces the
+            // same budget on the first and subsequent chunks.
+            let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+            if let Some(d) = model.stream_timeout_effective() {
+                ctx = ctx.with_deadline(d);
+            }
+            let attempt_started = Instant::now();
+            let outcome: Result<
+                (aisix_gateway::ChatChunkStream, aisix_gateway::ChatChunk),
+                BridgeError,
+            > = match bridge.chat_stream(req, &ctx).await {
+                Err(e) => Err(e),
+                Ok(up) => {
+                    let mut up =
+                        crate::stream_timeout::with_read_timeout(up, model.stream_read_timeout());
+                    match up.next().await {
+                        Some(Ok(chunk)) => Ok((up, chunk)),
+                        Some(Err(e)) => Err(e),
+                        None => Err(BridgeError::StreamAborted),
+                    }
+                }
+            };
+            let latency_ms = attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+            match outcome {
+                Ok((rest, chunk)) => {
+                    state.health.record_success(&model.display_name);
+                    state.runtime_status.mark_healthy(&attempt.id);
+                    stream_routing.attempts.push(AttemptRecord {
+                        index: idx,
+                        kind,
+                        target_model,
+                        provider_key_id: pk_entry.id.clone(),
+                        status: 200,
+                        success: true,
+                        error_class: String::new(),
+                        error_message: String::new(),
+                        latency_ms,
+                    });
+                    // Re-prepend the peeked first chunk so `build_sse_stream`
+                    // sees the whole stream (and still records TTFT on the
+                    // first content chunk). `rest` keeps enforcing the
+                    // per-chunk read timeout on everything after it.
+                    let upstream: aisix_gateway::ChatChunkStream = Box::pin(
+                        futures::stream::once(std::future::ready(Ok::<_, BridgeError>(chunk)))
+                            .chain(rest),
+                    );
+                    won = Some(StreamWin {
+                        model: model.clone(),
+                        provider_lc: provider.to_ascii_lowercase(),
+                        pk_id: pk_entry.id.clone(),
+                        upstream,
+                        idx,
+                        kind,
+                    });
+                    break 'targets;
+                }
+                Err(err) => {
+                    stream_routing.attempts.push(AttemptRecord {
+                        index: idx,
+                        kind,
+                        target_model,
                         provider_key_id: pk_entry.id.clone(),
                         status: err.http_status(),
                         success: false,
                         error_class: routing_error_class(&err).to_string(),
                         error_message: attempt_error_message(&err),
-                        latency_ms: attempt_latency_ms,
-                    })
-                } else {
-                    RoutingTelemetry::default()
-                };
-                return Err(with_model(ProxyError::Bridge(err)).with_routing(routing));
+                        latency_ms,
+                    });
+                    let retryable = is_retryable(&err, retry_on_429);
+                    tracing::warn!(
+                        target_model = %model.display_name,
+                        error = %err,
+                        retryable,
+                        "streaming routing target attempt failed",
+                    );
+                    if retryable {
+                        state.health.record_failure(&model.display_name);
+                    }
+                    if let Some((ttl, reason)) =
+                        decide_cooldown(&err, attempt.model.cooldown.as_ref())
+                    {
+                        state.runtime_status.mark_cooldown(&attempt.id, ttl, reason);
+                    }
+                    last_err = Some(err);
+                    if !retryable {
+                        break 'targets;
+                    }
+                }
             }
+        }
+
+        let Some(won) = won else {
+            let err = last_err.unwrap_or_else(|| {
+                BridgeError::Config("streaming routing exhausted with no targets".into())
+            });
+            return Err(with_model(ProxyError::Bridge(err)).with_routing(stream_routing));
         };
+        let StreamWin {
+            model,
+            provider_lc: provider,
+            pk_id,
+            upstream,
+            idx: winner_idx,
+            kind: winner_kind,
+        } = won;
+        let model = &model;
         // Hold concurrency for the stream's full lifetime instead of
         // releasing it at handler return. RPM was already counted by
         // pre_commit; TPM is updated retroactively on stream-end by
@@ -901,14 +1024,14 @@ async fn dispatch(
         let user_id_for_metrics = auth.key().user_id.clone();
         let provider_for_metrics = provider.to_ascii_lowercase();
         let model_for_metrics = req.model.clone();
-        let provider_key_id_for_metrics = pk_entry.id.clone();
+        let provider_key_id_for_metrics = pk_id.clone();
         // Captured for the stream-end telemetry closure so
         // emit_usage_event can look up `telemetry_tags` for per-PK
         // attribution (#302 M17 / AISIX-Cloud#436). The metrics
         // variant above is `&str`-scoped to inner scopes that consume
         // it as a borrow; the telem variant is owned for the move
         // into the on_complete closure.
-        let provider_key_id_for_telem = pk_entry.id.clone();
+        let provider_key_id_for_telem = pk_id.clone();
         let upstream_model_for_metrics = model.upstream_model().unwrap_or("unknown").to_string();
         let bypass_reason_for_telem = bypass_reason.clone().unwrap_or_default();
         // Applied guardrail set (#379), owned for the move into on_complete so
@@ -917,25 +1040,10 @@ async fn dispatch(
         // Downstream client attribution (#492) moved into the on_complete
         // closure so streamed responses log the same IP/UA as non-streaming.
         let client_for_telem = client.clone();
-        // Streaming attempts only the first target (#655): a single
-        // winning AttemptRecord drives the access log served-by + counts.
-        let stream_routing = if virtual_entry.value.routing.is_some() {
-            RoutingTelemetry::single(AttemptRecord {
-                index: 0,
-                kind: "initial",
-                target_model: model.display_name.clone(),
-                provider_key_id: pk_entry.id.clone(),
-                status: 200,
-                success: true,
-                error_class: String::new(),
-                error_message: String::new(),
-                latency_ms: 0,
-            })
-        } else {
-            RoutingTelemetry::default()
-        };
-        // Per-attempt target name for the on_complete winner event.
-        let attempt_model_for_telem = if virtual_entry.value.routing.is_some() {
+        // Per-attempt target name for the on_complete winner event. The
+        // real per-attempt RoutingTelemetry was accumulated by the
+        // fallback loop above (`stream_routing`).
+        let attempt_model_for_telem = if is_routing_request {
             model.display_name.clone()
         } else {
             String::new()
@@ -1016,10 +1124,10 @@ async fn dispatch(
                         cache_hit_saved_input_tokens: 0,
                         cache_hit_saved_output_tokens: 0,
                         ttft_ms: comp.ttft_ms,
-                        // Streaming is single-attempt (#655): the winner is
-                        // always the initial attempt of the first target.
-                        attempt_index: 0,
-                        attempt_kind: "initial".to_string(),
+                        // #554: the winning attempt may be a fallback target,
+                        // not the initial one — record the real index/kind.
+                        attempt_index: winner_idx,
+                        attempt_kind: winner_kind.to_string(),
                         attempt_model: attempt_model_for_telem.clone(),
                         error_class: String::new(),
                         error_message: String::new(),
@@ -1100,7 +1208,7 @@ async fn dispatch(
             cache_read_tokens: 0,
             provider_request_id: String::new(),
             provider_model_version: String::new(),
-            provider_key_id: pk_entry.id.clone(),
+            provider_key_id: pk_id.clone(),
             upstream_model: model.upstream_model().unwrap_or("unknown").to_string(),
             finish_reason: String::new(),
             bypass_reason: bypass_reason.clone(),
@@ -1111,13 +1219,12 @@ async fn dispatch(
             cache_hit_saved_input_tokens: 0,
             cache_hit_saved_output_tokens: 0,
             telemetry_handled_by_stream: true,
-            // Streaming attempts only `targets[0]` (no mid-stream
-            // fallback), so on the routing path the served target is
-            // unambiguously the first one. The helper enforces the
+            // #554: the served target is whichever one won the first-chunk
+            // race (may be a fallback). The helper enforces the
             // "direct model → None" rule consistently with the
             // non-streaming and cache paths.
             served_by_target: served_by_target_for_routing(
-                virtual_entry.value.routing.is_some(),
+                is_routing_request,
                 Some(model.display_name.clone()),
             ),
             routing: stream_routing,
@@ -1355,7 +1462,13 @@ async fn dispatch(
         };
         let model_arc = Arc::new(model.clone());
         let pk_arc = Arc::new(pk_entry.value.clone());
-        let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+        // Per-attempt non-streaming deadline (#554): an elapsed `timeout`
+        // surfaces as a retryable `BridgeError::Timeout`, so a slow target
+        // fails over to the next one via the loop below.
+        let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+        if let Some(d) = model.request_timeout() {
+            ctx = ctx.with_deadline(d);
+        }
 
         for attempt_idx in 0..=retries {
             // Per-attempt telemetry kind (#655): the first attempt overall

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -178,7 +178,11 @@ async fn dispatch(
 
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
-    let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    // #554: apply the configured request `timeout` as the upstream deadline.
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    if let Some(d) = model.request_timeout() {
+        ctx = ctx.with_deadline(d);
+    }
 
     let provider_label = provider.to_ascii_lowercase();
 

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -296,10 +296,13 @@ async fn count_tokens_to_target(
     }
 
     let client = crate::http_client::client();
-    let upstream_resp = client
-        .post(&url)
-        .headers(headers)
-        .json(&body)
+    let mut req = client.post(&url).headers(headers).json(&body);
+    // #554: count_tokens is non-streaming; apply the E2E request timeout.
+    if let Some(d) = model.request_timeout() {
+        req = req.timeout(d);
+    }
+    let send_started = Instant::now();
+    let upstream_resp = req
         .send()
         .await
         .map_err(|e| {
@@ -307,7 +310,7 @@ async fn count_tokens_to_target(
                 &state.runtime_status,
                 model_id,
                 model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::Transport(e.to_string()),
+                crate::dispatch::reqwest_error_to_bridge(&e, send_started),
             )
         })
         .map_err(ProxyError::Bridge)?;

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -18,10 +18,28 @@
 //! plumbing flows naturally.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use aisix_core::resource::ResourceEntry;
 use aisix_core::{AisixSnapshot, Model, ProviderKey};
-use aisix_gateway::{Bridge, Hub};
+use aisix_gateway::{Bridge, BridgeError, Hub};
+
+/// Map a `reqwest` transport error from a raw-passthrough dispatch
+/// (`/v1/responses`, `/v1/messages` Anthropic, `/v1/messages/count_tokens`)
+/// into the gateway's [`BridgeError`]. A timed-out request (the per-request
+/// `.timeout(model.request_timeout())` budget elapsed) becomes
+/// [`BridgeError::Timeout`] so it surfaces as 504, classifies as `"timeout"`
+/// in telemetry, and participates in routing failover exactly like the
+/// Bridge-trait path (#554). Everything else stays a transport error.
+pub(crate) fn reqwest_error_to_bridge(e: &reqwest::Error, started: Instant) -> BridgeError {
+    if e.is_timeout() {
+        BridgeError::Timeout {
+            elapsed_ms: started.elapsed().as_millis() as u64,
+        }
+    } else {
+        BridgeError::Transport(e.to_string())
+    }
+}
 
 use crate::error::ProxyError;
 

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -299,7 +299,11 @@ async fn dispatch(
 
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
-    let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    // #554: apply the configured request `timeout` as the upstream deadline.
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    if let Some(d) = model.request_timeout() {
+        ctx = ctx.with_deadline(d);
+    }
 
     match bridge.embed(&req, &ctx).await {
         Ok(embed_resp) => {

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -181,7 +181,11 @@ async fn dispatch(
 
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
-    let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    // #554: apply the configured request `timeout` as the upstream deadline.
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    if let Some(d) = model.request_timeout() {
+        ctx = ctx.with_deadline(d);
+    }
 
     let provider_label = provider.to_ascii_lowercase();
 

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -51,6 +51,7 @@ mod rerank;
 mod responses;
 mod routing;
 mod state;
+mod stream_timeout;
 mod util;
 
 pub use auth::AuthenticatedKey;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -435,10 +435,6 @@ async fn dispatch(
         &model_entry.value,
     )?;
 
-    let is_stream = body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
     let retry_on_429 = model_entry
         .value
         .routing
@@ -451,81 +447,14 @@ async fn dispatch(
     let is_routing_request = model_entry.value.routing.is_some();
     let mut routing = RoutingTelemetry::default();
 
-    // Streaming attempts only the first target (no mid-stream fallback),
-    // matching /v1/chat/completions. The winning UsageEvent is emitted by
-    // the stream's Drop guard; a connect failure records a single failed
-    // attempt the handler emits.
-    if is_stream {
-        let target = &attempt_models[0];
-        let (idx, kind) = routing.begin_attempt(&target.model.display_name);
-        let target_model = if is_routing_request {
-            target.model.display_name.clone()
-        } else {
-            String::new()
-        };
-        let pk_id = crate::dispatch::resolve_provider_key(&snapshot, &target.model)
-            .map(|e| e.id.clone())
-            .unwrap_or_default();
-        let attempt_started = Instant::now();
-        return match dispatch_to_target(
-            state,
-            &snapshot,
-            body,
-            target,
-            &model_name,
-            request_id,
-            started,
-            &auth.entry.id,
-            auth.key().team_id.clone(),
-            auth.key().user_id.clone(),
-            resolved_chain.clone(),
-            client,
-            AttemptInfo {
-                index: idx,
-                kind: kind.to_string(),
-                model: target_model.clone(),
-                ..Default::default()
-            },
-        )
-        .await
-        {
-            Ok(mut outcome) => {
-                routing.attempts.push(AttemptRecord {
-                    index: idx,
-                    kind,
-                    target_model,
-                    provider_key_id: outcome.provider_key_id.clone(),
-                    status: 200,
-                    success: true,
-                    error_class: String::new(),
-                    error_message: String::new(),
-                    latency_ms: ms_since(attempt_started),
-                });
-                outcome.routing = routing;
-                Ok(outcome)
-            }
-            Err(e) => {
-                let (error_class, error_message) = attempt_error_from_proxy(&e);
-                routing.attempts.push(AttemptRecord {
-                    index: idx,
-                    kind,
-                    target_model,
-                    provider_key_id: pk_id,
-                    status: e.status().as_u16(),
-                    success: false,
-                    error_class,
-                    error_message,
-                    latency_ms: ms_since(attempt_started),
-                });
-                Err(MessagesDispatchError { err: e, routing })
-            }
-        };
-    }
-
-    // Non-streaming: walk targets, failing over to the next only on a
-    // retryable upstream failure. A 4xx / config error is returned
-    // as-is — retrying other targets won't help. Each target attempt
-    // becomes its own per-attempt record (#655).
+    // Walk targets, failing over to the next only on a retryable upstream
+    // failure. A 4xx / config error is returned as-is — retrying other
+    // targets won't help. Streaming and non-streaming share this loop:
+    // `dispatch_to_target` branches internally and, for streaming, only
+    // returns Ok once the first chunk has arrived under `stream_timeout`
+    // (#554) — so the 200 is committed to exactly one target and a slow
+    // first chunk fails over like any other retryable error. Each target
+    // attempt becomes its own per-attempt record (#655).
     let n = attempt_models.len();
     let mut last_err: Option<ProxyError> = None;
     for (i, target) in attempt_models.iter().enumerate() {
@@ -772,20 +701,37 @@ async fn anthropic_passthrough_dispatch(
     }
 
     let client = crate::http_client::client();
-    let req_builder = client.post(&url).headers(headers).json(&body);
-
-    let upstream_resp = req_builder
-        .send()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                model_id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::Transport(e.to_string()),
-            )
-        })
-        .map_err(ProxyError::Bridge)?;
+    let mut req_builder = client.post(&url).headers(headers).json(&body);
+    // #554: non-streaming gets the E2E request timeout via reqwest's
+    // request-level timeout. Streaming must NOT use it (it would cap the
+    // whole stream); the streaming branch below enforces the per-chunk
+    // read timeout instead.
+    if !is_stream {
+        if let Some(d) = model.request_timeout() {
+            req_builder = req_builder.timeout(d);
+        }
+    }
+    let send_started = Instant::now();
+    // Streaming bounds the connect by the stream deadline (reqwest's
+    // request-level timeout can't be used — it would cap the whole stream);
+    // non-streaming relies on the request-level timeout set above.
+    let connect_deadline = if is_stream {
+        model.stream_timeout_effective()
+    } else {
+        None
+    };
+    let upstream_resp =
+        crate::stream_timeout::send_with_deadline(req_builder, connect_deadline, send_started)
+            .await
+            .map_err(|be| {
+                crate::cooldown::note_failure(
+                    &state.runtime_status,
+                    model_id,
+                    model.cooldown.as_ref(),
+                    be,
+                )
+            })
+            .map_err(ProxyError::Bridge)?;
 
     let status = upstream_resp.status();
 
@@ -826,7 +772,42 @@ async fn anthropic_passthrough_dispatch(
         // For SSE streaming: pass through the response body as a streaming
         // `text/event-stream` response.
         let headers = upstream_resp.headers().clone();
-        let body_stream = upstream_resp.bytes_stream();
+        // #554: enforce the per-chunk read timeout on the forwarded bytes,
+        // then peek the first byte so a slow first token fails over (the
+        // caller loops to the next target) before the 200 is committed. A
+        // mid-stream stall truncates the forwarded stream — there is no
+        // in-band error frame to inject into an opaque byte passthrough.
+        let mut body_stream: std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>> =
+            Box::pin(crate::stream_timeout::with_read_timeout_bytes(
+                upstream_resp.bytes_stream(),
+                model.stream_read_timeout(),
+            ));
+        let first_bytes = match body_stream.next().await {
+            Some(Ok(b)) => b,
+            Some(Err(e)) => {
+                let err = crate::dispatch::reqwest_error_to_bridge(&e, send_started);
+                if let Some((ttl, reason)) =
+                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                {
+                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                }
+                return Err(ProxyError::Bridge(err));
+            }
+            // Read timeout before the first byte (or an upstream that closed
+            // immediately): retryable stream-abort so the caller fails over.
+            None => {
+                let err = aisix_gateway::BridgeError::StreamAborted;
+                if let Some((ttl, reason)) =
+                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                {
+                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                }
+                return Err(ProxyError::Bridge(err));
+            }
+        };
+        let body_stream =
+            futures::stream::once(std::future::ready(Ok::<Bytes, reqwest::Error>(first_bytes)))
+                .chain(body_stream);
 
         // Issue #245: parity with the OpenAI streaming fix (#225 /
         // #196). Pre-fix this path forwarded raw bytes and emitted a
@@ -1203,7 +1184,19 @@ async fn cross_provider_dispatch(
     let is_stream = chat.is_streaming();
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(provider_key.clone());
-    let ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    // #554: bound the upstream connect with the appropriate deadline —
+    // the streaming read budget for stream calls, the E2E request timeout
+    // otherwise. The streaming path additionally enforces the per-chunk
+    // read timeout below.
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    let connect_deadline = if is_stream {
+        model.stream_timeout_effective()
+    } else {
+        model.request_timeout()
+    };
+    if let Some(d) = connect_deadline {
+        ctx = ctx.with_deadline(d);
+    }
     let provider_label = provider.to_ascii_lowercase();
     let provider_key_id = model.provider_key_id.as_deref().unwrap_or("unknown");
     let upstream_model = model.upstream_model().unwrap_or("unknown").to_string();
@@ -1217,8 +1210,39 @@ async fn cross_provider_dispatch(
             }
             ProxyError::Bridge(err)
         })?;
+        // #554: peek the first chunk under the per-chunk read timeout so a
+        // slow first token fails over (the caller loops to the next target)
+        // before the 200 is committed. The wrapped stream keeps enforcing
+        // the read timeout on the remaining chunks; a mid-stream stall
+        // surfaces as an error frame via `build_anthropic_sse_stream`.
+        let mut upstream =
+            crate::stream_timeout::with_read_timeout(upstream, model.stream_read_timeout());
+        let first_chunk = match upstream.next().await {
+            Some(Ok(chunk)) => chunk,
+            Some(Err(err)) => {
+                if let Some((ttl, reason)) =
+                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                {
+                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                }
+                return Err(ProxyError::Bridge(err));
+            }
+            None => {
+                return Err(ProxyError::Bridge(
+                    aisix_gateway::BridgeError::StreamAborted,
+                ))
+            }
+        };
         state.health.record_success(model_name);
         state.runtime_status.mark_healthy(model_id);
+        // Re-prepend the peeked chunk so the SSE encoder sees the whole
+        // stream (and records TTFT on the first content chunk).
+        let upstream: aisix_gateway::ChatChunkStream = Box::pin(
+            futures::stream::once(std::future::ready(Ok::<_, aisix_gateway::BridgeError>(
+                first_chunk,
+            )))
+            .chain(upstream),
+        );
 
         let message_id = format!("msg_{}", Uuid::new_v4().simple());
         let encoder = AnthropicSseEncoder::new(message_id, model_name, 0);

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -772,42 +772,53 @@ async fn anthropic_passthrough_dispatch(
         // For SSE streaming: pass through the response body as a streaming
         // `text/event-stream` response.
         let headers = upstream_resp.headers().clone();
-        // #554: enforce the per-chunk read timeout on the forwarded bytes,
-        // then peek the first byte so a slow first token fails over (the
-        // caller loops to the next target) before the 200 is committed. A
-        // mid-stream stall truncates the forwarded stream — there is no
-        // in-band error frame to inject into an opaque byte passthrough.
-        let mut body_stream: std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>> =
+        // #554: enforce the per-chunk read timeout on the forwarded bytes.
+        // When a `stream_timeout` is configured, peek the first byte so a
+        // slow/erroring first token fails over (the caller loops to the next
+        // target) before the 200 is committed; without one, forward directly
+        // (pre-#554 behavior). A mid-stream stall truncates the forwarded
+        // stream — there is no in-band error frame for an opaque passthrough.
+        let wrapped: std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>> =
             Box::pin(crate::stream_timeout::with_read_timeout_bytes(
                 upstream_resp.bytes_stream(),
                 model.stream_read_timeout(),
             ));
-        let first_bytes = match body_stream.next().await {
-            Some(Ok(b)) => b,
-            Some(Err(e)) => {
-                let err = crate::dispatch::reqwest_error_to_bridge(&e, send_started);
-                if let Some((ttl, reason)) =
-                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
-                {
-                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
-                }
-                return Err(ProxyError::Bridge(err));
-            }
-            // Read timeout before the first byte (or an upstream that closed
-            // immediately): retryable stream-abort so the caller fails over.
-            None => {
-                let err = aisix_gateway::BridgeError::StreamAborted;
-                if let Some((ttl, reason)) =
-                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
-                {
-                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
-                }
-                return Err(ProxyError::Bridge(err));
-            }
-        };
-        let body_stream =
-            futures::stream::once(std::future::ready(Ok::<Bytes, reqwest::Error>(first_bytes)))
-                .chain(body_stream);
+        let body_stream: std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>> =
+            if model.stream_read_timeout().is_some() {
+                let mut wrapped = wrapped;
+                let first_bytes = match wrapped.next().await {
+                    Some(Ok(b)) => b,
+                    Some(Err(e)) => {
+                        let err = crate::dispatch::reqwest_error_to_bridge(&e, send_started);
+                        if let Some((ttl, reason)) =
+                            crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                        {
+                            state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                        }
+                        return Err(ProxyError::Bridge(err));
+                    }
+                    // Read timeout before the first byte (or an upstream that
+                    // closed immediately): retryable stream-abort so the
+                    // caller fails over.
+                    None => {
+                        let err = aisix_gateway::BridgeError::StreamAborted;
+                        if let Some((ttl, reason)) =
+                            crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                        {
+                            state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                        }
+                        return Err(ProxyError::Bridge(err));
+                    }
+                };
+                Box::pin(
+                    futures::stream::once(std::future::ready(Ok::<Bytes, reqwest::Error>(
+                        first_bytes,
+                    )))
+                    .chain(wrapped),
+                )
+            } else {
+                wrapped
+            };
 
         // Issue #245: parity with the OpenAI streaming fix (#225 /
         // #196). Pre-fix this path forwarded raw bytes and emitted a
@@ -1210,39 +1221,45 @@ async fn cross_provider_dispatch(
             }
             ProxyError::Bridge(err)
         })?;
-        // #554: peek the first chunk under the per-chunk read timeout so a
-        // slow first token fails over (the caller loops to the next target)
-        // before the 200 is committed. The wrapped stream keeps enforcing
-        // the read timeout on the remaining chunks; a mid-stream stall
-        // surfaces as an error frame via `build_anthropic_sse_stream`.
-        let mut upstream =
+        // #554: when a `stream_timeout` is configured, peek the first chunk
+        // so a slow/erroring first token fails over (the caller loops to the
+        // next target) before the 200 is committed. Without one, commit the
+        // stream directly (pre-#554 behavior; a first-chunk error then
+        // surfaces in-band). The wrapper keeps enforcing the read timeout on
+        // the remaining chunks either way (no-op when unset).
+        let upstream =
             crate::stream_timeout::with_read_timeout(upstream, model.stream_read_timeout());
-        let first_chunk = match upstream.next().await {
-            Some(Ok(chunk)) => chunk,
-            Some(Err(err)) => {
-                if let Some((ttl, reason)) =
-                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
-                {
-                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
+        let upstream: aisix_gateway::ChatChunkStream = if model.stream_read_timeout().is_some() {
+            let mut upstream = upstream;
+            let first_chunk = match upstream.next().await {
+                Some(Ok(chunk)) => chunk,
+                Some(Err(err)) => {
+                    if let Some((ttl, reason)) =
+                        crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                    {
+                        state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                    }
+                    return Err(ProxyError::Bridge(err));
                 }
-                return Err(ProxyError::Bridge(err));
-            }
-            None => {
-                return Err(ProxyError::Bridge(
-                    aisix_gateway::BridgeError::StreamAborted,
-                ))
-            }
+                None => {
+                    return Err(ProxyError::Bridge(
+                        aisix_gateway::BridgeError::StreamAborted,
+                    ))
+                }
+            };
+            // Re-prepend the peeked chunk so the SSE encoder sees the whole
+            // stream (and records TTFT on the first content chunk).
+            Box::pin(
+                futures::stream::once(std::future::ready(Ok::<_, aisix_gateway::BridgeError>(
+                    first_chunk,
+                )))
+                .chain(upstream),
+            )
+        } else {
+            upstream
         };
         state.health.record_success(model_name);
         state.runtime_status.mark_healthy(model_id);
-        // Re-prepend the peeked chunk so the SSE encoder sees the whole
-        // stream (and records TTFT on the first content chunk).
-        let upstream: aisix_gateway::ChatChunkStream = Box::pin(
-            futures::stream::once(std::future::ready(Ok::<_, aisix_gateway::BridgeError>(
-                first_chunk,
-            )))
-            .chain(upstream),
-        );
 
         let message_id = format!("msg_{}", Uuid::new_v4().simple());
         let encoder = AnthropicSseEncoder::new(message_id, model_name, 0);

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -778,13 +778,14 @@ async fn anthropic_passthrough_dispatch(
         // target) before the 200 is committed; without one, forward directly
         // (pre-#554 behavior). A mid-stream stall truncates the forwarded
         // stream — there is no in-band error frame for an opaque passthrough.
+        let stream_budget = model.stream_timeout_effective();
         let wrapped: std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>> =
             Box::pin(crate::stream_timeout::with_read_timeout_bytes(
                 upstream_resp.bytes_stream(),
-                model.stream_read_timeout(),
+                stream_budget,
             ));
         let body_stream: std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>> =
-            if model.stream_read_timeout().is_some() {
+            if stream_budget.is_some() {
                 let mut wrapped = wrapped;
                 let first_bytes = match wrapped.next().await {
                     Some(Ok(b)) => b,
@@ -1221,15 +1222,16 @@ async fn cross_provider_dispatch(
             }
             ProxyError::Bridge(err)
         })?;
-        // #554: when a `stream_timeout` is configured, peek the first chunk
-        // so a slow/erroring first token fails over (the caller loops to the
-        // next target) before the 200 is committed. Without one, commit the
-        // stream directly (pre-#554 behavior; a first-chunk error then
-        // surfaces in-band). The wrapper keeps enforcing the read timeout on
-        // the remaining chunks either way (no-op when unset).
-        let upstream =
-            crate::stream_timeout::with_read_timeout(upstream, model.stream_read_timeout());
-        let upstream: aisix_gateway::ChatChunkStream = if model.stream_read_timeout().is_some() {
+        // #554: when a streaming budget is configured (`stream_timeout`,
+        // falling back to `timeout`), peek the first chunk so a slow/erroring
+        // first token fails over (the caller loops to the next target) before
+        // the 200 is committed. Without one, commit the stream directly
+        // (pre-#554 behavior; a first-chunk error then surfaces in-band). The
+        // wrapper keeps enforcing the read timeout on the remaining chunks
+        // either way (no-op when unset).
+        let stream_budget = model.stream_timeout_effective();
+        let upstream = crate::stream_timeout::with_read_timeout(upstream, stream_budget);
+        let upstream: aisix_gateway::ChatChunkStream = if stream_budget.is_some() {
             let mut upstream = upstream;
             let first_chunk = match upstream.next().await {
                 Some(Ok(chunk)) => chunk,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1242,9 +1242,13 @@ async fn cross_provider_dispatch(
                     return Err(ProxyError::Bridge(err));
                 }
                 None => {
-                    return Err(ProxyError::Bridge(
-                        aisix_gateway::BridgeError::StreamAborted,
-                    ))
+                    let err = aisix_gateway::BridgeError::StreamAborted;
+                    if let Some((ttl, reason)) =
+                        crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                    {
+                        state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                    }
+                    return Err(ProxyError::Bridge(err));
                 }
             };
             // Re-prepend the peeked chunk so the SSE encoder sees the whole

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -230,12 +230,18 @@ async fn dispatch(
     let url = crate::dispatch::build_v1_url(&base, "/rerank");
 
     let client = crate::http_client::client();
-    let upstream_resp = client
+    let mut req = client
         .post(&url)
         .header("authorization", format!("Bearer {api_key}"))
         .header("content-type", "application/json")
         .header("x-aisix-request-id", request_id)
-        .json(body)
+        .json(body);
+    // #554: rerank is non-streaming; apply the E2E request timeout.
+    if let Some(d) = model.request_timeout() {
+        req = req.timeout(d);
+    }
+    let send_started = Instant::now();
+    let upstream_resp = req
         .send()
         .await
         .map_err(|e| {
@@ -243,7 +249,7 @@ async fn dispatch(
                 &state.runtime_status,
                 &model_entry.id,
                 model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::Transport(e.to_string()),
+                crate::dispatch::reqwest_error_to_bridge(&e, send_started),
             )
         })
         .map_err(ProxyError::Bridge)?;

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -293,75 +293,17 @@ async fn dispatch(
     let is_routing_request = model_entry.value.routing.is_some();
     let mut routing = RoutingTelemetry::default();
 
-    let is_stream = body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
     let not_openai = || {
         ProxyError::InvalidRequest(format!(
             "model `{model_name}` is not an OpenAI provider; /v1/responses requires OpenAI"
         ))
     };
 
-    // Streaming attempts the first eligible target only (no mid-stream
-    // fallback), matching /v1/chat/completions and /v1/messages.
-    if is_stream {
-        let target = attempt_models
-            .iter()
-            .find(|t| t.model.provider.as_deref() == Some("openai"))
-            .ok_or_else(not_openai)?;
-        let (idx, kind) = routing.begin_attempt(&target.model.display_name);
-        let target_model = if is_routing_request {
-            target.model.display_name.clone()
-        } else {
-            String::new()
-        };
-        let attempt_started = Instant::now();
-        return match responses_to_target(
-            state,
-            &snapshot,
-            body,
-            &target.model,
-            &target.id,
-            request_id,
-            &resolved_chain,
-        )
-        .await
-        {
-            Ok(mut success) => {
-                routing.attempts.push(AttemptRecord {
-                    index: idx,
-                    kind,
-                    target_model,
-                    provider_key_id: String::new(),
-                    status: success.response.status().as_u16(),
-                    success: true,
-                    error_class: String::new(),
-                    error_message: String::new(),
-                    latency_ms: ms_since(attempt_started),
-                });
-                success.routing = routing;
-                Ok(success)
-            }
-            Err(e) => {
-                let (error_class, error_message) = attempt_error_from_proxy(&e);
-                routing.attempts.push(AttemptRecord {
-                    index: idx,
-                    kind,
-                    target_model,
-                    provider_key_id: String::new(),
-                    status: e.status().as_u16(),
-                    success: false,
-                    error_class,
-                    error_message,
-                    latency_ms: ms_since(attempt_started),
-                });
-                Err(ResponsesDispatchError { err: e, routing })
-            }
-        };
-    }
-
+    // Walk the OpenAI targets, failing over on a retryable failure.
+    // Streaming and non-streaming share this loop: `responses_to_target`
+    // branches internally and, for streaming, only returns Ok once the
+    // first chunk has arrived under `stream_timeout` (#554) — so the 200 is
+    // committed to exactly one target and a slow first chunk fails over.
     let mut last_err: Option<ProxyError> = None;
     let mut any_openai = false;
     for target in &attempt_models {
@@ -570,23 +512,42 @@ async fn responses_to_target(
         .unwrap_or(false);
 
     let client = crate::http_client::client();
-    let upstream_resp = client
+    let mut req = client
         .post(&url)
         .header("authorization", format!("Bearer {api_key}"))
         .header("content-type", "application/json")
         .header("x-aisix-request-id", request_id)
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                model_id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::Transport(e.to_string()),
-            )
-        })
-        .map_err(ProxyError::Bridge)?;
+        .json(&body);
+    // #554: non-streaming gets the E2E request timeout via reqwest's
+    // request-level timeout. Streaming must NOT use it (it would cap the
+    // whole stream); the streaming branch below enforces the per-chunk
+    // read timeout instead.
+    if !is_stream {
+        if let Some(d) = model.request_timeout() {
+            req = req.timeout(d);
+        }
+    }
+    let send_started = Instant::now();
+    // Streaming bounds the connect by the stream deadline (reqwest's
+    // request-level timeout can't be used — it would cap the whole stream);
+    // non-streaming relies on the request-level timeout set above.
+    let connect_deadline = if is_stream {
+        model.stream_timeout_effective()
+    } else {
+        None
+    };
+    let upstream_resp =
+        crate::stream_timeout::send_with_deadline(req, connect_deadline, send_started)
+            .await
+            .map_err(|be| {
+                crate::cooldown::note_failure(
+                    &state.runtime_status,
+                    model_id,
+                    model.cooldown.as_ref(),
+                    be,
+                )
+            })
+            .map_err(ProxyError::Bridge)?;
 
     let status = upstream_resp.status();
 
@@ -638,8 +599,31 @@ async fn responses_to_target(
             };
             let stream = upstream_resp.bytes_stream();
             futures::pin_mut!(stream);
+            let read_to = model.stream_read_timeout();
             let mut buf: Vec<u8> = Vec::new();
-            while let Some(chunk) = stream.next().await {
+            loop {
+                // #554: bound each read so a stalled upstream fails over —
+                // the buffer path hasn't sent anything to the client yet, so
+                // a read timeout is a retryable failure, not a truncation.
+                let next = match read_to {
+                    Some(d) => tokio::time::timeout(d, stream.next())
+                        .await
+                        .map_err(|_| {
+                            crate::cooldown::note_failure(
+                                &state.runtime_status,
+                                model_id,
+                                model.cooldown.as_ref(),
+                                aisix_gateway::BridgeError::Timeout {
+                                    elapsed_ms: d.as_millis() as u64,
+                                },
+                            )
+                        })
+                        .map_err(ProxyError::Bridge)?,
+                    None => stream.next().await,
+                };
+                let Some(chunk) = next else {
+                    break;
+                };
                 let chunk = chunk
                     .map_err(|e| {
                         crate::cooldown::note_failure(
@@ -696,7 +680,42 @@ async fn responses_to_target(
             });
         }
 
-        let body_stream = upstream_resp.bytes_stream();
+        // #554: enforce the per-chunk read timeout and peek the first byte
+        // so a slow first token fails over before the 200 is committed; a
+        // mid-stream stall truncates the forwarded stream (no in-band error
+        // frame for an opaque byte passthrough).
+        let mut body_stream: std::pin::Pin<
+            Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>,
+        > = Box::pin(crate::stream_timeout::with_read_timeout_bytes(
+            upstream_resp.bytes_stream(),
+            model.stream_read_timeout(),
+        ));
+        let first_bytes = match body_stream.next().await {
+            Some(Ok(b)) => b,
+            Some(Err(e)) => {
+                let err = crate::dispatch::reqwest_error_to_bridge(&e, send_started);
+                if let Some((ttl, reason)) =
+                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                {
+                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                }
+                return Err(ProxyError::Bridge(err));
+            }
+            None => {
+                let err = aisix_gateway::BridgeError::StreamAborted;
+                if let Some((ttl, reason)) =
+                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                {
+                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                }
+                return Err(ProxyError::Bridge(err));
+            }
+        };
+        let body_stream = futures::stream::once(std::future::ready(Ok::<
+            bytes::Bytes,
+            reqwest::Error,
+        >(first_bytes)))
+        .chain(body_stream);
         let mut response =
             axum::response::Response::new(axum::body::Body::from_stream(body_stream));
         apply_passthrough_headers(&mut response, &headers, request_id);

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -601,6 +601,7 @@ async fn responses_to_target(
             futures::pin_mut!(stream);
             let read_to = model.stream_read_timeout();
             let mut buf: Vec<u8> = Vec::new();
+            let mut saw_chunk = false;
             loop {
                 // #554: bound each read so a stalled upstream fails over —
                 // the buffer path hasn't sent anything to the client yet, so
@@ -622,8 +623,23 @@ async fn responses_to_target(
                     None => stream.next().await,
                 };
                 let Some(chunk) = next else {
+                    // #554: an upstream that returns 200 then closes with zero
+                    // bytes is a first-chunk failure — fail over rather than
+                    // serving an empty 200, matching the verbatim branch. Only
+                    // when a stream timeout is configured, so a model without
+                    // one keeps the pre-#554 behavior.
+                    if !saw_chunk && read_to.is_some() {
+                        let err = crate::cooldown::note_failure(
+                            &state.runtime_status,
+                            model_id,
+                            model.cooldown.as_ref(),
+                            aisix_gateway::BridgeError::StreamAborted,
+                        );
+                        return Err(ProxyError::Bridge(err));
+                    }
                     break;
                 };
+                saw_chunk = true;
                 let chunk = chunk
                     .map_err(|e| {
                         crate::cooldown::note_failure(

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -680,42 +680,52 @@ async fn responses_to_target(
             });
         }
 
-        // #554: enforce the per-chunk read timeout and peek the first byte
-        // so a slow first token fails over before the 200 is committed; a
-        // mid-stream stall truncates the forwarded stream (no in-band error
-        // frame for an opaque byte passthrough).
-        let mut body_stream: std::pin::Pin<
+        // #554: enforce the per-chunk read timeout on the forwarded bytes.
+        // When a `stream_timeout` is configured, peek the first byte so a
+        // slow/erroring first token fails over before the 200 is committed;
+        // without one, forward directly (pre-#554 behavior). A mid-stream
+        // stall truncates the forwarded stream (no in-band error frame for
+        // an opaque byte passthrough).
+        let wrapped: std::pin::Pin<
             Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>,
         > = Box::pin(crate::stream_timeout::with_read_timeout_bytes(
             upstream_resp.bytes_stream(),
             model.stream_read_timeout(),
         ));
-        let first_bytes = match body_stream.next().await {
-            Some(Ok(b)) => b,
-            Some(Err(e)) => {
-                let err = crate::dispatch::reqwest_error_to_bridge(&e, send_started);
-                if let Some((ttl, reason)) =
-                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
-                {
-                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
+        let body_stream: std::pin::Pin<
+            Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>,
+        > = if model.stream_read_timeout().is_some() {
+            let mut wrapped = wrapped;
+            let first_bytes = match wrapped.next().await {
+                Some(Ok(b)) => b,
+                Some(Err(e)) => {
+                    let err = crate::dispatch::reqwest_error_to_bridge(&e, send_started);
+                    if let Some((ttl, reason)) =
+                        crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                    {
+                        state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                    }
+                    return Err(ProxyError::Bridge(err));
                 }
-                return Err(ProxyError::Bridge(err));
-            }
-            None => {
-                let err = aisix_gateway::BridgeError::StreamAborted;
-                if let Some((ttl, reason)) =
-                    crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
-                {
-                    state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                None => {
+                    let err = aisix_gateway::BridgeError::StreamAborted;
+                    if let Some((ttl, reason)) =
+                        crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                    {
+                        state.runtime_status.mark_cooldown(model_id, ttl, reason);
+                    }
+                    return Err(ProxyError::Bridge(err));
                 }
-                return Err(ProxyError::Bridge(err));
-            }
+            };
+            Box::pin(
+                futures::stream::once(std::future::ready(Ok::<bytes::Bytes, reqwest::Error>(
+                    first_bytes,
+                )))
+                .chain(wrapped),
+            )
+        } else {
+            wrapped
         };
-        let body_stream = futures::stream::once(std::future::ready(Ok::<
-            bytes::Bytes,
-            reqwest::Error,
-        >(first_bytes)))
-        .chain(body_stream);
         let mut response =
             axum::response::Response::new(axum::body::Body::from_stream(body_stream));
         apply_passthrough_headers(&mut response, &headers, request_id);

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -599,7 +599,10 @@ async fn responses_to_target(
             };
             let stream = upstream_resp.bytes_stream();
             futures::pin_mut!(stream);
-            let read_to = model.stream_read_timeout();
+            // Effective streaming budget: `stream_timeout`, falling back to
+            // `timeout` — applied to every buffered read, consistent with the
+            // verbatim branch and the connect deadline.
+            let read_to = model.stream_timeout_effective();
             let mut buf: Vec<u8> = Vec::new();
             let mut saw_chunk = false;
             loop {
@@ -702,15 +705,16 @@ async fn responses_to_target(
         // without one, forward directly (pre-#554 behavior). A mid-stream
         // stall truncates the forwarded stream (no in-band error frame for
         // an opaque byte passthrough).
+        let stream_budget = model.stream_timeout_effective();
         let wrapped: std::pin::Pin<
             Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>,
         > = Box::pin(crate::stream_timeout::with_read_timeout_bytes(
             upstream_resp.bytes_stream(),
-            model.stream_read_timeout(),
+            stream_budget,
         ));
         let body_stream: std::pin::Pin<
             Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>,
-        > = if model.stream_read_timeout().is_some() {
+        > = if stream_budget.is_some() {
             let mut wrapped = wrapped;
             let first_bytes = match wrapped.next().await {
                 Some(Ok(b)) => b,

--- a/crates/aisix-proxy/src/stream_timeout.rs
+++ b/crates/aisix-proxy/src/stream_timeout.rs
@@ -1,0 +1,112 @@
+//! Per-chunk read-timeout combinators for streaming upstreams (#554).
+//!
+//! Mirrors LiteLLM's `stream_timeout` semantics: the deadline bounds the
+//! wait for EACH chunk — the first one and every inter-chunk gap — and
+//! resets after each successful read. A *first-chunk* timeout lets the
+//! caller fail over before any bytes reach the client (issue AC2); a
+//! *mid-stream* timeout terminates the stream like any other upstream
+//! error, because once the `200` is committed a clean fallback is no
+//! longer possible.
+//!
+//! Two flavours:
+//! - [`with_read_timeout`] for the typed [`ChatChunkStream`] path
+//!   (`/v1/chat/completions`, cross-provider `/v1/messages`): a read
+//!   timeout surfaces as [`BridgeError::Timeout`], which the SSE pump
+//!   already renders as an error frame.
+//! - [`with_read_timeout_bytes`] for the raw byte passthroughs
+//!   (`/v1/responses`, native-Anthropic `/v1/messages`): a read timeout
+//!   simply ends the forwarded byte stream (the client sees a truncated
+//!   response); there is no in-band error frame to inject into an opaque
+//!   passthrough.
+//!
+//! [`send_with_deadline`] bounds the connect phase of a raw passthrough so
+//! a slow upstream that never returns response headers also fails over.
+
+use std::time::{Duration, Instant};
+
+use aisix_gateway::{BridgeError, ChatChunkStream};
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+
+/// Wrap a [`ChatChunkStream`] so each `next()` is bounded by `per_chunk`.
+/// On elapse, yield a single [`BridgeError::Timeout`] and end the stream.
+/// `None` returns the stream unchanged (zero overhead on the hot path).
+pub(crate) fn with_read_timeout(
+    upstream: ChatChunkStream,
+    per_chunk: Option<Duration>,
+) -> ChatChunkStream {
+    let Some(d) = per_chunk else {
+        return upstream;
+    };
+    Box::pin(async_stream::stream! {
+        // `ChatChunkStream` is a `Pin<Box<..>>`, hence `Unpin`; a plain
+        // `mut` binding is enough to poll it via `StreamExt::next`.
+        let mut upstream = upstream;
+        loop {
+            match tokio::time::timeout(d, upstream.next()).await {
+                Ok(Some(item)) => yield item,
+                Ok(None) => break,
+                Err(_) => {
+                    yield Err(BridgeError::Timeout {
+                        elapsed_ms: d.as_millis() as u64,
+                    });
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Wrap a raw byte stream (`reqwest::Response::bytes_stream()`) so each
+/// `next()` is bounded by `per_chunk`. On elapse, end the stream (the
+/// forwarded client response is truncated). `None` returns a pass-through.
+pub(crate) fn with_read_timeout_bytes<S>(
+    upstream: S,
+    per_chunk: Option<Duration>,
+) -> impl Stream<Item = reqwest::Result<Bytes>> + Send
+where
+    S: Stream<Item = reqwest::Result<Bytes>> + Send + 'static,
+{
+    async_stream::stream! {
+        let mut upstream = std::pin::pin!(upstream);
+        loop {
+            match per_chunk {
+                Some(d) => match tokio::time::timeout(d, upstream.next()).await {
+                    Ok(Some(item)) => yield item,
+                    Ok(None) => break,
+                    // Read timeout mid-passthrough: truncate the forwarded
+                    // stream. We can't inject a typed error into opaque bytes.
+                    Err(_) => break,
+                },
+                None => match upstream.next().await {
+                    Some(item) => yield item,
+                    None => break,
+                },
+            }
+        }
+    }
+}
+
+/// Send a raw-passthrough request, optionally bounding the connect phase
+/// (everything up to and including response headers) by `deadline`. Maps
+/// both reqwest's own timeout and the outer deadline to
+/// [`BridgeError::Timeout`] so a slow connect fails over like the
+/// Bridge-trait path. `started` anchors the reported elapsed time.
+pub(crate) async fn send_with_deadline(
+    req: reqwest::RequestBuilder,
+    deadline: Option<Duration>,
+    started: Instant,
+) -> Result<reqwest::Response, BridgeError> {
+    match deadline {
+        Some(d) => match tokio::time::timeout(d, req.send()).await {
+            Ok(res) => res.map_err(|e| crate::dispatch::reqwest_error_to_bridge(&e, started)),
+            Err(_) => Err(BridgeError::Timeout {
+                elapsed_ms: started.elapsed().as_millis() as u64,
+            }),
+        },
+        None => req
+            .send()
+            .await
+            .map_err(|e| crate::dispatch::reqwest_error_to_bridge(&e, started)),
+    }
+}

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -86,7 +86,7 @@ A failed probe transitions the model to `unhealthy` in the runtime status tracke
 
 ### Timeouts
 
-Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**; `0` or absent means no timeout. They mirror LiteLLM's `timeout` and `stream_timeout`.
+Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**. Setting a knob to `0` disables that timeout; omitting `timeout` disables it too, while omitting `stream_timeout` makes streaming fall back to `timeout` (see below) rather than disabling the streaming timeout. They mirror LiteLLM's `timeout` and `stream_timeout`.
 
 ```json title="Direct model timeouts"
 {

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -86,7 +86,7 @@ A failed probe transitions the model to `unhealthy` in the runtime status tracke
 
 ### Timeouts
 
-Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**. Setting a knob to `0` disables that timeout; omitting `timeout` disables it too, while omitting `stream_timeout` makes streaming fall back to `timeout` (see below) rather than disabling the streaming timeout. They mirror LiteLLM's `timeout` and `stream_timeout`.
+Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**. `timeout` of `0` or absent means no non-streaming timeout. `stream_timeout` of a positive value bounds streaming; `0` or absent makes streaming fall back to `timeout` instead (so to disable streaming timeouts entirely, set `timeout` to `0` as well). They mirror LiteLLM's `timeout` and `stream_timeout`.
 
 ```json title="Direct model timeouts"
 {
@@ -96,7 +96,7 @@ Two optional per-model knobs bound how long the gateway waits on the upstream. B
 ```
 
 - `timeout` — end-to-end budget for a **non-streaming** (`stream:false`) upstream call. If the call doesn't finish in time, the gateway abandons it.
-- `stream_timeout` — read timeout for a **streaming** (`stream:true`) call, applied to the **first** chunk and to **every inter-chunk gap** (it resets after each chunk). When `stream_timeout` is absent, a streaming request falls back to `timeout` for this budget.
+- `stream_timeout` — read timeout for a **streaming** (`stream:true`) call, applied to the **first** chunk and to **every inter-chunk gap** (it resets after each chunk). When `stream_timeout` is `0` or absent, the streaming budget falls back to `timeout`.
 
 An elapsed timeout surfaces as a retryable upstream failure (HTTP `504`), so on a [routing model](routing-and-failover.md) it triggers failover to the next target — see [Routing § Timeout-Triggered Failover](routing-and-failover.md#timeout-triggered-failover). On a direct model with no fallback target it simply returns `504` to the caller.
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -29,6 +29,7 @@ Current required fields are:
 Optional fields include:
 
 - `timeout`
+- `stream_timeout`
 - `rate_limit`
 - `cost`
 - `cooldown`
@@ -82,6 +83,26 @@ Current semantics:
 - `interval_seconds` has a minimum of `5`; `timeout_seconds`, `max_tokens`, and `stale_after_seconds` have a minimum of `1`
 
 A failed probe transitions the model to `unhealthy` in the runtime status tracker. A subsequent successful probe clears that state. The routing filter excludes `unhealthy` candidates ahead of `cooldown` candidates.
+
+### Timeouts
+
+Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**; `0` or absent means no timeout. They mirror LiteLLM's `timeout` and `stream_timeout`.
+
+```json title="Direct model timeouts"
+{
+  "timeout": 15000,
+  "stream_timeout": 2500
+}
+```
+
+- `timeout` — end-to-end budget for a **non-streaming** (`stream:false`) upstream call. If the call doesn't finish in time, the gateway abandons it.
+- `stream_timeout` — read timeout for a **streaming** (`stream:true`) call, applied to the **first** chunk and to **every inter-chunk gap** (it resets after each chunk). When `stream_timeout` is absent, a streaming request falls back to `timeout` for this budget.
+
+An elapsed timeout surfaces as a retryable upstream failure (HTTP `504`), so on a [routing model](routing-and-failover.md) it triggers failover to the next target — see [Routing § Timeout-Triggered Failover](routing-and-failover.md#timeout-triggered-failover). On a direct model with no fallback target it simply returns `504` to the caller.
+
+A timeout also feeds [Cooldown](#cooldown) (`trigger_on_timeout`), so a repeatedly-slow target is taken out of rotation for subsequent requests.
+
+> A small `timeout` set for non-streaming traffic also becomes the streaming read budget when `stream_timeout` is unset (LiteLLM parity). Set `stream_timeout` explicitly if streaming needs a different budget.
 
 ### Cooldown
 

--- a/docs/configuration/routing-and-failover.md
+++ b/docs/configuration/routing-and-failover.md
@@ -10,7 +10,7 @@ This is the gateway's current virtual-model mechanism.
 
 Use it when you want to separate the caller contract from the individual upstream target that serves a given request.
 
-A routing alias works across the proxy's passthrough endpoints: `/v1/chat/completions` (OpenAI shape), `/v1/messages` (Anthropic shape), `/v1/responses`, and `/v1/messages/count_tokens`. Targets in one group may mix providers — e.g. an OpenAI target and an Anthropic target — and the gateway dispatches each target through the right path regardless of which endpoint the caller used. Streaming requests attempt only the first target (no mid-stream fallback); non-streaming requests fail over across targets.
+A routing alias works across the proxy's passthrough endpoints: `/v1/chat/completions` (OpenAI shape), `/v1/messages` (Anthropic shape), `/v1/responses`, and `/v1/messages/count_tokens`. Targets in one group may mix providers — e.g. an OpenAI target and an Anthropic target — and the gateway dispatches each target through the right path regardless of which endpoint the caller used. Both non-streaming and streaming requests fail over across targets. For streaming, failover can fire up to and including the first chunk — a connect failure or a slow first token (see [Timeout-Triggered Failover](#timeout-triggered-failover)) moves to the next target before any bytes reach the caller; once the first chunk is forwarded the response is committed to that target and a later mid-stream failure ends the stream rather than failing over.
 
 `/v1/responses` and `/v1/messages/count_tokens` are provider-restricted (OpenAI-only and Anthropic-only respectively). When a group is used on one of these endpoints, only the targets whose provider matches the endpoint are attempted, in order; if the group has no matching target the request is rejected with a 400.
 
@@ -85,6 +85,15 @@ Current rules:
 The proxy retries only on retryable upstream or transport failures. Upstream `4xx` responses are treated as caller-side problems and do not trigger retry or failover, except optional `429` handling when `retry_on_429` is enabled.
 
 This is an important operational boundary. Routing is not a way to mask bad caller requests or invalid model usage.
+
+## Timeout-Triggered Failover
+
+A target that is *too slow* fails over the same way a target that *errors* does. Slowness is defined per direct target by [`timeout`](models.md#timeouts) (non-streaming) and [`stream_timeout`](models.md#timeouts) (streaming), both in milliseconds.
+
+- **Non-streaming.** If a target doesn't return a complete response within its `timeout`, the gateway abandons it (a `504`-class timeout) and moves to the next target — identical to the retryable-failure path above.
+- **Streaming.** `stream_timeout` is a per-chunk read timeout (it resets after each chunk). A timeout on the **first** chunk fires before any bytes reach the caller, so the gateway fails over cleanly to the next target. Once the first chunk has been forwarded the response is committed to that target; a later inter-chunk stall **ends the stream** with an error rather than failing over (the gateway can't un-send bytes already on the wire). When `stream_timeout` is unset, the streaming budget falls back to `timeout`.
+
+Because a timed-out attempt is just another retryable failure, it composes with `retries`, `max_fallbacks`, and the runtime [cooldown](models.md#cooldown) (`trigger_on_timeout`) exactly like a `5xx`. These knobs mirror LiteLLM's `timeout` / `stream_timeout`.
 
 ## Runtime Filtering
 

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -86,7 +86,7 @@
       ]
     },
     "stream_timeout": {
-      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. 0 or absent = no timeout. A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error. Mirrors LiteLLM's `stream_timeout`.",
+      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. `0` = no timeout; when absent, streaming falls back to `timeout` (see [`Model::stream_timeout_effective`]). A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error. Mirrors LiteLLM's `stream_timeout`.",
       "type": [
         "integer",
         "null"
@@ -95,7 +95,7 @@
       "minimum": 0.0
     },
     "timeout": {
-      "description": "Non-streaming request timeout in ms — the end-to-end budget for a `stream:false` upstream call. 0 or absent = no timeout. On a routing model's target, an elapsed timeout fails over to the next target (the timeout error is retryable). Mirrors LiteLLM's `timeout`.",
+      "description": "Non-streaming request timeout in ms — the end-to-end budget for a `stream:false` upstream call. `0` or absent = no timeout. On a routing model's target, an elapsed timeout fails over to the next target (the timeout error is retryable). For `stream:true` requests it is also the fallback streaming budget when `stream_timeout` is unset (see [`Model::stream_timeout_effective`]). Mirrors LiteLLM's `timeout`.",
       "type": [
         "integer",
         "null"

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -85,8 +85,17 @@
         }
       ]
     },
+    "stream_timeout": {
+      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. 0 or absent = no timeout. A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error. Mirrors LiteLLM's `stream_timeout`.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "timeout": {
-      "description": "Request timeout in ms. 0 or absent = no timeout.",
+      "description": "Non-streaming request timeout in ms — the end-to-end budget for a `stream:false` upstream call. 0 or absent = no timeout. On a routing model's target, an elapsed timeout fails over to the next target (the timeout error is retryable). Mirrors LiteLLM's `timeout`.",
       "type": [
         "integer",
         "null"

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -86,7 +86,7 @@
       ]
     },
     "stream_timeout": {
-      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. `0` = no timeout; when absent, streaming falls back to `timeout` (see [`Model::stream_timeout_effective`]). A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error. Mirrors LiteLLM's `stream_timeout`.",
+      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. A positive value bounds each chunk wait; `0` or absent means \"no streaming-specific override\", so the effective streaming budget falls back to `timeout` (see [`Model::stream_timeout_effective`]) — set `timeout` to `0` too to disable streaming timeouts entirely. A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error. Mirrors LiteLLM's `stream_timeout`.",
       "type": [
         "integer",
         "null"

--- a/tests/e2e/src/cases/timeout-fallback-e2e.test.ts
+++ b/tests/e2e/src/cases/timeout-fallback-e2e.test.ts
@@ -1,0 +1,388 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for #554: timeout-triggered fallback.
+//
+// A "virtual" routing Model fails over to its next target not only on an
+// upstream error / 5xx (covered by fallback-e2e) but also when the primary
+// is too SLOW:
+//   - non-streaming `timeout` — the whole upstream call must finish in time;
+//   - streaming `stream_timeout` — each chunk (the first one and every
+//     inter-chunk gap) must arrive in time. A first-chunk timeout fails
+//     over before any bytes reach the client; a mid-stream stall terminates
+//     the stream like any other upstream error (no fallback once committed).
+//
+// Mirrors LiteLLM's `timeout` + `stream_timeout` knobs. Reference: OpenAI
+// Chat Completions spec for the request/response shape.
+
+const CALLER_PLAINTEXT = "sk-timeout-fb-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const SLOW_MS = 3000;
+const TIMEOUT_MS = 300;
+const GENEROUS_MS = 10_000;
+
+function reply(content: string): unknown {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: 0,
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+function chunk(content: string): string {
+  return JSON.stringify({
+    id: "evt",
+    object: "chat.completion.chunk",
+    model: "gpt-4o-mini",
+    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+  });
+}
+
+function finish(): string {
+  return JSON.stringify({
+    id: "evt",
+    object: "chat.completion.chunk",
+    model: "gpt-4o-mini",
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+  });
+}
+
+function streamFor(content: string): string[] {
+  return [chunk(content), finish(), "[DONE]"];
+}
+
+describe("timeout fallback e2e (#554)", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  // Non-streaming upstreams.
+  let nsSlow: OpenAiUpstream | undefined;
+  let nsFast: OpenAiUpstream | undefined;
+  let nsBackup: OpenAiUpstream | undefined;
+  // Streaming upstreams.
+  let stSlow: OpenAiUpstream | undefined;
+  let stFast: OpenAiUpstream | undefined;
+  let stStall: OpenAiUpstream | undefined;
+  let stBackup: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    nsSlow = await startOpenAiUpstream({
+      responseDelayMs: SLOW_MS,
+      nonStreamBody: reply("ns-slow"),
+    });
+    nsFast = await startOpenAiUpstream({ nonStreamBody: reply("ns-fast") });
+    nsBackup = await startOpenAiUpstream({ nonStreamBody: reply("ns-backup") });
+
+    stSlow = await startOpenAiUpstream({
+      // Headers fast, first token slow → TTFT timeout.
+      firstEventDelayMs: SLOW_MS,
+      streamEvents: streamFor("st-slow"),
+    });
+    stFast = await startOpenAiUpstream({ streamEvents: streamFor("st-fast") });
+    stStall = await startOpenAiUpstream({
+      // First chunk fast, then a long inter-chunk gap → mid-stream read
+      // timeout AFTER the 200 is committed (no fallback possible).
+      eventDelayMs: SLOW_MS,
+      streamEvents: [chunk("stall-1 "), chunk("stall-2 "), finish(), "[DONE]"],
+    });
+    stBackup = await startOpenAiUpstream({
+      streamEvents: streamFor("st-backup"),
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = async (name: string, u: OpenAiUpstream) =>
+      (
+        await admin!.createProviderKey({
+          display_name: name,
+          secret: "sk-mock",
+          api_base: `${u.baseUrl}/v1`,
+        })
+      ).id;
+
+    const nsSlowPk = await pk("t-ns-slow-pk", nsSlow);
+    const nsFastPk = await pk("t-ns-fast-pk", nsFast);
+    const nsBackupPk = await pk("t-ns-backup-pk", nsBackup);
+    const stSlowPk = await pk("t-st-slow-pk", stSlow);
+    const stFastPk = await pk("t-st-fast-pk", stFast);
+    const stStallPk = await pk("t-st-stall-pk", stStall);
+    const stBackupPk = await pk("t-st-backup-pk", stBackup);
+
+    // Direct targets. Cooldown is disabled on the slow/stall primaries so a
+    // timeout doesn't take them out of rotation between probe and test call
+    // (mirrors fallback-e2e).
+    await admin.createModel({
+      display_name: "t-m-ns-slow",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: nsSlowPk,
+      timeout: TIMEOUT_MS,
+      cooldown: { enabled: false },
+    });
+    await admin.createModel({
+      display_name: "t-m-ns-fast",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: nsFastPk,
+      timeout: GENEROUS_MS,
+    });
+    await admin.createModel({
+      display_name: "t-m-ns-backup",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: nsBackupPk,
+    });
+    await admin.createModel({
+      display_name: "t-m-st-slow",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stSlowPk,
+      stream_timeout: TIMEOUT_MS,
+      cooldown: { enabled: false },
+    });
+    await admin.createModel({
+      display_name: "t-m-st-fast",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stFastPk,
+      stream_timeout: GENEROUS_MS,
+    });
+    await admin.createModel({
+      display_name: "t-m-st-stall",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stStallPk,
+      stream_timeout: TIMEOUT_MS,
+      cooldown: { enabled: false },
+    });
+    await admin.createModel({
+      display_name: "t-m-st-backup",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stBackupPk,
+    });
+
+    const router = async (name: string, targets: string[]) =>
+      admin!.createModel({
+        display_name: name,
+        routing: { strategy: "failover", targets: targets.map((model) => ({ model })) },
+      });
+    await router("t-r-ns-timeout", ["t-m-ns-slow", "t-m-ns-backup"]);
+    await router("t-r-ns-fast", ["t-m-ns-fast", "t-m-ns-backup"]);
+    await router("t-r-st-ttft", ["t-m-st-slow", "t-m-st-backup"]);
+    await router("t-r-st-fast", ["t-m-st-fast", "t-m-st-backup"]);
+    await router("t-r-st-stall", ["t-m-st-stall", "t-m-st-backup"]);
+
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [
+        "t-r-ns-timeout",
+        "t-r-ns-fast",
+        "t-r-st-ttft",
+        "t-r-st-fast",
+        "t-r-st-stall",
+        "t-m-ns-backup",
+      ],
+    });
+
+    // Gate on a routing model so the test calls can't fire before the
+    // dispatcher has loaded the virtual models (and, transitively, their
+    // direct targets — all written before this poll).
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "t-r-ns-fast",
+          messages: [{ role: "user", content: "ready" }],
+        });
+        return probe.choices[0]?.message.content === "ns-fast";
+      } catch {
+        return false;
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(
+      [nsSlow, nsFast, nsBackup, stSlow, stFast, stStall, stBackup].map((u) =>
+        u?.close(),
+      ),
+    );
+  });
+
+  function caller(): OpenAI {
+    return new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app!.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  // AC1: non-streaming primary exceeds `timeout` → fall over to backup;
+  // caller sees a 200 from the backup.
+  test("non-streaming timeout falls over to the backup", async (ctx) => {
+    if (!etcdReachable || !app || !nsSlow || !nsBackup) {
+      ctx.skip();
+      return;
+    }
+    const slowBase = nsSlow.receivedRequests.length;
+    const backupBase = nsBackup.receivedRequests.length;
+
+    const completion = await caller().chat.completions.create({
+      model: "t-r-ns-timeout",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(completion.choices[0]?.message.content).toBe("ns-backup");
+    expect(nsSlow.receivedRequests.length - slowBase).toBe(1);
+    expect(nsBackup.receivedRequests.length - backupBase).toBe(1);
+  }, 30_000);
+
+  // AC2: streaming first token exceeds `stream_timeout` → fall over to the
+  // backup; the backup's tokens are piped to the caller with no error.
+  test("streaming TTFT timeout falls over; backup tokens pipe cleanly", async (ctx) => {
+    if (!etcdReachable || !app || !stSlow || !stBackup) {
+      ctx.skip();
+      return;
+    }
+    const slowBase = stSlow.receivedRequests.length;
+    const backupBase = stBackup.receivedRequests.length;
+
+    const collected: string[] = [];
+    let surfacedError = false;
+    const stream = await caller().chat.completions.create({
+      model: "t-r-st-ttft",
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+    });
+    try {
+      for await (const ev of stream) {
+        const c = ev.choices[0]?.delta?.content;
+        if (c) collected.push(c);
+      }
+    } catch {
+      surfacedError = true;
+    }
+
+    expect(surfacedError).toBe(false);
+    expect(collected.join("")).toContain("st-backup");
+    expect(stSlow.receivedRequests.length - slowBase).toBe(1);
+    expect(stBackup.receivedRequests.length - backupBase).toBe(1);
+  }, 30_000);
+
+  // AC3 (non-streaming): a fast primary is served and the backup is never
+  // touched — the timeout machinery doesn't interfere with healthy calls.
+  test("fast non-streaming primary is served; backup untouched", async (ctx) => {
+    if (!etcdReachable || !app || !nsFast || !nsBackup) {
+      ctx.skip();
+      return;
+    }
+    const fastBase = nsFast.receivedRequests.length;
+    const backupBase = nsBackup.receivedRequests.length;
+
+    const completion = await caller().chat.completions.create({
+      model: "t-r-ns-fast",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(completion.choices[0]?.message.content).toBe("ns-fast");
+    expect(nsFast.receivedRequests.length - fastBase).toBe(1);
+    expect(nsBackup.receivedRequests.length - backupBase).toBe(0);
+  }, 30_000);
+
+  // AC3 (streaming): a fast streaming primary is served and the backup is
+  // never touched.
+  test("fast streaming primary is served; backup untouched", async (ctx) => {
+    if (!etcdReachable || !app || !stFast || !stBackup) {
+      ctx.skip();
+      return;
+    }
+    const fastBase = stFast.receivedRequests.length;
+    const backupBase = stBackup.receivedRequests.length;
+
+    const collected: string[] = [];
+    const stream = await caller().chat.completions.create({
+      model: "t-r-st-fast",
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+    });
+    for await (const ev of stream) {
+      const c = ev.choices[0]?.delta?.content;
+      if (c) collected.push(c);
+    }
+
+    expect(collected.join("")).toContain("st-fast");
+    expect(stFast.receivedRequests.length - fastBase).toBe(1);
+    expect(stBackup.receivedRequests.length - backupBase).toBe(0);
+  }, 30_000);
+
+  // Read-timeout semantics: the first chunk arrives in time (200 committed),
+  // but a later inter-chunk gap exceeds `stream_timeout`. The stream is
+  // terminated with an error — NOT failed over (can't fall back once bytes
+  // are on the wire). The first chunk still reached the caller; the backup
+  // is never touched.
+  test("mid-stream stall terminates the stream without fallback", async (ctx) => {
+    if (!etcdReachable || !app || !stStall || !stBackup) {
+      ctx.skip();
+      return;
+    }
+    const stallBase = stStall.receivedRequests.length;
+    const backupBase = stBackup.receivedRequests.length;
+
+    const collected: string[] = [];
+    let surfacedError = false;
+    const stream = await caller().chat.completions.create({
+      model: "t-r-st-stall",
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+    });
+    try {
+      for await (const ev of stream) {
+        const c = ev.choices[0]?.delta?.content;
+        if (c) collected.push(c);
+      }
+    } catch (e) {
+      surfacedError = e instanceof APIError || e instanceof Error;
+    }
+
+    // First chunk made it to the caller before the stall.
+    expect(collected.join("")).toContain("stall-1");
+    // The stalled stream errored rather than completing or falling over.
+    expect(surfacedError).toBe(true);
+    expect(collected.join("")).not.toContain("st-backup");
+    expect(stStall.receivedRequests.length - stallBase).toBe(1);
+    expect(stBackup.receivedRequests.length - backupBase).toBe(0);
+  }, 30_000);
+});

--- a/tests/e2e/src/harness/upstream-openai.ts
+++ b/tests/e2e/src/harness/upstream-openai.ts
@@ -6,8 +6,15 @@ export interface OpenAiUpstreamOptions {
   nonStreamBody?: unknown;
   /** Sequence of SSE event payloads (already-stringified JSON or `[DONE]`). */
   streamEvents?: string[];
-  /** Inserted before the response is written. */
+  /** Inserted before the response is written (delays status + headers). */
   responseDelayMs?: number;
+  /**
+   * Inserted AFTER the SSE headers are flushed but BEFORE the first event.
+   * Models "connection + headers fast, first token slow", i.e. the TTFT
+   * timeout scenario (#554). Distinct from `responseDelayMs` (delays the
+   * headers too) and `eventDelayMs` (only applies between events).
+   */
+  firstEventDelayMs?: number;
   /** Inserted between SSE events. */
   eventDelayMs?: number;
   /** Status code to return (default 200). */
@@ -37,6 +44,8 @@ export interface OpenAiUpstreamStep {
   nonStreamBody?: unknown;
   streamEvents?: string[];
   responseDelayMs?: number;
+  /** See `OpenAiUpstreamOptions.firstEventDelayMs`. */
+  firstEventDelayMs?: number;
   eventDelayMs?: number;
   status?: number;
   errorBody?: unknown;
@@ -74,6 +83,12 @@ export async function startOpenAiUpstream(
   let requestIndex = 0;
 
   const server: Server = createServer((req, res) => {
+    // When the gateway abandons a slow upstream (e.g. a #554 request/stream
+    // timeout fires and the client connection is dropped), a later
+    // `res.write`/`res.end` here would emit an error on a closed socket.
+    // Swallow it so a deliberately-slow mock can't surface as an unhandled
+    // exception that fails the run.
+    res.on("error", () => {});
     let raw = "";
     req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
     req.on("end", async () => {
@@ -110,8 +125,17 @@ export async function startOpenAiUpstream(
         res.statusCode = 200;
         res.setHeader("content-type", "text/event-stream");
         res.setHeader("cache-control", "no-cache");
+        // Flush the 200 + headers immediately so the gateway's connect
+        // phase completes fast; `firstEventDelayMs` then models a slow
+        // first token (TTFT timeout) independently of the headers (#554).
+        res.flushHeaders();
+        if (step.firstEventDelayMs) await sleep(step.firstEventDelayMs);
         const events = step.streamEvents ?? [];
         for (let i = 0; i < events.length; i++) {
+          // The gateway may have abandoned a stalled stream (#554 read
+          // timeout) and closed the connection; stop writing rather than
+          // throwing on a dead socket.
+          if (res.writableEnded || res.destroyed) return;
           if (
             step.disconnectAfterEvents !== undefined &&
             i >= step.disconnectAfterEvents
@@ -122,7 +146,7 @@ export async function startOpenAiUpstream(
           res.write(`data: ${events[i]}\n\n`);
           if (step.eventDelayMs) await sleep(step.eventDelayMs);
         }
-        res.end();
+        if (!res.writableEnded && !res.destroyed) res.end();
         return;
       }
 


### PR DESCRIPTION
## Problem

Fallback in a routing model (Model Group) only triggered on upstream errors / `5xx`. A target that is *too slow* — a long non-streaming call, or a streaming response that takes too long to emit the first token — kept the request stuck on the primary instead of failing over. Tracks api7/AISIX-Cloud#554.

## What changed

Two per-model knobs now drive timeout-triggered failover, mirroring LiteLLM's `timeout` / `stream_timeout`:

- **`timeout`** (already in the schema but previously inert on the request path) is now applied as the end-to-end deadline for non-streaming upstream calls at every dispatch site (chat, messages, responses, count_tokens, embeddings, images, completions, rerank). An elapsed deadline is a retryable `BridgeError::Timeout` (504), so on a routing model it fails over to the next target; on a direct model it returns a clean 504.
- **`stream_timeout`** (new) is a per-chunk read timeout for streaming calls — applied to the first chunk and every inter-chunk gap (resets per chunk). A **first-chunk** timeout fails over to the next target before any bytes reach the client; a **mid-stream** stall terminates the stream like any other upstream error (no fallback once the 200 is committed). When `stream_timeout` is unset, streaming falls back to `timeout`.

The streaming dispatch paths (`/v1/chat/completions`, `/v1/messages` for both the cross-provider and native-Anthropic shapes, and `/v1/responses`) now loop over targets with a first-chunk peek instead of attempting only the first target. Shared `with_read_timeout` / `with_read_timeout_bytes` combinators and a `send_with_deadline` connect helper keep the chat-stream and raw-passthrough paths consistent. Per-attempt routing telemetry is recorded for the real winning attempt rather than a fabricated single record.

## Behavior / compatibility

`stream_timeout` is a new optional field; existing model configs are unaffected (both fields fold `0`/absent to "no timeout"). The control-plane + dashboard exposure of these fields is a separate follow-up PR.

## Tests

New `tests/e2e/src/cases/timeout-fallback-e2e.test.ts` covers non-streaming timeout → fallback, streaming first-token timeout → fallback (backup tokens piped, no client error), no-interference on healthy fast calls, and the mid-stream-stall read-timeout semantics. Adds a `firstEventDelayMs` mock-upstream knob to model "headers fast, first token slow". Docs updated on the Models and Routing pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-model streaming timeout plus per-chunk read/connect deadlines to detect stalls and bound upstream calls; peek-first-chunk behavior to enable safe failover.

* **Behavior**
  * Unified streaming/non-streaming failover: connect/first-chunk failures may fail over before bytes are sent; mid-stream stalls do not.
  * Model-specific request timeouts applied to upstream calls.

* **Telemetry**
  * Winner-scoped routing telemetry and improved mapping of transport errors to timeout semantics.

* **Documentation**
  * Docs updated with timeout fields, semantics, and failover behavior.

* **Tests**
  * New end-to-end tests and enhanced streaming test harness for timeout/failover scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->