### PR TITLE
feat(obs): dedicated metrics listener so a managed DP exposes /metrics

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,6 +54,13 @@ observability:
     prometheus:
       enabled: true
       path: "/metrics"
+      # Optional: serve `/metrics` on a dedicated listener instead of
+      # relying on the admin listener. Set this when the admin surface is
+      # private but you still want Prometheus to scrape, or to keep the
+      # scrape port separate from the data path. Required for managed-mode
+      # DPs (the admin listener is not bound there). Unset = `/metrics`
+      # stays on the admin listener.
+      # addr: "0.0.0.0:9090"
     otlp:
       enabled: false
       endpoint: "http://127.0.0.1:4317"

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -53,6 +53,12 @@ observability:
     prometheus:
       enabled: true
       path: "/metrics"
+      # Dedicated metrics listener. Managed mode never binds the admin
+      # listener that otherwise hosts `/metrics`, so this is what makes a
+      # managed DP scrapeable. Bound by default here (no control-plane
+      # change needed); expose this port in your deployment and point
+      # Prometheus at it. Override with AISIX_OBSERVABILITY__METRICS__PROMETHEUS__ADDR.
+      addr: "0.0.0.0:9090"
     otlp:
       enabled: false
   tracing:

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -53,8 +53,11 @@ pub use etcd_store::EtcdConfigStore;
 pub use state::AdminState;
 pub use store::{ConfigStore, InMemoryStore, StoreError};
 
+use aisix_core::config::PrometheusConfig;
+use aisix_obs::Metrics;
 use axum::routing::{get, post};
 use axum::{http::StatusCode, response::Response, Router};
