### PR TITLE
docs(observability): datadog credential_ref slug rule + list all exporter kinds in ops doc

### DIFF
--- a/docs/configuration/observability-exporters.md
+++ b/docs/configuration/observability-exporters.md
@@ -185,7 +185,7 @@ Sends each request event as one log to the Datadog Logs HTTP intake. The data pl
 | `content_mode` | string | No | `metadata_only` | `metadata_only` or `full`. See [Content capture](#content-capture). |
 | `content_max_bytes` | integer | No | `131072` | Per-field byte cap under `full`; minimum `1`, maximum `1048576` (1 MiB). Ignored under `metadata_only`. |
 
-The data plane resolves `credential_ref` to `DD_CRED_<SLUG>_API_KEY`, read from its local environment, where `<SLUG>` is the reference upper-cased with every character that is not an ASCII letter or digit folded to `_` (so `acme_dd` becomes `ACME_DD`).
+The data plane resolves `credential_ref` to `DD_CRED_<SLUG>_API_KEY`, read from its local environment, where `<SLUG>` is the reference upper-cased with every character that is not an ASCII letter or digit folded to `_` (so `acme_dd` becomes `ACME_DD`). To keep that mapping unambiguous — so two different references cannot silently fold onto the same variable — use only lowercase letters, digits, and underscores in `credential_ref`; the control plane and dashboard enforce `^[a-z0-9_]+$`.
 
 ```bash title="Create a datadog exporter"
 curl -sS -X POST http://127.0.0.1:3001/admin/v1/observability_exporters \

--- a/docs/operations/metrics-and-logs.md
+++ b/docs/operations/metrics-and-logs.md
@@ -78,7 +78,7 @@ Those headers are often the fastest per-request debugging hints available to a c
 
 Observability exporters are dynamic resources configured through `/admin/v1/observability_exporters`.
 
-Current exporter support is `otlp_http` only.
+Four kinds are supported — `otlp_http` (request traces), `object_store` (batched NDJSON to S3 / GCS / Azure Blob), `aliyun_sls` (Alibaba Cloud SLS logstore), and `datadog` (Datadog Logs intake). See [Observability Exporters](../configuration/observability-exporters.md) for each kind's fields, credential resolution, and destination validation.
 
 ## Operator Workflow
 


### PR DESCRIPTION
## What

Two small DP-docs accuracy fixes for observability exporters, following the now-complete Datadog feature (DP `kind=datadog` in #550; CP config + dashboard + real-chain e2e in api7/AISIX-Cloud#742 / #748).

1. **`docs/configuration/observability-exporters.md`** — the Datadog `credential_ref` paragraph described only the `DD_CRED_<SLUG>_API_KEY` slug folding. The control plane + dashboard now **enforce `^[a-z0-9_]+$`** on a datadog `credential_ref` (api7/AISIX-Cloud#742, #748), exactly as the `object_store` section already documents. Added the matching one-sentence note so an operator using e.g. `acme-dd` (hyphen) isn't surprised by a 400.
2. **`docs/operations/metrics-and-logs.md`** — the ops "Exporters" note still read *"Current exporter support is `otlp_http` only."* That has been stale since `object_store`, `aliyun_sls`, and `datadog` shipped. Now lists all four kinds and points to the reference page.

## Runbook

No change to the **Minimal Runbook** in `docs/operations/health-checks.md` — it is liveness/readiness-scoped (`livez`/`readyz`), not exporter-delivery; a Datadog section there would be out of place. Exporter delivery troubleshooting already lives in the reference page's Troubleshooting (per-kind, incl. `DD_CRED_<SLUG>_API_KEY` resolution) and the ops doc's generic exporter troubleshooting.

## Notes

- `aliyun_sls` intentionally still lacks the `^[a-z0-9_]+$` note: SLS does **not** enforce it yet (tracked in api7/AISIX-Cloud#744); its doc will gain the note when that lands.
- Docs-only; content reflects already-merged behavior, verified against the CP code and the live real-Datadog e2e.
