### PR TITLE
docs(comments): describe fields functionally, drop external-product parity framing

### DIFF
--- a/crates/aisix-admin/src/auth.rs
+++ b/crates/aisix-admin/src/auth.rs
@@ -2,8 +2,8 @@
 //!
 //! - Admin keys come from `config.admin.admin_keys` (static, bootstrap
 //!   config), not the `ApiKey` table in etcd.
-//! - Presentation matches OpenAI convention for symmetry —
-//!   `Authorization: Bearer <key>` with an `x-api-key` fallback.
+//! - Presented as `Authorization: Bearer <key>` with an `x-api-key`
+//!   fallback.
 //!
 //! This extractor short-circuits with an `AdminError::Unauthorized`
 //! envelope before any handler runs.

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -249,8 +249,7 @@ pub struct Model {
     /// routing model's target, an elapsed timeout fails over to the next
     /// target (the timeout error is retryable). For `stream:true` requests
     /// it is also the fallback streaming budget when `stream_timeout` is
-    /// unset (see [`Model::stream_timeout_effective`]). Mirrors the
-    /// common OpenAI-proxy `timeout` field.
+    /// unset (see [`Model::stream_timeout_effective`]).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
 
@@ -263,7 +262,7 @@ pub struct Model {
     /// to disable streaming timeouts entirely. A *first-chunk* timeout
     /// fails over to the next target (before any bytes reach the client); a
     /// *mid-stream* timeout terminates the stream like any other upstream
-    /// error. Mirrors the common OpenAI-proxy `stream_timeout` field.
+    /// error.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_timeout: Option<u64>,
 
@@ -329,10 +328,7 @@ impl Model {
     }
 
     /// Effective deadline for a streaming request: a positive
-    /// `stream_timeout`, otherwise the non-streaming `timeout`. Mirrors
-    /// the common OpenAI-proxy timeout-resolution rule, which uses
-    /// `stream_timeout` for stream calls and falls back to the general
-    /// `timeout`. Applied to the
+    /// `stream_timeout`, otherwise the non-streaming `timeout`. Applied to the
     /// connect phase, the per-chunk read timeout, and the first-chunk
     /// failover gate. Because `stream_read_timeout()` folds `0` to `None`,
     /// `stream_timeout: 0` is treated the same as absent — it falls back to
@@ -447,7 +443,7 @@ mod tests {
         assert_eq!(zero.stream_timeout_effective(), None);
 
         // Explicit `stream_timeout: 0` folds to absent → falls back to
-        // `timeout` (matches the falsy-0 convention), not "disable streaming".
+        // `timeout`, not "disable streaming".
         let stream_zero_timeout_set: Model = serde_json::from_str(
             r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","timeout":5000,"stream_timeout":0}"#,
         )

--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -169,8 +169,7 @@ pub enum BridgeError {
     /// (empty secret, api key with invalid HTTP-header bytes, unparseable
     /// service-account / AAD / Bedrock credential JSON). Maps to 401
     /// `authentication_error`, not 400: this is an auth-material problem,
-    /// and 401 matches the canonical provider mapping for the same providers
-    /// (Anthropic/OpenAI/Azure raise `AuthenticationError`). Non-retryable
+    /// not a request/routing-shape problem. Non-retryable
     /// (#367 follow-up). Distinct from [`InvalidUpstreamConfig`] (400),
     /// which is request/routing shape, not credentials.
     #[error("invalid upstream credentials: {0}")]
@@ -388,7 +387,7 @@ impl BridgeError {
         }
     }
 
-    /// Stable error-type token, mirroring OpenAI's error.type field.
+    /// Stable error-type token for the error envelope's `type` field.
     pub fn error_type(&self) -> &'static str {
         match self {
             BridgeError::Timeout { .. } => "timeout",
@@ -581,8 +580,7 @@ mod tests {
     fn invalid_upstream_credentials_maps_to_401_authentication() {
         // #367 follow-up: auth-material problems (empty/invalid secret,
         // unparseable credential JSON) are a 401 authentication_error,
-        // not a 400 — they're a distinct class from request/routing shape
-        // and match the canonical AuthenticationError mapping.
+        // not a 400 — they're a distinct class from request/routing shape.
         let e = BridgeError::InvalidUpstreamCredentials("provider_key.secret is empty".into());
         assert_eq!(e.http_status(), 401);
         assert_eq!(e.error_type(), "authentication_error");

--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -15,7 +15,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// Role of a chat message. Matches OpenAI's taxonomy; providers that only
+/// Role of a chat message. Providers that only
 /// support system/user/assistant are expected to reject `Tool` at their
 /// own boundary rather than silently collapsing roles.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -5,8 +5,8 @@
 //! fallback to a different target — becomes its own `UsageEvent`. Failed
 //! attempts carry zero tokens + error info; the winning attempt carries
 //! the real tokens/cost. All attempts of one request share `request_id`
-//! (the trace/group key) and are ordered by `index`. This mirrors
-//! a de-facto per-call logging model.
+//! (the trace/group key) and are ordered by `index` — each attempt
+//! is its own per-call log event.
 //!
 //! The type lives in its own module so `/v1/chat/completions`,
 //! `/v1/messages`, and `/v1/responses` cannot drift apart on how they

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -278,9 +278,9 @@ async fn dispatch(
 /// `completion_tokens`, by contrast, defaults to 0 when absent: a 200
 /// that reports a prompt side but omits the completion side is still a
 /// real billable call (the prompt was processed) and must be recorded.
-/// This matches the de-facto gateway behavior, which coerces a missing
-/// completion side to 0 and still logs/bills the event (the usage block's
-/// `completion_tokens` defaults to 0 when absent) — see
+/// A missing completion side coerces to 0 and the event is still
+/// logged/billed (the usage block's `completion_tokens` defaults to 0
+/// when absent) — see
 /// #429 follow-up. Dropping the whole event would under-record more than
 /// the zeroed-completion it was meant to avoid. Wire shape:
 /// <https://platform.openai.com/docs/api-reference/completions/object>
@@ -749,7 +749,7 @@ mod tests {
         }
     }
 
-    /// #429 (gateway-parity follow-up): a 200 whose `usage` carries
+    /// #429 follow-up: a 200 whose `usage` carries
     /// `prompt_tokens` but omits `completion_tokens` is still a real
     /// billable call — the prompt was processed. It MUST emit a
     /// UsageEvent with `completion_tokens = 0` (coercing the missing

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -850,9 +850,9 @@ async fn responses_to_target(
 ///
 /// `output_tokens`, by contrast, defaults to 0 when absent: a 200 that
 /// reports an input side but omits the output side is still a real
-/// billable call and must be recorded. This matches the de-facto gateway
-/// behavior, which coerces a missing completion/output side to 0 and still logs/bills
-/// the event (#429 follow-up; mirrors the tolerant wire-layer decode of
+/// billable call and must be recorded. A missing completion/output side
+/// coerces to 0 and the event is still logged/billed
+/// (#429 follow-up; mirrors the tolerant wire-layer decode of
 /// #474). Spec:
 /// <https://platform.openai.com/docs/api-reference/responses/object>
 fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
@@ -2551,7 +2551,7 @@ mod tests {
         }
     }
 
-    /// #429 (gateway-parity follow-up): a 200 whose `usage` carries
+    /// #429 follow-up: a 200 whose `usage` carries
     /// `input_tokens` but omits `output_tokens` is still a real billable
     /// call. It MUST emit a UsageEvent with `completion_tokens = 0`
     /// (coercing the missing side to 0), NOT be dropped. Only a

--- a/crates/aisix-proxy/src/stream_timeout.rs
+++ b/crates/aisix-proxy/src/stream_timeout.rs
@@ -1,6 +1,6 @@
 //! Per-chunk read-timeout combinators for streaming upstreams (#554).
 //!
-//! Mirrors the common OpenAI-proxy `stream_timeout` semantics: the deadline bounds the
+//! Per-chunk streaming read-timeout: the deadline bounds the
 //! wait for EACH chunk — the first one and every inter-chunk gap — and
 //! resets after each successful read. A *first-chunk* timeout lets the
 //! caller fail over before any bytes reach the client (issue AC2); a

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -86,7 +86,7 @@ A failed probe transitions the model to `unhealthy` in the runtime status tracke
 
 ### Timeouts
 
-Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**. `timeout` of `0` or absent means no non-streaming timeout. `stream_timeout` of a positive value bounds streaming; `0` or absent makes streaming fall back to `timeout` instead (so to disable streaming timeouts entirely, set `timeout` to `0` as well). They follow the common OpenAI-proxy `timeout` / `stream_timeout` convention.
+Two optional per-model knobs bound how long the gateway waits on the upstream. Both are in **milliseconds**. `timeout` of `0` or absent means no non-streaming timeout. `stream_timeout` of a positive value bounds streaming; `0` or absent makes streaming fall back to `timeout` instead (so to disable streaming timeouts entirely, set `timeout` to `0` as well).
 
 ```json title="Direct model timeouts"
 {

--- a/docs/configuration/routing-and-failover.md
+++ b/docs/configuration/routing-and-failover.md
@@ -93,7 +93,7 @@ A target that is *too slow* fails over the same way a target that *errors* does.
 - **Non-streaming.** If a target doesn't return a complete response within its `timeout`, the gateway abandons it (a `504`-class timeout) and moves to the next target — identical to the retryable-failure path above.
 - **Streaming.** `stream_timeout` is a per-chunk read timeout (it resets after each chunk). A timeout on the **first** chunk fires before any bytes reach the caller, so the gateway fails over cleanly to the next target. Once the first chunk has been forwarded the response is committed to that target; a later inter-chunk stall **ends the stream** with an error rather than failing over (the gateway can't un-send bytes already on the wire). When `stream_timeout` is unset, the streaming budget falls back to `timeout`.
 
-Because a timed-out attempt is just another retryable failure, it composes with `retries`, `max_fallbacks`, and the runtime [cooldown](models.md#cooldown) (`trigger_on_timeout`) exactly like a `5xx`. These knobs follow the common OpenAI-proxy `timeout` / `stream_timeout` convention.
+Because a timed-out attempt is just another retryable failure, it composes with `retries`, `max_fallbacks`, and the runtime [cooldown](models.md#cooldown) (`trigger_on_timeout`) exactly like a `5xx`.
 
 ## Runtime Filtering
 

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -86,7 +86,7 @@
       ]
     },
     "stream_timeout": {
-      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. A positive value bounds each chunk wait; `0` or absent means \"no streaming-specific override\", so the effective streaming budget falls back to `timeout` (see [`Model::stream_timeout_effective`]) — set `timeout` to `0` too to disable streaming timeouts entirely. A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error. Mirrors the common OpenAI-proxy `stream_timeout` field.",
+      "description": "Streaming read timeout in ms — the maximum gap the gateway waits for the next upstream chunk on a `stream:true` call, applied to the first chunk and to every inter-chunk gap. A positive value bounds each chunk wait; `0` or absent means \"no streaming-specific override\", so the effective streaming budget falls back to `timeout` (see [`Model::stream_timeout_effective`]) — set `timeout` to `0` too to disable streaming timeouts entirely. A *first-chunk* timeout fails over to the next target (before any bytes reach the client); a *mid-stream* timeout terminates the stream like any other upstream error.",
       "type": [
         "integer",
         "null"
@@ -95,7 +95,7 @@
       "minimum": 0.0
     },
     "timeout": {
-      "description": "Non-streaming request timeout in ms — the end-to-end budget for a `stream:false` upstream call. `0` or absent = no timeout. On a routing model's target, an elapsed timeout fails over to the next target (the timeout error is retryable). For `stream:true` requests it is also the fallback streaming budget when `stream_timeout` is unset (see [`Model::stream_timeout_effective`]). Mirrors the common OpenAI-proxy `timeout` field.",
+      "description": "Non-streaming request timeout in ms — the end-to-end budget for a `stream:false` upstream call. `0` or absent = no timeout. On a routing model's target, an elapsed timeout fails over to the next target (the timeout error is retryable). For `stream:true` requests it is also the fallback streaming budget when `stream_timeout` is unset (see [`Model::stream_timeout_effective`]).",
       "type": [
         "integer",
         "null"

--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -193,8 +193,8 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
 // E2E (#395): an Anthropic upstream that returns ONLY a `tool_use` block
 // (no text block) must surface `choices[0].message.content === null` on
 // the OpenAI shape — not `""`. The text-block join produced `""` before
-// the fix; we now map empty/absent text to `null` to match OpenAI's
-// documented `string | null` shape and the de-facto gateway behaviour.
+// the fix; we now map empty/absent text to `null`, per the documented
+// `string | null` content shape.
 const TOOL_CALLER_PLAINTEXT = "sk-an-e2e-toolnull-caller";
 const TOOL_CALLER_KEY_HASH = createHash("sha256")
   .update(TOOL_CALLER_PLAINTEXT)

--- a/tests/e2e/src/cases/invalid-upstream-credentials-401-e2e.test.ts
+++ b/tests/e2e/src/cases/invalid-upstream-credentials-401-e2e.test.ts
@@ -20,7 +20,7 @@ import {
 // api_base but a secret that can't be a valid Authorization header
 // value (a newline-injected key), so the bridge can't build the auth
 // header and errors before dispatch. Auth-material problems map to 401
-// to match the canonical AuthenticationError mapping, so SDKs that branch
+// (auth-material, not a request-shape 400), so SDKs that branch
 // on 401 to refresh credentials classify it right. (An empty secret is
 // the same error class but is rejected earlier by the admin schema's
 // min-length check, so this drives the post-admit header-bytes guard.)

--- a/tests/e2e/src/cases/timeout-fallback-e2e.test.ts
+++ b/tests/e2e/src/cases/timeout-fallback-e2e.test.ts
@@ -22,7 +22,7 @@ import {
 //     over before any bytes reach the client; a mid-stream stall terminates
 //     the stream like any other upstream error (no fallback once committed).
 //
-// Mirrors the common OpenAI-proxy `timeout` + `stream_timeout` knobs. Reference: OpenAI
+// Exercises the `timeout` + `stream_timeout` knobs. Reference: OpenAI
 // Chat Completions spec for the request/response shape.
 
 const CALLER_PLAINTEXT = "sk-timeout-fb-caller";


### PR DESCRIPTION
## What

Follow-up to review feedback: a description should state a field's **own function**, not frame it as *"mirrors / matches / follows"* an external product or convention. This removes that framing across 14 files (Rust doc-comments, 2 docs pages, 3 e2e test comments, and the generated `model.schema.json`), keeping the functional description intact.

## Examples

| Before | After |
|--------|-------|
| `…Mirrors the common OpenAI-proxy `timeout` field.` | *(dropped — the field is fully described above)* |
| `Effective deadline… Mirrors the common OpenAI-proxy timeout-resolution rule, which uses…` | `Effective deadline: a positive `stream_timeout`, otherwise the non-streaming `timeout`.` |
| `Stable error-type token, mirroring OpenAI's error.type field.` | `Stable error-type token for the error envelope's `type` field.` |
| `Role of a chat message. Matches OpenAI's taxonomy; providers…` | `Role of a chat message. Providers…` |
| `#429 (gateway-parity follow-up)` | `#429 follow-up` |

## Out of scope (left unchanged)

Internal architecture references that legitimately use "mirrors" — the struct *mirrors what cp-api writes*, `applied` *mirrors the chain 1:1*, the Datadog sink *mirrors the SLS sink*, issue-fixture mirrors — describe this codebase, not an external product. Bare spec pointers (e.g. "Reference: OpenAI Chat Completions spec") are kept as wire-format references.

## Verification

- `git grep` for the external-parity phrases (`common openai-proxy`, `de-facto`, `gateway-parity`, `matches/Matches OpenAI…`, `follows the common`, `canonical … mapping`, `falsy-0 convention`) → **0** repo-wide
- `schemas/resources/model.schema.json` regenerated via `dump-schema` (timeout/stream_timeout descriptions only; `schema-drift` gate clean)
- `cargo fmt --check` clean · comment/doc only — no behavior change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified timeout behavior semantics for model configurations and stream handling
  * Updated authentication and usage event attribution documentation for accuracy
  * Improved error handling and failover behavior descriptions
  * Enhanced schema field descriptions for timeout configuration options
  * Refined test documentation and comments for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->