### PR TITLE
test(object_store): keyless cloud_identity real-cloud smoke CI (OIDC)

### DIFF
--- a/.github/workflows/objstore-cloud-identity.yml
+++ b/.github/workflows/objstore-cloud-identity.yml
@@ -1,24 +1,27 @@
 # Real-cloud object_store smoke e2e — KEYLESS cloud_identity path.
 #
-# Proves the data plane's ambient-credential builders (`build_object_store_ambient`)
-# write to real S3 / GCS with NO static keys: the runner assumes an identity via
-# GitHub OIDC (an AWS IAM role / a GCP Workload Identity Federation provider), and
-# the object_store ambient chain (AWS `from_env` / GCP Application Default
-# Credentials) picks it up — exactly what a cloud-deployed DP does via an EC2
-# instance role / EKS IRSA / GKE Workload Identity. The static-key credential_ref
-# path is covered separately by `objstore-real-cloud.yml`.
+# Proves `build_object_store_ambient` writes to real S3 with NO static keys: the
+# runner mints a GitHub OIDC token to assume an AWS IAM role
+# (aws-actions/configure-aws-credentials), and the object_store ambient chain
+# (AWS `from_env`) picks it up — exactly what a cloud-deployed DP does via an EC2
+# instance role / EKS IRSA. The static-key credential_ref path is covered by
+# objstore-real-cloud.yml.
 #
-# Gated: never on a normal push. Triggered manually, nightly, or on a same-repo
-# PR labeled `objstore real cloud`. Each provider self-skips when its OIDC is
-# unconfigured, so an unconfigured run is a green no-op.
+# Scope note — GCS keyless is NOT exercised here. On a non-GCE GitHub runner,
+# object_store's GCS Application Default Credentials resolution targets the GCE
+# metadata server (169.254.169.254), which the runner doesn't have; it does not
+# consume the Workload Identity Federation credentials file. GCS cloud_identity
+# works on a real GKE/GCE deployment (the metadata path that
+# build_object_store_ambient(Gcs, …) uses in production); its real-runner
+# round-trip is tracked in #573. objstore_smoke_gcs_cloud_identity self-skips here.
 #
-# Required repository secrets — these are IDENTIFIERS, not static cloud keys:
-#   AISIX_E2E_OIDC_AWS_ROLE_ARN     IAM role to assume (trusts repo:api7/ai-gateway via GitHub OIDC)
-#   AISIX_E2E_OBJSTORE_S3_BUCKET    the S3 test bucket (reused from the credential_ref job)
-#   AISIX_E2E_OBJSTORE_S3_REGION
-#   AISIX_E2E_OIDC_GCP_WIF_PROVIDER Workload Identity provider resource name
-#   AISIX_E2E_OIDC_GCP_SA           service account to impersonate (writes the bucket)
-#   AISIX_E2E_OBJSTORE_GCS_BUCKET   the GCS test bucket (reused)
+# Gated: never on a normal push. workflow_dispatch / nightly / same-repo PR
+# labeled `objstore real cloud`. S3 self-skips when its OIDC is unconfigured.
+#
+# Required repository secrets (identifiers, not static keys):
+#   AISIX_E2E_OIDC_AWS_ROLE_ARN   IAM role to assume (trusts repo:api7/ai-gateway via GitHub OIDC)
+#   AISIX_E2E_OBJSTORE_S3_BUCKET  the S3 test bucket (reused from the credential_ref job)
+#   AISIX_E2E_OBJSTORE_S3_REGION  the bucket's region (configure-aws-credentials requires it)
 name: objstore-cloud-identity
 
 on:
@@ -31,7 +34,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # REQUIRED: lets the OIDC actions mint a token to assume the role / impersonate the SA
+  id-token: write # REQUIRED: lets the OIDC action mint a token to assume the role
 
 concurrency:
   group: objstore-cloud-identity-${{ github.ref }}
@@ -39,7 +42,7 @@ concurrency:
 
 jobs:
   smoke:
-    name: objstore keyless smoke (S3 OIDC role + GCS WIF)
+    name: objstore keyless smoke (S3 via GitHub OIDC role)
     # Same-repo + label gate on PRs; always run on manual dispatch / schedule.
     if: >-
       github.event_name != 'pull_request' ||
