### PR TITLE
fix(messages): accept system role inside messages[] on /v1/messages

### DIFF
--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -690,7 +690,7 @@ pub enum AnthropicInboundError {
     MissingMessages,
     #[error("messages[{idx}] missing `role`")]
     MessageMissingRole { idx: usize },
-    #[error("messages[{idx}] role {role:?} is not 'user' or 'assistant'")]
+    #[error("messages[{idx}] role {role:?} is not 'user', 'assistant' or 'system'")]
     UnsupportedRole { idx: usize, role: String },
     #[error("messages[{idx}].content must be a string or an array of text blocks")]
     UnsupportedContent { idx: usize },
@@ -768,6 +768,10 @@ pub fn parse_inbound_request(
         match role {
             "user" => messages.push(ChatMessage::user(content)),
             "assistant" => messages.push(ChatMessage::assistant(content)),
+            // Not in the Anthropic spec, but Claude Code/cc-switch send it
+            // (#597). Keep it as a system message so OpenAI-compatible
+            // upstreams receive it natively instead of a 400 here.
+            "system" => messages.push(ChatMessage::system(content)),
             other => {
                 return Err(AnthropicInboundError::UnsupportedRole {
                     idx,
@@ -1955,6 +1959,27 @@ mod tests {
         assert!(chat.extra.contains_key("tools"));
         assert!(!chat.extra.contains_key("model"));
         assert!(!chat.extra.contains_key("messages"));
+    }
+
+    /// #597: Claude Code/cc-switch send `role: "system"` inside `messages[]`
+    /// even though the Anthropic spec only allows user/assistant. Parse it
+    /// as Role::System instead of rejecting the whole request with a 400.
+    #[test]
+    fn parse_inbound_accepts_system_role_in_messages() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "respond in French"},
+                {"role": "user", "content": "hello again"},
+            ],
+        });
+        let chat = parse_inbound_request(&body).unwrap();
+        assert_eq!(chat.messages.len(), 3);
+        assert_eq!(chat.messages[0].role, Role::User);
+        assert_eq!(chat.messages[1].role, Role::System);
+        assert_eq!(chat.messages[1].content_str(), "respond in French");
+        assert_eq!(chat.messages[2].role, Role::User);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -2857,6 +2857,67 @@ mod tests {
         assert_eq!(v["usage"]["output_tokens"], 3);
     }
 
+    /// #597: Claude Code/cc-switch send `role: "system"` inside
+    /// `messages[]`. The cross-provider path must keep it as an OpenAI
+    /// system message instead of rejecting the request with a 400.
+    /// The wiremock matcher is strict on the translated body — if the
+    /// system turn is dropped or reordered the upstream 404s.
+    #[tokio::test]
+    async fn non_anthropic_model_preserves_system_role_in_messages() {
+        use aisix_provider_openai::OpenAiBridge;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_partial_json(serde_json::json!({
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "system", "content": "respond in French"},
+                    {"role": "user", "content": "hello again"},
+                ]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-XYZ",
+                "object": "chat.completion",
+                "created": 1_715_000_000_u64,
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Bonjour!"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("my-claude-alias"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let app = crate::build_router(crate::ProxyState::new(handle, hub, &cfg()).without_cache());
+
+        let body = serde_json::json!({
+            "model": "my-claude-alias",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "respond in French"},
+                {"role": "user", "content": "hello again"},
+            ],
+            "max_tokens": 100
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["content"][0]["text"], "Bonjour!");
+    }
+
     /// Streaming variant: the client asks for SSE; we translate
     /// OpenAI delta chunks to Anthropic message_start /
     /// content_block_delta / message_stop events.

--- a/tests/e2e/src/cases/messages-system-role-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-system-role-e2e.test.ts
@@ -1,0 +1,141 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E regression for #597: Claude Code/cc-switch send a non-spec
+// `role: "system"` entry inside `messages[]` on /v1/messages. The
+// inbound parser used to reject the whole request with
+//   400 "messages[i] role \"system\" is not 'user' or 'assistant'"
+// when the model routed to an OpenAI-protocol upstream. Post-fix the
+// gateway keeps the turn as a native OpenAI system message.
+
+const CALLER_PLAINTEXT = "sk-issue-597-system-role";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("anthropic /v1/messages with system role in messages[] (#597)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-issue597",
+        object: "chat.completion",
+        created: 1765000000,
+        model: "deepseek-chat",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "Bonjour!" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 },
+      },
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "issue597-pk",
+      secret: "sk-deepseek-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    // Mirrors the customer setup from #597: Claude CLI talking to a
+    // DeepSeek/OpenAI-protocol model through the Anthropic endpoint.
+    await admin.createModel({
+      display_name: "issue597-model",
+      provider: "deepseek",
+      model_name: "deepseek-chat",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["issue597-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  async function postMessages(): Promise<Response> {
+    return fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": CALLER_PLAINTEXT,
+        "user-agent": "claude-cli/2.1.118 (external, cli)",
+      },
+      body: JSON.stringify({
+        model: "issue597-model",
+        max_tokens: 200,
+        messages: [
+          { role: "user", content: "hi" },
+          { role: "system", content: "respond in French" },
+          { role: "user", content: "hello again" },
+        ],
+      }),
+    });
+  }
+
+  test("system turn inside messages[] is preserved, not a 400", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // Wait until the model/key config reached the DP. A pre-fix binary
+    // keeps answering 400 here, so distinguish "config not propagated"
+    // (404/401) from the regression itself.
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await postMessages();
+        return probe.status !== 404 && probe.status !== 401 && probe.status !== 403;
+      } catch {
+        return false;
+      }
+    });
+    upstream.receivedRequests.length = 0;
+
+    const resp = await postMessages();
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as {
+      type: string;
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(body.type).toBe("message");
+    expect(body.content[0]?.text).toBe("Bonjour!");
+
+    // The translated upstream request must keep the system turn in
+    // place — dropping it silently (LiteLLM behavior) loses content.
+    const sent = upstream.receivedRequests.find((r) =>
+      r.path.endsWith("/chat/completions"),
+    );
+    expect(sent).toBeDefined();
+    const sentBody = JSON.parse(sent!.body) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(sentBody.messages).toEqual([
+      { role: "user", content: "hi" },
+      { role: "system", content: "respond in French" },
+      { role: "user", content: "hello again" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

Claude Code sends a non-spec `role: "system"` entry inside `messages[]` on `POST /v1/messages` in some versions. When the requested model routes to an OpenAI-protocol upstream (DeepSeek etc.), the Anthropic inbound parser rejected the whole request:

```
400 request payload is invalid: invalid Anthropic body: messages[1] role "system" is not 'user' or 'assistant'
```

### Where this shape actually comes from

- Normal Claude Code paths are spec-compliant: system prompts go in the top-level `system` field (verified by capturing live CLI traffic on v2.1.175 — `messages[]` carries only `user`/`assistant`; even `<system-reminder>` blocks ride inside user content).
- The `messages[1].role == "system"` shape is a known **Claude Code regression**: since v2.1.154, invoking a custom agent via `/agents` puts the agent's system prompt into `messages[]` as a `role: "system"` entry (anthropics/claude-code#63457, anthropics/claude-code#63469). The official Anthropic API rejects these requests with the same 400 (`messages[1].role must be either 'user' or 'assistant', but got 'system'`), so this is acknowledged upstream as a client bug, not an API change.
- cc-switch (the tool in the original report) only edits Claude Code config files; it is not in the request path and cannot inject messages. Its connectivity probe is a user-only request — which is why the probe returned 200 while real custom-agent requests hit 400.

The gateway still has to handle this traffic: affected Claude Code versions are widely deployed, and the failing message position/error matches the customer report in #597 exactly.

## Fix

`parse_inbound_request` now maps `role: "system"` to the internal `Role::System` instead of erroring. Downstream this composes with existing machinery:

- OpenAI-protocol bridges forward it as a native `system` message (no content loss).
- Input guardrails on `/v1/messages` can now inspect these requests — previously the parse failure made the guardrail check silently skip the whole body.

### Why preserve instead of drop (LiteLLM divergence)

LiteLLM's Anthropic→OpenAI bridge silently **drops** system-role entries in `messages[]`. In the Claude Code bug scenario, the dropped content is the custom agent's entire system prompt — the request "succeeds" but the agent silently degrades to an instruction-less assistant, which is much harder to notice than a 400. Of the three possible behaviors (reject like the official API / drop like LiteLLM / preserve), only preserving keeps both availability and the semantics the client intended, so we deliberately diverge from LiteLLM here. This also matches the existing `split_system` convention of never silently dropping content.

## Scope audit (bug class)

`parse_inbound_request` is the only Anthropic inbound parser; its two call sites (`cross_provider_dispatch` and the `/v1/messages` guardrail gate) are both fixed by this change. `/v1/messages` and `/v1/messages/count_tokens` against Anthropic upstreams are raw passthrough and don't parse roles — upstream semantics apply there unchanged (the official API's own 400 for this shape passes through as-is).

## Tests

- Unit (`wire.rs`): `user → system → user` parses with `Role::System` preserved.
- Proxy (`messages.rs`): cross-provider dispatch test with a strict wiremock body matcher asserting the translated `/chat/completions` request keeps the system turn in order; fails before the fix (400), passes after.
- E2E (`tests/e2e`): real `aisix` binary + etcd + mock DeepSeek upstream, Claude-CLI-shaped request with a mid-conversation system turn → 200, and the upstream-received body retains the system message.

Fixes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)