### PR TITLE
feat(proxy): model-level client-IP CIDR access restriction (#557)

### DIFF
--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -269,6 +269,17 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<RateLimit>,
 
+    /// Client-IP allowlist in CIDR notation (IPv4/IPv6). Applies to both
+    /// direct and routing models — the gate binds to whichever model the
+    /// client names, so a Model Group can be IP-restricted too. Absent or
+    /// empty = no restriction (all clients allowed). When non-empty, a request
+    /// whose resolved client IP falls outside every range is rejected with 403
+    /// before the request is dispatched upstream (api7/AISIX-Cloud#557). The
+    /// resolved client IP honours the gateway's `proxy.real_ip` trusted-proxy
+    /// config (X-Forwarded-For), so the check works behind a load balancer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_cidrs: Option<Vec<String>>,
+
     /// Virtual-router config. When set, the proxy walks `routing.targets`
     /// to pick a downstream Model and dispatches against THAT model's
     /// `provider` / `model_name` / `provider_key_id`. The fields on
@@ -339,6 +350,29 @@ impl Model {
     pub fn stream_timeout_effective(&self) -> Option<std::time::Duration> {
         self.stream_read_timeout()
             .or_else(|| self.request_timeout())
+    }
+
+    /// Whether a client at `source_ip` may access this model (#557).
+    ///
+    /// Returns `true` when no `allowed_cidrs` restriction is configured (the
+    /// common case). When a restriction is set, returns `true` only if
+    /// `source_ip` parses as an IP address contained in at least one range.
+    /// Malformed CIDR entries are skipped; an empty or unparseable `source_ip`
+    /// against a configured restriction returns `false` (fail closed) so an
+    /// unattributable request can never slip past an allowlist.
+    pub fn ip_allowed(&self, source_ip: &str) -> bool {
+        let ranges = match self.allowed_cidrs.as_deref() {
+            Some(r) if !r.is_empty() => r,
+            _ => return true,
+        };
+        let ip: std::net::IpAddr = match source_ip.parse() {
+            Ok(ip) => ip,
+            Err(_) => return false,
+        };
+        ranges
+            .iter()
+            .filter_map(|cidr| cidr.parse::<ipnet::IpNet>().ok())
+            .any(|net| net.contains(&ip))
     }
 }
 
@@ -465,6 +499,64 @@ mod tests {
             }"#,
         );
         assert!(r.is_err());