@@ -48,43 +51,41 @@ jobs:
     runs-on: ubicloud-standard-2
     env:
       AWS_ROLE_ARN: ${{ secrets.AISIX_E2E_OIDC_AWS_ROLE_ARN }}
-      GCP_WIF_PROVIDER: ${{ secrets.AISIX_E2E_OIDC_GCP_WIF_PROVIDER }}
-      GCP_SA: ${{ secrets.AISIX_E2E_OIDC_GCP_SA }}
+      AWS_REGION_CFG: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2
 
-      - name: Report which keyless providers are configured
+      - name: Report configuration
         run: |
-          if [ -n "$AWS_ROLE_ARN" ]; then echo "AWS OIDC: configured"; else echo "::warning::AWS OIDC role absent — S3 keyless self-skips"; fi
-          if [ -n "$GCP_WIF_PROVIDER" ]; then echo "GCP WIF: configured"; else echo "::warning::GCP WIF absent — GCS keyless self-skips"; fi
-          if [ "${{ github.event_name }}" != "pull_request" ] && [ -z "$AWS_ROLE_ARN" ] && [ -z "$GCP_WIF_PROVIDER" ]; then
-            echo "::error::No object_store cloud_identity OIDC configured; this ${{ github.event_name }} run would test nothing."
+          if [ -n "$AWS_ROLE_ARN" ] && [ -n "$AWS_REGION_CFG" ]; then
+            echo "AWS OIDC: configured (role + region)"
+          elif [ -n "$AWS_ROLE_ARN" ]; then
+            echo "::warning::AWS_ROLE_ARN set but AISIX_E2E_OBJSTORE_S3_REGION is empty — S3 keyless self-skips"
+          else
+            echo "::warning::AWS OIDC role absent — S3 keyless self-skips"
+          fi
+          if [ "${{ github.event_name }}" != "pull_request" ] && { [ -z "$AWS_ROLE_ARN" ] || [ -z "$AWS_REGION_CFG" ]; }; then
+            echo "::error::AWS OIDC not fully configured (role ARN + region); this ${{ github.event_name }} run would test nothing."
             exit 1
           fi
 
       - name: Assume the AWS IAM role via GitHub OIDC (keyless)
-        if: env.AWS_ROLE_ARN != ''
+        if: env.AWS_ROLE_ARN != '' && env.AWS_REGION_CFG != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}
+          aws-region: ${{ env.AWS_REGION_CFG }}
 
-      - name: Authenticate to GCP via Workload Identity Federation (keyless)
-        if: env.GCP_WIF_PROVIDER != ''
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
-          service_account: ${{ env.GCP_SA }}
-
-      - name: Keyless round-trips (S3 + GCS)
+      - name: Keyless round-trip (S3)
         env:
-          # Gate each provider's smoke on its OIDC being set up: if the auth step
-          # above was skipped, the bucket is empty here and the test self-skips
-          # (rather than running with no ambient credentials and failing).
-          AISIX_E2E_OBJSTORE_CLOUDID_S3_BUCKET: ${{ secrets.AISIX_E2E_OIDC_AWS_ROLE_ARN != '' && secrets.AISIX_E2E_OBJSTORE_S3_BUCKET || '' }}
+          # Set the bucket only when the OIDC role + region are BOTH present, so
+          # the smoke self-skips rather than running with no ambient credentials.
+          AISIX_E2E_OBJSTORE_CLOUDID_S3_BUCKET: ${{ (secrets.AISIX_E2E_OIDC_AWS_ROLE_ARN != '' && secrets.AISIX_E2E_OBJSTORE_S3_REGION != '') && secrets.AISIX_E2E_OBJSTORE_S3_BUCKET || '' }}
           AISIX_E2E_OBJSTORE_CLOUDID_S3_REGION: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}
