### PR TITLE
docs(cleanup): refresh stale post-migration code comments

### DIFF
--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -52,7 +52,10 @@ pub enum Role {
 ///     blocks. For non-array shapes this is the original string (or
 ///     `""` for `null`). Bridges that don't speak content blocks
 ///     (Anthropic / Gemini cross-provider translation today) read this
-///     and silently skip non-text blocks per docs §4.5.
+///     and silently skip non-text blocks (images/audio): a cross-provider
+///     request keeps only the text. Documented for users under
+///     "Cross-Provider Content Limitations" in the provider-compatibility
+///     reference.
 ///   * [`Self::content_blocks`] holds the **raw array** verbatim when
 ///     the caller sent the typed-block form. Bridges that DO support
 ///     content blocks (the OpenAI-compat bridge) forward this verbatim
@@ -76,9 +79,9 @@ pub struct ChatMessage {
     /// `null` content shapes. Bridges that support content blocks
     /// (the OpenAI-compat bridge) forward this verbatim to upstream;
     /// bridges that don't (Anthropic / Gemini cross-provider
-    /// translation today) consult only `content` (concatenated text)
-    /// per docs §4.5 ("skip non-text blocks silently on the inbound
-    /// parse").
+    /// translation today) consult only `content` (concatenated text) and
+    /// silently skip the non-text blocks on the inbound parse, so a
+    /// cross-provider request drops images/audio.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_blocks: Option<Vec<Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/aisix-server/src/cert_bundle.rs
+++ b/crates/aisix-server/src/cert_bundle.rs
@@ -1,6 +1,7 @@
 //! Pre-provisioned mTLS bundle bootstrap path (api7ee parity).
 //!
-//! Counterpart to `register.rs`. When the operator mints a cert via
+//! This is the only bootstrap path — it replaces the removed legacy
+//! `/dp/register` round-trip. When the operator mints a cert via
 //! the dashboard's `CertIssueCard` (see AISIX-Cloud cp-api's
 //! `POST /api/environments/:env_id/gateway_certificates`), the
 //! resulting cert + key + CA PEM trio is inlined into the DP's

--- a/tests/e2e/src/cases/vision-input-e2e.test.ts
+++ b/tests/e2e/src/cases/vision-input-e2e.test.ts
@@ -30,11 +30,12 @@ import {
 // content-block array would break every multimodal caller.
 //
 // Cross-provider vision translation (caller's image_url →
-// Anthropic image content block) is documented as a known gap in
-// `docs/api-proxy.md` §4.5 ("image blocks ... skip non-text blocks
-// silently on the inbound parse") and is out of scope for this
-// PR — the OpenAI-native path is the most-used vision path and a
-// regression there breaks the largest callers.
+// Anthropic image content block) is a known gap: the translation path
+// keeps only the text and silently skips non-text blocks. It is
+// documented for users under "Cross-Provider Content Limitations" in the
+// provider-compatibility reference, and is out of scope for this test —
+// the OpenAI-native path is the most-used vision path and a regression
+// there breaks the largest callers.
 //
 // References:
 // - OpenAI Vision guide


### PR DESCRIPTION
## Problem

Two P2 cleanup items from the architecture review (AISIX-Cloud#788) resolve to documentation rather than behavior changes:

1. **Cross-provider multimodal drop.** When a request crosses provider families (e.g. an OpenAI-shape request routed to an Anthropic/Gemini-backed model), the translation path keeps only the message text and silently drops non-text content blocks (images/audio). The `ChatMessage` doc comments and the `vision-input` e2e pointed at `docs/api-proxy.md §4.5`, a path that no longer exists — the docs migrated to the `api7/docs` repo.
2. **Stale `/dp/register` reference.** `cert_bundle.rs` described itself as the "Counterpart to `register.rs`", a module that no longer exists. The pre-signed cert bundle is the only bootstrap path now; it replaced the removed `/dp/register` round-trip.

## Changes

- Made the multimodal `ChatMessage` comments and the `vision-input` e2e comment self-contained (describe the drop behavior without the dead `§4.5` pointer). The user-facing limitation is documented in the paired `api7/docs` PR under "Cross-Provider Content Limitations" in the provider-compatibility reference.
- Fixed the `cert_bundle.rs` module doc to drop the `register.rs` reference and state it is the only (cert-pre-signing) bootstrap path.

## Out of scope / intentional

- The **4xx-passthrough vs 5xx-redact** asymmetry (`render_bridge_upstream_envelope`) and the **per-request Bedrock SDK client** are intentional and already documented in their own doc comments — 4xx carries caller-actionable detail and SDK retry semantics, 5xx is redacted to avoid leaking infra detail; the Bedrock client is rebuilt per request to stay stateless so credential rotation lands without cache invalidation. Left unchanged.
- The broader sweep of dangling `docs/api-proxy.md` references across the proxy crate is a separate post-migration cleanup, not part of this item.

No behavior change; comment-only.

Part of api7/AISIX-Cloud#788


Fixes api7/AISIX-Cloud#788