+    }
+
+    #[test]
+    fn ip_allowed_matrix() {
+        fn model_with(cidrs: Option<Vec<&str>>) -> Model {
+            let mut m: Model = serde_json::from_str(sample_json()).unwrap();
+            m.allowed_cidrs = cidrs.map(|c| c.into_iter().map(String::from).collect());
+            m
+        }
+
+        // No restriction → everything allowed.
+        let open = model_with(None);
+        assert!(open.ip_allowed("203.0.113.7"));
+        assert!(open.ip_allowed("")); // even an unresolved IP
+
+        // Empty list behaves like no restriction.
+        assert!(model_with(Some(vec![])).ip_allowed("203.0.113.7"));
+
+        // IPv4 allowlist: in-range allowed, out-of-range denied.
+        let v4 = model_with(Some(vec!["10.0.0.0/8", "192.168.1.0/24"]));
+        assert!(v4.ip_allowed("10.1.2.3"));
+        assert!(v4.ip_allowed("192.168.1.42"));
+        assert!(!v4.ip_allowed("114.114.114.114"));
+        assert!(!v4.ip_allowed("192.168.2.1"));
+
+        // Fail closed: a restriction set but the client IP is empty/garbage.
+        assert!(!v4.ip_allowed(""));
+        assert!(!v4.ip_allowed("not-an-ip"));
+
+        // IPv6 allowlist.
+        let v6 = model_with(Some(vec!["2001:db8::/32"]));
+        assert!(v6.ip_allowed("2001:db8::1"));
+        assert!(!v6.ip_allowed("2001:db9::1"));
+
+        // Malformed CIDR entries are skipped, valid ones still apply.
+        let mixed = model_with(Some(vec!["garbage", "10.0.0.0/8"]));
+        assert!(mixed.ip_allowed("10.0.0.1"));
+        assert!(!mixed.ip_allowed("203.0.113.1"));
+    }
+
+    #[test]
+    fn deserialises_allowed_cidrs() {
+        let m: Model = serde_json::from_str(
+            r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","allowed_cidrs":["10.0.0.0/8"]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            m.allowed_cidrs.as_deref(),
+            Some(&["10.0.0.0/8".to_string()][..])
+        );
+
+        // Absent field → None → no restriction.
+        let none: Model = serde_json::from_str(
+            r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1"}"#,
+        )
+        .unwrap();
+        assert!(none.allowed_cidrs.is_none());
+        assert!(none.ip_allowed("203.0.113.7"));
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -135,6 +135,11 @@ fn model_schema() -> Value {
             "provider_key_id": { "type": "string", "minLength": 1 },
             "timeout":         { "type": "integer", "minimum": 0 },
             "stream_timeout":  { "type": "integer", "minimum": 0 },
+            // Client-IP allowlist (#557). Permitted on both direct and
+            // routing models — the gate binds to whichever model the client
+            // names, so a Model Group can be IP-restricted too. CIDR format
+            // is validated by cp-api on write; the DP skips malformed entries.
+            "allowed_cidrs":   { "type": "array", "items": { "type": "string", "minLength": 1 } },
             "rate_limit":      { "$ref": "#/$defs/rate_limit" },
             "routing": {
                 "type": "object",
@@ -809,6 +814,31 @@ mod tests {
             }
         });
         validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_allowed_cidrs_passes_on_direct_and_routing() {
+        // Direct model with an IP allowlist (#557).
+        let direct = json!({
+            "display_name": "ip-restricted",
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111",
+            "allowed_cidrs": ["10.0.0.0/8", "2001:db8::/32"]
+        });
+        validate_model(&direct).unwrap();
+
+        // Routing (Model Group) model can also be IP-restricted — the gate
+        // binds to the requested model name regardless of its shape.
+        let routing = json!({
+            "display_name": "router-restricted",
+            "routing": {
+                "strategy": "failover",
+                "targets": [{"model": "my-gpt4"}]
+            },
+            "allowed_cidrs": ["10.0.0.0/8"]
+        });
+        validate_model(&routing).unwrap();
     }
 
     #[test]

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -71,6 +71,7 @@ pub async fn transcriptions(
         // (build_v1_url) owns the `/v1` prefix.
         "/audio/transcriptions",
         &request_id,
+        &client.source_ip,
     )
     .await
     {
@@ -143,6 +144,7 @@ pub async fn translations(
         // (build_v1_url) owns the `/v1` prefix.
         "/audio/translations",
         &request_id,
+        &client.source_ip,
     )
     .await
     {
@@ -212,7 +214,7 @@ pub async fn speech(
         .unwrap_or("unknown")
         .to_string();
 
-    match speech_dispatch(&state, &auth, body, &request_id).await {
+    match speech_dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
         Ok((resp, provider, model_id)) => {
             let elapsed = started.elapsed();
             emit_access_log(
@@ -287,6 +289,7 @@ async fn multipart_dispatch(
     mut multipart: Multipart,
     upstream_path: &str,
     request_id: &str,
+    source_ip: &str,
 ) -> Result<AudioDispatchSuccess, ProxyError> {
     // Collect all fields first so we can find `model` before building the
     // outgoing reqwest multipart.
@@ -324,6 +327,9 @@ async fn multipart_dispatch(
     if !auth.key().can_access(&model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
+
+    // Client-IP allowlist gate (#557): reject before quota / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
@@ -459,6 +465,7 @@ async fn speech_dispatch(
     auth: &AuthenticatedKey,
     mut body: Value,
     request_id: &str,
+    source_ip: &str,
 ) -> Result<(Response, String, String), ProxyError> {
     let model_name = body
         .get("model")
@@ -475,6 +482,9 @@ async fn speech_dispatch(
     if !auth.key().can_access(&model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
+
+    // Client-IP allowlist gate (#557): reject before guardrails / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
 
     // #545: /v1/audio/speech must run input guardrails. Before this it
     // forwarded the user `input` text (synthesized to audio) with no

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -714,6 +714,11 @@ async fn dispatch(
         return Err(with_model(ProxyError::ModelForbidden(req.model.clone())));
     }
 
+    // Client-IP allowlist gate (#557): reject before any guardrail / upstream
+    // work when the resolved source IP is outside the model's allowed_cidrs.
+    crate::dispatch::check_ip_access(&virtual_entry.value, &client.source_ip)
+        .map_err(with_model)?;
+
     // Resolve the per-request guardrail chain from the index.
     // Done once here; `resolved_chain` is reused for both the input
     // check below, the output check later, and the streaming output

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -74,7 +74,7 @@ pub async fn completions(
         .unwrap_or("unknown")
         .to_string();
 
-    match dispatch(&state, &auth, body, &request_id).await {
+    match dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             // Audit MEDIUM-2 on PR #426: use the actual response
@@ -169,6 +169,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: Value,
     request_id: &str,
+    source_ip: &str,
 ) -> Result<CompletionDispatchSuccess, ProxyError> {
     let model_name = body
         .get("model")
@@ -185,6 +186,9 @@ async fn dispatch(
     if !auth.key().can_access(model_name) {
         return Err(ProxyError::ModelForbidden(model_name.to_string()));
     }
+
+    // Client-IP allowlist gate (#557): reject before guardrails / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
 
     // #545: /v1/completions must run input guardrails. Before this it
     // forwarded the user `prompt` to the upstream with no configured

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -49,6 +49,7 @@ use serde_json::Value;
 use std::time::{Duration, Instant};
 
 use crate::auth::AuthenticatedKey;
+use crate::client_ip::ClientContext;
 use crate::error::ProxyError;
 use crate::messages::ANTHROPIC_VERSION;
 use crate::request_id::new_request_id;
@@ -57,6 +58,7 @@ use crate::state::ProxyState;
 pub async fn count_tokens(
     State(state): State<ProxyState>,
     auth: Result<AuthenticatedKey, ProxyError>,
+    client: ClientContext,
     body: Result<Json<Value>, JsonRejection>,
 ) -> Response {
     // Auth / body-extractor rejections must render the Anthropic-shape
@@ -89,7 +91,7 @@ pub async fn count_tokens(
         .unwrap_or("")
         .to_string();
 
-    match dispatch(&state, &auth, &body, &request_id).await {
+    match dispatch(&state, &auth, &body, &request_id, &client.source_ip).await {
         Ok((resp, provider)) => {
             let elapsed = started.elapsed();
             let status = resp.status().as_u16();
@@ -140,6 +142,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: &Value,
     request_id: &str,
+    source_ip: &str,
 ) -> Result<(Response, String), ProxyError> {
     let snapshot = state.snapshot.load();
 
@@ -157,6 +160,9 @@ async fn dispatch(
     if !auth.key().can_access(&model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
+
+    // Client-IP allowlist gate (#557): reject before quota / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -97,6 +97,27 @@ pub(crate) fn require_provider(model: &Model) -> Result<&str, ProxyError> {
     })
 }
 
+/// Enforce a Model's client-IP allowlist (`allowed_cidrs`, #557).
+///
+/// Called by every request-serving endpoint right after the requested Model
+/// is resolved and before any upstream dispatch, so a disallowed source IP is
+/// rejected with 403 before the provider is ever contacted (issue AC-1). For
+/// routing models the check binds to the **requested** model — the access
+/// decision belongs to the name the client asked for, not the chosen target.
+///
+/// No-op when the Model has no `allowed_cidrs` configured (the common case).
+pub(crate) fn check_ip_access(model: &Model, source_ip: &str) -> Result<(), ProxyError> {
+    if model.ip_allowed(source_ip) {
+        return Ok(());
+    }
+    tracing::warn!(
+        model = %model.display_name,
+        source_ip = %source_ip,
+        "request rejected: client IP not in model allowed_cidrs"
+    );
+    Err(ProxyError::ModelIpRestricted(model.display_name.clone()))
+}
+
 /// Required upstream model id (`model_name`) for a non-routing Model.
 pub(crate) fn require_upstream_model(model: &Model) -> Result<&str, ProxyError> {
     model.model_name.as_deref().ok_or_else(|| {

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -125,7 +125,7 @@ pub async fn embeddings(
     };
     let model_name = body.model.clone();
 
-    match dispatch(&state, &auth, body, &request_id).await {
+    match dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             let status = 200u16;
@@ -223,6 +223,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: EmbeddingRequestBody,
     request_id: &str,
+    source_ip: &str,
 ) -> Result<EmbedDispatchSuccess, ProxyError> {
     let snapshot = state.snapshot.load();
 
@@ -234,6 +235,9 @@ async fn dispatch(
     if !auth.key().can_access(&body.model) {
         return Err(ProxyError::ModelForbidden(body.model.clone()));
     }
+
+    // Client-IP allowlist gate (#557): reject before guardrails / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
 
     let model = &model_entry.value;
     let provider = crate::dispatch::require_provider(model)?;

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -148,6 +148,13 @@ pub enum ProxyError {
     ModelNotFound(String),
     #[error("API key is not allowed to use model {0:?}")]
     ModelForbidden(String),
+    /// The resolved client IP is outside the model's `allowed_cidrs`
+    /// allowlist (#557). Caller-visible message is intentionally generic and
+    /// MUST NOT echo the configured CIDR ranges — handing back the allowlist
+    /// lets a probe enumerate it (mirrors the #153 guardrail-redaction rule).
+    /// The model name rides along for operator logs only.
+    #[error("Access denied: your client IP is not allowed to access this model")]
+    ModelIpRestricted(String),
     #[error("request payload is invalid: {0}")]
     InvalidRequest(String),
     #[error("no bridge registered for provider")]
@@ -202,6 +209,7 @@ impl ProxyError {
         match self {
             ProxyError::MissingAuth | ProxyError::InvalidApiKey => StatusCode::UNAUTHORIZED,
             ProxyError::ModelForbidden(_) => StatusCode::FORBIDDEN,
+            ProxyError::ModelIpRestricted(_) => StatusCode::FORBIDDEN,
             ProxyError::ModelNotFound(_) => StatusCode::NOT_FOUND,
             ProxyError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
             ProxyError::ProviderUnavailable => StatusCode::SERVICE_UNAVAILABLE,
@@ -220,6 +228,7 @@ impl ProxyError {
         match self {
             ProxyError::MissingAuth | ProxyError::InvalidApiKey => "invalid_api_key",
             ProxyError::ModelForbidden(_) => "permission_denied",
+            ProxyError::ModelIpRestricted(_) => "permission_denied",
             ProxyError::ModelNotFound(_) => "model_not_found",
             ProxyError::InvalidRequest(_) => "invalid_request_error",
             ProxyError::RequestTooLarge { .. } => "invalid_request_error",
@@ -282,6 +291,10 @@ impl ProxyError {
         let env = ErrorEnvelope::new(self.to_string(), self.kind());
         match self {
             ProxyError::BudgetExceeded(r) => env.with_code("budget_exceeded").with_budget(r),
+            // Stable machine-readable code for SDKs to branch on, distinct
+            // from the generic `permission_denied` type shared with
+            // ModelForbidden (#557 AC-1).
+            ProxyError::ModelIpRestricted(_) => env.with_code("ip_restricted"),
             _ => env,
         }
     }
@@ -508,6 +521,20 @@ mod tests {
     }
 
     #[test]
+    fn model_ip_restricted_is_403_with_ip_restricted_code() {
+        let e = ProxyError::ModelIpRestricted("gpt-4o".into());
+        assert_eq!(e.status(), StatusCode::FORBIDDEN);
+        assert_eq!(e.kind(), "permission_denied");
+        let json = serde_json::to_value(e.envelope()).unwrap();
+        assert_eq!(json["error"]["type"], "permission_denied");
+        assert_eq!(json["error"]["code"], "ip_restricted");
+        // Message must stay generic — never echo the configured CIDR list.
+        let msg = json["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("not allowed to access this model"));
+        assert!(!msg.contains("gpt-4o"));
+    }
+
+    #[test]
     fn bridge_error_inherits_status_and_type() {
         let bridge_err = BridgeError::upstream_status(429, "rate limited");
         let wrapped = ProxyError::Bridge(bridge_err);
@@ -651,6 +678,13 @@ mod tests {
     #[tokio::test]
     async fn anthropic_envelope_403_maps_to_permission_error() {
         let err = ProxyError::ModelForbidden("gpt-4o".into());
+        let resp = err.into_anthropic_response();
+        assert_anthropic_envelope(resp, StatusCode::FORBIDDEN, "permission_error").await;
+    }
+
+    #[tokio::test]
+    async fn anthropic_envelope_403_ip_restricted_maps_to_permission_error() {
+        let err = ProxyError::ModelIpRestricted("claude-sonnet-4-5".into());
         let resp = err.into_anthropic_response();
         assert_anthropic_envelope(resp, StatusCode::FORBIDDEN, "permission_error").await;
     }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -61,7 +61,7 @@ pub async fn image_generations(
         .unwrap_or("unknown")
         .to_string();
 
-    match dispatch(&state, &auth, body, &request_id).await {
+    match dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             emit_access_log(
@@ -143,6 +143,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: Value,
     request_id: &str,
+    source_ip: &str,
 ) -> Result<ImageDispatchSuccess, ProxyError> {
     let model_name = body
         .get("model")
@@ -159,6 +160,9 @@ async fn dispatch(
     if !auth.key().can_access(model_name) {
         return Err(ProxyError::ModelForbidden(model_name.to_string()));
     }
+
+    // Client-IP allowlist gate (#557): reject before guardrails / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
 
     // #545: /v1/images/generations must run input guardrails. Before this it
     // forwarded the user `prompt` with no configured content/DLP check, so a

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -369,6 +369,9 @@ async fn dispatch(
         return Err(ProxyError::ModelForbidden(model_name.clone()).into());
     }
 
+    // Client-IP allowlist gate (#557): reject before guardrails / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, &client.source_ip)?;
+
     // #448 (#22): /v1/messages must run input guardrails like
     // /v1/chat/completions — previously prompts reached the upstream without
     // any content/DLP check. Translate the Anthropic-shaped body into the

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -69,7 +69,7 @@ pub async fn rerank(
         .unwrap_or("")
         .to_string();
 
-    match dispatch(&state, &auth, &mut body, &request_id).await {
+    match dispatch(&state, &auth, &mut body, &request_id, &client.source_ip).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             let status = success.response.status().as_u16();
@@ -161,6 +161,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: &mut Value,
     request_id: &str,
+    source_ip: &str,
 ) -> Result<RerankDispatchSuccess, ProxyError> {
     let snapshot = state.snapshot.load();
 
@@ -178,6 +179,9 @@ async fn dispatch(
     if !auth.key().can_access(&model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
+
+    // Client-IP allowlist gate (#557): reject before guardrails / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
 
     // #545: /v1/rerank must run input guardrails. Before this it forwarded
     // the user `query` + `documents` with no configured content/DLP check,

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -110,7 +110,7 @@ pub async fn responses(
         .unwrap_or("")
         .to_string();
 
-    match dispatch(&state, &auth, &body, &request_id).await {
+    match dispatch(&state, &auth, &body, &request_id, &client.source_ip).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             let status = success.response.status().as_u16();
@@ -224,6 +224,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: &Value,
     request_id: &str,
+    source_ip: &str,
 ) -> Result<ResponseDispatchSuccess, ResponsesDispatchError> {
     let snapshot = state.snapshot.load();
 
@@ -241,6 +242,9 @@ async fn dispatch(
     if !auth.key().can_access(&model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()).into());
     }
+
+    // Client-IP allowlist gate (#557): reject before guardrails / upstream.
+    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
 
     // #719: /v1/responses must run input guardrails like /v1/chat/completions
     // and /v1/messages. Before this, user input reached the upstream without

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -31,6 +31,7 @@ Optional fields include:
 - `timeout`
 - `stream_timeout`
 - `rate_limit`
+- `allowed_cidrs`
 - `cost`
 - `cooldown`
 - `background_model_check`
@@ -103,6 +104,32 @@ An elapsed timeout surfaces as a retryable upstream failure (HTTP `504`), so on 
 A timeout also feeds [Cooldown](#cooldown) (`trigger_on_timeout`), so a repeatedly-slow target is taken out of rotation for subsequent requests.
 
 > A small `timeout` set for non-streaming traffic also becomes the streaming read budget when `stream_timeout` is unset. Set `stream_timeout` explicitly if streaming needs a different budget.
+
+### IP Access Control
+
+`allowed_cidrs` restricts which client source IPs may use a model. It is an optional list of CIDR ranges (IPv4 or IPv6); when present and non-empty, a request whose resolved client IP is outside every range is rejected with HTTP `403` **before** the upstream is contacted. Absent or empty means no restriction (all clients allowed).
+
+```json title="Model with an IP allowlist"
+{
+  "allowed_cidrs": ["10.0.0.0/8", "192.168.0.0/16", "2001:db8::/32"]
+}
+```
+
+The rejection uses the OpenAI error shape with a stable `code`:
+
+```json
+{
+  "error": {
+    "message": "Access denied: your client IP is not allowed to access this model",
+    "type": "permission_denied",
+    "code": "ip_restricted"
+  }
+}
+```
+
+The check applies to every request-serving endpoint (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/v1/embeddings`, `/v1/rerank`, images, audio, `…/count_tokens`) and to both direct and routing models — the gate binds to whichever model the client names, so a [routing model](routing-and-failover.md) can be IP-restricted too.
+
+The resolved client IP comes from the same trusted-proxy chain used for usage telemetry: configure [`proxy.real_ip`](../reference/runtime-config-schema.md) so the gateway reads the real client address from `X-Forwarded-For` when it sits behind a load balancer. Without trusted proxies configured, the immediate TCP peer is used.
 
 ### Cooldown
 

--- a/docs/reference/headers-and-error-codes.md
+++ b/docs/reference/headers-and-error-codes.md
@@ -33,6 +33,8 @@ Current proxy error `type` values include:
 
 These values appear in the proxy's OpenAI-compatible error envelope.
 
+Some errors also set a machine-readable `code` alongside `type`. Notably, a request rejected by a model's [`allowed_cidrs`](../configuration/models.md#ip-access-control) IP allowlist returns `type: permission_denied` with `code: ip_restricted` and HTTP `403`.
+
 This list covers gateway-generated errors on the OpenAI-shape proxy endpoints. Two surfaces are exceptions:
 
 - `POST /v1/messages` — uses the Anthropic-shape envelope with its own type-string set. See [Anthropic Messages — Error Shape](../integration/anthropic-messages.md#error-shape).
@@ -42,7 +44,7 @@ This list covers gateway-generated errors on the OpenAI-shape proxy endpoints. T
 
 - `400` invalid request
 - `401` missing or invalid caller auth
-- `403` model not allowed for the key
+- `403` model not allowed for the key, or client IP outside the model's `allowed_cidrs` allowlist (`code: ip_restricted`)
 - `404` model alias not found
 - `422` content blocked by policy
 - `429` rate limit or budget rejection

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -6,6 +6,16 @@
     "display_name"
   ],
   "properties": {
+    "allowed_cidrs": {
+      "description": "Client-IP allowlist in CIDR notation (IPv4/IPv6). Applies to both direct and routing models — the gate binds to whichever model the client names, so a Model Group can be IP-restricted too. Absent or empty = no restriction (all clients allowed). When non-empty, a request whose resolved client IP falls outside every range is rejected with 403 before the request is dispatched upstream (api7/AISIX-Cloud#557). The resolved client IP honours the gateway's `proxy.real_ip` trusted-proxy config (X-Forwarded-For), so the check works behind a load balancer.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
     "background_model_check": {
       "description": "Optional direct-model-only background health-check configuration.",
       "anyOf": [

--- a/tests/e2e/src/cases/model-ip-restriction-e2e.test.ts
+++ b/tests/e2e/src/cases/model-ip-restriction-e2e.test.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E (api7/AISIX-Cloud#557): model-level client-IP CIDR allowlist.
+//
+// A model with `allowed_cidrs` only serves requests whose resolved client
+// IP falls inside one of the ranges; everyone else gets 403 before the
+// upstream is ever contacted. An unrestricted model is unaffected. The
+// gateway resolves the real client IP from `x-forwarded-for` using the
+// nginx-style trusted-proxy chain (#492 plumbing), so the loopback e2e
+// client must be a trusted proxy for the forwarded IP to be honoured.
+//
+// Coverage:
+//   AC-1 allow  — in-range XFF → 200, upstream hit.
+//   AC-1 block  — out-of-range XFF → 403 `code: "ip_restricted"`, upstream
+//                 untouched (rejected pre-dispatch).
+//   AC-2 isolation — same external IP: restricted model 403, unrestricted 200.
+
+const CALLER_PLAINTEXT = "sk-model-ip-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const RESTRICTED_MODEL = "ip-restricted-model";
+const OPEN_MODEL = "ip-open-model";
+
+async function chat(
+  app: SpawnedApp,
+  model: string,
+  forwardedFor: string,
+): Promise<Response> {
+  return fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+      "x-forwarded-for": forwardedFor,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+}
+
+describe("model IP restriction e2e (#557): allowed_cidrs gate before upstream", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    // 127.0.0.1 (the loopback e2e client) is the trusted proxy, so the
+    // gateway honours `x-forwarded-for` and treats the forwarded value as
+    // the real client IP.
+    app = await spawnApp({
+      realIp: { trusted_proxies: ["127.0.0.1/32"], recursive: true },
+    });
+    const admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "model-ip-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    // Restricted model: only the 10.0.0.0/8 range may call it.
+    await admin.createModel({
+      display_name: RESTRICTED_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+      allowed_cidrs: ["10.0.0.0/8"],
+    });
+    // Open model: no restriction, same upstream.
+    await admin.createModel({
+      display_name: OPEN_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [RESTRICTED_MODEL, OPEN_MODEL],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test(
+    "in-range allowed, out-of-range 403 (upstream untouched), unrestricted model unaffected",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      // Readiness probe doubles as the AC-1 allow case: a client in
+      // 10.0.0.0/8 reaches the restricted model and gets a 200.
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await chat(app!, RESTRICTED_MODEL, "10.1.2.3");
+          await r.text();
+          return r.status === 200;
+        } catch {
+          return false;
+        }
+      });
+
+      // AC-1 allow: in-range request reaches upstream.
+      const allowed = await chat(app, RESTRICTED_MODEL, "10.255.255.254");
+      expect(allowed.status).toBe(200);
+      await allowed.text();
+
+      const upstreamHitsBeforeBlock = upstream.receivedRequests.length;
+
+      // AC-1 block: out-of-range request → 403 with the stable
+      // `ip_restricted` code, and the upstream is never contacted.
+      const blocked = await chat(app, RESTRICTED_MODEL, "114.114.114.114");
+      expect(blocked.status).toBe(403);
+      const body = (await blocked.json()) as {
+        error?: { type?: string; code?: string; message?: string };
+      };
+      expect(body.error?.code).toBe("ip_restricted");
+      expect(typeof body.error?.message).toBe("string");
+      // The block fires before dispatch — no new upstream request.
+      expect(upstream.receivedRequests.length).toBe(upstreamHitsBeforeBlock);
+
+      // AC-2 isolation: the SAME out-of-range IP reaches the unrestricted
+      // model with a 200.
+      const openOk = await chat(app, OPEN_MODEL, "114.114.114.114");
+      expect(openOk.status).toBe(200);
+      await openOk.text();
+      expect(upstream.receivedRequests.length).toBe(upstreamHitsBeforeBlock + 1);
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
Implements model-level client-IP access control for api7/AISIX-Cloud#557: some models should only be reachable from specific network ranges, and doing this per-API-key doesn't scale (the customer has ~10k keys), so the restriction lives on the model.

## What

Adds an optional `allowed_cidrs` allowlist (array of IPv4/IPv6 CIDR strings) to `Model`. When non-empty, a request whose resolved client IP falls outside every range is rejected with HTTP 403 **before** the upstream is contacted. Absent or empty means no restriction (all clients allowed).

Error envelope (OpenAI shape, stable machine code):

```json
{ "error": { "message": "Access denied: your client IP is not allowed to access this model", "type": "permission_denied", "code": "ip_restricted" } }
```

The message is intentionally generic and never echoes the configured ranges.

## How

- `Model::ip_allowed(source_ip)` in `aisix-core` does the CIDR match (via `ipnet`). Empty list → allow; a configured restriction with an empty/unparseable source IP → deny (fail closed).
- A single shared `dispatch::check_ip_access` helper enforces the gate at every request-serving endpoint right after model resolution: `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/rerank`, `/v1/images/generations`, `/v1/audio/*`, `/v1/messages`, `/v1/responses`, and `/v1/messages/count_tokens`. `count_tokens` previously didn't extract the client context — it now does, so the family stays in lockstep.
- Applies to **both** direct and routing models: the decision binds to whichever model the client names, so a Model Group can be IP-restricted too.
- The client IP is resolved through the existing `proxy.real_ip` trusted-proxy chain, so `X-Forwarded-For` is honored behind a load balancer (no new header parsing).

LiteLLM has no equivalent (its `allowed_ips` is global, exact-match, enterprise-only — no model-level or CIDR support on the main allowlist), so there was no baseline behavior to mirror.

## Tests

- `aisix-core` unit tests: CIDR match matrix (IPv4/IPv6, in/out of range, empty=allow, fail-closed, malformed-skip), schema acceptance on direct + routing models.
- `aisix-proxy` unit test: 403 status + `permission_denied` type + `ip_restricted` code, generic message, Anthropic-envelope 403 mapping.
- DP standalone E2E (`tests/e2e/model-ip-restriction-e2e.test.ts`): in-range XFF → 200, out-of-range XFF → 403 `ip_restricted` with the upstream untouched, and same-IP isolation between a restricted and an unrestricted model.

## Docs

Updated `docs/configuration/models.md` (new IP Access Control section) and `docs/reference/headers-and-error-codes.md`.

This is the data-plane half; the paired control-plane PR (admin API field, etcd projection, dashboard form) follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Models can now restrict API access by client IP address using CIDR allowlists.
* Requests from non-whitelisted client IPs receive HTTP 403 with error code `ip_restricted`.

## Documentation
* Updated configuration and error reference documentation to describe IP allowlist enforcement behavior across all API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->