### PR TITLE
test(object_store): real-cloud credential_ref smoke CI for S3 + GCS

### DIFF
--- a/.github/workflows/objstore-real-cloud.yml
+++ b/.github/workflows/objstore-real-cloud.yml
@@ -1,0 +1,79 @@
+# Real-cloud object_store smoke e2e — credential_ref (static-key) write path
+# against REAL Amazon S3 and Google Cloud Storage.
+#
+# Runs the `objstore_smoke_s3` / `objstore_smoke_gcs` round-trips (write a batch
+# → assert exactly one object under the prefix → re-deliver the same batch →
+# assert no duplicate key → clean up) against the actual cloud APIs. These
+# complement the emulator smoke in ci.yml's unit job, which cannot exercise real
+# S3 auth or (for GCS) the real PUT path that fake-gcs-server can't round-trip.
+#
+# Gated: never runs on a normal push. Triggered manually (workflow_dispatch),
+# nightly (schedule), or on a same-repo PR labeled `objstore real cloud`. Each
+# provider's test self-skips (logged) when its secrets are absent, so an
+# unconfigured run is a green no-op.
+#
+# ── Required repository secrets ──
+#   Settings → Secrets and variables → Actions → New repository secret
+#
+#   Amazon S3 (native AWS):
+#     AISIX_E2E_OBJSTORE_S3_BUCKET             test bucket name
+#     AISIX_E2E_OBJSTORE_S3_REGION             the bucket's region, e.g. us-east-1
+#     AISIX_E2E_OBJSTORE_S3_ACCESS_KEY_ID      IAM user access key id
+#     AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY  IAM user secret access key
+#     (For an S3-compatible host — MinIO / Cloudflare R2 — also set
+#      AISIX_E2E_OBJSTORE_S3_ENDPOINT.)
+#   Google Cloud Storage:
+#     AISIX_E2E_OBJSTORE_GCS_BUCKET            test bucket name
+#     AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT   the full service-account key JSON
+#                                              (paste the downloaded key as one secret)
+#
+# Least privilege — scope the identity to the test bucket only:
+#   AWS:  s3:PutObject, s3:GetObject, s3:DeleteObject on arn:aws:s3:::<bucket>/*
+#         + s3:ListBucket on arn:aws:s3:::<bucket>
+#   GCS:  roles/storage.objectAdmin on the bucket
+#
+# See crates/aisix-obs/tests/real-cloud.env.example for a local-run template.
+name: objstore-real-cloud
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 0 * * *" # 00:30 UTC (08:30 Asia/Shanghai)
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: objstore-real-cloud-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: objstore real-cloud smoke (S3 + GCS)
+    # Label-gate on PRs; always run on manual dispatch / schedule.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'objstore real cloud')
+    runs-on: ubicloud-standard-2
+    env:
+      AISIX_E2E_OBJSTORE_S3_BUCKET: ${{ secrets.AISIX_E2E_OBJSTORE_S3_BUCKET }}
+      AISIX_E2E_OBJSTORE_S3_REGION: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}
+      AISIX_E2E_OBJSTORE_S3_ENDPOINT: ${{ secrets.AISIX_E2E_OBJSTORE_S3_ENDPOINT }}
+      AISIX_E2E_OBJSTORE_S3_ACCESS_KEY_ID: ${{ secrets.AISIX_E2E_OBJSTORE_S3_ACCESS_KEY_ID }}
+      AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY: ${{ secrets.AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY }}
+      AISIX_E2E_OBJSTORE_GCS_BUCKET: ${{ secrets.AISIX_E2E_OBJSTORE_GCS_BUCKET }}
+      AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT: ${{ secrets.AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-protoc
+      - uses: Swatinem/rust-cache@v2
+      - name: Report which providers are configured
+        run: |
+          if [ -n "$AISIX_E2E_OBJSTORE_S3_BUCKET" ]; then echo "S3: configured"; else echo "::warning::S3 secrets absent — objstore_smoke_s3 will self-skip"; fi
+          if [ -n "$AISIX_E2E_OBJSTORE_GCS_BUCKET" ]; then echo "GCS: configured"; else echo "::warning::GCS secrets absent — objstore_smoke_gcs will self-skip"; fi
+      - name: objstore real-cloud round-trips (S3 + GCS)
+        run: cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3 objstore_smoke_gcs

--- a/.github/workflows/objstore-real-cloud.yml
+++ b/.github/workflows/objstore-real-cloud.yml
@@ -53,10 +53,15 @@ concurrency:
 jobs:
   smoke:
     name: objstore real-cloud smoke (S3 + GCS)
-    # Label-gate on PRs; always run on manual dispatch / schedule.
+    # Same-repo + label gate on PRs; always run on manual dispatch / schedule.
+    # The explicit same-repo check is defense-in-depth: plain `pull_request`
+    # withholds secrets from fork PRs by GitHub default today, but this gate
+    # keeps the credentials off fork-controlled code even if that default is
+    # ever flipped (mirrors docker-image.yml's `!= 'pull_request'` guard).
     if: >-
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'objstore real cloud')
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'objstore real cloud'))
     runs-on: ubicloud-standard-2
     env:
       AISIX_E2E_OBJSTORE_S3_BUCKET: ${{ secrets.AISIX_E2E_OBJSTORE_S3_BUCKET }}
