### PR TITLE
docs(comments): neutralize third-party-gateway parity references

### DIFF
--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -249,8 +249,8 @@ pub struct Model {
     /// routing model's target, an elapsed timeout fails over to the next
     /// target (the timeout error is retryable). For `stream:true` requests
     /// it is also the fallback streaming budget when `stream_timeout` is
-    /// unset (see [`Model::stream_timeout_effective`]). Mirrors LiteLLM's
-    /// `timeout`.
+    /// unset (see [`Model::stream_timeout_effective`]). Mirrors the
+    /// common OpenAI-proxy `timeout` field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
 
@@ -263,7 +263,7 @@ pub struct Model {
     /// to disable streaming timeouts entirely. A *first-chunk* timeout
     /// fails over to the next target (before any bytes reach the client); a
     /// *mid-stream* timeout terminates the stream like any other upstream
-    /// error. Mirrors LiteLLM's `stream_timeout`.
+    /// error. Mirrors the common OpenAI-proxy `stream_timeout` field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_timeout: Option<u64>,
 
@@ -330,8 +330,9 @@ impl Model {
 
     /// Effective deadline for a streaming request: a positive
     /// `stream_timeout`, otherwise the non-streaming `timeout`. Mirrors
-    /// LiteLLM's `Router._get_timeout`, which uses `stream_timeout` for
-    /// stream calls and falls back to the general `timeout`. Applied to the
+    /// the common OpenAI-proxy timeout-resolution rule, which uses
+    /// `stream_timeout` for stream calls and falls back to the general
+    /// `timeout`. Applied to the
     /// connect phase, the per-chunk read timeout, and the first-chunk
     /// failover gate. Because `stream_read_timeout()` folds `0` to `None`,
     /// `stream_timeout: 0` is treated the same as absent — it falls back to
@@ -446,7 +447,7 @@ mod tests {
         assert_eq!(zero.stream_timeout_effective(), None);
 
         // Explicit `stream_timeout: 0` folds to absent → falls back to
-        // `timeout` (matches LiteLLM's falsy 0), not "disable streaming".
+        // `timeout` (matches the falsy-0 convention), not "disable streaming".
         let stream_zero_timeout_set: Model = serde_json::from_str(
             r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","timeout":5000,"stream_timeout":0}"#,
         )

--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -169,7 +169,7 @@ pub enum BridgeError {
     /// (empty secret, api key with invalid HTTP-header bytes, unparseable
     /// service-account / AAD / Bedrock credential JSON). Maps to 401
     /// `authentication_error`, not 400: this is an auth-material problem,
-    /// and 401 matches LiteLLM's canonical mapping for the same providers
+    /// and 401 matches the canonical provider mapping for the same providers
     /// (Anthropic/OpenAI/Azure raise `AuthenticationError`). Non-retryable
     /// (#367 follow-up). Distinct from [`InvalidUpstreamConfig`] (400),
     /// which is request/routing shape, not credentials.
@@ -582,7 +582,7 @@ mod tests {
         // #367 follow-up: auth-material problems (empty/invalid secret,
         // unparseable credential JSON) are a 401 authentication_error,
         // not a 400 — they're a distinct class from request/routing shape
-        // and match LiteLLM's AuthenticationError mapping.
+        // and match the canonical AuthenticationError mapping.
         let e = BridgeError::InvalidUpstreamCredentials("provider_key.secret is empty".into());
         assert_eq!(e.http_status(), 401);
         assert_eq!(e.error_type(), "authentication_error");

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -209,7 +209,7 @@ pub struct UsageEvent {
     // Each UsageEvent now represents ONE upstream attempt. A request
     // that fails over emits multiple events sharing `request_id` (the
     // grouping/trace key); they are ordered by `attempt_index`. This
-    // mirrors LiteLLM's per-call logging model — `status_code`,
+    // mirrors a per-call logging model — `status_code`,
     // `latency_ms`, and `ttft_ms` are scoped to THIS attempt, so the
     // user-perceived total is reconstructed by summing the attempts of
     // one `request_id`. Direct (non-routing) requests emit a single

--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -6,7 +6,7 @@
 //! attempts carry zero tokens + error info; the winning attempt carries
 //! the real tokens/cost. All attempts of one request share `request_id`
 //! (the trace/group key) and are ordered by `index`. This mirrors
-//! LiteLLM's per-call logging model.
+//! a de-facto per-call logging model.
 //!
 //! The type lives in its own module so `/v1/chat/completions`,
 //! `/v1/messages`, and `/v1/responses` cannot drift apart on how they

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -278,9 +278,9 @@ async fn dispatch(
 /// `completion_tokens`, by contrast, defaults to 0 when absent: a 200
 /// that reports a prompt side but omits the completion side is still a
 /// real billable call (the prompt was processed) and must be recorded.
-/// This matches LiteLLM, which coerces a missing completion side to 0
-/// and still logs/bills the event (`completion_tokens=response["usage"].
-/// get("completion_tokens", 0)` in convert_dict_to_response.py) — see
+/// This matches the de-facto gateway behavior, which coerces a missing
+/// completion side to 0 and still logs/bills the event (the usage block's
+/// `completion_tokens` defaults to 0 when absent) — see
 /// #429 follow-up. Dropping the whole event would under-record more than
 /// the zeroed-completion it was meant to avoid. Wire shape:
 /// <https://platform.openai.com/docs/api-reference/completions/object>
@@ -749,11 +749,11 @@ mod tests {
         }
     }
 
-    /// #429 (LiteLLM-parity follow-up): a 200 whose `usage` carries
+    /// #429 (gateway-parity follow-up): a 200 whose `usage` carries
     /// `prompt_tokens` but omits `completion_tokens` is still a real
     /// billable call — the prompt was processed. It MUST emit a
-    /// UsageEvent with `completion_tokens = 0` (matching LiteLLM's
-    /// `get("completion_tokens", 0)`), NOT be dropped. Only a fully
+    /// UsageEvent with `completion_tokens = 0` (coercing the missing
+    /// side to 0), NOT be dropped. Only a fully
     /// absent / prompt-less usage block skips (see the two tests below).
     #[tokio::test]
     async fn emits_with_zero_completion_when_completion_tokens_missing() {

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -850,8 +850,8 @@ async fn responses_to_target(
 ///
 /// `output_tokens`, by contrast, defaults to 0 when absent: a 200 that
 /// reports an input side but omits the output side is still a real
-/// billable call and must be recorded. This matches LiteLLM, which
-/// coerces a missing completion/output side to 0 and still logs/bills
+/// billable call and must be recorded. This matches the de-facto gateway
+/// behavior, which coerces a missing completion/output side to 0 and still logs/bills
 /// the event (#429 follow-up; mirrors the tolerant wire-layer decode of
 /// #474). Spec:
 /// <https://platform.openai.com/docs/api-reference/responses/object>
@@ -2551,10 +2551,10 @@ mod tests {
         }
     }
 
-    /// #429 (LiteLLM-parity follow-up): a 200 whose `usage` carries
+    /// #429 (gateway-parity follow-up): a 200 whose `usage` carries
     /// `input_tokens` but omits `output_tokens` is still a real billable
     /// call. It MUST emit a UsageEvent with `completion_tokens = 0`
-    /// (matching LiteLLM's coerce-missing-to-0), NOT be dropped. Only a
+    /// (coercing the missing side to 0), NOT be dropped. Only a
     /// fully absent / input-less usage block skips.
     #[tokio::test]
     async fn emits_with_zero_output_when_output_tokens_missing() {

--- a/crates/aisix-proxy/src/stream_timeout.rs
+++ b/crates/aisix-proxy/src/stream_timeout.rs
@@ -1,6 +1,6 @@
 //! Per-chunk read-timeout combinators for streaming upstreams (#554).
 //!
-//! Mirrors LiteLLM's `stream_timeout` semantics: the deadline bounds the
+//! Mirrors the common OpenAI-proxy `stream_timeout` semantics: the deadline bounds the
 //! wait for EACH chunk — the first one and every inter-chunk gap — and
 //! resets after each successful read. A *first-chunk* timeout lets the
 //! caller fail over before any bytes reach the client (issue AC2); a

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -86,7 +86,7 @@ A failed probe transitions the model to `unhealthy` in the runtime status tracke
 
 ### Timeouts
 
-Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**. `timeout` of `0` or absent means no non-streaming timeout. `stream_timeout` of a positive value bounds streaming; `0` or absent makes streaming fall back to `timeout` instead (so to disable streaming timeouts entirely, set `timeout` to `0` as well). They mirror LiteLLM's `timeout` and `stream_timeout`.
+Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**. `timeout` of `0` or absent means no non-streaming timeout. `stream_timeout` of a positive value bounds streaming; `0` or absent makes streaming fall back to `timeout` instead (so to disable streaming timeouts entirely, set `timeout` to `0` as well). They follow the common OpenAI-proxy `timeout` / `stream_timeout` convention.
 
 ```json title="Direct model timeouts"
 {
@@ -102,7 +102,7 @@ An elapsed timeout surfaces as a retryable upstream failure (HTTP `504`), so on 
 
 A timeout also feeds [Cooldown](#cooldown) (`trigger_on_timeout`), so a repeatedly-slow target is taken out of rotation for subsequent requests.
 
-> A small `timeout` set for non-streaming traffic also becomes the streaming read budget when `stream_timeout` is unset (LiteLLM parity). Set `stream_timeout` explicitly if streaming needs a different budget.
+> A small `timeout` set for non-streaming traffic also becomes the streaming read budget when `stream_timeout` is unset. Set `stream_timeout` explicitly if streaming needs a different budget.
 
 ### Cooldown
 

--- a/docs/configuration/routing-and-failover.md
+++ b/docs/configuration/routing-and-failover.md
@@ -93,7 +93,7 @@ A target that is *too slow* fails over the same way a target that *errors* does.
 - **Non-streaming.** If a target doesn't return a complete response within its `timeout`, the gateway abandons it (a `504`-class timeout) and moves to the next target — identical to the retryable-failure path above.
 - **Streaming.** `stream_timeout` is a per-chunk read timeout (it resets after each chunk). A timeout on the **first** chunk fires before any bytes reach the caller, so the gateway fails over cleanly to the next target. Once the first chunk has been forwarded the response is committed to that target; a later inter-chunk stall **ends the stream** with an error rather than failing over (the gateway can't un-send bytes already on the wire). When `stream_timeout` is unset, the streaming budget falls back to `timeout`.
 
-Because a timed-out attempt is just another retryable failure, it composes with `retries`, `max_fallbacks`, and the runtime [cooldown](models.md#cooldown) (`trigger_on_timeout`) exactly like a `5xx`. These knobs mirror LiteLLM's `timeout` / `stream_timeout`.
+Because a timed-out attempt is just another retryable failure, it composes with `retries`, `max_fallbacks`, and the runtime [cooldown](models.md#cooldown) (`trigger_on_timeout`) exactly like a `5xx`. These knobs follow the common OpenAI-proxy `timeout` / `stream_timeout` convention.
 
 ## Runtime Filtering
 

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -86,7 +86,7 @@
       ]
     },
     "stream_timeout": {
-      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. A positive value bounds each chunk wait; `0` or absent means \"no streaming-specific override\", so the effective streaming budget falls back to `timeout` (see [`Model::stream_timeout_effective`]) — set `timeout` to `0` too to disable streaming timeouts entirely. A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error. Mirrors LiteLLM's `stream_timeout`.",
+      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. A positive value bounds each chunk wait; `0` or absent means \"no streaming-specific override\", so the effective streaming budget falls back to `timeout` (see [`Model::stream_timeout_effective`]) — set `timeout` to `0` too to disable streaming timeouts entirely. A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error. Mirrors the common OpenAI-proxy `stream_timeout` field.",
       "type": [
         "integer",
         "null"
@@ -95,7 +95,7 @@
       "minimum": 0.0
     },
     "timeout": {
-      "description": "Non-streaming request timeout in ms — the end-to-end budget for a `stream:false` upstream call. `0` or absent = no timeout. On a routing model's target, an elapsed timeout fails over to the next target (the timeout error is retryable). For `stream:true` requests it is also the fallback streaming budget when `stream_timeout` is unset (see [`Model::stream_timeout_effective`]). Mirrors LiteLLM's `timeout`.",
+      "description": "Non-streaming request timeout in ms — the end-to-end budget for a `stream:false` upstream call. `0` or absent = no timeout. On a routing model's target, an elapsed timeout fails over to the next target (the timeout error is retryable). For `stream:true` requests it is also the fallback streaming budget when `stream_timeout` is unset (see [`Model::stream_timeout_effective`]). Mirrors the common OpenAI-proxy `timeout` field.",
       "type": [
         "integer",
         "null"

--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -194,7 +194,7 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
 // (no text block) must surface `choices[0].message.content === null` on
 // the OpenAI shape — not `""`. The text-block join produced `""` before
 // the fix; we now map empty/absent text to `null` to match OpenAI's
-// documented `string | null` shape and LiteLLM's behaviour.
+// documented `string | null` shape and the de-facto gateway behaviour.
 const TOOL_CALLER_PLAINTEXT = "sk-an-e2e-toolnull-caller";
 const TOOL_CALLER_KEY_HASH = createHash("sha256")
   .update(TOOL_CALLER_PLAINTEXT)

--- a/tests/e2e/src/cases/invalid-upstream-credentials-401-e2e.test.ts
+++ b/tests/e2e/src/cases/invalid-upstream-credentials-401-e2e.test.ts
@@ -20,7 +20,7 @@ import {
 // api_base but a secret that can't be a valid Authorization header
 // value (a newline-injected key), so the bridge can't build the auth
 // header and errors before dispatch. Auth-material problems map to 401
-// to match LiteLLM's AuthenticationError mapping, so SDKs that branch
+// to match the canonical AuthenticationError mapping, so SDKs that branch
 // on 401 to refresh credentials classify it right. (An empty secret is
 // the same error class but is rejected earlier by the admin schema's
 // min-length check, so this drives the post-admit header-bytes guard.)

--- a/tests/e2e/src/cases/timeout-fallback-e2e.test.ts
+++ b/tests/e2e/src/cases/timeout-fallback-e2e.test.ts
@@ -22,7 +22,7 @@ import {
 //     over before any bytes reach the client; a mid-stream stall terminates
 //     the stream like any other upstream error (no fallback once committed).
 //
-// Mirrors LiteLLM's `timeout` + `stream_timeout` knobs. Reference: OpenAI
+// Mirrors the common OpenAI-proxy `timeout` + `stream_timeout` knobs. Reference: OpenAI
 // Chat Completions spec for the request/response shape.
 
 const CALLER_PLAINTEXT = "sk-timeout-fb-caller";


### PR DESCRIPTION
## What

Replaces references to a specific third-party OpenAI-compatible proxy (named in ~21 places) with neutral phrasing — across Rust doc-comments, two docs pages, three e2e test comments, and the generated `model.schema.json` descriptions.

## Why

Internal convention: that third party's name must not appear in shipped code, comments, docs, or schemas. Every reference was a *parity note* (timeout / auth-error-mapping / usage-logging); the surrounding text already conveys the behavior, so dropping the name loses nothing technical. Surfaced while reconciling the vendored schema copy in api7/AISIX-Cloud, whose `sync-schemas.sh` would otherwise have copied the two `model.schema.json` descriptions downstream.

## Scope (13 files, comment/doc only — no behavior change)

- `crates/aisix-core/src/models/model.rs`, `aisix-gateway/src/bridge.rs`, `aisix-obs/src/usage.rs`, `aisix-proxy/src/{attempt,completions,responses,stream_timeout}.rs` — doc-comments
- `docs/configuration/{models,routing-and-failover}.md` — parity parentheticals
- `tests/e2e/src/cases/{anthropic-upstream,invalid-upstream-credentials-401,timeout-fallback}-e2e.test.ts` — test comments
- `schemas/resources/model.schema.json` — **regenerated** from `model.rs` via `cargo run -p aisix-core --bin dump-schema` (descriptions only)

## Verification

- `git grep -i` for the name → **0 matches repo-wide**
- `cargo fmt --check` clean · schema regenerated so the `schema-drift` gate stays clean · no behavior change (comments/docs/strings only)
