### PR TITLE
fix(proxy): request the usage frame on every OpenAI-protocol streaming leg

### DIFF
--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -950,6 +950,18 @@ pub struct AnthropicSseEncoder {
     next_block_index: usize,
     /// Per-OpenAI-delta-index tool call state.
     tool_calls: std::collections::BTreeMap<u64, ToolCallState>,
+    /// Stop reason captured at the `finish_reason` chunk while the
+    /// closing `message_delta`/`message_stop` pair is withheld. With
+    /// `stream_options.include_usage` (AISIX-Cloud#790) an OpenAI
+    /// upstream sends its only `usage` frame AFTER the stop chunk;
+    /// emitting the pair at the stop chunk would hand the client
+    /// `output_tokens: 0` and drop the usage frame unread.
+    pending_stop_reason: Option<&'static str>,
+    /// Best-known cumulative usage across all chunks. Max semantics —
+    /// robust to providers that double-emit usage.
+    seen_input_tokens: u32,
+    seen_output_tokens: u32,
+    usage_seen: bool,
 }
 
 impl AnthropicSseEncoder {
@@ -972,13 +984,35 @@ impl AnthropicSseEncoder {
             finished: false,
             next_block_index: 0,
             tool_calls: std::collections::BTreeMap::new(),
+            pending_stop_reason: None,
+            seen_input_tokens: 0,
+            seen_output_tokens: 0,
+            usage_seen: false,
         }
     }
 
     /// Translate one chunk into the Anthropic SSE events to emit.
