### PR TITLE
fix(ensemble): report panel+judge aggregate as the client-facing usage (#614)

### DIFF
--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -349,6 +349,47 @@ impl UsageStats {
             ..Self::default()
         }
     }
+
+    /// Field-wise saturating sum of two usage records. Used to build an
+    /// ensemble's client-facing aggregate usage — the sum of every panel
+    /// member plus the judge (api7/AISIX-Cloud#804) — so a fan-out request
+    /// reports its full multiplicative cost to the caller rather than a
+    /// single sub-call's. The optional provider-native passthrough counters
+    /// (DeepSeek hit/miss, #542) add with `None` treated as 0, staying
+    /// `None` only when neither side carried one.
+    pub fn saturating_add(&self, other: &UsageStats) -> UsageStats {
+        fn add_opt(a: Option<u32>, b: Option<u32>) -> Option<u32> {
+            match (a, b) {
+                (None, None) => None,
+                _ => Some(a.unwrap_or(0).saturating_add(b.unwrap_or(0))),
+            }
+        }
+        UsageStats {
+            prompt_tokens: self.prompt_tokens.saturating_add(other.prompt_tokens),
+            completion_tokens: self
+                .completion_tokens
+                .saturating_add(other.completion_tokens),
+            total_tokens: self.total_tokens.saturating_add(other.total_tokens),
+            cached_prompt_tokens: self
+                .cached_prompt_tokens
+                .saturating_add(other.cached_prompt_tokens),
+            reasoning_tokens: self.reasoning_tokens.saturating_add(other.reasoning_tokens),
+            cache_creation_tokens: self
+                .cache_creation_tokens
+                .saturating_add(other.cache_creation_tokens),
+            cache_read_tokens: self
+                .cache_read_tokens
+                .saturating_add(other.cache_read_tokens),
+            prompt_cache_hit_tokens: add_opt(
+                self.prompt_cache_hit_tokens,
+                other.prompt_cache_hit_tokens,
+            ),
+            prompt_cache_miss_tokens: add_opt(
+                self.prompt_cache_miss_tokens,
+                other.prompt_cache_miss_tokens,
+            ),
+        }
+    }
 }
 
 /// Full (non-streaming) chat response.
