### PR TITLE
feat(redis): support cluster and sentinel connection modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,16 @@ jobs:
       # (shared cluster-level counters, #798). Same skip-if-unset /
       # no-AISIX_-prefix rules as CACHE_TEST_REDIS_URL above.
       RATELIMIT_TEST_REDIS_URL: redis://127.0.0.1:6379
+      # Redis Cluster + Sentinel topologies started by the "Start Redis
+      # Cluster + Sentinel" step below — exercise the `mode: cluster` /
+      # `mode: sentinel` connection paths in both cache + ratelimit
+      # integration tests. Same skip-if-unset / no-AISIX_-prefix rules.
+      RATELIMIT_TEST_REDIS_CLUSTER_NODES: redis://127.0.0.1:7000,redis://127.0.0.1:7001,redis://127.0.0.1:7002
+      RATELIMIT_TEST_REDIS_SENTINELS: redis://127.0.0.1:26379
+      RATELIMIT_TEST_REDIS_MASTER: mymaster
+      CACHE_TEST_REDIS_CLUSTER_NODES: redis://127.0.0.1:7000,redis://127.0.0.1:7001,redis://127.0.0.1:7002
+      CACHE_TEST_REDIS_SENTINELS: redis://127.0.0.1:26379
+      CACHE_TEST_REDIS_MASTER: mymaster
       # Picked up by crates/aisix-admin/tests/etcd_integration.rs.
       # Same skip-if-unset pattern as the Redis case above.
       ADMIN_TEST_ETCD_URL: http://127.0.0.1:2379
@@ -123,6 +133,33 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Start Redis Cluster + Sentinel
+        # The `redis` service above covers single-node. Here we bring up a
+        # 3-node cluster (7000-7002) and a sentinel (26379) monitoring the
+        # 6379 service as `mymaster`, so the cache + ratelimit integration
+        # tests exercise the cluster/sentinel connection modes. Host
+        # networking + announce-ip keep the advertised addresses reachable
+        # from the test process.
+        run: |
+          for p in 7000 7001 7002; do
+            docker run -d --name rediscl-$p --network host redis:7-alpine \
+              redis-server --port $p --cluster-enabled yes --cluster-config-file nodes.conf \
+              --cluster-node-timeout 5000 --cluster-announce-ip 127.0.0.1 --appendonly no
+          done
+          sleep 2
+          docker exec rediscl-7000 redis-cli --cluster create \
+            127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 --cluster-replicas 0 --cluster-yes
+          for i in $(seq 1 30); do
+            state=$(docker exec rediscl-7000 redis-cli -p 7000 cluster info | tr -d '\r' | grep -oP 'cluster_state:\K\w+')
+            [ "$state" = "ok" ] && break
+            sleep 1
+          done
+          docker exec rediscl-7000 redis-cli -p 7000 cluster info | grep cluster_state
+          printf 'port 26379\nsentinel monitor mymaster 127.0.0.1 6379 1\nsentinel down-after-milliseconds mymaster 5000\nsentinel failover-timeout mymaster 10000\n' > /tmp/sentinel.conf
+          docker run -d --name redis-sentinel --network host -v /tmp/sentinel.conf:/data/sentinel.conf \
+            redis:7-alpine redis-sentinel /data/sentinel.conf
+          sleep 2
+          docker exec redis-sentinel redis-cli -p 26379 sentinel get-master-addr-by-name mymaster
       - name: unit tests with coverage
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov-unit.info
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,12 +159,15 @@ jobs:
             [ "$state" = "ok" ] && break
             sleep 1
           done
-          docker exec rediscl-7000 redis-cli -p 7000 cluster info | grep cluster_state
+          # Fail fast if the cluster never formed, instead of letting the
+          # integration tests surface it later as confusing connection errors.
+          [ "$state" = "ok" ] || { echo "::error::Redis cluster did not become ready"; exit 1; }
           printf 'port 26379\nsentinel monitor mymaster 127.0.0.1 6379 1\nsentinel down-after-milliseconds mymaster 5000\nsentinel failover-timeout mymaster 10000\n' > /tmp/sentinel.conf
           docker run -d --name redis-sentinel --network host -v /tmp/sentinel.conf:/data/sentinel.conf \
             redis:7-alpine redis-sentinel /data/sentinel.conf
           sleep 2
-          docker exec redis-sentinel redis-cli -p 26379 sentinel get-master-addr-by-name mymaster
+          docker exec redis-sentinel redis-cli -p 26379 sentinel get-master-addr-by-name mymaster | tr -d '\r' | grep -qE '127\.0\.0\.1' \
+            || { echo "::error::Sentinel 26379 did not resolve mymaster"; exit 1; }
           # Failover topology: master (6381) + replica (6382) + sentinel
           # (26380) monitoring `myfo`, so the failover/reconnect test can
           # force a real promotion. The sentinel conf dir is mounted (not a
@@ -178,7 +181,8 @@ jobs:
           docker run -d --name redis-fo-sentinel --network host -v /tmp/sentinel-fo:/data \
             redis:7-alpine redis-sentinel /data/sentinel.conf
           sleep 2
-          docker exec redis-fo-sentinel redis-cli -p 26380 sentinel get-master-addr-by-name myfo
+          docker exec redis-fo-sentinel redis-cli -p 26380 sentinel get-master-addr-by-name myfo | tr -d '\r' | grep -qE '127\.0\.0\.1[[:space:]]+6381' \
+            || { echo "::error::Failover sentinel 26380 did not resolve myfo to the master"; exit 1; }
       - name: unit tests with coverage
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov-unit.info
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,11 @@ jobs:
       CACHE_TEST_REDIS_CLUSTER_NODES: redis://127.0.0.1:7000,redis://127.0.0.1:7001,redis://127.0.0.1:7002
       CACHE_TEST_REDIS_SENTINELS: redis://127.0.0.1:26379
       CACHE_TEST_REDIS_MASTER: mymaster
+      # Picked up by crates/aisix-redis/tests/sentinel_failover.rs — the
+      # master+replica+sentinel(26380) topology the setup step brings up,
+      # so the failover/reconnect test forces a real promotion in CI.
+      REDIS_FAILOVER_SENTINELS: redis://127.0.0.1:26380
+      REDIS_FAILOVER_MASTER: myfo
       # Picked up by crates/aisix-admin/tests/etcd_integration.rs.
       # Same skip-if-unset pattern as the Redis case above.
       ADMIN_TEST_ETCD_URL: http://127.0.0.1:2379
@@ -160,6 +165,20 @@ jobs:
             redis:7-alpine redis-sentinel /data/sentinel.conf
           sleep 2
           docker exec redis-sentinel redis-cli -p 26379 sentinel get-master-addr-by-name mymaster
+          # Failover topology: master (6381) + replica (6382) + sentinel
+          # (26380) monitoring `myfo`, so the failover/reconnect test can
+          # force a real promotion. The sentinel conf dir is mounted (not a
+          # single file) so sentinel can rewrite it on failover.
+          docker run -d --name redis-fo-master --network host redis:7-alpine redis-server --port 6381
+          docker run -d --name redis-fo-replica --network host redis:7-alpine \
+            redis-server --port 6382 --replicaof 127.0.0.1 6381 --replica-announce-ip 127.0.0.1
+          sleep 2
+          mkdir -p /tmp/sentinel-fo
+          printf 'port 26380\nsentinel monitor myfo 127.0.0.1 6381 1\nsentinel down-after-milliseconds myfo 5000\nsentinel failover-timeout myfo 10000\nsentinel parallel-syncs myfo 1\n' > /tmp/sentinel-fo/sentinel.conf
+          docker run -d --name redis-fo-sentinel --network host -v /tmp/sentinel-fo:/data \
+            redis:7-alpine redis-sentinel /data/sentinel.conf
+          sleep 2
+          docker exec redis-fo-sentinel redis-cli -p 26380 sentinel get-master-addr-by-name myfo
       - name: unit tests with coverage
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov-unit.info
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,10 @@ jobs:
           docker run -d --name redis-sentinel --network host -v /tmp/sentinel.conf:/data/sentinel.conf \
             redis:7-alpine redis-sentinel /data/sentinel.conf
           sleep 2
-          docker exec redis-sentinel redis-cli -p 26379 sentinel get-master-addr-by-name mymaster | tr -d '\r' | grep -qE '127\.0\.0\.1' \
+          # get-master-addr-by-name prints host and port on separate lines;
+          # join them so the IP+port match isn't defeated by grep's per-line
+          # matching.
+          docker exec redis-sentinel redis-cli -p 26379 sentinel get-master-addr-by-name mymaster | tr -d '\r' | tr '\n' ' ' | grep -qE '127\.0\.0\.1 +6379' \
             || { echo "::error::Sentinel 26379 did not resolve mymaster"; exit 1; }
           # Failover topology: master (6381) + replica (6382) + sentinel
           # (26380) monitoring `myfo`, so the failover/reconnect test can
@@ -181,7 +184,7 @@ jobs:
           docker run -d --name redis-fo-sentinel --network host -v /tmp/sentinel-fo:/data \
             redis:7-alpine redis-sentinel /data/sentinel.conf
           sleep 2
-          docker exec redis-fo-sentinel redis-cli -p 26380 sentinel get-master-addr-by-name myfo | tr -d '\r' | grep -qE '127\.0\.0\.1[[:space:]]+6381' \
+          docker exec redis-fo-sentinel redis-cli -p 26380 sentinel get-master-addr-by-name myfo | tr -d '\r' | tr '\n' ' ' | grep -qE '127\.0\.0\.1 +6381' \
             || { echo "::error::Failover sentinel 26380 did not resolve myfo to the master"; exit 1; }
       - name: unit tests with coverage
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov-unit.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,9 @@ dependencies = [
 name = "aisix-cache"
 version = "0.1.0"
 dependencies = [
+ "aisix-core",
  "aisix-gateway",
+ "aisix-redis",
  "async-trait",
  "moka",
  "redis",
@@ -322,6 +324,7 @@ name = "aisix-ratelimit"
 version = "0.1.0"
 dependencies = [
  "aisix-core",
+ "aisix-redis",
  "async-trait",
  "dashmap",
  "parking_lot",
@@ -330,6 +333,16 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aisix-redis"
+version = "0.1.0"
+dependencies = [
+ "aisix-core",
+ "redis",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/aisix-obs",
     "crates/aisix-ratelimit",
     "crates/aisix-cache",
+    "crates/aisix-redis",
     "crates/aisix-guardrails",
     "crates/aisix-server",
 ]
@@ -103,7 +104,7 @@ hex = "0.4"
 
 # Caching / storage backends
 moka = { version = "0.12", features = ["future"] }
-redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "cluster-async"] }
+redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "cluster-async", "sentinel"] }
 
 # Object-storage observability sink (aisix-obs): ONE crate covering S3 / GCS /
 # Azure Blob (+ S3-compatible MinIO/R2) behind a single `ObjectStore` trait, so

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,11 +95,16 @@ cache:
   #   url: "redis://127.0.0.1:6379"
   #   # mode: cluster → one or more seed node URLs:
   #   # nodes: ["redis://10.0.0.1:6379", "redis://10.0.0.2:6379"]
