### PR TITLE
feat(heartbeat): report supported guardrail kinds, applied revision, exporter delivery health

### DIFF
--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -36,7 +36,10 @@ use crate::snapshot_cache::SnapshotCache;
 /// supervisor last applied an event. Read by `/admin/v1/health` so
 /// operators can tell at a glance whether the gateway is serving from
 /// a frozen snapshot (etcd partition or watch supervisor wedged) vs
-/// from a live config stream. See issue #114.
+/// from a live config stream. See issue #114. Also read by the managed-
+/// mode heartbeat, which reports the revision as `applied_revision` so
+/// cp-api can compare it against the kine revision of its own writes
+/// (#519 B.3).
 ///
 /// The previous health endpoint only reported per-model upstream
 /// connectivity; it was silent on the gateway's own freshness, so a
@@ -630,11 +633,22 @@ impl<P: ConfigProvider> Supervisor<P> {
                 Some(Ok(WatchEvent::Put(raw))) => {
                     self.apply_put(&raw);
                 }
-                Some(Ok(WatchEvent::Delete { key, .. })) => {
+                Some(Ok(WatchEvent::Delete { key, revision })) => {
                     self.apply_delete(&key);
+                    // Advance the applied-revision floor to the delete's
+                    // mod_revision even when the key wasn't present —
+                    // "processed everything up to rev X" must cover
+                    // deletes, otherwise the heartbeat-reported
+                    // applied_revision (#519 B.3) stalls after a CP
+                    // delete until the next put arrives.
+                    self.set_revision_floor(revision);
                 }
-                Some(Ok(WatchEvent::Resync { entries, .. })) => {
+                Some(Ok(WatchEvent::Resync { entries, revision })) => {
                     self.apply_resync(&entries);
+                    // Same rationale: the resync's header revision is the
+                    // "consistent as of" point even when the entry set
+                    // is empty or only contains older mod_revisions.
+                    self.set_revision_floor(revision);
                 }
             }
         }
@@ -909,6 +923,42 @@ mod tests {
         // synchronously relative to the event stream being in-memory.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert_eq!(handle.load().models.len(), 1);
+
+        tx.send(true).unwrap();
+        join.await.unwrap();
+    }
+
+    /// #519 B.3: the cycle's Delete arm must advance the applied-
+    /// revision floor to the delete event's mod_revision — without it
+    /// the heartbeat-reported `applied_revision` stalls after a CP
+    /// delete and the dashboard shows "propagating…" until an unrelated
+    /// put arrives.
+    #[tokio::test]
+    async fn run_loop_advances_revision_on_delete_event() {
+        let provider = Arc::new(FakeProvider::new(vec![], 2).with_events(vec![
+            Ok(WatchEvent::Put(entry("/aisix/models/m-1", VALID_MODEL, 5))),
+            Ok(WatchEvent::Delete {
+                key: "/aisix/models/m-1".into(),
+                revision: 9,
+            }),
+        ]));
+        let sup = Arc::new(Supervisor::new(provider, "/aisix"));
+        let status = sup.watch_status();
+        let (tx, rx) = tokio::sync::watch::channel(false);
+
+        let join = tokio::spawn(sup.clone().run(rx));
+
+        // Poll until the finite event stream drains (bounded — the
+        // revision floor never decreases once it reaches 9).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while status.snapshot().revision < 9 && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            status.snapshot().revision,
+            9,
+            "delete event's mod_revision must advance the applied revision",
+        );
 
         tx.send(true).unwrap();
         join.await.unwrap();

--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -83,6 +83,77 @@ async fn watch_stream_delivers_events_after_put() {
         .expect("cleanup delete");
 }
 
+/// #519 B.3: the supervisor's applied revision (read by the heartbeat as
+/// `applied_revision`) must catch up to the header revision returned to a
+/// writer — for puts AND deletes. This is the exact comparison cp-api
+/// performs: it writes through kine, records the response revision W, and
+/// treats a DP with `applied_revision >= W` as caught up.
+#[tokio::test]
+async fn supervisor_applied_revision_catches_up_to_writer_revision() {
+    let url = match etcd_url() {
+        Some(u) => u,
+        None => {
+            eprintln!("ETCD_TEST_URL not set — skipping");
+            return;
+        }
+    };
+
+    let prefix = unique_prefix();
+    let endpoints = vec![url.clone()];
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None)
+        .await
+        .expect("connect");
+    let supervisor = std::sync::Arc::new(aisix_etcd::Supervisor::new(
+        std::sync::Arc::new(provider),
+        prefix.clone(),
+    ));
+    let status = supervisor.watch_status();
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    let run = tokio::spawn(supervisor.clone().run(cancel_rx));
+
+    let mut writer = Client::connect([url.as_str()], None)
+        .await
+        .expect("writer connect");
+
+    async fn wait_for_revision(status: &aisix_etcd::WatchStatus, want: i64, what: &str) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let got = status.snapshot().revision;
+            if got >= want {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "applied revision {got} did not reach {what} revision {want} within 5s",
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    // Put: the writer's response header revision is what cp-api records
+    // as W; the supervisor must report >= W once the event is applied.
+    let test_key = format!("{prefix}/models/rev-test");
+    let test_value = br#"{"display_name":"t","provider":"openai","model_name":"gpt-4o","provider_key_id":"11111111-1111-1111-1111-111111111111"}"#;
+    let put_resp = writer
+        .put(test_key.as_bytes(), test_value.as_ref(), None)
+        .await
+        .expect("put");
+    let put_rev = put_resp.header().expect("put header").revision();
+    wait_for_revision(&status, put_rev, "put").await;
+
+    // Delete: same contract. Before the #519 B.3 fix the Delete arm
+    // dropped the event's mod_revision, so applied_revision stalled here.
+    let del_resp = writer
+        .delete(test_key.as_bytes(), None)
+        .await
+        .expect("delete");
+    let del_rev = del_resp.header().expect("delete header").revision();
+    wait_for_revision(&status, del_rev, "delete").await;
+
+    let _ = cancel_tx.send(true);
+    let _ = run.await;
+}
+
 /// Regression test: an etcd transaction writes multiple keys atomically in a
 /// single revision, producing a single WatchResponse with multiple events.
 /// Before the fix, only the first event was emitted and the rest were dropped.

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -60,6 +60,29 @@ pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
     }
 }
 