+use std::sync::Arc;
 
 pub fn build_router(state: AdminState) -> Router {
     // Eagerly build the merged OpenAPI doc so any panic in schema
@@ -159,6 +162,44 @@ pub fn build_router(state: AdminState) -> Router {
     }
 
     router.with_state(state)
+}
+
+/// Build a minimal router for a **dedicated** Prometheus metrics
+/// listener — only the scrape endpoint at `prometheus.path`, backed by
+/// the shared [`Metrics`] handle. No admin state, no auth-protected
+/// routes, no playground.
+///
+/// `aisix-server` binds this on `observability.metrics.prometheus.addr`
+/// when that address is set. It exists because managed-mode DPs never
+/// bind the admin listener that normally hosts `/metrics`, so a separate
+/// listener is the only way they can be scraped. When the address is
+/// unset the gateway keeps `/metrics` on the admin listener and this
+/// router is not built.
+pub fn metrics_router(metrics: Arc<Metrics>, prometheus: &PrometheusConfig) -> Router {
+    Router::new()
+        .route(
+            &normalized_prometheus_path(&prometheus.path),
+            get(dedicated_metrics_handler),
+        )
+        .with_state(metrics)
+}
+
+/// Prometheus scrape handler for the dedicated metrics listener. The
+/// recorder is always present here (the handle is a required argument,
+/// unlike the admin variant's optional one), so there is no 503 branch.
+/// Emits `text/plain; version=0.0.4`.
+async fn dedicated_metrics_handler(
+    axum::extract::State(metrics): axum::extract::State<Arc<Metrics>>,
+) -> Response {
+    use axum::http::header::CONTENT_TYPE;
+    use axum::response::IntoResponse;
+
+    (
+        StatusCode::OK,
+        [(CONTENT_TYPE, "text/plain; version=0.0.4")],
+        metrics.render(),
+    )
+        .into_response()
 }
 
 fn normalized_prometheus_path(path: &str) -> String {
@@ -368,6 +409,7 @@ mod tests {
             .with_prometheus_config(PrometheusConfig {
                 enabled: true,
                 path: "/internal/prom".into(),
+                addr: None,
             });
         let app = build_router(state);
 
@@ -402,6 +444,7 @@ mod tests {
             .with_prometheus_config(PrometheusConfig {
                 enabled: true,
                 path: "internal/prom".into(),
+                addr: None,
             });
         let app = build_router(state);
 
@@ -426,6 +469,7 @@ mod tests {
             .with_prometheus_config(PrometheusConfig {
                 enabled: false,
                 path: "/metrics".into(),
+                addr: None,
             });
         let app = build_router(state);
         let req = Request::builder()
@@ -433,6 +477,102 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn dedicated_metrics_router_serves_scrape_decoupled_from_admin() {
+        use aisix_obs::{Metrics, RequestOutcome};
+        use std::time::Duration;
+
+        let metrics = Arc::new(Metrics::new(false));
+        metrics.record_request(
+            "openai",
+            "my-gpt4",
+            200,
+            RequestOutcome::Success,
+            Duration::from_millis(10),
+        );
+
+        let app = metrics_router(
+            metrics,
+            &PrometheusConfig {
+                enabled: true,
+                path: "/metrics".into(),
+                addr: Some("0.0.0.0:9090".into()),
+            },
+        );
+
+        // The dedicated listener serves the prometheus scrape.
+        let resp = run(
+            app.clone(),
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.starts_with("text/plain"),
+            "unexpected content-type: {ct}"
+        );
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(body.contains("aisix_requests_total"));
+        assert!(body.contains("provider=\"openai\""));
+
+        // It carries ONLY metrics — admin routes are not mounted on this
+        // listener, proving the scrape surface is decoupled from admin.
+        let resp = run(
+            app,
+            Request::builder()
+                .uri("/admin/v1/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn dedicated_metrics_router_honors_custom_path() {
+        use aisix_obs::Metrics;
+
+        let app = metrics_router(
+            Arc::new(Metrics::new(false)),
+            &PrometheusConfig {
+                enabled: true,
+                path: "internal/prom".into(),
+                addr: Some("0.0.0.0:9090".into()),
+            },
+        );
+
+        // Path is normalized to a leading slash and served there.
+        let resp = run(
+            app.clone(),
+            Request::builder()
+                .uri("/internal/prom")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // The default `/metrics` is not mounted when a custom path is set.
+        let resp = run(
+            app,
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -458,6 +458,22 @@ pub struct MetricsConfig {
 pub struct PrometheusConfig {
     pub enabled: bool,
     pub path: String,
+    /// Optional bind address for a **dedicated** metrics listener
+    /// (e.g. `0.0.0.0:9090`). When set, the gateway serves `path` on
+    /// its own listener — separate from the admin listener that
+    /// normally hosts `/metrics`.
+    ///
+    /// This is what lets a managed-mode DP be scraped at all: managed
+    /// mode never binds the admin listener (`ManagedConfig::is_managed`),
+    /// so without a dedicated address `/metrics` is configured but
+    /// stranded on a listener that never comes up. The baked-in
+    /// `config.managed.yaml` sets this so managed DPs expose metrics by
+    /// default with no control-plane change.
+    ///
+    /// Unset (the default) keeps `/metrics` on the admin listener only,
+    /// preserving the prior behavior for self-hosted deployments.
+    #[serde(default)]
+    pub addr: Option<String>,
 }
 
 impl Default for PrometheusConfig {
@@ -465,6 +481,7 @@ impl Default for PrometheusConfig {
         Self {
             enabled: true,
             path: "/metrics".into(),
+            addr: None,
         }
     }
 }
@@ -628,6 +645,16 @@ impl Config {
                 "proxy.real_ip.trusted_proxies invalid CIDR/IP: {bad}"
             )));
         }
+        // Dedicated metrics listener address, when configured, must be a
+        // bindable socket address. Unset keeps `/metrics` on the admin
+        // listener (no dedicated listener), so only validate when present.
+        if let Some(addr) = self.observability.metrics.prometheus.addr.as_deref() {
+            if addr.parse::<std::net::SocketAddr>().is_err() {
+                return Err(BootstrapError::Config(format!(
+                    "observability.metrics.prometheus.addr invalid socket address: {addr}"
+                )));
+            }
+        }
         Ok(())
     }
 }
@@ -661,6 +688,9 @@ admin:
         assert_eq!(cfg.etcd.endpoints, vec!["http://127.0.0.1:2379"]);
         assert_eq!(cfg.proxy.request_body_limit_bytes, 10 * 1024 * 1024);
         assert!(cfg.observability.metrics.prometheus.enabled);
+        // No dedicated metrics listener unless an addr is set — `/metrics`
+        // stays on the admin listener for self-hosted deployments.
+        assert!(cfg.observability.metrics.prometheus.addr.is_none());
         assert_eq!(cfg.cache.backend, CacheBackend::Memory);
         // real_ip defaults: trust nothing, non-recursive, x-forwarded-for.
         assert!(cfg.proxy.real_ip.trusted_proxies.is_empty());
@@ -766,6 +796,61 @@ admin:
         );
         let err = Config::load_from_path(Some(f.path())).unwrap_err();
         assert!(err.to_string().contains("proxy.addr"));
+    }
+
+    #[test]
+    fn parses_prometheus_addr_for_dedicated_listener() {
+        // A dedicated metrics listener address parses and round-trips.
+        // This is the managed-mode shape: `/metrics` is served on its
+        // own bound listener because the admin listener is never bound.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+observability:
+  metrics:
+    prometheus:
+      enabled: true
+      path: "/metrics"
+      addr: "0.0.0.0:9090"
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(
+            cfg.observability.metrics.prometheus.addr.as_deref(),
+            Some("0.0.0.0:9090"),
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_prometheus_addr() {
+        // A malformed dedicated-listener address must fail validation at
+        // boot, not at bind time — operators get a clear config error.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+observability:
+  metrics:
+    prometheus:
+      addr: "not-a-socket-addr"
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(
+            err.to_string().contains("prometheus.addr"),
+            "error should name the bad field: {err}"
+        );
     }
 
     #[test]

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -854,6 +854,28 @@ observability:
     }
 
     #[test]
+    fn shipped_managed_config_binds_a_dedicated_metrics_listener() {
+        // The baked managed-image config (`config.managed.yaml`) is the
+        // entire "no control-plane change" lever: a managed DP exposes
+        // `/metrics` only because this file binds a dedicated listener
+        // while the admin listener stays the unbindable sentinel. A typo
+        // here would silently un-scrape every managed DP — that file is
+        // only COPYd into the image, so nothing else catches it. Pin it.
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config.managed.yaml");
+        let cfg =
+            Config::load_from_path(Some(Path::new(path))).expect("config.managed.yaml must load");
+        assert!(cfg.managed.is_managed());
+        assert_eq!(
+            cfg.observability.metrics.prometheus.addr.as_deref(),
+            Some("0.0.0.0:9090"),
+            "managed DPs must bind a dedicated metrics listener so they can be scraped",
+        );
+        // Admin is the unbindable sentinel, so the dedicated listener is
+        // the only metrics surface in managed mode.
+        assert_eq!(cfg.admin.addr, "127.0.0.1:0");
+    }
+
+    #[test]
     fn rejects_unknown_fields() {
         let f = write_yaml(
             r#"

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -8,8 +8,8 @@
 //!  5. Bootstrap initial snapshot
 //!  6. Spawn watch supervisor
 //!  7. Build proxy router
-//!  8. Build admin router
-//!  9. Bind + serve both ports (tokio::select! with shutdown signal)
+//!  8. Build admin router (+ dedicated metrics listener when configured)
+//!  9. Bind + serve the ports (tokio::select! with shutdown signal)
 //! 10. On SIGINT/SIGTERM: cancel supervisor, stop accepting, join
 
 use std::error::Error as StdError;
@@ -521,6 +521,31 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         None
     };
 
+    // Dedicated metrics listener. The admin listener that normally hosts
+    // `/metrics` is never bound in managed mode, so a managed DP can only
+    // be scraped through a separate listener. Bound whenever
+    // `observability.metrics.prometheus.addr` is set — `config.managed.yaml`
+    // sets it by default (no control-plane change needed); self-hosted
+    // deployments keep `/metrics` on the admin listener unless they opt in
+    // by setting the address. Shares the same `metrics` handle as the proxy
+    // and admin surfaces, so one scrape reflects all request paths.
+    let metrics_serve_handle = {
+        let prom = &cfg.observability.metrics.prometheus;
+        if let (true, Some(addr)) = (prom.enabled, prom.addr.as_deref()) {
+            let metrics_addr: std::net::SocketAddr = addr.parse()?;
+            let metrics_router = aisix_admin::metrics_router(metrics.clone(), prom);
+            Some(tokio::spawn(serve_http(
+                metrics_addr,
+                metrics_router,
+                None,
+                cancel_rx.clone(),
+                "metrics",
+            )))
+        } else {
+            None
+        }
+    };
+
     // Step 9: bind + serve the proxy (always). Admin is handled above.
     let proxy_addr: std::net::SocketAddr = cfg.proxy.addr.parse()?;
     let proxy_tls = cfg.proxy.tls.clone();
@@ -544,6 +569,13 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             Ok(Ok(())) => {}
             Ok(Err(e)) => return Err(anyhow::anyhow!("admin serve error: {e}")),
             Err(e) => return Err(anyhow::anyhow!("admin task join error: {e}")),
+        }
+    }
+    if let Some(handle) = metrics_serve_handle {
+        match handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(anyhow::anyhow!("metrics serve error: {e}")),
+            Err(e) => return Err(anyhow::anyhow!("metrics task join error: {e}")),
         }
     }
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -533,6 +533,16 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         let prom = &cfg.observability.metrics.prometheus;
         if let (true, Some(addr)) = (prom.enabled, prom.addr.as_deref()) {
             let metrics_addr: std::net::SocketAddr = addr.parse()?;
+            // Fail boot loudly if the metrics port is unavailable, rather
+            // than silently serving no metrics until shutdown — the
+            // listener is spawned and only joined post-shutdown, so a
+            // swallowed bind error would leave the gateway looking healthy
+            // while every scrape gets connection-refused (the exact
+            // observability gap this listener exists to close). `serve_http`
+            // re-binds; the brief gap before re-bind is benign for a boot
+            // probe.
+            std::net::TcpListener::bind(metrics_addr)
+                .map_err(|e| anyhow::anyhow!("metrics listener bind {metrics_addr} failed: {e}"))?;
             let metrics_router = aisix_admin::metrics_router(metrics.clone(), prom);
             Some(tokio::spawn(serve_http(
                 metrics_addr,

--- a/docs/operations/metrics-and-logs.md
+++ b/docs/operations/metrics-and-logs.md
@@ -10,9 +10,9 @@ Use them together. No single signal tells the whole story.
 
 ## Metrics
 
-`GET /metrics` on the admin listener is the default Prometheus scrape endpoint. Operators can change it with `observability.metrics.prometheus.path`, or disable the endpoint with `observability.metrics.prometheus.enabled: false`.
+`GET /metrics` is the Prometheus scrape endpoint. By default it is served on the admin listener. You can change the path with `observability.metrics.prometheus.path`, disable it with `observability.metrics.prometheus.enabled: false`, or serve it on a **dedicated listener** with `observability.metrics.prometheus.addr` (for example `0.0.0.0:9090`). A dedicated listener is what lets you scrape a Cloud managed data plane — see [Managed data plane metrics](#managed-data-plane-metrics).
 
-This endpoint is unauthenticated by design on the private admin listener.
+This endpoint is unauthenticated by design. Keep it on a private listener and restrict access at the network layer (firewall, security group, or Kubernetes NetworkPolicy).
 
 Treat `/metrics` as infrastructure-facing, not as a public diagnostics surface.
 
@@ -22,9 +22,51 @@ Metric families are registered lazily on first observation — the gateway does 
 
 ### Managed Data Plane Metrics
 
-The `/metrics` endpoint lives on the **admin listener**, which a Cloud managed data plane does not bind. So a managed DP does **not** expose `/metrics` for local scraping.
+The `/metrics` endpoint is served on the **admin listener**, which a Cloud managed data plane does not bind. A managed DP therefore exposes metrics on a **dedicated metrics listener** instead, configured by `observability.metrics.prometheus.addr`. The managed image binds this on `0.0.0.0:9090` by default, so **no control-plane configuration is required** — you scrape it directly with your own Prometheus, from inside the data plane's network.
 
-To get metrics off a managed data plane into your own Prometheus/OTLP stack, configure an OTLP exporter through the AISIX Cloud control plane (the same `otlp_http` exporter resource described below). The data plane fans metrics/telemetry out to the configured collector rather than waiting to be scraped. Self-hosted standalone deployments keep using local `/metrics` scraping as usual.
+To scrape a managed data plane (or any deployment with a dedicated listener):
+
+1. **Expose the metrics port** in your data plane deployment. The proxy and admin ports are unaffected — only the metrics port needs to be reachable by your Prometheus.
+
+   Docker:
+
+   ```bash
+   docker run ... -p 9090:9090 <aisix-dp-image>
+   ```
+
+   Kubernetes — add the port to the container and a `Service`:
+
+   ```yaml
+   ports:
+     - { name: metrics, containerPort: 9090 }
+   ```
+
+2. **Point Prometheus at it.** A static scrape config:
+
+   ```yaml
+   scrape_configs:
+     - job_name: aisix-data-plane
+       metrics_path: /metrics
+       static_configs:
+         - targets: ["<data-plane-host>:9090"]
+   ```
+
+   Or, with the Prometheus Operator, a `ServiceMonitor`:
+
+   ```yaml
+   apiVersion: monitoring.coreos.com/v1
+   kind: ServiceMonitor
+   metadata:
+     name: aisix-data-plane
+   spec:
+     selector:
+       matchLabels: { app: aisix-dp }
+     endpoints:
+       - port: metrics
+         path: /metrics
+   ```
+
+Restrict access to the metrics port at the network layer — it is unauthenticated, like every Prometheus exporter. Self-hosted standalone deployments can keep scraping `/metrics` on the admin listener, or set `addr` to move it onto a dedicated listener too.
 
 AISIX exposes native metric names with the `aisix_` prefix. Existing compatibility series remain:
 

--- a/docs/operations/metrics-and-logs.md
+++ b/docs/operations/metrics-and-logs.md
@@ -66,7 +66,7 @@ To scrape a managed data plane (or any deployment with a dedicated listener):
          path: /metrics
    ```
 
-Restrict access to the metrics port at the network layer — it is unauthenticated, like every Prometheus exporter. Self-hosted standalone deployments can keep scraping `/metrics` on the admin listener, or set `addr` to move it onto a dedicated listener too.
+Restrict access to the metrics port at the network layer — it is unauthenticated, like every Prometheus exporter. Self-hosted standalone deployments can keep scraping `/metrics` on the admin listener, or set `addr` to also expose it on a dedicated listener.
 
 AISIX exposes native metric names with the `aisix_` prefix. Existing compatibility series remain:
 

--- a/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
@@ -195,6 +195,71 @@ describe("prometheus metrics e2e", () => {
       await disabledApp.exit();
     }
   });
+
+  // Issue #580: a managed DP never binds the admin listener that hosts
+  // `/metrics`, so the scrape surface must be available on a dedicated
+  // listener bound from `observability.metrics.prometheus.addr`. This
+  // pins the mechanism end-to-end: a separate port (distinct from admin)
+  // serves the AISIX-native series after real proxy traffic, and that
+  // listener carries ONLY metrics — no admin routes leak onto it.
+  test("dedicated metrics listener serves scrape on its own port", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+
+    const dedicatedUpstream = await startOpenAiUpstream({
+      nonStreamBody: responseBody(),
+    });
+    const dedicatedApp = await spawnApp({ metricsListener: true });
+    try {
+      expect(dedicatedApp.metricsUrl).toBeDefined();
+      const metricsUrl = dedicatedApp.metricsUrl as string;
+      // The dedicated listener is a different port from the admin listener.
+      expect(metricsUrl).not.toBe(dedicatedApp.adminUrl);
+
+      const dedicatedAdmin = new AdminClient(
+        dedicatedApp.adminUrl,
+        dedicatedApp.adminKey,
+      );
+      await configureOpenAi(
+        dedicatedAdmin,
+        dedicatedUpstream,
+        "prometheus-dedicated-gpt",
+      );
+      const proxy = new ProxyClient(dedicatedApp.proxyUrl, CALLER_PLAINTEXT);
+      await waitConfigPropagation(async () => {
+        const probe = await proxy.chat({
+          model: "prometheus-dedicated-gpt",
+          messages: [{ role: "user", content: "ready" }],
+        });
+        return probe.status === 200;
+      });
+
+      const { status, body } = await proxy.chat({
+        model: "prometheus-dedicated-gpt",
+        messages: [{ role: "user", content: "metrics" }],
+      });
+      expect(status, JSON.stringify(body)).toBe(200);
+
+      const scrape = await fetch(`${metricsUrl}/metrics`);
+      expect(scrape.status).toBe(200);
+      const text = await scrape.text();
+      expect(text).toContain("aisix_proxy_requests_total");
+      expect(text).toContain("aisix_llm_total_tokens_total");
+      expect(text).toMatch(
+        /aisix_proxy_requests_total\{[^}]*model="prometheus-dedicated-gpt"/,
+      );
+
+      // The dedicated listener carries ONLY metrics — admin routes are not
+      // mounted there, proving the scrape surface is decoupled from admin.
+      const adminProbe = await fetch(`${metricsUrl}/admin/v1/health`);
+      expect(adminProbe.status).toBe(404);
+    } finally {
+      await dedicatedApp.exit();
+      await dedicatedUpstream.close();
+    }
+  });
 });
 
 function responseBody() {

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -16,6 +16,13 @@ export interface AppOverrides {
   prometheus?: boolean;
   /** Prometheus scrape path. Defaults to `/metrics`. */
   prometheusPath?: string;
+  /**
+   * Bind `/metrics` on a dedicated listener (its own free port) instead
+   * of only the admin listener. Mirrors how a managed DP is scraped —
+   * the admin listener is not the scrape surface. When set, `metricsUrl`
+   * on the returned handle points at that listener.
+   */
+  metricsListener?: boolean;
   /** Extra raw config keys merged into the YAML at the top level. */
   extra?: Record<string, unknown>;
   /**
@@ -43,6 +50,8 @@ export interface SpawnedApp {
   adminUrl: string;
   adminKey: string;
   etcdPrefix: string;
+  /** Dedicated metrics listener URL — set only when `metricsListener` was requested. */
+  metricsUrl?: string;
   signal(signal: NodeJS.Signals): void;
   exit(): Promise<void>;
 }
@@ -68,7 +77,10 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
     );
   }
 
-  const [proxyPort, adminPort] = await pickFreePorts(2);
+  const wantMetricsListener = overrides.metricsListener ?? false;
+  const [proxyPort, adminPort, metricsPort] = await pickFreePorts(
+    wantMetricsListener ? 3 : 2,
+  );
   const adminKey = overrides.adminKey ?? `admin-${randomUUID()}`;
   const etcdPrefix = `/aisix-e2e-${randomUUID()}`;
 
@@ -93,6 +105,7 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
         prometheus: {
           enabled: overrides.prometheus ?? true,
           path: overrides.prometheusPath ?? "/metrics",
+          ...(wantMetricsListener ? { addr: `127.0.0.1:${metricsPort}` } : {}),
         },
         otlp: { enabled: false, endpoint: "http://127.0.0.1:4317" },
       },
@@ -149,6 +162,9 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
 
   const proxyUrl = `http://127.0.0.1:${proxyPort}`;
   const adminUrl = `http://127.0.0.1:${adminPort}`;
+  const metricsUrl = wantMetricsListener
+    ? `http://127.0.0.1:${metricsPort}`
+    : undefined;
 
   try {
     await Promise.all([
@@ -170,6 +186,7 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
     adminUrl,
     adminKey,
     etcdPrefix,
+    metricsUrl,
     signal(signal: NodeJS.Signals) {
       if (child.exitCode === null) child.kill(signal);
     },

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -170,6 +170,16 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
     await Promise.all([
       waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
       waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey),
+      // Gate on the dedicated metrics listener too, so scrapes in the test
+      // never race the listener coming up.
+      ...(metricsUrl
+        ? [
+            waitForReady(
+              `${metricsUrl}${overrides.prometheusPath ?? "/metrics"}`,
+              READY_TIMEOUT_MS,
+            ),
+          ]
+        : []),
     ]);
   } catch (err) {
     const detail = exitErr ?? "still running";


### PR DESCRIPTION
## What

Adds an optional dedicated Prometheus metrics listener so a **managed data plane can be scraped**, and corrects the observability doc that claimed managed DPs export metrics via OTLP.

Closes #580.

## Why

Today a managed DP has no usable Prometheus egress:

- `GET /metrics` is registered only on the **admin listener**, but managed mode never binds it (`config.managed.yaml` pins admin to `127.0.0.1:0`; `AdminConfig` comments it as "never bound"). The endpoint is configured (`prometheus.enabled: true`) but **stranded on a listener that never comes up**.
- There is **no metrics-push pipeline** as a fallback: `aisix-obs` exports only the tracer; the `otlp_http` sink emits traces (`resourceSpans`/`scopeSpans`) — no `MeterProvider`/exporter anywhere. So `docs/operations/metrics-and-logs.md`'s "managed exports metrics via OTLP" was inaccurate.

Topology: the DP runs in the customer's own network, outbound-only; the CP can't reach it, and each DP is single-customer. So the right model is **the customer scrapes the DP locally** — not a CP relay.

## What changed

- **`PrometheusConfig.addr: Option<String>`** (`aisix-core`) — optional dedicated metrics-listener bind address, env-overridable via `AISIX_OBSERVABILITY__METRICS__PROMETHEUS__ADDR`. Validated as a socket address at boot.
- **`aisix_admin::metrics_router`** — a minimal, admin-decoupled router carrying only the scrape endpoint, backed by the shared `Metrics` handle.
- **`aisix-server`** binds it via the existing `serve_http` when `enabled && addr.is_some()`, joined on shutdown in lockstep with proxy/admin.
- **`config.managed.yaml`** sets `addr: "0.0.0.0:9090"` — this is the entire "no control-plane change" lever: managed DPs expose metrics by default.
- **Docs** — corrected the managed section + added a scrape guide (port exposure, `scrape_config`, `ServiceMonitor`).

### Does the CP / dashboard need any change? — No

A managed DP's bootstrap config comes from the CP install snippet (baked `config.managed.yaml` + `AISIX_*` env). The listener is **bootstrap config, not a CP-delivered dynamic resource**. With the default bind in `config.managed.yaml`, the customer only: upgrades the DP image, exposes the metrics port in their own deployment, and points their Prometheus at it.

## Behavior / compatibility

- `addr` unset (default, self-hosted): **unchanged** — `/metrics` stays on the admin listener.
- `addr` set: dedicated listener serves the scrape; in managed mode that's the only metrics surface (admin isn't bound).
- Unauthenticated by design, like every Prometheus exporter — documented to restrict at the network layer. Auth/TLS on the metrics port are deliberately **out of scope** here (deferred; the existing admin `/metrics` is also unauthenticated). Not a regression.

## The contract this pins

A dedicated listener bound from `prometheus.addr` serves the AISIX-native series (`aisix_*`) on its own port, **decoupled from admin** (no admin routes leak onto it), reflecting real proxy traffic.

## Testing

- **Unit** — `aisix-core`: `addr` parses/round-trips + invalid addr rejected at boot. `aisix-admin`: `metrics_router` serves the scrape, honors a custom path, and 404s admin routes (decoupling).
- **e2e** (`prometheus-metrics-e2e.test.ts`, real etcd + real proxy) — new `spawnApp({ metricsListener: true })` test: drives a chat, scrapes the dedicated port, asserts `aisix_proxy_requests_total{...model=...}` + `aisix_llm_total_tokens_total`, asserts the port ≠ admin and `/admin/v1/health` → 404 there. **5/5 pass** locally; existing 4 unchanged.
- `cargo fmt` clean · `cargo clippy -D warnings` clean · core 233 / admin 69 / server 50 green.

## Out of scope

- Dashboard UI (none needed).
- OTLP `/v1/metrics` metrics push (separate, optional).
- Auth/TLS on the metrics port (deferred; network-layer restriction documented).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional dedicated Prometheus metrics listener configurable via observability.metrics.prometheus.addr; managed deployments default to 0.0.0.0:9090.

* **Documentation**
  * Updated observability guide with dedicated-listener setup, Kubernetes/Docker examples, and network-restriction guidance.

* **Tests**
  * Added end-to-end tests verifying dedicated metrics listener serves scrape data and is isolated from admin endpoints.

* **Bug Fixes**
  * Config now validates the metrics listener address at startup and fails on malformed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->