### PR TITLE
feat: ensemble model — panel + judge fan-out dispatch (config + non-streaming)

### DIFF
--- a/crates/aisix-core/src/bin/dump-schema.rs
+++ b/crates/aisix-core/src/bin/dump-schema.rs
@@ -31,8 +31,8 @@ use std::path::{Path, PathBuf};
 use schemars::JsonSchema;
 
 use aisix_core::models::{
-    ApiKey, CachePolicy, Guardrail, Model, ObservabilityExporter, ProviderKey, RateLimit,
-    RateLimitPolicy, Routing,
+    ApiKey, CachePolicy, EnsembleConfig, Guardrail, Model, ObservabilityExporter, ProviderKey,
+    RateLimit, RateLimitPolicy, Routing,
 };
 
 fn main() {
@@ -41,6 +41,7 @@ fn main() {
 
     dump::<ApiKey>(&out_dir, "api_key");
     dump::<CachePolicy>(&out_dir, "cache_policy");
+    dump::<EnsembleConfig>(&out_dir, "ensemble");
     dump::<Guardrail>(&out_dir, "guardrail");
     dump::<Model>(&out_dir, "model");
     dump::<ObservabilityExporter>(&out_dir, "observability_exporter");

--- a/crates/aisix-core/src/models/ensemble.rs
+++ b/crates/aisix-core/src/models/ensemble.rs
@@ -112,10 +112,6 @@ impl EnsembleConfig {
             .filter(|&ms| ms > 0)
             .map(std::time::Duration::from_millis)
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.panel.is_empty()
-    }
 }
 
 #[cfg(test)]
@@ -157,7 +153,7 @@ mod tests {
         assert!(e.panel[0].temperature.is_none());
         assert!(e.judge.synthesis_prompt.is_none());
         assert_eq!(e.timeout(), None);
-        assert!(!e.is_empty());
+        assert!(!e.panel.is_empty());
     }
 
     #[test]

--- a/crates/aisix-core/src/models/ensemble.rs
+++ b/crates/aisix-core/src/models/ensemble.rs
@@ -1,0 +1,215 @@
+//! Ensemble config attached to a [`Model`](super::Model).
+//!
+//! When a Model carries an `ensemble` block, the proxy fans the request
+//! out to every panel member concurrently, then calls the judge model to
+//! synthesize a single answer from the panel responses. Unlike a
+//! [`Routing`](super::Routing) model — which picks ONE target per request
+//! — an ensemble model calls ALL panel members and combines their output.
+//!
+//! Panel members and the judge reference other (direct) Models by
+//! `display_name`, the same way routing targets do. Mutual exclusivity
+//! with the direct-upstream fields and `routing` is enforced by the
+//! runtime schema (`super::schema`), not by this type.
+
+use serde::{Deserialize, Serialize};
+
+/// One member of an ensemble panel. `model` references another
+/// `Model.display_name` in the snapshot (must be a direct model).
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PanelMember {
+    pub model: String,
+    /// Sampling temperature for THIS member's call. Overrides the
+    /// request's `temperature`, so a panel of the same model repeated N
+    /// times still produces diverse answers (self-ensemble). Absent =
+    /// leave the request's temperature unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// Optional sampling seed for THIS member's call — pairs with
+    /// `temperature` for reproducible diversity. Absent = no seed override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<u64>,
+    /// Reserved for the future voting/quorum strategy; ignored by the v1
+    /// synthesis path. Carried on the wire now so enabling voting later
+    /// does not require a wire-format change.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<u32>,
+}
+
+impl PanelMember {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self {
+            model: model.into(),
+            temperature: None,
+            seed: None,
+            weight: None,
+        }
+    }
+}
+
+/// The judge model that synthesizes the panel responses into one answer.
+/// `model` references another `Model.display_name` (must be a direct model).
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Judge {
+    pub model: String,
+    /// Optional override for the built-in synthesis prompt template.
+    /// Absent = use the default template.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synthesis_prompt: Option<String>,
+}
+
+impl Judge {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self {
+            model: model.into(),
+            synthesis_prompt: None,
+        }
+    }
+}
+
+/// Default minimum number of successful panel responses required before
+/// the judge synthesizes, when the operator does not set `min_responses`.
+/// Always clamped to the panel size by [`EnsembleConfig::min_responses_or_default`],
+/// so a single-member (self-ensemble) panel still only needs one response.
+const DEFAULT_MIN_RESPONSES: usize = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct EnsembleConfig {
+    pub panel: Vec<PanelMember>,
+    pub judge: Judge,
+    /// Minimum successful panel responses required to proceed to
+    /// synthesis. Absent = `min(DEFAULT_MIN_RESPONSES, panel.len())`.
+    /// A value larger than the panel is clamped to the panel size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_responses: Option<u32>,
+    /// End-to-end budget in ms for the whole panel fan-out. `0` or absent
+    /// = no ensemble-level deadline. Each panel member is still bound by
+    /// its own model `timeout`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+impl EnsembleConfig {
+    /// Effective minimum successful panel responses. Defaults to
+    /// [`DEFAULT_MIN_RESPONSES`], never exceeds the panel size, and is at
+    /// least 1 for a non-empty panel.
+    pub fn min_responses_or_default(&self) -> usize {
+        let requested = self.min_responses.map(|n| n as usize);
+        requested
+            .unwrap_or(DEFAULT_MIN_RESPONSES)
+            .min(self.panel.len())
+            .max(1)
+    }
+
+    /// End-to-end fan-out deadline. Folds the `0`/absent sentinel into
+    /// `None` like [`Model::request_timeout`](super::Model::request_timeout)
+    /// so callers can apply it unconditionally.
+    pub fn timeout(&self) -> Option<std::time::Duration> {
+        self.timeout_ms
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.panel.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_full_ensemble_block() {
+        let json = r#"{
+            "panel": [
+                {"model": "gpt", "temperature": 0.5, "seed": 7, "weight": 1},
+                {"model": "claude", "temperature": 1.0}
+            ],
+            "judge": {"model": "opus", "synthesis_prompt": "combine them"},
+            "min_responses": 2,
+            "timeout_ms": 45000
+        }"#;
+        let e: EnsembleConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(e.panel.len(), 2);
+        assert_eq!(e.panel[0].model, "gpt");
+        assert_eq!(e.panel[0].temperature, Some(0.5));
+        assert_eq!(e.panel[0].seed, Some(7));
+        assert_eq!(e.panel[0].weight, Some(1));
+        assert_eq!(e.panel[1].temperature, Some(1.0));
+        assert_eq!(e.judge.model, "opus");
+        assert_eq!(e.judge.synthesis_prompt.as_deref(), Some("combine them"));
+        assert_eq!(e.min_responses_or_default(), 2);
+        assert_eq!(e.timeout(), Some(std::time::Duration::from_millis(45_000)));
+    }
+
+    #[test]
+    fn minimal_ensemble_block_uses_defaults() {
+        let e: EnsembleConfig = serde_json::from_str(
+            r#"{"panel":[{"model":"a"},{"model":"b"},{"model":"c"}],"judge":{"model":"j"}}"#,
+        )
+        .unwrap();
+        // Default min_responses is DEFAULT_MIN_RESPONSES (2), not the panel size.
+        assert_eq!(e.min_responses_or_default(), 2);
+        assert!(e.panel[0].temperature.is_none());
+        assert!(e.judge.synthesis_prompt.is_none());
+        assert_eq!(e.timeout(), None);
+        assert!(!e.is_empty());
+    }
+
+    #[test]
+    fn min_responses_clamps_to_panel_size() {
+        let e: EnsembleConfig = serde_json::from_str(
+            r#"{"panel":[{"model":"a"},{"model":"b"}],"judge":{"model":"j"},"min_responses":10}"#,
+        )
+        .unwrap();
+        assert_eq!(e.min_responses_or_default(), 2);
+    }
+
+    #[test]
+    fn single_member_panel_defaults_to_one_response() {
+        // Self-ensemble shrunk to one member: default min(2, 1) = 1.
+        let e: EnsembleConfig =
+            serde_json::from_str(r#"{"panel":[{"model":"solo"}],"judge":{"model":"j"}}"#).unwrap();
+        assert_eq!(e.min_responses_or_default(), 1);
+    }
+
+    #[test]
+    fn timeout_zero_folds_to_none() {
+        let e: EnsembleConfig = serde_json::from_str(
+            r#"{"panel":[{"model":"a"}],"judge":{"model":"j"},"timeout_ms":0}"#,
+        )
+        .unwrap();
+        assert_eq!(e.timeout(), None);
+    }
+
+    #[test]
+    fn rejects_unknown_ensemble_field() {
+        let r: Result<EnsembleConfig, _> =
+            serde_json::from_str(r#"{"panel":[{"model":"a"}],"judge":{"model":"j"},"foo":1}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_panel_member_field() {
+        let r: Result<PanelMember, _> = serde_json::from_str(r#"{"model":"a","bogus":true}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_judge_field() {
+        let r: Result<Judge, _> = serde_json::from_str(r#"{"model":"j","bogus":true}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn panel_member_new_has_no_overrides() {
+        let m = PanelMember::new("x");
+        assert_eq!(m.model, "x");
+        assert!(m.temperature.is_none());
+        assert!(m.seed.is_none());
+        assert!(m.weight.is_none());
+    }
+}

--- a/crates/aisix-core/src/models/ensemble.rs
+++ b/crates/aisix-core/src/models/ensemble.rs
@@ -84,9 +84,9 @@ pub struct EnsembleConfig {
     /// A value larger than the panel is clamped to the panel size.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_responses: Option<u32>,
-    /// End-to-end budget in ms for the whole panel fan-out. `0` or absent
-    /// = no ensemble-level deadline. Each panel member is still bound by
-    /// its own model `timeout`.
+    /// Per-call upstream deadline applied to each panel member and the
+    /// judge call (in addition to each member model's own `timeout`). `0`
+    /// or absent = no ensemble-level per-call deadline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
 }
@@ -103,9 +103,10 @@ impl EnsembleConfig {
             .max(1)
     }
 
-    /// End-to-end fan-out deadline. Folds the `0`/absent sentinel into
-    /// `None` like [`Model::request_timeout`](super::Model::request_timeout)
-    /// so callers can apply it unconditionally.
+    /// Per-call upstream deadline applied to each panel member and the
+    /// judge call. Folds the `0`/absent sentinel into `None` like
+    /// [`Model::request_timeout`](super::Model::request_timeout) so callers
+    /// can apply it unconditionally.
     pub fn timeout(&self) -> Option<std::time::Duration> {
         self.timeout_ms
             .filter(|&ms| ms > 0)

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod apikey;
 pub mod cache_policy;
+pub mod ensemble;
 pub mod guardrail;
 pub mod model;
 pub mod observability_exporter;
@@ -29,6 +30,7 @@ pub mod snapshot;
 
 pub use apikey::ApiKey;
 pub use cache_policy::{AppliesTo, CacheBackend, CachePolicy};
+pub use ensemble::{EnsembleConfig, Judge, PanelMember};
 pub use guardrail::{
     AliyunTextModerationConfig, AppliedGuardrail, AzureContentSafetyConfig,
     AzureContentSafetyTextModerationConfig, BedrockAWSCredentials, BedrockConfig,

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -14,6 +14,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::ensemble::EnsembleConfig;
 use super::rate_limit::RateLimit;
 use super::routing::Routing;
 use crate::resource::Resource;
@@ -287,6 +288,14 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing: Option<Routing>,
 
+    /// Ensemble config. When set, the proxy fans the request out to every
+    /// panel member concurrently and synthesizes their responses via the
+    /// judge model, instead of dispatching a single upstream. Mutually
+    /// exclusive with `provider`/`model_name`/`provider_key_id` and
+    /// `routing` (enforced by the runtime schema in `super::schema`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ensemble: Option<EnsembleConfig>,
+
     /// Per-token cost for budget tracking. Absent = no cost tracked.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<ModelCost>,
@@ -313,6 +322,12 @@ impl Model {
     /// instead of dispatching its own upstream config).
     pub fn is_routing(&self) -> bool {
         self.routing.is_some()
+    }
+
+    /// Whether this Model is an ensemble (fans out to a panel + judge
+    /// instead of dispatching a single upstream).
+    pub fn is_ensemble(&self) -> bool {
+        self.ensemble.is_some()
     }
 
     /// Convenience: borrow the upstream model id if this Model is a
@@ -572,6 +587,25 @@ mod tests {
         )
         .unwrap();
         assert!(m.is_routing());
+        assert!(m.provider.is_none());
+        assert!(m.model_name.is_none());
+        assert!(m.provider_key_id.is_none());
+    }
+
+    #[test]
+    fn ensemble_form_has_no_provider_and_reports_is_ensemble() {
+        let m: Model = serde_json::from_str(
+            r#"{
+              "display_name": "council",
+              "ensemble": {
+                "panel": [{"model": "my-gpt4"}, {"model": "my-claude"}],
+                "judge": {"model": "my-opus"}
+              }
+            }"#,
+        )
+        .unwrap();
+        assert!(m.is_ensemble());
+        assert!(!m.is_routing());
         assert!(m.provider.is_none());
         assert!(m.model_name.is_none());
         assert!(m.provider_key_id.is_none());

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -223,12 +223,46 @@ fn model_schema() -> Value {
                     "trigger_on_timeout":   { "type": "boolean" },
                     "trigger_on_transport": { "type": "boolean" }
                 }
+            },
+            "ensemble": {
+                "type": "object",
+                "required": ["panel", "judge"],
+                "additionalProperties": false,
+                "properties": {
+                    "panel": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "required": ["model"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "model":       { "type": "string", "minLength": 1 },
+                                "temperature": { "type": "number", "minimum": 0 },
+                                "seed":        { "type": "integer", "minimum": 0 },
+                                "weight":      { "type": "integer", "minimum": 0 }
+                            }
+                        }
+                    },
+                    "judge": {
+                        "type": "object",
+                        "required": ["model"],
+                        "additionalProperties": false,
+                        "properties": {
+                            "model":            { "type": "string", "minLength": 1 },
+                            "synthesis_prompt": { "type": "string", "minLength": 1 }
+                        }
+                    },
+                    "min_responses": { "type": "integer", "minimum": 1 },
+                    "timeout_ms":    { "type": "integer", "minimum": 0 }
+                }
             }
         },
-        // Direct vs routing model: a model EITHER ships a `routing`
-        // block (virtual router — provider/model_name/provider_key_id
-        // forbidden) OR ships those three required fields together
-        // (direct upstream — routing forbidden).
+        // Direct vs routing vs ensemble model: a model ships EXACTLY one
+        // of — a `routing` block (virtual router), an `ensemble` block
+        // (panel + judge fan-out), or the three direct upstream fields
+        // (provider/model_name/provider_key_id) together. The three
+        // shapes are mutually exclusive.
         "oneOf": [
             {
                 "required": ["routing"],
@@ -237,12 +271,27 @@ fn model_schema() -> Value {
                     { "required": ["model_name"] },
                     { "required": ["provider_key_id"] },
                     { "required": ["background_model_check"] },
-                    { "required": ["cooldown"] }
+                    { "required": ["cooldown"] },
+                    { "required": ["ensemble"] }
                 ]}
             },
             {
                 "required": ["provider", "model_name", "provider_key_id"],
-                "not": { "required": ["routing"] }
+                "not": { "anyOf": [
+                    { "required": ["routing"] },
+                    { "required": ["ensemble"] }
+                ]}
+            },
+            {
+                "required": ["ensemble"],
+                "not": { "anyOf": [
+                    { "required": ["provider"] },
+                    { "required": ["model_name"] },
+                    { "required": ["provider_key_id"] },
+                    { "required": ["routing"] },
+                    { "required": ["background_model_check"] },
+                    { "required": ["cooldown"] }
+                ]}
             }
         ],
         "$defs": {
@@ -821,6 +870,103 @@ mod tests {
             }
         });
         validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_ensemble_form_passes() {
+        let v = json!({
+            "display_name": "council",
+            "ensemble": {
+                "panel": [
+                    {"model": "my-gpt4", "temperature": 0.5},
+                    {"model": "my-claude", "temperature": 1.0}
+                ],
+                "judge": {"model": "my-opus"},
+                "min_responses": 2,
+                "timeout_ms": 45000
+            }
+        });
+        validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_ensemble_can_be_ip_restricted_and_rate_limited() {
+        // Top-level gates apply to the ensemble entry model too.
+        let v = json!({
+            "display_name": "council",
+            "ensemble": {
+                "panel": [{"model": "a"}, {"model": "b"}],
+                "judge": {"model": "j"}
+            },
+            "allowed_cidrs": ["10.0.0.0/8"],
+            "rate_limit": {"rpm": 60}
+        });
+        validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_ensemble_with_direct_fields_fails() {
+        // ensemble is mutually exclusive with the direct upstream triple.
+        let v = json!({
+            "display_name": "x",
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "pk-1",
+            "ensemble": {
+                "panel": [{"model": "a"}],
+                "judge": {"model": "j"}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_ensemble_with_routing_fails() {
+        // A model can't be both an ensemble and a router.
+        let v = json!({
+            "display_name": "x",
+            "routing": {"targets": [{"model": "a"}]},
+            "ensemble": {
+                "panel": [{"model": "a"}],
+                "judge": {"model": "j"}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_ensemble_missing_judge_fails() {
+        let v = json!({
+            "display_name": "x",
+            "ensemble": {
+                "panel": [{"model": "a"}, {"model": "b"}]
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_ensemble_empty_panel_fails() {
+        let v = json!({
+            "display_name": "x",
+            "ensemble": {
+                "panel": [],
+                "judge": {"model": "j"}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_ensemble_unknown_panel_field_fails() {
+        let v = json!({
+            "display_name": "x",
+            "ensemble": {
+                "panel": [{"model": "a", "bogus": true}],
+                "judge": {"model": "j"}
+            }
+        });
+        assert!(validate_model(&v).is_err());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1879,11 +1879,22 @@ async fn dispatch_ensemble<'a>(
     let with_model = |e: ProxyError| DispatchFailure::new(Some(model_id.to_string()), None, e);
 
     // The ensemble executor needs every panel member's full answer to
-    // synthesize, so a tool-using request can't be fanned out coherently
+    // synthesize, so a tool-USING request can't be fanned out coherently
     // (panel members might emit tool calls the judge can't reconcile).
     // `tools` / `tool_choice` are flattened keys in `ChatFormat.extra`,
-    // not struct fields. Reject up front with a 400.
-    if req.extra.contains_key("tools") || req.extra.contains_key("tool_choice") {
+    // not struct fields. Reject only when tools is a NON-EMPTY array, or
+    // `tool_choice` forces a call — an empty `tools: []` (which many SDKs
+    // always send) means "no tools" and must still fan out. `tool_choice`
+    // values `"none"` / `"auto"` don't force a call.
+    let has_tools = req
+        .extra
+        .get("tools")
+        .is_some_and(|v| v.as_array().is_none_or(|a| !a.is_empty()));
+    let forces_tool = req
+        .extra
+        .get("tool_choice")
+        .is_some_and(|v| v != "none" && v != "auto");
+    if has_tools || forces_tool {
         return Err(with_model(ProxyError::InvalidRequest(
             "ensemble models do not support tools".into(),
         )));
@@ -1906,64 +1917,9 @@ async fn dispatch_ensemble<'a>(
         ))
     })?;
 
-    let caller = crate::ensemble::ProxyModelCaller {
-        state,
-        snapshot,
-        request_id,
-    };
-    let outcome = match crate::ensemble::run_ensemble(req, ensemble_cfg, &caller).await {
-        Ok(outcome) => outcome,
-        Err(err) => {
-            // Map the executor error to a dispatch failure, preserving the
-            // executor's HTTP-status intent (`EnsembleError::http_status`
-            // is the single source of truth):
-            //  - Judge(be): carry the bridge error itself so its full
-            //    envelope + status mapping survives (judge 4xx stays 4xx,
-            //    upstream 5xx → 502), richer than a bare status code.
-            //  - InsufficientPanel: the panel fan-out is exhausted — an
-            //    upstream-side fault — surfaced at the executor's canonical
-            //    status (502).
-            let status = err.http_status();
-            let proxy_err = match err {
-                crate::ensemble::EnsembleError::Judge(be) => ProxyError::Bridge(be),
-                crate::ensemble::EnsembleError::InsufficientPanel { .. } => {
-                    ProxyError::Bridge(BridgeError::upstream_status(
-                        status,
-                        "ensemble panel did not reach the required number of responses",
-                    ))
-                }
-            };
-            return Err(with_model(proxy_err));
-        }
-    };
-
-    // Aggregate client-facing usage: every billed sub-call (panel members
-    // + judge) counts against quota, since each one already hit an
-    // upstream. Commit once against the single entry-level reservation.
-    let panel_total: u64 = outcome
-        .panel
-        .iter()
-        .map(|p| u64::from(p.usage.total_tokens))
-        .sum();
-    let judge_usage = outcome.response.usage.clone();
-    let total_tokens = panel_total + u64::from(judge_usage.total_tokens);
-    reservation.commit_tokens(total_tokens);
-
-    // Emit one usage event per sub-call (each panel member + the judge),
-    // all sharing `request_id`. Each event re-resolves its target by
-    // display_name to recover the sub-call's `model_id` + `provider_key_id`;
-    // a sub-call whose target was deleted between dispatch and emit lands
-    // with those fields empty (cp-api stores NULL). `attempt_kind` is the
-    // new `"panel"` / `"judge"` value; `attempt_index` is 0..N for the
-    // panel and N for the judge.
-    //
-    // This MUST run before the output-guardrail check on BOTH paths
-    // (allow and block): the panel + judge tokens are already committed
-    // above, so skipping these events on a block would under-report panel
-    // usage to cp-api. The `emit_subcalls` closure is therefore defined
-    // here and invoked from each branch of the guardrail match below —
-    // never from the post-match continuation alone.
-    let elapsed = started.elapsed();
+    // Resolve a sub-call's target by display_name → (model_id, provider_key_id)
+    // for telemetry; empty pair if the target was deleted between dispatch and
+    // emit (cp-api stores NULL). Shared by both the success and 502 paths.
     let resolve_sub = |display_name: &str| -> (String, String) {
         match snapshot.models.get_by_name(display_name) {
             Some(entry) => (
@@ -1973,13 +1929,14 @@ async fn dispatch_ensemble<'a>(
             None => (String::new(), String::new()),
         }
     };
+    // Emit one usage event for a single (already-billed) panel member.
+    // Defined before the `run_ensemble` match so the InsufficientPanel arm
+    // can bill the survivors too — they hit upstream just like a full panel.
     // `bypass` is passed per call (not captured) so the closure holds no
-    // borrow of the mutable `bypass_reason`, and so a block can carry the
-    // input-only bypass while the allow/bypass continuation carries the
-    // final (possibly output-bypass) value. `blocked` sets each event's
-    // `guardrail_blocked` flag.
-    let emit_subcalls = |blocked: bool, bypass: &str| {
-        for (index, member) in outcome.panel.iter().enumerate() {
+    // borrow of the mutable `bypass_reason`. `attempt_index` is the member's
+    // 0-based slot; `blocked` sets the event's `guardrail_blocked` flag.
+    let emit_panel_member =
+        |member: &crate::ensemble::PanelOutcome, index: usize, blocked: bool, bypass: &str| {
             let (sub_model_id, sub_provider_key_id) = resolve_sub(&member.model);
             emit_usage_event(
                 state,
@@ -1988,7 +1945,7 @@ async fn dispatch_ensemble<'a>(
                 &req.model,
                 api_key_id,
                 200,
-                elapsed,
+                started.elapsed(),
                 member.usage.prompt_tokens,
                 member.usage.completion_tokens,
                 UsageExtras {
@@ -2010,6 +1967,84 @@ async fn dispatch_ensemble<'a>(
                 client,
                 /* content */ None,
             );
+        };
+
+    let caller = crate::ensemble::ProxyModelCaller {
+        state,
+        snapshot,
+        request_id,
+    };
+    let outcome = match crate::ensemble::run_ensemble(req, ensemble_cfg, &caller).await {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            // Both error variants carry the panel members that already
+            // succeeded — those hit upstream and were billed, so the
+            // "successful panel members are always billed" invariant must
+            // hold on the failure exits too (same class as the output-block
+            // path). Extract the survivors + the client-facing ProxyError,
+            // then commit + emit them BEFORE returning. No judge usage event:
+            // the judge either never ran (InsufficientPanel) or produced no
+            // response (Judge). `charge: None` — the per-member events
+            // already carry the bill, so passing a charge would double-count.
+            //
+            // `EnsembleError::http_status` is the single source of truth for
+            // the status (judge → its bridge status; exhausted panel → 502);
+            // read it before destructuring.
+            let status = err.http_status();
+            let (panel, proxy_err) = match err {
+                crate::ensemble::EnsembleError::Judge { source, panel } => {
+                    // Carry the bridge error itself so its full envelope +
+                    // status mapping survives (richer than a bare status).
+                    (panel, ProxyError::Bridge(source))
+                }
+                crate::ensemble::EnsembleError::InsufficientPanel { panel, .. } => (
+                    panel,
+                    ProxyError::Bridge(BridgeError::upstream_status(
+                        status,
+                        "ensemble panel did not reach the required number of responses",
+                    )),
+                ),
+            };
+            let survivor_total: u64 = panel.iter().map(|p| u64::from(p.usage.total_tokens)).sum();
+            reservation.commit_tokens(survivor_total);
+            for (index, member) in panel.iter().enumerate() {
+                emit_panel_member(
+                    member, index, /* blocked */ false, /* bypass */ "",
+                );
+            }
+            return Err(DispatchFailure::new(
+                Some(model_id.to_string()),
+                None,
+                proxy_err,
+            ));
+        }
+    };
+
+    // Aggregate client-facing usage: every billed sub-call (panel members
+    // + judge) counts against quota, since each one already hit an
+    // upstream. Commit once against the single entry-level reservation.
+    let panel_total: u64 = outcome
+        .panel
+        .iter()
+        .map(|p| u64::from(p.usage.total_tokens))
+        .sum();
+    let judge_usage = outcome.response.usage.clone();
+    let total_tokens = panel_total + u64::from(judge_usage.total_tokens);
+    reservation.commit_tokens(total_tokens);
+
+    // Emit one usage event per sub-call (each panel member + the judge),
+    // all sharing `request_id`. `attempt_kind` is `"panel"` / `"judge"`;
+    // `attempt_index` is 0..N for the panel and N for the judge.
+    //
+    // This MUST run before the output-guardrail check on BOTH paths
+    // (allow and block): the panel + judge tokens are already committed
+    // above, so skipping these events on a block would under-report panel
+    // usage to cp-api. The `emit_subcalls` closure is therefore defined
+    // here and invoked from each branch of the guardrail match below —
+    // never from the post-match continuation alone.
+    let emit_subcalls = |blocked: bool, bypass: &str| {
+        for (index, member) in outcome.panel.iter().enumerate() {
+            emit_panel_member(member, index, blocked, bypass);
         }
         let (judge_model_id, judge_provider_key_id) = resolve_sub(&outcome.judge_model);
         emit_usage_event(
@@ -2019,7 +2054,7 @@ async fn dispatch_ensemble<'a>(
             &req.model,
             api_key_id,
             200,
-            elapsed,
+            started.elapsed(),
             judge_usage.prompt_tokens,
             judge_usage.completion_tokens,
             UsageExtras {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -819,7 +819,12 @@ async fn dispatch(
     // proper 503 rather than burying it inside a generic Bridge error.
     // Routing requests rely on the loop's `is_retryable` path so a
     // single bad provider doesn't take down the whole request.
-    if attempt_models.len() == 1 {
+    //
+    // Skip an ensemble entry: it intentionally carries no
+    // provider/provider_key_id (those live on its panel/judge members),
+    // so `require_provider` would 400 here. Its members are resolved
+    // and dispatched in `dispatch_ensemble`, branched below.
+    if attempt_models.len() == 1 && !virtual_entry.value.is_ensemble() {
         let only = &attempt_models[0].model;
         let _provider = crate::dispatch::require_provider(only).map_err(with_model)?;
         // Pre-flight the PK-based two-tier dispatch so a missing
@@ -842,6 +847,32 @@ async fn dispatch(
         crate::quota::enforce_rate_limit(state, auth, Some(&model_rl)).map_err(&with_model)?;
 
     let now = created_ts();
+
+    // Ensemble path: fan the request out to the panel + judge instead of
+    // dispatching a single upstream. Branches here — after the single
+    // entry-level rate-limit reservation, before the streaming/failover
+    // machinery — because an ensemble entry has no provider/provider_key_id
+    // and no `routing.targets`, so the attempt loop below does not apply to
+    // it. `dispatch_ensemble` owns the fan-out, judge synthesis, output
+    // guardrail, token commit, and per-sub-call telemetry.
+    if virtual_entry.value.is_ensemble() {
+        return dispatch_ensemble(
+            state,
+            &snapshot,
+            &virtual_entry,
+            req,
+            request_id,
+            now,
+            reservation,
+            &resolved_chain,
+            &applied_guardrails,
+            bypass_reason,
+            &model_id,
+            &auth.entry.id,
+            client,
+        )
+        .await;
+    }
 
     // Streaming path (#554): walk the target list with first-chunk
     // fallback. For each target we connect, then peek the first stream
@@ -1811,6 +1842,289 @@ async fn dispatch(
         served_by_target,
         routing,
         captured_content,
+    })
+}
+
+/// Orchestrate one ensemble request: fan out to the panel + judge via
+/// [`crate::ensemble::run_ensemble`], run the output guardrail on the
+/// synthesized answer, commit the aggregate token usage against the
+/// single entry-level reservation, and emit one usage event per
+/// sub-call (each panel member + the judge), all sharing `request_id`.
+///
+/// Lives here (not in `ensemble.rs`) so it can use the chat.rs-private
+/// `Success` / `DispatchFailure` types, `emit_usage_event`, and
+/// `UsageExtras`. The pure fan-out / min-responses / judge-synthesis
+/// logic stays in `ensemble.rs`; this is only the dispatch glue.
+///
+/// `created_ts` is the shared `created` unix timestamp for the rendered
+/// response. `reservation` is the SINGLE entry-level reservation taken
+/// in `dispatch` — ensemble does not add per-sub-call reservations.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_ensemble<'a>(
+    state: &'a ProxyState,
+    snapshot: &aisix_core::AisixSnapshot,
+    virtual_entry: &aisix_core::ResourceEntry<aisix_core::Model>,
+    req: &ChatFormat,
+    request_id: &str,
+    created_ts: i64,
+    reservation: aisix_ratelimit::MultiReservation<'a, aisix_ratelimit::SystemClock>,
+    resolved_chain: &Arc<dyn aisix_guardrails::Guardrail>,
+    applied_guardrails: &[AppliedGuardrail],
+    mut bypass_reason: Option<String>,
+    model_id: &str,
+    api_key_id: &str,
+    client: &ClientContext,
+) -> Result<Success, DispatchFailure> {
+    let started = Instant::now();
+    let with_model = |e: ProxyError| DispatchFailure::new(Some(model_id.to_string()), None, e);
+
+    // The ensemble executor needs every panel member's full answer to
+    // synthesize, so a tool-using request can't be fanned out coherently
+    // (panel members might emit tool calls the judge can't reconcile).
+    // `tools` / `tool_choice` are flattened keys in `ChatFormat.extra`,
+    // not struct fields. Reject up front with a 400.
+    if req.extra.contains_key("tools") || req.extra.contains_key("tool_choice") {
+        return Err(with_model(ProxyError::InvalidRequest(
+            "ensemble models do not support tools".into(),
+        )));
+    }
+    // TODO(PR3): ensemble streaming. There is no single-ChatResponse→SSE
+    // helper today, and streaming the judge's synthesized answer is a
+    // separate piece of work; reject streaming requests for now.
+    if req.is_streaming() {
+        return Err(with_model(ProxyError::InvalidRequest(
+            "streaming is not supported for ensemble models".into(),
+        )));
+    }
+
+    // `is_ensemble()` is the branch guard, so `ensemble` is always Some
+    // here; surface a 400 rather than panic if a future refactor breaks
+    // that invariant.
+    let ensemble_cfg = virtual_entry.value.ensemble.as_ref().ok_or_else(|| {
+        with_model(ProxyError::InvalidRequest(
+            "model is not an ensemble".into(),
+        ))
+    })?;
+
+    let caller = crate::ensemble::ProxyModelCaller {
+        state,
+        snapshot,
+        request_id,
+    };
+    let outcome = match crate::ensemble::run_ensemble(req, ensemble_cfg, &caller).await {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            // Map the executor error to a dispatch failure, preserving the
+            // executor's HTTP-status intent (`EnsembleError::http_status`
+            // is the single source of truth):
+            //  - Judge(be): carry the bridge error itself so its full
+            //    envelope + status mapping survives (judge 4xx stays 4xx,
+            //    upstream 5xx → 502), richer than a bare status code.
+            //  - InsufficientPanel: the panel fan-out is exhausted — an
+            //    upstream-side fault — surfaced at the executor's canonical
+            //    status (502).
+            let status = err.http_status();
+            let proxy_err = match err {
+                crate::ensemble::EnsembleError::Judge(be) => ProxyError::Bridge(be),
+                crate::ensemble::EnsembleError::InsufficientPanel { .. } => {
+                    ProxyError::Bridge(BridgeError::upstream_status(
+                        status,
+                        "ensemble panel did not reach the required number of responses",
+                    ))
+                }
+            };
+            return Err(with_model(proxy_err));
+        }
+    };
+
+    // Aggregate client-facing usage: every billed sub-call (panel members
+    // + judge) counts against quota, since each one already hit an
+    // upstream. Commit once against the single entry-level reservation.
+    let panel_total: u64 = outcome
+        .panel
+        .iter()
+        .map(|p| u64::from(p.usage.total_tokens))
+        .sum();
+    let judge_usage = outcome.response.usage.clone();
+    let total_tokens = panel_total + u64::from(judge_usage.total_tokens);
+    reservation.commit_tokens(total_tokens);
+
+    // Emit one usage event per sub-call (each panel member + the judge),
+    // all sharing `request_id`. Each event re-resolves its target by
+    // display_name to recover the sub-call's `model_id` + `provider_key_id`;
+    // a sub-call whose target was deleted between dispatch and emit lands
+    // with those fields empty (cp-api stores NULL). `attempt_kind` is the
+    // new `"panel"` / `"judge"` value; `attempt_index` is 0..N for the
+    // panel and N for the judge.
+    //
+    // This MUST run before the output-guardrail check on BOTH paths
+    // (allow and block): the panel + judge tokens are already committed
+    // above, so skipping these events on a block would under-report panel
+    // usage to cp-api. The `emit_subcalls` closure is therefore defined
+    // here and invoked from each branch of the guardrail match below —
+    // never from the post-match continuation alone.
+    let elapsed = started.elapsed();
+    let resolve_sub = |display_name: &str| -> (String, String) {
+        match snapshot.models.get_by_name(display_name) {
+            Some(entry) => (
+                entry.id.clone(),
+                entry.value.provider_key_id.clone().unwrap_or_default(),
+            ),
+            None => (String::new(), String::new()),
+        }
+    };
+    // `bypass` is passed per call (not captured) so the closure holds no
+    // borrow of the mutable `bypass_reason`, and so a block can carry the
+    // input-only bypass while the allow/bypass continuation carries the
+    // final (possibly output-bypass) value. `blocked` sets each event's
+    // `guardrail_blocked` flag.
+    let emit_subcalls = |blocked: bool, bypass: &str| {
+        for (index, member) in outcome.panel.iter().enumerate() {
+            let (sub_model_id, sub_provider_key_id) = resolve_sub(&member.model);
+            emit_usage_event(
+                state,
+                request_id,
+                &sub_model_id,
+                &req.model,
+                api_key_id,
+                200,
+                elapsed,
+                member.usage.prompt_tokens,
+                member.usage.completion_tokens,
+                UsageExtras {
+                    cached_prompt_tokens: member.usage.cached_prompt_tokens,
+                    reasoning_tokens: member.usage.reasoning_tokens,
+                    cache_creation_tokens: member.usage.cache_creation_tokens,
+                    cache_read_tokens: member.usage.cache_read_tokens,
+                    bypass_reason: bypass.to_string(),
+                    cache_status: CacheStatus::Disabled.as_str().to_string(),
+                    attempt_index: index as u32,
+                    attempt_kind: "panel".to_string(),
+                    attempt_model: member.model.clone(),
+                    applied_guardrails: applied_guardrails.to_vec(),
+                    provider_key_id: sub_provider_key_id,
+                    ..UsageExtras::default()
+                },
+                /* cost_usd */ 0.0,
+                blocked,
+                client,
+                /* content */ None,
+            );
+        }
+        let (judge_model_id, judge_provider_key_id) = resolve_sub(&outcome.judge_model);
+        emit_usage_event(
+            state,
+            request_id,
+            &judge_model_id,
+            &req.model,
+            api_key_id,
+            200,
+            elapsed,
+            judge_usage.prompt_tokens,
+            judge_usage.completion_tokens,
+            UsageExtras {
+                cached_prompt_tokens: judge_usage.cached_prompt_tokens,
+                reasoning_tokens: judge_usage.reasoning_tokens,
+                cache_creation_tokens: judge_usage.cache_creation_tokens,
+                cache_read_tokens: judge_usage.cache_read_tokens,
+                provider_request_id: outcome.response.id.clone(),
+                provider_model_version: outcome.response.model.clone(),
+                finish_reason: finish_reason_label(&outcome.response.finish_reason),
+                bypass_reason: bypass.to_string(),
+                cache_status: CacheStatus::Disabled.as_str().to_string(),
+                attempt_index: outcome.panel.len() as u32,
+                attempt_kind: "judge".to_string(),
+                attempt_model: outcome.judge_model.clone(),
+                applied_guardrails: applied_guardrails.to_vec(),
+                provider_key_id: judge_provider_key_id,
+                ..UsageExtras::default()
+            },
+            /* cost_usd */ 0.0,
+            blocked,
+            client,
+            /* content */ None,
+        );
+    };
+
+    // Output guardrail on the synthesized answer — same contract as the
+    // non-streaming path. The tokens are already committed above and the
+    // per-sub-call usage events fire inside each branch (so a block still
+    // bills the full panel + judge): on a block we therefore pass
+    // `charge: None` rather than a judge-only `UpstreamCharge`, which
+    // would double-count the judge AND still miss the panel.
+    match resolved_chain.check_output(&outcome.response).await {
+        GuardrailVerdict::Allow => {}
+        GuardrailVerdict::Block {
+            reason,
+            guardrail_name,
+        } => {
+            tracing::warn!(
+                guardrail_hook = "output",
+                model = %req.model,
+                reason = %reason,
+                "guardrail blocked ensemble response"
+            );
+            // Block is not a bypass, so the output guardrail did not mutate
+            // `bypass_reason`; carry the input-only bypass (if any).
+            emit_subcalls(true, &bypass_reason.clone().unwrap_or_default());
+            return Err(DispatchFailure::new(
+                Some(model_id.to_string()),
+                None,
+                ProxyError::ContentFiltered(crate::error::guardrail_block_message(
+                    "response",
+                    guardrail_name.as_deref(),
+                )),
+            ));
+        }
+        GuardrailVerdict::Bypass { reason } => {
+            // First bypass wins — keep an earlier input bypass if present.
+            if bypass_reason.is_none() {
+                bypass_reason = Some(reason);
+            }
+        }
+    }
+    // Allow / Bypass continuation: emit the (non-blocked) sub-call events
+    // with the final bypass value (which an output bypass above may have
+    // set).
+    emit_subcalls(false, &bypass_reason.clone().unwrap_or_default());
+
+    // The synthesized answer is the client-facing response, rendered with
+    // the requested (ensemble) model name. `telemetry_handled_by_stream`
+    // is reused as the "telemetry already emitted, do not double-emit"
+    // flag — `chat_completions` skips its own `emit_usage_event` when it
+    // is set, exactly as it does for the streaming path.
+    let response = Json(render_response(created_ts, outcome.response, &req.model)).into_response();
+    Ok(Success {
+        response,
+        // No single provider/model/key governs an ensemble response.
+        provider: "ensemble".to_string(),
+        model_id: model_id.to_string(),
+        // Per-sub-call usage was emitted above; the entry-level telemetry
+        // event is suppressed, so these top-level token fields are unused.
+        prompt_tokens: None,
+        completion_tokens: None,
+        total_tokens: None,
+        cached_prompt_tokens: 0,
+        reasoning_tokens: 0,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        provider_request_id: String::new(),
+        provider_model_version: String::new(),
+        provider_key_id: String::new(),
+        upstream_model: String::new(),
+        finish_reason: String::new(),
+        cost_usd: 0.0,
+        bypass_reason,
+        cache_status: CacheStatus::Disabled,
+        cache_hit_saved_input_tokens: 0,
+        cache_hit_saved_output_tokens: 0,
+        // Telemetry already emitted per-sub-call above; suppress the
+        // handler's own entry-level emission.
+        telemetry_handled_by_stream: true,
+        // Not a routing request — no `x-aisix-served-by` header.
+        served_by_target: None,
+        routing: RoutingTelemetry::default(),
+        captured_content: None,
     })
 }
 

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -88,7 +88,21 @@ pub(crate) fn resolve_provider_key(
 /// `ProviderKey.adapter` + `ProviderKey.provider` — this helper just
 /// confirms the Model has a non-routing shape and returns the vendor
 /// id for telemetry / logs.
+///
+/// An ensemble model is rejected here with an explicit, accurate message:
+/// it has no `provider` (its panel/judge members do), so without this guard
+/// the generic "routing models can't be dispatched directly" branch below
+/// would fire — misleading, since the model is an *ensemble*, not a router.
+/// chat.rs branches to `dispatch_ensemble` before reaching this chokepoint,
+/// so this guard is what every NON-chat endpoint (embeddings, images,
+/// audio, completions, …) hits for an ensemble model.
 pub(crate) fn require_provider(model: &Model) -> Result<&str, ProxyError> {
+    if model.is_ensemble() {
+        return Err(ProxyError::InvalidRequest(format!(
+            "model `{}` is an ensemble model; only /v1/chat/completions is supported",
+            model.display_name
+        )));
+    }
     model.provider.as_deref().ok_or_else(|| {
         ProxyError::InvalidRequest(format!(
             "model {:?} has no provider (routing models can't be dispatched directly)",

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -104,11 +104,17 @@ impl ModelCaller for ProxyModelCaller<'_> {
         let model = &entry.value;
 
         // ProviderKey + Bridge resolution mirrors the direct-dispatch path.
-        // `resolve_provider_key` yields a `ProxyError`; collapse it to a
-        // 400-class BridgeError so the ensemble executor's status mapping
-        // (judge 4xx preserved, panel failures dropped) stays well-defined.
-        let pk_entry = crate::dispatch::resolve_provider_key(self.snapshot, model)
-            .map_err(|e| BridgeError::InvalidUpstreamConfig(e.to_string()))?;
+        // `resolve_provider_key` yields a `ProxyError` whose message embeds
+        // the member's `display_name` + `provider_key_id`. For a misconfigured
+        // judge that error reaches the client envelope verbatim (judge err →
+        // EnsembleError::Judge → ProxyError::Bridge → transparent), so redact
+        // it the same way as the get_by_name path: detail to server logs only.
+        let pk_entry = crate::dispatch::resolve_provider_key(self.snapshot, model).map_err(|e| {
+            tracing::warn!(member = %target, error = %e, "ensemble member provider key unresolved");
+            BridgeError::InvalidUpstreamConfig(
+                "ensemble member has an unresolved provider key".to_string(),
+            )
+        })?;
         let bridge =
             crate::dispatch::resolve_bridge(&self.state.hub, &pk_entry.value).ok_or_else(|| {
                 tracing::warn!(member = %target, "ensemble member has no registered bridge");
@@ -150,9 +156,25 @@ pub struct EnsembleOutcome {
 #[derive(Debug, thiserror::Error)]
 pub enum EnsembleError {
     #[error("ensemble panel produced {got} response(s), need at least {needed}")]
-    InsufficientPanel { got: usize, needed: usize },
+    InsufficientPanel {
+        got: usize,
+        needed: usize,
+        /// The panel members that DID succeed before the run was abandoned.
+        /// Each one already hit an upstream and was billed, so the dispatch
+        /// layer must still commit + emit their usage even though the request
+        /// fails — dropping them would under-report panel usage to cp-api.
+        panel: Vec<PanelOutcome>,
+    },
     #[error("ensemble judge call failed")]
-    Judge(#[source] BridgeError),
+    Judge {
+        #[source]
+        source: BridgeError,
+        /// The panel members that DID succeed before the judge failed. The
+        /// full panel met `min_responses` and was billed, so the dispatch
+        /// layer must still commit + emit their usage on this exit too —
+        /// same invariant as `InsufficientPanel`.
+        panel: Vec<PanelOutcome>,
+    },
 }
 
 impl EnsembleError {
@@ -163,7 +185,7 @@ impl EnsembleError {
     pub fn http_status(&self) -> u16 {
         match self {
             EnsembleError::InsufficientPanel { .. } => 502,
-            EnsembleError::Judge(err) => err.http_status(),
+            EnsembleError::Judge { source, .. } => source.http_status(),
         }
     }
 }
@@ -208,9 +230,12 @@ pub async fn run_ensemble(
     }
     let needed = config.min_responses_or_default();
     if candidates.len() < needed {
+        // Carry the survivors out on the error: they were already billed,
+        // so the dispatch layer commits + emits their usage before failing.
         return Err(EnsembleError::InsufficientPanel {
             got: candidates.len(),
             needed,
+            panel,
         });
     }
 
@@ -219,8 +244,19 @@ pub async fn run_ensemble(
     // (`config.timeout()`), so the ensemble-level deadline applies uniformly
     // across the whole fan-out.
     let judge_req = judge_request(req, &config.judge, &candidates);
-    let response =
-        call_judge_with_retry(caller, &config.judge.model, &judge_req, per_call_timeout).await?;
+    let response = match call_judge_with_retry(
+        caller,
+        &config.judge.model,
+        &judge_req,
+        per_call_timeout,
+    )
+    .await
+    {
+        Ok(r) => r,
+        // Carry the (already-billed) panel survivors out on the judge
+        // failure so the dispatch layer commits + emits them too.
+        Err(source) => return Err(EnsembleError::Judge { source, panel }),
+    };
 
     Ok(EnsembleOutcome {
         response,
@@ -340,15 +376,13 @@ async fn call_judge_with_retry(
     target: &str,
     req: &ChatFormat,
     timeout: Option<Duration>,
-) -> Result<ChatResponse, EnsembleError> {
+) -> Result<ChatResponse, BridgeError> {
     match call_with_optional_timeout(caller, target, req, timeout).await {
         Ok(resp) => Ok(resp),
         Err(first) if is_transient(&first) => {
-            call_with_optional_timeout(caller, target, req, timeout)
-                .await
-                .map_err(EnsembleError::Judge)
+            call_with_optional_timeout(caller, target, req, timeout).await
         }
-        Err(err) => Err(EnsembleError::Judge(err)),
+        Err(err) => Err(err),
     }
 }
 
@@ -496,9 +530,13 @@ mod tests {
             .unwrap_err();
 
         match err {
-            EnsembleError::InsufficientPanel { got, needed } => {
+            EnsembleError::InsufficientPanel { got, needed, panel } => {
                 assert_eq!(got, 1);
                 assert_eq!(needed, 2);
+                // The one survivor (gpt) is carried out so the dispatch
+                // layer can still commit + emit its (already-billed) usage.
+                assert_eq!(panel.len(), 1);
+                assert_eq!(panel[0].model, "gpt");
             }
             other => panic!("unexpected error: {other:?}"),
         }
@@ -570,6 +608,16 @@ mod tests {
 
         assert_eq!(err.http_status(), 400); // judge 4xx preserved
         assert_eq!(caller.calls_to("judge").len(), 1); // not retried
+                                                       // The full panel succeeded and was billed before the judge failed,
+                                                       // so the survivors are carried out on the error for the dispatch
+                                                       // layer to commit + emit (FIX G).
+        match err {
+            EnsembleError::Judge { source, panel } => {
+                assert_eq!(source.http_status(), 400);
+                assert_eq!(panel.len(), 2);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -1,0 +1,641 @@
+//! Ensemble executor — fan a chat request out to a panel of models in
+//! parallel, then synthesize one answer via a judge model.
+//!
+//! This module is the pure orchestration core. It is parameterized over a
+//! [`ModelCaller`] so the fan-out / min-responses / synthesis logic is
+//! unit-testable without real bridges or a network. The proxy dispatch
+//! layer (`chat.rs`) supplies the production caller that resolves a model
+//! `display_name` to its Bridge + ProviderKey and emits per-sub-call usage.
+//!
+//! Shape of one ensemble request:
+//! 1. Build a per-member [`ChatFormat`] (the member's `temperature`/`seed`
+//!    override the request's, which is what makes self-ensemble produce
+//!    diverse answers) and dispatch every member concurrently.
+//! 2. Keep the successful responses; require at least
+//!    [`EnsembleConfig::min_responses_or_default`] of them, else error.
+//! 3. Ask the judge model to synthesize a single answer from the labeled
+//!    candidate answers, at a fixed low temperature. Retry the judge once
+//!    on a transient failure.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::future::join_all;
+
+use aisix_core::models::{EnsembleConfig, Judge, PanelMember};
+use aisix_core::AisixSnapshot;
+use aisix_gateway::bridge::{BridgeContext, BridgeError};
+use aisix_gateway::chat::{ChatFormat, ChatMessage, ChatResponse, Role, UsageStats};
+
+use crate::state::ProxyState;
+
+/// Fixed judge sampling temperature. The judge runs cool for stable
+/// synthesis; this is intentionally not operator-configurable in v1.
+const JUDGE_TEMPERATURE: f32 = 0.2;
+
+/// Per-candidate text cap (bytes) fed to the judge. Bounds the synthesis
+/// prompt so a panel of N long answers cannot overflow the judge's
+/// context window; oversized answers are truncated, not dropped.
+const MAX_CANDIDATE_BYTES: usize = 8 * 1024;
+
+/// Default synthesis instructions. Filled with the original request and
+/// the neutrally-labeled candidate answers, then sent to the judge as a
+/// single user message. Operators can override the whole template via
+/// `Judge.synthesis_prompt` (it must carry the two `{...}` placeholders).
+const DEFAULT_SYNTHESIS_TEMPLATE: &str = "You are the synthesis step of a multi-model answer pipeline. You are given the user's original request and several independent candidate answers to it.
+
+Your job: produce the single best possible answer to the user's ORIGINAL request.
+
+Use the candidates as evidence, not as text to copy:
+- Identify where they agree — treat consensus as likely reliable.
+- Identify where they contradict — resolve it by reasoning about which is correct and why; do not just take the majority.
+- Keep unique, correct, well-supported insights that only one candidate raised.
+- Discard claims that are unsupported, internally inconsistent, or look hallucinated, even if several candidates share them.
+
+Output rules (strict):
+- Respond ONLY with the final answer to the user's request — no meta-commentary.
+- Do NOT mention that multiple models, candidates, or a panel were involved.
+- Do NOT name or attribute any candidate (\"Answer 1 says...\", model names, etc.).
+- Write in the SAME language as the user's original request.
+- Match the format the user asked for (code, list, prose, length).
+
+User's original request:
+{original_request}
+
+Candidate answers:
+{labeled_candidates}";
+
+/// Dispatches one resolved chat request to a model by its `display_name`.
+/// The production impl resolves the name to a Bridge + ProviderKey and
+/// calls `Bridge::chat`; tests supply a scripted mock.
+#[async_trait]
+pub trait ModelCaller: Send + Sync {
+    async fn call(&self, target: &str, req: &ChatFormat) -> Result<ChatResponse, BridgeError>;
+}
+
+/// Production [`ModelCaller`] used by the chat dispatch layer. Resolves
+/// a panel/judge member's `display_name` to its Bridge + ProviderKey
+/// from the live snapshot and dispatches a single non-streaming
+/// `Bridge::chat`. Borrows everything it needs for the duration of one
+/// ensemble run, so it holds no owned state of its own.
+pub(crate) struct ProxyModelCaller<'a> {
+    pub state: &'a ProxyState,
+    pub snapshot: &'a AisixSnapshot,
+    pub request_id: &'a str,
+}
+
+#[async_trait]
+impl ModelCaller for ProxyModelCaller<'_> {
+    async fn call(&self, target: &str, req: &ChatFormat) -> Result<ChatResponse, BridgeError> {
+        // Resolve the member's display_name against the live snapshot.
+        // A missing entry is a misconfigured ensemble (a panel/judge name
+        // that no longer points at a real Model) → 400 InvalidUpstreamConfig.
+        // The member's display_name is operator-internal config; keep it in
+        // server logs but out of the client-visible `error.message` (a
+        // misconfigured judge surfaces its bridge error to the caller).
+        let entry = self.snapshot.models.get_by_name(target).ok_or_else(|| {
+            tracing::warn!(member = %target, "ensemble member references an unknown model");
+            BridgeError::InvalidUpstreamConfig(
+                "ensemble member references an unknown model".to_string(),
+            )
+        })?;
+        let model = &entry.value;
+
+        // ProviderKey + Bridge resolution mirrors the direct-dispatch path.
+        // `resolve_provider_key` yields a `ProxyError`; collapse it to a
+        // 400-class BridgeError so the ensemble executor's status mapping
+        // (judge 4xx preserved, panel failures dropped) stays well-defined.
+        let pk_entry = crate::dispatch::resolve_provider_key(self.snapshot, model)
+            .map_err(|e| BridgeError::InvalidUpstreamConfig(e.to_string()))?;
+        let bridge =
+            crate::dispatch::resolve_bridge(&self.state.hub, &pk_entry.value).ok_or_else(|| {
+                tracing::warn!(member = %target, "ensemble member has no registered bridge");
+                BridgeError::Config("ensemble member has no registered bridge".to_string())
+            })?;
+
+        // Per-member request deadline from the member Model's own `timeout`.
+        let mut ctx = BridgeContext::new(
+            self.request_id,
+            Arc::new(model.clone()),
+            Arc::new(pk_entry.value.clone()),
+        );
+        if let Some(deadline) = model.request_timeout() {
+            ctx = ctx.with_deadline(deadline);
+        }
+        bridge.chat(req, &ctx).await
+    }
+}
+
+/// Per successful panel member: which model answered and what it cost.
+/// Consumed by the dispatch layer to emit one usage event per sub-call.
+#[derive(Debug)]
+pub struct PanelOutcome {
+    pub model: String,
+    pub usage: UsageStats,
+}
+
+/// Everything the dispatch layer needs after an ensemble run: the judge's
+/// response (the client-facing answer, whose `usage` is the judge call's
+/// own), plus the per-sub-call accounting for telemetry and the aggregate
+/// client-facing usage.
+#[derive(Debug)]
+pub struct EnsembleOutcome {
+    pub response: ChatResponse,
+    pub panel: Vec<PanelOutcome>,
+    pub judge_model: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EnsembleError {
+    #[error("ensemble panel produced {got} response(s), need at least {needed}")]
+    InsufficientPanel { got: usize, needed: usize },
+    #[error("ensemble judge call failed")]
+    Judge(#[source] BridgeError),
+}
+
+impl EnsembleError {
+    /// Client-facing HTTP status. An exhausted panel is an upstream fault
+    /// (502); a judge failure preserves the bridge's own mapping, so a
+    /// customer-fixable 4xx (bad judge config/credentials) stays 4xx while
+    /// upstream 5xx collapses to 502.
+    pub fn http_status(&self) -> u16 {
+        match self {
+            EnsembleError::InsufficientPanel { .. } => 502,
+            EnsembleError::Judge(err) => err.http_status(),
+        }
+    }
+}
+
+/// Run one ensemble request to completion. See the module docs for the
+/// three phases.
+pub async fn run_ensemble(
+    req: &ChatFormat,
+    config: &EnsembleConfig,
+    caller: &dyn ModelCaller,
+) -> Result<EnsembleOutcome, EnsembleError> {
+    let per_call_timeout = config.timeout();
+
+    // Phase 1: fan out to every panel member concurrently.
+    let calls = config.panel.iter().map(|member| {
+        let model = member.model.clone();
+        let member_req = panel_request(req, member);
+        async move {
+            let result =
+                call_with_optional_timeout(caller, &model, &member_req, per_call_timeout).await;
+            (model, result)
+        }
+    });
+    let results = join_all(calls).await;
+
+    // Phase 2: keep the successes, enforce min_responses.
+    let mut panel: Vec<PanelOutcome> = Vec::new();
+    let mut candidates: Vec<ChatResponse> = Vec::new();
+    for (model, result) in results {
+        match result {
+            Ok(resp) => {
+                panel.push(PanelOutcome {
+                    model,
+                    usage: resp.usage.clone(),
+                });
+                candidates.push(resp);
+            }
+            Err(err) => {
+                tracing::warn!(panel_model = %model, error = %err, "ensemble panel member failed");
+            }
+        }
+    }
+    let needed = config.min_responses_or_default();
+    if candidates.len() < needed {
+        return Err(EnsembleError::InsufficientPanel {
+            got: candidates.len(),
+            needed,
+        });
+    }
+
+    // Phase 3: synthesize via the judge, retrying once on a transient error.
+    // The judge call gets the same per-call timeout as each panel member
+    // (`config.timeout()`), so the ensemble-level deadline applies uniformly
+    // across the whole fan-out.
+    let judge_req = judge_request(req, &config.judge, &candidates);
+    let response =
+        call_judge_with_retry(caller, &config.judge.model, &judge_req, per_call_timeout).await?;
+
+    Ok(EnsembleOutcome {
+        response,
+        panel,
+        judge_model: config.judge.model.clone(),
+    })
+}
+
+/// Build a panel member's request: the inbound request with this member's
+/// sampling overrides applied. Always non-streaming — the executor needs
+/// the full response to synthesize.
+fn panel_request(req: &ChatFormat, member: &PanelMember) -> ChatFormat {
+    let mut out = req.clone();
+    out.model = member.model.clone();
+    if let Some(temperature) = member.temperature {
+        out.temperature = Some(temperature);
+    }
+    if let Some(seed) = member.seed {
+        out.extra
+            .insert("seed".to_string(), serde_json::Value::from(seed));
+    }
+    out.stream = Some(false);
+    out
+}
+
+/// Build the judge's request from the labeled candidate answers.
+fn judge_request(req: &ChatFormat, judge: &Judge, candidates: &[ChatResponse]) -> ChatFormat {
+    let template = judge
+        .synthesis_prompt
+        .as_deref()
+        .unwrap_or(DEFAULT_SYNTHESIS_TEMPLATE);
+    let prompt = template
+        .replace(
+            "{original_request}",
+            &render_original_request(&req.messages),
+        )
+        .replace("{labeled_candidates}", &label_candidates(candidates));
+
+    let mut out = ChatFormat::new(judge.model.clone(), vec![ChatMessage::user(prompt)]);
+    out.temperature = Some(JUDGE_TEMPERATURE);
+    out.stream = Some(false);
+    out
+}
+
+/// Render the original conversation as plain text for the judge prompt.
+fn render_original_request(messages: &[ChatMessage]) -> String {
+    messages
+        .iter()
+        .map(|m| format!("{}: {}", role_label(m.role), m.content_str()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Present the candidates to the judge with neutral labels. Model names
+/// are deliberately omitted so the operator's provider/model choices never
+/// leak to the client through the synthesized answer.
+fn label_candidates(candidates: &[ChatResponse]) -> String {
+    candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            format!(
+                "Answer {}:\n{}",
+                i + 1,
+                truncate_bytes(c.message.content_str(), MAX_CANDIDATE_BYTES)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn role_label(role: Role) -> &'static str {
+    match role {
+        Role::System => "System",
+        Role::User => "User",
+        Role::Assistant => "Assistant",
+        Role::Tool => "Tool",
+    }
+}
+
+/// Truncate to at most `max` bytes on a UTF-8 boundary, marking the cut.
+fn truncate_bytes(s: &str, max: usize) -> Cow<'_, str> {
+    if s.len() <= max {
+        return Cow::Borrowed(s);
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    Cow::Owned(format!("{}…", &s[..end]))
+}
+
+async fn call_with_optional_timeout(
+    caller: &dyn ModelCaller,
+    target: &str,
+    req: &ChatFormat,
+    timeout: Option<Duration>,
+) -> Result<ChatResponse, BridgeError> {
+    match timeout {
+        Some(d) => match tokio::time::timeout(d, caller.call(target, req)).await {
+            Ok(result) => result,
+            Err(_) => Err(BridgeError::Timeout {
+                elapsed_ms: d.as_millis() as u64,
+            }),
+        },
+        None => caller.call(target, req).await,
+    }
+}
+
+/// Call the judge, retrying once if the first failure is transient
+/// (resolved decision: judge failure → 5xx after one in-process retry; no
+/// silent fallback to a raw panel answer). Each attempt is bound by the
+/// same per-call `timeout` as the panel members; a timed-out judge call
+/// surfaces as a transient [`BridgeError::Timeout`] and so is retried once.
+async fn call_judge_with_retry(
+    caller: &dyn ModelCaller,
+    target: &str,
+    req: &ChatFormat,
+    timeout: Option<Duration>,
+) -> Result<ChatResponse, EnsembleError> {
+    match call_with_optional_timeout(caller, target, req, timeout).await {
+        Ok(resp) => Ok(resp),
+        Err(first) if is_transient(&first) => {
+            call_with_optional_timeout(caller, target, req, timeout)
+                .await
+                .map_err(EnsembleError::Judge)
+        }
+        Err(err) => Err(EnsembleError::Judge(err)),
+    }
+}
+
+/// Conservative transient-failure classification for the judge retry:
+/// timeouts, transport faults, mid-stream aborts, and upstream 5xx are
+/// retryable; everything else (4xx, config, credentials, decode) is not.
+fn is_transient(err: &BridgeError) -> bool {
+    match err {
+        BridgeError::Timeout { .. } | BridgeError::Transport(_) | BridgeError::StreamAborted => {
+            true
+        }
+        BridgeError::UpstreamStatus { status, .. } => *status >= 500,
+        BridgeError::UpstreamDecode(_)
+        | BridgeError::Config(_)
+        | BridgeError::InvalidUpstreamConfig(_)
+        | BridgeError::InvalidUpstreamCredentials(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Mutex;
+
+    use aisix_gateway::chat::FinishReason;
+
+    /// A scripted [`ModelCaller`]: each target has a queue of results
+    /// returned on successive calls. Records every call for assertions.
+    struct MockCaller {
+        scripted: Mutex<HashMap<String, VecDeque<Result<ChatResponse, BridgeError>>>>,
+        calls: Mutex<Vec<(String, ChatFormat)>>,
+    }
+
+    impl MockCaller {
+        fn new() -> Self {
+            Self {
+                scripted: Mutex::new(HashMap::new()),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn on(self, target: &str, results: Vec<Result<ChatResponse, BridgeError>>) -> Self {
+            self.scripted
+                .lock()
+                .unwrap()
+                .insert(target.to_string(), results.into_iter().collect());
+            self
+        }
+
+        fn calls_to(&self, target: &str) -> Vec<ChatFormat> {
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|(t, _)| t == target)
+                .map(|(_, req)| req.clone())
+                .collect()
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait]
+    impl ModelCaller for MockCaller {
+        async fn call(&self, target: &str, req: &ChatFormat) -> Result<ChatResponse, BridgeError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((target.to_string(), req.clone()));
+            let mut scripted = self.scripted.lock().unwrap();
+            let queue = scripted
+                .get_mut(target)
+                .unwrap_or_else(|| panic!("no scripted response for target {target:?}"));
+            queue
+                .pop_front()
+                .unwrap_or_else(|| panic!("scripted responses exhausted for target {target:?}"))
+        }
+    }
+
+    fn ok(model: &str, content: &str) -> Result<ChatResponse, BridgeError> {
+        Ok(ChatResponse {
+            id: format!("id-{model}"),
+            model: model.to_string(),
+            message: ChatMessage::assistant(content),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(10, 20),
+        })
+    }
+
+    fn config(json: &str) -> EnsembleConfig {
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn user_request(text: &str) -> ChatFormat {
+        ChatFormat::new("council", vec![ChatMessage::user(text)])
+    }
+
+    #[tokio::test]
+    async fn happy_path_fans_out_then_synthesizes() {
+        let caller = MockCaller::new()
+            .on("gpt", vec![ok("gpt", "answer from gpt")])
+            .on("claude", vec![ok("claude", "answer from claude")])
+            .on("judge", vec![ok("judge", "synthesized answer")]);
+        let cfg =
+            config(r#"{"panel":[{"model":"gpt"},{"model":"claude"}],"judge":{"model":"judge"}}"#);
+
+        let out = run_ensemble(&user_request("what is 2+2?"), &cfg, &caller)
+            .await
+            .unwrap();
+
+        assert_eq!(out.response.message.content_str(), "synthesized answer");
+        assert_eq!(out.panel.len(), 2);
+        assert_eq!(out.judge_model, "judge");
+        assert_eq!(caller.call_count(), 3); // 2 panel + 1 judge
+
+        // The judge saw both candidates, neutrally labeled, plus the request.
+        let judge_prompt = caller.calls_to("judge")[0].messages[0]
+            .content_str()
+            .to_string();
+        assert!(judge_prompt.contains("Answer 1:"));
+        assert!(judge_prompt.contains("Answer 2:"));
+        assert!(judge_prompt.contains("answer from gpt"));
+        assert!(judge_prompt.contains("answer from claude"));
+        assert!(judge_prompt.contains("what is 2+2?"));
+    }
+
+    #[tokio::test]
+    async fn errors_when_min_responses_not_met() {
+        let caller = MockCaller::new()
+            .on("gpt", vec![ok("gpt", "only survivor")])
+            .on(
+                "claude",
+                vec![Err(BridgeError::upstream_status(503, "busy"))],
+            )
+            .on("judge", vec![ok("judge", "should not be called")]);
+        // Two-member panel defaults to min_responses = 2; only one succeeds.
+        let cfg =
+            config(r#"{"panel":[{"model":"gpt"},{"model":"claude"}],"judge":{"model":"judge"}}"#);
+
+        let err = run_ensemble(&user_request("hi"), &cfg, &caller)
+            .await
+            .unwrap_err();
+
+        match err {
+            EnsembleError::InsufficientPanel { got, needed } => {
+                assert_eq!(got, 1);
+                assert_eq!(needed, 2);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert!(caller.calls_to("judge").is_empty());
+    }
+
+    #[tokio::test]
+    async fn proceeds_on_partial_panel_when_min_met() {
+        // 3-member panel, one fails. Default min_responses = 2, so the two
+        // survivors are enough to synthesize.
+        let caller = MockCaller::new()
+            .on("a", vec![ok("a", "alpha")])
+            .on("b", vec![Err(BridgeError::Transport("reset".into()))])
+            .on("c", vec![ok("c", "gamma")])
+            .on("judge", vec![ok("judge", "merged")]);
+        let cfg = config(
+            r#"{"panel":[{"model":"a"},{"model":"b"},{"model":"c"}],"judge":{"model":"judge"}}"#,
+        );
+
+        let out = run_ensemble(&user_request("hi"), &cfg, &caller)
+            .await
+            .unwrap();
+
+        assert_eq!(out.panel.len(), 2);
+        let judge_prompt = caller.calls_to("judge")[0].messages[0]
+            .content_str()
+            .to_string();
+        assert!(judge_prompt.contains("alpha"));
+        assert!(judge_prompt.contains("gamma"));
+        assert!(!judge_prompt.contains("reset"));
+    }
+
+    #[tokio::test]
+    async fn retries_judge_once_on_transient_failure() {
+        let caller = MockCaller::new()
+            .on("a", vec![ok("a", "x")])
+            .on("b", vec![ok("b", "y")])
+            .on(
+                "judge",
+                vec![
+                    Err(BridgeError::Timeout { elapsed_ms: 1 }),
+                    ok("judge", "second attempt wins"),
+                ],
+            );
+        let cfg = config(r#"{"panel":[{"model":"a"},{"model":"b"}],"judge":{"model":"judge"}}"#);
+
+        let out = run_ensemble(&user_request("hi"), &cfg, &caller)
+            .await
+            .unwrap();
+
+        assert_eq!(out.response.message.content_str(), "second attempt wins");
+        assert_eq!(caller.calls_to("judge").len(), 2); // retried once
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_judge_on_non_transient_failure() {
+        let caller = MockCaller::new()
+            .on("a", vec![ok("a", "x")])
+            .on("b", vec![ok("b", "y")])
+            .on(
+                "judge",
+                vec![Err(BridgeError::InvalidUpstreamConfig("bad model".into()))],
+            );
+        let cfg = config(r#"{"panel":[{"model":"a"},{"model":"b"}],"judge":{"model":"judge"}}"#);
+
+        let err = run_ensemble(&user_request("hi"), &cfg, &caller)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.http_status(), 400); // judge 4xx preserved
+        assert_eq!(caller.calls_to("judge").len(), 1); // not retried
+    }
+
+    #[tokio::test]
+    async fn applies_per_member_temperature_and_judge_runs_cool() {
+        let caller = MockCaller::new()
+            .on("hot", vec![ok("hot", "h")])
+            .on("inherit", vec![ok("inherit", "i")])
+            .on("judge", vec![ok("judge", "done")]);
+        // `hot` overrides temperature; `inherit` has none so it keeps the
+        // request's temperature.
+        let cfg = config(
+            r#"{"panel":[{"model":"hot","temperature":1.0},{"model":"inherit"}],"judge":{"model":"judge"}}"#,
+        );
+        let mut req = user_request("hi");
+        req.temperature = Some(0.2);
+
+        run_ensemble(&req, &cfg, &caller).await.unwrap();
+
+        assert_eq!(caller.calls_to("hot")[0].temperature, Some(1.0));
+        assert_eq!(caller.calls_to("inherit")[0].temperature, Some(0.2));
+        assert_eq!(
+            caller.calls_to("judge")[0].temperature,
+            Some(JUDGE_TEMPERATURE)
+        );
+    }
+
+    #[tokio::test]
+    async fn judge_prompt_does_not_leak_panel_model_names() {
+        let caller = MockCaller::new()
+            .on("secret-vendor-x", vec![ok("secret-vendor-x", "ans one")])
+            .on("secret-vendor-y", vec![ok("secret-vendor-y", "ans two")])
+            .on("judge", vec![ok("judge", "final")]);
+        let cfg = config(
+            r#"{"panel":[{"model":"secret-vendor-x"},{"model":"secret-vendor-y"}],"judge":{"model":"judge"}}"#,
+        );
+
+        run_ensemble(&user_request("hi"), &cfg, &caller)
+            .await
+            .unwrap();
+
+        let judge_prompt = caller.calls_to("judge")[0].messages[0]
+            .content_str()
+            .to_string();
+        assert!(!judge_prompt.contains("secret-vendor-x"));
+        assert!(!judge_prompt.contains("secret-vendor-y"));
+    }
+
+    #[tokio::test]
+    async fn custom_synthesis_prompt_overrides_default() {
+        let caller = MockCaller::new()
+            .on("a", vec![ok("a", "alpha")])
+            .on("b", vec![ok("b", "beta")])
+            .on("judge", vec![ok("judge", "done")]);
+        let cfg = config(
+            r#"{"panel":[{"model":"a"},{"model":"b"}],"judge":{"model":"judge","synthesis_prompt":"PICK BEST. Q={original_request} A={labeled_candidates}"}}"#,
+        );
+
+        run_ensemble(&user_request("which?"), &cfg, &caller)
+            .await
+            .unwrap();
+
+        let judge_prompt = caller.calls_to("judge")[0].messages[0]
+            .content_str()
+            .to_string();
+        assert!(judge_prompt.starts_with("PICK BEST."));
+        assert!(judge_prompt.contains("which?"));
+        assert!(judge_prompt.contains("alpha"));
+    }
+}

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -36,6 +36,7 @@ pub(crate) mod cooldown;
 mod count_tokens;
 mod dispatch;
 mod embeddings;
+mod ensemble;
 mod error;
 mod error_translate;
 pub mod health;
@@ -5554,5 +5555,471 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
         assert_eq!(v["choices"][0]["message"]["content"], "Hello from Cohere!");
         assert_eq!(v["usage"]["total_tokens"], 7);
+    }
+
+    // ---------------------------------------------------------------
+    // Ensemble dispatch glue (feat/ensemble-model).
+    //
+    // The pure fan-out / synthesis logic is covered by the unit tests
+    // in `ensemble.rs` with a mock caller. This e2e test exercises the
+    // chat.rs wiring end-to-end through the real HTTP handler +
+    // ProxyModelCaller + bridge: an ensemble model fans out to two
+    // panel members and a judge over real (wiremock) upstreams, and the
+    // client receives the judge's synthesized answer rendered under the
+    // requested ensemble model name.
+    // ---------------------------------------------------------------
+
+    /// A direct OpenAI model with a caller-chosen id + upstream model
+    /// name, sharing the single test ProviderKey. Distinct `model_name`
+    /// values let the wiremock body-matchers tell panel calls from the
+    /// judge call apart.
+    fn direct_model_entry(id: &str, name: &str, upstream_model: &str) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "{upstream_model}",
+                "provider_key_id": "{PK_ID}"
+            }}"#
+        );
+        let model: Model = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new(id, model, 1)
+    }
+
+    /// An ensemble model referencing `panel` display names + a `judge`
+    /// display name. Carries no provider/model_name of its own.
+    fn ensemble_model_entry(
+        id: &str,
+        name: &str,
+        panel: &[&str],
+        judge: &str,
+    ) -> ResourceEntry<Model> {
+        let panel_json = panel
+            .iter()
+            .map(|m| format!(r#"{{"model":"{m}"}}"#))
+            .collect::<Vec<_>>()
+            .join(",");
+        let cfg = format!(
+            r#"{{
+                "display_name": "{name}",
+                "ensemble": {{
+                    "panel": [{panel_json}],
+                    "judge": {{"model": "{judge}"}}
+                }}
+            }}"#
+        );
+        let model: Model = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new(id, model, 1)
+    }
+
+    #[tokio::test]
+    async fn ensemble_fans_out_to_panel_and_returns_judge_synthesis() {
+        let upstream = MockServer::start().await;
+        // Judge synthesis call — its prompt embeds the neutrally-labeled
+        // candidate answers ("Answer 1:"). Highest priority so it wins
+        // over the catch-all panel mock for the judge request only.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-judge",
+                "model": "judge-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "synthesized final answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 30, "completion_tokens": 7, "total_tokens": 37}
+            })))
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        // Panel members — catch-all for any chat call that isn't the judge.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-panel-b", "panel-b", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a", "panel-b"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "what is the best answer?"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
+        // The client sees the JUDGE's synthesized answer, not a panel one.
+        assert_eq!(v["object"], "chat.completion");
+        assert_eq!(
+            v["choices"][0]["message"]["content"],
+            "synthesized final answer"
+        );
+        // Rendered under the requested ensemble model name — never the
+        // judge's upstream model id (no provider/model leakage).
+        assert_eq!(v["model"], "council");
+        // Client-facing usage is the judge call's own (the executor's
+        // `EnsembleOutcome.response` carries the judge usage).
+        assert_eq!(v["usage"]["total_tokens"], 37);
+    }
+
+    /// Tool-using requests can't be fanned out coherently across a panel,
+    /// so the ensemble path rejects them with a 400 before any upstream
+    /// call. `tools` is a flattened key in the request body.
+    #[tokio::test]
+    async fn ensemble_rejects_tool_requests_with_400() {
+        let upstream = MockServer::start().await;
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{
+                "type": "function",
+                "function": {"name": "get_weather", "parameters": {}}
+            }]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 4096).await.unwrap()).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+    }
+
+    /// Streaming is not supported for ensemble models yet (separate PR);
+    /// the request must be rejected with a 400, not silently downgraded.
+    #[tokio::test]
+    async fn ensemble_rejects_streaming_with_400() {
+        let upstream = MockServer::start().await;
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 4096).await.unwrap()).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+    }
+
+    /// Like `ensemble_model_entry` but with an explicit `min_responses`.
+    fn ensemble_model_entry_min(
+        id: &str,
+        name: &str,
+        panel: &[&str],
+        judge: &str,
+        min_responses: u32,
+    ) -> ResourceEntry<Model> {
+        let panel_json = panel
+            .iter()
+            .map(|m| format!(r#"{{"model":"{m}"}}"#))
+            .collect::<Vec<_>>()
+            .join(",");
+        let cfg = format!(
+            r#"{{
+                "display_name": "{name}",
+                "ensemble": {{
+                    "panel": [{panel_json}],
+                    "judge": {{"model": "{judge}"}},
+                    "min_responses": {min_responses}
+                }}
+            }}"#
+        );
+        let model: Model = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new(id, model, 1)
+    }
+
+    /// Output-guardrail block path — the case FIX 1 (billing) targets. The
+    /// judge's synthesized answer trips an output keyword guardrail. The
+    /// client must get the content-filtered status, AND every per-sub-call
+    /// usage event (panel members + judge) must still fire with
+    /// `guardrail_blocked == true` — the panel tokens are already committed,
+    /// so dropping these events would under-report panel usage to cp-api.
+    #[tokio::test]
+    async fn ensemble_output_block_still_emits_panel_and_judge_usage() {
+        use aisix_obs::UsageSink;
+        let upstream = MockServer::start().await;
+        // Judge synthesis call returns content that the output guardrail
+        // blocks ("secret-string"). Highest priority for the judge request.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-judge",
+                "model": "judge-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "here is the secret-string"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 30, "completion_tokens": 7, "total_tokens": 37}
+            })))
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        // Panel members — catch-all, benign content.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-panel-b", "panel-b", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a", "panel-b"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
+        // Output keyword guardrail blocking the judge's synthesized answer.
+        seed_guardrail(
+            &state.snapshot,
+            "g-ensemble-out",
+            r#"{"name":"ens-out-guard","kind":"keyword","hook_point":"output","patterns":[{"kind":"literal","value":"secret-string"}]}"#,
+        );
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "what is the answer?"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        // Content-filtered status reaches the client (ProxyError::ContentFiltered).
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 4096).await.unwrap()).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+
+        // Drain the usage sink: the two panel members + the judge must all
+        // have emitted, each flagged guardrail_blocked (FIX 1 — the panel
+        // bill is not lost on a block).
+        let mut events = Vec::new();
+        while let Ok(Some(ev)) =
+            tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await
+        {
+            events.push(ev);
+            if events.len() == 3 {
+                break;
+            }
+        }
+        assert_eq!(
+            events.len(),
+            3,
+            "expected 3 usage events (2 panel + judge) on the block path; got {}",
+            events.len()
+        );
+        let panel_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.attempt_kind == "panel")
+            .collect();
+        let judge_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.attempt_kind == "judge")
+            .collect();
+        assert_eq!(panel_events.len(), 2, "both panel members must emit");
+        assert_eq!(judge_events.len(), 1, "the judge must emit");
+        assert!(
+            events.iter().all(|e| e.guardrail_blocked),
+            "every sub-call event on the block path must be guardrail_blocked"
+        );
+        // Panel token counts survive (the bug under-reported these).
+        assert!(
+            panel_events
+                .iter()
+                .all(|e| e.prompt_tokens == 5 && e.completion_tokens == 11),
+            "panel usage must carry the panel call's own tokens"
+        );
+        assert_eq!(judge_events[0].prompt_tokens, 30);
+        assert_eq!(judge_events[0].completion_tokens, 7);
+    }
+
+    /// A panel that can't reach `min_responses` (one member 503s, min=2 on a
+    /// 2-member panel) surfaces as a 502 to the client — the executor's
+    /// `InsufficientPanel` maps to an upstream-fault status.
+    #[tokio::test]
+    async fn ensemble_insufficient_panel_returns_502() {
+        let upstream = MockServer::start().await;
+        // The failing panel member (distinct upstream model name) → 503.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains(
+                "panel-fail-upstream",
+            ))
+            .respond_with(ResponseTemplate::new(503).set_body_json(serde_json::json!({
+                "error": {"message": "upstream busy", "type": "server_error"}
+            })))
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        // Everything else (the surviving panel member) → 200. The judge is
+        // never reached because min_responses isn't met.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-ok-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "only survivor"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(direct_model_entry(
+            "m-panel-ok",
+            "panel-ok",
+            "panel-ok-upstream",
+        ));
+        snap.models.insert(direct_model_entry(
+            "m-panel-fail",
+            "panel-fail",
+            "panel-fail-upstream",
+        ));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry_min(
+            "m-council",
+            "council",
+            &["panel-ok", "panel-fail"],
+            "judge-m",
+            2,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5948,9 +5948,12 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
 
     /// A panel that can't reach `min_responses` (one member 503s, min=2 on a
     /// 2-member panel) surfaces as a 502 to the client — the executor's
-    /// `InsufficientPanel` maps to an upstream-fault status.
+    /// `InsufficientPanel` maps to an upstream-fault status. The SURVIVING
+    /// member already hit upstream and was billed, so its usage event must
+    /// still fire (FIX C — billed panel work is not lost on the 502 path).
     #[tokio::test]
     async fn ensemble_insufficient_panel_returns_502() {
+        use aisix_obs::UsageSink;
         let upstream = MockServer::start().await;
         // The failing panel member (distinct upstream model name) → 503.
         Mock::given(method("POST"))
@@ -6006,7 +6009,8 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             2,
         ));
         snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
-        let app = build_router(build_state(snap, hub));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_router(build_state(snap, hub).with_usage_sink(UsageSink::new(tx)));
 
         let body = serde_json::json!({
             "model": "council",
@@ -6021,5 +6025,411 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+        // The surviving panel member's usage event must still fire (FIX C):
+        // it hit upstream and was billed even though the request 502'd. The
+        // failed member and the never-run judge emit nothing here.
+        let mut events = Vec::new();
+        while let Ok(Some(ev)) =
+            tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await
+        {
+            events.push(ev);
+        }
+        let panel_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.attempt_kind == "panel")
+            .collect();
+        assert_eq!(
+            panel_events.len(),
+            1,
+            "exactly the one surviving panel member must emit a usage event; got {} events total",
+            events.len()
+        );
+        assert_eq!(panel_events[0].prompt_tokens, 5);
+        assert_eq!(panel_events[0].completion_tokens, 11);
+        assert!(
+            !panel_events[0].guardrail_blocked,
+            "the survivor's event is a normal (non-blocked) bill"
+        );
+        assert!(
+            events.iter().all(|e| e.attempt_kind != "judge"),
+            "the judge never ran, so no judge usage event"
+        );
+    }
+
+    /// Mount the standard panel + judge upstreams (judge matched by its
+    /// "Answer 1:" synthesis prompt; everything else is a panel member).
+    async fn mount_panel_and_judge(upstream: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-judge",
+                "model": "judge-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "synthesized final answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 30, "completion_tokens": 7, "total_tokens": 37}
+            })))
+            .with_priority(1)
+            .mount(upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(upstream)
+            .await;
+    }
+
+    /// Seed a 2-member council (panel-a, panel-b → judge-m) + the api key.
+    fn seed_two_member_council(snap: &AisixSnapshot) {
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-panel-b", "panel-b", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a", "panel-b"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+    }
+
+    /// FIX D: an empty `tools: []` (which many SDKs always send) means "no
+    /// tools" and must still fan out — NOT a 400.
+    #[tokio::test]
+    async fn ensemble_allows_empty_tools_array() {
+        let upstream = MockServer::start().await;
+        mount_panel_and_judge(&upstream).await;
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        seed_two_member_council(&snap);
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": []
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "empty tools:[] must fan out, not 400"
+        );
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
+        assert_eq!(
+            v["choices"][0]["message"]["content"],
+            "synthesized final answer"
+        );
+    }
+
+    /// FIX D: `tool_choice: "none"` does not force a tool call, so it must
+    /// still fan out.
+    #[tokio::test]
+    async fn ensemble_allows_tool_choice_none() {
+        let upstream = MockServer::start().await;
+        mount_panel_and_judge(&upstream).await;
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        seed_two_member_council(&snap);
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": "none"
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "tool_choice:\"none\" must fan out, not 400"
+        );
+    }
+
+    /// FIX D: a forcing `tool_choice` (object form selecting a function) still
+    /// 400s — the ensemble can't honour a forced tool call.
+    #[tokio::test]
+    async fn ensemble_rejects_forcing_tool_choice_with_400() {
+        let upstream = MockServer::start().await;
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        seed_two_member_council(&snap);
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 4096).await.unwrap()).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+    }
+
+    /// FIX A leak probe: a misconfigured JUDGE (its `provider_key_id` points
+    /// at a non-existent PK) surfaces an error to the client, but the
+    /// envelope `error.message` must contain NEITHER the judge display_name
+    /// NOR the dangling pk id — both are operator-internal config.
+    #[tokio::test]
+    async fn ensemble_misconfigured_judge_does_not_leak_internal_config() {
+        let upstream = MockServer::start().await;
+        // Panel members succeed so the run reaches the judge.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-panel-b", "panel-b", "panel-upstream"));
+        // The judge references a provider_key_id that is NOT in the snapshot.
+        let secret_judge_name = "secret-judge-name";
+        let dangling_pk = "99999999-9999-9999-9999-999999999999";
+        let judge_cfg = format!(
+            r#"{{"display_name":"{secret_judge_name}","provider":"openai","model_name":"judge-upstream","provider_key_id":"{dangling_pk}"}}"#
+        );
+        let judge_model: Model = serde_json::from_str(&judge_cfg).unwrap();
+        snap.models
+            .insert(ResourceEntry::new("m-judge-bad", judge_model, 1));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a", "panel-b"],
+            secret_judge_name,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        // The judge can't be dispatched → an error reaches the client.
+        assert!(
+            resp.status().is_client_error() || resp.status().is_server_error(),
+            "misconfigured judge must surface an error; got {}",
+            resp.status()
+        );
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 4096).await.unwrap()).unwrap();
+        let message = v["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            !message.contains(secret_judge_name),
+            "envelope must not leak the judge display_name; got: {message:?}"
+        );
+        assert!(
+            !message.contains(dangling_pk),
+            "envelope must not leak the provider_key_id; got: {message:?}"
+        );
+    }
+
+    /// FIX E: a non-chat endpoint must reject an ensemble model with an
+    /// explicit, accurate message (not the misleading "routing models"
+    /// branch). /v1/embeddings is the probe.
+    #[tokio::test]
+    async fn ensemble_model_on_embeddings_returns_400_with_explicit_message() {
+        let upstream = MockServer::start().await;
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "input": "embed me"
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/embeddings")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 4096).await.unwrap()).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        let message = v["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            message.contains("ensemble model") && message.contains("/v1/chat/completions"),
+            "non-chat endpoint must name the ensemble + chat-only constraint; got: {message:?}"
+        );
+        // Must NOT mislead by calling it a routing model.
+        assert!(
+            !message.contains("routing"),
+            "ensemble rejection must not say 'routing'; got: {message:?}"
+        );
+    }
+
+    /// FIX G: the full panel succeeds and is billed, then the judge upstream
+    /// 500s. The client gets a 502 (judge 5xx collapses), and the panel
+    /// members' usage events must STILL fire (they hit upstream) — with zero
+    /// judge events, since the judge produced no response.
+    #[tokio::test]
+    async fn ensemble_judge_failure_still_bills_panel() {
+        use aisix_obs::UsageSink;
+        let upstream = MockServer::start().await;
+        // Judge synthesis call (matched by its "Answer 1:" prompt) → 500.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "error": {"message": "judge upstream exploded", "type": "server_error"}
+            })))
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        // Panel members → 200 (catch-all). Both survive, so min_responses is
+        // met and the run proceeds to the (failing) judge.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        seed_two_member_council(&snap);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_router(build_state(snap, hub).with_usage_sink(UsageSink::new(tx)));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        // Judge 5xx collapses to 502 for the client.
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+        // Both panel members already hit upstream and were billed, so their
+        // usage events must still fire (FIX G). The judge produced no
+        // response → no judge event.
+        let mut events = Vec::new();
+        while let Ok(Some(ev)) =
+            tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await
+        {
+            events.push(ev);
+        }
+        let panel_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.attempt_kind == "panel")
+            .collect();
+        assert_eq!(
+            panel_events.len(),
+            2,
+            "both billed panel members must emit a usage event; got {} events total",
+            events.len()
+        );
+        assert!(
+            panel_events
+                .iter()
+                .all(|e| e.prompt_tokens == 5 && e.completion_tokens == 11),
+            "panel events must carry the panel call's own tokens"
+        );
+        assert!(
+            panel_events.iter().all(|e| !e.guardrail_blocked),
+            "the judge-failure panel bill is not a guardrail block"
+        );
+        assert!(
+            events.iter().all(|e| e.attempt_kind != "judge"),
+            "the judge produced no response, so no judge usage event"
+        );
     }
 }

--- a/schemas/resources/ensemble.schema.json
+++ b/schemas/resources/ensemble.schema.json
@@ -26,7 +26,7 @@
       }
     },
     "timeout_ms": {
-      "description": "End-to-end budget in ms for the whole panel fan-out. `0` or absent = no ensemble-level deadline. Each panel member is still bound by its own model `timeout`.",
+      "description": "Per-call upstream deadline applied to each panel member and the judge call (in addition to each member model's own `timeout`). `0` or absent = no ensemble-level per-call deadline.",
       "type": [
         "integer",
         "null"

--- a/schemas/resources/ensemble.schema.json
+++ b/schemas/resources/ensemble.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "EnsembleConfig",
+  "type": "object",
+  "required": [
+    "judge",
+    "panel"
+  ],
+  "properties": {
+    "judge": {
+      "$ref": "#/definitions/Judge"
+    },
+    "min_responses": {
+      "description": "Minimum successful panel responses required to proceed to synthesis. Absent = `min(DEFAULT_MIN_RESPONSES, panel.len())`. A value larger than the panel is clamped to the panel size.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "panel": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PanelMember"
+      }
+    },
+    "timeout_ms": {
+      "description": "End-to-end budget in ms for the whole panel fan-out. `0` or absent = no ensemble-level deadline. Each panel member is still bound by its own model `timeout`.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Judge": {
+      "description": "The judge model that synthesizes the panel responses into one answer. `model` references another `Model.display_name` (must be a direct model).",
+      "type": "object",
+      "required": [
+        "model"
+      ],
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "synthesis_prompt": {
+          "description": "Optional override for the built-in synthesis prompt template. Absent = use the default template.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "PanelMember": {
+      "description": "One member of an ensemble panel. `model` references another `Model.display_name` in the snapshot (must be a direct model).",
+      "type": "object",
+      "required": [
+        "model"
+      ],
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "seed": {
+          "description": "Optional sampling seed for THIS member's call — pairs with `temperature` for reproducible diversity. Absent = no seed override.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "temperature": {
+          "description": "Sampling temperature for THIS member's call. Overrides the request's `temperature`, so a panel of the same model repeated N times still produces diverse answers (self-ensemble). Absent = leave the request's temperature unchanged.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
+        },
+        "weight": {
+          "description": "Reserved for the future voting/quorum strategy; ignored by the v1 synthesis path. Carried on the wire now so enabling voting later does not require a wire-format change.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -53,6 +53,17 @@
       "description": "Operator-facing unique label. Surfaces on `/v1/models`, `req.model` on chat completions, ApiKey.allowed_models, and the dashboard model list. `Resource::name()` returns this.",
       "type": "string"
     },
+    "ensemble": {
+      "description": "Ensemble config. When set, the proxy fans the request out to every panel member concurrently and synthesizes their responses via the judge model, instead of dispatching a single upstream. Mutually exclusive with `provider`/`model_name`/`provider_key_id` and `routing` (enforced by the runtime schema in `super::schema`).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnsembleConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "model_name": {
       "description": "Upstream model id sent to the provider — the literal string the upstream LLM API expects in its `model` field (e.g. `\"gpt-4o\"`, `\"claude-sonnet-4-5\"`, `\"gpt-4o-mini-2024-08-06\"`). `None` for routing models.\n\n**NOTE — this field name is a known footgun.** Some other proxy gateways define a `model_name` field that holds the *customer-facing alias* (the name a client SDK sends), with a separate `model` sub-field holding the upstream id. In this codebase the convention is reversed: `display_name` (above) is the customer-facing alias, and **`model_name` is the upstream id**. When reading or writing this struct, do not assume the field name alone disambiguates the role — read the docs.\n\nRenaming this field to `upstream_id` to remove the ambiguity is tracked at api7/AISIX-Cloud#470 but deferred behind a coordinated wire-format change across cp-api + dashboard.",
       "type": [
@@ -229,6 +240,63 @@
       },
       "additionalProperties": false
     },
+    "EnsembleConfig": {
+      "type": "object",
+      "required": [
+        "judge",
+        "panel"
+      ],
+      "properties": {
+        "judge": {
+          "$ref": "#/definitions/Judge"
+        },
+        "min_responses": {
+          "description": "Minimum successful panel responses required to proceed to synthesis. Absent = `min(DEFAULT_MIN_RESPONSES, panel.len())`. A value larger than the panel is clamped to the panel size.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "panel": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PanelMember"
+          }
+        },
+        "timeout_ms": {
+          "description": "End-to-end budget in ms for the whole panel fan-out. `0` or absent = no ensemble-level deadline. Each panel member is still bound by its own model `timeout`.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Judge": {
+      "description": "The judge model that synthesizes the panel responses into one answer. `model` references another `Model.display_name` (must be a direct model).",
+      "type": "object",
+      "required": [
+        "model"
+      ],
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "synthesis_prompt": {
+          "description": "Optional override for the built-in synthesis prompt template. Absent = use the default template.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "ModelCost": {
       "description": "Per-token cost for budget tracking. Both values are in USD per 1,000 tokens.",
       "type": "object",
@@ -268,6 +336,45 @@
           ]
         }
       ]
+    },
+    "PanelMember": {
+      "description": "One member of an ensemble panel. `model` references another `Model.display_name` in the snapshot (must be a direct model).",
+      "type": "object",
+      "required": [
+        "model"
+      ],
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "seed": {
+          "description": "Optional sampling seed for THIS member's call — pairs with `temperature` for reproducible diversity. Absent = no seed override.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "temperature": {
+          "description": "Sampling temperature for THIS member's call. Overrides the request's `temperature`, so a panel of the same model repeated N times still produces diverse answers (self-ensemble). Absent = leave the request's temperature unchanged.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
+        },
+        "weight": {
+          "description": "Reserved for the future voting/quorum strategy; ignored by the v1 synthesis path. Carried on the wire now so enabling voting later does not require a wire-format change.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
     },
     "RateLimit": {
       "type": "object",

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -266,7 +266,7 @@
           }
         },
         "timeout_ms": {
-          "description": "End-to-end budget in ms for the whole panel fan-out. `0` or absent = no ensemble-level deadline. Each panel member is still bound by its own model `timeout`.",
+          "description": "Per-call upstream deadline applied to each panel member and the judge call (in addition to each member model's own `timeout`). `0` or absent = no ensemble-level per-call deadline.",
           "type": [
             "integer",
             "null"


### PR DESCRIPTION
## Summary

First slice of the **ensemble** virtual-model feature (DP side, tracked in #601; CP umbrella api7/AISIX-Cloud#804). An `ensemble` model fans one `/v1/chat/completions` request out to a **panel** of N upstream models in parallel, then a **judge** model synthesizes a single answer. It extends the existing virtual-model machinery: `routing` picks **one** target; `ensemble` calls **all** and synthesizes.

This PR lands the **config layer** and the **non-streaming dispatch**. Streaming, per-target rate-limiting, and hardening are separate follow-ups (see Deferred) — so this does **not** close #601.

## What's in this PR

**`1a89a6e` — config layer (new `ensemble` model kind)**
- `EnsembleConfig { panel: [{model, temperature?, seed?, weight?}], judge: {model, synthesis_prompt?}, min_responses?, timeout_ms? }` in `aisix-core`.
- `Model.ensemble` + `Model::is_ensemble()` (DP convention: virtual-model kind = presence of the block, same as `routing`).
- Both DP schemas updated in lockstep so an ensemble row is never silently dropped on the kine watch path: the schemars-generated `schemas/resources/model.schema.json` (+ a standalone `ensemble.schema.json`) and the hand-written runtime validator `models/schema.rs::model_schema()`, whose `oneOf` is now a 3-way XOR (`direct | routing | ensemble`).

**`8375c85` — non-streaming fan-out dispatch**
- `ensemble.rs`: pure executor `run_ensemble` (parallel `join_all` fan-out, `min_responses` gate, per-member `temperature`/`seed` override for self-ensemble diversity, judge synthesis with neutral `Answer 1..N` labels + per-candidate truncation, judge retry-once-on-transient), plus the production `ProxyModelCaller` that resolves each member → ProviderKey → Bridge via the existing routing helpers.
- `chat.rs::dispatch_ensemble`: branches at the post-rate-limit-reservation seam; rejects `tools`/`tool_choice` and `stream:true` with 400; runs the output guardrail on the synthesized answer; commits the aggregate panel+judge tokens once against the single entry-level reservation; emits **one usage event per sub-call** (`attempt_kind` = `panel`/`judge`, sharing `request_id`) **before** the guardrail check so a blocked response still bills the full fan-out; suppresses the entry-level usage event (no double-emit).
- The client sees the ensemble's own model name; panel/judge model names never reach the client (synthesized answer, `response.model`, or error messages).

## Behavior / contract

- Config-driven: the operator curates the panel + judge; clients just call the model name. No per-request panel override.
- Self-ensemble works with a single provider key (panel = the same model with per-member temperature).
- v1 scope: chat-only; no server-side web retrieval; `tools`/streaming rejected (see Deferred).

## Deferred (separate PRs, tracked in #601)

- **Streaming** — `stream:true` is 400-rejected here; there is no single-`ChatResponse`→SSE path today, so it's net-new.
- **Per-target rate-limiting** — today only the entry model is debited; per-panel-member reservation is net-new (avoids N× provider-quota amplification).
- **Hardening** — the response cache key must include the ensemble config; misc edges.
- **[CP] api7/AISIX-Cloud#804** — schema/projection/dashboard so operators can create ensemble models; the dashboard must also learn the new `attempt_kind` values `panel`/`judge` (free-string on the wire — won't break ingestion).

## Independent audit (merge-gate)

An independent cold-review agent audited this change. It confirmed: no double-emit / double-commit; authorization consistent with routing (panel/judge are internal targets — no escalation beyond what routing already allows); sound snapshot lifetimes across the fan-out; model names not leaked to the client response body. It caught and we fixed:

- **HIGH** — on an output-guardrail *block*, the per-sub-call usage events were skipped while the panel tokens were already committed → cp-api under-reported a blocked-but-billed request. Fixed (emit before the guardrail check on both paths; `charge: None` on block) and locked with `ensemble_output_block_still_emits_panel_and_judge_usage`.
- **LOW** — a misconfigured judge's model name leaked into the client-visible `error.message` → redacted (detail kept in server logs).
- **LOW** — `timeout_ms` doc/behavior mismatch → behavior made uniform (now also applies to the judge call) + doc corrected.

## Test plan

- `cargo test -p aisix-core` — **259 pass** (config types, runtime-validator 3-way XOR, schema round-trip; e.g. `model_ensemble_with_direct_fields_fails`, `model_ensemble_with_routing_fails`).
- `cargo test -p aisix-proxy` — **433 pass**: 8 executor unit tests + 5 handler e2e through a real `OpenAiBridge` against wiremock:
  - `ensemble_fans_out_to_panel_and_returns_judge_synthesis` (judge answer returned, `model == "council"`, no upstream-id leak)
  - `ensemble_rejects_tool_requests_with_400`, `ensemble_rejects_streaming_with_400`
  - `ensemble_insufficient_panel_returns_502`
  - `ensemble_output_block_still_emits_panel_and_judge_usage` (HIGH regression lock — asserts 2 panel + 1 judge usage events still fire on a block)
- `cargo clippy --all-targets -- -D warnings` — clean; full workspace builds.
- [ ] CP-side e2e (create an ensemble model via the dashboard → call it end-to-end) lands with api7/AISIX-Cloud#804.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added ensemble model support for chat completions, running multiple panel models in parallel and using a designated judge model to synthesize the final response.
* Supports per-panel sampling overrides plus configurable minimum successful responses and optional per-member timeouts.
* Enforces ensemble-only behavior in chat completions, with validation for streaming/tool fields and improved error handling.

## Bug Fixes
* Ensured schema generation and validation include the new ensemble configuration, with strict JSON field rejection and correct canonical schema outputs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->