### PR TITLE
ci: upgrade GitHub Actions to current majors (Node 24 runtimes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: lint (fmt + clippy)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -30,7 +30,7 @@ jobs:
     name: schema drift (resources)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2
@@ -48,7 +48,7 @@ jobs:
     name: generate admin openapi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2
@@ -115,7 +115,7 @@ jobs:
       # Picked up by crates/aisix-etcd/tests/watch_integration.rs.
       ETCD_TEST_URL: http://127.0.0.1:2379
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -125,7 +125,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: unit tests with coverage
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov-unit.info
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: coverage-unit
           path: lcov-unit.info
@@ -138,7 +138,7 @@ jobs:
       RUSTFLAGS: "-C instrument-coverage"
       LLVM_PROFILE_FILE: "coverage/aisix-%p-%m.profraw"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -146,7 +146,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: build
         run: cargo build -p aisix-server --bin aisix
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: aisix-bin
           path: target/debug/aisix
@@ -169,16 +169,16 @@ jobs:
         image: redis:7-alpine
         ports: ["6379:6379"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: aisix-bin
           path: target/debug
       - run: chmod +x target/debug/aisix
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
       - name: check harness exists
@@ -198,7 +198,7 @@ jobs:
         if: steps.harness.outputs.present == 'true'
         working-directory: tests/e2e
         run: pnpm test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-e2e
@@ -211,10 +211,10 @@ jobs:
     needs: [rust-unit, e2e]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with: { name: coverage-unit, path: cov/unit }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         # The e2e job invokes `pnpm test` which is `vitest run` with no
         # `--coverage` flag, so `tests/e2e/coverage/lcov.info` is never
         # written and no `coverage-e2e` artifact is produced. The upload
@@ -238,7 +238,7 @@ jobs:
             echo "::error::Coverage ${pct}% below threshold ${threshold}%"
             exit 1
           }
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: coverage-combined
           path: cov/combined.info

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,14 +55,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Compute tags + labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -99,7 +99,7 @@ jobs:
         run: echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: steps.openapi-secrets.outputs.enabled == 'true'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/objstore-cloud-identity.yml
+++ b/.github/workflows/objstore-cloud-identity.yml
@@ -53,7 +53,7 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AISIX_E2E_OIDC_AWS_ROLE_ARN }}
       AWS_REGION_CFG: ${{ secrets.AISIX_E2E_OBJSTORE_S3_REGION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2
@@ -74,7 +74,7 @@ jobs:
 
       - name: Assume the AWS IAM role via GitHub OIDC (keyless)
         if: env.AWS_ROLE_ARN != '' && env.AWS_REGION_CFG != ''
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION_CFG }}

--- a/.github/workflows/objstore-real-cloud.yml
+++ b/.github/workflows/objstore-real-cloud.yml
@@ -84,7 +84,7 @@ jobs:
       AISIX_E2E_OBJSTORE_AZURE_CONTAINER: ${{ secrets.AISIX_E2E_OBJSTORE_AZURE_CONTAINER }}
       AISIX_E2E_OBJSTORE_AZURE_ENDPOINT: ${{ secrets.AISIX_E2E_OBJSTORE_AZURE_ENDPOINT }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## What

Bump every GitHub-maintained / third-party action that was still on a Node 20 (or older) runtime to its current major. GitHub is force-migrating Actions to Node 24 starting 2026-06-16, and the runs in #625 were already emitting the Node 20 deprecation warning for `actions/checkout` and `aws-actions/configure-aws-credentials`.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/setup-node` | v4 | v6 |
| `aws-actions/configure-aws-credentials` | v4 **and** v1 | v6 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/build-push-action` | v6 | v7 |
| `pnpm/action-setup` | v4 | v6 |

The `docker-image` OpenAPI-publish step was still pinned to `configure-aws-credentials@v1` (Node 16 era) — folded into the same v6 bump. Its static-key inputs (`aws-access-key-id` / `aws-secret-access-key` / `aws-region`) are unchanged in v6.

Left as-is: `Swatinem/rust-cache@v2` (latest major), `dtolnay/rust-toolchain@stable` and `./.github/actions/setup-protoc` (shell composite, no Node runtime), `taiki-e/install-action@cargo-llvm-cov` (moving alias on latest major), `chetan/invalidate-cloudfront-action@v2` (latest major).

## Compatibility

Pure `uses:` tag swaps — no input/usage changes were needed:

- Artifact usage already follows the v4 immutable model (unique names per job, by-name downloads), so `upload@v7` / `download@v8` are drop-in.
- `pnpm/action-setup@v6` keeps the explicit `version:` input; no `packageManager` field exists in any `package.json` to conflict with it.
- `configure-aws-credentials@v6` still exports env credentials by default, so the keyless `objstore-cloud-identity` ambient `from_env` chain is unaffected.

## Verification

CI exercises `ci.yml` (checkout/upload/download/setup-node/pnpm) and `docker-image` build on `ubuntu-latest`. The gated objstore workflows (`objstore-real-cloud`, `objstore-cloud-identity`) are dispatched on this branch to confirm `checkout@v6` and `configure-aws-credentials@v6` against the real clouds, since they don't run on normal PRs.