+/// The guardrail `kind` discriminators compiled into this binary.
+///
+/// Every non-keyword kind sits behind a cargo feature (see `build.rs`'s
+/// `BuildError::FeatureDisabled` arms); a DP built without one silently
+/// rejects rows of that kind while the dashboard still offers it
+/// (#519 B.6). The heartbeat reports this list so cp-api can hide /
+/// flag kinds the connected DP can't serve. Strings MUST stay equal to
+/// the serde `kind` tags in `aisix_core::models::GuardrailKind`
+/// (`GuardrailKind::kind_str`).
+pub fn supported_kinds() -> &'static [&'static str] {
+    &[
+        "keyword",
+        #[cfg(feature = "azure-content-safety")]
+        "azure_content_safety",
+        #[cfg(feature = "azure-content-safety")]
+        "azure_content_safety_text_moderation",
+        #[cfg(feature = "aliyun-text-moderation")]
+        "aliyun_text_moderation",
+        #[cfg(feature = "bedrock")]
+        "bedrock",
+    ]
+}
+
 #[cfg(feature = "aliyun-text-moderation")]
 pub use aliyun::AliyunTextModerationGuardrail;
 #[cfg(feature = "bedrock")]
@@ -345,6 +368,69 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// Pins `supported_kinds()` under the default feature set (all
+    /// features on): exact contents, and every string round-trips
+    /// through the config parser to the matching
+    /// `GuardrailKind::kind_str` — so the heartbeat-reported list can
+    /// never drift from the wire `kind` discriminators (#519 B.6).
+    #[cfg(all(
+        feature = "bedrock",
+        feature = "azure-content-safety",
+        feature = "aliyun-text-moderation"
+    ))]
+    #[test]
+    fn supported_kinds_matches_kind_str_under_default_features() {
+        assert_eq!(
+            supported_kinds(),
+            &[
+                "keyword",
+                "azure_content_safety",
+                "azure_content_safety_text_moderation",
+                "aliyun_text_moderation",
+                "bedrock",
+            ],
+        );
+        for kind in supported_kinds() {
+            // Minimal valid config per kind; parse failure or a
+            // kind_str mismatch means the heartbeat list drifted from
+            // the schema's serde tags.
+            let config = match *kind {
+                "keyword" => serde_json::json!({
+                    "kind": "keyword",
+                    "patterns": [{"kind": "literal", "value": "x"}],
+                }),
+                "azure_content_safety" => serde_json::json!({
+                    "kind": "azure_content_safety",
+                    "endpoint": "https://x.cognitiveservices.azure.com",
+                    "api_key": "k",
+                }),
+                "azure_content_safety_text_moderation" => serde_json::json!({
+                    "kind": "azure_content_safety_text_moderation",
+                    "endpoint": "https://x.cognitiveservices.azure.com",
+                    "api_key": "k",
+                }),
+                "aliyun_text_moderation" => serde_json::json!({
+                    "kind": "aliyun_text_moderation",
+                    "region": "ap-southeast-1",
+                    "access_key_id": "ak",
+                    "access_key_secret": "sk",
+                }),
+                "bedrock" => serde_json::json!({
+                    "kind": "bedrock",
+                    "guardrail_id": "gr-1",
+                    "guardrail_version": "1",
+                    "region": "us-east-1",
+                    "aws_credentials": {"kind": "static", "access_key_id": "ak", "secret_access_key": "sk"},
+                    "latency_mode": {"kind": "serial"},
+                }),
+                other => panic!("no parse fixture for kind {other:?}"),
+            };
+            let parsed: aisix_core::models::GuardrailKind = serde_json::from_value(config)
+                .unwrap_or_else(|e| panic!("kind {kind:?} failed to parse: {e}"));
+            assert_eq!(parsed.kind_str(), *kind);
+        }
     }
 
     #[test]

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -43,7 +43,7 @@ use crate::sink::{
     build_object_store_sink, resolve_datadog_credential, resolve_sls_credential, AliyunSlsSink,
     BatchUnit, CapturedContent, DatadogSink, EventBatch, ExporterPipelines, IdempotencyMarker,
     IdempotencyScheme, ObservabilitySink, OrderingScope, PipelineConfig, SinkAck, SinkCapabilities,
-    SinkContent, SinkError, SinkHealth, SinkRecord, SinkResult,
+    SinkContent, SinkError, SinkHealth, SinkRecord, SinkResult, SinkStatsSnapshot,
 };
 use crate::usage::UsageEvent;
 