@@ -671,6 +712,56 @@ mod tests {
     fn usage_stats_saturates_total() {
         let u = UsageStats::new(u32::MAX, 10);
         assert_eq!(u.total_tokens, u32::MAX);
+    }
+
+    #[test]
+    fn usage_stats_saturating_add_sums_every_field() {
+        let a = UsageStats {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: 15,
+            cached_prompt_tokens: 2,
+            reasoning_tokens: 3,
+            cache_creation_tokens: 1,
+            cache_read_tokens: 4,
+            prompt_cache_hit_tokens: Some(2),
+            prompt_cache_miss_tokens: None,
+        };
+        let b = UsageStats {
+            prompt_tokens: 20,
+            completion_tokens: 7,
+            total_tokens: 27,
+            cached_prompt_tokens: 1,
+            reasoning_tokens: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 6,
+            prompt_cache_hit_tokens: None,
+            prompt_cache_miss_tokens: Some(8),
+        };
+        let sum = a.saturating_add(&b);
+        assert_eq!(sum.prompt_tokens, 30);
+        assert_eq!(sum.completion_tokens, 12);
+        assert_eq!(sum.total_tokens, 42);
+        assert_eq!(sum.cached_prompt_tokens, 3);
+        assert_eq!(sum.reasoning_tokens, 3);
+        assert_eq!(sum.cache_creation_tokens, 1);
+        assert_eq!(sum.cache_read_tokens, 10);
+        // None + Some(8) = Some(8); Some(2) + None = Some(2). None + None stays None.
+        assert_eq!(sum.prompt_cache_hit_tokens, Some(2));
+        assert_eq!(sum.prompt_cache_miss_tokens, Some(8));
+        assert_eq!(
+            UsageStats::default()
+                .saturating_add(&UsageStats::default())
+                .prompt_cache_hit_tokens,
+            None,
+        );
+        // Saturates instead of overflowing.
+        assert_eq!(
+            UsageStats::new(u32::MAX, 0)
+                .saturating_add(&UsageStats::new(10, 0))
+                .prompt_tokens,
+            u32::MAX,
+        );
     }
 
     /// PR #442 audit MEDIUM-4 (forward-compat): an *old-shape*

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -3278,10 +3278,18 @@ where
                     {
                         continue;
                     }
-                    // #614: fold any pre-incurred usage (an ensemble's panel)
-                    // into the client-facing usage frame, AFTER `comp` captured
-                    // the stream-only counts above. No-op when `base_usage` is
-                    // zero (every single-upstream caller).
+                    // #614: fold the ensemble panel's usage (`base_usage`) into
+                    // the client-facing usage frame, AFTER `comp` captured the
+                    // stream-only counts above. No-op when `base_usage` is zero
+                    // (every single-upstream caller).
+                    //
+                    // Assumes the judge emits `usage` on a SINGLE terminal frame
+                    // (true for the OpenAI/Anthropic/DeepSeek bridges via the
+                    // injected include_usage, so the panel sum lands exactly
+                    // once). A judge that stamps usage on multiple chunks
+                    // (Gemini/Vertex) would add the panel sum more than once —
+                    // tracked in #617 (fix: synthesize one terminal usage frame
+                    // from `comp + base_usage`).
                     if let Some(u) = chunk.usage.as_mut() {
                         *u = u.saturating_add(&base_usage);
                     }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1159,6 +1159,8 @@ async fn dispatch(
             req.model.clone(),
             content_cap,
             client_requested_usage,
+            // Single upstream: nothing pre-incurred, so no usage to fold in.
+            aisix_gateway::chat::UsageStats::default(),
             move |comp: StreamCompletion| {
                 // Rate-limit accounting (TPM cap) for all layers.
                 for key in &post_stream_keys {
@@ -2114,6 +2116,15 @@ async fn dispatch_ensemble(
             })
             .collect();
         let panel_total: u64 = panel.iter().map(|p| u64::from(p.usage.total_tokens)).sum();
+        // #614: field-wise panel usage sum (not just total_tokens) folded into
+        // the client-facing terminal usage chunk via build_sse_stream's
+        // `base_usage`, so a streamed ensemble reports the full panel+judge
+        // aggregate — matching the non-streaming path.
+        let panel_usage_sum = panel
+            .iter()
+            .fold(aisix_gateway::chat::UsageStats::default(), |acc, p| {
+                acc.saturating_add(&p.usage)
+            });
         let (judge_model_id, judge_provider_key_id) = resolve_sub(&ensemble_cfg.judge.model);
         let judge_attempt_model = ensemble_cfg.judge.model.clone();
         let judge_attempt_index = panel.len() as u32;
@@ -2169,6 +2180,7 @@ async fn dispatch_ensemble(
             req.model.clone(),
             content_cap,
             client_requested_usage,
+            panel_usage_sum,
             move |comp: StreamCompletion| {
                 // Rate-limit accounting: the panel tokens (already round-tripped)
                 // plus the streamed judge's final total, against every layer.
@@ -2292,7 +2304,7 @@ async fn dispatch_ensemble(
         });
     }
 
-    let outcome = match crate::ensemble::run_ensemble(req, ensemble_cfg, &caller).await {
+    let mut outcome = match crate::ensemble::run_ensemble(req, ensemble_cfg, &caller).await {
         Ok(outcome) => outcome,
         Err(err) => {
             // Both error variants carry the panel members that already
@@ -2446,6 +2458,17 @@ async fn dispatch_ensemble(
     // is reused as the "telemetry already emitted, do not double-emit"
     // flag — `chat_completions` skips its own `emit_usage_event` when it
     // is set, exactly as it does for the streaming path.
+    // #614: the client-facing response reports the AGGREGATE usage — every
+    // panel member plus the judge (api7/AISIX-Cloud#804) — so the caller sees
+    // the full fan-out cost, not just the judge sub-call's. The per-sub-call
+    // breakdown stays in the usage events emitted above (`judge_usage` carried
+    // the judge-only count for its event; starting the fold from it adds the
+    // judge once, then every panel member).
+    let aggregate_usage = outcome
+        .panel
+        .iter()
+        .fold(judge_usage.clone(), |acc, p| acc.saturating_add(&p.usage));
+    outcome.response.usage = aggregate_usage;
     let response = Json(render_response(created_ts, outcome.response, &req.model)).into_response();
     Ok(Success {
         response,
@@ -3062,6 +3085,12 @@ fn build_sse_stream<F>(
     // gateway asks the upstream regardless (#790, for telemetry); the
     // terminal usage-only chunk is forwarded only when this is true.
     client_requested_usage: bool,
+    // Usage already incurred before this stream begins — the buffered panel
+    // members of an ensemble (#614). Folded into the client-facing terminal
+    // usage chunk so the caller sees the full panel+judge aggregate; the
+    // `on_complete` (`comp`) counts stay stream-only. Zero for single-upstream
+    // callers, where the fold is a no-op.
+    base_usage: aisix_gateway::chat::UsageStats,
     on_complete: F,
 ) -> impl Stream<Item = Result<Event, Infallible>>
 where
@@ -3145,7 +3174,7 @@ where
         let mut first_chunk_seen = false;
         while let Some(item) = upstream.next().await {
             let (ev, is_error_ev) = match item {
-                Ok(chunk) => {
+                Ok(mut chunk) => {
                     // Record TTFT on the first chunk carrying generated
                     // output (content or tool calls). Skip role-only
                     // chunks that OpenAI emits before actual tokens.
@@ -3248,6 +3277,13 @@ where
                         && chunk.delta.reasoning_content.is_none()
                     {
                         continue;
+                    }
+                    // #614: fold any pre-incurred usage (an ensemble's panel)
+                    // into the client-facing usage frame, AFTER `comp` captured
+                    // the stream-only counts above. No-op when `base_usage` is
+                    // zero (every single-upstream caller).
+                    if let Some(u) = chunk.usage.as_mut() {
+                        *u = u.saturating_add(&base_usage);
                     }
                     let rendered = render_chunk(created, chunk, &client_facing_model);
                     match serde_json::to_string(&rendered) {

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5694,9 +5694,11 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         // Rendered under the requested ensemble model name — never the
         // judge's upstream model id (no provider/model leakage).
         assert_eq!(v["model"], "council");
-        // Client-facing usage is the judge call's own (the executor's
-        // `EnsembleOutcome.response` carries the judge usage).
-        assert_eq!(v["usage"]["total_tokens"], 37);
+        // #614: client-facing usage is the AGGREGATE of every panel member
+        // plus the judge, not the judge's alone — so the caller sees the full
+        // fan-out cost. Here: two panel members at total_tokens=16 each (32)
+        // plus the judge's 37 = 69.
+        assert_eq!(v["usage"]["total_tokens"], 69);
     }
 
     /// Tool-using requests can't be fanned out coherently across a panel,
@@ -5894,6 +5896,112 @@ data: [DONE]\n\n";
         // The judge event carries the streamed terminal-chunk usage.
         assert_eq!(judge_events[0].prompt_tokens, 30);
         assert_eq!(judge_events[0].completion_tokens, 7);
+    }
+
+    /// #614: a STREAMING ensemble's client-facing terminal usage frame (sent
+    /// when the client asked for `stream_options.include_usage`) is the
+    /// panel+judge AGGREGATE, not the judge's alone — matching the
+    /// non-streaming path. Here: two panel members at total_tokens=16 each
+    /// (prompt 5 / completion 11) + the judge's streamed 37 (prompt 30 /
+    /// completion 7) ⇒ total 69, prompt 40, completion 29.
+    #[tokio::test]
+    async fn ensemble_streaming_usage_frame_is_panel_judge_aggregate() {
+        let upstream = MockServer::start().await;
+        let judge_sse = "\
+data: {\"id\":\"cmpl-judge\",\"model\":\"judge-upstream\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"synthesized final answer\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-judge\",\"model\":\"judge-upstream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":30,\"completion_tokens\":7,\"total_tokens\":37}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(judge_sse),
+            )
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-panel-b", "panel-b", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a", "panel-b"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "what is the best answer?"}],
+            "stream": true,
+            "stream_options": {"include_usage": true}
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut body_stream = resp.into_body().into_data_stream();
+        let mut decoder = SseDecoder::new();
+        let mut events = Vec::new();
+        while let Some(chunk) = body_stream.next().await {
+            events.extend(decoder.feed(chunk.unwrap().as_ref()));
+        }
+        // The client asked for usage, so exactly one terminal usage-bearing
+        // frame must reach it — carrying the aggregate, re-stamped under the
+        // ensemble alias (never the judge upstream id).
+        let usage_frame = events
+            .iter()
+            .filter_map(|e| match e {
+                SseEvent::Data(s) => serde_json::from_str::<serde_json::Value>(s).ok(),
+                _ => None,
+            })
+            .find(|v| !v["usage"].is_null())
+            .expect("include_usage was requested; a terminal usage frame must be sent");
+        assert_eq!(
+            usage_frame["usage"]["total_tokens"], 69,
+            "aggregate total = 2*16 panel + 37 judge"
+        );
+        assert_eq!(
+            usage_frame["usage"]["prompt_tokens"], 40,
+            "aggregate prompt = 5 + 5 + 30"
+        );
+        assert_eq!(
+            usage_frame["usage"]["completion_tokens"], 29,
+            "aggregate completion = 11 + 11 + 7"
+        );
+        assert_eq!(usage_frame["model"], "council");
     }
 
     /// Streaming ensemble, judge connect failure: the panel members all

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5981,14 +5981,23 @@ data: [DONE]\n\n";
         // The client asked for usage, so exactly one terminal usage-bearing
         // frame must reach it — carrying the aggregate, re-stamped under the
         // ensemble alias (never the judge upstream id).
-        let usage_frame = events
+        // Collect ALL usage-bearing frames: the client must receive EXACTLY
+        // one (the panel sum is folded once). More than one would mean the
+        // base_usage fold ran per-chunk against a multi-emit judge (#617).
+        let usage_frames: Vec<_> = events
             .iter()
             .filter_map(|e| match e {
                 SseEvent::Data(s) => serde_json::from_str::<serde_json::Value>(s).ok(),
                 _ => None,
             })
-            .find(|v| !v["usage"].is_null())
-            .expect("include_usage was requested; a terminal usage frame must be sent");
+            .filter(|v| !v["usage"].is_null())
+            .collect();
+        assert_eq!(
+            usage_frames.len(),
+            1,
+            "client must receive exactly one usage frame (panel sum folded once)"
+        );
+        let usage_frame = &usage_frames[0];
         assert_eq!(
             usage_frame["usage"]["total_tokens"], 69,
             "aggregate total = 2*16 panel + 37 judge"


### PR DESCRIPTION
## Summary

Fixes #614: an `ensemble` model surfaced only the **judge** call's usage to the client, so a fan-out request reported the cost of a single call. Per api7/AISIX-Cloud#804 the client-facing `usage` is the **aggregate** — the sum of every panel member plus the judge. This corrects the client-facing total only; the per-sub-call telemetry (one `UsageEvent` per panel member + the judge, `attempt_kind = panel|judge`) is unchanged.

## Root cause

`run_ensemble` returns the judge's `ChatResponse`, whose `usage` is the judge's own, and both client paths surfaced it verbatim — `crates/aisix-proxy/src/ensemble.rs` even documented "the client-facing answer, whose `usage` is the judge call's own".

## Change

- **`UsageStats::saturating_add`** (`aisix-gateway`): field-wise saturating sum incl. the cache / reasoning counters and the DeepSeek-native passthrough `Option`s (`None + None = None`).
- **Non-streaming** (`dispatch_ensemble`): set `outcome.response.usage` to `fold(panel + judge)` before `render_response`. The telemetry just above already consumed the judge-only count for its own event.
- **Streaming** (`build_sse_stream`): new `base_usage` parameter folded into the client's terminal usage chunk **after** `comp` captured the stream-only counts (telemetry stays judge-only). It is a **no-op for the single-upstream caller** (`base_usage` is zero → `x + 0`), so non-ensemble streaming is byte-for-byte unchanged.

## Tests

- Updated `ensemble_fans_out_to_panel_and_returns_judge_synthesis` — the assertion pinned the old judge-only total (`37`); it now asserts the aggregate (`69` = 2 panel ×16 + judge 37).
- New `ensemble_streaming_usage_frame_is_panel_judge_aggregate` — with `stream_options.include_usage`, the terminal frame reports total 69 / prompt 40 / completion 29, re-stamped under the ensemble alias.
- All 495 lib tests pass (54 `aisix-gateway` + 441 `aisix-proxy`); `cargo clippy` + `cargo fmt` clean.

## Prior art (§7)

Aggregating usage across a server-side fan-out is a novel surface: mainstream gateways report a single upstream's usage (or the final attempt's), because none expose an ensemble as one model. #804 defines the aggregate contract; this implements it while keeping the flat OpenAI `usage` object shape, so SDKs are unaffected — only the totals are (correctly) larger.

## Follow-up

The CP e2e `dp-ensemble-live` (api7/AISIX-Cloud#814) holds its aggregate-usage assertion back pending this fix reaching `:dev`; it is re-enabled once this lands.

Fixes #614.

---

## Independent audit resolution (CLAUDE.md §8)

Cold review before merge. Findings + resolutions (commit `fc6c308`):

| # | Sev | Finding | Resolution |
|---|-----|---------|------------|
| HIGH-1 | HIGH | The streaming `base_usage` fold runs per forwarded usage-bearing chunk, so a judge that stamps `usage` on multiple chunks (Gemini/Vertex) would add the panel sum more than once | **Justified + follow-up.** Exact for the dominant judge providers — OpenAI/Anthropic/DeepSeek emit a single terminal usage frame (via the injected `include_usage`), so the panel sum lands once. The narrow multi-emit case (streaming + Gemini/Vertex judge + client `include_usage`) is filed as **#617** (fix: synthesize one terminal usage frame from `comp + base_usage`) and documented at the fold site. Non-streaming is unaffected; this is usage-reporting accuracy, not a correctness/safety issue. |
| HIGH-2 | HIGH | The streaming test couldn't catch HIGH-1 (single-emit fixture, `.find` rather than a count) | **Fixed.** The streaming test now asserts the client receives **exactly one** usage frame (pins the single-fold contract); a multi-emit regression test lands with the #617 fix. |

Audit-verified clean (no change needed): non-streaming aggregate correctness, `saturating_add` field coverage, single-upstream no-op, telemetry + rate-limit unchanged (no double-bill of cp-api), no panics/empty-panel issues, and `build_sse_stream` being crate-private with both (and only) callers updated.

Re-verified post-fix (`fc6c308`): `cargo fmt` + `cargo clippy` clean; 495 lib tests pass incl. all 21 ensemble tests.
