### PR TITLE
fix(ensemble): reserve each panel member + judge rate limit during fan-out (#620)

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2081,6 +2081,35 @@ async fn dispatch_ensemble(
             judge_ctx = judge_ctx.with_deadline(deadline);
         }
 
+        // #620: enforce the judge's OWN model rate limit for the streamed
+        // synthesis too. The panel was reserved per-member in
+        // `run_ensemble_panel` (via `ProxyModelCaller::call`), and the
+        // non-streaming judge is reserved on that same path — but the streaming
+        // judge is dispatched here via `chat_stream`, bypassing it. Reserve
+        // before opening the stream so a rate-limited judge fails fast (429);
+        // the slot is then held for the stream's lifetime and the judge's own
+        // tokens are added post-stream, mirroring the entry reservation below.
+        let judge_reservation = match crate::quota::reserve_model_only(
+            state,
+            &ensemble_cfg.judge.model,
+            &judge_entry.id,
+            judge_model,
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => {
+                reservation.commit_tokens(survivor_total(&panel)).await;
+                return Err(emit_panel_then_fail(
+                    &panel,
+                    ProxyError::Bridge(BridgeError::upstream_status(
+                        429,
+                        "rate limit exceeded for the ensemble judge",
+                    )),
+                ));
+            }
+        };
+
         let judge_stream = match judge_bridge.chat_stream(&judge_req, &judge_ctx).await {
             Ok(s) => s,
             // Judge connect failed AFTER the panel round-tripped: bill the
@@ -2168,6 +2197,11 @@ async fn dispatch_ensemble(
         // keys BEFORE consuming the reservation into the owned guard.
         let post_stream_keys = reservation.keys();
         let stream_concurrency_hold = reservation.into_stream_hold();
+        // #620: hold the judge's own concurrency slot for the stream lifetime
+        // and add its tokens post-stream, the same way the entry reservation is
+        // handled (snapshot keys before consuming into the owned guard).
+        let judge_post_stream_keys = judge_reservation.keys();
+        let judge_concurrency_hold = judge_reservation.into_stream_hold();
         let limiter = Arc::clone(&state.limiter);
 
         let sse_stream = build_sse_stream(
@@ -2186,6 +2220,11 @@ async fn dispatch_ensemble(
                 // plus the streamed judge's final total, against every layer.
                 for key in &post_stream_keys {
                     limiter.add_tokens_post_stream(key, panel_total + comp.total_tokens);
+                }
+                // #620: the judge's own model bucket gets only the judge's
+                // streamed tokens (each panel member was billed per-member).
+                for key in &judge_post_stream_keys {
+                    limiter.add_tokens_post_stream(key, comp.total_tokens);
                 }
                 // Telemetry: one event per panel member (attempt_kind "panel",
                 // index 0..N) carrying that member's own buffered usage, then
@@ -2265,6 +2304,7 @@ async fn dispatch_ensemble(
                 // Release the concurrency permit(s) now the stream is done
                 // (or was cancelled) — on_complete fires on both paths (#450).
                 drop(stream_concurrency_hold);
+                drop(judge_concurrency_hold);
             },
         );
         let response =

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -26,7 +26,7 @@ use futures::future::join_all;
 
 use aisix_core::models::{EnsembleConfig, Judge, PanelMember};
 use aisix_core::AisixSnapshot;
-use aisix_gateway::bridge::{BridgeContext, BridgeError};
+use aisix_gateway::bridge::{BridgeContext, BridgeError, UpstreamWire};
 use aisix_gateway::chat::{ChatFormat, ChatMessage, ChatResponse, Role, UsageStats};
 
 use crate::state::ProxyState;
@@ -130,7 +130,32 @@ impl ModelCaller for ProxyModelCaller<'_> {
         if let Some(deadline) = model.request_timeout() {
             ctx = ctx.with_deadline(deadline);
         }
-        bridge.chat(req, &ctx).await
+
+        // Enforce THIS member's own model rate limit before the sub-call and
+        // bill its own tokens after (#620). The request-level layers (api_key
+        // / team / member) are already reserved on the entry alias; here we add
+        // only the member's `model:` layer + model-scope policies. A member
+        // that exceeds its own limit becomes a failed sub-call: the panel drops
+        // it toward `min_responses`, and the judge surfaces it as a 429 judge
+        // failure. An unlimited member reserves nothing (zero overhead).
+        let reservation = crate::quota::reserve_model_only(self.state, target, &entry.id, model)
+            .await
+            .map_err(|_| BridgeError::UpstreamStatus {
+                status: 429,
+                message: "rate limit exceeded for an ensemble sub-call".to_string(),
+                parsed: None,
+                wire: UpstreamWire::Unknown,
+                retry_after: None,
+            })?;
+
+        // On a bridge error the reservation drops here → concurrency slots
+        // release and no tokens are counted. On success we commit the member's
+        // own token cost to its model bucket.
+        let response = bridge.chat(req, &ctx).await?;
+        reservation
+            .commit_tokens(u64::from(response.usage.total_tokens))
+            .await;
+        Ok(response)
     }
 }
 

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -26,7 +26,7 @@ use futures::future::join_all;
 
 use aisix_core::models::{EnsembleConfig, Judge, PanelMember};
 use aisix_core::AisixSnapshot;
-use aisix_gateway::bridge::{BridgeContext, BridgeError, UpstreamWire};
+use aisix_gateway::bridge::{BridgeContext, BridgeError};
 use aisix_gateway::chat::{ChatFormat, ChatMessage, ChatResponse, Role, UsageStats};
 
 use crate::state::ProxyState;
@@ -140,12 +140,8 @@ impl ModelCaller for ProxyModelCaller<'_> {
         // failure. An unlimited member reserves nothing (zero overhead).
         let reservation = crate::quota::reserve_model_only(self.state, target, &entry.id, model)
             .await
-            .map_err(|_| BridgeError::UpstreamStatus {
-                status: 429,
-                message: "rate limit exceeded for an ensemble sub-call".to_string(),
-                parsed: None,
-                wire: UpstreamWire::Unknown,
-                retry_after: None,
+            .map_err(|_| {
+                BridgeError::upstream_status(429, "rate limit exceeded for an ensemble sub-call")
             })?;
 
         // On a bridge error the reservation drops here → concurrency slots

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5776,6 +5776,91 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         assert_eq!(run(app, make_req()).await.status(), StatusCode::OK);
     }
 
+    /// #620: the STREAMING judge bypasses `ProxyModelCaller::call` (it streams
+    /// via `build_sse_stream`), so its own rate limit must be reserved on the
+    /// streaming path too. With the judge capped at `rpm: 1`, the first streamed
+    /// ensemble request consumes the judge's only request slot (200); the second
+    /// finds it exhausted and fails before opening the stream (429).
+    #[tokio::test]
+    async fn ensemble_streaming_judge_rate_limit_enforced() {
+        let upstream = MockServer::start().await;
+        let judge_sse = "\
+data: {\"id\":\"cmpl-judge\",\"model\":\"judge-upstream\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"final\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-judge\",\"model\":\"judge-upstream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":30,\"completion_tokens\":7,\"total_tokens\":37}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(judge_sse),
+            )
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-panel-a", "panel-a", "panel-upstream"));
+        snap.models
+            .insert(direct_model_entry("m-panel-b", "panel-b", "panel-upstream"));
+        // Judge capped at one request per minute.
+        snap.models.insert(direct_model_entry_rl(
+            "m-judge",
+            "judge-m",
+            "judge-upstream",
+            serde_json::json!({ "rpm": 1 }),
+        ));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["panel-a", "panel-b"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let make_req = || {
+            let body = serde_json::json!({
+                "model": "council",
+                "messages": [{"role": "user", "content": "what is the best answer?"}],
+                "stream": true
+            });
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+        // First streamed request consumes the judge's only rpm slot.
+        assert_eq!(run(app.clone(), make_req()).await.status(), StatusCode::OK);
+        // Second finds the judge rpm exhausted → 429 before the stream opens.
+        assert_eq!(
+            run(app, make_req()).await.status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+
     #[tokio::test]
     async fn ensemble_fans_out_to_panel_and_returns_judge_synthesis() {
         let upstream = MockServer::start().await;

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5612,6 +5612,170 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         ResourceEntry::new(id, model, 1)
     }
 
+    fn direct_model_entry_rl(
+        id: &str,
+        name: &str,
+        upstream_model: &str,
+        rate_limit: serde_json::Value,
+    ) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "{upstream_model}",
+                "provider_key_id": "{PK_ID}",
+                "rate_limit": {rate_limit}
+            }}"#
+        );
+        let model: Model = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new(id, model, 1)
+    }
+
+    /// #620: a panel member must reserve its OWN model rate limit during
+    /// fan-out. A self-ensemble of two copies of a model capped at
+    /// `concurrency: 1` can only run one copy at a time, so the second is
+    /// dropped and the panel falls below `min_responses` (which defaults to 2
+    /// for a two-member panel) → 502. Before the per-target reservation both
+    /// copies ran and the request returned 200.
+    #[tokio::test]
+    async fn ensemble_panel_member_concurrency_limit_enforced_per_target() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = new_snap(&upstream.uri());
+        // Panel member capped at one concurrent call.
+        snap.models.insert(direct_model_entry_rl(
+            "m-capped",
+            "capped",
+            "panel-upstream",
+            serde_json::json!({ "concurrency": 1 }),
+        ));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        // Self-ensemble: the SAME capped model twice → two concurrent calls
+        // contend for one concurrency:1 bucket. Default min_responses = 2.
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["capped", "capped"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "council",
+            "messages": [{"role": "user", "content": "what is the best answer?"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        // Only one copy acquires the concurrency:1 slot; the other is dropped,
+        // leaving one panel response < min_responses(2) → insufficient panel.
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    /// #620: the per-member reservation must RELEASE on success (commit), not
+    /// leak the slot. Two sequential requests through a single-member panel
+    /// whose model is capped at `concurrency: 1` must BOTH succeed — if the
+    /// first request leaked the slot, the second would be starved (502).
+    #[tokio::test]
+    async fn ensemble_panel_member_concurrency_slot_released_after_success() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-judge",
+                "model": "judge-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "synthesized final answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 30, "completion_tokens": 7, "total_tokens": 37}
+            })))
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(direct_model_entry_rl(
+            "m-capped",
+            "capped",
+            "panel-upstream",
+            serde_json::json!({ "concurrency": 1 }),
+        ));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        // Single-member panel → min_responses defaults to 1.
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["capped"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let make_req = || {
+            let body = serde_json::json!({
+                "model": "council",
+                "messages": [{"role": "user", "content": "what is the best answer?"}]
+            });
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+        // First request acquires + releases the capped model's only slot.
+        assert_eq!(run(app.clone(), make_req()).await.status(), StatusCode::OK);
+        // Second request must find the slot free (released on commit).
+        assert_eq!(run(app, make_req()).await.status(), StatusCode::OK);
+    }
+
     #[tokio::test]
     async fn ensemble_fans_out_to_panel_and_returns_judge_synthesis() {
         let upstream = MockServer::start().await;

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5861,6 +5861,185 @@ data: [DONE]\n\n";
         );
     }
 
