### PR TITLE
fix(object_store): harden cloud_identity — fail-fast on S3 endpoint, omit empty credential_ref

### DIFF
--- a/crates/aisix-core/src/models/observability_exporter.rs
+++ b/crates/aisix-core/src/models/observability_exporter.rs
@@ -284,9 +284,10 @@ pub struct ObjectStoreConfig {
     /// Opaque pointer to the cloud credentials, resolved locally by the DP
     /// at delivery time. The plaintext key MUST NOT live in etcd/kine — the
     /// control plane stores only this reference, never the secret itself.
-    /// Required when `auth_mode = credential_ref`; unused (and may be empty)
-    /// when `auth_mode = cloud_identity`.
-    #[serde(default)]
+    /// Required when `auth_mode = credential_ref`; omitted (not empty) when
+    /// `auth_mode = cloud_identity` — `skip_serializing_if` keeps an empty
+    /// reference off the wire so the two encodings never diverge.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub credential_ref: String,
 }
 
@@ -629,6 +630,14 @@ mod tests {
             }
             other => panic!("expected object_store, got {other:?}"),
         }
+        // An empty credential_ref is omitted on the wire (skip_serializing_if),
+        // so a keyless config never carries an empty key reference.
+        let v = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["auth_mode"], "cloud_identity");
+        assert!(
+            v.get("credential_ref").is_none(),
+            "empty credential_ref must be omitted under cloud_identity, got {v}"
+        );
     }
 
     #[test]

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -280,7 +280,9 @@ pub fn build_object_store(
 /// Build the backend using the DP host's OWN attached cloud identity, with no
 /// static keys ("cloud identity" auth). **S3** uses the AWS default credential
 /// chain via [`object_store::aws::AmazonS3Builder::from_env`] (env / EKS IRSA
-/// web-identity / ECS task role / EC2 instance profile). **GCS** uses
+/// web-identity / ECS task role / EC2 instance profile); a custom `endpoint`
+/// is rejected for S3, since ambient credentials require the provider's
+/// metadata service. **GCS** uses
 /// Application Default Credentials (GKE Workload Identity / GCE metadata) by
 /// constructing the builder with no service-account key. **Azure** is not
 /// supported here — its managed identity still needs a non-secret account name
@@ -294,15 +296,23 @@ pub fn build_object_store_ambient(
 ) -> Result<Arc<dyn ObjectStore>, SinkError> {
     match provider {
         ObjectStoreProvider::S3 => {
+            // Ambient AWS credentials come from the instance metadata service
+            // (IMDS / IRSA / ECS task role), which only the provider's native
+            // endpoint exposes. A custom endpoint means an S3-compatible host
+            // (MinIO / R2 / OSS) with no cloud IAM identity, so fail fast with a
+            // clear permanent error instead of building a sink that fails soft
+            // on every delivery. (cp-api also rejects this at create time.)
+            if endpoint.is_some() {
+                return Err(SinkError::Permanent(
+                    "object_store: cloud_identity for s3 does not support a custom \
+                     endpoint (ambient AWS credentials require the provider's \
+                     metadata service); use credential_ref for S3-compatible hosts"
+                        .to_string(),
+                ));
+            }
             let mut b = object_store::aws::AmazonS3Builder::from_env().with_bucket_name(bucket);
             if let Some(r) = region {
                 b = b.with_region(r);
-            }
-            if let Some(ep) = endpoint {
-                b = b.with_endpoint(ep).with_virtual_hosted_style_request(false);
-                if ep.starts_with("http://") {
-                    b = b.with_allow_http(true);
-                }
             }
             let store = b.build().map_err(|e| {
                 SinkError::Permanent(format!("object_store: build s3 (cloud identity): {e}"))
@@ -755,6 +765,29 @@ mod tests {
         let store =
             build_object_store_ambient(ObjectStoreProvider::S3, "bucket", Some("us-east-1"), None);
         assert!(store.is_ok(), "s3 ambient build: {store:?}");
+    }
+
+    #[test]
+    fn build_object_store_ambient_s3_rejects_endpoint() {
+        // A custom endpoint with cloud_identity S3 is a misconfiguration:
+        // ambient AWS credentials need the provider's metadata service, which an
+        // S3-compatible host (MinIO / R2 / OSS) does not expose. Fail fast with
+        // a clear permanent error pointing back to credential_ref.
+        let r = build_object_store_ambient(
+            ObjectStoreProvider::S3,
+            "bucket",
+            Some("us-east-1"),
+            Some("https://minio.internal:9000"),
+        );
+        match r {
+            Err(SinkError::Permanent(msg)) => {
+                assert!(msg.contains("endpoint"), "msg: {msg}");
+                assert!(msg.contains("credential_ref"), "msg: {msg}");
+            }
+            other => {
+                panic!("expected Permanent error for s3 cloud_identity + endpoint, got {other:?}")
+            }
+        }
     }
 
     #[test]

--- a/schemas/resources/observability_exporter.schema.json
+++ b/schemas/resources/observability_exporter.schema.json
@@ -114,8 +114,7 @@
           ]
         },
         "credential_ref": {
-          "description": "Opaque pointer to the cloud credentials, resolved locally by the DP at delivery time. The plaintext key MUST NOT live in etcd/kine — the control plane stores only this reference, never the secret itself. Required when `auth_mode = credential_ref`; unused (and may be empty) when `auth_mode = cloud_identity`.",
-          "default": "",
+          "description": "Opaque pointer to the cloud credentials, resolved locally by the DP at delivery time. The plaintext key MUST NOT live in etcd/kine — the control plane stores only this reference, never the secret itself. Required when `auth_mode = credential_ref`; omitted (not empty) when `auth_mode = cloud_identity` — `skip_serializing_if` keeps an empty reference off the wire so the two encodings never diverge.",
           "type": "string"
         },
         "endpoint": {


### PR DESCRIPTION
## What

Two hardening follow-ups surfaced by #549's audit and tracked in #552 (items 1 & 2). Both are small, fully unit-tested DP changes.

### 1. DP fail-fast on `cloud_identity` + custom `endpoint` (S3)

`build_object_store_ambient` honored a custom `endpoint` for cloud_identity S3. But ambient AWS credentials are sourced from the instance metadata service (IMDS / IRSA / ECS task role), which only the provider's native endpoint exposes — a custom endpoint means an S3-compatible host (MinIO / R2 / OSS) with no cloud IAM identity. So `build()` succeeded (lazy) and **every delivery failed soft** at runtime.

Now the S3 arm returns a clear `SinkError::Permanent` when an endpoint is set, pointing the operator back to `credential_ref`. cp-api already rejects this combination at create time (AISIX-Cloud#736); this is the DP-side backstop.

### 2. `credential_ref` omitted, not empty, under cloud_identity

`ObjectStoreConfig::credential_ref` now carries `#[serde(default, skip_serializing_if = "String::is_empty")]`, so an empty reference never serializes onto the wire. This keeps the keyless encoding consistent with the omitted-field path the loader accepts (the loader's `minLength: 1` would reject an explicit `credential_ref: ""`, but accepts the field omitted). The doc comment is tightened to "omitted (not empty)", and the generated schema is regenerated (it drops the now-moot `default: ""`).

## Tests

- `build_object_store_ambient_s3_rejects_endpoint` — the S3 ambient builder returns a `Permanent` error (mentioning `endpoint` + `credential_ref`) when a custom endpoint is supplied.
- `object_store_auth_mode_defaults_and_cloud_identity` — extended to assert a cloud_identity config serializes **without** `credential_ref` (`v.get("credential_ref").is_none()`).

Local verification: `cargo fmt`, `cargo clippy -p aisix-obs -p aisix-core --all-targets` (clean), `cargo test -p aisix-obs -p aisix-core` (111 pass + the 2 new), and `cargo run -p aisix-core --bin dump-schema` + committed the regenerated schema (no remaining drift).

## Scope

Pure DP hardening + tests; no wire-protocol break (an empty `credential_ref` was never a valid keyless input — it was already rejected by the loader's `minLength: 1`; this only stops the DP from *emitting* one). Real-cloud e2e for `cloud_identity` (#552 item 3) lands separately.

Refs: #549 (DP cloud_identity), #552 (this issue), AISIX-Cloud#736 (cp-api reject), AISIX-Cloud#724.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * S3 cloud identity authentication now rejects custom endpoints and provides a clear error message directing users to use credential references for S3-compatible hosts.

* **Documentation**
  * Updated observability exporter schema documentation to clarify credential field behavior based on authentication mode configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->