### PR TITLE
ci(docker-image): mirror release tags to the api7 Docker Hub org

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,11 +62,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Release tags (vX.Y.Z) are additionally mirrored to the api7
+      # Docker Hub org for private/offline deployments (#789). dev / poc
+      # / sha builds stay GHCR-only.
+      - name: Log in to Docker Hub
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Compute tags + labels
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # GHCR always; Docker Hub mirror only on release tags. The
+          # second line resolves to an empty string (ignored) otherwise.
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ startsWith(github.ref, 'refs/tags/v') && format('{0}/{1}', secrets.DOCKER_REGISTRY, env.IMAGE_NAME) || '' }}
           tags: |
             type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=poc,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/poc' }}


### PR DESCRIPTION
Fixes api7/AISIX-Cloud#789 (CP private/offline deployment).

Private/offline deployments pull production images from Docker Hub, not GHCR. This mirrors the `aisix` data-plane image to the api7 Docker Hub org on release tags.

- On `vX.Y.Z` tags the image is pushed to **both** `ghcr.io/api7/aisix` and `${DOCKER_REGISTRY}/api7/aisix` (e.g. `docker.io/api7/aisix`), with the same tag set (`X.Y.Z`, `X.Y`, `X`, `latest`, `sha-…`).
- `dev` / `poc` / `sha` / PR builds stay GHCR-only — the Docker Hub image line resolves to an empty string off-tag, and the Docker Hub login step only runs on tags.
- Reuses the `DOCKER_REGISTRY` / `DOCKER_USERNAME` / `DOCKER_PASSWORD` secrets, matching the existing aisix-ee "Login to Docker Hub" step.
- amd64-only, unchanged from today.

No code or image-name changes; GHCR publishing is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image distribution by adding Docker Hub as a secondary registry for release versions, while maintaining GHCR as the primary repository for all builds. Release images now mirror across multiple registries for enhanced accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->