### PR TITLE
feat(heartbeat): report the image sha in the DP version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -82,6 +82,15 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.licenses=Apache-2.0
 
+      # Same short sha the `type=sha,prefix=sha-` tag uses, stamped into
+      # the binary so the DP's heartbeat reports `0.1.0+sha-<short>` and
+      # operators can match a node to its image tag.
+      - name: Compute short sha
+        id: shortsha
+        # First 7 chars of the commit sha — identical to what
+        # metadata-action's `type=sha,format=short` puts in the tag.
+        run: echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -89,6 +98,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_SHA=${{ steps.shortsha.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false   # keep manifest format compatible with older clients

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,14 @@ RUN apt-get update \
 
 WORKDIR /src
 
+# Short git sha stamped into the binary (heartbeat `version` =
+# `<crate-version>+sha-<BUILD_SHA>`) so a running DP can be matched to
+# its image tag. CI passes the same short sha that tags the image;
+# plain `docker build` (no arg) produces a binary that reports the bare
+# crate version.
+ARG BUILD_SHA=
+ENV AISIX_BUILD_SHA=$BUILD_SHA
+
 # BuildKit cache mounts carry `~/.cargo/registry` + `target/` across
 # builds, so changes to source files still reuse compiled dependencies.
 # We could split dep-build from source-build via a manifests-only warm

--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -21,6 +21,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 
 use aisix_etcd::loader::RejectedEntry;
@@ -28,6 +29,25 @@ use aisix_obs::SinkStatsSnapshot;
 use anyhow::{anyhow, Context};
 use serde::Serialize;
 use tokio::sync::watch;
+
+/// Build identity reported to cp-api (heartbeat `version` field + HTTP
+/// User-Agent). CI stamps `AISIX_BUILD_SHA` — the same short git sha
+/// that tags the container image — at compile time, so the wire carries
+/// `0.1.0+sha-103d3ec` and an operator can match a DP node directly to
+/// its `ghcr.io/...:sha-103d3ec` image. Local builds (no stamp) report
+/// the bare crate version. cp-api persists this into
+/// `dpmgr_nodes.dp_version`, replacing the `"pending"` placeholder it
+/// wrote at install-command time.
+pub static BUILD_VERSION: LazyLock<String> = LazyLock::new(|| {
+    format_build_version(env!("CARGO_PKG_VERSION"), option_env!("AISIX_BUILD_SHA"))
+});
+
+fn format_build_version(pkg_version: &str, build_sha: Option<&str>) -> String {
+    match build_sha {
+        Some(sha) if !sha.is_empty() => format!("{pkg_version}+sha-{sha}"),
+        _ => pkg_version.to_string(),
+    }
+}
 
 /// Cheap clonable callback the heartbeat invokes once per tick to pull
 /// the supervisor's most recent loader rejections. Returning a clone
@@ -332,7 +352,7 @@ async fn send(client: &reqwest::Client, cfg: &HeartbeatConfig, uptime: i64) -> a
         .json(&HeartbeatBody {
             dp_id: &cfg.dp_id,
             uptime_seconds: uptime,
-            version: env!("CARGO_PKG_VERSION"),
+            version: &BUILD_VERSION,
             supported_guardrail_kinds: aisix_guardrails::supported_kinds(),
             applied_revision,
             exporter_health,
@@ -395,7 +415,7 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
 
     let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
-        .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")))
+        .user_agent(format!("aisix-dp/{}", &*BUILD_VERSION))
         .identity(identity)
         .add_root_certificate(ca)
         // Pin HTTP/1.1 for the dp-manager REST calls. dp-manager
@@ -429,6 +449,20 @@ mod tests {
     use std::path::Path;
     use wiremock::matchers::{body_string_contains, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// The reported version must correlate a DP node with its container
+    /// image: CI stamps the image-tag sha, local builds stay bare.
+    #[test]
+    fn build_version_appends_stamped_image_sha() {
+        assert_eq!(
+            format_build_version("0.1.0", Some("103d3ec")),
+            "0.1.0+sha-103d3ec"
+        );
+        assert_eq!(format_build_version("0.1.0", None), "0.1.0");
+        // An empty stamp (e.g. `AISIX_BUILD_SHA=` in a misconfigured CI
+        // env) must not produce a dangling "0.1.0+sha-".
+        assert_eq!(format_build_version("0.1.0", Some("")), "0.1.0");
+    }
 
     /// Bundle on disk used by the build_client test: generates a real
     /// self-signed CA + leaf so reqwest's PEM parser actually accepts

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -241,7 +241,7 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
 
     let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
-        .user_agent(format!("aisix-dp/{}", env!("CARGO_PKG_VERSION")))
+        .user_agent(format!("aisix-dp/{}", &*crate::heartbeat::BUILD_VERSION))
         .identity(identity)
         .add_root_certificate(ca)
         // Pin HTTP/1.1 — see heartbeat::build_client. dp-manager cmux


### PR DESCRIPTION
## Problem

The heartbeat's `version` field carries `CARGO_PKG_VERSION` — a static `0.1.0` that is identical for every build, so a connected DP cannot be matched to the image it actually runs (api7/AISIX-Cloud#792; bit us in the api7/AISIX-Cloud#790 investigation, where the customer's DP version had to be inferred from ArgoCD pin history).

## Change

- CI passes the commit's short sha as the `BUILD_SHA` build-arg (the same 7 chars that tag the image via `type=sha,prefix=sha-`); the Dockerfile exports it as `AISIX_BUILD_SHA` for the cargo build.
- The binary stamps it at compile time (`option_env!`) into `BUILD_VERSION` = `0.1.0+sha-<short>`, reported in the heartbeat `version` field and in the heartbeat/telemetry `User-Agent`s.
- Builds without the stamp (local `cargo build`, plain `docker build`) keep reporting the bare crate version; an empty stamp does not produce a dangling `0.1.0+sha-`.

Wire-compatible in both directions: the field already exists on the wire and cp-api currently ignores it. The cp-api side (persisting it into `dpmgr_nodes.dp_version` to replace the never-updated `"pending"` placeholder + dashboard display) lands separately in AISIX-Cloud.

## Tests

- `build_version_appends_stamped_image_sha` covers stamped / unstamped / empty-stamp formatting.
- Existing heartbeat wiremock tests cover the body shape end-to-end.

Fixes api7/AISIX-Cloud#792.