@@ -241,6 +241,15 @@ impl OtlpHttpFanOut {
     /// exporters.
     pub fn gc(&self, live: &std::collections::HashSet<String>) {
         self.inner.exporters.retain(live);
+    }
+
+    /// Per-exporter delivery counters, keyed by exporter name. Read by the
+    /// managed-mode heartbeat to report `exporter_health` to cp-api
+    /// (#519 D.2). Counters are per-pipeline: a reconfigured exporter gets
+    /// a rebuilt pipeline, so its counters reset — consumers must treat
+    /// them as resettable.
+    pub fn exporter_stats(&self) -> std::collections::HashMap<String, SinkStatsSnapshot> {
+        self.inner.exporters.stats()
     }
 
     /// Drain every exporter pipeline at graceful shutdown.

--- a/crates/aisix-obs/src/sink/pipeline.rs
+++ b/crates/aisix-obs/src/sink/pipeline.rs
@@ -11,7 +11,7 @@
 //! *wire encoding*, including chunking a batch down to its own per-request
 //! byte limit inside `append_batch` (only the sink knows the encoded size).
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -55,12 +55,22 @@ impl Default for PipelineConfig {
 
 /// Live delivery counters for one sink, shared between the producer handle
 /// and the worker. Cheap atomics; read via [`SinkStats::snapshot`].
+///
+/// Lifetime note: the stats live as long as the pipeline. A reconfigured
+/// or removed-then-re-added exporter gets a fresh pipeline (see
+/// `ExporterPipelines::get_or_create`) and therefore fresh zeroed
+/// counters — consumers (heartbeat `exporter_health`, #519 D.2) must
+/// treat the counters as resettable, not lifetime-of-process totals.
 #[derive(Debug, Default)]
 pub struct SinkStats {
     sent: AtomicU64,
     dropped: AtomicU64,
     retries: AtomicU64,
+    delivered_batches: AtomicU64,
     failed_batches: AtomicU64,
+    /// Unix seconds of the most recent batch outcome; 0 = never.
+    last_success_unix: AtomicI64,
+    last_failure_unix: AtomicI64,
     last_error: Mutex<Option<String>>,
 }
 
@@ -74,10 +84,27 @@ pub struct SinkStatsSnapshot {
     pub dropped: u64,
     /// Retry attempts made across all batches.
     pub retries: u64,
+    /// Batches the sink acknowledged.
+    pub delivered_batches: u64,
     /// Batches given up on after retries (or a permanent error).
     pub failed_batches: u64,
-    /// Masked excerpt of the most recent delivery error, if any.
+    /// Masked excerpt of the most recent delivery error. Cleared on the
+    /// next successful delivery, so `Some` means "currently failing".
     pub last_error: Option<String>,
+    /// Unix seconds of the most recent successful batch delivery.
+    pub last_success_unix: Option<i64>,
+    /// Unix seconds of the most recent dropped batch. Unlike
+    /// `last_error` this persists across later successes — it answers
+    /// "when did this exporter last lose data".
+    pub last_failure_unix: Option<i64>,
+}
+
+fn now_unix_secs() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 impl SinkStats {
@@ -90,8 +117,15 @@ impl SinkStats {
     fn add_retries(&self, n: u64) {
         self.retries.fetch_add(n, Ordering::Relaxed);
     }
-    fn add_failed_batch(&self) {
+    fn record_batch_delivered(&self) {
+        self.delivered_batches.fetch_add(1, Ordering::Relaxed);
+        self.last_success_unix
+            .store(now_unix_secs(), Ordering::Relaxed);
+    }
+    fn record_batch_failed(&self) {
         self.failed_batches.fetch_add(1, Ordering::Relaxed);
+        self.last_failure_unix
+            .store(now_unix_secs(), Ordering::Relaxed);
     }
     fn set_error(&self, detail: String) {
         *self.last_error.lock() = Some(detail);
@@ -102,12 +136,16 @@ impl SinkStats {
 
     /// Read the current counters.
     pub fn snapshot(&self) -> SinkStatsSnapshot {
+        let to_opt = |v: i64| (v != 0).then_some(v);
         SinkStatsSnapshot {
             sent: self.sent.load(Ordering::Relaxed),
             dropped: self.dropped.load(Ordering::Relaxed),
             retries: self.retries.load(Ordering::Relaxed),
+            delivered_batches: self.delivered_batches.load(Ordering::Relaxed),
             failed_batches: self.failed_batches.load(Ordering::Relaxed),
             last_error: self.last_error.lock().clone(),
+            last_success_unix: to_opt(self.last_success_unix.load(Ordering::Relaxed)),
+            last_failure_unix: to_opt(self.last_failure_unix.load(Ordering::Relaxed)),
         }
     }
 }
@@ -256,6 +294,7 @@ impl SinkPipeline {
             match self.sink.append_batch(batch, &marker).await {
                 Ok(ack) => {
                     self.stats.add_sent(ack.accepted as u64);
+                    self.stats.record_batch_delivered();
                     self.stats.clear_error();
                     return;
                 }
@@ -275,7 +314,7 @@ impl SinkPipeline {
                         tokio::time::sleep(delay).await;
                         continue;
                     }
-                    self.stats.add_failed_batch();
+                    self.stats.record_batch_failed();
                     self.stats.add_dropped(count as u64);
                     self.stats.set_error(detail.clone());
                     tracing::warn!(
@@ -475,6 +514,13 @@ mod tests {
         assert_eq!(s.sent, 1, "record eventually delivered");
         assert_eq!(s.dropped, 0);
         assert_eq!(sink.delivered(), 1);
+        // #519 D.2 delivery-health counters: an eventual success counts
+        // one delivered batch, no failed batch, and stamps the success
+        // timestamp (retried attempts are not failed batches).
+        assert_eq!(s.delivered_batches, 1);
+        assert_eq!(s.failed_batches, 0);
+        assert!(s.last_success_unix.is_some(), "success timestamp recorded");
+        assert!(s.last_failure_unix.is_none(), "no batch was dropped");
     }
 
     #[tokio::test]
@@ -498,6 +544,11 @@ mod tests {
             s.last_error.is_some(),
             "last error recorded for the dashboard"
         );
+        // #519 D.2: a dropped batch stamps the failure timestamp and
+        // counts zero delivered batches.
+        assert_eq!(s.delivered_batches, 0);
+        assert!(s.last_failure_unix.is_some(), "failure timestamp recorded");
+        assert!(s.last_success_unix.is_none(), "nothing was delivered");
     }
 
     #[tokio::test]

--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -18,11 +18,13 @@
 //!   - cancelled via the shared `watch::Receiver<bool>` so graceful
 //!     shutdown doesn't leave an in-flight request dangling
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aisix_etcd::loader::RejectedEntry;
+use aisix_obs::SinkStatsSnapshot;
 use anyhow::{anyhow, Context};
 use serde::Serialize;
 use tokio::sync::watch;
@@ -36,6 +38,22 @@ use tokio::sync::watch;
 /// who saved an invalid resource in the dashboard saw "Saved" but the
 /// DP dropped the row — no signal back. See issue #115.
 pub type RejectionFetcher = Arc<dyn Fn() -> Vec<RejectedEntry> + Send + Sync>;
+
+/// Per-tick source of the highest etcd/kine revision the watch
+/// supervisor has applied to its snapshot (`WatchStatus.revision`).
+/// Reported as `applied_revision` so cp-api can compare it against the
+/// revision returned when IT wrote a resource through kine and show
+/// "propagating…" until the DP catches up (#519 B.3). `0` = the
+/// supervisor has not completed its first load yet.
+pub type AppliedRevisionFetcher = Arc<dyn Fn() -> i64 + Send + Sync>;
+
+/// Per-tick source of the observability exporters' delivery counters,
+/// keyed by exporter name (`OtlpHttpFanOut::exporter_stats`). Reported
+/// as `exporter_health` so cp-api can surface silently-failing
+/// exporters in the dashboard (#519 D.2). Counters reset when an
+/// exporter's pipeline is rebuilt on config change — the CP must treat
+/// them as resettable, not lifetime totals.
+pub type ExporterHealthFetcher = Arc<dyn Fn() -> HashMap<String, SinkStatsSnapshot> + Send + Sync>;
 
 /// File paths to the on-disk mTLS bundle the heartbeat client presents
 /// to cp-api. Same three files written by cert-bundle provisioning and
@@ -73,6 +91,13 @@ pub struct HeartbeatConfig {
     /// kept for tests / managed-mode configs that don't have a
     /// supervisor wired in. See issue #115.
     pub rejection_fetcher: Option<RejectionFetcher>,
+    /// Optional source of the supervisor's applied etcd revision.
+    /// `None` (tests / no supervisor) reports `applied_revision: 0`,
+    /// the same value as "not yet loaded". See #519 B.3.
+    pub applied_revision_fetcher: Option<AppliedRevisionFetcher>,
+    /// Optional source of per-exporter delivery counters. `None`
+    /// reports an empty `exporter_health` array. See #519 D.2.
+    pub exporter_health_fetcher: Option<ExporterHealthFetcher>,
 }
 
 impl std::fmt::Debug for HeartbeatConfig {
@@ -85,6 +110,14 @@ impl std::fmt::Debug for HeartbeatConfig {
             .field(
                 "rejection_fetcher",
                 &self.rejection_fetcher.as_ref().map(|_| "<fn>"),
+            )
+            .field(
+                "applied_revision_fetcher",
+                &self.applied_revision_fetcher.as_ref().map(|_| "<fn>"),
+            )
+            .field(
+                "exporter_health_fetcher",
+                &self.exporter_health_fetcher.as_ref().map(|_| "<fn>"),
             )
             .finish()
     }
@@ -103,6 +136,8 @@ impl HeartbeatConfig {
             interval,
             mtls,
             rejection_fetcher: None,
+            applied_revision_fetcher: None,
+            exporter_health_fetcher: None,
         }
     }
 
@@ -110,6 +145,18 @@ impl HeartbeatConfig {
     /// per-heartbeat call (cheap — it's an Arc).
     pub fn with_rejection_fetcher(mut self, fetcher: RejectionFetcher) -> Self {
         self.rejection_fetcher = Some(fetcher);
+        self
+    }
+
+    /// Wire the supervisor's applied-revision source (#519 B.3).
+    pub fn with_applied_revision_fetcher(mut self, fetcher: AppliedRevisionFetcher) -> Self {
+        self.applied_revision_fetcher = Some(fetcher);
+        self
+    }
+
+    /// Wire the exporter delivery-counter source (#519 D.2).
+    pub fn with_exporter_health_fetcher(mut self, fetcher: ExporterHealthFetcher) -> Self {
+        self.exporter_health_fetcher = Some(fetcher);
         self
     }
 }
@@ -173,12 +220,60 @@ struct HeartbeatBody<'a> {
     dp_id: &'a str,
     uptime_seconds: i64,
     version: &'a str,
+    /// Guardrail `kind` discriminators compiled into this binary
+    /// (#519 B.6). Always present so cp-api can hide / flag kinds the
+    /// DP can't serve (e.g. a build without the `bedrock` feature).
+    supported_guardrail_kinds: &'static [&'static str],
+    /// Highest etcd/kine revision the watch supervisor has applied
+    /// (#519 B.3). `0` = snapshot not loaded yet. cp-api compares this
+    /// against the revision returned by its own kine writes: a DP with
+    /// `applied_revision >= write_revision` has seen that write.
+    applied_revision: i64,
+    /// Per-exporter delivery counters (#519 D.2), sorted by exporter
+    /// name. Always present; empty when no exporter pipeline has
+    /// started. Counters reset when an exporter's pipeline is rebuilt
+    /// on config change.
+    exporter_health: Vec<ExporterHealthWire>,
     /// Loader rejections the supervisor has accumulated since last
     /// drain. Omitted from the wire when empty so legacy / managed-mode
     /// CP endpoints (which don't yet parse this field) still see the
     /// historical body shape. See issue #115.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     rejected_resources: Vec<RejectedResourceWire>,
+}
+
+/// Cap on the `last_error` excerpt forwarded per exporter. The pipeline
+/// already trims sink errors to 200 chars; this is the wire-side
+/// guarantee so a future verbose sink can't bloat the heartbeat.
+const EXPORTER_LAST_ERROR_MAX_CHARS: usize = 256;
+
+/// On-the-wire shape of one exporter's delivery health (#519 D.2). Kept
+/// separate from `aisix_obs::SinkStatsSnapshot` so the obs crate's
+/// internal counters can evolve without forcing a wire bump.
+#[derive(Debug, Serialize)]
+struct ExporterHealthWire {
+    name: String,
+    delivered_batches: u64,
+    failed_batches: u64,
+    last_error: Option<String>,
+    last_failure_unix: Option<i64>,
+    last_success_unix: Option<i64>,
+}
+
+impl ExporterHealthWire {
+    fn from_stats(name: String, stats: &SinkStatsSnapshot) -> Self {
+        Self {
+            name,
+            delivered_batches: stats.delivered_batches,
+            failed_batches: stats.failed_batches,
+            last_error: stats
+                .last_error
+                .as_ref()
+                .map(|e| e.chars().take(EXPORTER_LAST_ERROR_MAX_CHARS).collect()),
+            last_failure_unix: stats.last_failure_unix,
+            last_success_unix: stats.last_success_unix,
+        }
+    }
 }
 
 /// On-the-wire shape for one rejection. Kept as a separate type from
@@ -212,6 +307,23 @@ async fn send(client: &reqwest::Client, cfg: &HeartbeatConfig, uptime: i64) -> a
         .as_ref()
         .map(|fetcher| fetcher().iter().map(RejectedResourceWire::from).collect())
         .unwrap_or_default();
+    let applied_revision = cfg
+        .applied_revision_fetcher
+        .as_ref()
+        .map(|fetcher| fetcher())
+        .unwrap_or(0);
+    let mut exporter_health: Vec<ExporterHealthWire> = cfg
+        .exporter_health_fetcher
+        .as_ref()
+        .map(|fetcher| {
+            fetcher()
+                .into_iter()
+                .map(|(name, stats)| ExporterHealthWire::from_stats(name, &stats))
+                .collect()
+        })
+        .unwrap_or_default();
+    // Deterministic order — the fetcher hands back a HashMap.
+    exporter_health.sort_by(|a, b| a.name.cmp(&b.name));
 
     let resp = client
         .post(&cfg.url)
@@ -221,6 +333,9 @@ async fn send(client: &reqwest::Client, cfg: &HeartbeatConfig, uptime: i64) -> a
             dp_id: &cfg.dp_id,
             uptime_seconds: uptime,
             version: env!("CARGO_PKG_VERSION"),
+            supported_guardrail_kinds: aisix_guardrails::supported_kinds(),
+            applied_revision,
+            exporter_health,
             rejected_resources: rejections,
         })
         .send()
@@ -409,6 +524,117 @@ mod tests {
             req.headers.get("authorization").is_none(),
             "v3 heartbeat MUST NOT carry Authorization header (mTLS-only auth)",
         );
+    }
+
+    /// #519 B.6 + B.3 + D.2: the heartbeat body always carries the
+    /// compiled-in guardrail kinds, the applied etcd revision, and the
+    /// per-exporter delivery health (sorted by name).
+    #[tokio::test]
+    async fn send_includes_guardrail_kinds_revision_and_exporter_health() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/dp/heartbeat"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true
+            })))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mtls = write_test_bundle(dir.path());
+        let cfg = cfg_with_bundle(format!("{}/dp/heartbeat", server.uri()), mtls)
+            .with_applied_revision_fetcher(Arc::new(|| 42))
+            .with_exporter_health_fetcher(Arc::new(|| {
+                let mut m = std::collections::HashMap::new();
+                m.insert(
+                    "zeta-exporter".to_string(),
+                    aisix_obs::SinkStatsSnapshot {
+                        delivered_batches: 3,
+                        failed_batches: 1,
+                        last_error: Some("HTTP 503: upstream sad".into()),
+                        last_failure_unix: Some(1_770_000_000),
+                        last_success_unix: Some(1_770_000_100),
+                        ..Default::default()
+                    },
+                );
+                m.insert(
+                    "alpha-exporter".to_string(),
+                    aisix_obs::SinkStatsSnapshot::default(),
+                );
+                m
+            }));
+        send(&plain_client(), &cfg, 7).await.unwrap();
+
+        let received = server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+
+        // B.6 — exact compiled-in kinds under default features.
+        assert_eq!(
+            body["supported_guardrail_kinds"],
+            serde_json::json!([
+                "keyword",
+                "azure_content_safety",
+                "azure_content_safety_text_moderation",
+                "aliyun_text_moderation",
+                "bedrock",
+            ]),
+        );
+
+        // B.3 — the fetched applied revision.
+        assert_eq!(body["applied_revision"], 42);
+
+        // D.2 — both exporters, sorted by name, with the wire fields.
+        let health = body["exporter_health"].as_array().unwrap();
+        assert_eq!(health.len(), 2);
+        assert_eq!(health[0]["name"], "alpha-exporter");
+        assert_eq!(health[0]["delivered_batches"], 0);
+        assert_eq!(health[0]["last_error"], serde_json::Value::Null);
+        assert_eq!(health[1]["name"], "zeta-exporter");
+        assert_eq!(health[1]["delivered_batches"], 3);
+        assert_eq!(health[1]["failed_batches"], 1);
+        assert_eq!(health[1]["last_error"], "HTTP 503: upstream sad");
+        assert_eq!(health[1]["last_failure_unix"], 1_770_000_000_i64);
+        assert_eq!(health[1]["last_success_unix"], 1_770_000_100_i64);
+
+        // `rejected_resources` keeps its omit-when-empty behavior.
+        assert!(
+            body.get("rejected_resources").is_none(),
+            "empty rejected_resources must stay off the wire",
+        );
+    }
+
+    /// Without fetchers (tests / no supervisor), the new fields still
+    /// serialize: revision 0 and an empty exporter_health array.
+    #[tokio::test]
+    async fn send_defaults_new_fields_without_fetchers() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/dp/heartbeat"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true
+            })))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mtls = write_test_bundle(dir.path());
+        send(
+            &plain_client(),
+            &cfg_with_bundle(format!("{}/dp/heartbeat", server.uri()), mtls),
+            7,
+        )
+        .await
+        .unwrap();
+
+        let received = server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(body["applied_revision"], 0);
+        assert_eq!(body["exporter_health"], serde_json::json!([]));
+        assert!(body["supported_guardrail_kinds"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|k| k == "keyword"));
     }
 
     #[tokio::test]

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -366,18 +366,6 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             }
         }
     });