@@ -73,7 +78,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Report which providers are configured
         run: |
-          if [ -n "$AISIX_E2E_OBJSTORE_S3_BUCKET" ]; then echo "S3: configured"; else echo "::warning::S3 secrets absent — objstore_smoke_s3 will self-skip"; fi
-          if [ -n "$AISIX_E2E_OBJSTORE_GCS_BUCKET" ]; then echo "GCS: configured"; else echo "::warning::GCS secrets absent — objstore_smoke_gcs will self-skip"; fi
+          s3=0; gcs=0
+          if [ -n "$AISIX_E2E_OBJSTORE_S3_BUCKET" ]; then echo "S3: configured"; s3=1; else echo "::warning::S3 secrets absent — objstore_smoke_s3 will self-skip"; fi
+          if [ -n "$AISIX_E2E_OBJSTORE_GCS_BUCKET" ]; then echo "GCS: configured"; gcs=1; else echo "::warning::GCS secrets absent — objstore_smoke_gcs will self-skip"; fi
+          # A manual dispatch or scheduled run is deliberate — secrets are
+          # expected. Fail rather than pass green while testing nothing. PR
+          # runs may legitimately have no secrets, so they still self-skip.
+          if [ "${{ github.event_name }}" != "pull_request" ] && [ "$s3" = 0 ] && [ "$gcs" = 0 ]; then
+            echo "::error::No object_store real-cloud secrets configured; this ${{ github.event_name }} run would test nothing."
+            exit 1
+          fi
       - name: objstore real-cloud round-trips (S3 + GCS)
         run: cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3 objstore_smoke_gcs

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ coverage/
 .env
 .env.*
 !.env.example
+
+# Filled-in real-cloud objstore credentials (template: real-cloud.env.example)
+/crates/aisix-obs/tests/real-cloud.env

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -941,12 +941,11 @@ mod smoke {
     }
 
     #[tokio::test]