-          AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET: ${{ secrets.AISIX_E2E_OIDC_GCP_WIF_PROVIDER != '' && secrets.AISIX_E2E_OBJSTORE_GCS_BUCKET || '' }}
+          # GCS keyless self-skips on a non-GCE runner (no metadata server) — see
+          # the scope note above and #573. The test stays in the cargo filter so
+          # it runs (and greens) when executed on a real GKE/GCE runner.
         run: cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3_cloud_identity objstore_smoke_gcs_cloud_identity

--- a/.github/workflows/objstore-cloud-identity.yml
+++ b/.github/workflows/objstore-cloud-identity.yml
@@ -1,0 +1,90 @@
+# Real-cloud object_store smoke e2e — KEYLESS cloud_identity path.
+#
+# Proves the data plane's ambient-credential builders (`build_object_store_ambient`)
+# write to real S3 / GCS with NO static keys: the runner assumes an identity via
+# GitHub OIDC (an AWS IAM role / a GCP Workload Identity Federation provider), and
+# the object_store ambient chain (AWS `from_env` / GCP Application Default
+# Credentials) picks it up — exactly what a cloud-deployed DP does via an EC2
+# instance role / EKS IRSA / GKE Workload Identity. The static-key credential_ref
+# path is covered separately by `objstore-real-cloud.yml`.
+#
+# Gated: never on a normal push. Triggered manually, nightly, or on a same-repo
+# PR labeled `objstore real cloud`. Each provider self-skips when its OIDC is
+# unconfigured, so an unconfigured run is a green no-op.
+#
+# Required repository secrets — these are IDENTIFIERS, not static cloud keys:
+#   AISIX_E2E_OIDC_AWS_ROLE_ARN     IAM role to assume (trusts repo:api7/ai-gateway via GitHub OIDC)
+#   AISIX_E2E_OBJSTORE_S3_BUCKET    the S3 test bucket (reused from the credential_ref job)
+#   AISIX_E2E_OBJSTORE_S3_REGION
+#   AISIX_E2E_OIDC_GCP_WIF_PROVIDER Workload Identity provider resource name
+#   AISIX_E2E_OIDC_GCP_SA           service account to impersonate (writes the bucket)
+#   AISIX_E2E_OBJSTORE_GCS_BUCKET   the GCS test bucket (reused)
+name: objstore-cloud-identity
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "45 0 * * *" # 00:45 UTC (08:45 Asia/Shanghai)
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write # REQUIRED: lets the OIDC actions mint a token to assume the role / impersonate the SA
+
+concurrency:
+  group: objstore-cloud-identity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: objstore keyless smoke (S3 OIDC role + GCS WIF)
+    # Same-repo + label gate on PRs; always run on manual dispatch / schedule.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'objstore real cloud'))
+    runs-on: ubicloud-standard-2
+    env:
+      AWS_ROLE_ARN: ${{ secrets.AISIX_E2E_OIDC_AWS_ROLE_ARN }}
+      GCP_WIF_PROVIDER: ${{ secrets.AISIX_E2E_OIDC_GCP_WIF_PROVIDER }}
+      GCP_SA: ${{ secrets.AISIX_E2E_OIDC_GCP_SA }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-protoc
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Report which keyless providers are configured
+        run: |
+          if [ -n "$AWS_ROLE_ARN" ]; then echo "AWS OIDC: configured"; else echo "::warning::AWS OIDC role absent — S3 keyless self-skips"; fi
+          if [ -n "$GCP_WIF_PROVIDER" ]; then echo "GCP WIF: configured"; else echo "::warning::GCP WIF absent — GCS keyless self-skips"; fi
+          if [ "${{ github.event_name }}" != "pull_request" ] && [ -z "$AWS_ROLE_ARN" ] && [ -z "$GCP_WIF_PROVIDER" ]; then
+            echo "::error::No object_store cloud_identity OIDC configured; this ${{ github.event_name }} run would test nothing."
+            exit 1
+          fi
+
+      - name: Assume the AWS IAM role via GitHub OIDC (keyless)
+        if: env.AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}
+
+      - name: Authenticate to GCP via Workload Identity Federation (keyless)
+        if: env.GCP_WIF_PROVIDER != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_SA }}
+
+      - name: Keyless round-trips (S3 + GCS)
+        env:
+          # Gate each provider's smoke on its OIDC being set up: if the auth step
+          # above was skipped, the bucket is empty here and the test self-skips
+          # (rather than running with no ambient credentials and failing).
+          AISIX_E2E_OBJSTORE_CLOUDID_S3_BUCKET: ${{ secrets.AISIX_E2E_OIDC_AWS_ROLE_ARN != '' && secrets.AISIX_E2E_OBJSTORE_S3_BUCKET || '' }}
+          AISIX_E2E_OBJSTORE_CLOUDID_S3_REGION: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}
+          AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET: ${{ secrets.AISIX_E2E_OIDC_GCP_WIF_PROVIDER != '' && secrets.AISIX_E2E_OBJSTORE_GCS_BUCKET || '' }}
+        run: cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3_cloud_identity objstore_smoke_gcs_cloud_identity

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -1240,11 +1240,11 @@ mod smoke {
 
     #[tokio::test]
     #[ignore = "KEYLESS cloud_identity GCS round-trip — set \
-                AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET to a real bucket the runtime's \
-                AMBIENT identity can write (GKE Workload Identity / GCE metadata / \
-                GitHub-OIDC Workload Identity Federation). No service-account key: \
-                ADC is sourced with no key. cargo test -p aisix-obs -- --ignored \
-                objstore_smoke_gcs_cloud_identity"]
+                AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET on a real GKE pod with Workload \
+                Identity (or a GCE VM with an attached service account), where \
+                object_store's ADC reaches the GCE metadata server. A non-GCE runner \
+                (incl. GitHub Actions via WIF) cannot — see #573. No service-account \
+                key. cargo test -p aisix-obs -- --ignored objstore_smoke_gcs_cloud_identity"]
     async fn objstore_smoke_gcs_cloud_identity() {
         let Some(bucket) = env("AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET") else {
             eprintln!(

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -1031,7 +1031,9 @@ mod tests {
 /// `cargo test -p aisix-obs -- --ignored objstore_smoke`.
 #[cfg(test)]
 mod smoke {
-    use super::{build_object_store, ObjectStoreCredentials, ObjectStoreSink};
+    use super::{
+        build_object_store, build_object_store_ambient, ObjectStoreCredentials, ObjectStoreSink,
+    };
     use crate::sink::{EventBatch, IdempotencyMarker, ObservabilitySink, SinkRecord};
     use crate::usage::UsageEvent;
     use aisix_core::models::observability_exporter::{ObjectStoreCompression, ObjectStoreProvider};
@@ -1209,6 +1211,51 @@ mod smoke {
             },
         )
         .expect("build GCS store");
+        smoke_roundtrip(store).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "KEYLESS cloud_identity S3 round-trip — set \
+                AISIX_E2E_OBJSTORE_CLOUDID_S3_BUCKET to a real bucket the runtime's \
+                AMBIENT identity can write (EC2 instance role / EKS IRSA / \
+                GitHub-OIDC-assumed role). No static keys: from_env sources the \
+                ambient chain. cargo test -p aisix-obs -- --ignored \
+                objstore_smoke_s3_cloud_identity"]
+    async fn objstore_smoke_s3_cloud_identity() {
+        let Some(bucket) = env("AISIX_E2E_OBJSTORE_CLOUDID_S3_BUCKET") else {
+            eprintln!(
+                "objstore_smoke_s3_cloud_identity: AISIX_E2E_OBJSTORE_CLOUDID_S3_BUCKET not set — skipping"
+            );
+            return;
+        };
+        let region =
+            env("AISIX_E2E_OBJSTORE_CLOUDID_S3_REGION").unwrap_or_else(|| "us-east-1".to_string());
+        // Keyless: no credential_ref, no static keys — the ambient AWS chain
+        // (instance role / IRSA / OIDC-assumed role) is sourced by from_env.
+        let store =
+            build_object_store_ambient(ObjectStoreProvider::S3, &bucket, Some(&region), None)
+                .expect("build keyless S3 store");
+        smoke_roundtrip(store).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "KEYLESS cloud_identity GCS round-trip — set \
+                AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET to a real bucket the runtime's \
+                AMBIENT identity can write (GKE Workload Identity / GCE metadata / \
+                GitHub-OIDC Workload Identity Federation). No service-account key: \
+                ADC is sourced with no key. cargo test -p aisix-obs -- --ignored \
+                objstore_smoke_gcs_cloud_identity"]
+    async fn objstore_smoke_gcs_cloud_identity() {
+        let Some(bucket) = env("AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET") else {
+            eprintln!(
+                "objstore_smoke_gcs_cloud_identity: AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET not set — skipping"
+            );
+            return;
+        };
+        // Keyless: no service-account key — Application Default Credentials
+        // (Workload Identity / WIF) are sourced at request time.
+        let store = build_object_store_ambient(ObjectStoreProvider::Gcs, &bucket, None, None)
+            .expect("build keyless GCS store");
         smoke_roundtrip(store).await;
     }
 }


### PR DESCRIPTION
## What

The **keyless `cloud_identity`** half of #552 item 3: prove the data plane's ambient-credential builders write to **real S3 and GCS with no static keys**, the way a cloud-deployed DP authenticates via an EC2 instance role / EKS IRSA / GKE Workload Identity. The static-key `credential_ref` half landed in #569.

## Changes

**`crates/aisix-obs/src/sink/object_store.rs`** (test-only, `mod smoke`):
- `objstore_smoke_s3_cloud_identity` — keyless round-trip via `build_object_store_ambient(S3, …)`; AWS `from_env` sources the ambient chain (no static keys). Gated on `AISIX_E2E_OBJSTORE_CLOUDID_S3_BUCKET` (+ optional `_REGION`).
- `objstore_smoke_gcs_cloud_identity` — keyless round-trip via `build_object_store_ambient(Gcs, …)`; Application Default Credentials with no service-account key. Gated on `AISIX_E2E_OBJSTORE_CLOUDID_GCS_BUCKET`.
- Both reuse `smoke_roundtrip` (write → exactly one object → re-deliver → still one → clean up).

**`.github/workflows/objstore-cloud-identity.yml`** (new):
- `permissions: id-token: write` — the job mints a GitHub OIDC token to **assume an AWS IAM role** (`aws-actions/configure-aws-credentials`) and to **impersonate a GCP service account via Workload Identity Federation** (`google-github-actions/auth`). No static cloud keys touch CI.
- Gated: `workflow_dispatch` / nightly / same-repo PR labeled `objstore real cloud`. Each provider's auth step + smoke self-skips when its OIDC identifier secret is absent; a deliberate run with neither configured fails (not green) so it can't pass while testing nothing.

## OIDC setup (provisioned)

| Cloud | Identity | Secret (identifier, not a key) |
|---|---|---|
| AWS | IAM role `aisix-objstore-smoke-oidc`, trust `repo:api7/ai-gateway:*`, least-priv `s3:PutObject/GetObject/DeleteObject` + `ListBucket` on the test bucket | `AISIX_E2E_OIDC_AWS_ROLE_ARN` |
| GCP | Workload Identity Pool `github-actions` + provider `github` (restricted to `api7/ai-gateway`), impersonating the existing `objectAdmin` SA | `AISIX_E2E_OIDC_GCP_WIF_PROVIDER`, `AISIX_E2E_OIDC_GCP_SA` |

Buckets are reused from #569's secrets. **No static cloud key is stored anywhere** — only OIDC role/provider identifiers.

## Verification

`cargo fmt`, `cargo clippy -p aisix-obs --all-targets` (clean), and the two smokes self-skip + pass with no `CLOUDID` env set. The real keyless round-trips run in CI once this PR is labeled `objstore real cloud` (evidence will be posted on the PR).

Refs: #552 (item 3), #549 (DP cloud_identity), #569 (credential_ref real-cloud), #568 (DP hardening).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added ignored, environment-gated end-to-end smoke tests for cloud identity (keyless) authentication against AWS S3 and Google Cloud Storage; tests self-skip when required environment variables are unset.

* **Chores**
  * Added a CI workflow to run the cloud-identity E2E smoke tests (manual, nightly, and PR triggers). Uses GitHub OIDC for keyless AWS access and gate conditions to avoid running when configuration is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->