-    /// Returns an empty Vec on no-op chunks (e.g. usage-only).
+    /// Returns an empty Vec on no-op chunks.
     pub fn next_events(&mut self, chunk: &ChatChunk) -> Vec<AnthropicSseEvent> {
         if self.finished {
+            return Vec::new();
+        }
+
+        if let Some(u) = chunk.usage.as_ref() {
+            self.usage_seen = true;
+            self.seen_input_tokens = self.seen_input_tokens.max(u.prompt_tokens);
+            self.seen_output_tokens = self.seen_output_tokens.max(u.completion_tokens);
+        }
+
+        // Closing pair withheld at the stop chunk: only the trailing
+        // usage frame releases it (stream end does too, via
+        // `force_finish`). Post-stop chunks carry no renderable
+        // content, so nothing else is emitted from here.
+        if let Some(reason) = self.pending_stop_reason {
+            if self.usage_seen {
+                self.pending_stop_reason = None;
+                return self.closing_pair(reason);
+            }
             return Vec::new();
         }
 
@@ -1113,12 +1147,35 @@ impl AnthropicSseEncoder {
                 FinishReason::ToolCalls => "tool_use",
                 FinishReason::Other(_) => "end_turn",
             };
-            let output_tokens = chunk
-                .usage
-                .as_ref()
-                .map(|u| u.completion_tokens)
-                .unwrap_or(0);
-            events.push(AnthropicSseEvent {
+            if self.usage_seen {
+                // Usage already known (provider attached it to the stop
+                // chunk or earlier) — close out immediately.
+                events.extend(self.closing_pair(stop_reason));
+            } else {
+                // OpenAI's `stream_options.include_usage` frame arrives
+                // AFTER the stop chunk — withhold the closing pair so
+                // it can carry real token counts.
+                self.pending_stop_reason = Some(stop_reason);
+            }
+        }
+
+        events
+    }
+
+    /// The closing `message_delta` + `message_stop` pair, carrying the
+    /// best-known cumulative usage. `input_tokens` is included when
+    /// known — on a translated stream `message_start` fires before any
+    /// usage frame exists and always reports 0, so this is the only
+    /// place the client can learn the prompt token count.
+    fn closing_pair(&mut self, stop_reason: &'static str) -> Vec<AnthropicSseEvent> {
+        let mut usage = serde_json::Map::new();
+        if self.seen_input_tokens > 0 {
+            usage.insert("input_tokens".into(), self.seen_input_tokens.into());
+        }
+        usage.insert("output_tokens".into(), self.seen_output_tokens.into());
+        self.finished = true;
+        vec![
+            AnthropicSseEvent {
                 event: "message_delta",
                 data: serde_json::json!({
                     "type": "message_delta",
@@ -1126,17 +1183,14 @@ impl AnthropicSseEncoder {
                         "stop_reason": stop_reason,
                         "stop_sequence": serde_json::Value::Null,
                     },
-                    "usage": {"output_tokens": output_tokens},
+                    "usage": serde_json::Value::Object(usage),
                 }),
-            });
-            events.push(AnthropicSseEvent {
+            },
+            AnthropicSseEvent {
                 event: "message_stop",
                 data: serde_json::json!({"type": "message_stop"}),
-            });
-            self.finished = true;
-        }
-
-        events
+            },
+        ]
     }
 
     pub fn is_finished(&self) -> bool {
@@ -1144,12 +1198,21 @@ impl AnthropicSseEncoder {
     }
 
     /// Force-close the stream when the upstream ended without
-    /// emitting a chunk with `finish_reason`. Emits the closing trio
-    /// with `stop_reason: "end_turn"` and `output_tokens: 0`.
+    /// releasing the closing pair — either no `finish_reason` chunk at
+    /// all (closes with `end_turn`), or a stop chunk arrived but the
+    /// trailing usage frame never did (flushes the withheld pair with
+    /// the real stop reason). Usage carries the best-known counts.
     /// Idempotent.
     pub fn force_finish(&mut self) -> Vec<AnthropicSseEvent> {
         if self.finished {
             return Vec::new();
+        }
+        // A withheld closing pair (stop seen, but the upstream ignored
+        // `stream_options` and never sent a usage frame): flush it with
+        // the real stop reason. Content blocks were already closed at
+        // the stop chunk.
+        if let Some(reason) = self.pending_stop_reason.take() {
+            return self.closing_pair(reason);
         }
         let mut events = Vec::new();
         if !self.sent_message_start {
@@ -1164,22 +1227,7 @@ impl AnthropicSseEncoder {
                 events.push(content_block_stop_event(state.content_block_index));
             }
         }
-        events.push(AnthropicSseEvent {
-            event: "message_delta",
-            data: serde_json::json!({
-                "type": "message_delta",
-                "delta": {
-                    "stop_reason": "end_turn",
-                    "stop_sequence": serde_json::Value::Null,
-                },
-                "usage": {"output_tokens": 0},
-            }),
-        });
-        events.push(AnthropicSseEvent {
-            event: "message_stop",
-            data: serde_json::json!({"type": "message_stop"}),
-        });
-        self.finished = true;
+        events.extend(self.closing_pair("end_turn"));
         events
     }
 
@@ -2079,6 +2127,70 @@ mod tests {
         assert!(enc.is_finished());
         // Subsequent chunks are silent.
         assert!(enc.next_events(&delta_chunk("ignored")).is_empty());
+    }
+
+    /// #790: OpenAI's `stream_options.include_usage` frame arrives
+    /// AFTER the stop chunk. The closing pair must wait for it so the
+    /// client sees real token counts instead of `output_tokens: 0`.
+    #[test]
+    fn sse_encoder_holds_close_until_post_stop_usage_frame() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "alias", 0);
+        let _ = enc.next_events(&delta_chunk("hi"));
+
+        // Stop chunk with NO usage — only the content block closes.
+        let stop_no_usage = ChatChunk {
+            id: "cmpl-1".into(),
+            model: "u".into(),
+            delta: ChatDelta::default(),
+            finish_reason: Some(FinishReason::Stop),
+            usage: None,
+        };
+        let events = enc.next_events(&stop_no_usage);
+        let kinds: Vec<_> = events.iter().map(|e| e.event).collect();
+        assert_eq!(kinds, vec!["content_block_stop"]);
+        assert!(!enc.is_finished());
+
+        // The trailing usage-only frame releases the closing pair,
+        // carrying both input and output tokens.
+        let usage_only = ChatChunk {
+            id: "cmpl-1".into(),
+            model: "u".into(),
+            delta: ChatDelta::default(),
+            finish_reason: None,
+            usage: Some(UsageStats::new(17, 23)),
+        };
+        let events = enc.next_events(&usage_only);
+        let kinds: Vec<_> = events.iter().map(|e| e.event).collect();
+        assert_eq!(kinds, vec!["message_delta", "message_stop"]);
+        assert_eq!(events[0].data["delta"]["stop_reason"], "end_turn");
+        assert_eq!(events[0].data["usage"]["input_tokens"], 17);
+        assert_eq!(events[0].data["usage"]["output_tokens"], 23);
+        assert!(enc.is_finished());
+    }
+
+    /// An upstream that ignores `stream_options` never sends the usage
+    /// frame — stream end (force_finish) must flush the withheld pair
+    /// with the REAL stop reason, not `end_turn`.
+    #[test]
+    fn sse_encoder_force_finish_flushes_held_close_with_real_stop_reason() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "alias", 0);
+        let _ = enc.next_events(&delta_chunk("hi"));
+        let stop_no_usage = ChatChunk {
+            id: "cmpl-1".into(),
+            model: "u".into(),
+            delta: ChatDelta::default(),
+            finish_reason: Some(FinishReason::ToolCalls),
+            usage: None,
+        };
+        let _ = enc.next_events(&stop_no_usage);
+        assert!(!enc.is_finished());
+
+        let events = enc.force_finish();
+        let kinds: Vec<_> = events.iter().map(|e| e.event).collect();
+        assert_eq!(kinds, vec!["message_delta", "message_stop"]);
+        assert_eq!(events[0].data["delta"]["stop_reason"], "tool_use");
+        assert_eq!(events[0].data["usage"]["output_tokens"], 0);
+        assert!(enc.is_finished());
     }
 
     #[test]

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -44,6 +44,15 @@ pub struct OpenAiRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
     pub stream: bool,
