### PR TITLE
fix(cache): honor per-policy TTL on the Redis backend

### DIFF
--- a/crates/aisix-cache/src/redis.rs
+++ b/crates/aisix-cache/src/redis.rs
@@ -60,8 +60,10 @@ impl RedisCache {
         })
     }
 
-    /// Override the per-entry TTL. Caps at `u64::MAX / 1000` to stay
-    /// inside Redis's `EX` second range.
+    /// Override the instance **default** TTL — the fallback `put` uses
+    /// when a write carries no per-entry value. Per-policy writes go
+    /// through `put_with_ttl` and use their own `CachePolicy.ttl_seconds`
+    /// instead, ignoring this. Floors at 1s (`EX 0` expires immediately).
     pub fn with_ttl(mut self, ttl: Duration) -> Self {
         self.ttl_secs = ttl.as_secs().max(1);
         self
@@ -97,12 +99,29 @@ impl Cache for RedisCache {
     }
 
     async fn put(&self, key: &str, value: ChatResponse) -> Result<(), CacheError> {
+        // No per-entry TTL supplied: fall back to the instance default.
+        self.put_with_ttl(key, value, Duration::from_secs(self.ttl_secs))
+            .await
+    }
+
+    /// Honors the caller-supplied per-entry TTL — the matched
+    /// `CachePolicy.ttl_seconds` the proxy threads in — rather than the
+    /// instance default, so a Redis-backed policy expires its entries on
+    /// its own schedule. Floors at 1s: Redis `EX 0` expires immediately,
+    /// turning every entry into a guaranteed miss.
+    async fn put_with_ttl(
+        &self,
+        key: &str,
+        value: ChatResponse,
+        ttl: Duration,
+    ) -> Result<(), CacheError> {
         let json = serde_json::to_string(&value)
             .map_err(|e| CacheError::Backend(format!("redis encode: {e}")))?;
         let mut conn = self.conn.clone();
         let full = self.full_key(key);
+        let secs = ttl.as_secs().max(1);
         let _: () = conn
-            .set_ex(&full, json, self.ttl_secs)
+            .set_ex(&full, json, secs)
             .await
             .map_err(|e| CacheError::Backend(format!("redis SET EX: {e}")))?;
         Ok(())

--- a/crates/aisix-cache/tests/redis_integration.rs
+++ b/crates/aisix-cache/tests/redis_integration.rs
@@ -105,6 +105,47 @@ async fn ttl_eviction_drops_entry_after_window() {
 }
 
 #[tokio::test]
+async fn put_with_ttl_honors_per_entry_window_over_global() {
+    // Regression: a Redis-backed `CachePolicy` carries its own
+    // `ttl_seconds`, which the proxy passes via `put_with_ttl`. The entry
+    // must expire on that per-policy window, NOT the instance-global
+    // default. With a 300s global and a 1s per-entry TTL, a backend that
+    // drops the per-entry value keeps the entry alive well past 1.5s; the
+    // contract requires it gone.
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: CACHE_TEST_REDIS_URL not set");
+        return;
+    };
+
+    let cache = RedisCache::connect(&url)
+        .await
+        .expect("redis connect")
+        .with_prefix(format!("aisix:test:{}", uuid_like()))
+        .with_ttl(Duration::from_secs(300));
+
+    cache
+        .put_with_ttl(
+            "per-entry-ttl",
+            sample("short-lived"),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+    assert!(
+        cache.get("per-entry-ttl").await.unwrap().is_some(),
+        "entry must be present immediately after write"
+    );
+
+    // Per-entry TTL is 1s (EX 1 = expire within ≤1s); sleep past it with
+    // headroom. The 300s instance global must not win.
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+    assert!(
+        cache.get("per-entry-ttl").await.unwrap().is_none(),
+        "per-policy ttl_seconds (1s) must be honored, not the 300s instance global"
+    );
+}
+
+#[tokio::test]
 async fn missing_key_returns_none() {
     let Some(url) = redis_url() else {
         eprintln!("skipping: CACHE_TEST_REDIS_URL not set");


### PR DESCRIPTION
## Summary

`RedisCache` implemented only `put`, so `Cache::put_with_ttl` fell through to the trait's **default impl** (which calls `put`). The proxy threads the matched `CachePolicy.ttl_seconds` into `put_with_ttl` (`aisix-proxy/src/chat.rs`), but on the Redis backend that value was **silently dropped** — every entry got the instance-global TTL, hardcoded at `DEFAULT_TTL = 300s` (bootstrap never calls `with_ttl`, and there is no config knob for it).

Net effect — a `CachePolicy` with `backend: redis` and `ttl_seconds != 300` expired entries on the wrong schedule:

- `ttl_seconds > 300` → premature eviction → weaker cache, more upstream calls/cost than configured.
- `ttl_seconds < 300` → stale responses served up to the 300s window (e.g. 5× a 60s policy).

The in-memory backend already honored per-entry TTL (`MemoryCache::put_with_ttl`), so the defect was **backend-divergent and silent** (no error/warn). Surfaced during an internal architecture review of the DP cache path.

## Fix

- Add `RedisCache::put_with_ttl` that sets the key TTL to the caller-supplied value (`SET … EX`, floored at 1s — `EX 0` expires immediately). `put` now delegates to it with the instance default, so `put`'s behavior is unchanged.
- Correct the `with_ttl` doc, which mislabeled the instance default as a "per-entry TTL" (and referenced a cap that isn't in the code).

The only observable change is that **redis-backed cache policies now expire on their own `ttl_seconds`** instead of a flat 300s — the documented intent of the `Cache::put_with_ttl` seam.

## Prior art

Per-entry expiry in a response/prompt cache is universally delegated to the store's native per-key TTL — Redis `SET … EX` / `PEXPIRE`. This change makes the Redis backend do exactly what the `Cache` trait contract already specifies and what the in-memory backend already does; no design divergence.

## Test plan

- **New** `tests/redis_integration.rs::put_with_ttl_honors_per_entry_window_over_global`: writes with a **1s** per-entry TTL on a cache whose **global** default is 300s, asserts the entry is present immediately and **gone after 1.5s**. Before this fix the entry survives (global 300s wins); after, it evicts on the per-entry window. So a real regression fails the assertion.
  - Runs against the CI `redis:7-alpine` service via `CACHE_TEST_REDIS_URL` (`.github/workflows/ci.yml`).
  - ⚠️ **Local caveat (transparency):** I could **not** run the live-Redis cases locally — Docker Hub egress is blocked in this environment and I avoided installing Redis — so they **self-skipped** locally. The live red/green executes in CI. Locally verified: `cargo clippy -p aisix-cache --features redis --all-targets -- -D warnings` clean; `cargo test -p aisix-cache --features redis` → 23 unit tests pass (incl. the memory backend's per-entry-TTL test) and the integration suite compiles under `--features redis`.
- `put`'s existing behavior stays covered by the unchanged `ttl_eviction_drops_entry_after_window` test (global TTL via `with_ttl` + `put`).

## Risk / breaking changes

None to API / wire / config / on-disk format. `put` is byte-for-byte equivalent. The behavior change is the intended fix (redis policies honor `ttl_seconds`). No new dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Redis cache expiration logic to support configurable per-entry time-to-live settings that can override instance-level defaults, providing more granular control over cache behavior
  * Enforced a minimum 1-second expiration window for all cached entries

* **Tests**
  * Added integration test validating per-entry cache expiration behavior against global defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes api7/AISIX-Cloud#788
