### PR TITLE
ci: publish the container image as ghcr.io/api7/aisix

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,13 +34,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  # Pinned, NOT ${{ github.repository }}: the published image must stay
-  # ghcr.io/api7/ai-gateway — an api7-org, public package already linked to
-  # this repo (GITHUB_TOKEN can write it) and already consumed downstream as
-  # :dev (api7/AISIX-Cloud, etc.). The api7/ai-gateway -> api7/aisix repo
-  # rename would otherwise retarget the push to a different, private
-  # ghcr.io/api7/aisix package (owned by api7/aisix-archived) and 403.
-  IMAGE_NAME: api7/ai-gateway
+  IMAGE_NAME: api7/aisix
 
 permissions:
   contents: read

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,14 +5,14 @@
 # /etc/aisix/config.yaml). Two intended modes:
 #
 #   Standalone — operator mounts their own config:
-#       docker run -v ./config.yaml:/etc/aisix/config.yaml ghcr.io/api7/ai-gateway:dev
+#       docker run -v ./config.yaml:/etc/aisix/config.yaml ghcr.io/api7/aisix:dev
 #
 #   Managed (aisix.cloud tenant) — use the baked-in template + env vars:
 #       docker run \
 #         -e AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml \
 #         -e AISIX_MANAGED__REGISTRATION_TOKEN=$DEPLOYMENT_TOKEN \
 #         -e AISIX_MANAGED__CP_BASE_URL=https://api.us.aisix.cloud \
-#         ghcr.io/api7/ai-gateway:dev
+#         ghcr.io/api7/aisix:dev
 #
 # The Rust binary's `Config::load_from_path` already layers
 # `AISIX_<UPPER>__<UPPER>` env vars on top of the YAML, so any field

--- a/docs/quickstart/self-hosted.md
+++ b/docs/quickstart/self-hosted.md
@@ -114,7 +114,7 @@ services:
       - "2379:2379"
 
   aisix:
-    image: ghcr.io/api7/ai-gateway:dev
+    image: ghcr.io/api7/aisix:dev
     command: ["--config", "/etc/aisix/config.yaml"]
     volumes:
       - ./config.yaml:/etc/aisix/config.yaml:ro
@@ -130,7 +130,7 @@ docker compose up -d
 ```
 
 :::note
-`ghcr.io/api7/ai-gateway:dev` tracks the `main` branch. For a reproducible deployment, pin a released version tag (for example `ghcr.io/api7/ai-gateway:v1.2.3`) once one is available.
+`ghcr.io/api7/aisix:dev` tracks the `main` branch. For a reproducible deployment, pin a released version tag (for example `ghcr.io/api7/aisix:v1.2.3`) once one is available.
 :::
 
 The proxy listener is now on `http://127.0.0.1:3000` and the admin listener on `http://127.0.0.1:3001`, the same as the local build, so the verification below applies unchanged. To stop the stack, run `docker compose down`.


### PR DESCRIPTION
> **DRAFT — do not merge until the `ghcr.io/api7/aisix` package is freed**, otherwise the `main` push 403s (the exact failure #624 fixed). Mark ready once the old package is deleted (or granted Write + Public to this repo) AND the coordinated downstream PRs below are queued.

## What

Switch the published OSS data-plane image from `ghcr.io/api7/ai-gateway` to **`ghcr.io/api7/aisix`** (publish-only-aisix, no dual-publish):

- `docker-image.yml`: `IMAGE_NAME` `api7/ai-gateway` → `api7/aisix` (drops the #624 pin).
- `docs/quickstart/self-hosted.md` + `docker/entrypoint.sh`: image refs → `ghcr.io/api7/aisix`.
- The S3 OpenAPI path (`s3://…/ai-gateway/openapi-*.json`) is **left as-is** — that's the docs.api7.ai OpenAPI hosting path, not the container image.

## Prerequisite (org admin)

The old `ghcr.io/api7/aisix` package is `private` and linked to `api7/aisix-archived`. Its EE producer/consumer are gone (aisix-ee#21 + api7ee-3#2754 merged), so free it: **delete it**, or grant this repo **Write** + set **Public**. After it's freed, merging this makes the first `main` push recreate `ghcr.io/api7/aisix` owned by `api7/aisix` (its token), which is then set **Public**.

## ⚠️ Breaking — `ghcr.io/api7/ai-gateway:dev` freezes; coordinate these downstream PRs

This stops publishing `ghcr.io/api7/ai-gateway` (no dual-publish), so its `:dev` tag freezes. Consumers to switch to `ghcr.io/api7/aisix:dev` as a coordinated set with this PR:

- **`api7/AISIX-Cloud`** (~14 spots): prod `internal/config/config.go` `DPImage` default, `helm/values.yaml`, `deploy/compose.yml` + `.env.example`, Go + TS e2e harness defaults, `ci.yml`, nightly `real-chain`. Also update the e2e **assertion literals** (`publicconfig_test.go` `:v1.0.0`, gateway-cert specs `:dev`/`:test`) or those tests fail post-switch.
- **`api7/docs`** (4 **public** pages): `docker run … ghcr.io/api7/ai-gateway:dev` in `getting-started/self-hosted-quickstart`, `reference/configuration-files`, `reference/environment-variables`, `cloud/gateway-certificates-and-managed-gateway`. Customer-visible → needs a parallel `→ ghcr.io/api7/aisix` PR.
- `api7/rfcs`: one ref, but sha-pinned (`:sha-…`, frozen PoC report) → inert, no change.

Out of scope here: `Cargo.toml` `repository = github.com/moonming/ai-gateway` (stale pre-existing personal-fork URL) — separate cleanup.