### PR TITLE
feat(ratelimit): team_member policy scope for per-member team defaults

### DIFF
--- a/crates/aisix-core/src/models/rate_limit_policy.rs
+++ b/crates/aisix-core/src/models/rate_limit_policy.rs
@@ -2,14 +2,18 @@
 //! under `rate_limit_policies/<uuid>`.
 //!
 //! Each policy targets a single subject via `(scope, scope_ref)`:
-//! - `api_key` — matches by API key entry ID
-//! - `model`   — matches by model entry ID
-//! - `team`    — matches by team ID on the API key
-//! - `member`  — matches by user ID on the API key
+//! - `api_key`     — matches by API key entry ID
+//! - `model`       — matches by model entry ID
+//! - `team`        — matches by team ID on the API key (one shared bucket)
+//! - `member`      — matches by user ID on the API key
+//! - `team_member` — matches by team ID, but buckets per member: every
+//!   key in the team inherits this default with its own independent
+//!   counter keyed on the API key's user ID
 //!
 //! The proxy iterates all policies on each request, converts the
 //! `window`+`max_requests`/`max_tokens` into a `RateLimit`, and
-//! reserves under `policy:<scope>:<scope_ref>:<policy_id>`.
+//! reserves under `policy:<scope>:<scope_ref>:<policy_id>` — with the
+//! member's `user_id` appended for the `team_member` scope.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -746,7 +746,7 @@ fn rate_limit_policy_schema() -> Value {
         "additionalProperties": false,
         "properties": {
             "name":         { "type": "string", "minLength": 1 },
-            "scope":        { "type": "string", "enum": ["api_key", "model", "team", "member"] },
+            "scope":        { "type": "string", "enum": ["api_key", "model", "team", "member", "team_member"] },
             "scope_ref":    { "type": "string", "minLength": 1 },
             "window":       { "type": "string", "enum": ["second", "minute", "hour"] },
             "max_requests": { "type": "integer", "minimum": 1 },

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -5,7 +5,11 @@
 //! 2. API-key inline rate limit (`auth.entry.id`)
 //! 3. Model inline rate limit (`model:<name>`) — when the resolved Model has one
 //! 4. Policy-based rate limits — looked up from the snapshot's
-//!    `rate_limit_policies` table, matched by scope (api_key/model/team/member)
+//!    `rate_limit_policies` table, matched by scope
+//!    (api_key/model/team/member/team_member). `team_member` is a
+//!    per-member default for a team: it matches every key in the team
+//!    but buckets the counter per `user_id`, so each member gets an
+//!    independent identical quota (vs. `team`, one shared bucket).
 //!
 //! All layers use AND logic — every layer must pass or the request gets
 //! 429. The returned [`MultiReservation`] commits token usage to all
@@ -101,6 +105,21 @@ fn policy_to_rate_limit(policy: &RateLimitPolicy) -> RateLimit {
     rl
 }
 
+/// Bucket key for a policy reservation. Most scopes share one counter
+/// across every key the policy matches (`policy:<scope>:<scope_ref>:<id>`).
+/// `team_member` is the exception: it appends the request's `user_id` so
+/// each member of the team counts against an independent identical bucket
+/// (LiteLLM's `{team_id}:{user_id}` shape).
+fn policy_bucket_key(policy: &RateLimitPolicy, entry_id: &str, auth: &AuthenticatedKey) -> String {
+    let base = format!("policy:{}:{}:{}", policy.scope, policy.scope_ref, entry_id);
+    if policy.scope == "team_member" {
+        if let Some(user_id) = auth.key().user_id.as_deref() {
+            return format!("{base}:{user_id}");
+        }
+    }
+    base
+}
+
 /// Reserve across all applicable rate-limit layers (api_key, model, policies).
 fn reserve_layers<'a>(
     state: &'a ProxyState,
@@ -140,6 +159,13 @@ fn reserve_layers<'a>(
             "model" => model_rl.is_some_and(|m| policy.scope_ref == m.entry_id),
             "team" => auth.key().team_id.as_deref() == Some(policy.scope_ref.as_str()),
             "member" => auth.key().user_id.as_deref() == Some(policy.scope_ref.as_str()),
+            // Per-member default for a team: matches every key whose
+            // team_id == scope_ref, but only when the key carries a
+            // user_id (the bucket is keyed per member below).
+            "team_member" => {
+                auth.key().team_id.as_deref() == Some(policy.scope_ref.as_str())
+                    && auth.key().user_id.is_some()
+            }
             _ => false,
         };
         if !applies {
@@ -149,7 +175,7 @@ fn reserve_layers<'a>(
         if rl.is_unrestricted() {
             continue;
         }
-        let bucket_key = format!("policy:{}:{}:{}", policy.scope, policy.scope_ref, entry.id);
+        let bucket_key = policy_bucket_key(policy, &entry.id, auth);
         let r = state
             .limiter
             .pre_commit(&bucket_key, &rl)
@@ -223,6 +249,61 @@ mod tests {
             "max_tokens": max_tok,
         }))
         .unwrap()
