### PR TITLE
docs: document the shared-Redis cluster rate-limit backend

### DIFF
--- a/docs/architecture/two-phase-rate-limit.md
+++ b/docs/architecture/two-phase-rate-limit.md
@@ -100,14 +100,15 @@ key); reads of other keys touch independent `DashMap` shards.
 Every operation under the mutex is O(1) — increment, compare,
 release.
 
-This is deliberately in-process, not Redis. The cost of a
-network round-trip per rate-limit check is roughly the same as
-the upstream's TLS handshake; pushing it onto the hot path
-defeats the purpose of running an in-process gateway. The
-trade-off is documented in [What this design does not
-do](#what-this-design-does-not-do) — counters are per-DP, not
-fleet-wide, and multi-DP deployments lose cap precision
-proportional to the fleet size.
+This `DashMap` is the **default** (`ratelimit.backend: memory`)
+counter store: per-process, one in-memory mutex per key, no
+network on the hot path. It is exact on a single replica, but a
+multi-replica cluster running this backend counts per-replica —
+every cap is effectively multiplied by the replica count. An
+opt-in shared backend (`ratelimit.backend: redis`) eliminates
+that by moving the same counters into Redis; both are described
+in [Counter storage: local vs shared](#counter-storage-local-vs-shared)
+below.
 
 ## The fixed-window counter
 
@@ -412,25 +413,89 @@ math but never increments. A `peek` on a key that has never been
 seen returns `None`, and the handler omits all the headers in
 that case.
 
+## Counter storage: local vs shared
+
+The two-phase logic above is independent of *where* the counters
+live. That is a pluggable backend selected by the
+`ratelimit.backend` bootstrap field (api7/AISIX-Cloud#798):
+
+- **`memory`** (default) — the per-process `DashMap` of
+  `FixedWindowCounter`s described above. No network on the hot
+  path; exact on a single replica; **per-replica** on a cluster,
+  so each cap is effectively multiplied by the replica count.
+- **`redis`** — the same fixed-window math, but the counters
+  live in a shared Redis so every replica enforces **one global
+  window**. Enable it on any multi-replica deployment that needs
+  its configured caps to hold cluster-wide.
+
+Both implement one internal `RateStore` trait, so the proxy
+handlers, the `Reservation` lifecycle, and the wire surface are
+identical regardless of backend — only the storage changes.
+
+### How the Redis backend stays equivalent
+
+The Redis store mirrors `FixedWindowCounter` exactly so swapping
+`memory ↔ redis` does not change observable limits, only whether
+the count is shared:
+
+- **Windowed counters** (RPS/RPM/RPH/RPD, TPM/TPD) are plain
+  `INCR`/`GET` keys named
+  `aisix:rl:{<bucket>}:<dim>:<window_start>`, where
+  `window_start = now - now % window` — the same wall-clock
+  bucket boundary `roll_if_stale` uses — with an `EXPIRE` of the
+  window length plus a small grace. A new window is simply a new
+  key that auto-expires.
+- **Concurrency** is a ZSET (`member → score=now`) acting as a
+  crash-safe distributed semaphore: each acquire prunes entries
+  older than `concurrency_ttl_secs` before counting, so an
+  in-flight slot leaked by a crashed or hung replica is reclaimed
+  within that TTL rather than wedging the cap forever. (This is a
+  deliberate divergence from a plain window-TTL counter — a
+  streaming response can outlive a 60s window, the same reason
+  the [`StreamConcurrencyGuard`](#streaming-the-deferred-phase-2)
+  exists.)
+- **`now` comes from `redis.call('TIME')`** inside every Lua
+  script, so window boundaries are identical across replicas
+  regardless of host clock skew.
+- Per-bucket keys share a Redis Cluster hash tag (`{<bucket>}`)
+  so the per-bucket acquire stays a single atomic Lua call even
+  in Cluster mode.
+
+The acquire is one all-or-nothing Lua per bucket (concurrency
+gate + token check-only + request check-and-increment), which
+replaces the in-memory backend's RPM/RPD compensation dance with
+server-side atomicity.
+
+### Failing open
+
+If Redis becomes unreachable, the Redis store **fails open** to a
+per-process in-memory store (logged once) — requests keep flowing
+with per-replica enforcement during the outage rather than being
+blocked, and global enforcement resumes automatically when Redis
+recovers. This trades strict cluster-wide precision for
+availability during a Redis outage, matching the response cache's
+"Redis error → proceed" stance.
+
 ## Failure modes and observability
 
-### Counters drift on per-DP basis under multi-replica fan-out
+### Counters drift on per-DP basis under multi-replica fan-out (memory backend)
 
-The counters are in-process. A two-DP deployment with a `rpm =
-60` cap can in principle pass 120 requests in a minute if the
-load balancer round-robins. There is no shared store. This is
-the explicit trade-off for in-process latency.
+With the default `memory` backend the counters are in-process. A
+two-DP deployment with a `rpm = 60` cap can in principle pass 120
+requests in a minute if the load balancer round-robins, because
+each replica counts only what it served.
 
-Mitigations available today:
+Options:
+- **Switch to `ratelimit.backend: redis`** so the counters are
+  shared and the configured caps hold cluster-wide — the direct
+  fix, recommended for multi-replica deployments (see
+  [Counter storage](#counter-storage-local-vs-shared)).
 - **Stick to per-DP caps** that are 1/N of the desired global cap
-  when running with N DPs. This is operator policy, not
-  enforced by the gateway.
+  when running N DPs on the memory backend. This is operator
+  policy, not enforced by the gateway.
 - **Use the policy layer** to scope different caps at api_key /
   team / member granularity, which reduces the blast radius of
   the per-DP error.
-- **Future: distributed counter backend** is filed as a roadmap
-  item but is not on the v1 path; per-DP precision has been
-  sufficient for every workload we've seen.
 
 ### Counter eviction under churn
 
@@ -465,12 +530,15 @@ End-to-end isolation across callers is verified in
 
 ## What this design does not do
 
-- **No cross-replica coordination.** Each DP process owns its
-  own counters. Multi-DP deployments must either accept the
-  per-DP-multiplied effective cap or upstream the policy to a
-  shared store outside the proxy. There is no Redis dependency,
-  and adding one is a deliberate non-goal for the latency
-  budget.
+- **No cross-replica coordination on the default backend.** With
+  `ratelimit.backend: memory` (the default) each DP process owns
+  its own counters, so a multi-replica cluster gets a
+  per-DP-multiplied effective cap. Deployments that need
+  cluster-wide caps opt into `ratelimit.backend: redis`, which
+  shares the counters (see
+  [Counter storage](#counter-storage-local-vs-shared)); the
+  memory backend deliberately keeps Redis off the hot path for
+  the latency budget.
 - **No pre-flight token estimation.** Even with a local
   tokeniser, the upstream's count is the only one that matters
   for billing and for matching the provider's own rate limits.

--- a/docs/configuration/bootstrap-config.md
+++ b/docs/configuration/bootstrap-config.md
@@ -38,13 +38,14 @@ The current root config includes:
 - `admin`
 - `observability`
 - `cache`
+- `ratelimit`
 - `managed`
 - optional top-level `bedrock_endpoint_url`
 
 As a practical split:
 
 - `etcd`, `proxy`, and `admin` define how the process starts
-- `observability` and `cache` define process-wide runtime helpers
+- `observability`, `cache`, and `ratelimit` define process-wide runtime helpers
 - `managed` switches the bootstrap mode from standalone to control-plane-managed
 
 ## Minimal Self-Hosted Example
@@ -81,6 +82,9 @@ observability:
       addr: "0.0.0.0:9090"
 
 cache:
+  backend: "memory"
+
+ratelimit:
   backend: "memory"
 ```
 
@@ -208,6 +212,40 @@ Important fields:
 A cache policy that requests `backend: redis` on a process without `cache.redis` gets no caching for its requests (`cache_status = disabled`, one warning per policy in the gateway log) — never a silent fallback to memory.
 
 Use bootstrap cache settings to decide which cache backends the process has available. Use dynamic cache policies to decide which requests actually participate in caching, and on which backend.
+
+## `ratelimit`
+
+Use `ratelimit` to choose where rate-limit counters live. This is the difference between each replica counting on its own and the whole cluster sharing one counter.
+
+The `memory` backend (the default) keeps counters in the process. With a single replica this is exact, but with **N replicas behind a load balancer every limit is effectively multiplied by N** — each replica only counts the traffic it personally served, so a key capped at `rpm: 60` can pass up to `60 × N` per minute. The `redis` backend shares the counters across every replica through one Redis, so the cluster enforces **one global window** regardless of replica count. All dimensions are shared — requests, tokens, and concurrency.
+
+Important fields:
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `backend` | `memory` (per-process) or `redis` (shared across replicas). The selector — a `redis` block under `backend: memory` is ignored | `memory` |
+| `redis` | Redis connection block (`url`, optional `mode`); **required** when `backend: redis`, rejected at boot otherwise | none |
+| `concurrency_ttl_secs` | Redis backend only — seconds before an unreleased concurrency slot (crashed replica / hung upstream) is reclaimed. Must be `> 0` | `300` |
+
+```yaml title="Shared rate limiting for a multi-replica cluster"
+ratelimit:
+  backend: "redis"
+  redis:
+    url: "redis://127.0.0.1:6379"
+    mode: "single"   # single | cluster | sentinel
+  concurrency_ttl_secs: 300
+```
+
+Or via environment overrides on a containerized deployment:
+
+```bash
+export AISIX_RATELIMIT__BACKEND="redis"
+export AISIX_RATELIMIT__REDIS__URL="redis://my-redis:6379"
+```
+
+The rate-limit Redis may be the same instance used by `cache.redis` — counter keys are namespaced `aisix:rl:` and hash-tagged per bucket so they never collide with cache entries. If Redis becomes unreachable the limiter **fails open** to per-replica in-memory counting (logged once) so traffic keeps flowing; cluster-wide enforcement resumes automatically when Redis recovers.
+
+The *limits themselves* (`ApiKey.rate_limit`, `Model.rate_limit`, `RateLimitPolicy` rows) are unchanged dynamic resources — this section only changes where their counters are stored. See [Rate Limits](rate-limits.md) for the limit fields and policy scopes.
 
 ## `managed`
 

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -44,6 +44,23 @@ The legacy `cache.backend` knob no longer selects a single global cache; `backen
 
 `memory`-backed policies remain the simplest production baseline, making them the lowest-risk default for first rollout.
 
+## Rate-Limit Backend Choice
+
+Rate-limit counters default to per-process memory (`ratelimit.backend: memory`). On a **single replica** this is exact. On **multiple replicas behind a load balancer**, per-process counters mean every configured limit is effectively multiplied by the replica count — a key capped at `rpm: 60` can pass up to `60 × N` per minute across `N` replicas, because each replica only counts the traffic it served.
+
+For any multi-replica deployment where the configured caps must hold cluster-wide, set `ratelimit.backend: redis` and point every replica at the same Redis:
+
+```yaml title="Shared rate limiting"
+ratelimit:
+  backend: "redis"
+  redis:
+    url: "redis://my-redis:6379"
+```
+
+All dimensions (requests, tokens, concurrency) are then enforced against one shared counter. This may be the same Redis used for `cache.redis` (keys are namespaced). If Redis is unreachable the limiter fails open to per-replica counting so traffic keeps flowing. See [Bootstrap Configuration → `ratelimit`](../configuration/bootstrap-config.md) for the full field reference, and [Rate Limits](../configuration/rate-limits.md) for the limit fields themselves.
+
+Single-replica deployments can stay on `memory` — it is exact there and needs no extra infrastructure.
+
 ## Managed Versus Standalone
 
 In standalone mode:


### PR DESCRIPTION
Documentation for the cluster-level rate limiting shipped in #607 (issue api7/AISIX-Cloud#798). Docs-only — no code changes.

The feature added a pluggable rate-limit counter backend (`ratelimit.backend: memory | redis`); this PR makes it discoverable in the docs and corrects statements the change made stale.

## Changes

- **`docs/configuration/bootstrap-config.md`** — new `## ratelimit` section: what it does (per-process vs shared), the field table (`backend`, `redis`, `concurrency_ttl_secs`), a config + env-override example, and the same-Redis-as-cache / fail-open notes. Also listed `ratelimit` in *Root Sections* and the minimal example.
- **`docs/operations/production-deployment.md`** — new *Rate-Limit Backend Choice* section (mirroring *Cache Backend Choice*) steering multi-replica deployments to `backend: redis` so configured caps hold cluster-wide.
- **`docs/architecture/two-phase-rate-limit.md`** — new *Counter storage: local vs shared* section explaining the `RateStore` backends, the Redis key layout, `redis.call('TIME')` for cross-replica window consistency, the crash-safe ZSET concurrency semaphore, and fail-open. Corrected the previously-true-now-false claims ("no shared store", "There is no Redis dependency", "distributed counter backend ... not on the v1 path").

The `docs/configuration/rate-limits.md` "Counter Storage" section was already added with #607; this PR adds the config reference, operations guidance, and architecture detail around it.

## Notes

- Docs-only; no tests. The `data-plane/docs/**` tree has no build/lint step in CI, and the feature's behavior is already covered by the tests in #607.
- LiteLLM baseline rule does not apply (no behavior change — documentation only).