### PR TITLE
ci: GitHub-hosted runners + keep publishing ghcr.io/api7/ai-gateway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   lint:
     name: lint (fmt + clippy)
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -28,7 +28,7 @@ jobs:
 
   schema-drift:
     name: schema drift (resources)
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -46,7 +46,7 @@ jobs:
 
   openapi-generate:
     name: generate admin openapi
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -72,7 +72,7 @@ jobs:
 
   rust-unit:
     name: rust unit + coverage
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     services:
       redis:
         image: redis:7-alpine
@@ -133,7 +133,7 @@ jobs:
 
   build-bin:
     name: build aisix (instrumented)
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C instrument-coverage"
       LLVM_PROFILE_FILE: "coverage/aisix-%p-%m.profraw"
@@ -157,7 +157,7 @@ jobs:
   e2e:
     name: e2e (vitest) + coverage
     needs: [build-bin]
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     services:
       etcd:
         image: quay.io/coreos/etcd:v3.5.15
@@ -209,7 +209,7 @@ jobs:
   coverage-gate:
     name: coverage >= 90%
     needs: [rust-unit, e2e]
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,7 +34,13 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}   # ghcr.io/moonming/ai-gateway
+  # Pinned, NOT ${{ github.repository }}: the published image must stay
+  # ghcr.io/api7/ai-gateway — an api7-org, public package already linked to
+  # this repo (GITHUB_TOKEN can write it) and already consumed downstream as
+  # :dev (api7/AISIX-Cloud, etc.). The api7/ai-gateway -> api7/aisix repo
+  # rename would otherwise retarget the push to a different, private
+  # ghcr.io/api7/aisix package (owned by api7/aisix-archived) and 403.
+  IMAGE_NAME: api7/ai-gateway
 
 permissions:
   contents: read
@@ -46,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,14 +5,14 @@
 # /etc/aisix/config.yaml). Two intended modes:
 #
 #   Standalone — operator mounts their own config:
-#       docker run -v ./config.yaml:/etc/aisix/config.yaml ghcr.io/moonming/ai-gateway:main
+#       docker run -v ./config.yaml:/etc/aisix/config.yaml ghcr.io/api7/ai-gateway:dev
 #
 #   Managed (aisix.cloud tenant) — use the baked-in template + env vars:
 #       docker run \
 #         -e AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml \
 #         -e AISIX_MANAGED__REGISTRATION_TOKEN=$DEPLOYMENT_TOKEN \
 #         -e AISIX_MANAGED__CP_BASE_URL=https://api.us.aisix.cloud \
-#         ghcr.io/moonming/ai-gateway:main
+#         ghcr.io/api7/ai-gateway:dev
 #
 # The Rust binary's `Config::load_from_path` already layers
 # `AISIX_<UPPER>__<UPPER>` env vars on top of the YAML, so any field


### PR DESCRIPTION
## Context

`api7/ai-gateway` was renamed to `api7/aisix` and is now a **public** repo. The rename broke `main`'s `docker-image` job. This fixes it and moves CI to GitHub-hosted runners.

## What changed (3 files)

- **Runners → `ubuntu-latest`.** `ci.yml` (all 7 jobs) + `docker-image.yml` move off the Ubicloud self-hosted runners (`ubicloud-standard-2`). Public repos get free GitHub-hosted minutes.
- **Pin `IMAGE_NAME: api7/ai-gateway`** (was `${{ github.repository }}`). Keeps publishing to the existing api7-org package; see below.
- **`docker/entrypoint.sh`**: fix two stale `ghcr.io/moonming/ai-gateway:main` run-examples → `ghcr.io/api7/ai-gateway:dev`.

## Why `main` was red

[run 27601729575](https://github.com/api7/aisix/actions/runs/27601729575/job/81604099773) failed at **Build and push** with `403 Forbidden` on `ghcr.io/api7/aisix:dev` (build/login/tagging all passed). The `ai-gateway → aisix` rename made `${{ github.repository }}` resolve to `api7/aisix`, so the push retargeted from `ghcr.io/api7/ai-gateway` to `ghcr.io/api7/aisix` — a **different, private** package owned by `api7/aisix-archived`, which this repo's `GITHUB_TOKEN` can't write. The innocent failing commit (`b756939`, dep cleanup) just happened to be the first push after the rename.

## Why pin to `ai-gateway` (not republish under `aisix`)

`ghcr.io/api7/ai-gateway` is **already** an api7-org, **public** package **linked to this repo** — the token writes it today (it did at 07:20 on the day of the failure), so pinning makes `main` green with **no registry-admin step**. Redirecting to `ghcr.io/api7/aisix` instead would be worse on three counts:

1. **It's not free real estate.** `ghcr.io/api7/aisix` is a live package actively pulled by other repos — `api7/api7ee-3-control-plane` e2e (`docker pull ghcr.io/api7/aisix:dev`, runs daily), `api7/aisix-ee` build (`FROM ghcr.io/api7/aisix:<ver>`), `api7/aisix-archived` smoke-test. Publishing this repo's DP there would overwrite `:dev` for those consumers; deleting it would 404 their pulls.
2. **Downstream staleness.** `ghcr.io/api7/ai-gateway:dev` is pinned by ~14 places in `api7/AISIX-Cloud` (prod `config.go` `DPImage`, `helm/values.yaml`, compose, e2e harnesses) and its nightly `real-chain.yml` cron. Moving off it freezes that tag and silently regresses them.
3. **It needs an admin grant** (private + foreign-linked) that this PR can't perform.

If consolidating the ecosystem DP image onto `ghcr.io/api7/aisix` is genuinely wanted, that's a separate **coordinated** migration (dual-publish during transition + atomic consumer sweep across AISIX-Cloud / api7ee-3-control-plane / aisix-ee), not a name flip here.

## Out of scope

`objstore-cloud-identity.yml` / `objstore-real-cloud.yml` stay on Ubicloud — GitHub OIDC / real-cloud creds may depend on a cloud-side IP allowlist. They're gated/scheduled and don't run on normal pushes.

## Verification

- PR CI runs `ci.yml` (all jobs) + `docker-image` (build-only on PRs) on `ubuntu-latest`.
- The GHCR **push** runs on `main`; pinning reproduces the same target/token that succeeded at 07:20, so merge restores green with no further action.