-  #   # mode: sentinel → sentinel node URLs + the monitored master name
-  #   # (password, if set, is for the data node reached via Sentinel):
+  #   # mode: sentinel → sentinel node URLs + the monitored master name.
+  #   # Sentinel auth goes in the sentinels URLs; username/password/database
+  #   # below authenticate the data node (master) Sentinel discovers — it
+  #   # has no URL of its own. Supply `password` via the matching env var
+  #   # (AISIX_CACHE__REDIS__PASSWORD) to keep it out of this file.
   #   # sentinels: ["redis://10.0.0.1:26379", "redis://10.0.0.2:26379"]
   #   # master_name: "mymaster"
+  #   # username: "default"      # Redis ACL user (cluster nodes / sentinel master)
   #   # password: "s3cret"
+  #   # database: 0              # DB index for the sentinel master (not used by cluster)
 
 # Rate-limit counter backend (api7/AISIX-Cloud#798).
 #

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -88,8 +88,18 @@ cache:
   # `redis` block below (validated at boot).
   backend: "memory"   # memory | redis
   # redis:
-  #   url: "redis://127.0.0.1:6379"
+  #   # mode picks the topology. Credentials and TLS (rediss://) travel
+  #   # inside the URLs, as in single mode.
   #   mode: "single"   # single | cluster | sentinel
+  #   # mode: single  → one endpoint:
+  #   url: "redis://127.0.0.1:6379"
+  #   # mode: cluster → one or more seed node URLs:
+  #   # nodes: ["redis://10.0.0.1:6379", "redis://10.0.0.2:6379"]
+  #   # mode: sentinel → sentinel node URLs + the monitored master name
+  #   # (password, if set, is for the data node reached via Sentinel):
+  #   # sentinels: ["redis://10.0.0.1:26379", "redis://10.0.0.2:26379"]
+  #   # master_name: "mymaster"
+  #   # password: "s3cret"
 
 # Rate-limit counter backend (api7/AISIX-Cloud#798).
 #
@@ -103,8 +113,12 @@ cache:
 ratelimit:
   backend: "memory"   # memory | redis
   # redis:
-  #   url: "redis://127.0.0.1:6379"
+  #   # Same shape as cache.redis above — single / cluster / sentinel.
   #   mode: "single"   # single | cluster | sentinel
+  #   url: "redis://127.0.0.1:6379"            # mode: single
+  #   # nodes: ["redis://10.0.0.1:6379"]        # mode: cluster
+  #   # sentinels: ["redis://10.0.0.1:26379"]   # mode: sentinel
+  #   # master_name: "mymaster"                  # mode: sentinel
   # Seconds before an unreleased concurrency slot (crashed replica /
   # hung upstream) is reclaimed. Redis backend only.
   # concurrency_ttl_secs: 300

--- a/crates/aisix-cache/Cargo.toml
+++ b/crates/aisix-cache/Cargo.toml
@@ -10,6 +10,8 @@ description = "aisix: response cache (in-memory / Redis / semantic)"
 
 [dependencies]
 aisix-gateway = { path = "../aisix-gateway" }
+aisix-core = { path = "../aisix-core" }
+aisix-redis = { path = "../aisix-redis", optional = true }
 tokio.workspace = true
 async-trait.workspace = true
 serde_json.workspace = true
@@ -23,4 +25,4 @@ tokio = { workspace = true, features = ["macros", "rt", "time"] }
 [features]
 default = ["memory"]
 memory = []
-redis = ["dep:redis"]
+redis = ["dep:redis", "dep:aisix-redis"]

--- a/crates/aisix-cache/src/redis.rs
+++ b/crates/aisix-cache/src/redis.rs
@@ -1,9 +1,10 @@
 //! Redis-backed exact-match response cache.
 //!
-//! Implements [`Cache`] against a Redis instance via the `redis` crate's
-//! async ConnectionManager (single-node) — Cluster and Sentinel modes
-//! drop in under the same connection-manager pattern in a follow-up
-//! when the operator config exposes them.
+//! Implements [`Cache`] against Redis through the shared
+//! [`aisix_redis::RedisConn`], so the operator's `cache.redis.mode`
+//! (`single` / `cluster` / `sentinel`) is honored transparently — `GET`
+//! and `SET` route by their key on cluster, and sentinel failovers are
+//! recovered via [`aisix_redis::RedisConn::note_error`].
 //!
 //! Storage shape: each entry is JSON-encoded `ChatResponse` stored under
 //! key `<prefix>:<fingerprint>` with a TTL set on insert (`SET ... EX ttl`).
@@ -13,9 +14,10 @@
 
 use std::time::Duration;
 
+use aisix_core::RedisConnConfig;
 use aisix_gateway::ChatResponse;
+use aisix_redis::RedisConn;
 use async_trait::async_trait;
-use redis::aio::ConnectionManager;
 use redis::AsyncCommands;
 
 use crate::cache::{Cache, CacheError};
@@ -29,7 +31,7 @@ pub const DEFAULT_PREFIX: &str = "aisix:cache";
 
 #[derive(Clone)]
 pub struct RedisCache {
-    conn: ConnectionManager,
+    conn: RedisConn,
     ttl_secs: u64,
     prefix: String,
 }
