### PR TITLE
ci: move objstore-* workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/objstore-cloud-identity.yml
+++ b/.github/workflows/objstore-cloud-identity.yml
@@ -19,7 +19,7 @@
 # labeled `objstore real cloud`. S3 self-skips when its OIDC is unconfigured.
 #
 # Required repository secrets (identifiers, not static keys):
-#   AISIX_E2E_OIDC_AWS_ROLE_ARN   IAM role to assume (trusts repo:api7/ai-gateway via GitHub OIDC)
+#   AISIX_E2E_OIDC_AWS_ROLE_ARN   IAM role to assume (trusts repo:api7/aisix via GitHub OIDC)
 #   AISIX_E2E_OBJSTORE_S3_BUCKET  the S3 test bucket (reused from the credential_ref job)
 #   AISIX_E2E_OBJSTORE_S3_REGION  the bucket's region (configure-aws-credentials requires it)
 name: objstore-cloud-identity
@@ -48,7 +48,7 @@ jobs:
       github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
        contains(github.event.pull_request.labels.*.name, 'objstore real cloud'))
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     env:
       AWS_ROLE_ARN: ${{ secrets.AISIX_E2E_OIDC_AWS_ROLE_ARN }}
       AWS_REGION_CFG: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}

--- a/.github/workflows/objstore-real-cloud.yml
+++ b/.github/workflows/objstore-real-cloud.yml
@@ -70,7 +70,7 @@ jobs:
       github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
        contains(github.event.pull_request.labels.*.name, 'objstore real cloud'))
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     env:
       AISIX_E2E_OBJSTORE_S3_BUCKET: ${{ secrets.AISIX_E2E_OBJSTORE_S3_BUCKET }}
       AISIX_E2E_OBJSTORE_S3_REGION: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}


### PR DESCRIPTION
## What

Move the last two workflows still on Ubicloud — `objstore-cloud-identity.yml` and `objstore-real-cloud.yml` — to GitHub-hosted `ubuntu-latest`, finishing the runner migration started in [#624](https://github.com/api7/aisix/pull/624) (`ci.yml` + `docker-image.yml`). After this, **no workflow references `ubicloud`**. Public repos get free GitHub-hosted minutes, and on a public repo `ubuntu-latest` is a 4-vCPU runner (vs `ubicloud-standard-2`'s 2 vCPU).

The swap is mechanical: both jobs only run `checkout` / `rust-toolchain` / local `setup-protoc` / `rust-cache` / `cargo test` — nothing Ubicloud-specific. Both are gated (`workflow_dispatch` / nightly `schedule` / same-repo PR labeled `objstore real cloud`) and self-skip when their cloud secrets are absent, so they don't run on normal pushes and can't block `main`.

Also fixes a stale reference in `objstore-cloud-identity.yml`: the OIDC role-trust comment said `repo:api7/ai-gateway` → now `repo:api7/aisix`.

## Verified on ubuntu-latest

Dispatched both workflows on this branch (real-cloud secrets present) — both green:

- `objstore-real-cloud`: S3 / GCS / Azure round-trips all `ok` (static-key path), `5 passed; 0 failed`.
- `objstore-cloud-identity`: GitHub OIDC assume-role succeeded (`Authenticated as assumedRoleId …:GitHubActions`) and the keyless S3 round-trip passed. GCS keyless self-skips on a non-GCE runner as before (#573).

So the two cloud-side caveats flagged earlier — the OIDC trust policy after the `ai-gateway → aisix` rename, and any IP allowlist scoped to Ubicloud egress — are both confirmed non-issues: the IAM role already trusts `repo:api7/aisix`, and S3/GCS/Azure all accept GitHub-hosted runner IPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cloud identity workflow documentation for the required OIDC secret reference.
  * Changed CI/CD job runner infrastructure from `ubicloud-standard-2` to `ubuntu-latest` for keyless S3/GitHub OIDC smoke tests.
  * Changed CI/CD job runner infrastructure from `ubicloud-standard-2` to `ubuntu-latest` for real-cloud object store smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