-    // Issue #115: supply the supervisor's rejection callback so each
-    // heartbeat carries the loader's most recent failures up to cp-api.
-    // Pre-fix the loader logged a warning and silently moved on —
-    // dashboard customers saw "Saved successfully" but the DP had
-    // dropped the row.
-    let heartbeat_task = heartbeat_cfg.map(|mut h| {
-        let supervisor_for_heartbeat = Arc::clone(&supervisor);
-        h = h.with_rejection_fetcher(Arc::new(move || {
-            supervisor_for_heartbeat.recent_rejections()
-        }));
-        heartbeat::spawn(h, cancel_rx.clone())
-    });
     let (usage_sink, telemetry_task) = match telemetry_cfg {
         Some(cfg) => {
             let (sink, handle) = telemetry::spawn(cfg, cancel_rx.clone());
@@ -440,6 +428,25 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         snapshot_handle.clone(),
         bedrock_endpoint_url,
     ));
+    // Heartbeat worker — spawned after proxy_state exists so it can read
+    // the exporter fan-out's delivery counters. Each tick reports:
+    //   - rejected_resources: the supervisor's loader rejections (#115)
+    //   - applied_revision: the highest etcd revision the supervisor has
+    //     applied, so cp-api can show "propagating…" until the DP catches
+    //     up with a kine write (#519 B.3)
+    //   - supported_guardrail_kinds + exporter_health (#519 B.6 / D.2)
+    let heartbeat_task = heartbeat_cfg.map(|mut h| {
+        let supervisor_for_heartbeat = Arc::clone(&supervisor);
+        h = h.with_rejection_fetcher(Arc::new(move || {
+            supervisor_for_heartbeat.recent_rejections()
+        }));
+        let watch_status = supervisor.watch_status();
+        h = h.with_applied_revision_fetcher(Arc::new(move || watch_status.snapshot().revision));
+        let fan_out = proxy_state.otlp_fan_out.clone();
+        h = h.with_exporter_health_fetcher(Arc::new(move || fan_out.exporter_stats()));
+        heartbeat::spawn(h, cancel_rx.clone())
+    });
+
     // Clone shared trackers before consuming proxy_state in build_router.
     let health_tracker = proxy_state.health.clone();
     let livez_state = proxy_state.livez.clone();

