### PR TITLE
feat: stream ensemble judge synthesis

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1899,15 +1899,6 @@ async fn dispatch_ensemble<'a>(
             "ensemble models do not support tools".into(),
         )));
     }
-    // TODO(PR3): ensemble streaming. There is no single-ChatResponse→SSE
-    // helper today, and streaming the judge's synthesized answer is a
-    // separate piece of work; reject streaming requests for now.
-    if req.is_streaming() {
-        return Err(with_model(ProxyError::InvalidRequest(
-            "streaming is not supported for ensemble models".into(),
-        )));
-    }
-
     // `is_ensemble()` is the branch guard, so `ensemble` is always Some
     // here; surface a 400 rather than panic if a future refactor breaks
     // that invariant.
@@ -1974,6 +1965,332 @@ async fn dispatch_ensemble<'a>(
         snapshot,
         request_id,
     };
+
+    // Streaming ensemble (OPTION A): the panel must be buffered to synthesize,
+    // so phases 1-2 run NON-streaming; only the judge's tokens are streamed,
+    // by reusing `build_sse_stream` exactly as the single-upstream path does.
+    //
+    // TODO(follow-up): keep the socket warm during the panel phase. The panel
+    // fan-out runs BEFORE the `Sse` is constructed, so it is not covered by the
+    // 15s keep-alive below. This is no worse than the non-streaming ensemble
+    // path, which likewise holds the socket bytes-free across panel + judge;
+    // warming it would need an early SSE handshake before the panel completes.
+    if req.is_streaming() {
+        // Commit + emit the already-billed panel survivors, then fail. Shared
+        // by both streaming error exits (panel exhausted, or judge connect
+        // failed): in either case every surviving panel member round-tripped
+        // an upstream and must be billed, exactly like the non-streaming error
+        // paths. `charge: None` — the per-member events already carry the bill.
+        let bill_panel_and_fail =
+            |panel: Vec<crate::ensemble::PanelOutcome>,
+             reservation: aisix_ratelimit::MultiReservation<'a, aisix_ratelimit::SystemClock>,
+             proxy_err: ProxyError|
+             -> DispatchFailure {
+                let survivor_total: u64 =
+                    panel.iter().map(|p| u64::from(p.usage.total_tokens)).sum();
+                reservation.commit_tokens(survivor_total);
+                for (index, member) in panel.iter().enumerate() {
+                    emit_panel_member(
+                        member, index, /* blocked */ false, /* bypass */ "",
+                    );
+                }
+                DispatchFailure::new(Some(model_id.to_string()), None, proxy_err)
+            };
+
+        // Phases 1-2 + judge-request construction. An exhausted panel bills
+        // the survivors and returns 502 (same status mapping as the
+        // non-streaming `InsufficientPanel` path).
+        let (panel, _candidates, mut judge_req) =
+            match crate::ensemble::run_ensemble_panel(req, ensemble_cfg, &caller).await {
+                Ok(triple) => triple,
+                Err(crate::ensemble::EnsembleError::InsufficientPanel { panel, .. }) => {
+                    return Err(bill_panel_and_fail(
+                        panel,
+                        reservation,
+                        ProxyError::Bridge(BridgeError::upstream_status(
+                            502,
+                            "ensemble panel did not reach the required number of responses",
+                        )),
+                    ));
+                }
+                // `run_ensemble_panel` never returns `Judge` (it stops before
+                // the judge call), but the enum is non-exhaustive to us here.
+                Err(crate::ensemble::EnsembleError::Judge { panel, source }) => {
+                    return Err(bill_panel_and_fail(
+                        panel,
+                        reservation,
+                        ProxyError::Bridge(source),
+                    ));
+                }
+            };
+
+        // Stream the judge's synthesized answer. Flip the judge request to
+        // streaming (the executor built it non-streaming for the buffered
+        // path) and resolve its bridge exactly as `ProxyModelCaller::call`
+        // does for the non-streaming judge.
+        judge_req.stream = Some(true);
+        // Resolve the judge model from the snapshot. Effectively unreachable
+        // (the panel calls already resolved member names against the same
+        // snapshot, and the judge is required config), but stay total: bill the
+        // panel + fail rather than panic if the entry vanished mid-request.
+        let Some(judge_entry) = snapshot.models.get_by_name(&ensemble_cfg.judge.model) else {
+            return Err(bill_panel_and_fail(
+                panel,
+                reservation,
+                ProxyError::Bridge(BridgeError::InvalidUpstreamConfig(
+                    "ensemble judge references an unknown model".into(),
+                )),
+            ));
+        };
+        let judge_model = &judge_entry.value;
+        let judge_pk = match crate::dispatch::resolve_provider_key(snapshot, judge_model) {
+            Ok(pk) => pk,
+            Err(e) => {
+                tracing::warn!(error = %e, "ensemble judge provider key unresolved");
+                return Err(bill_panel_and_fail(
+                    panel,
+                    reservation,
+                    ProxyError::Bridge(BridgeError::InvalidUpstreamConfig(
+                        "ensemble judge has an unresolved provider key".into(),
+                    )),
+                ));
+            }
+        };
+        let Some(judge_bridge) = crate::dispatch::resolve_bridge(&state.hub, &judge_pk.value)
+        else {
+            return Err(bill_panel_and_fail(
+                panel,
+                reservation,
+                ProxyError::Bridge(BridgeError::Config(
+                    "ensemble judge has no registered bridge".into(),
+                )),
+            ));
+        };
+        let mut judge_ctx = BridgeContext::new(
+            request_id,
+            Arc::new(judge_model.clone()),
+            Arc::new(judge_pk.value.clone()),
+        );
+        if let Some(deadline) = judge_model.request_timeout() {
+            judge_ctx = judge_ctx.with_deadline(deadline);
+        }
+
+        let judge_stream = match judge_bridge.chat_stream(&judge_req, &judge_ctx).await {
+            Ok(s) => s,
+            // Judge connect failed AFTER the panel round-tripped: bill the
+            // panel (same invariant as the non-streaming judge-failure path),
+            // then surface the bridge error (5xx → 502, 4xx preserved).
+            Err(be) => {
+                return Err(bill_panel_and_fail(
+                    panel,
+                    reservation,
+                    ProxyError::Bridge(be),
+                ));
+            }
+        };
+
+        // Pre-resolve every owned value the `'static` on_complete needs. It
+        // CANNOT borrow `state`/`snapshot`/`req`/`client` (the closure outlives
+        // this frame — it fires on stream drop), so the `emit_panel_member` /
+        // `resolve_sub` borrowing closures above are unusable inside it. Clone
+        // the per-member + judge telemetry inputs up front.
+        struct PanelTelem {
+            model_id: String,
+            provider_key_id: String,
+            attempt_model: String,
+            usage: aisix_gateway::chat::UsageStats,
+        }
+        let panel_telem: Vec<PanelTelem> = panel
+            .iter()
+            .map(|p| {
+                let (model_id, provider_key_id) = resolve_sub(&p.model);
+                PanelTelem {
+                    model_id,
+                    provider_key_id,
+                    attempt_model: p.model.clone(),
+                    usage: p.usage.clone(),
+                }
+            })
+            .collect();
+        let panel_total: u64 = panel.iter().map(|p| u64::from(p.usage.total_tokens)).sum();
+        let (judge_model_id, judge_provider_key_id) = resolve_sub(&ensemble_cfg.judge.model);
+        let judge_attempt_model = ensemble_cfg.judge.model.clone();
+        let judge_attempt_index = panel.len() as u32;
+
+        // Output guardrail context — built the same way as the single-upstream
+        // streaming path (skip entirely when the resolved chain is empty).
+        let stream_guardrail = if resolved_chain.is_empty() {
+            None
+        } else {
+            Some(StreamGuardrailContext {
+                chain: Arc::clone(resolved_chain),
+                model_name: req.model.clone(),
+            })
+        };
+        // #790: the client only receives the terminal usage-only chunk when it
+        // asked for `stream_options.include_usage`. Computed exactly as the
+        // single-upstream path does.
+        let client_requested_usage = req
+            .extra
+            .get("stream_options")
+            .and_then(|so| so.get("include_usage"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        // Content-capturing exporters: the ensemble streams the JUDGE answer,
+        // so content capture would mirror the single-upstream path. v1 keeps
+        // the ensemble content-free (matching the non-streaming ensemble path,
+        // which also passes `content: None`), so no per-chunk accumulation.
+        let content_cap: Option<u32> = None;
+
+        // Owned clones for the on_complete telemetry closure (mirrors the
+        // single-upstream path's capture block).
+        let state_for_telem = state.clone();
+        let request_id_for_telem = request_id.to_string();
+        let client_model_for_telem = req.model.clone();
+        let api_key_id_for_telem = api_key_id.to_string();
+        let applied_guardrails_for_telem = applied_guardrails.to_vec();
+        let client_for_telem = client.clone();
+        let bypass_for_telem = bypass_reason.clone().unwrap_or_default();
+
+        // Hold concurrency for the stream's full lifetime (#450). Snapshot the
+        // keys BEFORE consuming the reservation into the owned guard.
+        let post_stream_keys = reservation.keys();
+        let stream_concurrency_hold = reservation.into_stream_hold(Arc::clone(&state.limiter));
+        let limiter = Arc::clone(&state.limiter);
+
+        let sse_stream = build_sse_stream(
+            judge_stream,
+            created_ts,
+            stream_guardrail,
+            started,
+            // Re-stamp the client-facing ensemble model name (e.g. "council")
+            // onto every chunk — never the judge's upstream model id.
+            req.model.clone(),
+            content_cap,
+            client_requested_usage,
+            move |comp: StreamCompletion| {
+                // Rate-limit accounting: the panel tokens (already round-tripped)
+                // plus the streamed judge's final total, against every layer.
+                for key in &post_stream_keys {
+                    limiter.add_tokens_post_stream(key, panel_total + comp.total_tokens);
+                }
+                // Telemetry: one event per panel member (attempt_kind "panel",
+                // index 0..N) carrying that member's own buffered usage, then
+                // one judge event (attempt_kind "judge", index N) from the
+                // streamed `StreamCompletion`. All share `request_id`. This
+                // mirrors the non-streaming ensemble's per-sub-call emission,
+                // moved into on_complete because the judge counts only land on
+                // the terminal SSE chunk.
+                for (index, member) in panel_telem.iter().enumerate() {
+                    emit_usage_event(
+                        &state_for_telem,
+                        &request_id_for_telem,
+                        &member.model_id,
+                        &client_model_for_telem,
+                        &api_key_id_for_telem,
+                        200,
+                        started.elapsed(),
+                        member.usage.prompt_tokens,
+                        member.usage.completion_tokens,
+                        UsageExtras {
+                            cached_prompt_tokens: member.usage.cached_prompt_tokens,
+                            reasoning_tokens: member.usage.reasoning_tokens,
+                            cache_creation_tokens: member.usage.cache_creation_tokens,
+                            cache_read_tokens: member.usage.cache_read_tokens,
+                            bypass_reason: bypass_for_telem.clone(),
+                            cache_status: CacheStatus::Disabled.as_str().to_string(),
+                            attempt_index: index as u32,
+                            attempt_kind: "panel".to_string(),
+                            attempt_model: member.attempt_model.clone(),
+                            applied_guardrails: applied_guardrails_for_telem.clone(),
+                            provider_key_id: member.provider_key_id.clone(),
+                            ..UsageExtras::default()
+                        },
+                        /* cost_usd */ 0.0,
+                        comp.guardrail_blocked,
+                        &client_for_telem,
+                        /* content */ None,
+                    );
+                }
+                emit_usage_event(
+                    &state_for_telem,
+                    &request_id_for_telem,
+                    &judge_model_id,
+                    &client_model_for_telem,
+                    &api_key_id_for_telem,
+                    200,
+                    started.elapsed(),
+                    comp.prompt_tokens,
+                    comp.completion_tokens,
+                    UsageExtras {
+                        cached_prompt_tokens: comp.cached_prompt_tokens,
+                        reasoning_tokens: comp.reasoning_tokens,
+                        cache_creation_tokens: comp.cache_creation_tokens,
+                        cache_read_tokens: comp.cache_read_tokens,
+                        provider_request_id: comp.provider_request_id,
+                        provider_model_version: comp.provider_model_version,
+                        finish_reason: comp.finish_reason,
+                        bypass_reason: if !bypass_for_telem.is_empty() {
+                            bypass_for_telem.clone()
+                        } else {
+                            comp.bypass_reason
+                        },
+                        cache_status: CacheStatus::Disabled.as_str().to_string(),
+                        ttft_ms: comp.ttft_ms,
+                        attempt_index: judge_attempt_index,
+                        attempt_kind: "judge".to_string(),
+                        attempt_model: judge_attempt_model.clone(),
+                        applied_guardrails: applied_guardrails_for_telem.clone(),
+                        provider_key_id: judge_provider_key_id.clone(),
+                        ..UsageExtras::default()
+                    },
+                    /* cost_usd */ 0.0,
+                    comp.guardrail_blocked,
+                    &client_for_telem,
+                    /* content */ None,
+                );
+                // Release the concurrency permit(s) now the stream is done
+                // (or was cancelled) — on_complete fires on both paths (#450).
+                drop(stream_concurrency_hold);
+            },
+        );
+        let response =
+            Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
+        return Ok(Success {
+            response: response.into_response(),
+            // No single provider/model/key governs an ensemble response.
+            provider: "ensemble".to_string(),
+            model_id: model_id.to_string(),
+            // Token totals land on the SSE terminal chunk and are forwarded
+            // into telemetry from on_complete; the handler skips its own
+            // emission via `telemetry_handled_by_stream`.
+            prompt_tokens: None,
+            completion_tokens: None,
+            total_tokens: None,
+            cost_usd: 0.0,
+            cached_prompt_tokens: 0,
+            reasoning_tokens: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            provider_request_id: String::new(),
+            provider_model_version: String::new(),
+            provider_key_id: String::new(),
+            upstream_model: String::new(),
+            finish_reason: String::new(),
+            bypass_reason,
+            cache_status: CacheStatus::Disabled,
+            cache_hit_saved_input_tokens: 0,
+            cache_hit_saved_output_tokens: 0,
+            // Per-sub-call usage is emitted from on_complete; suppress the
+            // handler's own entry-level emission.
+            telemetry_handled_by_stream: true,
+            // Not a routing request — no `x-aisix-served-by` header.
+            served_by_target: None,
+            routing: RoutingTelemetry::default(),
+            captured_content: None,
+        });
+    }
+
     let outcome = match crate::ensemble::run_ensemble(req, ensemble_cfg, &caller).await {
         Ok(outcome) => outcome,
         Err(err) => {

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -190,13 +190,27 @@ impl EnsembleError {
     }
 }
 
-/// Run one ensemble request to completion. See the module docs for the
-/// three phases.
-pub async fn run_ensemble(
+/// Run only the panel phase of an ensemble request: fan out to every
+/// panel member concurrently (phase 1), enforce `min_responses` (phase 2),
+/// and build the judge's synthesis request from the labeled candidates.
+/// The judge itself is NOT called — that is left to the caller so the
+/// streaming dispatch path can stream the judge's tokens while the
+/// non-streaming path ([`run_ensemble`]) buffers them.
+///
+/// Returns the per-member accounting (`panel`), the raw candidate
+/// responses (`candidates`, kept so the caller can re-derive context if
+/// needed), and the ready-to-dispatch `judge_req`. The returned
+/// `judge_req` is non-streaming (`stream = Some(false)`); a streaming
+/// caller flips it to `Some(true)` before dispatching.
+///
+/// An exhausted panel returns [`EnsembleError::InsufficientPanel`] with
+/// the already-billed survivors, exactly as before — the dispatch layer
+/// must still commit + emit their usage.
+pub(crate) async fn run_ensemble_panel(
     req: &ChatFormat,
     config: &EnsembleConfig,
     caller: &dyn ModelCaller,
-) -> Result<EnsembleOutcome, EnsembleError> {
+) -> Result<(Vec<PanelOutcome>, Vec<ChatResponse>, ChatFormat), EnsembleError> {
     let per_call_timeout = config.timeout();
 
     // Phase 1: fan out to every panel member concurrently.
@@ -239,16 +253,30 @@ pub async fn run_ensemble(
         });
     }
 
+    // Build the judge's synthesis request from the labeled candidates.
+    let judge_req = judge_request(req, &config.judge, &candidates);
+    Ok((panel, candidates, judge_req))
+}
+
+/// Run one ensemble request to completion. See the module docs for the
+/// three phases.
+pub async fn run_ensemble(
+    req: &ChatFormat,
+    config: &EnsembleConfig,
+    caller: &dyn ModelCaller,
+) -> Result<EnsembleOutcome, EnsembleError> {
+    // Phases 1-2 + judge-request construction.
+    let (panel, _candidates, judge_req) = run_ensemble_panel(req, config, caller).await?;
+
     // Phase 3: synthesize via the judge, retrying once on a transient error.
     // The judge call gets the same per-call timeout as each panel member
     // (`config.timeout()`), so the ensemble-level deadline applies uniformly
     // across the whole fan-out.
-    let judge_req = judge_request(req, &config.judge, &candidates);
     let response = match call_judge_with_retry(
         caller,
         &config.judge.model,
         &judge_req,
-        per_call_timeout,
+        config.timeout(),
     )
     .await
     {

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5744,11 +5744,53 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         assert_eq!(v["error"]["type"], "invalid_request_error");
     }
 
-    /// Streaming is not supported for ensemble models yet (separate PR);
-    /// the request must be rejected with a 400, not silently downgraded.
+    /// Streaming ensemble (OPTION A): the panel runs non-streaming (buffered
+    /// to synthesize) and ONLY the judge's tokens are streamed back as SSE.
+    /// The client must receive the judge's synthesized content + a `[DONE]`
+    /// sentinel, every chunk re-stamped under the requested ensemble model
+    /// name ("council") — never an upstream id. Telemetry must emit one event
+    /// per panel member + one judge event, all sharing the same request_id.
     #[tokio::test]
-    async fn ensemble_rejects_streaming_with_400() {
+    async fn ensemble_streams_judge_synthesis() {
+        use aisix_obs::UsageSink;
         let upstream = MockServer::start().await;
+        // Judge synthesis call (matched by its "Answer 1:" prompt) streams its
+        // answer back as SSE — this is the leg the gateway now streams to the
+        // client. The terminal chunk carries the judge's usage block.
+        let judge_sse = "\
+data: {\"id\":\"cmpl-judge\",\"model\":\"judge-upstream\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-judge\",\"model\":\"judge-upstream\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"synthesized final answer\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-judge\",\"model\":\"judge-upstream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":30,\"completion_tokens\":7,\"total_tokens\":37}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(judge_sse),
+            )
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        // Panel members — catch-all, NON-streaming JSON (the executor buffers
+        // these to build the judge prompt).
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
         let hub = Arc::new(Hub::new());
         hub.register_specialized("openai", Arc::new(openai_test_bridge()));
 
@@ -5756,15 +5798,149 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         snap.models
             .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
         snap.models
+            .insert(direct_model_entry("m-panel-b", "panel-b", "panel-upstream"));
+        snap.models
             .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
         snap.models.insert(ensemble_model_entry(
             "m-council",
             "council",
-            &["panel-a"],
+            &["panel-a", "panel-b"],
             "judge-m",
         ));
         snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
-        let app = build_router(build_state(snap, hub));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_router(build_state(snap, hub).with_usage_sink(UsageSink::new(tx)));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "what is the best answer?"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .contains("text/event-stream"));
+
+        // Drain + decode the SSE body. Assert the judge's content streamed
+        // through, a [DONE] sentinel terminates it, and every data chunk is
+        // re-stamped under "council" (no upstream id leakage).
+        let mut body_stream = resp.into_body().into_data_stream();
+        let mut decoder = SseDecoder::new();
+        let mut events = Vec::new();
+        while let Some(chunk) = body_stream.next().await {
+            events.extend(decoder.feed(chunk.unwrap().as_ref()));
+        }
+        assert!(events.contains(&SseEvent::Done), "missing [DONE] sentinel");
+        let data: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                SseEvent::Data(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        let joined = data.join("\n");
+        assert!(
+            joined.contains("synthesized final answer"),
+            "client must receive the judge's synthesized content; got: {joined}"
+        );
+        // Every chunk's `model` is the ensemble alias, never the judge upstream.
+        for d in &data {
+            let v: serde_json::Value = serde_json::from_str(d).unwrap();
+            assert_eq!(
+                v["model"], "council",
+                "streamed chunk must be re-stamped under the ensemble model name"
+            );
+            assert_ne!(v["model"], "judge-upstream");
+        }
+
+        // Telemetry (emitted from on_complete once the stream is drained):
+        // two panel events + one judge event, all sharing one request_id.
+        let mut usage = Vec::new();
+        while let Ok(Some(ev)) =
+            tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await
+        {
+            usage.push(ev);
+            if usage.len() == 3 {
+                break;
+            }
+        }
+        assert_eq!(
+            usage.len(),
+            3,
+            "expected 3 usage events (2 panel + 1 judge); got {}",
+            usage.len()
+        );
+        let panel_events: Vec<_> = usage.iter().filter(|e| e.attempt_kind == "panel").collect();
+        let judge_events: Vec<_> = usage.iter().filter(|e| e.attempt_kind == "judge").collect();
+        assert_eq!(panel_events.len(), 2, "both panel members must emit");
+        assert_eq!(judge_events.len(), 1, "the judge must emit one event");
+        let rid = usage[0].request_id.clone();
+        assert!(
+            !rid.is_empty() && usage.iter().all(|e| e.request_id == rid),
+            "all sub-call events share the request_id (trace key)"
+        );
+        // The judge event carries the streamed terminal-chunk usage.
+        assert_eq!(judge_events[0].prompt_tokens, 30);
+        assert_eq!(judge_events[0].completion_tokens, 7);
+    }
+
+    /// Streaming ensemble, judge connect failure: the panel members all
+    /// succeed (and are billed) but the judge upstream returns a hard error
+    /// on the streaming connect. The panel's usage events must STILL fire —
+    /// every panel member round-tripped an upstream, exactly like the
+    /// non-streaming judge-failure path.
+    #[tokio::test]
+    async fn ensemble_streaming_judge_connect_failure_still_bills_panel() {
+        use aisix_obs::UsageSink;
+        let upstream = MockServer::start().await;
+        // Judge synthesis call (matched by "Answer 1:") → 500 on connect. A
+        // non-2xx upstream status surfaces as a connect-time error from
+        // `chat_stream`, so the gateway never commits a 200 to the client.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "error": {"message": "judge upstream exploded", "type": "server_error"}
+            })))
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        // Panel members → 200 (catch-all). Both survive, so min_responses is
+        // met and the run proceeds to the (failing) judge connect.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        seed_two_member_council(&snap);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_router(build_state(snap, hub).with_usage_sink(UsageSink::new(tx)));
 
         let body = serde_json::json!({
             "model": "council",
@@ -5779,10 +5955,39 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             .body(Body::from(body.to_string()))
             .unwrap();
         let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-        let v: serde_json::Value =
-            serde_json::from_slice(&to_bytes(resp.into_body(), 4096).await.unwrap()).unwrap();
-        assert_eq!(v["error"]["type"], "invalid_request_error");
+        // Judge 5xx collapses to 502 for the client (connect failed before any
+        // SSE byte was committed).
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+        // Both panel members already hit upstream and were billed, so their
+        // usage events must still fire. The judge produced no response → no
+        // judge event.
+        let mut events = Vec::new();
+        while let Ok(Some(ev)) =
+            tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await
+        {
+            events.push(ev);
+        }
+        let panel_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.attempt_kind == "panel")
+            .collect();
+        assert_eq!(
+            panel_events.len(),
+            2,
+            "both billed panel members must emit a usage event; got {} events total",
+            events.len()
+        );
+        assert!(
+            panel_events
+                .iter()
+                .all(|e| e.prompt_tokens == 5 && e.completion_tokens == 11),
+            "panel events must carry the panel call's own tokens"
+        );
+        assert!(
+            events.iter().all(|e| e.attempt_kind != "judge"),
+            "the judge connect failed, so no judge usage event"
+        );
     }
 
     /// Like `ensemble_model_entry` but with an explicit `min_responses`.