@@ -44,13 +46,11 @@ impl std::fmt::Debug for RedisCache {
 }
 
 impl RedisCache {
-    /// Connect to Redis using a single-node URL like `redis://host:port/`.
-    /// Uses [`ConnectionManager`] which transparently reconnects on
-    /// dropped connections — no per-request handshake cost.
-    pub async fn connect(url: &str) -> Result<Self, CacheError> {
-        let client = redis::Client::open(url)
-            .map_err(|e| CacheError::Backend(format!("redis client open: {e}")))?;
-        let conn = ConnectionManager::new(client)
+    /// Connect using the operator's `cache.redis` config. The topology
+    /// (`single` / `cluster` / `sentinel`) is selected by `mode`; see
+    /// [`aisix_redis::connect`].
+    pub async fn connect(cfg: &RedisConnConfig) -> Result<Self, CacheError> {
+        let conn = aisix_redis::connect(cfg)
             .await
             .map_err(|e| CacheError::Backend(format!("redis connect: {e}")))?;
         Ok(Self {
@@ -84,12 +84,19 @@ impl RedisCache {
 #[async_trait]
 impl Cache for RedisCache {
     async fn get(&self, key: &str) -> Result<Option<ChatResponse>, CacheError> {
-        let mut conn = self.conn.clone();
-        let full = self.full_key(key);
-        let raw: Option<String> = conn
-            .get(&full)
+        let mut conn = self
+            .conn
+            .acquire()
             .await
-            .map_err(|e| CacheError::Backend(format!("redis GET: {e}")))?;
+            .map_err(|e| CacheError::Backend(format!("redis acquire: {e}")))?;
+        let full = self.full_key(key);
+        let raw: Option<String> = match conn.get(&full).await {
+            Ok(v) => v,
+            Err(e) => {
+                self.conn.note_error().await;
+                return Err(CacheError::Backend(format!("redis GET: {e}")));
+            }
+        };
         match raw {
             None => Ok(None),
             Some(json) => serde_json::from_str::<ChatResponse>(&json)
@@ -117,13 +124,17 @@ impl Cache for RedisCache {
     ) -> Result<(), CacheError> {
         let json = serde_json::to_string(&value)
             .map_err(|e| CacheError::Backend(format!("redis encode: {e}")))?;
-        let mut conn = self.conn.clone();
+        let mut conn = self
+            .conn
+            .acquire()
+            .await
+            .map_err(|e| CacheError::Backend(format!("redis acquire: {e}")))?;
         let full = self.full_key(key);
         let secs = ttl.as_secs().max(1);
-        let _: () = conn
-            .set_ex(&full, json, secs)
-            .await
-            .map_err(|e| CacheError::Backend(format!("redis SET EX: {e}")))?;
+        if let Err(e) = conn.set_ex::<_, _, ()>(&full, json, secs).await {
+            self.conn.note_error().await;
+            return Err(CacheError::Backend(format!("redis SET EX: {e}")));
+        }
         Ok(())
     }
 }
@@ -161,7 +172,12 @@ mod tests {
 
     #[tokio::test]
     async fn connect_to_invalid_url_errors() {
-        let err = RedisCache::connect("not-a-url").await.unwrap_err();
+        let cfg = aisix_core::RedisConnConfig {
+            mode: aisix_core::RedisMode::Single,
+            url: Some("not-a-url".into()),
+            ..Default::default()
+        };
+        let err = RedisCache::connect(&cfg).await.unwrap_err();
         let CacheError::Backend(msg) = err;
         assert!(msg.contains("redis"));
     }

--- a/crates/aisix-cache/tests/redis_integration.rs
+++ b/crates/aisix-cache/tests/redis_integration.rs
@@ -10,10 +10,39 @@
 use std::time::Duration;
 
 use aisix_cache::{Cache, RedisCache};
+use aisix_core::{RedisConnConfig, RedisMode};
 use aisix_gateway::{ChatMessage, ChatResponse, FinishReason, UsageStats};
 
 fn redis_url() -> Option<String> {
     std::env::var("CACHE_TEST_REDIS_URL").ok()
+}
+
+fn single(url: &str) -> RedisConnConfig {
+    RedisConnConfig {
+        mode: RedisMode::Single,
+        url: Some(url.to_string()),
+        ..Default::default()
+    }
+}
+
+fn cluster_cfg() -> Option<RedisConnConfig> {
+    let nodes = std::env::var("CACHE_TEST_REDIS_CLUSTER_NODES").ok()?;
+    Some(RedisConnConfig {
+        mode: RedisMode::Cluster,
+        nodes: nodes.split(',').map(|s| s.trim().to_string()).collect(),
+        ..Default::default()
+    })
+}
+
+fn sentinel_cfg() -> Option<RedisConnConfig> {
+    let sentinels = std::env::var("CACHE_TEST_REDIS_SENTINELS").ok()?;
+    let master = std::env::var("CACHE_TEST_REDIS_MASTER").ok()?;
+    Some(RedisConnConfig {
+        mode: RedisMode::Sentinel,
+        sentinels: sentinels.split(',').map(|s| s.trim().to_string()).collect(),
+        master_name: Some(master),
+        ..Default::default()
+    })
 }
 
 fn sample(content: &str) -> ChatResponse {
@@ -33,7 +62,7 @@ async fn put_then_get_round_trips_against_real_redis() {
         return;
     };
 
-    let cache = RedisCache::connect(&url)
+    let cache = RedisCache::connect(&single(&url))
         .await
         .expect("redis connect")
         .with_prefix(format!("aisix:test:{}", uuid_like()));
@@ -57,7 +86,7 @@ async fn put_then_get_preserves_null_content_through_cache() {
         return;
     };
 
-    let cache = RedisCache::connect(&url)
+    let cache = RedisCache::connect(&single(&url))
         .await
         .expect("redis connect")
         .with_prefix(format!("aisix:test:{}", uuid_like()));
@@ -89,7 +118,7 @@ async fn ttl_eviction_drops_entry_after_window() {
         return;
     };
 
-    let cache = RedisCache::connect(&url)
+    let cache = RedisCache::connect(&single(&url))
         .await
         .expect("redis connect")
         .with_prefix(format!("aisix:test:{}", uuid_like()))
@@ -117,7 +146,7 @@ async fn put_with_ttl_honors_per_entry_window_over_global() {
         return;
     };
 
-    let cache = RedisCache::connect(&url)
+    let cache = RedisCache::connect(&single(&url))
         .await
         .expect("redis connect")
         .with_prefix(format!("aisix:test:{}", uuid_like()))
@@ -152,12 +181,47 @@ async fn missing_key_returns_none() {
         return;
     };
 
-    let cache = RedisCache::connect(&url)
+    let cache = RedisCache::connect(&single(&url))
         .await
         .expect("redis connect")
         .with_prefix(format!("aisix:test:{}", uuid_like()));
 
     assert!(cache.get("does-not-exist").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn put_then_get_round_trips_against_cluster() {
+    let Some(cfg) = cluster_cfg() else {
+        eprintln!("skipping: CACHE_TEST_REDIS_CLUSTER_NODES not set");
+        return;
+    };
+    let cache = RedisCache::connect(&cfg)
+        .await
+        .expect("cluster connect")
+        .with_prefix(format!("aisix:test:{}", uuid_like()));
+
+    cache.put("cluster-key", sample("clustered")).await.unwrap();
+    let got = cache.get("cluster-key").await.unwrap().expect("hit");
+    assert_eq!(got.message.content_str(), "clustered");
+}
+
+#[tokio::test]
+async fn put_then_get_round_trips_against_sentinel() {
+    let Some(cfg) = sentinel_cfg() else {
+        eprintln!("skipping: CACHE_TEST_REDIS_SENTINELS / _MASTER not set");
+        return;
+    };
+    let cache = RedisCache::connect(&cfg)
+        .await
+        .expect("sentinel connect")
+        .with_prefix(format!("aisix:test:{}", uuid_like()));
+
+    cache
+        .put("sentinel-key", sample("via-master"))
+        .await
+        .unwrap();
+    let got = cache.get("sentinel-key").await.unwrap().expect("hit");
+    assert_eq!(got.message.content_str(), "via-master");
 }
 
 /// Cheap unique-ish suffix to keep tests from clobbering each other.

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -532,7 +532,7 @@ impl Default for OtlpTracingConfig {
 #[serde(deny_unknown_fields, default)]
 pub struct CacheConfig {
     pub backend: CacheBackend,
-    pub redis: Option<RedisCacheConfig>,
+    pub redis: Option<RedisConnConfig>,
 }
 
 impl Default for CacheConfig {
@@ -551,17 +551,80 @@ pub enum CacheBackend {
     Redis,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RedisCacheConfig {
-    pub url: String,
-    #[serde(default = "RedisCacheConfig::default_mode")]
-    pub mode: String,
+/// Connection topology for a shared Redis backend (cache + rate-limit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum RedisMode {
+    /// One Redis endpoint (`url`). The historical default.
+    #[default]
+    Single,
+    /// Redis Cluster — seeded from `nodes`, topology discovered at connect.
+    Cluster,
+    /// Redis Sentinel — the master is discovered (and re-discovered after
+    /// failover) via `sentinels` for the group named `master_name`.
+    Sentinel,
 }
 
-impl RedisCacheConfig {
-    fn default_mode() -> String {
-        "single".into()
+/// Shared connection shape for the Redis-backed response cache and the
+/// shared rate-limit counter store. `mode` selects the topology; the
+/// fields each mode needs are validated at boot ([`Self::validate`]):
+///
+/// - `single`   → `url` (e.g. `redis://host:6379`)
+/// - `cluster`  → `nodes` (one or more seed node URLs)
+/// - `sentinel` → `sentinels` (sentinel node URLs) + `master_name`
+///
+/// Credentials and TLS (`rediss://`) travel inside the URLs, matching the
+/// single-node convention; `password` additionally sets the password for
+/// the data node (master) discovered through Sentinel.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct RedisConnConfig {
+    pub mode: RedisMode,
+    /// Single-node URL. Required when `mode = single`.
+    pub url: Option<String>,
+    /// Cluster seed node URLs. Required (≥1) when `mode = cluster`.
+    pub nodes: Vec<String>,
+    /// Sentinel node URLs. Required (≥1) when `mode = sentinel`.
+    pub sentinels: Vec<String>,
+    /// Monitored master group name. Required when `mode = sentinel`.
+    pub master_name: Option<String>,
+    /// Password for the data node (master) reached via Sentinel. Sentinel
+    /// node auth travels in the `sentinels` URLs instead.
+    pub password: Option<String>,
+}
+
+impl RedisConnConfig {
+    /// Fail-fast check that the fields the selected `mode` needs are
+    /// present. `ctx` labels the offending block (e.g. `cache.redis`).
+    pub fn validate(&self, ctx: &str) -> Result<(), String> {
+        let non_empty = |v: &[String]| v.iter().any(|s| !s.trim().is_empty());
+        match self.mode {
+            RedisMode::Single => {
+                if self.url.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(format!("{ctx}.url is required when mode = single"));
+                }
+            }
+            RedisMode::Cluster => {
+                if !non_empty(&self.nodes) {
+                    return Err(format!(
+                        "{ctx}.nodes must list at least one node when mode = cluster"
+                    ));
+                }
+            }
+            RedisMode::Sentinel => {
+                if !non_empty(&self.sentinels) {
+                    return Err(format!(
+                        "{ctx}.sentinels must list at least one sentinel when mode = sentinel"
+                    ));
+                }
+                if self.master_name.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(format!(
+                        "{ctx}.master_name is required when mode = sentinel"
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -571,14 +634,15 @@ impl RedisCacheConfig {
 /// N-replica cluster enforces N× the configured limit. `Redis` shares
 /// the counters across replicas via a single Redis so the whole cluster
 /// enforces one global window. The `redis` block is required iff
-/// `backend = redis` (validated at boot). Reuses [`RedisCacheConfig`]
-/// for the connection shape; may point at the same Redis as `cache`
-/// (keys are namespaced `aisix:rl:`).
+/// `backend = redis` (validated at boot). Reuses [`RedisConnConfig`]
+/// for the connection shape, so it supports `single`/`cluster`/`sentinel`
+/// modes too; may point at the same Redis as `cache` (keys are namespaced
+/// `aisix:rl:`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct RateLimitConfig {
     pub backend: RateLimitBackend,
-    pub redis: Option<RedisCacheConfig>,
+    pub redis: Option<RedisConnConfig>,
     /// Seconds after which an unreleased concurrency slot is reclaimed
     /// (crashed replica / hung upstream). Generous enough for a long
     /// streaming response. Redis backend only.
@@ -702,10 +766,15 @@ impl Config {
             )));
         }
         if self.ratelimit.backend == RateLimitBackend::Redis {
-            if self.ratelimit.redis.is_none() {
-                return Err(BootstrapError::Config(
-                    "ratelimit.backend = redis requires a ratelimit.redis block".into(),
-                ));
+            match &self.ratelimit.redis {
+                None => {
+                    return Err(BootstrapError::Config(
+                        "ratelimit.backend = redis requires a ratelimit.redis block".into(),
+                    ));
+                }
+                Some(redis) => redis
+                    .validate("ratelimit.redis")
+                    .map_err(BootstrapError::Config)?,
             }
             // A zero concurrency TTL would prune a slot in the same second
             // it was taken, silently disabling concurrency limiting.
@@ -714,6 +783,13 @@ impl Config {
                     "ratelimit.concurrency_ttl_secs must be > 0 for the redis backend".into(),
                 ));
             }
+        }
+        // A `cache.redis` block, when present, is built regardless of the
+        // legacy `cache.backend` knob, so validate its mode fields too.
+        if let Some(redis) = &self.cache.redis {
+            redis
+                .validate("cache.redis")
+                .map_err(BootstrapError::Config)?;
         }
         Ok(())
     }
@@ -901,6 +977,75 @@ ratelimit:
         assert!(err.to_string().contains("concurrency_ttl_secs"));
     }
 
+    fn redis_backend_yaml(redis_block: &str) -> tempfile::NamedTempFile {
+        write_yaml(&format!(
+            r#"
+etcd:
+  endpoints: ["http://localhost:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+ratelimit:
+  backend: "redis"
+  redis:
+{redis_block}
+"#
+        ))
+    }
+
+    #[test]
+    fn redis_mode_defaults_to_single() {
+        let f = redis_backend_yaml("    url: \"redis://127.0.0.1:6379\"");
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        let redis = cfg.ratelimit.redis.unwrap();
+        assert_eq!(redis.mode, RedisMode::Single);
+        assert_eq!(redis.url.as_deref(), Some("redis://127.0.0.1:6379"));
+    }
+
+    #[test]
+    fn redis_single_mode_requires_url() {
+        let f = redis_backend_yaml("    mode: \"single\"");
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("ratelimit.redis.url"));
+    }
+
+    #[test]
+    fn redis_cluster_mode_parses_and_requires_nodes() {
+        let ok = redis_backend_yaml(
+            "    mode: \"cluster\"\n    nodes: [\"redis://n1:6379\", \"redis://n2:6379\"]",
+        );
+        let cfg = Config::load_from_path(Some(ok.path())).unwrap();
+        let redis = cfg.ratelimit.redis.unwrap();
+        assert_eq!(redis.mode, RedisMode::Cluster);
+        assert_eq!(redis.nodes.len(), 2);
+
+        let bad = redis_backend_yaml("    mode: \"cluster\"");
+        let err = Config::load_from_path(Some(bad.path())).unwrap_err();
+        assert!(err.to_string().contains("ratelimit.redis.nodes"));
+    }
+
+    #[test]
+    fn redis_sentinel_mode_parses_and_requires_master_name() {
+        let ok = redis_backend_yaml(
+            "    mode: \"sentinel\"\n    sentinels: [\"redis://s1:26379\"]\n    master_name: \"mymaster\"",
+        );
+        let cfg = Config::load_from_path(Some(ok.path())).unwrap();
+        let redis = cfg.ratelimit.redis.unwrap();
+        assert_eq!(redis.mode, RedisMode::Sentinel);
+        assert_eq!(redis.master_name.as_deref(), Some("mymaster"));
+
+        let no_master =
+            redis_backend_yaml("    mode: \"sentinel\"\n    sentinels: [\"redis://s1:26379\"]");
+        let err = Config::load_from_path(Some(no_master.path())).unwrap_err();
+        assert!(err.to_string().contains("ratelimit.redis.master_name"));
+
+        let no_sentinels = redis_backend_yaml("    mode: \"sentinel\"\n    master_name: \"m\"");
+        let err = Config::load_from_path(Some(no_sentinels.path())).unwrap_err();
+        assert!(err.to_string().contains("ratelimit.redis.sentinels"));
+    }
+
     #[test]
     fn loads_ratelimit_redis_config() {
         let f = write_yaml(
@@ -922,8 +1067,8 @@ ratelimit:
         let cfg = Config::load_from_path(Some(f.path())).unwrap();
         assert_eq!(cfg.ratelimit.backend, RateLimitBackend::Redis);
         assert_eq!(
-            cfg.ratelimit.redis.as_ref().unwrap().url,
-            "redis://127.0.0.1:6379"
+            cfg.ratelimit.redis.as_ref().unwrap().url.as_deref(),
+            Some("redis://127.0.0.1:6379")
         );
         assert_eq!(cfg.ratelimit.concurrency_ttl_secs, 120);
     }

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -573,9 +573,17 @@ pub enum RedisMode {
 /// - `cluster`  → `nodes` (one or more seed node URLs)
 /// - `sentinel` → `sentinels` (sentinel node URLs) + `master_name`
 ///
-/// Credentials and TLS (`rediss://`) travel inside the URLs, matching the
-/// single-node convention; `password` additionally sets the password for
-/// the data node (master) discovered through Sentinel.
+/// In `single` mode all credentials and TLS (`rediss://`) travel inside
+/// `url`. In `cluster`/`sentinel` mode they can travel in the node /
+/// sentinel URLs the same way, but the **data node** (cluster nodes, or
+/// the Sentinel-discovered master) can also be authenticated explicitly
+/// with `username` + `password` (Redis ACL) and, for sentinel, a
+/// `database` — useful because the Sentinel-discovered master has no URL
+/// of its own. Sentinel-node auth still travels in the `sentinels` URLs,
+/// so Sentinel and master credentials may differ.
+///
+/// To keep secrets out of the config file, supply `password` via the
+/// matching env var instead, e.g. `AISIX_RATELIMIT__REDIS__PASSWORD`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields, default)]
 pub struct RedisConnConfig {
@@ -588,9 +596,13 @@ pub struct RedisConnConfig {
     pub sentinels: Vec<String>,
     /// Monitored master group name. Required when `mode = sentinel`.
     pub master_name: Option<String>,
-    /// Password for the data node (master) reached via Sentinel. Sentinel
-    /// node auth travels in the `sentinels` URLs instead.
+    /// ACL username for the data node (cluster nodes / sentinel master).
+    pub username: Option<String>,
+    /// Password for the data node (cluster nodes / sentinel master).
     pub password: Option<String>,
+    /// Database index for the Sentinel-discovered master (default 0).
+    /// Not applicable to `cluster` (Redis Cluster only has DB 0).
+    pub database: Option<i64>,
 }
 
 impl RedisConnConfig {
@@ -1035,6 +1047,19 @@ ratelimit:
         let redis = cfg.ratelimit.redis.unwrap();
         assert_eq!(redis.mode, RedisMode::Sentinel);
         assert_eq!(redis.master_name.as_deref(), Some("mymaster"));
+
+        // ACL username/password + database for the discovered master parse.
+        let acl = redis_backend_yaml(
+            "    mode: \"sentinel\"\n    sentinels: [\"redis://s1:26379\"]\n    master_name: \"m\"\n    username: \"default\"\n    password: \"s3cret\"\n    database: 2",
+        );
+        let redis = Config::load_from_path(Some(acl.path()))
+            .unwrap()
+            .ratelimit
+            .redis
+            .unwrap();
+        assert_eq!(redis.username.as_deref(), Some("default"));
+        assert_eq!(redis.password.as_deref(), Some("s3cret"));
+        assert_eq!(redis.database, Some(2));
 
         let no_master =
             redis_backend_yaml("    mode: \"sentinel\"\n    sentinels: [\"redis://s1:26379\"]");

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -25,7 +25,7 @@ pub mod snapshot;
 pub use config::{
     AdminConfig, CacheBackend, CacheConfig, Config, EtcdConfig, EtcdTlsConfig, ManagedConfig,
     ObservabilityConfig, ProxyConfig, RateLimitBackend, RateLimitConfig, RealIpConfig,
-    RedisCacheConfig, TlsConfig,
+    RedisConnConfig, RedisMode, TlsConfig,
 };
 pub use error::{
     AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,

--- a/crates/aisix-ratelimit/Cargo.toml
+++ b/crates/aisix-ratelimit/Cargo.toml
@@ -10,6 +10,7 @@ description = "aisix: fixed-window rate limiter (commit/read-only modes) + semap
 
 [dependencies]
 aisix-core = { path = "../aisix-core" }
+aisix-redis = { path = "../aisix-redis" }
 tokio.workspace = true
 dashmap.workspace = true
 parking_lot.workspace = true

--- a/crates/aisix-ratelimit/src/store/redis.rs
+++ b/crates/aisix-ratelimit/src/store/redis.rs
@@ -27,13 +27,21 @@
 //! enforcement during an outage instead of being blocked. Counts may
 //! diverge from Redis until it recovers — availability over strict global
 //! enforcement, matching the cache's "Redis error → proceed" stance.
+//!
+//! The connection is the shared [`aisix_redis::RedisConn`], so `single`,
+//! `cluster`, and `sentinel` topologies all work. Because every script
+//! touches several keys, each `EVAL` declares the bucket key (carrying the
+//! `{<bucket>}` hash tag) so Redis Cluster routes it to the slot that owns
+//! every key the script reads/writes; on single/sentinel the declared key
+//! is simply ignored by the script body, which still reads the prefix from
+//! `ARGV[1]`.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use aisix_core::RateLimit;
+use aisix_core::{RateLimit, RedisConnConfig};
+use aisix_redis::RedisConn;
 use async_trait::async_trait;
-use redis::aio::ConnectionManager;
 use redis::Script;
 
 use super::{local::LocalStore, token_dims, Dim, RateStore};
@@ -187,7 +195,7 @@ return {rpm, tpm, inflight, 60 - (now % 60)}
 "#;
 
 pub struct RedisStore {
-    conn: ConnectionManager,
+    conn: RedisConn,
     prefix: String,
     conc_ttl: u64,
     grace: u64,
@@ -208,11 +216,11 @@ impl std::fmt::Debug for RedisStore {
 }
 
 impl RedisStore {
-    /// Connect to Redis via [`ConnectionManager`] (transparent reconnect,
-    /// no per-request handshake). Single-node URL like `redis://host:port/`.
-    pub async fn connect(url: &str) -> Result<Self, redis::RedisError> {
-        let client = redis::Client::open(url)?;
-        let conn = ConnectionManager::new(client).await?;
+    /// Connect using the operator's `ratelimit.redis` config. The topology
+    /// (`single` / `cluster` / `sentinel`) is selected by `mode`; see
+    /// [`aisix_redis::connect`].
+    pub async fn connect(cfg: &RedisConnConfig) -> Result<Self, redis::RedisError> {
+        let conn = aisix_redis::connect(cfg).await?;
         Ok(Self {
             conn,
             prefix: DEFAULT_PREFIX.into(),
@@ -284,10 +292,19 @@ impl RateStore for RedisStore {
 
         let script = Script::new(ACQUIRE_LUA);
         let mut invocation = script.prepare_invoke();
+        // KEYS[1] carries the {bucket} hash tag for Redis Cluster routing;
+        // args[0] is the same prefix the script reads from ARGV[1].
+        invocation.key(&args[0]);
         for a in &args {
             invocation.arg(a);
         }
-        let mut conn = self.conn.clone();
+        let mut conn = match self.conn.acquire().await {
+            Ok(c) => c,
+            Err(e) => {
+                self.warn_degraded("acquire", &e);
+                return self.local.acquire(key, limits, member).await;
+            }
+        };
         match invocation.invoke_async::<Vec<i64>>(&mut conn).await {
             Ok(reply) => {
                 self.mark_ok();
@@ -309,6 +326,7 @@ impl RateStore for RedisStore {
             }
             Err(e) => {
                 self.warn_degraded("acquire", &e);
+                self.conn.note_error().await;
                 self.local.acquire(key, limits, member).await
             }
         }
@@ -316,8 +334,15 @@ impl RateStore for RedisStore {
 
     async fn commit(&self, key: &str, tokens: u64, member: &str) {
         let prefix = self.bucket_prefix(key);
-        let mut conn = self.conn.clone();
+        let mut conn = match self.conn.acquire().await {
+            Ok(c) => c,
+            Err(e) => {
+                self.warn_degraded("commit", &e);
+                return self.local.commit(key, tokens, member).await;
+            }
+        };
         let res: Result<i64, redis::RedisError> = Script::new(COMMIT_LUA)
+            .key(&prefix)
             .arg(&prefix)
             .arg(member)
             .arg(tokens)
@@ -328,6 +353,7 @@ impl RateStore for RedisStore {
             Ok(_) => self.mark_ok(),
             Err(e) => {
                 self.warn_degraded("commit", &e);
+                self.conn.note_error().await;
                 self.local.commit(key, tokens, member).await;
             }
         }
@@ -338,15 +364,22 @@ impl RateStore for RedisStore {
         // never acquired locally); covers the degraded-acquire case.
         self.local.release(key, member);
         let conc_key = format!("{}:conc", self.bucket_prefix(key));
-        let mut conn = self.conn.clone();
+        let conn = self.conn.clone();
         let member = member.to_string();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                let _: Result<(), redis::RedisError> = redis::cmd("ZREM")
+                // ZREM's first arg is the key, so Redis Cluster routes it.
+                let Ok(mut c) = conn.acquire().await else {
+                    return;
+                };
+                let res: Result<(), redis::RedisError> = redis::cmd("ZREM")
                     .arg(&conc_key)
                     .arg(&member)
-                    .query_async(&mut conn)
+                    .query_async(&mut c)
                     .await;
+                if res.is_err() {
+                    conn.note_error().await;
+                }
             });
         }
     }
@@ -360,15 +393,22 @@ impl RateStore for RedisStore {
         self.local.add_tokens(key, tokens);
         let prefix = self.bucket_prefix(key);
         let grace = self.grace;
-        let mut conn = self.conn.clone();
+        let conn = self.conn.clone();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                let _: Result<i64, redis::RedisError> = Script::new(ADD_TOKENS_LUA)
+                let Ok(mut c) = conn.acquire().await else {
+                    return;
+                };
+                let res: Result<i64, redis::RedisError> = Script::new(ADD_TOKENS_LUA)
+                    .key(&prefix)
                     .arg(&prefix)
                     .arg(tokens)
                     .arg(grace)
-                    .invoke_async(&mut conn)
+                    .invoke_async(&mut c)
                     .await;
+                if res.is_err() {
+                    conn.note_error().await;
+                }
             });
         }
     }
@@ -378,8 +418,15 @@ impl RateStore for RedisStore {
             return None;
         }
         let prefix = self.bucket_prefix(key);
-        let mut conn = self.conn.clone();
+        let mut conn = match self.conn.acquire().await {
+            Ok(c) => c,
+            Err(e) => {
+                self.warn_degraded("peek", &e);
+                return self.local.peek(key, limits).await;
+            }
+        };
         let reply: Result<Vec<i64>, redis::RedisError> = Script::new(PEEK_LUA)
+            .key(&prefix)
             .arg(&prefix)
             .arg(self.conc_ttl)
             .invoke_async(&mut conn)
@@ -400,6 +447,7 @@ impl RateStore for RedisStore {
             }
             Err(e) => {
                 self.warn_degraded("peek", &e);
+                self.conn.note_error().await;
                 self.local.peek(key, limits).await
             }
         }

--- a/crates/aisix-ratelimit/tests/redis_integration.rs
+++ b/crates/aisix-ratelimit/tests/redis_integration.rs
@@ -262,10 +262,22 @@ async fn cluster_shared_counter_routes_multi_key_lua() {
         .expect("first allowed on cluster");
     // commit also runs a multi-key script on the same slot.
     a.commit(&key, 10, "a-1").await;
-    // Second replica is rejected by the shared rpm counter.
+    // Second replica is rejected by the shared rpm counter — assert the
+    // specific rejection, not just any error (which would also pass on a
+    // routing/connection failure and mask a real cluster regression).
+    let err = b
+        .acquire(&key, &limits, "b-1")
+        .await
+        .expect_err("second replica must be rejected by the shared rpm counter");
     assert!(
-        b.acquire(&key, &limits, "b-1").await.is_err(),
-        "rpm counter must be shared cluster-wide"
+        matches!(
+            err,
+            aisix_ratelimit::RateLimitError::Requests {
+                scope: RateLimitScope::Requests,
+                ..
+            }
+        ),
+        "got {err:?}"
     );
 }
 
@@ -289,8 +301,18 @@ async fn sentinel_shared_counter_round_trips() {
     a.acquire(&key, &limits, "a-1")
         .await
         .expect("first allowed via sentinel master");
+    let err = b
+        .acquire(&key, &limits, "b-1")
+        .await
+        .expect_err("second replica must be rejected by the shared rpm counter");
     assert!(
-        b.acquire(&key, &limits, "b-1").await.is_err(),
-        "rpm counter shared via the sentinel-resolved master"
+        matches!(
+            err,
+            aisix_ratelimit::RateLimitError::Requests {
+                scope: RateLimitScope::Requests,
+                ..
+            }
+        ),
+        "got {err:?}"
     );
 }

--- a/crates/aisix-ratelimit/tests/redis_integration.rs
+++ b/crates/aisix-ratelimit/tests/redis_integration.rs
@@ -8,11 +8,42 @@
 
 use std::time::Duration;
 
-use aisix_core::{RateLimit, RateLimitScope};
+use aisix_core::{RateLimit, RateLimitScope, RedisConnConfig, RedisMode};
 use aisix_ratelimit::{RateStore, RedisStore};
 
 fn redis_url() -> Option<String> {
     std::env::var("RATELIMIT_TEST_REDIS_URL").ok()
+}
+
+fn single(url: &str) -> RedisConnConfig {
+    RedisConnConfig {
+        mode: RedisMode::Single,
+        url: Some(url.to_string()),
+        ..Default::default()
+    }
+}
+
+/// Cluster seed nodes, e.g. `RATELIMIT_TEST_REDIS_CLUSTER_NODES=redis://127.0.0.1:7000,redis://127.0.0.1:7001`.
+fn cluster_cfg() -> Option<RedisConnConfig> {
+    let nodes = std::env::var("RATELIMIT_TEST_REDIS_CLUSTER_NODES").ok()?;
+    Some(RedisConnConfig {
+        mode: RedisMode::Cluster,
+        nodes: nodes.split(',').map(|s| s.trim().to_string()).collect(),
+        ..Default::default()
+    })
+}
+
+/// Sentinel topology, e.g. `RATELIMIT_TEST_REDIS_SENTINELS=redis://127.0.0.1:26379`
+/// plus `RATELIMIT_TEST_REDIS_MASTER=mymaster`.
+fn sentinel_cfg() -> Option<RedisConnConfig> {
+    let sentinels = std::env::var("RATELIMIT_TEST_REDIS_SENTINELS").ok()?;
+    let master = std::env::var("RATELIMIT_TEST_REDIS_MASTER").ok()?;
+    Some(RedisConnConfig {
+        mode: RedisMode::Sentinel,
+        sentinels: sentinels.split(',').map(|s| s.trim().to_string()).collect(),
+        master_name: Some(master),
+        ..Default::default()
+    })
 }
 
 /// Unique bucket key per test so they don't clobber each other (the store
@@ -31,7 +62,9 @@ fn rl() -> RateLimit {
 }
 
 async fn store(url: &str) -> RedisStore {
-    RedisStore::connect(url).await.expect("redis connect")
+    RedisStore::connect(&single(url))
+        .await
+        .expect("redis connect")
 }
 
 #[tokio::test]
@@ -201,4 +234,63 @@ async fn stale_concurrency_slot_is_reclaimed_after_ttl() {
     b.acquire(&key, &limits, "b-2")
         .await
         .expect("stale slot reclaimed after conc_ttl");
+}
+
+/// Redis Cluster: the multi-key acquire/commit Lua must route to the slot
+/// owning the `{bucket}` hash tag and enforce one shared window. A wrong
+/// (or missing) routing key would surface as a CROSSSLOT/MOVED error here.
+#[tokio::test]
+async fn cluster_shared_counter_routes_multi_key_lua() {
+    let Some(cfg) = cluster_cfg() else {
+        eprintln!("skipping: RATELIMIT_TEST_REDIS_CLUSTER_NODES not set");
+        return;
+    };
+    let a = RedisStore::connect(&cfg).await.expect("cluster connect");
+    let b = RedisStore::connect(&cfg).await.expect("cluster connect");
+    let key = unique_key("cluster-rpm");
+    let limits = RateLimit {
+        rpm: Some(1),
+        tpm: Some(1_000),
+        concurrency: Some(5),
+        ..rl()
+    };
+
+    // First acquire (touches conc ZSET + rpm + tpm keys, all hash-tagged
+    // to one slot) must succeed — proves the EVAL routed correctly.
+    a.acquire(&key, &limits, "a-1")
+        .await
+        .expect("first allowed on cluster");
+    // commit also runs a multi-key script on the same slot.
+    a.commit(&key, 10, "a-1").await;
+    // Second replica is rejected by the shared rpm counter.
+    assert!(
+        b.acquire(&key, &limits, "b-1").await.is_err(),
+        "rpm counter must be shared cluster-wide"
+    );
+}
+
+/// Redis Sentinel: connect resolves the master through the sentinels, and
+/// the shared-counter semantics work end-to-end against the discovered
+/// master.
+#[tokio::test]
+async fn sentinel_shared_counter_round_trips() {
+    let Some(cfg) = sentinel_cfg() else {
+        eprintln!("skipping: RATELIMIT_TEST_REDIS_SENTINELS / _MASTER not set");
+        return;
+    };
+    let a = RedisStore::connect(&cfg).await.expect("sentinel connect");
+    let b = RedisStore::connect(&cfg).await.expect("sentinel connect");
+    let key = unique_key("sentinel-rpm");
+    let limits = RateLimit {
+        rpm: Some(1),
+        ..rl()
+    };
+
+    a.acquire(&key, &limits, "a-1")
+        .await
+        .expect("first allowed via sentinel master");
+    assert!(
+        b.acquire(&key, &limits, "b-1").await.is_err(),
+        "rpm counter shared via the sentinel-resolved master"
+    );
 }

--- a/crates/aisix-redis/Cargo.toml
+++ b/crates/aisix-redis/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aisix-redis"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "aisix: shared Redis connection layer (single / cluster / sentinel) for cache + rate-limit stores"
+
+[dependencies]
+aisix-core = { path = "../aisix-core" }
+redis.workspace = true
+tokio.workspace = true
+tracing.workspace = true

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -158,7 +158,17 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty())
                 .collect();
-            let client = ClusterClient::new(nodes)?;
+            // ACL creds for the nodes can travel in the node URLs, or be
+            // set explicitly here (applied to every node). Cluster has no
+            // DB index, so `database` is ignored in this mode.
+            let mut builder = ClusterClient::builder(nodes);
+            if let Some(u) = &cfg.username {
+                builder = builder.username(u.clone());
+            }
+            if let Some(p) = &cfg.password {
+                builder = builder.password(p.clone());
+            }
+            let client = builder.build()?;
             let conn = client.get_async_connection().await?;
             tracing::info!(
                 target: "aisix::redis",
@@ -184,12 +194,23 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
                 .first()
                 .filter(|u| u.starts_with("rediss://"))
                 .map(|_| redis::TlsMode::Secure);
+            // Auth/DB for the discovered master. It has no URL of its own,
+            // so ACL username/password and the DB index are configured
+            // here; this is independent of the sentinels' own auth.
+            let redis_connection_info =
+                if cfg.username.is_some() || cfg.password.is_some() || cfg.database.is_some() {
+                    Some(redis::RedisConnectionInfo {
+                        db: cfg.database.unwrap_or(0),
+                        username: cfg.username.clone(),
+                        password: cfg.password.clone(),
+                        ..Default::default()
+                    })
+                } else {
+                    None
+                };
             let node_info = SentinelNodeConnectionInfo {
                 tls_mode,
-                redis_connection_info: cfg.password.clone().map(|p| redis::RedisConnectionInfo {
-                    password: Some(p),
-                    ..Default::default()
-                }),
+                redis_connection_info,
             };
             let mut client = SentinelClient::build(
                 sentinels,

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -1,0 +1,235 @@
+//! Shared Redis connection layer for the response cache
+//! ([`aisix-cache`]) and the shared rate-limit counter store
+//! ([`aisix-ratelimit`]).
+//!
+//! Both subsystems used to hold a single-node [`ConnectionManager`]
+//! directly. This crate factors the connection out behind one
+//! [`RedisConn`] so the operator can pick the topology with
+//! `redis.mode` — `single`, `cluster`, or `sentinel` — and both
+//! subsystems support all three without each re-implementing the
+//! dispatch (and drifting apart).
+//!
+//! A live connection is obtained per operation via
+//! [`RedisConn::acquire`], which yields a [`RedisConnHandle`] that
+//! implements [`redis::aio::ConnectionLike`], so existing call sites
+//! keep running `Script::invoke_async`/`cmd().query_async` against it
+//! unchanged.
+//!
+//! - **single** — a [`ConnectionManager`] (transparent reconnect). The
+//!   handle is a cheap clone; `acquire` never fails.
+//! - **cluster** — a [`cluster_async::ClusterConnection`] that discovers
+//!   the slot topology and reconnects internally. The handle is a cheap
+//!   clone; `acquire` never fails. NOTE: scripts that touch multiple keys
+//!   must declare a key carrying the bucket hash tag so the `EVAL` routes
+//!   to the slot owning every key it touches — callers are responsible
+//!   for that (see `aisix-ratelimit`).
+//! - **sentinel** — a [`SentinelClient`] that resolves the current master
+//!   for `master_name`. `redis` 0.27 has no auto-reconnecting sentinel
+//!   connection, so on a master failover the cached connection breaks;
+//!   [`RedisConn::note_error`] drops it and the next `acquire` re-resolves
+//!   the new master through the sentinels.
+
+use std::sync::Arc;
+
+use aisix_core::{RedisConnConfig, RedisMode};
+use redis::aio::{ConnectionLike, ConnectionManager, MultiplexedConnection};
+use redis::cluster::ClusterClient;
+use redis::cluster_async::ClusterConnection;
+use redis::sentinel::{SentinelClient, SentinelNodeConnectionInfo, SentinelServerType};
+use redis::RedisResult;
+use tokio::sync::Mutex;
+
+/// A long-lived Redis client handle. Cheap to [`Clone`] (every variant is
+/// `Arc`-backed). Build one with [`connect`].
+// `Single` (the hot, common path) is the largest variant; boxing it to
+// equalize variant size would add an allocation to the common case to
+// shrink the rarer ones — not worth it for a handful of instances.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
+pub enum RedisConn {
+    Single(ConnectionManager),
+    Cluster(ClusterConnection),
+    Sentinel(SentinelPool),
+}
+
+/// Sentinel client plus the most recently resolved master connection.
+/// The cache is cleared on error ([`RedisConn::note_error`]) so the next
+/// [`RedisConn::acquire`] re-discovers the master after a failover.
+#[derive(Clone)]
+pub struct SentinelPool {
+    client: Arc<Mutex<SentinelClient>>,
+    cached: Arc<Mutex<Option<MultiplexedConnection>>>,
+}
+
+/// A live connection usable for one or more operations. Implements
+/// [`ConnectionLike`] by delegating to the underlying connection.
+#[allow(clippy::large_enum_variant)]
+pub enum RedisConnHandle {
+    Single(ConnectionManager),
+    Cluster(ClusterConnection),
+    Sentinel(MultiplexedConnection),
+}
+
+impl RedisConn {
+    /// Obtain a live connection. For `single`/`cluster` this is an
+    /// infallible cheap clone of the multiplexed connection. For
+    /// `sentinel` it returns the cached master connection, resolving one
+    /// through the sentinels on the first call or after a failover.
+    pub async fn acquire(&self) -> RedisResult<RedisConnHandle> {
+        match self {
+            RedisConn::Single(c) => Ok(RedisConnHandle::Single(c.clone())),
+            RedisConn::Cluster(c) => Ok(RedisConnHandle::Cluster(c.clone())),
+            RedisConn::Sentinel(pool) => {
+                if let Some(conn) = pool.cached.lock().await.clone() {
+                    return Ok(RedisConnHandle::Sentinel(conn));
+                }
+                let mut client = pool.client.lock().await;
+                let conn = client.get_async_connection().await?;
+                *pool.cached.lock().await = Some(conn.clone());
+                Ok(RedisConnHandle::Sentinel(conn))
+            }
+        }
+    }
+
+    /// Invalidate any cached connection after an operation error. Only
+    /// meaningful for `sentinel`, where it forces the next [`acquire`] to
+    /// re-resolve the master (the prior one may have failed over).
+    ///
+    /// [`acquire`]: RedisConn::acquire
+    pub async fn note_error(&self) {
+        if let RedisConn::Sentinel(pool) = self {
+            *pool.cached.lock().await = None;
+        }
+    }
+}
+
+impl ConnectionLike for RedisConnHandle {
+    fn req_packed_command<'a>(
+        &'a mut self,
+        cmd: &'a redis::Cmd,
+    ) -> redis::RedisFuture<'a, redis::Value> {
+        match self {
+            RedisConnHandle::Single(c) => c.req_packed_command(cmd),
+            RedisConnHandle::Cluster(c) => c.req_packed_command(cmd),
+            RedisConnHandle::Sentinel(c) => c.req_packed_command(cmd),
+        }
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a redis::Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> redis::RedisFuture<'a, Vec<redis::Value>> {
+        match self {
+            RedisConnHandle::Single(c) => c.req_packed_commands(cmd, offset, count),
+            RedisConnHandle::Cluster(c) => c.req_packed_commands(cmd, offset, count),
+            RedisConnHandle::Sentinel(c) => c.req_packed_commands(cmd, offset, count),
+        }
+    }
+
+    fn get_db(&self) -> i64 {
+        match self {
+            RedisConnHandle::Single(c) => c.get_db(),
+            RedisConnHandle::Cluster(c) => c.get_db(),
+            RedisConnHandle::Sentinel(c) => c.get_db(),
+        }
+    }
+}
+
+/// Build a [`RedisConn`] from operator config. Validates connectivity
+/// eagerly: a single/cluster handshake or an initial sentinel master
+/// resolution must succeed, so a misconfigured backend fails at boot
+/// rather than per request. Assumes [`RedisConnConfig::validate`] already
+/// passed (the boot path validates before calling this).
+pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
+    match cfg.mode {
+        RedisMode::Single => {
+            let url = cfg.url.as_deref().unwrap_or_default();
+            let client = redis::Client::open(url)?;
+            let conn = ConnectionManager::new(client).await?;
+            tracing::info!(target: "aisix::redis", mode = "single", "connected");
+            Ok(RedisConn::Single(conn))
+        }
+        RedisMode::Cluster => {
+            let nodes: Vec<&str> = cfg
+                .nodes
+                .iter()
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .collect();
+            let client = ClusterClient::new(nodes)?;
+            let conn = client.get_async_connection().await?;
+            tracing::info!(
+                target: "aisix::redis",
+                mode = "cluster",
+                nodes = cfg.nodes.len(),
+                "connected"
+            );
+            Ok(RedisConn::Cluster(conn))
+        }
+        RedisMode::Sentinel => {
+            let sentinels: Vec<String> = cfg
+                .sentinels
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            let master_name = cfg.master_name.clone().unwrap_or_default();
+            // The master/data node may need its own auth and TLS; the
+            // sentinels themselves carry theirs in `sentinels` URLs. Derive
+            // the master's TLS from whether the sentinels are reached over
+            // `rediss://`, the common uniform-TLS deployment.
+            let tls_mode = sentinels
+                .first()
+                .filter(|u| u.starts_with("rediss://"))
+                .map(|_| redis::TlsMode::Secure);
+            let node_info = SentinelNodeConnectionInfo {
+                tls_mode,
+                redis_connection_info: cfg.password.clone().map(|p| redis::RedisConnectionInfo {
+                    password: Some(p),
+                    ..Default::default()
+                }),
+            };
+            let mut client = SentinelClient::build(
+                sentinels,
+                master_name,
+                Some(node_info),
+                SentinelServerType::Master,
+            )?;
+            // Eagerly resolve the master once so a broken sentinel/master
+            // setup fails at boot, and seed the cache.
+            let conn = client.get_async_connection().await?;
+            tracing::info!(
+                target: "aisix::redis",
+                mode = "sentinel",
+                master = %cfg.master_name.as_deref().unwrap_or_default(),
+                "connected"
+            );
+            Ok(RedisConn::Sentinel(SentinelPool {
+                client: Arc::new(Mutex::new(client)),
+                cached: Arc::new(Mutex::new(Some(conn))),
+            }))
+        }
+    }
+}
+
+/// Re-export so dependents don't need a direct `redis` dependency just to
+/// name the connect error.
+pub use redis::RedisError as ConnectError;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn single_mode_bad_url_errors() {
+        let cfg = RedisConnConfig {
+            mode: RedisMode::Single,
+            url: Some("not-a-url".into()),
+            ..Default::default()
+        };
+        // Any error is fine — the point is it returns Err, not panics.
+        assert!(connect(&cfg).await.is_err());
+    }
+}

--- a/crates/aisix-redis/tests/sentinel_failover.rs
+++ b/crates/aisix-redis/tests/sentinel_failover.rs
@@ -99,7 +99,14 @@ async fn sentinel_reresolves_master_after_failover() {
     // accept writes after role change.
     let mut wrote = false;
     for _ in 0..40 {
-        let mut handle = conn.acquire().await.expect("acquire after failover");
+        // acquire itself can fail transiently right after a failover (the
+        // sentinel master lookup may briefly error); retry rather than
+        // abort, since absorbing that instability is the loop's whole job.
+        let Ok(mut handle) = conn.acquire().await else {
+            conn.note_error().await;
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            continue;
+        };
         if handle
             .set::<_, _, ()>("aisix:failover:probe", "after")
             .await

--- a/crates/aisix-redis/tests/sentinel_failover.rs
+++ b/crates/aisix-redis/tests/sentinel_failover.rs
@@ -1,0 +1,118 @@
+//! Sentinel failover / reconnect coverage for [`aisix_redis::RedisConn`].
+//!
+//! Runs only when `REDIS_FAILOVER_SENTINELS` and `REDIS_FAILOVER_MASTER`
+//! are set, pointing at a master + replica + sentinel topology (CI brings
+//! one up). The test forces a Sentinel failover, then proves that after
+//! [`RedisConn::note_error`] the next [`RedisConn::acquire`] re-resolves
+//! the *new* master — a write (rejected by a read-only replica) succeeds
+//! only if the connection followed the promotion.
+
+use std::time::Duration;
+
+use aisix_core::{RedisConnConfig, RedisMode};
+use aisix_redis::{connect, RedisConn};
+use redis::AsyncCommands;
+
+fn sentinel_cfg() -> Option<(RedisConnConfig, String, String)> {
+    let sentinels = std::env::var("REDIS_FAILOVER_SENTINELS").ok()?;
+    let master = std::env::var("REDIS_FAILOVER_MASTER").ok()?;
+    let first_sentinel = sentinels.split(',').next().unwrap().trim().to_string();
+    let cfg = RedisConnConfig {
+        mode: RedisMode::Sentinel,
+        sentinels: sentinels.split(',').map(|s| s.trim().to_string()).collect(),
+        master_name: Some(master.clone()),
+        // Optional: when the master is password-protected this exercises
+        // the ACL auth path to the Sentinel-discovered master too.
+        username: std::env::var("REDIS_FAILOVER_USERNAME").ok(),
+        password: std::env::var("REDIS_FAILOVER_PASSWORD").ok(),
+        ..Default::default()
+    };
+    Some((cfg, first_sentinel, master))
+}
+
+async fn master_addr(sentinel_url: &str, master: &str) -> (String, String) {
+    let client = redis::Client::open(sentinel_url).expect("sentinel client");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("sentinel conn");
+    let addr: Vec<String> = redis::cmd("SENTINEL")
+        .arg("get-master-addr-by-name")
+        .arg(master)
+        .query_async(&mut conn)
+        .await
+        .expect("get-master-addr");
+    (addr[0].clone(), addr[1].clone())
+}
+
+#[tokio::test]
+async fn sentinel_reresolves_master_after_failover() {
+    let Some((cfg, sentinel_url, master)) = sentinel_cfg() else {
+        eprintln!("skipping: REDIS_FAILOVER_SENTINELS / _MASTER not set");
+        return;
+    };
+
+    let conn: RedisConn = connect(&cfg).await.expect("sentinel connect");
+
+    // Write succeeds against the current master.
+    let mut handle = conn.acquire().await.expect("acquire");
+    let _: () = handle
+        .set("aisix:failover:probe", "before")
+        .await
+        .expect("write to initial master");
+
+    let (_, port_before) = master_addr(&sentinel_url, &master).await;
+
+    // Force a failover; the old master is demoted to a (read-only) replica.
+    {
+        let client = redis::Client::open(sentinel_url.as_str()).expect("sentinel client");
+        let mut s = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("sentinel conn");
+        let _: redis::Value = redis::cmd("SENTINEL")
+            .arg("FAILOVER")
+            .arg(&master)
+            .query_async(&mut s)
+            .await
+            .expect("trigger failover");
+    }
+
+    // Wait until Sentinel reports a different master port (promotion done).
+    let mut promoted = false;
+    for _ in 0..60 {
+        let (_, port_now) = master_addr(&sentinel_url, &master).await;
+        if port_now != port_before {
+            promoted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    assert!(promoted, "sentinel did not promote a new master in time");
+
+    // The cached connection now points at the demoted (read-only) old
+    // master. note_error() drops it so acquire re-resolves the new master.
+    conn.note_error().await;
+
+    // A write must succeed again — proving acquire followed the promotion.
+    // Retry briefly: the freshly promoted master may take a moment to
+    // accept writes after role change.
+    let mut wrote = false;
+    for _ in 0..40 {
+        let mut handle = conn.acquire().await.expect("acquire after failover");
+        if handle
+            .set::<_, _, ()>("aisix:failover:probe", "after")
+            .await
+            .is_ok()
+        {
+            wrote = true;
+            break;
+        }
+        conn.note_error().await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    assert!(
+        wrote,
+        "write must succeed against the re-resolved master after failover"
+    );
+}

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -395,10 +395,10 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 "connecting shared rate-limit backend"
             );
             // No URL in the message: redis URLs carry credentials.
-            let store = RedisStore::connect(&redis_cfg.url)
+            let store = RedisStore::connect(redis_cfg)
                 .await
                 .map_err(|e| {
-                    anyhow::anyhow!("redis rate-limit connect failed (ratelimit.redis.url): {e}")
+                    anyhow::anyhow!("redis rate-limit connect failed (ratelimit.redis): {e}")
                 })?
                 .with_conc_ttl(cfg.ratelimit.concurrency_ttl_secs);
             Limiter::with_store(Arc::new(store))
@@ -420,11 +420,11 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let redis_cache: Option<Arc<dyn Cache>> = match cfg.cache.redis.as_ref() {
         Some(redis_cfg) => {
             tracing::info!(target: "aisix::cache", backend = "redis", "connecting cache backend");
-            let redis = RedisCache::connect(&redis_cfg.url).await.map_err(|e| {
+            let redis = RedisCache::connect(redis_cfg).await.map_err(|e| {
                 // Deliberately no URL in the message: redis URLs carry
                 // credentials (redis://user:pass@host) and this error
                 // lands in logs that may ship to centralized sinks.
-                anyhow::anyhow!("redis cache connect failed (cache.redis.url): {e}")
+                anyhow::anyhow!("redis cache connect failed (cache.redis): {e}")
             })?;
             Some(Arc::new(redis) as Arc<dyn Cache>)
         }

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -83,6 +83,25 @@ The proxy selects the cache instance per request from the matched policy's `back
 
 A `redis` policy on a process without `cache.redis` gets no caching for its requests: responses carry no `x-aisix-cache` header, telemetry reports `cache_status = disabled`, and the gateway logs a warning once per policy. There is no silent fallback to the in-process memory cache — a memory stand-in would serve per-node answers while the policy claims shared-cache semantics.
 
+### `cache.redis` connection modes
+
+The `cache.redis` block accepts the same `mode` field as the rate-limiter — `single` (default), `cluster`, or `sentinel` — so the shared cache can target a standalone Redis, a Redis Cluster, or a Sentinel-managed master. The field shapes are identical to the rate-limit backend; see [Redis connection modes](rate-limits.md#redis-connection-modes).
+
+```yaml title="cache.redis examples"
+cache:
+  backend: "redis"
+  redis:
+    mode: "single"                       # one endpoint
+    url: "redis://127.0.0.1:6379"
+    # mode: "cluster"                     # seed nodes:
+    # nodes: ["redis://10.0.0.1:6379", "redis://10.0.0.2:6379"]
+    # mode: "sentinel"                    # sentinels + master group:
+    # sentinels: ["redis://10.0.0.1:26379"]
+    # master_name: "mymaster"
+```
+
+Cache reads/writes are single-key (`GET`/`SET`), so Redis Cluster routes them automatically; in sentinel mode the master is resolved through the sentinels and re-resolved after a failover.
+
 ## Operator Guidance
 
 - start with `memory` plus a narrowly scoped policy

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -98,9 +98,12 @@ cache:
     # mode: "sentinel"                    # sentinels + master group:
     # sentinels: ["redis://10.0.0.1:26379"]
     # master_name: "mymaster"
+    # username: "default"                 # ACL auth for the data node
+    # password: "s3cret"                  # (or AISIX_CACHE__REDIS__PASSWORD)
+    # database: 0
 ```
 
-Cache reads/writes are single-key (`GET`/`SET`), so Redis Cluster routes them automatically; in sentinel mode the master is resolved through the sentinels and re-resolved after a failover.
+Cache reads/writes are single-key (`GET`/`SET`), so Redis Cluster routes them automatically; in sentinel mode the master is resolved through the sentinels and re-resolved after a failover. ACL `username`/`password` and the sentinel-vs-master credential split work exactly as for the rate-limiter — see [Sentinel vs master credentials](rate-limits.md#redis-connection-modes).
 
 ## Operator Guidance
 

--- a/docs/configuration/rate-limits.md
+++ b/docs/configuration/rate-limits.md
@@ -144,19 +144,58 @@ Every limit above is enforced against a counter. Where that counter lives is set
 ratelimit:
   backend: "memory"   # memory | redis
   # redis:
+  #   mode: "single"   # single | cluster | sentinel
   #   url: "redis://127.0.0.1:6379"
-  #   mode: "single"
   # concurrency_ttl_secs: 300
 ```
 
 - `memory` (default) — counters live in each gateway process. With a single replica this is exact. With **N replicas behind a load balancer, every limit is effectively multiplied by N**: a key capped at `rpm: 60` gets up to `60 × N` per minute, because each replica counts only the traffic it personally served.
 - `redis` — counters are shared across every replica through one Redis, so the whole cluster enforces **one global window** regardless of replica count. Enable this on any multi-replica deployment. The Redis may be the same instance used for the response cache; rate-limit keys are namespaced `aisix:rl:` and hash-tagged per bucket. All dimensions are shared — requests, tokens, and `concurrency` (tracked as a crash-safe distributed semaphore; a slot held by a crashed replica is reclaimed after `concurrency_ttl_secs`, default 300s).
 
-Enable it via config, or via env on a managed/containerized deployment:
+### Redis connection modes
+
+`redis.mode` selects how the gateway connects, so the same backend works against a standalone Redis, a Redis Cluster, or a Sentinel-managed HA pair. Credentials and TLS (`rediss://`) travel inside the URLs in every mode.
+
+```yaml title="single (default)"
+ratelimit:
+  backend: "redis"
+  redis:
+    mode: "single"
+    url: "redis://127.0.0.1:6379"
+```
+
+```yaml title="cluster"
+ratelimit:
+  backend: "redis"
+  redis:
+    mode: "cluster"
+    nodes:                       # one or more seed nodes; the rest are discovered
+      - "redis://10.0.0.1:6379"
+      - "redis://10.0.0.2:6379"
+```
+
+```yaml title="sentinel"
+ratelimit:
+  backend: "redis"
+  redis:
+    mode: "sentinel"
+    sentinels:                   # sentinel node URLs (their own auth goes in the URL)
+      - "redis://10.0.0.1:26379"
+      - "redis://10.0.0.2:26379"
+    master_name: "mymaster"      # the monitored master group
+    # password: "s3cret"         # optional: password for the data node (master)
+```
+
+In **cluster** mode each rate-limit bucket's keys share one hash slot (the `{bucket}` hash tag), so the per-bucket counter update stays atomic. In **sentinel** mode the gateway resolves the current master through the sentinels and transparently re-resolves it after a failover.
+
+Enable the backend via config, or via env on a managed/containerized deployment (`__` nests, list indices are appended):
 
 ```bash
 AISIX_RATELIMIT__BACKEND=redis
+AISIX_RATELIMIT__REDIS__MODE=single
 AISIX_RATELIMIT__REDIS__URL=redis://my-redis:6379
+# cluster:  AISIX_RATELIMIT__REDIS__MODE=cluster  AISIX_RATELIMIT__REDIS__NODES__0=redis://node-1:6379
+# sentinel: AISIX_RATELIMIT__REDIS__MODE=sentinel AISIX_RATELIMIT__REDIS__SENTINELS__0=redis://s-1:26379 AISIX_RATELIMIT__REDIS__MASTER_NAME=mymaster
 ```
 
 If Redis becomes unreachable, the limiter **fails open** to per-replica in-memory counting (logged once) so requests keep flowing; cluster-wide limits are not enforced for the duration of the outage and resume automatically when Redis recovers.

--- a/docs/configuration/rate-limits.md
+++ b/docs/configuration/rate-limits.md
@@ -183,10 +183,16 @@ ratelimit:
       - "redis://10.0.0.1:26379"
       - "redis://10.0.0.2:26379"
     master_name: "mymaster"      # the monitored master group
-    # password: "s3cret"         # optional: password for the data node (master)
+    # ACL auth for the data node (the master Sentinel discovers — it has
+    # no URL of its own); independent of the sentinels' own auth above:
+    # username: "default"
+    # password: "s3cret"
+    # database: 0
 ```
 
-In **cluster** mode each rate-limit bucket's keys share one hash slot (the `{bucket}` hash tag), so the per-bucket counter update stays atomic. In **sentinel** mode the gateway resolves the current master through the sentinels and transparently re-resolves it after a failover.
+In **cluster** mode each rate-limit bucket's keys share one hash slot (the `{bucket}` hash tag), so the per-bucket counter update stays atomic. ACL `username`/`password` apply to every node (or put credentials in the node URLs). In **sentinel** mode the gateway resolves the current master through the sentinels and transparently re-resolves it after a failover.
+
+**Sentinel vs master credentials.** The sentinels and the Redis master can have different auth. Sentinel-node credentials travel inside the `sentinels` URLs (`redis://:sentinelpass@host:26379`); the master is authenticated with the block-level `username` / `password` (Redis ACL) plus `database`, because Sentinel hands back a host:port for the master with no URL. TLS (`rediss://`) on the sentinels propagates to the master connection. To keep the master password out of the config file, supply it via `AISIX_RATELIMIT__REDIS__PASSWORD` instead. Sentinel discovery/connection failures are logged (mode + master name, never credentials) and the limiter fails open until Redis recovers.
 
 Enable the backend via config, or via env on a managed/containerized deployment (`__` nests, list indices are appended):
 


### PR DESCRIPTION
Fixes #631

## Problem

The `ratelimit.redis.mode` / `cache.redis.mode` field existed in config but was parsed-and-ignored — only single-node Redis actually worked. `mode: cluster` or `mode: sentinel` had no effect, so operators running Sentinel had to put a writable proxy/endpoint in front of Redis.

## What changed

A new `aisix-redis` crate factors the Redis connection out behind one `RedisConn` enum (`single | cluster | sentinel`) that yields a per-operation `RedisConnHandle` implementing `ConnectionLike`, so the existing `Script::invoke_async` / `cmd().query_async` call sites in the cache and rate-limiter are unchanged. Both subsystems now honor `mode`.

- **single** → `ConnectionManager` (unchanged behaviour).
- **cluster** → `ClusterClient` seeded from `nodes`. The rate-limit Lua scripts touch several keys per bucket, so each `EVAL` now declares the bucket key carrying the `{bucket}` hash tag — this routes the script to the slot that owns every key it reads/writes (a missing routing key would CROSSSLOT on a cluster). Cache `GET`/`SET` are single-key and route automatically.
- **sentinel** → `SentinelClient` resolves the master for `master_name` through `sentinels`. `redis` 0.27 has no auto-reconnecting sentinel connection, so the resolved master connection is cached and dropped on error (`note_error`), and the next operation re-resolves the current master after a failover.

`RedisConnConfig` gains a typed `RedisMode` plus `nodes`, `sentinels`, `master_name`, `username`, `password`, and `database`, validated per mode at boot. Sentinel-node auth travels in the `sentinels` URLs while the discovered master is authenticated with `username`/`password`/`database` (it has no URL of its own), so Sentinel and master credentials may differ. The existing fail-open-to-local behaviour on a Redis outage is preserved for all modes.

## Config

```yaml
ratelimit:                       # same shape under cache.redis
  backend: "redis"
  redis:
    mode: "sentinel"
    sentinels: ["redis://10.0.0.1:26379", "redis://10.0.0.2:26379"]
    master_name: "mymaster"
    username: "default"          # ACL auth for the discovered master
    password: "s3cret"           # or via AISIX_RATELIMIT__REDIS__PASSWORD
    # mode: "cluster"  nodes: ["redis://n1:6379", "redis://n2:6379"]
    # mode: "single"   url: "redis://127.0.0.1:6379"
```

## Acceptance criteria (#631)

- `mode: sentinel` discovers the current master via Sentinel — yes, `SentinelClient` master discovery.
- Multiple Sentinel endpoints — yes, `sentinels` is a list.
- Redis ACL username/password — yes, `username`/`password` on the data node (master / cluster nodes).
- Sentinel vs master auth — documented; sentinel auth in the URLs, master auth in `username`/`password`/`database`.
- Documented for both `ratelimit.redis` and `cache.redis` — yes.
- Existing `single` config unchanged — yes.
- Failures logged without leaking credentials — connect/degrade logs carry only mode + master name.
- Tests for discovery and reconnect/failover — yes (see below).

## Tests

- Per-mode config parsing/validation unit tests (incl. ACL username/password/database).
- Rate-limit and cache integration tests connect in **cluster** and **sentinel** modes against real topologies (gated on env vars); the cluster test exercises the multi-key acquire/commit Lua to prove slot routing.
- A **sentinel failover** test forces a real `SENTINEL FAILOVER` and asserts the next acquire follows the promotion (a write succeeds only against the re-resolved master); it also covers ACL auth to a password-protected master.
- CI brings up a 3-node cluster, a sentinel, and a master+replica+sentinel failover topology so all of the above run on every build.

## Docs

- `docs/configuration/rate-limits.md`: new "Redis connection modes" section (single/cluster/sentinel, ACL auth, sentinel-vs-master credentials, env-var password) and env-var forms.
- `docs/configuration/caching.md`: documents `cache.redis.mode` and auth.
- `config.example.yaml`: shows all three field shapes for both blocks.

Note: the issue also suggested a `redis+sentinel://...` URL form as an alternative to explicit config; this PR implements the explicit-config shape (the issue's primary proposal), which covers the same capability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified Redis connection support for `single`, `cluster`, and `sentinel` across cache and rate limiting.
  * Added master discovery and automatic re-resolution for Sentinel to support failover scenarios.
* **Bug Fixes**
  * Fixed Redis Cluster routing to keep limiter state consistent.
  * Improved behavior during Redis operation failures by failing over to local storage when needed.
* **Documentation**
  * Expanded configuration examples for `cache.redis` and `ratelimit` Redis modes.
* **Tests**
  * Added end-to-end integration tests for Redis Cluster and Sentinel (including failover/reconnect coverage).
* **Chores**
  * Updated CI to provision Redis Cluster and Sentinel topologies for integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes api7/AISIX-Cloud#788