--- a/docs/architecture/snapshot-and-watch.md
+++ b/docs/architecture/snapshot-and-watch.md
@@ -388,8 +388,11 @@ event apply at info level when `access_log` is enabled.
   `/admin/v1/models` instead of relying on the cp-api response.
 - **No multi-DP coordination.** Each DP instance runs its own
   supervisor against the same etcd; they pick up events
-  independently. There is no concept of "this DP has applied the
-  event, others have not" — eventual consistency only.
+  independently — eventual consistency only. Each DP does report
+  the highest revision it has applied as the `applied_revision`
+  field of its heartbeat payload, so cp-api can compare it against
+  the revision returned by its own kine write and surface per-DP
+  propagation state, but the DPs never coordinate among themselves.
 - **No partial loads.** The loader is all-or-nothing per entry —
   schema fails ⇒ entry rejected ⇒ never enters the snapshot. The
   proxy never sees a half-valid Model with a missing field. The


### PR DESCRIPTION
DP half of findings B.6, B.3, D.2 from the api7/AISIX-Cloud#519 audit. Adds three always-present fields to the `POST /dp/heartbeat` body; a CP follow-up PR will consume them. The CP's Go JSON decoding tolerates unknown fields, so this is DP-first safe.

**`supported_guardrail_kinds` (B.6).** Every non-keyword guardrail kind compiles behind a cargo feature; a DP built without one (e.g. `bedrock`) silently rejects rows of that kind while the dashboard still offers it. `aisix_guardrails::supported_kinds()` returns the kind discriminators actually compiled in — strings are pinned by test to the `GuardrailKind` serde tags (`keyword`, `azure_content_safety`, `azure_content_safety_text_moderation`, `aliyun_text_moderation`, `bedrock`) so the list can't drift from the config schema. The CP can hide/flag kinds the connected DP can't serve.