### PR DESCRIPTION
## Summary

Adds streaming support for `ensemble` models (DP; follow-up to #604, tracked in #601). `stream:true` to an ensemble model now streams the judge's synthesized answer token-by-token, instead of the previous 400.

## Design: Option A — judge-leg streaming, shared builder reused unmodified

The panel must be buffered to synthesize, so phases 1-2 run non-streaming; only the **judge's** tokens stream. This reuses the existing `build_sse_stream` **unmodified** — all change is isolated to the ensemble dispatch branch; the shared SSE builder and the single-upstream streaming path are byte-for-byte untouched. (Safety property: a bug in the shared builder would hit *every* streaming request, so this PR deliberately doesn't touch it.)

**Deferred — panel-phase keep-alive.** The panel fan-out runs before the `Sse` is constructed, so the 15s SSE keep-alive doesn't cover it. This is **no worse than the already-merged non-streaming ensemble path**, which likewise holds the socket bytes-free across panel + judge; TTFB actually improves (judge-first-token vs full answer). True panel keep-alive needs an early SSE handshake before the panel completes — a self-contained follow-up kept out of this PR to avoid refactoring the shared builder. Marked with a `TODO`.

## What's in it

- **`ensemble.rs`**: split `run_ensemble` into `run_ensemble_panel` (phases 1-2 + `judge_request`) + the judge call, so the judge leg can be streamed. No behavior change to the non-streaming path (all existing executor + handler tests pass unchanged).
- **`chat.rs::dispatch_ensemble`** streaming arm: run the panel → resolve the judge bridge → `judge.chat_stream()` → feed it to `build_sse_stream` with an `on_complete` that emits one usage event per sub-call (panel + judge, `attempt_kind` `panel`/`judge`, sharing `request_id`) and commits the panel+judge tokens via `add_tokens_post_stream` (the streaming token-commit API). `telemetry_handled_by_stream: true` suppresses the entry-level emit — no double-emit.
- The **"successful panel members are always billed"** invariant now also covers the judge-connect-failure and judge-resolution-failure exits (the panel already round-tripped upstream).
- Client sees the ensemble model name on every chunk (re-stamped); judge model names never leak; judge-resolution errors are redacted to generic messages (detail to server logs).

## Test plan

- `cargo test -p aisix-core` — **259 pass**.
- `cargo test -p aisix-proxy` — **440 pass**, incl. 2 new e2e through real wiremock bridges:
  - `ensemble_streams_judge_synthesis` (replaces the now-obsolete `ensemble_rejects_streaming_with_400`): `stream:true` → SSE body contains the judge content + `[DONE]`, every chunk `model == "council"` (not the upstream id), and the usage sink shows 2 panel + 1 judge events sharing one `request_id`.
  - `ensemble_streaming_judge_connect_failure_still_bills_panel`: judge 500 on the streaming connect → 502, panel usage events still fire.
- `cargo clippy --all-targets -- -D warnings` clean; schema-drift gate clean.

An independent audit will follow (merge-gate); I'll post findings + resolutions before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ensemble models now support streaming API responses, enabling real-time output delivery.
  * Proper usage tracking and billing for streamed ensemble responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->