### PR TITLE
feat(managed): make the DP heartbeat interval configurable

### DIFF
--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -84,5 +84,11 @@ managed:
   # Set to "" to disable.
   snapshot_cache_path: "/var/lib/aisix/config_cache.json"
 
+  # Heartbeat interval, in seconds. The DP POSTs a heartbeat to
+  # dp-manager every interval; the CP marks the DP "connected" on its
+  # first heartbeat. Clamped to [5, 300]. Default 15s; lower it (e.g. 5s)
+  # in dev/e2e so connect detection isn't bound by the interval.
+  heartbeat_interval_secs: 15
+
 cache:
   backend: "memory"

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -239,6 +239,15 @@ pub struct ManagedConfig {
     /// runs where you don't want a stale cache to mask a real failure.
     #[serde(default = "ManagedConfig::default_snapshot_cache_path")]
     pub snapshot_cache_path: String,
+
+    /// Heartbeat interval, in seconds. The DP POSTs a heartbeat to
+    /// dp-manager every `heartbeat_interval_secs`; CP surfaces a DP as
+    /// "connected" on its first heartbeat. Clamped to [5, 300] by
+    /// [`crate`]-external `HeartbeatConfig::sanitised`. Default 15s in
+    /// production; e2e/dev can lower it (min 5s) so connect-detection
+    /// tests aren't bound by the interval.
+    #[serde(default = "ManagedConfig::default_heartbeat_interval_secs")]
+    pub heartbeat_interval_secs: u64,
 }
 
 impl ManagedConfig {
@@ -272,6 +281,9 @@ impl ManagedConfig {
     }
     fn default_snapshot_cache_path() -> String {
         "/var/lib/aisix/config_cache.json".into()
+    }
+    const fn default_heartbeat_interval_secs() -> u64 {
+        15
     }
 }
 
@@ -845,6 +857,33 @@ admin:
         assert!(!cfg.proxy.real_ip.recursive);
         assert_eq!(cfg.proxy.real_ip.header, "x-forwarded-for");
         assert!(cfg.proxy.real_ip.parse_trusted().unwrap().is_empty());
+    }
+
+    #[test]
+    fn managed_heartbeat_interval_defaults_to_15_and_can_be_lowered() {
+        let base = r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+managed:
+  enabled: true
+  cp_base_url: "https://cp.example"
+"#;
+        // Omitted → production default 15s.
+        let f = write_yaml(base);
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.managed.heartbeat_interval_secs, 15);
+
+        // Explicit → e2e/dev can lower it (the 5s floor is enforced later
+        // by HeartbeatConfig::sanitised, not here).
+        let f = write_yaml(&format!("{base}  heartbeat_interval_secs: 5\n"));
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.managed.heartbeat_interval_secs, 5);
     }
 
     #[test]

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -197,7 +197,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             Some(heartbeat::HeartbeatConfig::sanitised(
                 format!("{}/dp/heartbeat", cp_base.trim_end_matches('/')),
                 p.dp_id,
-                std::time::Duration::from_secs(15),
+                std::time::Duration::from_secs(cfg.managed.heartbeat_interval_secs),
                 heartbeat::MtlsBundle {
                     ca_cert_path: p.ca_cert_path,
                     client_cert_path: p.client_cert_path,
@@ -874,7 +874,7 @@ fn load_heartbeat_config_from_disk(
     Ok(heartbeat::HeartbeatConfig::sanitised(
         url,
         dp_id,
-        std::time::Duration::from_secs(15),
+        std::time::Duration::from_secs(managed.heartbeat_interval_secs),
         heartbeat::MtlsBundle {
             ca_cert_path: managed_bundle::ca_cert_path(&managed.mtls_dir),
             client_cert_path: managed_bundle::client_cert_path(&managed.mtls_dir),


### PR DESCRIPTION
## Why

CP marks a DP "connected" on its **first heartbeat**, so DP-connect e2e detection is heartbeat-interval-bound. The interval was hardcoded to **15s**, which makes the `dp-wait-for-connect` tests slow and flaky under CI load (api7/AISIX-Cloud#847 — they wait up to 90–150s for the connect nudge).

## What

Expose `managed.heartbeat_interval_secs` (default **15s**, unchanged production behavior; the existing `[5, 300]` clamp in `HeartbeatConfig::sanitised` still applies). Both managed-boot sites — the register path (`main.rs`) and the disk-bootstrap path (`load_heartbeat_config_from_disk`) — now read it instead of the hardcoded `15`.

The paired e2e harness change in api7/AISIX-Cloud sets it to `5s`, so connect detection drops from ~15–30s to ~5–11s and the e2e connect ceiling can come back down from the 150s stopgap.

## Tests

`managed_heartbeat_interval_defaults_to_15_and_can_be_lowered` — omitted → 15s, explicit → honored. Surfaced in `config.managed.yaml`. No behavior change unless the operator sets it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable heartbeat interval for managed-mode deployments. Users can now customize the heartbeat interval via configuration (default: 15 seconds, valid range: 5–300 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->