### PR TITLE
refactor(obs): unify Prometheus scrape on the dedicated metrics listener

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,8 @@ COPY config.managed.yaml /etc/aisix/config.managed.yaml
 COPY docker/entrypoint.sh /usr/local/bin/aisix-entrypoint
 RUN chmod 0755 /usr/local/bin/aisix-entrypoint
 
-# Proxy + admin listeners from config.example.yaml.
-EXPOSE 3000 3001
+# Proxy + admin + metrics listeners from config.example.yaml.
+EXPOSE 3000 3001 9090
 
 USER aisix
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,13 +54,11 @@ observability:
     prometheus:
       enabled: true
       path: "/metrics"
-      # Optional: serve `/metrics` on a dedicated listener instead of
-      # relying on the admin listener. Set this when the admin surface is
-      # private but you still want Prometheus to scrape, or to keep the
-      # scrape port separate from the data path. Required for managed-mode
-      # DPs (the admin listener is not bound there). Unset = `/metrics`
-      # stays on the admin listener.
-      # addr: "0.0.0.0:9090"
+      # Dedicated metrics listener — the only Prometheus scrape surface,
+      # the same in every deployment mode. Point Prometheus at this
+      # address; the endpoint is unauthenticated, so restrict access at
+      # the network layer.
+      addr: "0.0.0.0:9090"
     otlp:
       enabled: false
       endpoint: "http://127.0.0.1:4317"

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -53,11 +53,10 @@ observability:
     prometheus:
       enabled: true
       path: "/metrics"
-      # Dedicated metrics listener. Managed mode never binds the admin
-      # listener that otherwise hosts `/metrics`, so this is what makes a
-      # managed DP scrapeable. Bound by default here (no control-plane
-      # change needed); expose this port in your deployment and point
-      # Prometheus at it. Override with AISIX_OBSERVABILITY__METRICS__PROMETHEUS__ADDR.
+      # Dedicated metrics listener — the only Prometheus scrape surface,
+      # the same in every deployment mode. Expose this port in your
+      # deployment and point Prometheus at it. Override with
+      # AISIX_OBSERVABILITY__METRICS__PROMETHEUS__ADDR.
       addr: "0.0.0.0:9090"
     otlp:
       enabled: false

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -2,9 +2,12 @@
 //!
 //! Public admin-listener endpoints:
 //! - `GET  /livez`
-//! - `GET  /metrics`
 //! - `GET  /admin/openapi.json`
 //! - `GET  /admin/openapi-scalar`
+//!
+//! Prometheus metrics are NOT served here — the scrape endpoint always
+//! lives on the dedicated metrics listener (see [`metrics_router`]),
+//! identical in standalone and managed mode.
 //!
 //! Admin-key protected routes:
 //! - `GET|POST            /admin/v1/models`
@@ -66,9 +69,9 @@ pub fn build_router(state: AdminState) -> Router {
     // subsequent handler call is a free lookup.
     let _ = openapi::merged_openapi();
 
-    let mut router = Router::new()
+    let router = Router::new()
         .route("/livez", get(livez))
-        // OpenAPI scalar UI is unauthenticated like /metrics — admin
+        // OpenAPI scalar UI is unauthenticated like /livez — admin
         // listener is private in production.
         .route("/admin/openapi.json", get(openapi::openapi_json))
         .route("/admin/openapi-scalar", get(openapi::openapi_scalar))
@@ -154,41 +157,32 @@ pub fn build_router(state: AdminState) -> Router {
             post(playground_handler::playground_chat_completions),
         );
 
-    if state.prometheus.enabled {
-        router = router.route(
-            &normalized_prometheus_path(&state.prometheus.path),
-            get(metrics_handler),
-        );
-    }
-
     router.with_state(state)
 }
 
-/// Build a minimal router for a **dedicated** Prometheus metrics
-/// listener — only the scrape endpoint at `prometheus.path`, backed by
-/// the shared [`Metrics`] handle. No admin state, no auth-protected
-/// routes, no playground.
+/// Build the router for the **dedicated** Prometheus metrics listener —
+/// only the scrape endpoint at `prometheus.path`, backed by the shared
+/// [`Metrics`] handle. No admin state, no auth-protected routes, no
+/// playground.
 ///
 /// `aisix-server` binds this on `observability.metrics.prometheus.addr`
-/// when that address is set. It exists because managed-mode DPs never
-/// bind the admin listener that normally hosts `/metrics`, so a separate
-/// listener is the only way they can be scraped. When the address is
-/// unset the gateway keeps `/metrics` on the admin listener and this
-/// router is not built.
+/// whenever prometheus is enabled. This is the only metrics surface —
+/// the same in standalone and managed mode; the admin listener never
+/// serves `/metrics`.
 pub fn metrics_router(metrics: Arc<Metrics>, prometheus: &PrometheusConfig) -> Router {
     Router::new()
         .route(
             &normalized_prometheus_path(&prometheus.path),
-            get(dedicated_metrics_handler),
+            get(metrics_handler),
         )
         .with_state(metrics)
 }
 
