### PR TITLE
docs(guardrails): refresh stale "Bedrock not enforced" doc-comments + regen schema

### DIFF
--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -25,10 +25,9 @@
 //!   * `keyword` — literal/regex blocklist; runs entirely in DP
 //!     process. Configured via `keyword.patterns` (list of
 //!     `{ kind: "literal" | "regex", value: "..." }`).
-//!   * `bedrock` — calls AWS Bedrock's `ApplyGuardrail`. Phase 1
-//!     parses + accepts the kind but the chain builder logs
-//!     "bedrock not yet implemented" and skips the row; Phase 2
-//!     wires the actual dispatch (PRD-09c §6.7).
+//!   * `bedrock` — calls AWS Bedrock's `ApplyGuardrail` on input
+//!     and/or output. The DP signs the call with SigV4 and maps
+//!     `GUARDRAIL_INTERVENED` to a block (PRD-09c §6.7).
 //!   * `azure_content_safety` — calls Azure AI Content Safety Prompt
 //!     Shield (`/contentsafety/text:shieldPrompt`). Detects jailbreak
 //!     and indirect injection attacks. P1 (PRD-09c §6 P1).
@@ -337,9 +336,9 @@ fn default_aliyun_window_overlap_size() -> u32 {
     128
 }
 
-/// Config block for `kind: "bedrock"`. Phase 1 stores the shape +
-/// passes it through `aisix-guardrails::build` which logs
-/// `bedrock not yet implemented` and skips the row.
+/// Config block for `kind: "bedrock"`. The DP builds an
+/// `aisix-guardrails::BedrockGuardrail` from this and dispatches
+/// `ApplyGuardrail` on every governed request.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BedrockConfig {
@@ -362,9 +361,9 @@ pub struct BedrockConfig {
 pub enum GuardrailKind {
     /// In-process literal/regex blocklist. Always available.
     Keyword(KeywordConfig),
-    /// AWS Bedrock managed guardrail. Phase 1 parses + persists;
-    /// the chain builder skips it with a warn log. Phase 2 wires
-    /// real `ApplyGuardrail` dispatch.
+    /// AWS Bedrock managed guardrail. The chain builder constructs a
+    /// `BedrockGuardrail` that calls AWS `ApplyGuardrail` (real SigV4
+    /// dispatch) on input and/or output per the row's hook point.
     Bedrock(BedrockConfig),
     /// Azure AI Content Safety Prompt Shield. Detects jailbreak and
     /// indirect injection attacks via the `/contentsafety/text:shieldPrompt`

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -28,7 +28,7 @@
       }
     },
     {
-      "description": "AWS Bedrock managed guardrail. Phase 1 parses + persists; the chain builder skips it with a warn log. Phase 2 wires real `ApplyGuardrail` dispatch.",
+      "description": "AWS Bedrock managed guardrail. The chain builder constructs a `BedrockGuardrail` that calls AWS `ApplyGuardrail` (real SigV4 dispatch) on input and/or output per the row's hook point.",
       "type": "object",
       "required": [
         "aws_credentials",


### PR DESCRIPTION
## What

Refreshes three stale doc-comments in `aisix-core::models::guardrail` that still claimed the `kind=bedrock` chain builder logs `"bedrock not yet implemented"` and **skips** the row, and regenerates `schemas/resources/guardrail.schema.json` from them.

## Why

The Bedrock guardrail has enforced since Phase 2: `aisix-guardrails::build::build_one` constructs a `BedrockGuardrail` that signs real `ApplyGuardrail` SigV4 calls on input/output. The stale comments contradicted the actual code and propagated (via `schemars`) into the generated `guardrail.schema.json` `description`, and from there into the **vendored copy in api7/AISIX-Cloud** (`schemas/resources/guardrail.schema.json`). This was the last "Phase 1 / not enforced" remnant after the dashboard banner removal (AISIX-Cloud#733).

## Changes

- `crates/aisix-core/src/models/guardrail.rs` — module-level, `BedrockConfig`, and `GuardrailKind::Bedrock` doc-comments rewritten to describe current enforcing behavior.
- `schemas/resources/guardrail.schema.json` — regenerated via `cargo run -p aisix-core --bin dump-schema` (1-line `description` change; no structural change; drift-check clean).

The `enforcement_mode` / `direction` "not yet implemented" comments are accurate (those genuinely aren't wired) and are **left untouched**.

## Follow-up

After merge, the vendored copy in api7/AISIX-Cloud will be refreshed by bumping `schemas/.upstream-pin` to this merge SHA + running `./scripts/sync-schemas.sh`. Ticks two boxes on #51 (banner contradiction resolved + doc-comment corrected).

Refs #51.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Bedrock guardrail documentation to clarify behavior and invocation based on hook configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->