### PR TITLE
feat(obs): per-exporter sample_rate + content capture for otlp_http

### DIFF
--- a/crates/aisix-core/src/models/observability_exporter.rs
+++ b/crates/aisix-core/src/models/observability_exporter.rs
@@ -90,7 +90,8 @@ pub struct OtlpHttpConfig {
     /// exporter's spans. `metadata_only` (default) ships only operational
     /// metadata — never a prompt or response. `full` additionally attaches
     /// the request prompt and the assembled response as span attributes
-    /// (`aisix.prompt` / `aisix.response`), each truncated to
+    /// (`gen_ai.prompt` / `gen_ai.completion` — the same keys the Datadog
+    /// sink ships the captured content under), each truncated to
     /// [`content_max_bytes`]. Enabling `full` writes end-user prompt /
     /// response text into the customer's tracing backend, so the dashboard
     /// must surface the privacy implication when an operator turns it on.
@@ -105,7 +106,7 @@ pub struct OtlpHttpConfig {
 
     /// Per-field byte cap for captured content under `content_mode = full`.
     /// The prompt and the response are each truncated to this many bytes
-    /// (UTF-8-boundary safe), and the span carries a
+    /// (UTF-8-boundary safe), and the span carries an
     /// `aisix.content_truncated` attribute when either was cut. Ignored
     /// under `metadata_only`. Defaults to 128 KiB.
     ///

--- a/crates/aisix-core/src/models/observability_exporter.rs
+++ b/crates/aisix-core/src/models/observability_exporter.rs
@@ -43,7 +43,12 @@ use crate::resource::Resource;
 /// `tag = "kind"` puts the variant tag inline with the inner struct's
 /// fields — same shape as `GuardrailKind` so the kine wire stays
 /// consistent across resource types.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+///
+/// `PartialEq` (not `Eq`) because [`OtlpHttpConfig::sample_rate`] is an
+/// `f64`, whose NaN semantics make a derived `Eq` unsound (same precedent
+/// as `ProviderKey`). Tests compare via `assert_eq!`, which only needs
+/// `PartialEq`.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ExporterKind {
     OtlpHttp(OtlpHttpConfig),
@@ -52,7 +57,8 @@ pub enum ExporterKind {
     Datadog(DatadogConfig),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+/// `PartialEq` (not `Eq`): `sample_rate` is an `f64` — see [`ExporterKind`].
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct OtlpHttpConfig {
     /// Full URL of the OTLP/HTTP traces endpoint. Must already include
@@ -67,6 +73,48 @@ pub struct OtlpHttpConfig {
     /// `provider_keys`. Field-level encryption arrives in Phase 2.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headers: BTreeMap<String, String>,
+
+    /// Fraction of requests whose spans are exported, `0.0`–`1.0`.
+    /// Absent = `1.0` (export everything — the pre-knob behaviour).
+    /// The decision is per REQUEST, made deterministically from the
+    /// `request_id` hash, so every attempt span of one request (initial /
+    /// retries / fallbacks, which share the id) samples consistently —
+    /// a trace is exported whole or not at all. Bounds are enforced by
+    /// the loader's JSON-schema validation
+    /// (`schema::validate_observability_exporter`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub sample_rate: Option<f64>,
+
+    /// Whether captured request/response content is delivered on this
+    /// exporter's spans. `metadata_only` (default) ships only operational
+    /// metadata — never a prompt or response. `full` additionally attaches
+    /// the request prompt and the assembled response as span attributes
+    /// (`aisix.prompt` / `aisix.response`), each truncated to
+    /// [`content_max_bytes`]. Enabling `full` writes end-user prompt /
+    /// response text into the customer's tracing backend, so the dashboard
+    /// must surface the privacy implication when an operator turns it on.
+    /// Reuses [`SlsContentMode`] — the codebase's existing
+    /// `metadata_only | full` model — so the shared content-capture
+    /// plumbing (`content_record` / `content_capture_cap`) stays
+    /// single-sourced.
+    ///
+    /// [`content_max_bytes`]: OtlpHttpConfig::content_max_bytes
+    #[serde(default)]
+    pub content_mode: SlsContentMode,
+
+    /// Per-field byte cap for captured content under `content_mode = full`.
+    /// The prompt and the response are each truncated to this many bytes
+    /// (UTF-8-boundary safe), and the span carries a
+    /// `aisix.content_truncated` attribute when either was cut. Ignored
+    /// under `metadata_only`. Defaults to 128 KiB.
+    ///
+    /// `0` is rejected — `full` with a zero cap captures nothing, which is a
+    /// misconfiguration. The `range(min = 1)` keeps the generated JSON schema
+    /// in step with the runtime validator so the CP and DP agree on the floor.
+    #[serde(default = "default_content_max_bytes")]
+    #[schemars(range(min = 1))]
+    pub content_max_bytes: u32,
 }
 
 /// Aliyun SLS (Simple Log Service) PutLogs target. Unlike `otlp_http`,
@@ -126,9 +174,10 @@ pub struct AliyunSlsConfig {
     pub content_max_bytes: u32,
 }
 
-/// Content-capture mode for an SLS / Datadog exporter. Defaults to the
-/// privacy-preserving `metadata_only`. (`Hash` so a Datadog exporter's
-/// fingerprint can cover its content config; see `fingerprint_datadog`.)
+/// Content-capture mode for an SLS / Datadog / OTLP exporter. Defaults to
+/// the privacy-preserving `metadata_only`. (`Hash` so an exporter's
+/// fingerprint can cover its content config; see `fingerprint_datadog` /
+/// `fingerprint_otlp`.)
 #[derive(
     Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq, Hash,
 )]
@@ -338,7 +387,10 @@ pub enum ObjectStoreAuthMode {
 /// field. Strict typo rejection happens at the JSON Schema layer
 /// (`schema::validate_observability_exporter`) which the etcd loader
 /// runs before the serde deserialize.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+///
+/// `PartialEq` (not `Eq`): the flattened [`ExporterKind`] carries an `f64`
+/// (`OtlpHttpConfig::sample_rate`) — see [`ExporterKind`].
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct ObservabilityExporter {
     /// Operator-facing label, surfaced in /logs and the dashboard list.
     /// Not used for routing — the etcd-key uuid is the identity.
@@ -429,6 +481,53 @@ mod tests {
             ExporterKind::OtlpHttp(c) => assert!(c.headers.is_empty()),
             other => panic!("expected otlp_http, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn otlp_http_defaults_pin_pre_knob_behaviour() {
+        // A CP payload carrying only endpoint+headers (the current kine
+        // projection) must parse unchanged: no sampling (rate absent =
+        // 1.0) and metadata-only content — the exact pre-knob behaviour.
+        let e: ObservabilityExporter = serde_json::from_str(VALID_OTLP).unwrap();
+        match &e.kind {
+            ExporterKind::OtlpHttp(c) => {
+                assert_eq!(c.sample_rate, None);
+                assert_eq!(c.content_mode, SlsContentMode::MetadataOnly);
+                assert_eq!(c.content_max_bytes, 128 * 1024);
+            }
+            other => panic!("expected otlp_http, got {other:?}"),
+        }
+        // Absent knobs stay off the wire on re-serialize, so a round-trip
+        // through the DP cannot change what the CP wrote.
+        let v = serde_json::to_value(&e).unwrap();
+        assert!(v.get("sample_rate").is_none());
+    }
+
+    #[test]
+    fn otlp_http_opts_into_sampling_and_full_content_capture() {
+        let json = r#"{
+            "name": "otlp-knobs",
+            "kind": "otlp_http",
+            "endpoint": "https://api.honeycomb.io/v1/traces",
+            "sample_rate": 0.25,
+            "content_mode": "full",
+            "content_max_bytes": 4096
+        }"#;
+        let e: ObservabilityExporter = serde_json::from_str(json).unwrap();
+        match &e.kind {
+            ExporterKind::OtlpHttp(c) => {
+                assert_eq!(c.sample_rate, Some(0.25));
+                assert_eq!(c.content_mode, SlsContentMode::Full);
+                assert_eq!(c.content_max_bytes, 4096);
+            }
+            other => panic!("expected otlp_http, got {other:?}"),
+        }
+        // Round-trips flat with the knobs present.
+        let v = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["kind"], "otlp_http");
+        assert_eq!(v["sample_rate"], 0.25);
+        assert_eq!(v["content_mode"], "full");
+        assert_eq!(v["content_max_bytes"], 4096);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -621,14 +621,20 @@ fn observability_exporter_schema() -> Value {
             "project":        { "type": "string", "minLength": 1 },
             "logstore":       { "type": "string", "minLength": 1 },
             "credential_ref": { "type": "string", "minLength": 1 },
-            // Content capture (opt-in), shared by aliyun_sls + datadog. `full`
-            // writes captured prompt / response to the sink; `content_max_bytes`
-            // truncates each FIELD. It is not a per-log bound — a datadog log
-            // carries both prompt and response, so byte-aware splitting to
-            // Datadog's 1 MB-per-log / 5 MB-per-request intake limits is tracked
-            // separately (api7/ai-gateway#556), not enforced by this cap.
+            // Content capture (opt-in), shared by aliyun_sls + datadog +
+            // otlp_http. `full` writes captured prompt / response to the sink;
+            // `content_max_bytes` truncates each FIELD. It is not a per-log
+            // bound — a datadog log carries both prompt and response, so
+            // byte-aware splitting to Datadog's 1 MB-per-log / 5 MB-per-request
+            // intake limits is tracked separately (api7/ai-gateway#556), not
+            // enforced by this cap.
             "content_mode":      { "type": "string", "enum": ["metadata_only", "full"] },
             "content_max_bytes": { "type": "integer", "minimum": 1, "maximum": 1048576 },
+            // otlp_http per-request sampling (#519 B.2). Absent = 1.0 (export
+            // everything). serde's `deny_unknown_fields` keeps it off the
+            // other kinds; this is the bounds check the loader runs before
+            // deserialize, so an out-of-range rate never reaches the sink.
+            "sample_rate": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
             // object_store fields (S3 / GCS / Azure Blob, one variant). Cloud
             // credentials are NEVER here — only the shared `credential_ref`.
             "provider":    { "type": "string", "enum": ["s3", "gcs", "azure_blob"] },
@@ -1461,6 +1467,38 @@ mod tests {
             "endpoint": "http://api.honeycomb.io/v1/traces"
         });
         assert!(validate_observability_exporter(&v).is_err());
+    }
+
+    #[test]
+    fn exporter_otlp_http_accepts_in_range_knobs() {
+        // #519 B.2: sampling + content capture are real per-exporter knobs.
+        for rate in [0.0, 0.5, 1.0] {
+            let v = json!({
+                "name": "otlp-knobs",
+                "kind": "otlp_http",
+                "endpoint": "https://api.honeycomb.io/v1/traces",
+                "sample_rate": rate,
+                "content_mode": "full",
+                "content_max_bytes": 4096
+            });
+            validate_observability_exporter(&v).unwrap();
+        }
+    }
+
+    #[test]
+    fn exporter_otlp_http_rejects_out_of_range_sample_rate() {
+        for rate in [-0.1, 1.1, 2.0] {
+            let v = json!({
+                "name": "x",
+                "kind": "otlp_http",
+                "endpoint": "https://api.honeycomb.io/v1/traces",
+                "sample_rate": rate
+            });
+            assert!(
+                validate_observability_exporter(&v).is_err(),
+                "sample_rate {rate} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -19,14 +19,25 @@
 //!    OpenTelemetry's GenAI semantic conventions
 //!    (<https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md>).
 //!
+//! ## Per-exporter knobs (#519 B.2)
+//!
+//! - **`sample_rate`** — fraction of requests exported, decided per REQUEST
+//!   from a deterministic FNV-1a hash of `request_id` (absent = 1.0). The
+//!   decision happens at fan-out time, before any pipeline work, so a
+//!   dropped request enqueues nothing for that exporter; and because every
+//!   attempt span of one request shares the `request_id`, a trace is
+//!   exported whole or not at all — consistently across retries/fallbacks.
+//! - **`content_mode` / `content_max_bytes`** — same opt-in content capture
+//!   the SLS / Datadog sinks use ([`content_record`]); under `full` the span
+//!   carries `aisix.prompt` / `aisix.response` (plus
+//!   `aisix.content_truncated` when cut). Defaults to `metadata_only`, where
+//!   the record never carries content fields, so it cannot leak.
+//!
 //! ## What's intentionally NOT here yet
 //!
 //! - **No gRPC** — `otlp_grpc` is a separate kind we'll add when a user
 //!   actually asks for it; the JSON-over-HTTP form works against every
 //!   receiver in the wild and avoids pulling in tonic on the hot path.
-//! - **No content_mode redaction** — defaults to `metadata_only` (no
-//!   prompt/response bodies in the span). The record never carries content
-//!   fields, so it cannot leak.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -116,10 +127,10 @@ impl OtlpHttpFanOut {
     ///
     /// `content` is the request's captured prompt/response, or `None` when the
     /// handler captured none (the default). It is attached ONLY to an
-    /// `aliyun_sls` or `datadog` exporter whose `content_mode = full`; every
-    /// other exporter — and the CP telemetry path, which is not in this loop —
-    /// receives the shared metadata-only record, so prompt/response can never
-    /// leak there.
+    /// `aliyun_sls`, `datadog`, or `otlp_http` exporter whose
+    /// `content_mode = full`; every other exporter — and the CP telemetry
+    /// path, which is not in this loop — receives the shared metadata-only
+    /// record, so prompt/response can never leak there.
     pub fn fan_out<'a, I>(
         &self,
         event: &UsageEvent,
@@ -145,6 +156,15 @@ impl OtlpHttpFanOut {
             let client = self.inner.client.clone();
             let handle = match &exp.kind {
                 ExporterKind::OtlpHttp(cfg) => {
+                    // Per-request sampling (#519 B.2), decided here — before
+                    // any pipeline work — so an unsampled request enqueues
+                    // nothing for THIS exporter (other exporters in the loop
+                    // still see the event). Deterministic on `request_id`, so
+                    // every attempt span of one request drops or ships
+                    // together.
+                    if !otlp_should_sample(cfg.sample_rate, &event.request_id) {
+                        continue;
+                    }
                     let fingerprint = fingerprint_otlp(cfg);
                     let name = exp.name.clone();
                     let endpoint = cfg.endpoint.clone();
@@ -264,15 +284,57 @@ impl Default for OtlpHttpFanOut {
     }
 }
 
-/// Hash an `otlp_http` exporter's delivery-relevant config. A change to
-/// endpoint or headers yields a new fingerprint, so the manager rebuilds the
-/// exporter's pipeline against the edited target.
+/// Hash an `otlp_http` exporter's delivery-relevant config. A change to any
+/// field — endpoint, headers, or the #519 B.2 knobs (sample_rate / content
+/// config) — yields a new fingerprint, so the manager rebuilds the exporter's
+/// pipeline against the edited config. `sample_rate` hashes by bit pattern
+/// (`f64` has no `Hash`); the schema bounds it to finite 0.0–1.0, where bit
+/// equality is value equality.
 fn fingerprint_otlp(cfg: &OtlpHttpConfig) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     cfg.endpoint.hash(&mut hasher);
     cfg.headers.hash(&mut hasher);
+    cfg.sample_rate.map(f64::to_bits).hash(&mut hasher);
+    cfg.content_mode.hash(&mut hasher);
+    cfg.content_max_bytes.hash(&mut hasher);
     hasher.finish()
+}
+
+/// Granularity of the sampling decision: rates are compared at 1/10_000
+/// (0.01%) resolution, plenty for an operator-facing percentage knob.
+const SAMPLE_PRECISION: u64 = 10_000;
+
+/// Per-request sampling decision for an `otlp_http` exporter. `rate` is the
+/// exporter's `sample_rate` (`None` = 1.0, the pre-knob default).
+///
+/// Deterministic — no clock, no RNG: the request's `request_id` is hashed
+/// (FNV-1a 64, stable across processes and versions) into a bucket in
+/// `0..SAMPLE_PRECISION`, and the request is sampled when the bucket falls
+/// below `rate × SAMPLE_PRECISION`. Same id → same decision, so the
+/// per-attempt events of one request (#655, which share `request_id`) are
+/// exported all-or-nothing, and every DP replica samples the same set.
+fn otlp_should_sample(rate: Option<f64>, request_id: &str) -> bool {
+    let rate = rate.unwrap_or(1.0);
+    if rate >= 1.0 {
+        return true;
+    }
+    if rate <= 0.0 {
+        return false;
+    }
+    let threshold = (rate * SAMPLE_PRECISION as f64).round() as u64;
+    fnv1a_64(request_id.as_bytes()) % SAMPLE_PRECISION < threshold
+}
+
+/// FNV-1a 64-bit — implemented inline (a fold over two constants) so the
+/// sampling hash is under our control and documented, rather than tied to
+/// `DefaultHasher`'s unspecified algorithm or a `rand` dependency.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    bytes.iter().fold(OFFSET_BASIS, |hash, b| {
+        (hash ^ u64::from(*b)).wrapping_mul(PRIME)
+    })
 }
 
 /// Hash an `aliyun_sls` exporter's delivery-relevant config. The fingerprint
@@ -293,12 +355,12 @@ fn fingerprint_sls(cfg: &AliyunSlsConfig) -> u64 {
 /// The content-bearing [`SinkRecord`] for one exporter, or `None` to fall back
 /// to the shared metadata-only record.
 ///
-/// Content is attached ONLY to an `aliyun_sls` OR `datadog` exporter whose
-/// `content_mode = full`, and ONLY when the handler captured content — every
-/// other exporter (and the CP telemetry path, which never enters the fan-out)
-/// gets metadata only. The captured prompt/response are truncated to the
-/// exporter's `content_max_bytes`, ORing in any truncation the handler already
-/// applied at capture time.
+/// Content is attached ONLY to an `aliyun_sls`, `datadog`, OR `otlp_http`
+/// exporter whose `content_mode = full`, and ONLY when the handler captured
+/// content — every other exporter (and the CP telemetry path, which never
+/// enters the fan-out) gets metadata only. The captured prompt/response are
+/// truncated to the exporter's `content_max_bytes`, ORing in any truncation
+/// the handler already applied at capture time.
 fn content_record(
     kind: &ExporterKind,
     event: &UsageEvent,
@@ -310,6 +372,7 @@ fn content_record(
     let (mode, max_bytes) = match kind {
         ExporterKind::AliyunSls(cfg) => (cfg.content_mode, cfg.content_max_bytes),
         ExporterKind::Datadog(cfg) => (cfg.content_mode, cfg.content_max_bytes),
+        ExporterKind::OtlpHttp(cfg) => (cfg.content_mode, cfg.content_max_bytes),
         _ => return None,
     };
     if mode != SlsContentMode::Full {
@@ -342,6 +405,9 @@ pub fn content_capture_cap<'a>(
                 Some(cfg.content_max_bytes)
             }
             ExporterKind::Datadog(cfg) if cfg.content_mode == SlsContentMode::Full => {
+                Some(cfg.content_max_bytes)
+            }
+            ExporterKind::OtlpHttp(cfg) if cfg.content_mode == SlsContentMode::Full => {
                 Some(cfg.content_max_bytes)
             }
             _ => None,
@@ -443,7 +509,7 @@ impl ObservabilitySink for OtlpSink {
         let spans: Vec<Value> = batch
             .records
             .iter()
-            .map(|record| build_otlp_span(&record.usage, &self.name))
+            .map(|record| build_otlp_span(record, &self.name))
             .collect();
         let body = otlp_export_request(spans);
         let bytes = serde_json::to_vec(&body)
@@ -498,7 +564,7 @@ impl ObservabilitySink for OtlpSink {
     }
 }
 
-/// Build the single OTLP span object for one usage event. Attribute names
+/// Build the single OTLP span object for one sink record. Attribute names
 /// match the OpenTelemetry GenAI semantic conventions:
 /// <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md>.
 ///
@@ -507,7 +573,16 @@ impl ObservabilitySink for OtlpSink {
 ///   `{"intValue": "..."}` (string-encoded int per OTLP/JSON spec).
 /// - Trace ID + span ID are random 16-byte / 8-byte hex values.
 /// - Timestamps are nanos-since-epoch, OTLP's required unit.
-fn build_otlp_span(event: &UsageEvent, exporter_name: &str) -> Value {
+///
+/// When the record carries captured content (this exporter's
+/// `content_mode = full`, see [`content_record`]) the span additionally
+/// carries `aisix.prompt` / `aisix.response` — the same prompt / assembled
+/// response the SLS path ships as log fields — plus
+/// `aisix.content_truncated` when either field was cut to the exporter's
+/// `content_max_bytes`. Metadata-only records never reach this branch with
+/// content, so the default span shape is unchanged.
+fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
+    let event = &record.usage;
     let trace_id = random_trace_id();
     let span_id = random_span_id();
 

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -29,8 +29,9 @@
 //!   exported whole or not at all — consistently across retries/fallbacks.
 //! - **`content_mode` / `content_max_bytes`** — same opt-in content capture
 //!   the SLS / Datadog sinks use ([`content_record`]); under `full` the span
-//!   carries `aisix.prompt` / `aisix.response` (plus
-//!   `aisix.content_truncated` when cut). Defaults to `metadata_only`, where
+//!   carries `gen_ai.prompt` / `gen_ai.completion` (plus
+//!   `aisix.content_truncated` when cut) — the same keys the Datadog sink
+//!   ships the captured content under. Defaults to `metadata_only`, where
 //!   the record never carries content fields, so it cannot leak.
 //!
 //! ## What's intentionally NOT here yet
@@ -576,11 +577,11 @@ impl ObservabilitySink for OtlpSink {
 ///
 /// When the record carries captured content (this exporter's
 /// `content_mode = full`, see [`content_record`]) the span additionally
-/// carries `aisix.prompt` / `aisix.response` — the same prompt / assembled
-/// response the SLS path ships as log fields — plus
+/// carries `gen_ai.prompt` / `gen_ai.completion` — the same prompt /
+/// assembled response the Datadog sink ships under those keys — plus
 /// `aisix.content_truncated` when either field was cut to the exporter's
-/// `content_max_bytes`. Metadata-only records never reach this branch with
-/// content, so the default span shape is unchanged.
+/// `content_max_bytes`. Metadata-only records never carry content, so the
+/// default span shape is unchanged.
 fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
     let event = &record.usage;
     let trace_id = random_trace_id();
@@ -681,6 +682,17 @@ fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
             &event.client_user_agent,
         ));
     }
+    // Opt-in captured content (#519 B.2) — present ONLY on a record built by
+    // [`content_record`] for a `content_mode = full` exporter. Keys match the
+    // Datadog sink's flattened content fields, so one query vocabulary works
+    // across both backends.
+    if let Some(content) = &record.content {
+        attributes.push(attr_string("gen_ai.prompt", &content.prompt));
+        attributes.push(attr_string("gen_ai.completion", &content.response));
+        if content.truncated {
+            attributes.push(attr_bool("aisix.content_truncated", true));
+        }
+    }
 
     json!({
         "traceId": trace_id,
@@ -711,12 +723,14 @@ fn otlp_export_request(spans: Vec<Value>) -> Value {
     })
 }
 
-/// One event -> one-span export request. Test-only helper for the payload
-/// assertions; production paths build spans via [`build_otlp_span`] and batch
-/// them through [`otlp_export_request`] inside [`OtlpSink`].
+/// One event -> one-span export request over a metadata-only record (the
+/// default shape). Test-only helper for the payload assertions; production
+/// paths build spans via [`build_otlp_span`] and batch them through
+/// [`otlp_export_request`] inside [`OtlpSink`].
 #[cfg(test)]
 fn build_otlp_traces_payload(event: &UsageEvent, exporter_name: &str) -> Value {
-    otlp_export_request(vec![build_otlp_span(event, exporter_name)])
+    let record = SinkRecord::metadata_only(event.clone());
+    otlp_export_request(vec![build_otlp_span(&record, exporter_name)])
 }
 
 fn attr_string(key: &str, value: &str) -> Value {
@@ -731,6 +745,13 @@ fn attr_int(key: &str, value: i64) -> Value {
         "key": key,
         // OTLP/JSON encodes int as a string to avoid JS Number precision loss.
         "value": { "intValue": value.to_string() },
+    })
+}
+
+fn attr_bool(key: &str, value: bool) -> Value {
+    json!({
+        "key": key,
+        "value": { "boolValue": value },
     })
 }
 
@@ -901,6 +922,16 @@ mod tests {
         })
     }
 
+    fn otlp_kind(content_mode: SlsContentMode, max_bytes: u32) -> ExporterKind {
+        ExporterKind::OtlpHttp(OtlpHttpConfig {
+            endpoint: "https://x/v1/traces".into(),
+            headers: Default::default(),
+            sample_rate: None,
+            content_mode,
+            content_max_bytes: max_bytes,
+        })
+    }
+
     fn datadog_kind(content_mode: SlsContentMode, max_bytes: u32) -> ExporterKind {
         ExporterKind::Datadog(DatadogConfig {
             site: "datadoghq.com".into(),
@@ -922,11 +953,9 @@ mod tests {
             truncated: false,
         };
 
-        // otlp never carries content, even when content was captured.
-        let otlp = ExporterKind::OtlpHttp(OtlpHttpConfig {
-            endpoint: "https://x/v1/traces".into(),
-            headers: Default::default(),
-        });
+        // otlp on its default (metadata_only) never carries content, even
+        // when content was captured.
+        let otlp = otlp_kind(SlsContentMode::MetadataOnly, 1024);
         assert!(content_record(&otlp, &event, Some(&captured)).is_none());
 
         // object_store never carries content either — content_record gates on
@@ -1004,6 +1033,147 @@ mod tests {
             content_record(&datadog_kind(SlsContentMode::Full, 16), &event, Some(&big)).unwrap();
         assert_eq!(rec.content.as_ref().unwrap().prompt.len(), 16);
         assert!(rec.content.as_ref().unwrap().truncated);
+
+        // otlp_http behaves identically (#519 B.2): full + captured content →
+        // a content-bearing record; full with nothing captured → metadata.
+        let otlp_full = otlp_kind(SlsContentMode::Full, 1024);
+        assert!(content_record(&otlp_full, &event, None).is_none());
+        let rec = content_record(&otlp_full, &event, Some(&captured))
+            .expect("full-capture otlp with content yields a content record");
+        let c = rec.content.as_ref().expect("content attached");
+        assert_eq!(c.prompt, "the prompt");
+        assert_eq!(c.response, "the response");
+        // Per-exporter cap truncates an otlp record too.
+        let rec = content_record(&otlp_kind(SlsContentMode::Full, 16), &event, Some(&big)).unwrap();
+        assert_eq!(rec.content.as_ref().unwrap().prompt.len(), 16);
+        assert!(rec.content.as_ref().unwrap().truncated);
+    }
+
+    #[test]
+    fn span_carries_content_attrs_only_for_content_bearing_records() {
+        let event = sample_event();
+
+        // Metadata-only record (the default): no content keys on the span.
+        let meta = SinkRecord::metadata_only(event.clone());
+        let span = build_otlp_span(&meta, "x");
+        let keys: Vec<&str> = span["attributes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|a| a["key"].as_str().unwrap())
+            .collect();
+        assert!(!keys.contains(&"gen_ai.prompt"));
+        assert!(!keys.contains(&"gen_ai.completion"));
+        assert!(!keys.contains(&"aisix.content_truncated"));
+
+        // Content-bearing record (content_mode = full): prompt + completion
+        // ride the span under the Datadog sink's key names.
+        let captured = CapturedContent {
+            prompt: "what is 2+2?".into(),
+            response: "4".into(),
+            truncated: false,
+        };
+        let rec = content_record(
+            &otlp_kind(SlsContentMode::Full, 1024),
+            &event,
+            Some(&captured),
+        )
+        .unwrap();
+        let span = build_otlp_span(&rec, "x");
+        let attrs = span["attributes"].as_array().unwrap();
+        let find = |k: &str| attrs.iter().find(|a| a["key"] == k);
+        assert_eq!(
+            find("gen_ai.prompt").expect("prompt attr")["value"]["stringValue"],
+            "what is 2+2?"
+        );
+        assert_eq!(
+            find("gen_ai.completion").expect("completion attr")["value"]["stringValue"],
+            "4"
+        );
+        // Nothing was truncated → no flag.
+        assert!(find("aisix.content_truncated").is_none());
+
+        // Truncation (here: per-exporter cap cut the prompt) flags the span.
+        let big = CapturedContent {
+            prompt: "a".repeat(500),
+            response: "ok".into(),
+            truncated: false,
+        };
+        let rec = content_record(&otlp_kind(SlsContentMode::Full, 16), &event, Some(&big)).unwrap();
+        let span = build_otlp_span(&rec, "x");
+        let attrs = span["attributes"].as_array().unwrap();
+        let flag = attrs
+            .iter()
+            .find(|a| a["key"] == "aisix.content_truncated")
+            .expect("truncated flag");
+        assert_eq!(flag["value"]["boolValue"], true);
+    }
+
+    #[test]
+    fn sampling_extremes_drop_all_or_keep_all() {
+        let ids: Vec<String> = (0..1000).map(|i| format!("req-{i}")).collect();
+        for id in &ids {
+            // Absent (None) = 1.0 = the pre-knob behaviour: keep everything.
+            assert!(otlp_should_sample(None, id));
+            assert!(otlp_should_sample(Some(1.0), id));
+            // 0.0 drops everything.
+            assert!(!otlp_should_sample(Some(0.0), id));
+        }
+    }
+
+    #[test]
+    fn sampling_is_deterministic_and_roughly_proportional() {
+        // Same id → same decision, every time (the all-or-nothing guarantee
+        // for a request's per-attempt spans, which share request_id).
+        for id in ["req-a", "req-b", "req-c"] {
+            let first = otlp_should_sample(Some(0.5), id);
+            for _ in 0..10 {
+                assert_eq!(otlp_should_sample(Some(0.5), id), first);
+            }
+        }
+
+        // Across many distinct ids the kept fraction tracks the rate. The id
+        // set is fixed, so the count is exact and the test cannot flake.
+        let kept = (0..1000)
+            .filter(|i| otlp_should_sample(Some(0.5), &format!("req-{i}")))
+            .count();
+        assert!(
+            (350..=650).contains(&kept),
+            "rate 0.5 kept {kept}/1000 — hash badly skewed"
+        );
+    }
+
+    #[test]
+    fn fingerprint_otlp_covers_the_new_knobs() {
+        let base = OtlpHttpConfig {
+            endpoint: "https://x/v1/traces".into(),
+            headers: Default::default(),
+            sample_rate: None,
+            content_mode: SlsContentMode::MetadataOnly,
+            content_max_bytes: 128 * 1024,
+        };
+        assert_eq!(
+            fingerprint_otlp(&base),
+            fingerprint_otlp(&base.clone()),
+            "same config must fingerprint identically"
+        );
+
+        // Each knob edit must rebuild the pipeline (#519 B.2).
+        let mut sampled = base.clone();
+        sampled.sample_rate = Some(0.5);
+        assert_ne!(fingerprint_otlp(&base), fingerprint_otlp(&sampled));
+
+        let mut full = base.clone();
+        full.content_mode = SlsContentMode::Full;
+        assert_ne!(fingerprint_otlp(&base), fingerprint_otlp(&full));
+
+        let mut capped = base.clone();
+        capped.content_max_bytes = 4096;
+        assert_ne!(fingerprint_otlp(&base), fingerprint_otlp(&capped));
+
+        let mut moved = base.clone();
+        moved.endpoint = "https://y/v1/traces".into();
+        assert_ne!(fingerprint_otlp(&base), fingerprint_otlp(&moved));
     }
 
     #[test]
@@ -1060,6 +1230,29 @@ mod tests {
         assert_eq!(content_capture_cap([&full, &dd_full]), Some(16384));
         let dd_meta = datadog("dd", true, "metadata_only", 4096);
         assert_eq!(content_capture_cap([&dd_meta]), None);
+
+        // A full-capture otlp_http exporter counts toward the cap too
+        // (#519 B.2); a metadata-only one (the default) does not — the
+        // `sample_exporter()` fixture above already proved the default shape
+        // yields None.
+        fn otlp_exp(name: &str, mode: &str, max: u32) -> ObservabilityExporter {
+            serde_json::from_value(serde_json::json!({
+                "name": name,
+                "enabled": true,
+                "kind": "otlp_http",
+                "endpoint": "https://x/v1/traces",
+                "content_mode": mode,
+                "content_max_bytes": max,
+            }))
+            .unwrap()
+        }
+        let otlp_full = otlp_exp("ot", "full", 32768);
+        assert_eq!(content_capture_cap([&otlp_full]), Some(32768));
+        assert_eq!(content_capture_cap([&dd_full, &otlp_full]), Some(32768));
+        assert_eq!(
+            content_capture_cap([&otlp_exp("ot", "metadata_only", 4096)]),
+            None
+        );
     }
 
     #[test]
@@ -1321,6 +1514,61 @@ mod tests {
         exp.enabled = false;
         let f = OtlpHttpFanOut::new();
         f.fan_out(&sample_event(), None, std::iter::once(&exp));
+    }
+
+    #[tokio::test]
+    async fn fan_out_sampling_zero_skips_only_that_exporter() {
+        // Two otlp exporters on one fan-out: `sampled-out` at rate 0.0 and
+        // `control` with the rate absent (= 1.0). One event must reach the
+        // control's receiver while the rate-0 exporter enqueues nothing —
+        // its pipeline is never even created.
+        let zero_srv = wiremock::MockServer::start().await;
+        let ctrl_srv = wiremock::MockServer::start().await;
+        for srv in [&zero_srv, &ctrl_srv] {
+            wiremock::Mock::given(wiremock::matchers::method("POST"))
+                .respond_with(wiremock::ResponseTemplate::new(200))
+                .mount(srv)
+                .await;
+        }
+        let mk = |name: &str, uri: &str, rate: Option<f64>| -> ObservabilityExporter {
+            let mut v = serde_json::json!({
+                "name": name,
+                "enabled": true,
+                "kind": "otlp_http",
+                "endpoint": format!("{uri}/v1/traces"),
+            });
+            if let Some(r) = rate {
+                v["sample_rate"] = serde_json::json!(r);
+            }
+            serde_json::from_value(v).unwrap()
+        };
+        let zero = mk("sampled-out", &zero_srv.uri(), Some(0.0));
+        let control = mk("control", &ctrl_srv.uri(), None);
+
+        let f = OtlpHttpFanOut::new();
+        f.fan_out(&sample_event(), None, [&zero, &control]);
+
+        // The control's span lands after the 1s flush…
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if !ctrl_srv.received_requests().await.unwrap().is_empty() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "control exporter saw no OTLP POST within 5s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        // …while the rate-0 exporter never even created a pipeline (stats
+        // read before shutdown, which tears pipelines down)…
+        assert!(!f.exporter_stats().contains_key("sampled-out"));
+        assert!(f.exporter_stats().contains_key("control"));
+        f.shutdown().await;
+
+        // …and delivered nothing: shutdown drained every pipeline, so
+        // anything enqueued would have been flushed by now.
+        assert!(zero_srv.received_requests().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/schemas/resources/observability_exporter.schema.json
+++ b/schemas/resources/observability_exporter.schema.json
@@ -1,16 +1,33 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ObservabilityExporter",
-  "description": "Top-level `ObservabilityExporter` resource. `deny_unknown_fields` deliberately NOT set — serde's `flatten` + `tag = \"kind\"` interaction makes outer-strict-mode reject the inner discriminator field. Strict typo rejection happens at the JSON Schema layer (`schema::validate_observability_exporter`) which the etcd loader runs before the serde deserialize.",
+  "description": "Top-level `ObservabilityExporter` resource. `deny_unknown_fields` deliberately NOT set — serde's `flatten` + `tag = \"kind\"` interaction makes outer-strict-mode reject the inner discriminator field. Strict typo rejection happens at the JSON Schema layer (`schema::validate_observability_exporter`) which the etcd loader runs before the serde deserialize.\n\n`PartialEq` (not `Eq`): the flattened [`ExporterKind`] carries an `f64` (`OtlpHttpConfig::sample_rate`) — see [`ExporterKind`].",
   "type": "object",
   "oneOf": [
     {
+      "description": "`PartialEq` (not `Eq`): `sample_rate` is an `f64` — see [`ExporterKind`].",
       "type": "object",
       "required": [
         "endpoint",
         "kind"
       ],
       "properties": {
+        "content_max_bytes": {
+          "description": "Per-field byte cap for captured content under `content_mode = full`. The prompt and the response are each truncated to this many bytes (UTF-8-boundary safe), and the span carries an `aisix.content_truncated` attribute when either was cut. Ignored under `metadata_only`. Defaults to 128 KiB.\n\n`0` is rejected — `full` with a zero cap captures nothing, which is a misconfiguration. The `range(min = 1)` keeps the generated JSON schema in step with the runtime validator so the CP and DP agree on the floor.",
+          "default": 131072,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 1.0
+        },
+        "content_mode": {
+          "description": "Whether captured request/response content is delivered on this exporter's spans. `metadata_only` (default) ships only operational metadata — never a prompt or response. `full` additionally attaches the request prompt and the assembled response as span attributes (`gen_ai.prompt` / `gen_ai.completion` — the same keys the Datadog sink ships the captured content under), each truncated to [`content_max_bytes`]. Enabling `full` writes end-user prompt / response text into the customer's tracing backend, so the dashboard must surface the privacy implication when an operator turns it on. Reuses [`SlsContentMode`] — the codebase's existing `metadata_only | full` model — so the shared content-capture plumbing (`content_record` / `content_capture_cap`) stays single-sourced.\n\n[`content_max_bytes`]: OtlpHttpConfig::content_max_bytes",
+          "default": "metadata_only",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SlsContentMode"
+            }
+          ]
+        },
         "endpoint": {
           "description": "Full URL of the OTLP/HTTP traces endpoint. Must already include the `/v1/traces` path the receiver expects — we don't append it because some vendors (Honeycomb, Grafana) use a different path.",
           "type": "string"
@@ -27,6 +44,16 @@
           "enum": [
             "otlp_http"
           ]
+        },
+        "sample_rate": {
+          "description": "Fraction of requests whose spans are exported, `0.0`–`1.0`. Absent = `1.0` (export everything — the pre-knob behaviour). The decision is per REQUEST, made deterministically from the `request_id` hash, so every attempt span of one request (initial / retries / fallbacks, which share the id) samples consistently — a trace is exported whole or not at all. Bounds are enforced by the loader's JSON-schema validation (`schema::validate_observability_exporter`).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double",
+          "maximum": 1.0,
+          "minimum": 0.0
         }
       }
     },
@@ -275,7 +302,7 @@
       ]
     },
     "SlsContentMode": {
-      "description": "Content-capture mode for an SLS / Datadog exporter. Defaults to the privacy-preserving `metadata_only`. (`Hash` so a Datadog exporter's fingerprint can cover its content config; see `fingerprint_datadog`.)",
+      "description": "Content-capture mode for an SLS / Datadog / OTLP exporter. Defaults to the privacy-preserving `metadata_only`. (`Hash` so an exporter's fingerprint can cover its content config; see `fingerprint_datadog` / `fingerprint_otlp`.)",
       "oneOf": [
         {
           "description": "Operational metadata only — never the prompt or response.",

--- a/tests/e2e/src/cases/otlp-knobs-e2e.test.ts
+++ b/tests/e2e/src/cases/otlp-knobs-e2e.test.ts
@@ -1,0 +1,292 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E (#519 B.2): per-exporter `sample_rate` + content capture for
+// kind=otlp_http.
+//
+//   1. Defaults unchanged — an exporter with neither knob ships spans
+//      for every request and never carries prompt/response content.
+//   2. `content_mode: full` attaches `gen_ai.prompt` / `gen_ai.completion`
+//      truncated to `content_max_bytes` (with `aisix.content_truncated`).
+//   3. `sample_rate: 0` ships nothing; the same traffic against a
+//      rate-1.0 exporter (positive control) ships spans — proving the
+//      absence was the sampler, not a broken pipeline.
+
+const CALLER_PLAINTEXT = "sk-otlp-knobs-caller-PLAINTEXT";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+const PROVIDER_SECRET = "sk-mock-otlp-knobs";
+
+interface OtlpReceiver {
+  url: string;
+  spanAttrs: Array<Record<string, string>>;
+  close(): Promise<void>;
+}
+
+async function startOtlpReceiver(): Promise<OtlpReceiver> {
+  const spanAttrs: Array<Record<string, string>> = [];
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(raw);
+        for (const rs of body.resourceSpans ?? []) {
+          for (const ss of rs.scopeSpans ?? []) {
+            for (const span of ss.spans ?? []) {
+              const attrs: Record<string, string> = {};
+              for (const a of span.attributes ?? []) {
+                const v = a.value ?? {};
+                attrs[a.key] =
+                  v.stringValue ?? String(v.intValue ?? v.boolValue ?? "");
+              }
+              spanAttrs.push(attrs);
+            }
+          }
+        }
+      } catch {
+        // ignore malformed bodies — assertions fail on missing spans
+      }
+      res.statusCode = 200;
+      res.end("{}");
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${port}/v1/traces`,
+    spanAttrs,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+async function seedRouting(admin: AdminClient, upstream: OpenAiUpstream) {
+  const pk = await admin.createProviderKey({
+    display_name: "otlp-knobs-pk",
+    secret: PROVIDER_SECRET,
+    api_base: `${upstream.baseUrl}/v1`,
+  });
+  await admin.createModel({
+    display_name: "otlp-knobs-model",
+    provider: "openai",
+    model_name: "gpt-4o-mini",
+    provider_key_id: pk.id,
+  });
+  await admin.createApiKey({
+    key_hash: CALLER_KEY_HASH,
+    allowed_models: ["otlp-knobs-model"],
+  });
+}
+
+async function chat(app: SpawnedApp, content: string) {
+  return fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "otlp-knobs-model",
+      messages: [{ role: "user", content }],
+    }),
+  });
+}
+
+async function waitForSpan(
+  recv: OtlpReceiver,
+  predicate: (attrs: Record<string, string>) => boolean,
+  timeoutMs = 10_000,
+): Promise<Record<string, string>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hit = recv.spanAttrs.find(predicate);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(
+    `no matching OTLP span recorded within timeout; ${recv.spanAttrs.length} spans seen; ` +
+      `sample keys: ${JSON.stringify(recv.spanAttrs.slice(0, 2).map((a) => Object.keys(a)))}; ` +
+      `prompts: ${JSON.stringify(recv.spanAttrs.slice(0, 3).map((a) => a["gen_ai.prompt"]))}`,
+  );
+}
+
+describe("otlp exporter knobs e2e (#519 B.2): sample_rate + content capture", () => {
+  let etcdReachable = false;
+  let upstream: OpenAiUpstream | undefined;
+  const apps: SpawnedApp[] = [];
+  const receivers: OtlpReceiver[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    upstream = await startOpenAiUpstream();
+  });
+
+  afterAll(async () => {
+    await Promise.all(apps.map((a) => a.exit()));
+    await Promise.all(receivers.map((r) => r.close()));
+    await upstream?.close();
+  });
+
+  test(
+    "defaults unchanged: knobless exporter ships every span, no content",
+    async (ctx) => {
+      if (!etcdReachable || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const otlp = await startOtlpReceiver();
+      receivers.push(otlp);
+      const app = await spawnApp();
+      apps.push(app);
+      const admin = new AdminClient(app.adminUrl, app.adminKey);
+      await admin.createObservabilityExporter({
+        name: "otlp-defaults",
+        enabled: true,
+        kind: "otlp_http",
+        endpoint: otlp.url,
+      });
+      await seedRouting(admin, upstream);
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await chat(app, "default-probe");
+          await r.text();
+          return r.status === 200;
+        } catch {
+          return false;
+        }
+      });
+
+      const span = await waitForSpan(otlp, (a) => "aisix.request_id" in a);
+      expect(span["gen_ai.prompt"]).toBeUndefined();
+      expect(span["gen_ai.completion"]).toBeUndefined();
+    },
+    60_000,
+  );
+
+  test(
+    "content_mode=full attaches prompt/completion, truncated to content_max_bytes",
+    async (ctx) => {
+      if (!etcdReachable || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const otlp = await startOtlpReceiver();
+      receivers.push(otlp);
+      const app = await spawnApp();
+      apps.push(app);
+      const admin = new AdminClient(app.adminUrl, app.adminKey);
+      await admin.createObservabilityExporter({
+        name: "otlp-full",
+        enabled: true,
+        kind: "otlp_http",
+        endpoint: otlp.url,
+        content_mode: "full",
+        // The captured prompt is the serialized request JSON (model +
+        // messages wrapper ≈ 60 bytes before the user text), so the cap
+        // must leave room for the probe to stay visible untruncated.
+        content_max_bytes: 200,
+      });
+      await seedRouting(admin, upstream);
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await chat(app, "content-probe");
+          await r.text();
+          return r.status === 200;
+        } catch {
+          return false;
+        }
+      });
+
+      // Short prompt: captured whole, no truncation flag.
+      const shortSpan = await waitForSpan(
+        otlp,
+        (a) => (a["gen_ai.prompt"] ?? "").includes("content-probe"),
+      );
+      expect(shortSpan["gen_ai.completion"]).toBeTruthy();
+      expect(shortSpan["aisix.content_truncated"]).toBeUndefined();
+
+      // Oversized prompt: captured but cut at the 200-byte cap.
+      const long = "long-content-".repeat(40); // ~520 bytes
+      const res = await chat(app, long);
+      expect(res.status).toBe(200);
+      await res.text();
+      const longSpan = await waitForSpan(
+        otlp,
+        (a) =>
+          (a["gen_ai.prompt"] ?? "").includes("long-content-") &&
+          a["aisix.content_truncated"] === "true",
+      );
+      expect(longSpan["gen_ai.prompt"].length).toBeLessThanOrEqual(200);
+    },
+    60_000,
+  );
+
+  test(
+    "sample_rate=0 ships nothing while a rate-1.0 exporter ships the same traffic",
+    async (ctx) => {
+      if (!etcdReachable || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const otlpZero = await startOtlpReceiver();
+      const otlpAll = await startOtlpReceiver();
+      receivers.push(otlpZero, otlpAll);
+      const app = await spawnApp();
+      apps.push(app);
+      const admin = new AdminClient(app.adminUrl, app.adminKey);
+      await admin.createObservabilityExporter({
+        name: "otlp-sample-zero",
+        enabled: true,
+        kind: "otlp_http",
+        endpoint: otlpZero.url,
+        sample_rate: 0,
+      });
+      await admin.createObservabilityExporter({
+        name: "otlp-sample-all",
+        enabled: true,
+        kind: "otlp_http",
+        endpoint: otlpAll.url,
+        sample_rate: 1.0,
+      });
+      await seedRouting(admin, upstream);
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await chat(app, "sampling-probe");
+          await r.text();
+          return r.status === 200;
+        } catch {
+          return false;
+        }
+      });
+
+      for (let i = 0; i < 5; i++) {
+        const r = await chat(app, `sampling-probe-${i}`);
+        expect(r.status).toBe(200);
+        await r.text();
+      }
+
+      // Positive control first: the rate-1.0 exporter saw the traffic …
+      await waitForSpan(otlpAll, (a) => "aisix.request_id" in a, 15_000);
+      // … so the rate-0 silence is the sampler, not a dead pipeline.
+      expect(otlpZero.spanAttrs).toHaveLength(0);
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
Part of api7/AISIX-Cloud#519 — DP half of finding **B.2** (the OTLP exporter form exposes only name/endpoint/headers while the DP hardcodes metadata-only export at 100% sampling). A CP follow-up exposes the new fields in the dashboard form.

## What

`OtlpHttpConfig` gains three optional knobs — absent fields preserve today's behavior exactly (pinned by test):

- **`sample_rate`** (0.0–1.0, absent = 1.0): per-request decision via an FNV-1a hash of `request_id`, so every attempt span of one request (initial/retries/fallbacks share the id) samples consistently — a trace ships whole or not at all, and replicas agree. Decided before any pipeline work; an unsampled request enqueues nothing for that exporter. Bounds enforced by the loader's validation schema.
- **`content_mode` / `content_max_bytes`**: reuses the `SlsContentMode` model SLS/Datadog already ship end-to-end. `full` attaches `gen_ai.prompt` / `gen_ai.completion` span attributes (same keys as the Datadog sink's content fields — one query vocabulary across backends), each truncated UTF-8-safely to the cap, with `aisix.content_truncated` when cut. The shared `content_capture_cap` aggregation now counts OTLP full-mode exporters, so the proxy captures only when some exporter consumes it.
- `fingerprint_otlp` covers the knobs so a config edit rebuilds the sink pipeline.

`ExporterKind`/`OtlpHttpConfig` drop derived `Eq` (kept `PartialEq`) because `sample_rate` is an `f64`; the fingerprint hashes its bit pattern.

## Tests

- Unit: parse defaults + round-trip, out-of-range `sample_rate` rejected by the validation schema, fingerprint sensitivity, content attach/omit per mode, sampler edge rates (0.0 drops all / 1.0 keeps all / deterministic split at 0.5).
- e2e (`otlp-knobs-e2e`): knobless exporter ships every span with no content (defaults pinned); `content_mode=full` carries prompt/completion with truncation at the cap; `sample_rate=0` ships nothing while a rate-1.0 exporter on the same traffic ships spans (positive control proving the silence is the sampler, not a dead pipeline).
- Full workspace suite green in an isolated target dir; fmt (pinned toolchain) + clippy `-D warnings` clean; schemas regenerated.

Closes api7/AISIX-Cloud#519