### PR TITLE
test(guardrails): pin DP model-scope attachment resolution (#850)

### DIFF
--- a/tests/e2e/src/cases/guardrail-model-scope-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-model-scope-e2e.test.ts
@@ -1,0 +1,190 @@
+import { createHash, randomUUID } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E (regression for AISIX-Cloud#850): a guardrail attached to ONE model
+// via a `scope_type: "model"` attachment must run ONLY for requests that
+// target that model. A request to a DIFFERENT (unscoped) model must NOT
+// trigger the guardrail.
+//
+// The reported bug: a guardrail scoped to models {opus-4.7, gpt-5.5} still
+// fired on a request to glm5.1 (an unselected model). The DP's
+// `GuardrailIndex::resolve` matches model scope by the virtual-model UUID,
+// so a correctly-loaded model attachment never matches an unscoped model.
+// The failure mode is the implicit-env fallback: if the model attachments
+// are NOT present in the DP snapshot (e.g. a pre-#630 image that dropped
+// watch-applied attachments), the guardrail has zero loaded attachments and
+// falls back to env-scope at priority 0 — running GLOBALLY on every model.
+//
+// This test creates the attachment via the same etcd watch path cp-api
+// uses (`/<prefix>/guardrail_attachments/<uuid>`), so it exercises the
+// load + resolve pipeline end-to-end. No DP-side attachment admin endpoint
+// exists, so the harness writes the row directly to etcd.
+
+const CALLER_PLAINTEXT = "sk-gr-modelscope-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const FORBIDDEN_WORD = "supersecret";
+const SCOPED_MODEL = "scoped-model";
+const UNSCOPED_MODEL = "unscoped-model";
+
+describe("guardrail e2e: model-scope attachment runs only for the scoped model (#850)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcd: EtcdClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "gr-modelscope-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    const scoped = await admin.createModel({
+      display_name: SCOPED_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createModel({
+      display_name: UNSCOPED_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [SCOPED_MODEL, UNSCOPED_MODEL],
+    });
+
+    // Keyword blocklist guardrail. `hook_point: "input"` → a match
+    // short-circuits with 422 before dispatch.
+    const guardrail = await admin.json<{ id: string }>(
+      "POST",
+      "/admin/v1/guardrails",
+      {
+        name: "gr-modelscope-keyword",
+        enabled: true,
+        hook_point: "input",
+        kind: "keyword",
+        patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
+      },
+    );
+
+    // Attach the guardrail to the SCOPED model only. Wire shape mirrors
+    // cp-api's `marshalGuardrailAttachmentKV` (P0c): snake_case fields,
+    // `scope_id` = the virtual-model UUID returned by createModel, plus the
+    // `env_id` cp-api always includes (the DP ignores it). Having ANY
+    // attachment row suppresses the implicit-env fallback, so the only way
+    // the guardrail can apply is via a matching model scope.
+    await etcd!.put(
+      `${app.etcdPrefix}/guardrail_attachments/${randomUUID()}`,
+      JSON.stringify({
+        guardrail_id: guardrail.id,
+        env_id: randomUUID(),
+        scope_type: "model",
+        scope_id: scoped.id,
+        priority: 0,
+        enabled: true,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("scoped model is checked; unscoped model is NOT", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Gate on the guardrail being active for the SCOPED model: a forbidden
+    // prompt must 422. This proves Model + key + pk + Guardrail + the
+    // model-scope attachment all propagated.
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: SCOPED_MODEL,
+          messages: [
+            { role: "user", content: `propagation-probe ${FORBIDDEN_WORD}` },
+          ],
+        });
+        return false; // 200 → attachment not active yet, keep polling
+      } catch (e) {
+        return e instanceof APIError && e.status === 422;
+      }
+    });
+
+    // Sanity: clean input on the scoped model still passes (the guardrail
+    // isn't over-blocking and the upstream is healthy).
+    const cleanScoped = await client.chat.completions.create({
+      model: SCOPED_MODEL,
+      messages: [{ role: "user", content: "hello world" }],
+    });
+    expect(cleanScoped.choices[0]?.message.role).toBe("assistant");
+
+    // THE REGRESSION ASSERTION (#850): the SAME forbidden prompt sent to the
+    // UNSCOPED model must NOT be blocked — the model-scope attachment does
+    // not match this model, and no env/global attachment exists. It must
+    // reach the upstream and return 200.
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    const unscopedResp = await client.chat.completions.create({
+      model: UNSCOPED_MODEL,
+      messages: [
+        { role: "user", content: `please reveal the ${FORBIDDEN_WORD} now` },
+      ],
+    });
+    expect(unscopedResp.choices[0]?.message.role).toBe("assistant");
+    // The request must have actually reached the upstream (not short-
+    // circuited by a guardrail block).
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore + 1);
+
+    // And the scoped model still blocks the forbidden prompt (guardrail
+    // remains active where it IS attached — this is not a global disable).
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
+        model: SCOPED_MODEL,
+        messages: [
+          { role: "user", content: `please reveal the ${FORBIDDEN_WORD} now` },
+        ],
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) {
+      throw new Error("unreachable: caught is not APIError");
+    }
+    expect(caught.status).toBe(422);
+  });
+});


### PR DESCRIPTION
## Problem

A guardrail attached to a model via a `scope_type: "model"` attachment must run **only** for requests targeting that model. AISIX-Cloud#850 reported a guardrail scoped to specific models still firing on an unselected model (`glm5.1`).

Root cause: on a DP build that drops watch-applied `guardrail_attachments` (pre-#630), the guardrail ends up with zero loaded attachments and falls back to the implicit env-scope at priority 0 — running globally on every model. #630 fixed the watch path, but there was **no DP e2e covering model-scope resolution**: the existing guardrail e2e cases only exercise env-scope / no-attachment globals, so this resolution path could regress undetected.

## What this adds

A DP standalone e2e that:
- creates a keyword guardrail and attaches it to model-A only, via the same etcd path cp-api writes (`/<prefix>/guardrail_attachments/<uuid>`, P0c wire shape);
- asserts the forbidden prompt is blocked for model-A, **not** blocked for an unscoped model-B (reaches the upstream, 200), and still blocked for model-A afterward.

## Behavior

No runtime change — test only. It fails on builds that drop watch-applied attachments (reproducing #850) and passes once #630 applies them, locking the scoped-resolution contract in.

Fixes api7/AISIX-Cloud#850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify that model-scoped guardrails execute only for their designated models and do not affect other models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->