### PR TITLE
docs: use release image in Docker examples

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,14 +5,14 @@
 # /etc/aisix/config.yaml). Two intended modes:
 #
 #   Standalone — operator mounts their own config:
-#       docker run -v ./config.yaml:/etc/aisix/config.yaml ghcr.io/api7/aisix:dev
+#       docker run -v ./config.yaml:/etc/aisix/config.yaml ghcr.io/api7/aisix:0.1.0
 #
 #   Managed (aisix.cloud tenant) — use the baked-in template + env vars:
 #       docker run \
 #         -e AISIX_CONFIG_PATH=/etc/aisix/config.managed.yaml \
 #         -e AISIX_MANAGED__REGISTRATION_TOKEN=$DEPLOYMENT_TOKEN \
 #         -e AISIX_MANAGED__CP_BASE_URL=https://api.us.aisix.cloud \
-#         ghcr.io/api7/aisix:dev
+#         ghcr.io/api7/aisix:0.1.0
 #
 # The Rust binary's `Config::load_from_path` already layers
 # `AISIX_<UPPER>__<UPPER>` env vars on top of the YAML, so any field

--- a/docs/quickstart/self-hosted.md
+++ b/docs/quickstart/self-hosted.md
@@ -114,7 +114,7 @@ services:
       - "2379:2379"
 
   aisix:
-    image: ghcr.io/api7/aisix:dev
+    image: ghcr.io/api7/aisix:0.1.0
     command: ["--config", "/etc/aisix/config.yaml"]
     volumes:
       - ./config.yaml:/etc/aisix/config.yaml:ro
@@ -130,7 +130,7 @@ docker compose up -d
 ```
 
 :::note
-`ghcr.io/api7/aisix:dev` tracks the `main` branch. For a reproducible deployment, pin a released version tag (for example `ghcr.io/api7/aisix:v1.2.3`) once one is available.
+Use a released image tag for reproducible deployments. The `dev` tag tracks the `main` branch and is intended for testing unreleased changes.
 :::
 
 The proxy listener is now on `http://127.0.0.1:3000` and the admin listener on `http://127.0.0.1:3001`, the same as the local build, so the verification below applies unchanged. To stop the stack, run `docker compose down`.

--- a/docs/quickstart/self-hosted.md
+++ b/docs/quickstart/self-hosted.md
@@ -129,10 +129,6 @@ services:
 docker compose up -d
 ```
 
-:::note
-Use a released image tag for reproducible deployments. The `dev` tag tracks the `main` branch and is intended for testing unreleased changes.
-:::
-
 The proxy listener is now on `http://127.0.0.1:3000` and the admin listener on `http://127.0.0.1:3001`, the same as the local build, so the verification below applies unchanged. To stop the stack, run `docker compose down`.
 
 ## Step 4: Verify the listeners


### PR DESCRIPTION
## Summary

- Update the self-hosted quickstart Compose example from `ghcr.io/api7/aisix:dev` to `ghcr.io/api7/aisix:0.1.0`.
- Update entrypoint Docker examples to use the same release image tag.

## Context

AISIX now has versioned release artifacts. User-facing examples should use released image tags by default, while `dev` remains available for validating unreleased changes.

## Verification

- Confirmed `v0.1.0` points to current `main` at `e80dac38e1617ee4b0a0da5e9fff00aa1ed89075`.
- Previously verified `ghcr.io/api7/aisix:0.1.0` pulls successfully.
- Ran `git diff --check`.