### PR TITLE
test(object_store): real-cloud Azure Blob credential_ref smoke

### DIFF
--- a/.github/workflows/objstore-real-cloud.yml
+++ b/.github/workflows/objstore-real-cloud.yml
@@ -1,7 +1,8 @@
 # Real-cloud object_store smoke e2e — credential_ref (static-key) write path
-# against REAL Amazon S3 and Google Cloud Storage.
+# against REAL Amazon S3, Google Cloud Storage, and Azure Blob.
 #
-# Runs the `objstore_smoke_s3` / `objstore_smoke_gcs` round-trips (write a batch
+# Runs the `objstore_smoke_s3` / `objstore_smoke_gcs` / `objstore_smoke_azure`
+# round-trips (write a batch
 # → assert exactly one object under the prefix → re-deliver the same batch →
 # assert no duplicate key → clean up) against the actual cloud APIs. These
 # complement the emulator smoke in ci.yml's unit job, which cannot exercise real
@@ -26,11 +27,18 @@
 #     AISIX_E2E_OBJSTORE_GCS_BUCKET            test bucket name
 #     AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT   the full service-account key JSON
 #                                              (paste the downloaded key as one secret)
+#   Azure Blob:
+#     AISIX_E2E_OBJSTORE_AZURE_ACCOUNT         storage account name
+#     AISIX_E2E_OBJSTORE_AZURE_ACCESS_KEY      a storage account access key
+#     AISIX_E2E_OBJSTORE_AZURE_CONTAINER       test container name
+#     (For Azurite instead of a real account, also set AISIX_E2E_OBJSTORE_AZURE_ENDPOINT.)
 #
 # Least privilege — scope the identity to the test bucket only:
-#   AWS:  s3:PutObject, s3:GetObject, s3:DeleteObject on arn:aws:s3:::<bucket>/*
-#         + s3:ListBucket on arn:aws:s3:::<bucket>
-#   GCS:  roles/storage.objectAdmin on the bucket
+#   AWS:    s3:PutObject, s3:GetObject, s3:DeleteObject on arn:aws:s3:::<bucket>/*
+#           + s3:ListBucket on arn:aws:s3:::<bucket>
+#   GCS:    roles/storage.objectAdmin on the bucket
+#   Azure:  an account key is account-wide, so use a DEDICATED test storage
+#           account (object_store's azure backend authenticates with account+key)
 #
 # See crates/aisix-obs/tests/real-cloud.env.example for a local-run template.
 name: objstore-real-cloud
@@ -52,7 +60,7 @@ concurrency:
 
 jobs:
   smoke:
-    name: objstore real-cloud smoke (S3 + GCS)
+    name: objstore real-cloud smoke (S3 + GCS + Azure)
     # Same-repo + label gate on PRs; always run on manual dispatch / schedule.
     # The explicit same-repo check is defense-in-depth: plain `pull_request`
     # withholds secrets from fork PRs by GitHub default today, but this gate
@@ -71,6 +79,10 @@ jobs:
       AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY: ${{ secrets.AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY }}
       AISIX_E2E_OBJSTORE_GCS_BUCKET: ${{ secrets.AISIX_E2E_OBJSTORE_GCS_BUCKET }}
       AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT: ${{ secrets.AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT }}