+    /// `{"include_usage": true}` injected on streaming requests when the
+    /// caller didn't set `stream_options` itself — OpenAI-protocol
+    /// upstreams omit the terminal `usage` frame without it, which
+    /// zeroed token telemetry for every streaming request whose client
+    /// didn't ask (AISIX-Cloud#790). `None` whenever `extra` already
+    /// carries a client-supplied `stream_options` (the flattened map
+    /// wins; a typed duplicate would emit the key twice).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<serde_json::Value>,
     #[serde(flatten)]
     pub extra: &'a serde_json::Map<String, serde_json::Value>,
 }
@@ -99,6 +108,8 @@ pub fn build_request<'a>(
         top_p: req.top_p,
         max_tokens: req.max_tokens,
         stream,
+        stream_options: (stream && !req.extra.contains_key("stream_options"))
+            .then(|| serde_json::json!({"include_usage": true})),
         extra: &req.extra,
     }
 }
@@ -1277,6 +1288,76 @@ mod tests {
         assert_eq!(json["stream"], true);
         assert_eq!(json["messages"][0]["role"], "user");
         assert_eq!(json["messages"][0]["content"], "hi");
+    }
+
+    /// #790: streaming requests must ask the upstream for the terminal
+    /// usage frame — without `stream_options.include_usage` an OpenAI
+    /// upstream never sends usage and token telemetry records 0.
+    #[test]
+    fn build_request_injects_include_usage_on_streaming() {
+        let req = ChatFormat {
+            model: "m".into(),
+            messages: vec![ChatMessage::user("hi")],
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            stream: Some(true),
+            extra: serde_json::Map::new(),
+        };
+        let msgs = messages_from(&req);
+        let json = serde_json::to_value(build_request(&req, "gpt-4o", &msgs, true)).unwrap();
+        assert_eq!(
+            json["stream_options"],
+            serde_json::json!({"include_usage": true})
+        );
+    }
+
+    /// A client-supplied `stream_options` wins verbatim — the typed
+    /// injection must not duplicate or override it.
+    #[test]
+    fn build_request_respects_client_stream_options() {
+        let mut extra = serde_json::Map::new();
+        extra.insert(
+            "stream_options".into(),
+            serde_json::json!({"include_usage": false}),
+        );
+        let req = ChatFormat {
+            model: "m".into(),
+            messages: vec![],
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            stream: Some(true),
+            extra,
+        };
+        let msgs = messages_from(&req);
+        let raw = serde_json::to_string(&build_request(&req, "gpt-4o", &msgs, true)).unwrap();
+        // Exactly one stream_options key on the wire (flatten + typed
+        // field would double-emit if both were set).
+        assert_eq!(raw.matches("stream_options").count(), 1);
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            json["stream_options"],
+            serde_json::json!({"include_usage": false})
+        );
+    }
+
+    /// Non-streaming requests must not carry stream_options at all —
+    /// OpenAI rejects it when `stream` is false.
+    #[test]
+    fn build_request_omits_stream_options_when_not_streaming() {
+        let req = ChatFormat {
+            model: "m".into(),
+            messages: vec![],
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            stream: None,
+            extra: serde_json::Map::new(),
+        };
+        let msgs = messages_from(&req);
+        let json = serde_json::to_value(build_request(&req, "gpt-4o", &msgs, false)).unwrap();
+        assert!(json.get("stream_options").is_none());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1083,6 +1083,17 @@ async fn dispatch(
         // `content_cap` (None on the common content-free path).
         let captured_prompt_for_telem =
             content_cap.map(|_| serde_json::to_string(req).unwrap_or_default());
+        // #790: the bridge injects `stream_options.include_usage` on the
+        // upstream leg whenever the client didn't set stream_options — the
+        // terminal usage-only chunk that produces is for the gateway's own
+        // telemetry. It reaches the client only when the client itself
+        // asked for usage.
+        let client_requested_usage = req
+            .extra
+            .get("stream_options")
+            .and_then(|so| so.get("include_usage"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         let sse_stream = build_sse_stream(
             upstream,
             now,
@@ -1090,6 +1101,7 @@ async fn dispatch(
             started,
             req.model.clone(),
             content_cap,
+            client_requested_usage,
             move |comp: StreamCompletion| {
                 // Rate-limit accounting (TPM cap) for all layers.
                 for key in &post_stream_keys {
@@ -2333,6 +2345,7 @@ impl<F: FnOnce(StreamCompletion)> Drop for CompleteOnDrop<F> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_sse_stream<F>(
     upstream: aisix_gateway::ChatChunkStream,
     created: i64,
@@ -2345,6 +2358,10 @@ fn build_sse_stream<F>(
     // Largest content cap any content-capturing exporter wants, or `None` to
     // skip response accumulation entirely (the common, content-free path).
     content_cap: Option<u32>,
+    // Whether the CLIENT asked for `stream_options.include_usage`. The
+    // gateway asks the upstream regardless (#790, for telemetry); the
+    // terminal usage-only chunk is forwarded only when this is true.
+    client_requested_usage: bool,
     on_complete: F,
 ) -> impl Stream<Item = Result<Event, Infallible>>
 where
@@ -2516,6 +2533,21 @@ where
                         if u.cache_read_tokens > comp.cache_read_tokens {
                             comp.cache_read_tokens = u.cache_read_tokens;
                         }
+                    }
+                    // #790: a usage-only terminal chunk (no delta payload, no
+                    // finish_reason) exists because the gateway injected
+                    // `include_usage` on the upstream leg. Its counts are
+                    // already folded into `comp` above — forward it only when
+                    // the client itself asked for usage.
+                    if !client_requested_usage
+                        && chunk.usage.is_some()
+                        && chunk.finish_reason.is_none()
+                        && chunk.delta.role.is_none()
+                        && chunk.delta.content.is_none()
+                        && chunk.delta.tool_calls.is_none()
+                        && chunk.delta.reasoning_content.is_none()
+                    {
+                        continue;
                     }
                     let rendered = render_chunk(created, chunk, &client_facing_model);
                     match serde_json::to_string(&rendered) {

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -2466,12 +2466,12 @@ data: [DONE]\n\n"
     #[tokio::test]
     async fn streaming_chat_tpm_cap_enforced_after_post_stream_commit_issue_108() {
         let upstream = MockServer::start().await;
-        // Final SSE chunk carries usage. OpenAI emits this when the
-        // client sets `stream_options.include_usage=true`; the proxy
-        // doesn't yet add that on the streamed leg, but the OpenAI
-        // bridge does parse `usage` off any chunk that has one — so
-        // our mock can include it on the terminal chunk and the
-        // bridge will surface it.
+        // Final SSE chunk carries usage attached to the stop chunk —
+        // some OpenAI-compatible servers do this instead of OpenAI's
+        // separate usage-only terminal frame. The bridge parses
+        // `usage` off any chunk that has one, so both shapes commit
+        // tokens (the separate-frame shape is covered by the #790
+        // tests below).
         let sse = "\
 data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
 data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
@@ -2532,6 +2532,153 @@ data: [DONE]\n\n";
         let body_bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         assert_eq!(v["error"]["type"], "rate_limit_exceeded");
+    }
+
+    /// #790 (AISIX-Cloud): every OpenAI-protocol streaming leg now asks
+    /// the upstream for the terminal usage frame by injecting
+    /// `stream_options: {"include_usage": true}` when the client didn't
+    /// set stream_options itself. Token telemetry used to record 0 for
+    /// every streaming request whose client didn't ask. Three contracts,
+    /// one mock (OpenAI's real include_usage shape — stop chunk without
+    /// usage, then a usage-only frame with empty `choices`):
+    ///  1. the outbound upstream body carries the injected stream_options;
+    ///  2. the usage frame feeds the UsageEvent (500/1000, not 0/0);
+    ///  3. the usage-only frame is stripped from the client-visible
+    ///     stream — the client never asked for usage.
+    #[tokio::test]
+    async fn streaming_chat_injects_include_usage_and_strips_usage_frame_issue_790() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"up-790\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"up-790\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"up-790\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: {\"id\":\"up-790\",\"model\":\"gpt-4o\",\"choices\":[],\"usage\":{\"prompt_tokens\":500,\"completion_tokens\":1000,\"total_tokens\":1500}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(build_router(state), req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut body_stream = resp.into_body().into_data_stream();
+        let mut client_bytes = Vec::new();
+        while let Some(chunk) = body_stream.next().await {
+            client_bytes.extend_from_slice(&chunk.unwrap());
+        }
+        let client_body = String::from_utf8(client_bytes).unwrap();
+
+        // (3) Content reaches the client; the unrequested usage frame
+        // does not.
+        assert!(client_body.contains("hi"));
+        assert!(
+            !client_body.contains("\"usage\""),
+            "usage-only frame must be stripped when the client didn't \
+             request stream_options.include_usage; got:\n{client_body}"
+        );
+
+        // (2) Telemetry carries the upstream-billed counts.
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("usage event was never emitted")
+            .expect("sender dropped without sending");
+        assert_eq!(event.prompt_tokens, 500);
+        assert_eq!(event.completion_tokens, 1000);
+
+        // (1) The outbound request asked for the usage frame.
+        let reqs = upstream.received_requests().await.unwrap();
+        let sent: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(
+            sent["stream_options"],
+            serde_json::json!({"include_usage": true}),
+            "streaming leg must inject stream_options.include_usage (#790)"
+        );
+    }
+
+    /// Companion to the #790 test above: a client that asked for usage
+    /// itself still receives the usage frame, and its stream_options
+    /// passes through verbatim (no duplicate injection).
+    #[tokio::test]
+    async fn streaming_chat_forwards_usage_frame_when_client_asked_issue_790() {
+        let upstream = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"up-790b\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"up-790b\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: {\"id\":\"up-790b\",\"model\":\"gpt-4o\",\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":7,\"total_tokens\":12}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true,
+            "stream_options": {"include_usage": true}
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(build_router(state), req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut body_stream = resp.into_body().into_data_stream();
+        let mut client_bytes = Vec::new();
+        while let Some(chunk) = body_stream.next().await {
+            client_bytes.extend_from_slice(&chunk.unwrap());
+        }
+        let client_body = String::from_utf8(client_bytes).unwrap();
+        assert!(
+            client_body.contains("\"prompt_tokens\":5"),
+            "client asked for usage — the frame must be forwarded; got:\n{client_body}"
+        );
+
+        let reqs = upstream.received_requests().await.unwrap();
+        let raw = String::from_utf8(reqs[0].body.clone()).unwrap();
+        assert_eq!(
+            raw.matches("stream_options").count(),
+            1,
+            "client-supplied stream_options must pass through exactly once"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/src/cases/messages-cross-provider-stream-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-cross-provider-stream-usage-e2e.test.ts
@@ -1,0 +1,241 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E regression for AISIX-Cloud#790: Anthropic /v1/messages STREAMING
+// through an OpenAI-protocol provider recorded prompt_tokens=0 /
+// completion_tokens=0 — the translated upstream request carried
+// `stream: true` without `stream_options: {include_usage: true}`, so
+// OpenAI-protocol upstreams never attached usage to the stream.
+//
+// Post-fix contracts exercised here against a real `aisix` binary:
+//  1. The outbound (translated) request carries the injected
+//     stream_options.
+//  2. The terminal usage-only frame (OpenAI's real include_usage shape:
+//     empty `choices` + `usage`, AFTER the stop chunk) feeds the token
+//     metrics — pre-fix these stayed 0 because the SSE pump stopped at
+//     the stop chunk.
+//  3. The client-visible Anthropic SSE carries the real counts in the
+//     closing `message_delta.usage` (pre-fix: output_tokens 0).
+//  4. An upstream that IGNORES stream_options still produces a
+//     well-formed Anthropic close (message_delta + message_stop) at
+//     stream end.
+
+const CALLER_PLAINTEXT = "sk-issue-790-regression";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const PROMPT_TOKENS = 17;
+const COMPLETION_TOKENS = 23;
+
+function chunk(json: Record<string, unknown>): string {
+  return JSON.stringify({
+    id: "chatcmpl-issue790",
+    object: "chat.completion.chunk",
+    created: 1765000000,
+    model: "mog-6",
+    ...json,
+  });
+}
+
+// OpenAI's real include_usage stream shape: content → stop chunk
+// (no usage) → usage-only frame with empty choices → [DONE].
+const STREAM_WITH_TRAILING_USAGE = [
+  chunk({ choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }),
+  chunk({ choices: [{ index: 0, delta: { content: "hello from mog-6" }, finish_reason: null }] }),
+  chunk({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+  chunk({
+    choices: [],
+    usage: {
+      prompt_tokens: PROMPT_TOKENS,
+      completion_tokens: COMPLETION_TOKENS,
+      total_tokens: PROMPT_TOKENS + COMPLETION_TOKENS,
+    },
+  }),
+  "[DONE]",
+];
+
+// An upstream that ignores stream_options: stop chunk, no usage, ever.
+const STREAM_NO_USAGE = [
+  chunk({ choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }),
+  chunk({ choices: [{ index: 0, delta: { content: "hello from mog-6" }, finish_reason: null }] }),
+  chunk({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+  "[DONE]",
+];
+
+async function postMessages(proxyUrl: string, model: string): Promise<Response> {
+  return fetch(`${proxyUrl}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": CALLER_PLAINTEXT,
+      "user-agent": "claude-cli/2.1.118 (external, cli)",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 200,
+      stream: true,
+      messages: [{ role: "user", content: "issue 790 regression" }],
+    }),
+  });
+}
+
+/** Sum a token counter across label sets matching the given model label. */
+function sumMetricByModel(scrape: string, metric: string, model: string): number {
+  let total = 0;
+  for (const line of scrape.split("\n")) {
+    if (!line.startsWith(`${metric}{`)) continue;
+    if (!line.includes(`model="${model}"`)) continue;
+    const v = Number(line.slice(line.lastIndexOf(" ") + 1));
+    if (Number.isFinite(v)) total += v;
+  }
+  return total;
+}
+
+describe("anthropic→openai streaming usage (#790)", () => {
+  let app: SpawnedApp | undefined;
+  let upstreamUsage: OpenAiUpstream | undefined;
+  let upstreamNoUsage: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstreamUsage = await startOpenAiUpstream({
+      streamEvents: STREAM_WITH_TRAILING_USAGE,
+      eventDelayMs: 2,
+    });
+    upstreamNoUsage = await startOpenAiUpstream({
+      streamEvents: STREAM_NO_USAGE,
+      eventDelayMs: 2,
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pkUsage = await admin.createProviderKey({
+      display_name: "issue790-pk",
+      secret: "sk-openai-mock",
+      api_base: `${upstreamUsage.baseUrl}/v1`,
+    });
+    const pkNoUsage = await admin.createProviderKey({
+      display_name: "issue790-pk-nousage",
+      secret: "sk-openai-mock",
+      api_base: `${upstreamNoUsage.baseUrl}/v1`,
+    });
+    // Mirrors the customer config from #790: alias gpt-5.5 → upstream
+    // model mog-6 on an OpenAI-protocol provider.
+    await admin.createModel({
+      display_name: "gpt-5.5",
+      provider: "openai",
+      model_name: "mog-6",
+      provider_key_id: pkUsage.id,
+    });
+    await admin.createModel({
+      display_name: "gpt-5.5-nousage",
+      provider: "openai",
+      model_name: "mog-6",
+      provider_key_id: pkNoUsage.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["gpt-5.5", "gpt-5.5-nousage"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstreamUsage?.close();
+    await upstreamNoUsage?.close();
+  });
+
+  test("injects stream_options, records tokens, surfaces usage in message_delta", async (ctx) => {
+    if (!etcdReachable || !app || !upstreamUsage) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      try {
+        return (await postMessages(app!.proxyUrl, "gpt-5.5")).ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await postMessages(app.proxyUrl, "gpt-5.5");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+
+    // Anthropic SSE wire shape intact, content delivered.
+    expect(body).toContain("message_start");
+    expect(body).toContain("hello from mog-6");
+    expect(body).toContain("message_stop");
+
+    // (1) The translated upstream request asked for the usage frame.
+    const lastReq = upstreamUsage.receivedRequests.at(-1);
+    expect(lastReq).toBeDefined();
+    const outbound = JSON.parse(lastReq!.body) as Record<string, unknown>;
+    expect(outbound.model).toBe("mog-6");
+    expect(outbound.stream).toBe(true);
+    expect(outbound.stream_options).toEqual({ include_usage: true });
+
+    // (3) The closing message_delta carries the real counts — the
+    // pre-fix encoder closed at the stop chunk with output_tokens 0.
+    const messageDelta = body
+      .split("\n")
+      .filter((l) => l.startsWith("data: "))
+      .map((l) => JSON.parse(l.slice("data: ".length)))
+      .find((d) => d.type === "message_delta");
+    expect(messageDelta?.usage?.output_tokens).toBe(COMPLETION_TOKENS);
+    expect(messageDelta?.usage?.input_tokens).toBe(PROMPT_TOKENS);
+
+    // (2) Token metrics record the usage (pre-fix: stuck at 0). The
+    // readiness probes above also hit gpt-5.5 so use >= not ==.
+    const deadline = Date.now() + 5_000;
+    let inTok = 0;
+    let outTok = 0;
+    while (Date.now() < deadline) {
+      const scrape = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+      inTok = sumMetricByModel(scrape, "aisix_llm_input_tokens_total", "gpt-5.5");
+      outTok = sumMetricByModel(scrape, "aisix_llm_output_tokens_total", "gpt-5.5");
+      if (inTok >= PROMPT_TOKENS && outTok >= COMPLETION_TOKENS) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(inTok).toBeGreaterThanOrEqual(PROMPT_TOKENS);
+    expect(outTok).toBeGreaterThanOrEqual(COMPLETION_TOKENS);
+  });
+
+  test("upstream ignoring stream_options still gets a well-formed close", async (ctx) => {
+    if (!etcdReachable || !app || !upstreamNoUsage) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await postMessages(app.proxyUrl, "gpt-5.5-nousage");
+    expect(res.status).toBe(200);
+    const body = await res.text();
+
+    // The closing pair is withheld waiting for a usage frame that never
+    // comes — stream end must flush it (force_finish), keeping the
+    // Anthropic wire shape valid for the client.
+    expect(body).toContain("hello from mog-6");
+    const events = body
+      .split("\n")
+      .filter((l) => l.startsWith("data: "))
+      .map((l) => JSON.parse(l.slice("data: ".length)));
+    const messageDelta = events.find((d) => d.type === "message_delta");
+    expect(messageDelta?.delta?.stop_reason).toBe("end_turn");
+    expect(events.some((d) => d.type === "message_stop")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

api7/AISIX-Cloud#790: a claude-cli (Anthropic protocol, streaming) request served by an OpenAI-protocol provider logged `prompt_tokens`/`completion_tokens` = NULL and cost $0, despite a healthy 200. In the customer's environment **46/46** anthropic→openai streaming 200s had no tokens, while 31/31 anthropic→anthropic ones did.

Root cause: every OpenAI-protocol streaming leg sent `stream: true` **without** `stream_options: {"include_usage": true}`. Per the OpenAI protocol the upstream then never attaches `usage` to the stream, so the gateway's accumulator stayed at 0. The same gap applied to `/v1/chat/completions` for any client that streams without setting `stream_options` itself (most SDKs).

## Fix

- `build_request` (openai wire, shared by the **openai** and **azure-openai** bridges) injects `stream_options: {"include_usage": true}` on streaming requests when the caller didn't set `stream_options`. A client-supplied value passes through verbatim — the typed field is gated on absence, so the key can never be emitted twice.
- The Anthropic SSE encoder (cross-provider `/v1/messages`) **withholds the closing `message_delta`/`message_stop` pair until the trailing usage-only frame arrives** — OpenAI sends usage AFTER the stop chunk, and the pre-fix pump stopped at the stop chunk, dropping the usage frame unread and reporting `output_tokens: 0` to the client. The held pair now carries real `input_tokens`/`output_tokens`; if an upstream ignores `stream_options`, stream end flushes the pair with the real stop reason (wire shape stays valid).
- `/v1/chat/completions` strips the gateway-induced usage-only frame from the client-visible stream unless the client asked for usage itself; the counts still feed the UsageEvent.

## Behavior changes

- Streaming token telemetry (and therefore cost, TPM post-stream commits, budgets) now works for OpenAI-protocol upstreams regardless of client `stream_options`.
- Translated `/v1/messages` streams now report real usage in the closing `message_delta` (claude-cli `/cost` etc. were seeing 0).
- Clients that didn't request usage see no new frames on `/v1/chat/completions`; clients that did keep the existing behavior.

## Sibling-endpoint audit

- `/v1/messages` cross-provider + `/v1/chat/completions` (openai & azure bridges): fixed here via the shared `build_request`.
- `/v1/responses` streaming: **different mechanism** — byte passthrough never parses SSE, and the Responses API carries usage in `response.completed` unconditionally (no `stream_options` involved); tracked as the existing #404 follow-up, not addressed here.
- Legacy `/v1/completions`: no streaming support, no gap.
- anthropic/bedrock/vertex bridges: usage rides in-protocol stream events, unaffected.

## Baseline (LiteLLM)

LiteLLM injects `include_usage` unconditionally on its anthropic-adapter streaming path (`adapters/handler.py`). For generic OpenAI-compatible upstreams its default is hostname-gated (`api.openai.com` only) with an opt-in proxy flag — but it has a tokenizer fallback for missing usage that we don't. Since billing correctness is core here and upstreams are operator-configured, we inject for all OpenAI-protocol upstreams (decision recorded in api7/AISIX-Cloud#790).

## Tests

- Unit: `build_request` injects / respects client value / omits when non-streaming; encoder holds the close until the post-stop usage frame, `force_finish` flushes with the real stop reason.
- Integration (proxy): streaming chat injects `stream_options`, records 500/1000 in the UsageEvent, and strips the unrequested usage frame; companion test for a client that asked for usage.
- E2E (real binary + mock upstream): `messages-cross-provider-stream-usage-e2e.test.ts` mirrors the #790 customer config (alias gpt-5.5 → upstream mog-6), asserts the outbound `stream_options`, non-zero token metrics, real counts in `message_delta`, and a well-formed close when the upstream ignores `stream_options`.

Fixes api7/AISIX-Cloud#790.