-/// Prometheus scrape handler for the dedicated metrics listener. The
-/// recorder is always present here (the handle is a required argument,
-/// unlike the admin variant's optional one), so there is no 503 branch.
-/// Emits `text/plain; version=0.0.4`.
-async fn dedicated_metrics_handler(
+/// Prometheus scrape handler. The recorder handle is a required
+/// argument, so there is no 503 branch. Unauthenticated by design —
+/// restrict access at the network layer. Emits
+/// `text/plain; version=0.0.4`.
+async fn metrics_handler(
     axum::extract::State(metrics): axum::extract::State<Arc<Metrics>>,
 ) -> Response {
     use axum::http::header::CONTENT_TYPE;
@@ -219,33 +213,6 @@ async fn livez(
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Response {
     aisix_proxy::health::livez_response(&state.livez_state, params.contains_key("verbose"))
-}
-
-/// Prometheus `/metrics` endpoint. Unauthenticated by design — the admin
-/// listener is bound to a private address in production, and scrapers
-/// don't carry bearer tokens. Emits `text/plain; version=0.0.4`.
-async fn metrics_handler(
-    axum::extract::State(state): axum::extract::State<AdminState>,
-) -> axum::response::Response {
-    use axum::http::header::CONTENT_TYPE;
-    use axum::response::IntoResponse;
-
-    match state.metrics.as_ref() {
-        Some(m) => {
-            let body = m.render();
-            (
-                StatusCode::OK,
-                [(CONTENT_TYPE, "text/plain; version=0.0.4")],
-                body,
-            )
-                .into_response()
-        }
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "metrics recorder not configured",
-        )
-            .into_response(),
-    }
 }
 
 #[cfg(test)]
@@ -345,133 +312,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn metrics_endpoint_returns_prometheus_text_when_configured() {
-        use aisix_obs::{Metrics, RequestOutcome};
-        use std::time::Duration;
-
-        let handle = SnapshotHandle::new(AisixSnapshot::new());
-        let store = InMemoryStore::new() as Arc<dyn ConfigStore>;
-        let metrics = Arc::new(Metrics::new(false));
-        // Pre-populate so the assertion doesn't depend on a separate
-        // proxy call landing samples.
-        metrics.record_request(
-            "openai",
-            "my-gpt4",
-            200,
-            RequestOutcome::Success,
-            Duration::from_millis(10),
-        );
-
-        let state = AdminState::new(handle, store, &cfg()).with_metrics(metrics);
-        let app = build_router(state);
-
-        let req = Request::builder()
-            .uri("/metrics")
-            .body(Body::empty())
-            .unwrap();
-        let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
-        let ct = resp
-            .headers()
-            .get(axum::http::header::CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        assert!(
-            ct.starts_with("text/plain"),
-            "unexpected content-type: {ct}"
-        );
-
-        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
-        let body = String::from_utf8(bytes.to_vec()).unwrap();
-        assert!(body.contains("aisix_requests_total"));
-        assert!(body.contains("provider=\"openai\""));
-    }
-
-    #[tokio::test]
-    async fn metrics_endpoint_returns_503_when_recorder_not_wired() {
-        let state = build_state(); // no with_metrics
-        let app = build_router(state);
-        let req = Request::builder()
-            .uri("/metrics")
-            .body(Body::empty())
-            .unwrap();
-        let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-    }
-
-    #[tokio::test]
-    async fn metrics_endpoint_uses_configured_path() {
-        use aisix_core::config::PrometheusConfig;
-        use aisix_obs::Metrics;
-
-        let state = build_state()
-            .with_metrics(Arc::new(Metrics::new(false)))
-            .with_prometheus_config(PrometheusConfig {
-                enabled: true,
-                path: "/internal/prom".into(),
-                addr: None,
-            });
-        let app = build_router(state);
-
-        let resp = run(
-            app.clone(),
-            Request::builder()
-                .uri("/metrics")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-
-        let resp = run(
-            app,
-            Request::builder()
-                .uri("/internal/prom")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn metrics_endpoint_normalizes_configured_path() {
-        use aisix_core::config::PrometheusConfig;
-        use aisix_obs::Metrics;
-
-        let state = build_state()
-            .with_metrics(Arc::new(Metrics::new(false)))
-            .with_prometheus_config(PrometheusConfig {
-                enabled: true,
-                path: "internal/prom".into(),
-                addr: None,
-            });
-        let app = build_router(state);
-
-        let resp = run(
-            app,
-            Request::builder()
-                .uri("/internal/prom")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn metrics_endpoint_can_be_disabled() {
-        use aisix_core::config::PrometheusConfig;
-        use aisix_obs::Metrics;
-
-        let state = build_state()
-            .with_metrics(Arc::new(Metrics::new(false)))
-            .with_prometheus_config(PrometheusConfig {
-                enabled: false,
-                path: "/metrics".into(),
-                addr: None,
-            });
-        let app = build_router(state);
+    async fn admin_router_does_not_serve_metrics() {
+        // The scrape endpoint lives exclusively on the dedicated metrics
+        // listener — the admin router must not mount it.
+        let app = build_router(build_state());
         let req = Request::builder()
             .uri("/metrics")
             .body(Body::empty())
@@ -481,7 +325,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dedicated_metrics_router_serves_scrape_decoupled_from_admin() {
+    async fn metrics_router_serves_scrape_decoupled_from_admin() {
         use aisix_obs::{Metrics, RequestOutcome};
         use std::time::Duration;
 
@@ -499,7 +343,7 @@ mod tests {
             &PrometheusConfig {
                 enabled: true,
                 path: "/metrics".into(),
-                addr: Some("0.0.0.0:9090".into()),
+                addr: "0.0.0.0:9090".into(),
             },
         );
 
@@ -541,7 +385,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dedicated_metrics_router_honors_custom_path() {
+    async fn metrics_router_honors_custom_path() {
         use aisix_obs::Metrics;
 
         let app = metrics_router(
@@ -549,7 +393,7 @@ mod tests {
             &PrometheusConfig {
                 enabled: true,
                 path: "internal/prom".into(),
-                addr: Some("0.0.0.0:9090".into()),
+                addr: "0.0.0.0:9090".into(),
             },
         );
 

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -78,16 +78,6 @@ const OPENAPI_JSON_BASE: &str = r##"{
         }
       }
     },
-    "/metrics": {
-      "get": {
-        "summary": "Prometheus metrics (text/plain; version=0.0.4)",
-        "security": [],
-        "responses": {
-          "200": {"description": "OK"},
-          "503": {"description": "metrics recorder not configured"}
-        }
-      }
-    },
     "/admin/openapi.json": {
       "get": {
         "summary": "this OpenAPI document",
@@ -505,7 +495,6 @@ mod tests {
         // Every route mounted in build_router should be documented.
         for path in [
             "/livez",
-            "/metrics",
             "/admin/openapi.json",
             "/admin/openapi-scalar",
             "/admin/v1/models",
@@ -559,19 +548,13 @@ mod tests {
 
     #[tokio::test]
     async fn openapi_unauthenticated_routes_carry_empty_security() {
-        // /livez, /metrics, and the openapi self-references are public
-        // (mirrors the `unauthenticated like /metrics` design note in
-        // build_router). The spec must mark them with security: [] so
-        // Scalar's "Try it" doesn't prompt for an admin key on those
-        // routes.
+        // /livez and the openapi self-references are public (mirrors the
+        // design note in build_router). The spec must mark them with
+        // security: [] so Scalar's "Try it" doesn't prompt for an admin
+        // key on those routes.
         let parsed: serde_json::Value =
             serde_json::from_str(merged_openapi()).expect("merged_openapi must parse");
-        for path in [
-            "/livez",
-            "/metrics",
-            "/admin/openapi.json",
-            "/admin/openapi-scalar",
-        ] {
+        for path in ["/livez", "/admin/openapi.json", "/admin/openapi-scalar"] {
             let security = &parsed["paths"][path]["get"]["security"];
             assert!(
                 security.is_array() && security.as_array().unwrap().is_empty(),

--- a/crates/aisix-admin/src/state.rs
+++ b/crates/aisix-admin/src/state.rs
@@ -4,18 +4,14 @@
 //! - the bootstrap-config-provided `admin_keys` (auth)
 //! - the `ConfigStore` trait object (CRUD backend)
 //! - a `SnapshotHandle` for authenticated operator-health handlers
-//! - an optional `Metrics` handle — when present, `/metrics` renders
-//!   the same Prometheus exposition that the proxy's middleware writes to
 //!
 //! The store is held behind an `Arc<dyn ConfigStore>` so production can
 //! wire an etcd-backed impl and tests can use `InMemoryStore` via the
 //! same type.
 
-use aisix_core::config::PrometheusConfig;
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AdminConfig, AisixSnapshot};
 use aisix_etcd::WatchStatus;
-use aisix_obs::Metrics;
 use aisix_proxy::{HealthTracker, LivezState, ModelRuntimeStatusTracker};
 use axum::Router;
 use std::sync::Arc;
@@ -27,8 +23,6 @@ pub struct AdminState {
     pub snapshot: SnapshotHandle<AisixSnapshot>,
     pub admin_keys: Arc<[String]>,
     pub store: Arc<dyn ConfigStore>,
-    pub metrics: Option<Arc<Metrics>>,
-    pub prometheus: PrometheusConfig,
     /// Shared in-process health tracker from the proxy. Used by the
     /// `/admin/v1/health` endpoint to report per-model health status.
     pub health_tracker: Option<Arc<HealthTracker>>,
@@ -60,8 +54,6 @@ impl AdminState {
             snapshot,
             admin_keys: Arc::from(cfg.admin_keys.clone()),
             store,
-            metrics: None,
-            prometheus: PrometheusConfig::default(),
             health_tracker: None,
             runtime_status_tracker: None,
             watch_status: None,
@@ -75,19 +67,6 @@ impl AdminState {
     /// age so operators can spot a wedged config stream.
     pub fn with_watch_status(mut self, status: WatchStatus) -> Self {
         self.watch_status = Some(status);
-        self
-    }
-
-    /// Attach a metrics handle. Production wires the same handle that
-    /// lives in `ProxyState` so a single call to `/metrics` reflects
-    /// requests from both surfaces.
-    pub fn with_metrics(mut self, metrics: Arc<Metrics>) -> Self {
-        self.metrics = Some(metrics);
-        self
-    }
-
-    pub fn with_prometheus_config(mut self, prometheus: PrometheusConfig) -> Self {
-        self.prometheus = prometheus;
         self
     }
 

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -458,22 +458,16 @@ pub struct MetricsConfig {
 pub struct PrometheusConfig {
     pub enabled: bool,
     pub path: String,
-    /// Optional bind address for a **dedicated** metrics listener
-    /// (e.g. `0.0.0.0:9090`). When set, the gateway serves `path` on
-    /// its own listener — separate from the admin listener that
-    /// normally hosts `/metrics`.
-    ///
-    /// This is what lets a managed-mode DP be scraped at all: managed
-    /// mode never binds the admin listener (`ManagedConfig::is_managed`),
-    /// so without a dedicated address `/metrics` is configured but
-    /// stranded on a listener that never comes up. The baked-in
-    /// `config.managed.yaml` sets this so managed DPs expose metrics by
-    /// default with no control-plane change.
-    ///
-    /// Unset (the default) keeps `/metrics` on the admin listener only,
-    /// preserving the prior behavior for self-hosted deployments.
-    #[serde(default)]
-    pub addr: Option<String>,
+    /// Bind address of the **dedicated** metrics listener (default
+    /// `0.0.0.0:9090`). The scrape endpoint always lives on its own
+    /// listener — identical in standalone and managed mode — so the
+    /// scrape surface never depends on which other listeners a
+    /// deployment binds. The admin listener does not serve `/metrics`.
+    pub addr: String,
+}
+
+impl PrometheusConfig {
+    pub const DEFAULT_ADDR: &'static str = "0.0.0.0:9090";
 }
 
 impl Default for PrometheusConfig {
@@ -481,7 +475,7 @@ impl Default for PrometheusConfig {
         Self {
             enabled: true,
             path: "/metrics".into(),
-            addr: None,
+            addr: Self::DEFAULT_ADDR.into(),
         }
     }
 }
@@ -656,15 +650,13 @@ impl Config {
                 "proxy.real_ip.trusted_proxies invalid CIDR/IP: {bad}"
             )));
         }
-        // Dedicated metrics listener address, when configured, must be a
-        // bindable socket address. Unset keeps `/metrics` on the admin
-        // listener (no dedicated listener), so only validate when present.
-        if let Some(addr) = self.observability.metrics.prometheus.addr.as_deref() {
-            if addr.parse::<std::net::SocketAddr>().is_err() {
-                return Err(BootstrapError::Config(format!(
-                    "observability.metrics.prometheus.addr invalid socket address: {addr}"
-                )));
-            }
+        // The dedicated metrics listener address must be a bindable
+        // socket address — it is always bound when prometheus is enabled.
+        let metrics_addr = &self.observability.metrics.prometheus.addr;
+        if metrics_addr.parse::<std::net::SocketAddr>().is_err() {
+            return Err(BootstrapError::Config(format!(
+                "observability.metrics.prometheus.addr invalid socket address: {metrics_addr}"
+            )));
         }
         Ok(())
     }
@@ -699,9 +691,9 @@ admin:
         assert_eq!(cfg.etcd.endpoints, vec!["http://127.0.0.1:2379"]);
         assert_eq!(cfg.proxy.request_body_limit_bytes, 10 * 1024 * 1024);
         assert!(cfg.observability.metrics.prometheus.enabled);
-        // No dedicated metrics listener unless an addr is set — `/metrics`
-        // stays on the admin listener for self-hosted deployments.
-        assert!(cfg.observability.metrics.prometheus.addr.is_none());
+        // The dedicated metrics listener defaults to 0.0.0.0:9090 in
+        // every mode — no admin-listener fallback to fall out of sync with.
+        assert_eq!(cfg.observability.metrics.prometheus.addr, "0.0.0.0:9090");
         assert_eq!(cfg.cache.backend, CacheBackend::Memory);
         // real_ip defaults: trust nothing, non-recursive, x-forwarded-for.
         assert!(cfg.proxy.real_ip.trusted_proxies.is_empty());
@@ -811,9 +803,7 @@ admin:
 
     #[test]
     fn parses_prometheus_addr_for_dedicated_listener() {
-        // A dedicated metrics listener address parses and round-trips.
-        // This is the managed-mode shape: `/metrics` is served on its
-        // own bound listener because the admin listener is never bound.
+        // An explicit metrics listener address parses and round-trips.
         let f = write_yaml(
             r#"
 etcd:
@@ -828,14 +818,11 @@ observability:
     prometheus:
       enabled: true
       path: "/metrics"
-      addr: "0.0.0.0:9090"
+      addr: "127.0.0.1:19090"
 "#,
         );
         let cfg = Config::load_from_path(Some(f.path())).unwrap();
-        assert_eq!(
-            cfg.observability.metrics.prometheus.addr.as_deref(),
-            Some("0.0.0.0:9090"),
-        );
+        assert_eq!(cfg.observability.metrics.prometheus.addr, "127.0.0.1:19090");
     }
 
     #[test]
@@ -865,25 +852,32 @@ observability:
     }
 
     #[test]
-    fn shipped_managed_config_binds_a_dedicated_metrics_listener() {
-        // The baked managed-image config (`config.managed.yaml`) is the
-        // entire "no control-plane change" lever: a managed DP exposes
-        // `/metrics` only because this file binds a dedicated listener
-        // while the admin listener stays the unbindable sentinel. A typo
-        // here would silently un-scrape every managed DP — that file is
-        // only COPYd into the image, so nothing else catches it. Pin it.
+    fn shipped_managed_config_binds_the_metrics_listener() {
+        // The baked managed-image config (`config.managed.yaml`) is only
+        // COPYd into the image, so nothing else catches a typo that would
+        // silently un-scrape every managed DP. Pin the scrape address.
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config.managed.yaml");
         let cfg =
             Config::load_from_path(Some(Path::new(path))).expect("config.managed.yaml must load");
         assert!(cfg.managed.is_managed());
+        assert!(cfg.observability.metrics.prometheus.enabled);
         assert_eq!(
-            cfg.observability.metrics.prometheus.addr.as_deref(),
-            Some("0.0.0.0:9090"),
-            "managed DPs must bind a dedicated metrics listener so they can be scraped",
+            cfg.observability.metrics.prometheus.addr, "0.0.0.0:9090",
+            "managed DPs are scraped on the dedicated metrics listener",
         );
-        // Admin is the unbindable sentinel, so the dedicated listener is
-        // the only metrics surface in managed mode.
         assert_eq!(cfg.admin.addr, "127.0.0.1:0");
+    }
+
+    #[test]
+    fn shipped_example_config_binds_the_metrics_listener() {
+        // `config.example.yaml` is the self-hosted reference shape; pin
+        // the explicit unified scrape address so standalone and managed
+        // deployments document the same metrics surface.
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config.example.yaml");
+        let cfg =
+            Config::load_from_path(Some(Path::new(path))).expect("config.example.yaml must load");
+        assert!(cfg.observability.metrics.prometheus.enabled);
+        assert_eq!(cfg.observability.metrics.prometheus.addr, "0.0.0.0:9090");
     }
 
     #[test]

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -8,7 +8,7 @@
 //!  5. Bootstrap initial snapshot
 //!  6. Spawn watch supervisor
 //!  7. Build proxy router
-//!  8. Build admin router (+ dedicated metrics listener when configured)
+//!  8. Build admin router + dedicated metrics listener
 //!  9. Bind + serve the ports (tokio::select! with shutdown signal)
 //! 10. On SIGINT/SIGTERM: cancel supervisor, stop accepting, join
 
@@ -502,8 +502,6 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         let admin_store: Arc<dyn ConfigStore> =
             Arc::new(EtcdConfigStore::new(admin_client, etcd_prefix.clone()));
         let admin_state = AdminState::new(snapshot_handle.clone(), admin_store, &cfg.admin)
-            .with_metrics(metrics.clone())
-            .with_prometheus_config(cfg.observability.metrics.prometheus.clone())
             // Share the health tracker so /admin/v1/health reflects live
             // per-model upstream failure counts.
             .with_health_tracker(health_tracker)
@@ -539,18 +537,14 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         None
     };
 
-    // Dedicated metrics listener. The admin listener that normally hosts
-    // `/metrics` is never bound in managed mode, so a managed DP can only
-    // be scraped through a separate listener. Bound whenever
-    // `observability.metrics.prometheus.addr` is set — `config.managed.yaml`
-    // sets it by default (no control-plane change needed); self-hosted
-    // deployments keep `/metrics` on the admin listener unless they opt in
-    // by setting the address. Shares the same `metrics` handle as the proxy
-    // and admin surfaces, so one scrape reflects all request paths.
+    // Dedicated metrics listener — the only Prometheus scrape surface,
+    // bound whenever prometheus is enabled, identical in standalone and
+    // managed mode (default `0.0.0.0:9090`). Shares the same `metrics`
+    // handle as the proxy, so one scrape reflects all request paths.
     let metrics_serve_handle = {
         let prom = &cfg.observability.metrics.prometheus;
-        if let (true, Some(addr)) = (prom.enabled, prom.addr.as_deref()) {
-            let metrics_addr: std::net::SocketAddr = addr.parse()?;
+        if prom.enabled {
+            let metrics_addr: std::net::SocketAddr = prom.addr.parse()?;
             // Fail boot loudly if the metrics port is unavailable, rather
             // than silently serving no metrics until shutdown — the
             // listener is spawned and only joined post-shutdown, so a

--- a/docs/configuration/admin-api.md
+++ b/docs/configuration/admin-api.md
@@ -1,6 +1,6 @@
 ---
 title: Admin API
-description: Use the AISIX AI Gateway admin API to manage models, API keys, provider keys, guardrails, cache policies, observability exporters, health, metrics, and the in-process playground.
+description: Use the AISIX AI Gateway admin API to manage models, API keys, provider keys, guardrails, cache policies, observability exporters, health, and the in-process playground.
 sidebar_position: 31
 ---
 
@@ -33,9 +33,10 @@ Admin authentication is static and bootstrap-based for the authenticated operato
 The following routes are currently public on the admin listener:
 
 - `GET /livez`
-- `GET /metrics`
 - `GET /admin/openapi.json`
 - `GET /admin/openapi-scalar`
+
+Prometheus `/metrics` is not part of the admin surface — it is served on the dedicated metrics listener (`observability.metrics.prometheus.addr`, default `0.0.0.0:9090`). See [Metrics And Logs](../operations/metrics-and-logs.md).
 
 Example:
 
@@ -56,7 +57,6 @@ Do not mix them.
 The current admin router exposes:
 
 - `GET /livez`
-- `GET /metrics`
 - `GET /admin/openapi.json`
 - `GET /admin/openapi-scalar`
 - `GET|POST /admin/v1/models`
@@ -77,7 +77,7 @@ The current admin router exposes:
 
 Think about these routes in three groups:
 
-- public operator helpers: livez, metrics, and OpenAPI discovery
+- public operator helpers: livez and OpenAPI discovery
 - CRUD resources: models, API keys, provider keys, guardrails, cache policies, exporters
 - convenience operator workflow: the in-process playground
 
@@ -101,7 +101,7 @@ Current status behavior includes:
 - `409` for conflicts such as duplicate names
 - `500` for store failures
 
-Public routes such as `/livez`, `/metrics`, and the OpenAPI endpoints do not require admin auth.
+Public routes such as `/livez` and the OpenAPI endpoints do not require admin auth.
 
 Use `GET /livez` for simple admin-listener reachability. Use `GET /admin/v1/health` when you need authenticated per-model operator health.
 
@@ -223,10 +223,6 @@ Use it to answer operator questions such as:
 - is the admin surface alive
 - does the process have a current snapshot
 - are configured models currently healthy from the gateway's point of view
-
-### `GET /metrics`
-
-This is the Prometheus scrape endpoint on the admin listener.
 
 ### `POST /playground/chat/completions`
 

--- a/docs/configuration/bootstrap-config.md
+++ b/docs/configuration/bootstrap-config.md
@@ -78,6 +78,7 @@ observability:
     prometheus:
       enabled: true
       path: "/metrics"
+      addr: "0.0.0.0:9090"
 
 cache:
   backend: "memory"
@@ -180,8 +181,9 @@ Important fields:
 | `service_name` | service-name attribute on the tracing subscriber initialised at boot | `"aisix"` | wired |
 | `log_level` | fallback `EnvFilter` directive when `RUST_LOG` is not set in the environment | `"info"` | wired |
 | `access_log` | reserved field; access logs are currently emitted by every proxy handler regardless of this setting | `true` | reserved (not yet consulted) |
-| `metrics.prometheus.enabled` | controls whether the admin listener mounts the Prometheus scrape endpoint; when `false`, no `/metrics` route is registered | `true` | wired |
+| `metrics.prometheus.enabled` | controls whether the dedicated metrics listener is bound; when `false`, the gateway serves no Prometheus scrape endpoint | `true` | wired |
 | `metrics.prometheus.path` | mount path for the Prometheus scrape endpoint | `"/metrics"` | wired |
+| `metrics.prometheus.addr` | bind address of the dedicated metrics listener — the only Prometheus scrape surface, identical in standalone and managed mode | `"0.0.0.0:9090"` | wired |
 | `metrics.otlp.enabled` | reserved field; no OTLP metrics export pipeline is installed in the current release | `false` | reserved (not yet wired) |
 | `metrics.otlp.endpoint` | OTLP/gRPC metrics endpoint | none | reserved (not yet wired) |
 | `tracing.otlp.enabled` | boot-time endpoint validation; OTLP traces pipeline deferred | `false` | partial (validation only) |

--- a/docs/operations/metrics-and-logs.md
+++ b/docs/operations/metrics-and-logs.md
@@ -10,9 +10,9 @@ Use them together. No single signal tells the whole story.
 
 ## Metrics
 
-`GET /metrics` is the Prometheus scrape endpoint. By default it is served on the admin listener. You can change the path with `observability.metrics.prometheus.path`, disable it with `observability.metrics.prometheus.enabled: false`, or serve it on a **dedicated listener** with `observability.metrics.prometheus.addr` (for example `0.0.0.0:9090`). A dedicated listener is what lets you scrape a Cloud managed data plane — see [Managed data plane metrics](#managed-data-plane-metrics).
+`GET /metrics` is the Prometheus scrape endpoint, served on a **dedicated metrics listener** bound at `observability.metrics.prometheus.addr` (default `0.0.0.0:9090`). The mechanism is identical in every deployment mode — standalone and Cloud managed data planes are scraped the same way, and the admin listener does not serve `/metrics`. You can change the path with `observability.metrics.prometheus.path` or disable the listener entirely with `observability.metrics.prometheus.enabled: false`.
 
-This endpoint is unauthenticated by design. Keep it on a private listener and restrict access at the network layer (firewall, security group, or Kubernetes NetworkPolicy).
+This endpoint is unauthenticated by design. Keep it on a private network and restrict access at the network layer (firewall, security group, or Kubernetes NetworkPolicy).
 
 Treat `/metrics` as infrastructure-facing, not as a public diagnostics surface.
 
@@ -20,11 +20,9 @@ Treat `/metrics` as infrastructure-facing, not as a public diagnostics surface.
 Metric families are registered lazily on first observation — the gateway does not pre-register `# HELP` / `# TYPE` lines at startup. Immediately after boot, `GET /metrics` returns an empty body. This is expected, not a misconfigured endpoint. To smoke-test, send one model request and then re-check `/metrics`; you should now see series such as `aisix_requests_total` and `aisix_tokens_consumed_total`.
 :::
 
-### Managed Data Plane Metrics
+### Scraping The Data Plane
 
-The `/metrics` endpoint is served on the **admin listener**, which a Cloud managed data plane does not bind. A managed DP therefore exposes metrics on a **dedicated metrics listener** instead, configured by `observability.metrics.prometheus.addr`. The managed image binds this on `0.0.0.0:9090` by default, so **no control-plane configuration is required** — you scrape it directly with your own Prometheus, from inside the data plane's network.
-
-To scrape a managed data plane (or any deployment with a dedicated listener):
+To scrape any data plane (standalone or managed):
 
 1. **Expose the metrics port** in your data plane deployment. The proxy and admin ports are unaffected — only the metrics port needs to be reachable by your Prometheus.
 
@@ -66,7 +64,7 @@ To scrape a managed data plane (or any deployment with a dedicated listener):
          path: /metrics
    ```
 
-Restrict access to the metrics port at the network layer — it is unauthenticated, like every Prometheus exporter. Self-hosted standalone deployments can keep scraping `/metrics` on the admin listener, or set `addr` to also expose it on a dedicated listener.
+Restrict access to the metrics port at the network layer — it is unauthenticated, like every Prometheus exporter.
 
 AISIX exposes native metric names with the `aisix_` prefix. Existing compatibility series remain:
 

--- a/docs/operations/network-and-security.md
+++ b/docs/operations/network-and-security.md
@@ -20,7 +20,7 @@ Recommended boundary:
 
 Do not assume admin auth alone is enough protection. Current admin design intentionally leaves some routes unauthenticated on that private listener.
 
-Current admin design intentionally leaves `/livez`, `/metrics`, and OpenAPI endpoints unauthenticated on that private listener, so network placement matters.
+Current admin design intentionally leaves `/livez` and OpenAPI endpoints unauthenticated on that private listener, so network placement matters. The Prometheus scrape endpoint lives on its own dedicated metrics listener (default `0.0.0.0:9090`) and is also unauthenticated — restrict that port at the network layer too.
 
 ## Secrets And Credentials
 

--- a/docs/reference/admin-api-reference.md
+++ b/docs/reference/admin-api-reference.md
@@ -7,11 +7,10 @@ sidebar_position: 61
 ## Public Admin-Listener Routes
 
 - `GET /livez`
-- `GET /metrics`
 - `GET /admin/openapi.json`
 - `GET /admin/openapi-scalar`
 
-These are operator-facing helper and discovery routes, not dynamic-resource write paths.
+These are operator-facing helper and discovery routes, not dynamic-resource write paths. Prometheus `/metrics` is served on the dedicated metrics listener, not the admin listener — see [Metrics And Logs](../operations/metrics-and-logs.md).
 
 ## Authenticated Operator Routes
 

--- a/tests/e2e/src/cases/anthropic-streaming-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-streaming-usage-e2e.test.ts
@@ -183,7 +183,7 @@ describe("anthropic /v1/messages streaming usage telemetry (#245)", () => {
     let inTokens = 0;
     let outTokens = 0;
     while (Date.now() < deadline) {
-      const scrape = await fetch(`${app.adminUrl}/metrics`).then((r) =>
+      const scrape = await fetch(`${app.metricsUrl}/metrics`).then((r) =>
         r.text(),
       );
       inTokens = sumMetric(scrape, "aisix_llm_input_tokens_total", "/v1/messages");

--- a/tests/e2e/src/cases/audio-images-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/audio-images-usage-e2e.test.ts
@@ -93,7 +93,7 @@ describe("audio + images UsageEvent emission (#406/#407)", () => {
       });
       expect((await call()).status).toBe(200);
 
-      const emitted = await pollUsageEmitted(app.adminUrl, "images");
+      const emitted = await pollUsageEmitted(app.metricsUrl, "images");
       expect(emitted, "handler=images emit counter must be > 0 (#407)").toBeGreaterThan(0);
     } finally {
       await app.exit();
@@ -153,7 +153,7 @@ describe("audio + images UsageEvent emission (#406/#407)", () => {
       });
       expect((await call()).status).toBe(200);
 
-      const emitted = await pollUsageEmitted(app.adminUrl, "audio");
+      const emitted = await pollUsageEmitted(app.metricsUrl, "audio");
       expect(emitted, "handler=audio emit counter must be > 0 (#406)").toBeGreaterThan(0);
     } finally {
       await app.exit();
@@ -169,11 +169,11 @@ describe("audio + images UsageEvent emission (#406/#407)", () => {
  * consistent). Bounded so a regression (no emit) fails rather than
  * hangs. Sums all label-sets for the handler.
  */
-async function pollUsageEmitted(adminUrl: string, handler: string): Promise<number> {
+async function pollUsageEmitted(metricsUrl: string, handler: string): Promise<number> {
   const deadline = Date.now() + 5_000;
   let total = 0;
   while (Date.now() < deadline) {
-    const text = await fetch(`${adminUrl}/metrics`).then((r) => r.text());
+    const text = await fetch(`${metricsUrl}/metrics`).then((r) => r.text());
     total = 0;
     for (const line of text.split("\n")) {
       if (!line.startsWith("aisix_usage_events_emitted_total{")) continue;

--- a/tests/e2e/src/cases/chat-anthropic-stream-input-tokens-e2e.test.ts
+++ b/tests/e2e/src/cases/chat-anthropic-stream-input-tokens-e2e.test.ts
@@ -113,7 +113,7 @@ describe("/v1/chat/completions anthropic streaming input tokens (#450)", () => {
     let inTok = 0;
     let outTok = 0;
     while (Date.now() < deadline) {
-      const scrape = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+      const scrape = await fetch(`${app.metricsUrl}/metrics`).then((r) => r.text());
       inTok = sumMetric(scrape, "aisix_llm_input_tokens_total", "/v1/chat/completions");
       outTok = sumMetric(scrape, "aisix_llm_output_tokens_total", "/v1/chat/completions");
       if (inTok > 0 && outTok > 0) break;

--- a/tests/e2e/src/cases/listener-tls-e2e.test.ts
+++ b/tests/e2e/src/cases/listener-tls-e2e.test.ts
@@ -15,7 +15,7 @@ import { EtcdClient, pickFreePorts } from "../harness/index.js";
 // serving plain HTTP while the docs claimed TLS. This spec configures a
 // self-signed cert on both listeners and asserts:
 //   1. HTTPS works on the proxy listener (`/livez`).
-//   2. HTTPS works on the admin listener (`/metrics`, unauthenticated).
+//   2. HTTPS works on the admin listener (`/livez`, unauthenticated).
 //   3. A plain-HTTP request to the TLS proxy port does NOT succeed.
 
 const BIN_PATH =
@@ -63,7 +63,8 @@ describe("listener TLS (#473)", () => {
       "-addext", "subjectAltName=IP:127.0.0.1",
     ]);
 
-    [proxyPort, adminPort] = await pickFreePorts(2);
+    let metricsPort = 0;
+    [proxyPort, adminPort, metricsPort] = await pickFreePorts(3);
     const adminKey = `admin-${randomUUID()}`;
     const cfg = {
       etcd: {
@@ -86,7 +87,15 @@ describe("listener TLS (#473)", () => {
         service_name: "aisix-e2e-tls",
         log_level: "warn",
         access_log: false,
-        metrics: { prometheus: { enabled: true, path: "/metrics" } },
+        // Explicit free port so concurrent test files never collide on
+        // the default 0.0.0.0:9090 metrics listener.
+        metrics: {
+          prometheus: {
+            enabled: true,
+            path: "/metrics",
+            addr: `127.0.0.1:${metricsPort}`,
+          },
+        },
       },
       cache: { backend: "memory" },
     };
@@ -136,7 +145,7 @@ describe("listener TLS (#473)", () => {
 
   test("admin listener serves HTTPS", async (ctx) => {
     if (!etcdReachable) return ctx.skip();
-    const res = await request(`https://127.0.0.1:${adminPort}/metrics`, {
+    const res = await request(`https://127.0.0.1:${adminPort}/livez`, {
       dispatcher: insecureAgent,
     });
     res.body.dump();

--- a/tests/e2e/src/cases/messages-cross-provider-stream-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-cross-provider-stream-usage-e2e.test.ts
@@ -206,7 +206,7 @@ describe("anthropic→openai streaming usage (#790)", () => {
     let inTok = 0;
     let outTok = 0;
     while (Date.now() < deadline) {
-      const scrape = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+      const scrape = await fetch(`${app.metricsUrl}/metrics`).then((r) => r.text());
       inTok = sumMetricByModel(scrape, "aisix_llm_input_tokens_total", "gpt-5.5");
       outTok = sumMetricByModel(scrape, "aisix_llm_output_tokens_total", "gpt-5.5");
       if (inTok >= PROMPT_TOKENS && outTok >= COMPLETION_TOKENS) break;

--- a/tests/e2e/src/cases/metric-cardinality-passthrough-e2e.test.ts
+++ b/tests/e2e/src/cases/metric-cardinality-passthrough-e2e.test.ts
@@ -39,7 +39,7 @@ describe("metric label cardinality for passthrough (#451)", () => {
       }).catch(() => {});
     }
 
-    const scrape = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+    const scrape = await fetch(`${app.metricsUrl}/metrics`).then((r) => r.text());
     const inFlightLines = scrape
       .split("\n")
       .filter((l) => l.startsWith("aisix_proxy_in_flight_requests{"));

--- a/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
@@ -61,7 +61,7 @@ describe("prometheus metrics e2e", () => {
     });
     expect(status, JSON.stringify(body)).toBe(200);
 
-    const scrape = await fetch(`${app.adminUrl}/metrics`);
+    const scrape = await fetch(`${app.metricsUrl}/metrics`);
     expect(scrape.status).toBe(200);
     const text = await scrape.text();
 
@@ -104,10 +104,10 @@ describe("prometheus metrics e2e", () => {
         return probe.status === 200;
       });
 
-      const defaultScrape = await fetch(`${customApp.adminUrl}/metrics`);
+      const defaultScrape = await fetch(`${customApp.metricsUrl}/metrics`);
       expect(defaultScrape.status).toBe(404);
 
-      const scrape = await fetch(`${customApp.adminUrl}/custom-metrics`);
+      const scrape = await fetch(`${customApp.metricsUrl}/custom-metrics`);
       expect(scrape.status).toBe(200);
       const text = await scrape.text();
       expect(text).toMatch(
@@ -146,7 +146,7 @@ describe("prometheus metrics e2e", () => {
       return probe.status === 200;
     });
 
-    const before = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+    const before = await fetch(`${app.metricsUrl}/metrics`).then((r) => r.text());
     const beforeCount = parseUsageEmittedCount(before, "chat", "2xx", "openai");
 
     const { status } = await proxy.chat({
@@ -155,7 +155,7 @@ describe("prometheus metrics e2e", () => {
     });
     expect(status).toBe(200);
 
-    const after = await fetch(`${app.adminUrl}/metrics`).then((r) => r.text());
+    const after = await fetch(`${app.metricsUrl}/metrics`).then((r) => r.text());
     expect(after).toContain("aisix_usage_events_emitted_total");
     // The counter line must carry all three #408 labels — handler,
     // bucketed status_code, inbound_protocol. A regression that
@@ -180,7 +180,7 @@ describe("prometheus metrics e2e", () => {
     expect(afterCount - beforeCount).toBeGreaterThanOrEqual(1);
   });
 
-  test("disabled prometheus endpoint is not mounted", async (ctx) => {
+  test("disabled prometheus leaves the metrics port unbound", async (ctx) => {
     if (!etcdReachable) {
       ctx.skip();
       return;
@@ -188,77 +188,53 @@ describe("prometheus metrics e2e", () => {
 
     const disabledApp = await spawnApp({ prometheus: false });
     try {
-      const scrape = await fetch(`${disabledApp.adminUrl}/metrics`);
-      expect(scrape.status).toBe(404);
-      expect(await scrape.text()).not.toContain("aisix_");
+      // No listener at all: the fetch must fail at the connection level,
+      // not return an HTTP error.
+      await expect(fetch(`${disabledApp.metricsUrl}/metrics`)).rejects.toThrow();
     } finally {
       await disabledApp.exit();
     }
   });
 
-  // Issue #580: a managed DP never binds the admin listener that hosts
-  // `/metrics`, so the scrape surface must be available on a dedicated
-  // listener bound from `observability.metrics.prometheus.addr`. This
-  // pins the mechanism end-to-end: a separate port (distinct from admin)
-  // serves the AISIX-native series after real proxy traffic, and that
-  // listener carries ONLY metrics — no admin routes leak onto it.
-  test("dedicated metrics listener serves scrape on its own port", async (ctx) => {
-    if (!etcdReachable) {
+  // The dedicated metrics listener is the ONLY scrape surface — the same
+  // mechanism in standalone and managed mode. This pins the topology
+  // end-to-end: the metrics port (distinct from admin) serves the
+  // AISIX-native series after real proxy traffic, no admin routes leak
+  // onto it, and the admin listener does not serve `/metrics` at all.
+  test("metrics listener is the only scrape surface", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
       ctx.skip();
       return;
     }
 
-    const dedicatedUpstream = await startOpenAiUpstream({
-      nonStreamBody: responseBody(),
+    // A different port from the admin listener.
+    expect(app.metricsUrl).not.toBe(app.adminUrl);
+
+    // Drive traffic so the AISIX-native series exist regardless of
+    // which tests ran before this one.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const probe = await proxy.chat({
+        model: "prometheus-gpt",
+        messages: [{ role: "user", content: "ready" }],
+      });
+      return probe.status === 200;
     });
-    const dedicatedApp = await spawnApp({ metricsListener: true });
-    try {
-      expect(dedicatedApp.metricsUrl).toBeDefined();
-      const metricsUrl = dedicatedApp.metricsUrl as string;
-      // The dedicated listener is a different port from the admin listener.
-      expect(metricsUrl).not.toBe(dedicatedApp.adminUrl);
 
-      const dedicatedAdmin = new AdminClient(
-        dedicatedApp.adminUrl,
-        dedicatedApp.adminKey,
-      );
-      await configureOpenAi(
-        dedicatedAdmin,
-        dedicatedUpstream,
-        "prometheus-dedicated-gpt",
-      );
-      const proxy = new ProxyClient(dedicatedApp.proxyUrl, CALLER_PLAINTEXT);
-      await waitConfigPropagation(async () => {
-        const probe = await proxy.chat({
-          model: "prometheus-dedicated-gpt",
-          messages: [{ role: "user", content: "ready" }],
-        });
-        return probe.status === 200;
-      });
+    const scrape = await fetch(`${app.metricsUrl}/metrics`);
+    expect(scrape.status).toBe(200);
+    const text = await scrape.text();
+    expect(text).toContain("aisix_proxy_requests_total");
+    expect(text).toContain("aisix_llm_total_tokens_total");
 
-      const { status, body } = await proxy.chat({
-        model: "prometheus-dedicated-gpt",
-        messages: [{ role: "user", content: "metrics" }],
-      });
-      expect(status, JSON.stringify(body)).toBe(200);
+    // The metrics listener carries ONLY metrics — admin routes are not
+    // mounted there.
+    const adminProbe = await fetch(`${app.metricsUrl}/admin/v1/health`);
+    expect(adminProbe.status).toBe(404);
 
-      const scrape = await fetch(`${metricsUrl}/metrics`);
-      expect(scrape.status).toBe(200);
-      const text = await scrape.text();
-      expect(text).toContain("aisix_proxy_requests_total");
-      expect(text).toContain("aisix_llm_total_tokens_total");
-      expect(text).toMatch(
-        /aisix_proxy_requests_total\{[^}]*model="prometheus-dedicated-gpt"/,
-      );
-
-      // The dedicated listener carries ONLY metrics — admin routes are not
-      // mounted there, proving the scrape surface is decoupled from admin.
-      const adminProbe = await fetch(`${metricsUrl}/admin/v1/health`);
-      expect(adminProbe.status).toBe(404);
-    } finally {
-      await dedicatedApp.exit();
-      await dedicatedUpstream.close();
-    }
+    // And the admin listener no longer hosts the scrape endpoint.
+    const adminScrape = await fetch(`${app.adminUrl}/metrics`);
+    expect(adminScrape.status).toBe(404);
   });
 });
 

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -16,13 +16,6 @@ export interface AppOverrides {
   prometheus?: boolean;
   /** Prometheus scrape path. Defaults to `/metrics`. */
   prometheusPath?: string;
-  /**
-   * Bind `/metrics` on a dedicated listener (its own free port) instead
-   * of only the admin listener. Mirrors how a managed DP is scraped —
-   * the admin listener is not the scrape surface. When set, `metricsUrl`
-   * on the returned handle points at that listener.
-   */
-  metricsListener?: boolean;
   /** Extra raw config keys merged into the YAML at the top level. */
   extra?: Record<string, unknown>;
   /**
@@ -50,8 +43,12 @@ export interface SpawnedApp {
   adminUrl: string;
   adminKey: string;
   etcdPrefix: string;
-  /** Dedicated metrics listener URL — set only when `metricsListener` was requested. */
-  metricsUrl?: string;
+  /**
+   * Dedicated metrics listener URL — the only Prometheus scrape surface.
+   * The port is reserved even when `prometheus: false` (nothing listens
+   * there in that case).
+   */
+  metricsUrl: string;
   signal(signal: NodeJS.Signals): void;
   exit(): Promise<void>;
 }
@@ -63,10 +60,11 @@ const SHUTDOWN_GRACE_MS = 3_000;
 
 /**
  * Per-test handle to a spawned `aisix` binary. Each call writes a fresh
- * config YAML into a tmp dir, picks two free ports, picks a unique etcd
- * prefix, and waits up to 10s for `/livez` on the proxy and `/admin/v1/health`
- * on the admin listener to respond 200. `exit()` issues SIGTERM and waits up to
- * 3s, escalating to SIGKILL.
+ * config YAML into a tmp dir, picks three free ports (proxy, admin,
+ * metrics), picks a unique etcd prefix, and waits up to 10s for `/livez`
+ * on the proxy, `/admin/v1/health` on the admin listener, and the scrape
+ * path on the metrics listener to respond 200. `exit()` issues SIGTERM
+ * and waits up to 3s, escalating to SIGKILL.
  */
 export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   const etcd = new EtcdClient();
@@ -77,10 +75,8 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
     );
   }
 
-  const wantMetricsListener = overrides.metricsListener ?? false;
-  const [proxyPort, adminPort, metricsPort] = await pickFreePorts(
-    wantMetricsListener ? 3 : 2,
-  );
+  const prometheusEnabled = overrides.prometheus ?? true;
+  const [proxyPort, adminPort, metricsPort] = await pickFreePorts(3);
   const adminKey = overrides.adminKey ?? `admin-${randomUUID()}`;
   const etcdPrefix = `/aisix-e2e-${randomUUID()}`;
 
@@ -103,9 +99,9 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
       access_log: false,
       metrics: {
         prometheus: {
-          enabled: overrides.prometheus ?? true,
+          enabled: prometheusEnabled,
           path: overrides.prometheusPath ?? "/metrics",
-          ...(wantMetricsListener ? { addr: `127.0.0.1:${metricsPort}` } : {}),
+          addr: `127.0.0.1:${metricsPort}`,
         },
         otlp: { enabled: false, endpoint: "http://127.0.0.1:4317" },
       },
@@ -162,17 +158,16 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
 
   const proxyUrl = `http://127.0.0.1:${proxyPort}`;
   const adminUrl = `http://127.0.0.1:${adminPort}`;
-  const metricsUrl = wantMetricsListener
-    ? `http://127.0.0.1:${metricsPort}`
-    : undefined;
+  const metricsUrl = `http://127.0.0.1:${metricsPort}`;
 
   try {
     await Promise.all([
       waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
       waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey),
       // Gate on the dedicated metrics listener too, so scrapes in the test
-      // never race the listener coming up.
-      ...(metricsUrl
+      // never race the listener coming up. Skipped when prometheus is
+      // disabled — nothing binds the metrics port then.
+      ...(prometheusEnabled
         ? [
             waitForReady(
               `${metricsUrl}${overrides.prometheusPath ?? "/metrics"}`,


### PR DESCRIPTION
## Problem

The Prometheus scrape surface depended on deployment mode: standalone DPs served `/metrics` on the admin listener, while managed DPs (which never bind the admin listener) needed a dedicated listener opted in via `observability.metrics.prometheus.addr`. Two topologies for the same endpoint made the mechanism unnecessarily confusing to configure and document.

## Change

The dedicated metrics listener is now the **only** scrape surface, identical in standalone and managed mode:

- `observability.metrics.prometheus.addr` becomes a required field with default `0.0.0.0:9090`; the listener is bound whenever `prometheus.enabled` is true (still failing boot loudly if the port is taken).
- The admin router no longer mounts `/metrics` — the admin-side handler, the `AdminState` metrics/prometheus fields, and the OpenAPI `/metrics` entry are removed. `metrics_router` keeps serving the configured path on the dedicated listener.
- `config.example.yaml` and `config.managed.yaml` both pin `addr: "0.0.0.0:9090"` explicitly; the Dockerfile now `EXPOSE`s 9090.
- Docs (metrics-and-logs, admin-api, admin-api-reference, bootstrap-config, network-and-security) updated to describe the single unified surface.

## Behavior change / compatibility

- Scraping `http://<dp>:3001/metrics` (admin listener) no longer works for standalone deployments — point Prometheus at `<dp>:9090/metrics` instead. The project is in early development with no backward-compatibility constraints.
- Managed DPs are unaffected (they already scraped `0.0.0.0:9090` via the baked managed config).
- `prometheus.enabled: false` now means no metrics listener is bound at all.

## Tests

- Unit: config default/parse/validation tests updated; admin tests now pin that the admin router returns 404 for `/metrics`; `metrics_router` path/normalization tests retained.
- E2E (`tests/e2e`): the harness always provisions the metrics listener and exposes `metricsUrl`; all scrape-based tests moved to it. New/updated cases pin that the metrics listener is the only scrape surface (admin 404s `/metrics`, metrics port carries no admin routes) and that `enabled: false` leaves the port unbound. The TLS test now uses an explicit free metrics port so concurrent test files cannot collide on the 9090 default.

LiteLLM baseline note: LiteLLM mounts `/metrics` on its main proxy app and has no admin/managed listener split, so there is no equivalent topology to compare against; the unified dedicated-listener design was decided explicitly for this project.