+      AISIX_E2E_OBJSTORE_AZURE_ACCOUNT: ${{ secrets.AISIX_E2E_OBJSTORE_AZURE_ACCOUNT }}
+      AISIX_E2E_OBJSTORE_AZURE_ACCESS_KEY: ${{ secrets.AISIX_E2E_OBJSTORE_AZURE_ACCESS_KEY }}
+      AISIX_E2E_OBJSTORE_AZURE_CONTAINER: ${{ secrets.AISIX_E2E_OBJSTORE_AZURE_CONTAINER }}
+      AISIX_E2E_OBJSTORE_AZURE_ENDPOINT: ${{ secrets.AISIX_E2E_OBJSTORE_AZURE_ENDPOINT }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -78,15 +90,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Report which providers are configured
         run: |
-          s3=0; gcs=0
+          s3=0; gcs=0; azure=0
           if [ -n "$AISIX_E2E_OBJSTORE_S3_BUCKET" ]; then echo "S3: configured"; s3=1; else echo "::warning::S3 secrets absent — objstore_smoke_s3 will self-skip"; fi
           if [ -n "$AISIX_E2E_OBJSTORE_GCS_BUCKET" ]; then echo "GCS: configured"; gcs=1; else echo "::warning::GCS secrets absent — objstore_smoke_gcs will self-skip"; fi
+          if [ -n "$AISIX_E2E_OBJSTORE_AZURE_ACCOUNT" ]; then echo "Azure: configured"; azure=1; else echo "::warning::Azure secrets absent — objstore_smoke_azure will self-skip"; fi
           # A manual dispatch or scheduled run is deliberate — secrets are
           # expected. Fail rather than pass green while testing nothing. PR
           # runs may legitimately have no secrets, so they still self-skip.
-          if [ "${{ github.event_name }}" != "pull_request" ] && [ "$s3" = 0 ] && [ "$gcs" = 0 ]; then
+          if [ "${{ github.event_name }}" != "pull_request" ] && [ "$s3" = 0 ] && [ "$gcs" = 0 ] && [ "$azure" = 0 ]; then
             echo "::error::No object_store real-cloud secrets configured; this ${{ github.event_name }} run would test nothing."
             exit 1
           fi
-      - name: objstore real-cloud round-trips (S3 + GCS)
-        run: cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3 objstore_smoke_gcs
+      - name: objstore real-cloud round-trips (S3 + GCS + Azure)
+        run: cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3 objstore_smoke_gcs objstore_smoke_azure

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -1157,12 +1157,11 @@ mod smoke {
     }
 
     #[tokio::test]
-    #[ignore = "hits a real Azure Blob emulator (Azurite). \
+    #[ignore = "hits a real Azure Blob account (or the Azurite emulator). \
                 Run with AISIX_E2E_OBJSTORE_AZURE_* set; \
                 cargo test -p aisix-obs -- --ignored objstore_smoke_azure"]
     async fn objstore_smoke_azure_roundtrip() {
-        let (Some(endpoint), Some(container), Some(account), Some(access_key)) = (
-            env("AISIX_E2E_OBJSTORE_AZURE_ENDPOINT"),
+        let (Some(container), Some(account), Some(access_key)) = (
             env("AISIX_E2E_OBJSTORE_AZURE_CONTAINER"),
             env("AISIX_E2E_OBJSTORE_AZURE_ACCOUNT"),
             env("AISIX_E2E_OBJSTORE_AZURE_ACCESS_KEY"),
@@ -1170,11 +1169,15 @@ mod smoke {
             eprintln!("objstore_smoke_azure: AISIX_E2E_OBJSTORE_AZURE_* not set — skipping");
             return;
         };
+        // endpoint optional: set it for the Azurite emulator
+        // (http://127.0.0.1:10000/devstoreaccount1); omit it for a real Azure
+        // account, where the builder derives https://<account>.blob.core.windows.net.
+        let endpoint = env("AISIX_E2E_OBJSTORE_AZURE_ENDPOINT");
         let store = build_object_store(
             ObjectStoreProvider::AzureBlob,
             &container,
             None,
-            Some(&endpoint),
+            endpoint.as_deref(),
             ObjectStoreCredentials::Azure {
                 account,
                 access_key,

--- a/crates/aisix-obs/tests/real-cloud.env.example
+++ b/crates/aisix-obs/tests/real-cloud.env.example
@@ -2,7 +2,7 @@
 # storage (the credential_ref / static-key path). Copy to a gitignored file,
 # fill in real values, then:
 #   set -a; source crates/aisix-obs/tests/real-cloud.env; set +a
-#   cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3 objstore_smoke_gcs
+#   cargo test -p aisix-obs -- --ignored --nocapture objstore_smoke_s3 objstore_smoke_gcs objstore_smoke_azure
 #
 # In CI these same names are repository secrets — see
 # .github/workflows/objstore-real-cloud.yml. DO NOT commit a filled-in copy;
@@ -25,3 +25,11 @@ AISIX_E2E_OBJSTORE_S3_SECRET_ACCESS_KEY=your-secret-access-key
 # the full downloaded key JSON, single-quoted (it contains commas):
 AISIX_E2E_OBJSTORE_GCS_BUCKET=your-aisix-smoke-bucket
 AISIX_E2E_OBJSTORE_GCS_SERVICE_ACCOUNT='{"type":"service_account","project_id":"your-project","private_key_id":"...","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n","client_email":"aisix-smoke@your-project.iam.gserviceaccount.com","client_id":"...","token_uri":"https://oauth2.googleapis.com/token"}'
+
+# ── Azure Blob ──
+# An account key is account-wide, so use a DEDICATED test storage account.
+# (For the Azurite emulator instead, also set AISIX_E2E_OBJSTORE_AZURE_ENDPOINT
+#  to http://127.0.0.1:10000/devstoreaccount1.)
+AISIX_E2E_OBJSTORE_AZURE_ACCOUNT=youraisixsmokeacct
+AISIX_E2E_OBJSTORE_AZURE_ACCESS_KEY=your-account-access-key
+AISIX_E2E_OBJSTORE_AZURE_CONTAINER=aisix-smoke


### PR DESCRIPTION
## What

Adds **real Azure Blob** to the credential_ref real-cloud smoke. The gated `objstore-real-cloud` workflow already ran S3 + GCS (#569); Azure was out of that scope. Now all three providers run against the real cloud APIs.

## Changes

- **`crates/aisix-obs/src/sink/object_store.rs`** (`mod smoke`): `objstore_smoke_azure_roundtrip` — `endpoint` is now **optional**. Omit it for a real Azure account (the `MicrosoftAzureBuilder` derives `https://<account>.blob.core.windows.net` from the account name); set it for the Azurite emulator. Requires only `account` + `access_key` + `container`. (Mirrors the native-cloud tweak #569 made for S3.)
- **`.github/workflows/objstore-real-cloud.yml`**: the gated job now runs `objstore_smoke_azure` too. Adds the three `AISIX_E2E_OBJSTORE_AZURE_{ACCOUNT,ACCESS_KEY,CONTAINER}` secrets, an Azure preflight `::warning`, and counts Azure in the "deliberate run with nothing configured → fail" guard. Azure self-skips when its secrets are absent.
- **`crates/aisix-obs/tests/real-cloud.env.example`**: Azure block added.

## Verification

Provisioned a dedicated real Azure storage account + container and ran the smoke locally with no `endpoint` (derived from the account):

```
test sink::object_store::smoke::objstore_smoke_azure_roundtrip ... ok   (1 passed, 3.66s)
```

That is the full observable contract against live Azure — real shared-key auth + PUT/LIST/DELETE (write a batch → exactly one object → re-deliver → still one → clean up). `cargo fmt`, `cargo clippy -p aisix-obs --all-targets` clean; the smoke self-skips + passes with no Azure env set. The real round-trip runs in CI once this PR is labeled `objstore real cloud` (evidence to be posted).

## Notes

- **Least privilege**: an Azure account key is account-wide, so a **dedicated test storage account** is used (the product's azure backend authenticates with account + key — `ObjectStoreCredentials::Azure`).
- **Azure `cloud_identity` is intentionally not covered** — the product rejects keyless Azure (`build_object_store_ambient` returns a permanent error for `azure_blob`; managed identity needs a non-secret account name the keyless config doesn't carry). So Azure has only the credential_ref path.

Refs: #569 (S3+GCS real-cloud), #552, AISIX-Cloud#724.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded cloud storage smoke tests to include Azure Blob Storage support.
  * Added capability to test with both real Azure accounts and Azurite emulator.

* **Chores**
  * Updated CI/CD workflows to validate Azure Blob Storage configuration alongside existing S3 and GCS providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->