+    }
+
+    fn make_scoped_policy(scope: &str, scope_ref: &str) -> RateLimitPolicy {
+        serde_json::from_value(serde_json::json!({
+            "name": "test",
+            "scope": scope,
+            "scope_ref": scope_ref,
+            "window": "minute",
+            "max_requests": 10,
+        }))
+        .unwrap()
+    }
+
+    fn make_auth(team_id: Option<&str>, user_id: Option<&str>) -> AuthenticatedKey {
+        let key: aisix_core::ApiKey = serde_json::from_value(serde_json::json!({
+            "key_hash": "h",
+            "allowed_models": [],
+            "team_id": team_id,
+            "user_id": user_id,
+        }))
+        .unwrap();
+        AuthenticatedKey {
+            entry: std::sync::Arc::new(aisix_core::resource::ResourceEntry::new(
+                "key-entry-1",
+                key,
+                1,
+            )),
+        }
+    }
+
+    #[test]
+    fn team_member_bucket_key_is_per_user() {
+        let policy = make_scoped_policy("team_member", "team-1");
+        let auth_a = make_auth(Some("team-1"), Some("user-a"));
+        let auth_b = make_auth(Some("team-1"), Some("user-b"));
+
+        let key_a = policy_bucket_key(&policy, "pol-1", &auth_a);
+        let key_b = policy_bucket_key(&policy, "pol-1", &auth_b);
+
+        // Same team + same policy, but distinct members → distinct buckets,
+        // so member A exhausting the default never throttles member B.
+        assert_eq!(key_a, "policy:team_member:team-1:pol-1:user-a");
+        assert_eq!(key_b, "policy:team_member:team-1:pol-1:user-b");
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn team_bucket_key_is_shared_across_members() {
+        // Contrast with `team`: one bucket for the whole team regardless
+        // of which member sends the request (pooled quota).
+        let policy = make_scoped_policy("team", "team-1");
+        let key_a = policy_bucket_key(&policy, "pol-1", &make_auth(Some("team-1"), Some("user-a")));
+        let key_b = policy_bucket_key(&policy, "pol-1", &make_auth(Some("team-1"), Some("user-b")));
+        assert_eq!(key_a, "policy:team:team-1:pol-1");
+        assert_eq!(key_a, key_b);
     }
 
     #[test]

--- a/docs/configuration/rate-limits.md
+++ b/docs/configuration/rate-limits.md
@@ -57,12 +57,13 @@ Example on an API key:
 ### Policy Fields
 
 - `name`: human label (string, required).
-- `scope`: which subject the policy targets — one of `api_key`, `model`, `team`, `member` (required).
+- `scope`: which subject the policy targets — one of `api_key`, `model`, `team`, `member`, `team_member` (required).
 - `scope_ref`: the resource ID the policy applies to. Interpretation depends on `scope`:
   - `api_key` → matches when the authenticated `ApiKey` entry id equals `scope_ref`.
   - `model` → matches when the resolved `Model` entry id equals `scope_ref`.
-  - `team` → matches when the authenticated `ApiKey.team_id` equals `scope_ref`.
+  - `team` → matches when the authenticated `ApiKey.team_id` equals `scope_ref`. **One shared bucket** is pooled across every key in the team.
   - `member` → matches when the authenticated `ApiKey.user_id` equals `scope_ref`.
+  - `team_member` → matches when the authenticated `ApiKey.team_id` equals `scope_ref` (like `team`), but the counter is bucketed **per member** (`ApiKey.user_id`). One policy thus gives *every* member of the team their own independent, identical quota — a per-member default. New members inherit it automatically; no per-member policy needed.
 - `window`: `second`, `minute`, or `hour` (required).
 - `max_requests`: maximum requests allowed in the window (optional).
 - `max_tokens`: maximum tokens allowed in the window (optional).
@@ -107,7 +108,21 @@ A per-member burst limit:
 }
 ```
 
-For `scope = team` or `scope = member` to match, the authenticated `ApiKey` must carry the corresponding `team_id` or `user_id` field. Set those on the API key resource at create time.
+A per-member default — every member of a team independently capped at 1M tokens per minute:
+
+```json title="RateLimitPolicy: per-member default for a team"
+{
+  "name": "team-acme-per-member-tpm",
+  "scope": "team_member",
+  "scope_ref": "team-uuid-acme",
+  "window": "minute",
+  "max_tokens": 1000000
+}
+```
+
+Unlike `scope = team` (one shared bucket for the whole team), `team_member` gives each member their own bucket: member A exhausting the cap never throttles member B, and a member's multiple keys share one bucket (the counter keys on `user_id`).
+
+For `scope = team`, `scope = member`, or `scope = team_member` to match, the authenticated `ApiKey` must carry the corresponding `team_id` / `user_id` field. `team_member` requires **both** `team_id` (to match) and `user_id` (to bucket). Set those on the API key resource at create time.
 
 ### Provisioning
 

--- a/tests/e2e/src/cases/team-member-ratelimit-e2e.test.ts
+++ b/tests/e2e/src/cases/team-member-ratelimit-e2e.test.ts
@@ -1,0 +1,141 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a `team_member` rate-limit policy is a per-member DEFAULT for a
+// team — it matches every key whose `team_id` equals the policy's
+// `scope_ref`, but each member counts against an INDEPENDENT bucket
+// keyed by the API key's `user_id`. Contrast with `team` scope, which
+// pools one bucket across the whole team.
+//
+// With rpm=1 we assert three things:
+//   1. member A's 2nd call → 429 (their own bucket is exhausted)
+//   2. member B's 1st call → 200 (independent bucket; A doesn't throttle B)
+//   3. a SECOND key owned by member A → 429 (the bucket is per user_id,
+//      not per API key, so A can't dodge the cap by minting more keys)
+
+const TEAM_ID = "team-tm-e2e";
+const POLICY_ID = "11111111-1111-1111-1111-111111111111";
+
+const KEY_A1 = "sk-tm-a1";
+const KEY_A2 = "sk-tm-a2";
+const KEY_B = "sk-tm-b";
+
+const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
+
+describe("rate limit e2e: team_member per-member default buckets", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    const admin = new AdminClient(app.adminUrl, app.adminKey);
+    const etcd = new EtcdClient();
+
+    // Seed the policy FIRST (lower etcd revision) so that once the
+    // probe sees the model (created below, higher revision) the policy
+    // is guaranteed already applied — events arrive in revision order.
+    await etcd.put(
+      `${app.etcdPrefix}/rate_limit_policies/${POLICY_ID}`,
+      JSON.stringify({
+        name: "tm-default",
+        scope: "team_member",
+        scope_ref: TEAM_ID,
+        window: "minute",
+        max_requests: 1,
+      }),
+    );
+
+    const pk = await admin.createProviderKey({
+      display_name: "tm-e2e-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "tm-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    // Members A and B both belong to TEAM_ID; A owns two keys. The
+    // standalone Admin API omits team_id/user_id (CP writes those in
+    // production), so seed the keys straight to etcd with the full shape.
+    const seedKey = (id: string, plaintext: string, userId: string) =>
+      etcd.put(
+        `${app!.etcdPrefix}/api_keys/${id}`,
+        JSON.stringify({
+          key_hash: sha256(plaintext),
+          allowed_models: ["tm-e2e"],
+          team_id: TEAM_ID,
+          user_id: userId,
+        }),
+      );
+    await seedKey("a0000000-0000-0000-0000-000000000001", KEY_A1, "user-a");
+    await seedKey("a0000000-0000-0000-0000-000000000002", KEY_A2, "user-a");
+    await seedKey("b0000000-0000-0000-0000-000000000001", KEY_B, "user-b");
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("per-member buckets are independent and per-user, not per-key", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // listModels doesn't consume an rpm slot — safe readiness probe.
+    const probe = new ProxyClient(app.proxyUrl, KEY_A1);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "tm-e2e");
+    });
+
+    const chat = (apiKey: string) =>
+      new OpenAI({ apiKey, baseURL: `${app!.proxyUrl}/v1`, maxRetries: 0 });
+
+    const callStatus = async (apiKey: string): Promise<number> => {
+      try {
+        await chat(apiKey).chat.completions.create({
+          model: "tm-e2e",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        return 200;
+      } catch (e) {
+        if (e instanceof APIError) return e.status ?? -1;
+        throw e;
+      }
+    };
+
+    // Member A burns their single slot, then is throttled.
+    expect(await callStatus(KEY_A1)).toBe(200);
+    expect(await callStatus(KEY_A1)).toBe(429);
+
+    // Member B is on the same team + same policy but a separate bucket,
+    // so their first call still succeeds — the per-member isolation.
+    expect(await callStatus(KEY_B)).toBe(200);
+
+    // A second key owned by member A shares A's (already-exhausted)
+    // bucket → 429. Proves the counter keys on user_id, not key id.
+    expect(await callStatus(KEY_A2)).toBe(429);
+  });
+});

--- a/tests/e2e/src/cases/team-member-ratelimit-e2e.test.ts
+++ b/tests/e2e/src/cases/team-member-ratelimit-e2e.test.ts
@@ -102,12 +102,19 @@ describe("rate limit e2e: team_member per-member default buckets", () => {
     }
 
     // listModels doesn't consume an rpm slot — safe readiness probe.
-    const probe = new ProxyClient(app.proxyUrl, KEY_A1);
+    // Probe EVERY key the assertions use, not just KEY_A1: the keys are
+    // seeded at higher etcd revisions than the model, so a model+KEY_A1
+    // hit doesn't guarantee KEY_A2/KEY_B have propagated — an
+    // unpropagated key would 401 and flake the later assertions.
+    const keysToProbe = [KEY_A1, KEY_A2, KEY_B];
     await waitConfigPropagation(async () => {
-      const res = await probe.listModels();
-      if (res.status !== 200) return false;
-      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
-      return data.some((m) => m.id === "tm-e2e");
+      for (const key of keysToProbe) {
+        const res = await new ProxyClient(app.proxyUrl, key).listModels();
+        if (res.status !== 200) return false;
+        const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+        if (!data.some((m) => m.id === "tm-e2e")) return false;
+      }
+      return true;
     });
 
     const chat = (apiKey: string) =>

--- a/tests/e2e/src/harness/etcd.ts
+++ b/tests/e2e/src/harness/etcd.ts
@@ -45,6 +45,26 @@ export class EtcdClient {
     }
   }
 
+  /**
+   * Put a single key/value (etcd v3 `/v3/kv/put`). Used to seed
+   * resources the Admin API doesn't expose (e.g. rate_limit_policies),
+   * written under `<prefix>/<kind>/<id>` so the DP loader picks them up.
+   */
+  async put(key: string, value: string): Promise<void> {
+    const res = await harnessRequest(`${this.endpoint}/v3/kv/put`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        key: Buffer.from(key, "utf8").toString("base64"),
+        value: Buffer.from(value, "utf8").toString("base64"),
+      }),
+    });
+    if (res.statusCode >= 300) {
+      const body = await res.body.text();
+      throw new Error(`etcd put failed (${res.statusCode}): ${body}`);
+    }
+  }
+
   /** Delete every key under `prefix` (range delete in etcd v3 semantics). */
   async deletePrefix(prefix: string): Promise<void> {
     const key = Buffer.from(prefix, "utf8").toString("base64");


### PR DESCRIPTION
## Problem

Operators can already cap a whole team with a `team`-scoped `RateLimitPolicy` (one shared bucket pooled across the team's keys). There was no way to express "every member of this team gets their own identical quota" without creating one `member`-scoped policy per user — which doesn't scale and doesn't auto-apply to newly added members.

## What this adds

A new `team_member` policy scope. It matches every key whose `team_id == scope_ref` (same as `team`), but the rate-limit counter is bucketed **per member** (`ApiKey.user_id`). So a single policy gives each member of the team an independent, identical quota:

- member A exhausting their quota never throttles member B;
- a member's multiple keys share one bucket (the counter keys on `user_id`, not key id);
- new members inherit the default automatically — no per-member policy.

This mirrors LiteLLM's `team_member_rpm/tpm_limit` (counter key `{team_id}:{user_id}`). Enforcement stacks via AND with the existing key/model/team layers, unchanged.

## Changes

- `quota.rs`: `team_member` arm in the policy `applies` match (requires both `team_id` match and a present `user_id`), plus a `policy_bucket_key` helper that appends `user_id` only for `team_member`.
- `schema.rs`: allow `team_member` in the `rate_limit_policy` `scope` enum used at etcd load.
- `rate_limit_policy.rs` / `docs/configuration/rate-limits.md`: document the new scope.

## Tests

- Unit tests for the per-member vs shared bucket-key shapes.
- DP E2E `team-member-ratelimit-e2e`: one team, two members, two keys for member A. Asserts A's 2nd call → 429 while B's 1st call → 200 (independent buckets), and A's second key → 429 (per-user, not per-key). Adds an `etcd.put` harness helper to seed the policy + team-bound keys the standalone Admin API doesn't expose.

## Compatibility

`team_member` is just a new `scope` string value — the DP↔etcd wire is unchanged, and existing policies are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `team_member` scope for rate limit policies, enabling per-member rate limiting within teams (individual quota buckets per user).

* **Documentation**
  * Updated rate-limit docs to explain `team_member` behavior, required fields, and examples contrasting per-member vs team-wide limits.

* **Tests**
  * Added end-to-end and unit/regression tests validating per-user vs pooled team bucketing.
  * Test harness: added an etcd put helper for test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->