### PR TITLE
fix(e2e): audio/images propagation predicates tolerate transport failures

### DIFF
--- a/tests/e2e/src/cases/audio-images-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/audio-images-usage-e2e.test.ts
@@ -81,7 +81,16 @@ describe("audio + images UsageEvent emission (#406/#407)", () => {
           },
           body: JSON.stringify({ model: "img-usage", prompt: "a cat", n: 1 }),
         });
-      await waitConfigPropagation(async () => (await call()).ok);
+      await waitConfigPropagation(async () => {
+        // The DP may drop the connection mid-write (EPIPE) while the
+        // route is still propagating — treat transport failures as
+        // "not ready yet", like every other spec's predicate does.
+        try {
+          return (await call()).ok;
+        } catch {
+          return false;
+        }
+      });
       expect((await call()).status).toBe(200);
 
       const emitted = await pollUsageEmitted(app.adminUrl, "images");
@@ -132,7 +141,16 @@ describe("audio + images UsageEvent emission (#406/#407)", () => {
           body: form,
         });
       };
-      await waitConfigPropagation(async () => (await call()).ok);
+      await waitConfigPropagation(async () => {
+        // The DP may drop the connection mid-write (EPIPE) while the
+        // route is still propagating — treat transport failures as
+        // "not ready yet", like every other spec's predicate does.
+        try {
+          return (await call()).ok;
+        } catch {
+          return false;
+        }
+      });
       expect((await call()).status).toBe(200);
 
       const emitted = await pollUsageEmitted(app.adminUrl, "audio");


### PR DESCRIPTION
CI flake root-cause (seen on #587's e2e job): `audio-images-usage-e2e` polls `waitConfigPropagation` with a bare `fetch` — when the DP drops the connection mid-multipart-write while the route is still propagating, the predicate throws `TypeError: fetch failed (EPIPE)` instead of returning false, failing the spec. Both call sites now wrap the probe in try/catch → false, the same contract every other spec's predicate follows. Test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced audio and image generation endpoint tests to more robustly handle connection failures during propagation verification, improving test reliability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of api7/AISIX-Cloud#519 (surfaced while landing finding B.8's PR).

Closes api7/AISIX-Cloud#519