-    #[ignore = "hits a real S3-compatible server (MinIO/LocalStack). \
+    #[ignore = "hits a real S3 or S3-compatible server (native AWS / MinIO / LocalStack). \
                 Run: docker compose -f crates/aisix-obs/tests/object-store-emulators.compose.yml up -d \
                 then AISIX_E2E_OBJSTORE_S3_* set; cargo test -p aisix-obs -- --ignored objstore_smoke_s3"]
     async fn objstore_smoke_s3_roundtrip() {
-        let (Some(endpoint), Some(bucket), Some(key_id), Some(secret)) = (
-            env("AISIX_E2E_OBJSTORE_S3_ENDPOINT"),
+        let (Some(bucket), Some(key_id), Some(secret)) = (
             env("AISIX_E2E_OBJSTORE_S3_BUCKET"),
             env("AISIX_E2E_OBJSTORE_S3_ACCESS_KEY_ID"),
             env("AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY"),
@@ -954,11 +953,16 @@ mod smoke {
             eprintln!("objstore_smoke_s3: AISIX_E2E_OBJSTORE_S3_* not set — skipping");
             return;
         };
+        // endpoint optional: set it for an S3-compatible host (MinIO /
+        // LocalStack / R2 — path-style); omit it for native AWS S3
+        // (virtual-hosted, region only). region defaults to us-east-1.
+        let endpoint = env("AISIX_E2E_OBJSTORE_S3_ENDPOINT");
+        let region = env("AISIX_E2E_OBJSTORE_S3_REGION").unwrap_or_else(|| "us-east-1".to_string());
         let store = build_object_store(
             ObjectStoreProvider::S3,
             &bucket,
-            Some("us-east-1"),
-            Some(&endpoint),
+            Some(&region),
+            endpoint.as_deref(),
             ObjectStoreCredentials::S3 {
                 access_key_id: key_id,
                 secret_access_key: secret,
@@ -1004,19 +1008,21 @@ mod smoke {
                 %2F), so build + auth verify there but the PUT only greens on real GCS. \
                 cargo test -p aisix-obs -- --ignored objstore_smoke_gcs"]
     async fn objstore_smoke_gcs_roundtrip() {
-        let (Some(endpoint), Some(bucket), Some(service_account_key)) = (
-            env("AISIX_E2E_OBJSTORE_GCS_ENDPOINT"),
+        let (Some(bucket), Some(service_account_key)) = (
             env("AISIX_E2E_OBJSTORE_GCS_BUCKET"),
             env("AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT"),
         ) else {
             eprintln!("objstore_smoke_gcs: AISIX_E2E_OBJSTORE_GCS_* not set — skipping");
             return;
         };
+        // GCS ignores the `endpoint` arg (an emulator base URL rides the
+        // service-account JSON's `gcs_base_url` instead), so it is not read
+        // here — native GCS needs only the bucket + service-account key.
         let store = build_object_store(
             ObjectStoreProvider::Gcs,
             &bucket,
             None,
-            Some(&endpoint),
+            None,
             ObjectStoreCredentials::Gcs {
                 service_account_key,
             },

--- a/crates/aisix-obs/tests/real-cloud.env.example
+++ b/crates/aisix-obs/tests/real-cloud.env.example
@@ -1,0 +1,27 @@
+# Template for running the `objstore_smoke_*` round-trips against REAL cloud
+# storage (the credential_ref / static-key path). Copy to a gitignored file,
+# fill in real values, then:
+#   set -a; source crates/aisix-obs/tests/real-cloud.env; set +a
+#   cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3 objstore_smoke_gcs
+#
+# In CI these same names are repository secrets — see
+# .github/workflows/objstore-real-cloud.yml. DO NOT commit a filled-in copy;
+# these are real credentials (`real-cloud.env` is gitignored).
+
+# ── Amazon S3 (native AWS) ──
+# Least privilege — scope an IAM user to the test bucket only:
+#   s3:PutObject, s3:GetObject, s3:DeleteObject  on  arn:aws:s3:::<bucket>/*
+#   s3:ListBucket                                on  arn:aws:s3:::<bucket>
+AISIX_E2E_OBJSTORE_S3_BUCKET=your-aisix-smoke-bucket
+AISIX_E2E_OBJSTORE_S3_REGION=us-east-1
+AISIX_E2E_OBJSTORE_S3_ACCESS_KEY_ID=AKIAxxxxxxxxxxxxxxxx
+AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY=your-secret-access-key
+# For an S3-compatible host (MinIO / Cloudflare R2 / OSS) instead of native AWS,
+# also set the endpoint (path-style):
+# AISIX_E2E_OBJSTORE_S3_ENDPOINT=https://your-s3-compatible-host
+
+# ── Google Cloud Storage ──
+# Grant the service account roles/storage.objectAdmin on the test bucket. Paste
+# the full downloaded key JSON, single-quoted (it contains commas):
+AISIX_E2E_OBJSTORE_GCS_BUCKET=your-aisix-smoke-bucket
+AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT='{"type":"service_account","project_id":"your-project","private_key_id":"...","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n","client_email":"aisix-smoke@your-project.iam.gserviceaccount.com","client_id":"...","token_uri":"https://oauth2.googleapis.com/token"}'


### PR DESCRIPTION
## What

A **gated CI workflow** that runs the existing `objstore_smoke_*` round-trips against **real Amazon S3 and Google Cloud Storage**, plus the small test changes needed to target native cloud (not just S3-compatible emulators). This is the credential_ref (static-key) half of #552 item 3 — real-cloud verification that the object_store write path works against the actual cloud APIs, which the emulator smoke in `ci.yml` cannot do (no real S3 auth; fake-gcs-server can't round-trip the real GCS PUT path).

## Changes

**`crates/aisix-obs/src/sink/object_store.rs`** (test-only, inside `mod smoke`):
- `objstore_smoke_s3_roundtrip` — `endpoint` is now **optional**: omit it for native AWS S3 (virtual-hosted + region); set it for an S3-compatible host (MinIO / R2, path-style). Region comes from `AISIX_E2E_OBJSTORE_S3_REGION` (default `us-east-1`). Requires only bucket + key + secret.
- `objstore_smoke_gcs_roundtrip` — drop the **unused** `_ENDPOINT` requirement. `build_object_store` intentionally ignores `endpoint` for GCS (an emulator base URL rides the service-account JSON's `gcs_base_url`), so native GCS needs only bucket + service-account key.

**`.github/workflows/objstore-real-cloud.yml`** (new):
- Gated — never runs on a normal push. Triggers: `workflow_dispatch`, nightly `schedule`, and a same-repo PR labeled `objstore real cloud`.
- Runs `cargo test -p aisix-obs -- --ignored objstore_smoke_s3 objstore_smoke_gcs` with credentials from repository secrets.
- Each provider's test **self-skips** (the test's own `eprintln`, plus a `::warning` from a preflight step) when its secrets are absent, so an unconfigured run is a green no-op — it never breaks CI before the secrets exist.

**`crates/aisix-obs/tests/real-cloud.env.example`** (new): a local-run template documenting the env vars + the least-privilege IAM policy (`s3:PutObject/GetObject/DeleteObject` + `s3:ListBucket`) and GCS role (`roles/storage.objectAdmin`). The filled-in `real-cloud.env` is gitignored.

## Required repository secrets (operator-configured)

| Secret | Provider |
|---|---|
| `AISIX_E2E_OBJSTORE_S3_BUCKET`, `_REGION`, `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY` (+ optional `_ENDPOINT` for S3-compatible) | S3 |
| `AISIX_E2E_OBJSTORE_GCS_BUCKET`, `_SERVICE_ACCOUNT` (full SA key JSON) | GCS |

Scope each identity to the test bucket only (policy in the workflow header + `real-cloud.env.example`).

## What the smoke asserts (observable contract)

`smoke_roundtrip`: write a batch → exactly one object under the prefix → re-deliver the same batch → still exactly one (content-addressed key is idempotent) → clean up. Real auth + real PUT/LIST/DELETE against the cloud.

## Verification

`cargo fmt`, `cargo clippy -p aisix-obs --all-targets` (clean), `cargo test -p aisix-obs -- --ignored objstore_smoke_s3 objstore_smoke_gcs` with no secrets set → both self-skip and pass (compile + skip path verified). Workflow YAML parses. The real round-trips run once the secrets are configured.

## Notes

- No emulator regression: the existing `object-store-emulators.env` path still works — S3 still honors `_ENDPOINT` when set; GCS never used `_ENDPOINT` (the SA JSON's `gcs_base_url` drives the emulator).
- Scope: credential_ref only. The keyless `cloud_identity` real-cloud path (OIDC / Workload Identity Federation) lands in a follow-up PR — it needs a runner with an attached cloud identity, not static keys.

Refs: #552 (item 3), #549, #568 (DP hardening).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added GitHub Actions workflow for real cloud object-store smoke tests against S3 and GCS.
  * Updated S3 and GCS smoke test configurations to support optional endpoint configuration and service account authentication.

* **Chores**
  * Added environment template file and gitignore configuration for cloud storage credentials management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->