**`applied_revision` (B.3).** The highest etcd/kine revision the watch supervisor has applied to its snapshot, read from the existing `WatchStatus` atomic (`0` = not yet loaded). Semantics chosen so the CP can compare directly against the revision returned by its own kine write: initial full load floors to the range response header revision, watch puts record the kv `mod_revision`, and the watch cycle's Delete/Resync arms now also floor to the event revision — previously a delete never advanced the revision, so `applied_revision` would stall after a CP delete until an unrelated put arrived. A DP with `applied_revision >= write_revision` has processed that write (standard etcd watch semantics), which is what the dashboard needs for "propagating…" state.

**`exporter_health` (D.2).** Observability-exporter delivery failures were only `tracing::warn!`. The shared `SinkPipeline` stats now track per-exporter `delivered_batches` / `failed_batches` plus `last_success_unix` / `last_failure_unix`, alongside the existing `last_error` excerpt (capped at 256 chars on the wire). Exposed via `OtlpHttpFanOut::exporter_stats()` and reported sorted by exporter name. Counters are per-pipeline: a reconfigured exporter gets a rebuilt pipeline with zeroed counters, so the CP must treat them as resettable, not lifetime totals.

`rejected_resources` keeps its existing omit-when-empty behavior.

Tests: heartbeat body serialization (fields present, sorted, defaults without fetchers, `rejected_resources` still omitted when empty); `supported_kinds()` round-trips every string through the config parser to `kind_str` under default features; pipeline counter/timestamp assertions on the success and retry-exhausted paths; supervisor unit test pinning that a Delete event's `mod_revision` advances the applied revision; and a real-etcd integration test (`supervisor_applied_revision_catches_up_to_writer_revision`) asserting the supervisor's applied revision catches up to the writer's response header revision after a put and after a delete. No DP e2e: `tests/e2e` has no managed-mode/mock dp-manager harness, so heartbeat-body coverage lives in the unit layer.

Part of api7/AISIX-Cloud#519

Closes api7/AISIX-Cloud#519