+    /// #620 (audit M-1): the per-member `commit_tokens` must accrue to the
+    /// member's OWN `model:` TPM bucket. Panel member capped at tpm:10 returns
+    /// 16 tokens: request 1 succeeds and commits 16 (overshoot allowed for the
+    /// in-flight call); request 2's pre-commit sees tpm 16 ≥ 10 and refuses, so
+    /// the single-member panel falls below min_responses → 502. If the member's
+    /// tokens were never committed (or committed to the wrong bucket), tpm would
+    /// stay 0 and request 2 would also succeed.
+    #[tokio::test]
+    async fn ensemble_panel_member_token_commit_accrues_to_model_bucket() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-judge",
+                "model": "judge-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "synthesized final answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 30, "completion_tokens": 7, "total_tokens": 37}
+            })))
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        // Member's TPM cap (10) is below its per-call token cost (16).
+        snap.models.insert(direct_model_entry_rl(
+            "m-capped",
+            "capped",
+            "panel-upstream",
+            serde_json::json!({ "tpm": 10 }),
+        ));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        // Single-member panel → min_responses defaults to 1.
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["capped"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let make_req = || {
+            let body = serde_json::json!({
+                "model": "council",
+                "messages": [{"role": "user", "content": "what is the best answer?"}]
+            });
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+        // First request commits the member's 16 tokens to its model: TPM bucket.
+        assert_eq!(run(app.clone(), make_req()).await.status(), StatusCode::OK);
+        // Second request: the committed 16 now exceeds tpm:10 → member refused →
+        // panel below min_responses → 502.
+        assert_eq!(run(app, make_req()).await.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    /// #620 (audit M-2): a panel member's reservation must RELEASE on a bridge
+    /// ERROR (not just on commit). The member is capped at concurrency:1 and the
+    /// upstream 503s on the first call: request 1's member fails (panel < min →
+    /// 502), and its reservation must drop, freeing the slot. Request 2 (upstream
+    /// 200) must then acquire the slot and succeed. A leaked slot would starve
+    /// request 2 → 502.
+    #[tokio::test]
+    async fn ensemble_panel_member_reservation_released_on_bridge_error() {
+        let upstream = MockServer::start().await;
+        // First panel call fails (503), one time only.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        // Judge synthesis (only reached on the successful second request).
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(wiremock::matchers::body_string_contains("Answer 1:"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-judge",
+                "model": "judge-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "synthesized final answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 30, "completion_tokens": 7, "total_tokens": 37}
+            })))
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+        // Panel candidate (the second request's panel call, after the 503 is spent).
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-panel",
+                "model": "panel-upstream",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "a panel candidate answer"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 11, "total_tokens": 16}
+            })))
+            .with_priority(3)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(direct_model_entry_rl(
+            "m-capped",
+            "capped",
+            "panel-upstream",
+            serde_json::json!({ "concurrency": 1 }),
+        ));
+        snap.models
+            .insert(direct_model_entry("m-judge", "judge-m", "judge-upstream"));
+        snap.models.insert(ensemble_model_entry(
+            "m-council",
+            "council",
+            &["capped"],
+            "judge-m",
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["council"]));
+        let app = build_router(build_state(snap, hub));
+
+        let make_req = || {
+            let body = serde_json::json!({
+                "model": "council",
+                "messages": [{"role": "user", "content": "what is the best answer?"}]
+            });
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+        // Request 1: the member's upstream 503s → member fails → panel below
+        // min_responses → 502. Its concurrency:1 slot must be released on drop.
+        assert_eq!(
+            run(app.clone(), make_req()).await.status(),
+            StatusCode::BAD_GATEWAY
+        );
+        // Request 2: upstream now 200. The slot is free (released on the prior
+        // error), so the member succeeds and the ensemble synthesizes → 200.
+        assert_eq!(run(app, make_req()).await.status(), StatusCode::OK);
+    }
+
     #[tokio::test]
     async fn ensemble_fans_out_to_panel_and_returns_judge_synthesis() {
         let upstream = MockServer::start().await;

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -238,6 +238,63 @@ pub(crate) async fn enforce_rate_limit(
     reserve_layers(state, auth, model_rl).await
 }
 
+/// Reserve ONLY the model-scoped layers (a model's inline `rate_limit` plus
+/// any `model`-scope `RateLimitPolicy` rows) for one model, identified by its
+/// display name + entry id.
+///
+/// The ensemble fan-out uses this per sub-call: each panel member and the
+/// judge is a separate upstream call that must honor its own model limits,
+/// even though the request-level layers (api_key / team / member) are reserved
+/// once on the entry alias and committed with the aggregate (#620). It
+/// deliberately omits those request-level layers so they are not double-counted
+/// per member. Returns an empty [`MultiReservation`] (zero overhead, no
+/// `pre_commit` calls) when the model carries no limits, so unlimited members
+/// pay nothing. On a partial failure the already-acquired layers release on the
+/// dropped `Vec`, same as [`reserve_layers`].
+pub(crate) async fn reserve_model_only(
+    state: &ProxyState,
+    model_name: &str,
+    model_entry_id: &str,
+    model: &aisix_core::Model,
+) -> Result<MultiReservation, ProxyError> {
+    let mut reservations = Vec::new();
+
+    // Inline model rate limit.
+    let mrl = ModelRateLimit::from_model(model_name, model_entry_id, model);
+    if let Some(ref limits) = mrl.limits {
+        let key = format!("model:{}", mrl.name);
+        let r = state
+            .limiter
+            .pre_commit(&key, limits)
+            .await
+            .map_err(ProxyError::from)?;
+        reservations.push(r);
+    }
+
+    // `model`-scope rate-limit policies for this model. (model scope never
+    // buckets per-user, so the base bucket key suffices — no auth needed.)
+    let snap = state.snapshot.load();
+    for entry in snap.rate_limit_policies.entries() {
+        let policy = &entry.value;
+        if policy.scope != "model" || policy.scope_ref != model_entry_id {
+            continue;
+        }
+        let rl = policy_to_rate_limit(policy);
+        if rl.is_unrestricted() {
+            continue;
+        }
+        let bucket_key = format!("policy:{}:{}:{}", policy.scope, policy.scope_ref, entry.id);
+        let r = state
+            .limiter
+            .pre_commit(&bucket_key, &rl)
+            .await
+            .map_err(ProxyError::from)?;
+        reservations.push(r);
+    }
+
+    Ok(MultiReservation::new(reservations))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

Fixes the P0 gap from #620: ensemble fan-out reserved only the **entry alias's** rate limit (a virtual model with no limit), so each panel member's and the judge's **own** `Model.rate_limit` was bypassed. Per-model RPM/TPM/concurrency went unenforced and one ensemble request burned each provider's quota N× without governance.

## Change

- **`crates/aisix-proxy/src/quota.rs`** — new `reserve_model_only(state, name, entry_id, model)`: reserves *only* the model-scoped layers (the model's inline `rate_limit` + `model`-scope `RateLimitPolicy` rows). It deliberately omits the request-level layers (api_key / team / member) — those are reserved once on the entry alias and committed with the aggregate, so reserving them per member would double-count. Returns an empty `MultiReservation` (no `pre_commit` calls) for unlimited models → zero overhead.
- **`crates/aisix-proxy/src/ensemble.rs`** — `ProxyModelCaller::call` (the per-sub-call dispatch for every panel member and the **non-streaming** judge) now reserves the member's model-scoped layers before `bridge.chat` and `commit_tokens(member total)` after. On a bridge error or timeout the reservation drops → concurrency slot released, no tokens counted (rollback via `Reservation`'s `Drop`).
- **`crates/aisix-proxy/src/chat.rs`** — the **streaming** judge is dispatched via `build_sse_stream`, not `ProxyModelCaller::call`, so `dispatch_ensemble` reserves the judge's model-scoped layers before `chat_stream` (429 + bill-panel on rejection), holds the slot for the stream lifetime via `into_stream_hold`, and adds the judge's own tokens post-stream — mirroring the entry reservation handled right beside it. (Streaming panel members already route through `run_ensemble_panel` → `ProxyModelCaller::call`, so they're covered.)

## Failure semantics

A sub-call that exceeds its own limit fails at reservation → mapped to a 429. The existing orchestration then does the right thing:
- **panel member** → counted as a failed member, dropped toward `min_responses` (degrade);
- **judge** → `EnsembleError::Judge` (429), since synthesis can't proceed.

Mapped via `BridgeError::upstream_status(429, …)` (synthesized, `wire:Unknown`) for the correct client status + non-retryable classification (the judge isn't pointlessly retried). No new `BridgeError` variant (would touch 15 files); the ensemble fan-out path doesn't feed errors to cooldown, so no spurious cooldown.

## Prior art (CLAUDE.md §7)

Panel+judge ensembling is a novel surface — mainstream gateways don't fan out to a panel + judge — so there's no external pattern to match. The per-target reservation mirrors AISIX's **own** routing-target reservation (`MultiReservation`, #607): a multi-upstream request must debit each upstream's bucket.

## Out of scope (tracked separately)

- Pre-flight **cost/token cap → degrade** for the N× spend: #621.
- A dedicated `BridgeError::RateLimited` variant (deferred — the 429-via-UpstreamStatus mapping is sufficient and far less invasive).

## Tests (`crates/aisix-proxy/src/lib.rs`)

- `ensemble_panel_member_concurrency_limit_enforced_per_target` — self-ensemble of two copies of a `concurrency:1` model: only one acquires the slot, the other drops below `min_responses(2)` → **502** (was **200** before the fix). Deterministic (concurrency, no clock).
- `ensemble_panel_member_concurrency_slot_released_after_success` — two sequential single-member requests both **200**, proving the slot is released on commit (no leak).
- `ensemble_streaming_judge_rate_limit_enforced` — judge capped at `rpm:1`: the first streamed ensemble request succeeds (**200**), the second is rejected before the stream opens (**429**), proving the streaming judge's own limit is enforced.

## Verification

`cargo test -p aisix-proxy --lib` → **444 passed** (incl. all 24 ensemble tests); `cargo clippy -p aisix-proxy --all-targets` clean; `cargo fmt` applied.

## Independent audit resolution (CLAUDE.md §8)

Cold review — the auditor mutation-tested the original 3 tests (each goes red without the fix) and traced every exit path. **No code defects found**: concurrency-slot + token release verified on every exit (panel bridge-error, member timeout, insufficient-panel, non-streaming + streaming judge failure, stream completion AND client-cancel); no double-counting (each member commits to its own `model:` bucket, the entry commits the aggregate once); self-ensemble + judge-also-a-member debited once per actual call; the 429 message is generic (no model-name leak), non-retryable, no spurious cooldown.

Two MEDIUM **test-coverage gaps** resolved (commit `2d7058a`):

| # | Gap | Resolution |
|---|-----|------------|
| M-1 | No test for the token/TPM-commit-accrual half | **Fixed** — `ensemble_panel_member_token_commit_accrues_to_model_bucket` (member `tpm:10` returns 16 → req1 commits, req2 refused → 502). |
| M-2 | No test that a member's reservation releases on a bridge ERROR (vs commit) | **Fixed** — `ensemble_panel_member_reservation_released_on_bridge_error` (`concurrency:1`, upstream 503 on req1 → slot released → req2 acquires it → 200). |

LOW-3 (streaming-judge rpm test has a minute-boundary flake window) — accepted: matches the existing rpm-test convention in this suite; the integration harness exposes no `TestClock`. LOW-4 (streaming-judge re-resolves the judge bridge inline) — pre-existing, not introduced here.

Re-verified post-fix (`2d7058a`): `cargo test -p aisix-proxy --lib` → 446 passed (26 ensemble); clippy `-D warnings` + fmt clean.

Closes #620. Tracking: api7/AISIX-Cloud#804.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced rate-limit and quota enforcement for ensemble model requests to ensure fair distribution across concurrent calls and accurate per-model token tracking.
  * Judge models in streaming ensembles now properly respect configured rate limits.
  * Concurrency slots are now correctly released after successful request completion.

* **Tests**
  * Added comprehensive test suite validating rate-limit reservation semantics across ensemble and judge execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->