### PR TITLE
feat: semantic routing (data plane)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Covered by 90+ E2E tests.
   both ways when a model points at a non-Anthropic provider.
 - **Routing & failover** — virtual/routing models, weighted load balancing, automatic
   failover, retry budgets, cooldowns, and per-attempt timeouts.
+- **Semantic routing** — one virtual model that dispatches by the *meaning* of each
+  request: it embeds the prompt, scores it against per-route example utterances, and routes
+  to the best match (or a default). See [docs/semantic-routing.md](docs/semantic-routing.md).
 - **Rate limiting & concurrency** — RPM/RPD + TPM/TPD + concurrency caps, AND-combined
   across `ApiKey`, `Model`, and policy scopes (`api_key` / `model` / `team` / `member`).
 - **Guardrails** — content-policy enforcement on input and output: keyword/regex

--- a/crates/aisix-admin/src/models_status_handler.rs
+++ b/crates/aisix-admin/src/models_status_handler.rs
@@ -16,6 +16,8 @@ use crate::state::AdminState;
 pub enum ModelKind {
     Direct,
     Routing,
+    Ensemble,
+    Semantic,
 }
 
 #[derive(Debug, Serialize)]
@@ -37,11 +39,23 @@ pub async fn get_models_status(
     let models = all_models
         .into_iter()
         .map(|entry| {
-            if entry.value.is_routing() {
+            // Virtual routers (routing / ensemble / semantic) have no
+            // upstream of their own, so runtime health is not applicable —
+            // it lives on the direct Models they dispatch to.
+            let virtual_kind = if entry.value.is_routing() {
+                Some(ModelKind::Routing)
+            } else if entry.value.is_ensemble() {
+                Some(ModelKind::Ensemble)
+            } else if entry.value.is_semantic() {
+                Some(ModelKind::Semantic)
+            } else {
+                None
+            };
+            if let Some(kind) = virtual_kind {
                 ModelStatusView {
                     id: entry.id,
                     display_name: entry.value.display_name,
-                    kind: ModelKind::Routing,
+                    kind,
                     details: RuntimeStatusSnapshot {
                         status: RuntimeStatus::NotApplicable,
                         ..RuntimeStatusSnapshot::default()

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3232,11 +3232,27 @@ fn add_variant_titles(doc: &mut Value) {
             &["Literal", "Regex"],
         ),
         (
-            // Model's top-level direct/routing/ensemble mutual-exclusion
-            // `oneOf` (injected by `aisix_core::models::schema::model_root_schema`).
-            // Order must match `aisix_core::models::model::model_one_of`.
+            // Model's top-level direct/routing/ensemble/semantic
+            // mutual-exclusion `oneOf` (injected by
+            // `aisix_core::models::schema::model_root_schema`). Order must
+            // match `aisix_core::models::model::model_one_of`.
             "/components/schemas/Model/oneOf",
-            &["Routing model", "Direct model", "Ensemble model"],
+            &[
+                "Routing model",
+                "Direct model",
+                "Ensemble model",
+                "Semantic router",
+            ],
+        ),
+        ("/components/schemas/DistanceMetric/oneOf", &["Cosine"]),
+        ("/components/schemas/Aggregation/oneOf", &["Max"]),
+        (
+            "/components/schemas/EmbeddingFailureMode/oneOf",
+            &["Default", "Fail"],
+        ),
+        (
+            "/components/schemas/OnEmbeddingFailure/anyOf",
+            &["Default or fail policy", "Target model"],
         ),
         (
             "/components/schemas/ObjectStoreAuthMode/oneOf",

--- a/crates/aisix-core/src/bin/dump-schema.rs
+++ b/crates/aisix-core/src/bin/dump-schema.rs
@@ -31,7 +31,7 @@ use std::path::{Path, PathBuf};
 use schemars::JsonSchema;
 
 use aisix_core::models::schema;
-use aisix_core::models::{EnsembleConfig, RateLimit, Routing};
+use aisix_core::models::{EmbeddingConfig, EnsembleConfig, RateLimit, Routing, Semantic};
 
 fn main() {
     let out_dir = workspace_root().join("schemas").join("resources");
@@ -66,6 +66,8 @@ fn main() {
     dump::<EnsembleConfig>(&out_dir, "ensemble");
     dump::<RateLimit>(&out_dir, "rate_limit");
     dump::<Routing>(&out_dir, "routing");
+    dump::<Semantic>(&out_dir, "semantic");
+    dump::<EmbeddingConfig>(&out_dir, "embedding");
 }
 
 fn dump<T: JsonSchema>(out_dir: &Path, name: &str) {

--- a/crates/aisix-core/src/models/embedding.rs
+++ b/crates/aisix-core/src/models/embedding.rs
@@ -1,0 +1,62 @@
+//! Embedding-modality config attached to a [`Model`](super::Model).
+//!
+//! A direct Model that carries an `embedding` block is an embedding model:
+//! it keeps the direct-upstream triple (`provider` / `model_name` /
+//! `provider_key_id`) pointing at an OpenAI-compatible `/v1/embeddings`
+//! endpoint, and the block records the modality metadata the gateway needs
+//! to use the vectors — the output `dimensions` and whether the endpoint
+//! already returns L2-normalized vectors.
+//!
+//! Such a model can be called directly via `/v1/embeddings` and referenced
+//! by a [`Semantic`](super::Semantic) router as its `embedding_model`. The
+//! presence of this block is what marks the modality; it does not change
+//! the dispatch kind (the model stays `Direct`).
+
+use serde::{Deserialize, Serialize};
+
+fn default_normalize() -> bool {
+    true
+}
+
+/// Embedding-modality metadata for a direct Model.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EmbeddingConfig {
+    /// Output vector dimensionality. Used to validate vectors, key the
+    /// example-vector cache, and (for endpoints that support it) request a
+    /// reduced output size.
+    #[schemars(range(min = 1))]
+    pub dimensions: u32,
+    /// Whether the endpoint already returns L2-normalized vectors. When
+    /// `false`, the gateway normalizes before computing cosine similarity.
+    /// Defaults to `true`.
+    #[serde(default = "default_normalize")]
+    pub normalize: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_full_embedding_block() {
+        let e: EmbeddingConfig =
+            serde_json::from_str(r#"{"dimensions": 1024, "normalize": false}"#).unwrap();
+        assert_eq!(e.dimensions, 1024);
+        assert!(!e.normalize);
+    }
+
+    #[test]
+    fn normalize_defaults_to_true() {
+        let e: EmbeddingConfig = serde_json::from_str(r#"{"dimensions": 1536}"#).unwrap();
+        assert_eq!(e.dimensions, 1536);
+        assert!(e.normalize);
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        let r: Result<EmbeddingConfig, _> =
+            serde_json::from_str(r#"{"dimensions": 1024, "bogus": true}"#);
+        assert!(r.is_err());
+    }
+}

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -54,13 +54,13 @@ pub use provider_key::{
 pub use rate_limit::RateLimit;
 pub use rate_limit_policy::{PolicyScope, PolicyWindow, RateLimitPolicy};
 pub use routing::{OnAllFilteredPolicy, Routing, RoutingStrategy, RoutingTarget};
-pub use semantic::{
-    Aggregation, DistanceMetric, EmbeddingFailureMode, OnEmbeddingFailure, Semantic, SemanticMatch,
-    SemanticRoute,
-};
 pub use schema::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_guardrail_attachment,
     validate_model, validate_observability_exporter, validate_provider_key,
     validate_rate_limit_policy, SchemaError,
+};
+pub use semantic::{
+    Aggregation, DistanceMetric, EmbeddingFailureMode, OnEmbeddingFailure, Semantic, SemanticMatch,
+    SemanticRoute,
 };
 pub use snapshot::AisixSnapshot;

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod apikey;
 pub mod cache_policy;
+pub mod embedding;
 pub mod ensemble;
 pub mod guardrail;
 pub mod model;
@@ -26,10 +27,12 @@ pub mod rate_limit;
 pub mod rate_limit_policy;
 pub mod routing;
 pub mod schema;
+pub mod semantic;
 pub mod snapshot;
 
 pub use apikey::ApiKey;
 pub use cache_policy::{AppliesTo, CacheBackend, CachePolicy};
+pub use embedding::EmbeddingConfig;
 pub use ensemble::{EnsembleConfig, Judge, PanelMember};
 pub use guardrail::{
     AliyunTextModerationConfig, AppliedGuardrail, AzureContentSafetyConfig,
@@ -51,6 +54,10 @@ pub use provider_key::{
 pub use rate_limit::RateLimit;
 pub use rate_limit_policy::{PolicyScope, PolicyWindow, RateLimitPolicy};
 pub use routing::{OnAllFilteredPolicy, Routing, RoutingStrategy, RoutingTarget};
+pub use semantic::{
+    Aggregation, DistanceMetric, EmbeddingFailureMode, OnEmbeddingFailure, Semantic, SemanticMatch,
+    SemanticRoute,
+};
 pub use schema::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_guardrail_attachment,
     validate_model, validate_observability_exporter, validate_provider_key,

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -15,9 +15,11 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use super::embedding::EmbeddingConfig;
 use super::ensemble::EnsembleConfig;
 use super::rate_limit::RateLimit;
 use super::routing::Routing;
+use super::semantic::Semantic;
 use crate::resource::Resource;
 
 // `Provider` enum removed as part of #302 Phase A clean cut. Vendor
@@ -212,6 +214,18 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ensemble: Option<EnsembleConfig>,
 
+    /// Semantic-routing configuration. When set, the gateway embeds the
+    /// request and dispatches to the route whose examples it matches best,
+    /// using that route's target Model for upstream dispatch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic: Option<Semantic>,
+
+    /// Embedding-modality metadata. Present on direct Models that serve an
+    /// OpenAI-compatible `/v1/embeddings` endpoint (and can be referenced
+    /// by a semantic router's `embedding_model`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<EmbeddingConfig>,
+
     /// Per-token cost for budget tracking. Omit it when cost tracking is not needed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<ModelCost>,
@@ -242,6 +256,18 @@ impl Model {
     /// instead of dispatching a single upstream).
     pub fn is_ensemble(&self) -> bool {
         self.ensemble.is_some()
+    }
+
+    /// Whether this Model is a semantic router (picks a target by the
+    /// meaning of the request instead of dispatching its own upstream).
+    pub fn is_semantic(&self) -> bool {
+        self.semantic.is_some()
+    }
+
+    /// Whether this Model is an embedding-modality model (a direct model
+    /// that also carries embedding metadata).
+    pub fn is_embedding(&self) -> bool {
+        self.embedding.is_some()
     }
 
     /// Convenience: borrow the upstream model id if this Model is a
@@ -307,8 +333,11 @@ impl Model {
 
 /// The one cross-field invariant the runtime schema enforces that
 /// `schemars` cannot derive from the flat struct: a Model ships EXACTLY
-/// one shape — a `routing` block, an `ensemble` block, or the three direct
-/// upstream fields (`provider`/`model_name`/`provider_key_id`) together.
+/// one dispatch shape — a `routing` block, an `ensemble` block, a
+/// `semantic` block, or the three direct upstream fields
+/// (`provider`/`model_name`/`provider_key_id`) together. The `embedding`
+/// block is modality metadata on the direct shape, so it is permitted only
+/// alongside the direct triple, never on a virtual router.
 /// [`crate::models::schema::model_root_schema`] injects this as a top-level
 /// `oneOf` into the generated schema, so the published schema and the
 /// runtime validator share this single definition.
@@ -322,14 +351,17 @@ pub fn model_one_of() -> Value {
                 { "required": ["provider_key_id"] },
                 { "required": ["background_model_check"] },
                 { "required": ["cooldown"] },
-                { "required": ["ensemble"] }
+                { "required": ["ensemble"] },
+                { "required": ["semantic"] },
+                { "required": ["embedding"] }
             ]}
         },
         {
             "required": ["provider", "model_name", "provider_key_id"],
             "not": { "anyOf": [
                 { "required": ["routing"] },
-                { "required": ["ensemble"] }
+                { "required": ["ensemble"] },
+                { "required": ["semantic"] }
             ]}
         },
         {
@@ -340,7 +372,22 @@ pub fn model_one_of() -> Value {
                 { "required": ["provider_key_id"] },
                 { "required": ["routing"] },
                 { "required": ["background_model_check"] },
-                { "required": ["cooldown"] }
+                { "required": ["cooldown"] },
+                { "required": ["semantic"] },
+                { "required": ["embedding"] }
+            ]}
+        },
+        {
+            "required": ["semantic"],
+            "not": { "anyOf": [
+                { "required": ["provider"] },
+                { "required": ["model_name"] },
+                { "required": ["provider_key_id"] },
+                { "required": ["routing"] },
+                { "required": ["ensemble"] },
+                { "required": ["background_model_check"] },
+                { "required": ["cooldown"] },
+                { "required": ["embedding"] }
             ]}
         }
     ])

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -537,6 +537,224 @@ mod tests {
         assert!(validate_model(&v).is_err());
     }
 
+    // ---- semantic-routing + embedding-modality schema tests (#641) ----
+
+    #[test]
+    fn model_semantic_form_passes() {
+        let v = json!({
+            "display_name": "prod-chat",
+            "semantic": {
+                "embedding_model": "bge-m3",
+                "routes": [
+                    {
+                        "name": "legal",
+                        "target": "claude-opus",
+                        "description": "Contract & legal risk analysis",
+                        "examples": ["分析这份合同里的潜在风险", "Review this NDA"],
+                        "threshold": 0.8
+                    },
+                    {"name": "translate", "target": "gpt-4o-mini", "examples": ["帮我翻译这句话"]}
+                ],
+                "default": "gpt-4o",
+                "match": {"distance_metric": "cosine", "aggregation": "max", "threshold": 0.75},
+                "embedding_timeout_ms": 500,
+                "on_embedding_failure": {"target": "gpt-4o-mini"}
+            }
+        });
+        validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_semantic_minimal_form_passes() {
+        let v = json!({
+            "display_name": "prod-chat",
+            "semantic": {
+                "embedding_model": "bge-m3",
+                "routes": [{"name": "a", "target": "m", "examples": ["hi"]}],
+                "default": "gpt-4o",
+                "match": {"threshold": 0.5}
+            }
+        });
+        validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_semantic_can_be_ip_restricted_and_rate_limited() {
+        // Top-level gates apply to the semantic router entry too.
+        let v = json!({
+            "display_name": "prod-chat",
+            "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "a", "target": "m", "examples": ["x"]}],
+                "default": "d",
+                "match": {"threshold": 0.5}
+            },
+            "allowed_cidrs": ["10.0.0.0/8"],
+            "rate_limit": {"rpm": 60}
+        });
+        validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_semantic_on_embedding_failure_accepts_bare_modes() {
+        for mode in ["default", "fail"] {
+            let v = json!({
+                "display_name": "prod-chat",
+                "semantic": {
+                    "embedding_model": "e",
+                    "routes": [{"name": "a", "target": "m", "examples": ["x"]}],
+                    "default": "d",
+                    "match": {"threshold": 0.5},
+                    "on_embedding_failure": mode
+                }
+            });
+            validate_model(&v).unwrap_or_else(|e| panic!("mode {mode:?} must validate: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn model_semantic_with_direct_fields_fails() {
+        // semantic is mutually exclusive with the direct upstream triple.
+        let v = json!({
+            "display_name": "x",
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "pk-1",
+            "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "a", "target": "m", "examples": ["x"]}],
+                "default": "d",
+                "match": {"threshold": 0.5}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_semantic_with_routing_fails() {
+        let v = json!({
+            "display_name": "x",
+            "routing": {"targets": [{"model": "a"}]},
+            "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "a", "target": "m", "examples": ["x"]}],
+                "default": "d",
+                "match": {"threshold": 0.5}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_semantic_missing_required_fields_fails() {
+        // Missing `default`.
+        let v = json!({
+            "display_name": "x",
+            "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "a", "target": "m", "examples": ["x"]}],
+                "match": {"threshold": 0.5}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_semantic_empty_routes_fails() {
+        let v = json!({
+            "display_name": "x",
+            "semantic": {
+                "embedding_model": "e",
+                "routes": [],
+                "default": "d",
+                "match": {"threshold": 0.5}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_semantic_route_without_examples_fails() {
+        // examples-only matching: a route needs at least one example.
+        let v = json!({
+            "display_name": "x",
+            "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "a", "target": "m", "examples": []}],
+                "default": "d",
+                "match": {"threshold": 0.5}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_semantic_threshold_out_of_range_fails() {
+        let v = json!({
+            "display_name": "x",
+            "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "a", "target": "m", "examples": ["x"]}],
+                "default": "d",
+                "match": {"threshold": 1.5}
+            }
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_embedding_modality_on_direct_passes() {
+        // An embedding model is a direct model that also carries the
+        // embedding-modality block.
+        let v = json!({
+            "display_name": "bge-m3",
+            "provider": "openai",
+            "model_name": "bge-m3",
+            "provider_key_id": "pk-1",
+            "embedding": {"dimensions": 1024, "normalize": false}
+        });
+        validate_model(&v).unwrap();
+    }
+
+    #[test]
+    fn model_embedding_without_dimensions_fails() {
+        let v = json!({
+            "display_name": "bge-m3",
+            "provider": "openai",
+            "model_name": "bge-m3",
+            "provider_key_id": "pk-1",
+            "embedding": {"normalize": true}
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_embedding_on_routing_fails() {
+        // The embedding block is modality metadata on a direct model — it
+        // has no meaning on a virtual router.
+        let v = json!({
+            "display_name": "x",
+            "routing": {"targets": [{"model": "a"}]},
+            "embedding": {"dimensions": 1024}
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
+    #[test]
+    fn model_embedding_on_semantic_fails() {
+        let v = json!({
+            "display_name": "x",
+            "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "a", "target": "m", "examples": ["x"]}],
+                "default": "d",
+                "match": {"threshold": 0.5}
+            },
+            "embedding": {"dimensions": 1024}
+        });
+        assert!(validate_model(&v).is_err());
+    }
+
     #[test]
     fn model_allowed_cidrs_passes_on_direct_and_routing() {
         // Direct model with an IP allowlist (#557).

--- a/crates/aisix-core/src/models/semantic.rs
+++ b/crates/aisix-core/src/models/semantic.rs
@@ -228,10 +228,15 @@ mod tests {
         // falls back to it.
         assert_eq!(s.route_threshold(&s.routes[0]), 0.8);
         assert_eq!(s.route_threshold(&s.routes[1]), 0.75);
-        assert_eq!(s.embedding_timeout(), Some(std::time::Duration::from_millis(500)));
+        assert_eq!(
+            s.embedding_timeout(),
+            Some(std::time::Duration::from_millis(500))
+        );
         assert_eq!(
             s.on_embedding_failure,
-            OnEmbeddingFailure::Target { target: "gpt-4o-mini".into() }
+            OnEmbeddingFailure::Target {
+                target: "gpt-4o-mini".into()
+            }
         );
     }
 
@@ -305,9 +310,14 @@ mod tests {
     fn on_embedding_failure_serializes_to_proposal_wire_shape() {
         // Bare-string mode round-trips as a string.
         let mode = OnEmbeddingFailure::Mode(EmbeddingFailureMode::Fail);
-        assert_eq!(serde_json::to_value(&mode).unwrap(), serde_json::json!("fail"));
+        assert_eq!(
+            serde_json::to_value(&mode).unwrap(),
+            serde_json::json!("fail")
+        );
         // Target round-trips as { "target": "alias" }, not a nested object.
-        let target = OnEmbeddingFailure::Target { target: "safe".into() };
+        let target = OnEmbeddingFailure::Target {
+            target: "safe".into(),
+        };
         assert_eq!(
             serde_json::to_value(&target).unwrap(),
             serde_json::json!({"target": "safe"})

--- a/crates/aisix-core/src/models/semantic.rs
+++ b/crates/aisix-core/src/models/semantic.rs
@@ -1,0 +1,316 @@
+//! Semantic-routing config attached to a [`Model`](super::Model).
+//!
+//! When a Model carries a `semantic` block, the proxy treats it as a
+//! virtual router that picks a target by the *meaning* of the request,
+//! rather than by health/weight ([`Routing`](super::Routing)) or by
+//! fanning out to a panel ([`EnsembleConfig`](super::EnsembleConfig)).
+//!
+//! Per request the proxy embeds the latest user message via the
+//! `embedding_model`, scores it against each route's example embeddings
+//! (cosine, aggregated per route), and dispatches to the highest route
+//! whose score clears its threshold — or to `default` when none does.
+//! Route example vectors are computed once at apply time and cached, so
+//! the per-request cost is a single embedding call plus local arithmetic.
+//!
+//! Routes reference direct Models by `display_name`, the same way routing
+//! targets and ensemble panel members do. Mutual exclusivity with the
+//! direct-upstream fields, `routing`, and `ensemble` is enforced by the
+//! runtime schema (`super::schema`), not by this type.
+
+use serde::{Deserialize, Serialize};
+
+/// Distance metric used to compare the request embedding against route
+/// example embeddings. v1 supports cosine only.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum DistanceMetric {
+    /// Cosine similarity — higher is more similar.
+    #[default]
+    Cosine,
+}
+
+/// How a request's per-example similarity scores collapse into one score
+/// for the route. v1 uses `max` (the single best-matching example),
+/// chosen for explainability — the UI surfaces "the top matching example"
+/// — over semantic-router's default sum/mean-over-top_k.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Aggregation {
+    /// Route score = the highest cosine across its examples.
+    #[default]
+    Max,
+}
+
+/// One semantic route: a labeled set of example utterances whose
+/// embeddings define the route. A request that scores high enough against
+/// them dispatches to `target`.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticRoute {
+    /// Operator-facing route label. Surfaced in the `x-aisix-route`
+    /// response header and access logs (e.g. `prod-chat -> route:legal`).
+    #[schemars(length(min = 1))]
+    pub name: String,
+    /// Direct model alias that receives traffic matching this route.
+    #[schemars(length(min = 1))]
+    pub target: String,
+    /// Human-facing description. Documentation only — v1 matches on
+    /// `examples`, not on this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub description: Option<String>,
+    /// Example utterances that define this route. The DP embeds each at
+    /// apply time and caches the vector; a request is matched against
+    /// these. At least one is required (description does not participate
+    /// in matching).
+    #[schemars(length(min = 1), inner(length(min = 1)))]
+    pub examples: Vec<String>,
+    /// Per-route similarity threshold. A request matches this route only
+    /// when its aggregated score is `>=` this value. When omitted, the
+    /// router-level [`SemanticMatch::threshold`] applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub threshold: Option<f32>,
+}
+
+/// Matching parameters shared across every route in a semantic router.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticMatch {
+    /// Similarity metric. v1: cosine.
+    #[serde(default)]
+    pub distance_metric: DistanceMetric,
+    /// Per-example score aggregation. v1: max.
+    #[serde(default)]
+    pub aggregation: Aggregation,
+    /// Default similarity threshold for routes that do not set their own
+    /// `threshold`. Higher is stricter.
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub threshold: f32,
+}
+
+/// Mode for an enum-only failure policy: route to the router's `default`,
+/// or fail the request with `503`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingFailureMode {
+    /// Route to the semantic router's `default` model.
+    #[default]
+    Default,
+    /// Reject the request with `503`.
+    Fail,
+}
+
+/// What the router does when the embedding call errors or times out.
+///
+/// Wire shape mirrors the proposal: the bare string `"default"` / `"fail"`,
+/// or an object `{ "target": "<direct alias>" }` to fall back to a specific
+/// safe model. Replicates the spirit of
+/// [`OnAllFilteredPolicy`](super::OnAllFilteredPolicy) with the added
+/// explicit-target option.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum OnEmbeddingFailure {
+    /// `"default"` or `"fail"`.
+    Mode(EmbeddingFailureMode),
+    /// `{ "target": "<direct alias>" }` — route to a specific safe model.
+    Target {
+        #[schemars(length(min = 1))]
+        target: String,
+    },
+}
+
+impl Default for OnEmbeddingFailure {
+    fn default() -> Self {
+        OnEmbeddingFailure::Mode(EmbeddingFailureMode::Default)
+    }
+}
+
+/// Semantic-routing config: pick a target by request meaning.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Semantic {
+    /// Alias of an `embedding`-modality Model used to embed the request
+    /// and (at apply time) the route examples.
+    #[schemars(length(min = 1))]
+    pub embedding_model: String,
+    /// Routes evaluated for each request. At least one is required.
+    #[schemars(length(min = 1))]
+    pub routes: Vec<SemanticRoute>,
+    /// Direct model alias used when no route clears its threshold.
+    #[schemars(length(min = 1))]
+    pub default: String,
+    /// Shared matching parameters (metric, aggregation, default threshold).
+    pub r#match: SemanticMatch,
+    /// Per-call deadline for the embedding request in milliseconds. `0` or
+    /// absent disables the embedding-specific deadline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_timeout_ms: Option<u64>,
+    /// Behavior when the embedding call fails or times out. Defaults to
+    /// routing to `default`.
+    #[serde(default, skip_serializing_if = "is_default_failure")]
+    pub on_embedding_failure: OnEmbeddingFailure,
+}
+
+fn is_default_failure(p: &OnEmbeddingFailure) -> bool {
+    *p == OnEmbeddingFailure::default()
+}
+
+impl Semantic {
+    /// Effective threshold for a route: its own `threshold` if set,
+    /// otherwise the router-level `match.threshold`.
+    pub fn route_threshold(&self, route: &SemanticRoute) -> f32 {
+        route.threshold.unwrap_or(self.r#match.threshold)
+    }
+
+    /// Per-call embedding deadline. Folds the `0`/absent sentinel into
+    /// `None` like [`Model::request_timeout`](super::Model::request_timeout)
+    /// so callers can apply it unconditionally.
+    pub fn embedding_timeout(&self) -> Option<std::time::Duration> {
+        self.embedding_timeout_ms
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis)
+    }
+
+    /// Every direct-model alias this router can dispatch to: each route's
+    /// `target` plus `default`. Used by the loader for reference-integrity
+    /// checks and the runtime for resolution.
+    pub fn referenced_targets(&self) -> impl Iterator<Item = &str> {
+        self.routes
+            .iter()
+            .map(|r| r.target.as_str())
+            .chain(std::iter::once(self.default.as_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_full_semantic_block() {
+        let json = r#"{
+            "embedding_model": "bge-m3",
+            "routes": [
+                {
+                    "name": "legal",
+                    "target": "claude-opus",
+                    "description": "Contract & legal risk analysis",
+                    "examples": ["分析这份合同里的潜在风险", "Review this NDA"],
+                    "threshold": 0.8
+                },
+                {
+                    "name": "translate",
+                    "target": "gpt-4o-mini",
+                    "examples": ["帮我翻译这句话"]
+                }
+            ],
+            "default": "gpt-4o",
+            "match": {"distance_metric": "cosine", "aggregation": "max", "threshold": 0.75},
+            "embedding_timeout_ms": 500,
+            "on_embedding_failure": {"target": "gpt-4o-mini"}
+        }"#;
+        let s: Semantic = serde_json::from_str(json).unwrap();
+        assert_eq!(s.embedding_model, "bge-m3");
+        assert_eq!(s.routes.len(), 2);
+        assert_eq!(s.routes[0].name, "legal");
+        assert_eq!(s.routes[0].target, "claude-opus");
+        assert_eq!(s.routes[0].examples.len(), 2);
+        assert_eq!(s.default, "gpt-4o");
+        assert_eq!(s.r#match.threshold, 0.75);
+        // Per-route override beats the router default; absent override
+        // falls back to it.
+        assert_eq!(s.route_threshold(&s.routes[0]), 0.8);
+        assert_eq!(s.route_threshold(&s.routes[1]), 0.75);
+        assert_eq!(s.embedding_timeout(), Some(std::time::Duration::from_millis(500)));
+        assert_eq!(
+            s.on_embedding_failure,
+            OnEmbeddingFailure::Target { target: "gpt-4o-mini".into() }
+        );
+    }
+
+    #[test]
+    fn minimal_semantic_block_uses_defaults() {
+        let s: Semantic = serde_json::from_str(
+            r#"{
+                "embedding_model": "bge-m3",
+                "routes": [{"name": "a", "target": "m", "examples": ["hi"]}],
+                "default": "fallback",
+                "match": {"threshold": 0.5}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(s.r#match.distance_metric, DistanceMetric::Cosine);
+        assert_eq!(s.r#match.aggregation, Aggregation::Max);
+        assert_eq!(s.embedding_timeout(), None);
+        // Absent on_embedding_failure defaults to routing to `default`.
+        assert_eq!(s.on_embedding_failure, OnEmbeddingFailure::default());
+        assert_eq!(
+            s.on_embedding_failure,
+            OnEmbeddingFailure::Mode(EmbeddingFailureMode::Default)
+        );
+    }
+
+    #[test]
+    fn on_embedding_failure_accepts_bare_string_modes() {
+        for (raw, expected) in [
+            ("\"default\"", EmbeddingFailureMode::Default),
+            ("\"fail\"", EmbeddingFailureMode::Fail),
+        ] {
+            let p: OnEmbeddingFailure = serde_json::from_str(raw).unwrap();
+            assert_eq!(p, OnEmbeddingFailure::Mode(expected));
+        }
+    }
+
+    #[test]
+    fn referenced_targets_lists_routes_then_default() {
+        let s: Semantic = serde_json::from_str(
+            r#"{
+                "embedding_model": "e",
+                "routes": [
+                    {"name": "a", "target": "m1", "examples": ["x"]},
+                    {"name": "b", "target": "m2", "examples": ["y"]}
+                ],
+                "default": "d",
+                "match": {"threshold": 0.5}
+            }"#,
+        )
+        .unwrap();
+        let refs: Vec<&str> = s.referenced_targets().collect();
+        assert_eq!(refs, vec!["m1", "m2", "d"]);
+    }
+
+    #[test]
+    fn rejects_unknown_semantic_field() {
+        let r: Result<Semantic, _> = serde_json::from_str(
+            r#"{"embedding_model":"e","routes":[{"name":"a","target":"m","examples":["x"]}],"default":"d","match":{"threshold":0.5},"foo":1}"#,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_route_field() {
+        let r: Result<SemanticRoute, _> =
+            serde_json::from_str(r#"{"name":"a","target":"m","examples":["x"],"bogus":true}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn on_embedding_failure_serializes_to_proposal_wire_shape() {
+        // Bare-string mode round-trips as a string.
+        let mode = OnEmbeddingFailure::Mode(EmbeddingFailureMode::Fail);
+        assert_eq!(serde_json::to_value(&mode).unwrap(), serde_json::json!("fail"));
+        // Target round-trips as { "target": "alias" }, not a nested object.
+        let target = OnEmbeddingFailure::Target { target: "safe".into() };
+        assert_eq!(
+            serde_json::to_value(&target).unwrap(),
+            serde_json::json!({"target": "safe"})
+        );
+    }
+}

--- a/crates/aisix-core/src/models/semantic.rs
+++ b/crates/aisix-core/src/models/semantic.rs
@@ -121,6 +121,7 @@ pub enum OnEmbeddingFailure {
     Mode(EmbeddingFailureMode),
     /// `{ "target": "<direct alias>" }` — route to a specific safe model.
     Target {
+        /// Direct-model alias to route to when embedding fails.
         #[schemars(length(min = 1))]
         target: String,
     },

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1882,7 +1882,7 @@ async fn dispatch(
     // three branches (non-streaming, streaming, cache hit) with the
     // same policy so a refactor can't silently flip one of them.
     let served_by_target = served_by_target_for_routing(
-        virtual_entry.value.routing.is_some(),
+        virtual_entry.value.routing.is_some() || virtual_entry.value.is_semantic(),
         chosen_target_display_name,
     );
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -289,6 +289,26 @@ pub async fn chat_completions(
                     }
                 }
             }
+            // `x-aisix-route` exposes which semantic route matched (#641).
+            // Only present for a semantic router that resolved to a route;
+            // absent on a fall-through to `default` and on non-semantic
+            // requests. Same RFC 7230 header-value guard as above.
+            if let Some(route) = success.served_by_route.as_deref() {
+                match axum::http::HeaderValue::try_from(route) {
+                    Ok(v) => {
+                        success.response.headers_mut().insert("x-aisix-route", v);
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            route_name = %route,
+                            error = %err,
+                            "semantic route name is not a valid HTTP header value; \
+                             omitting x-aisix-route — rename the route to use only \
+                             visible ASCII (no CR/LF, no non-ASCII characters)"
+                        );
+                    }
+                }
+            }
             success.response
         }
         Err(failure) => {
@@ -528,6 +548,11 @@ struct Success {
     /// mid-stream, but the header remains useful because callers asked for
     /// the routing group's display name.
     served_by_target: Option<String>,
+    /// Name of the semantic route that matched this request (#641).
+    /// Surfaces in the `x-aisix-route` response header so callers can see
+    /// which intent the router resolved to. `None` for non-semantic
+    /// requests and for a semantic request that fell through to `default`.
+    served_by_route: Option<String>,
     routing: RoutingTelemetry,
     /// Captured request/response content for the observability fan-out, built
     /// (gated on the snapshot's content-capturing exporters) where the request
@@ -563,6 +588,19 @@ impl CacheStatus {
             CacheStatus::Hit => "hit",
         }
     }
+}
+
+/// Text of the latest user turn, used as the semantic-routing query.
+/// Walks `messages` in reverse and returns the first `role: "user"`
+/// message's text. `ChatMessage::content` already carries the
+/// concatenated text of multimodal content blocks, so this also covers
+/// vision/array-shaped messages (non-text blocks are skipped upstream).
+fn last_user_message_text(req: &ChatFormat) -> Option<String> {
+    req.messages
+        .iter()
+        .rev()
+        .find(|m| m.role == aisix_gateway::Role::User)
+        .and_then(|m| m.content.clone())
 }
 
 /// Compute the value of [`Success::served_by_target`] for a request.
@@ -802,18 +840,33 @@ async fn dispatch(
         ))));
     }
 
-    // Resolve the attempt-list of underlying Model entries. For a
-    // routing model we walk targets per the configured strategy; for a
-    // single-provider Model we just dispatch to it directly.
-    let attempt_models: Vec<AttemptModel> = resolve_attempt_models(
-        &state.routing,
-        &state.runtime_status,
-        &snapshot,
-        &req.model,
-        &virtual_entry.id,
-        &virtual_entry.value,
-    )
-    .map_err(&with_model)?;
+    // Resolve the attempt-list of underlying Model entries. A semantic
+    // router embeds the request and scores it against route examples to
+    // pick its single target; a routing group walks targets per strategy;
+    // a direct model dispatches to itself. Either way the dispatch loop
+    // below drives the resulting attempt list, so semantic routing reuses
+    // the full streaming / failover / telemetry machinery and only adds
+    // the "which target + which route" decision. `semantic_route` carries
+    // the matched route name (None on a fall-through to `default` or a
+    // non-semantic request) for the `x-aisix-route` response header.
+    let (attempt_models, semantic_route): (Vec<AttemptModel>, Option<String>) =
+        if virtual_entry.value.is_semantic() {
+            let prompt = last_user_message_text(req).unwrap_or_default();
+            crate::semantic::resolve(state, &snapshot, &virtual_entry, &prompt, request_id)
+                .await
+                .map_err(&with_model)?
+        } else {
+            let attempts = resolve_attempt_models(
+                &state.routing,
+                &state.runtime_status,
+                &snapshot,
+                &req.model,
+                &virtual_entry.id,
+                &virtual_entry.value,
+            )
+            .map_err(&with_model)?;
+            (attempts, None)
+        };
 
     // For non-routing requests, surface a misconfigured bridge as a
     // proper 503 rather than burying it inside a generic Bridge error.
@@ -892,7 +945,8 @@ async fn dispatch(
             .as_ref()
             .map(|r| r.retry_on_429_or_default())
             .unwrap_or(false);
-        let is_routing_request = virtual_entry.value.routing.is_some();
+        let is_routing_request =
+            virtual_entry.value.routing.is_some() || virtual_entry.value.is_semantic();
         let mut stream_routing = RoutingTelemetry::default();
         let mut last_err: Option<BridgeError> = None;
 
@@ -1312,6 +1366,7 @@ async fn dispatch(
                 is_routing_request,
                 Some(model.display_name.clone()),
             ),
+            served_by_route: semantic_route.clone(),
             routing: stream_routing,
             // Streaming content capture lands in C3b.
             captured_content: None,
@@ -1496,6 +1551,7 @@ async fn dispatch(
                     // target produced it on the original miss. See the
                     // `served_by_target` field docs on `Success`.
                     served_by_target: None,
+                    served_by_route: None,
                     routing: RoutingTelemetry::default(),
                     captured_content,
                 });
@@ -1855,6 +1911,7 @@ async fn dispatch(
         cache_hit_saved_output_tokens: 0,
         telemetry_handled_by_stream: false,
         served_by_target,
+        served_by_route: semantic_route.clone(),
         routing,
         captured_content,
     })
@@ -2351,6 +2408,7 @@ async fn dispatch_ensemble(
             telemetry_handled_by_stream: true,
             // Not a routing request — no `x-aisix-served-by` header.
             served_by_target: None,
+            served_by_route: None,
             routing: RoutingTelemetry::default(),
             captured_content: None,
         });
@@ -2551,6 +2609,7 @@ async fn dispatch_ensemble(
         telemetry_handled_by_stream: true,
         // Not a routing request — no `x-aisix-served-by` header.
         served_by_target: None,
+        served_by_route: None,
         routing: RoutingTelemetry::default(),
         captured_content: None,
     })

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1587,7 +1587,8 @@ async fn dispatch(
         .as_ref()
         .map(|routing| routing.retry_on_429_or_default())
         .unwrap_or(false);
-    let is_routing_request = virtual_entry.value.routing.is_some();
+    let is_routing_request =
+        virtual_entry.value.routing.is_some() || virtual_entry.value.is_semantic();
     let mut routing = RoutingTelemetry::default();
 
     for attempt in &attempt_models {

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -52,6 +52,7 @@ mod rerank;
 mod responses;
 mod responses_bridge;
 mod routing;
+mod semantic;
 mod state;
 mod stream_timeout;
 mod util;

--- a/crates/aisix-proxy/src/semantic.rs
+++ b/crates/aisix-proxy/src/semantic.rs
@@ -1,0 +1,482 @@
+//! Semantic-routing runtime: embed the request, score it against each
+//! route's cached example embeddings, and resolve a single direct-model
+//! target (or the router's `default`).
+//!
+//! [`resolve`] produces a one-element `attempt_models` list that the
+//! existing chat dispatch loop then drives exactly like a routing target —
+//! so semantic routing reuses all of the streaming / failover / telemetry
+//! machinery and only adds the "which target" decision on top.
+//!
+//! The scoring core ([`cosine_similarity`], [`decide`],
+//! [`embedding_failure_target`]) and the example-vector cache
+//! ([`SemanticVectorCache`]) are pure and unit-tested in isolation; the
+//! async embedding call lives in [`resolve`].
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+
+use aisix_core::models::{EmbeddingFailureMode, OnEmbeddingFailure, Semantic};
+use aisix_core::resource::ResourceEntry;
+use aisix_core::{AisixSnapshot, Model};
+use aisix_gateway::{BridgeContext, EmbeddingRequest, EmbeddingVector};
+
+use crate::error::ProxyError;
+use crate::routing::AttemptModel;
+use crate::state::ProxyState;
+
+/// Cosine similarity of two equal-length vectors. Returns `0.0` for a
+/// length mismatch or a zero-magnitude vector, so a degenerate embedding
+/// can never inject `NaN` into the `max` aggregation.
+pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+/// Outcome of scoring a request against a semantic router.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteDecision {
+    /// Index into `Semantic::routes` of the winning route, or `None` when
+    /// no route cleared its threshold (the caller falls back to `default`).
+    pub winner: Option<usize>,
+    /// Per-route aggregated score, aligned with `Semantic::routes`.
+    pub scores: Vec<f32>,
+}
+
+/// Score `request_vec` against each route's example vectors and pick the
+/// highest-scoring route that clears its (per-route or router-level)
+/// threshold. `max` aggregation: a route's score is its single
+/// best-matching example. `route_example_vecs[i]` are the cached vectors
+/// for `semantic.routes[i]`.
+pub(crate) fn decide(
+    semantic: &Semantic,
+    request_vec: &[f32],
+    route_example_vecs: &[Vec<Arc<Vec<f32>>>],
+) -> RouteDecision {
+    let mut scores = Vec::with_capacity(semantic.routes.len());
+    for ex_vecs in route_example_vecs {
+        let best = ex_vecs
+            .iter()
+            .map(|v| cosine_similarity(request_vec, v))
+            .fold(f32::NEG_INFINITY, f32::max);
+        scores.push(if best.is_finite() { best } else { 0.0 });
+    }
+    let mut winner: Option<usize> = None;
+    let mut best = f32::NEG_INFINITY;
+    for (i, route) in semantic.routes.iter().enumerate() {
+        if scores[i] >= semantic.route_threshold(route) && scores[i] > best {
+            best = scores[i];
+            winner = Some(i);
+        }
+    }
+    RouteDecision { winner, scores }
+}
+
+/// Direct-model alias to dispatch to when the embedding call fails, per
+/// `on_embedding_failure`. `None` means the policy is `fail` — the caller
+/// returns `503`.
+pub(crate) fn embedding_failure_target(semantic: &Semantic) -> Option<&str> {
+    match &semantic.on_embedding_failure {
+        OnEmbeddingFailure::Mode(EmbeddingFailureMode::Default) => Some(&semantic.default),
+        OnEmbeddingFailure::Mode(EmbeddingFailureMode::Fail) => None,
+        OnEmbeddingFailure::Target { target } => Some(target),
+    }
+}
+
+/// Per-instance cache of route example-utterance embeddings, populated
+/// lazily on the first request that needs them and reused across requests
+/// so the steady-state per-request cost is a single embedding call for the
+/// prompt. Keyed by `(embedding_model_id, dimensions, example_text)` —
+/// changing the embedding model or its dimensions auto-invalidates, since
+/// a stale vector of the wrong dimension must never be served.
+#[derive(Debug, Default)]
+pub struct SemanticVectorCache {
+    vectors: DashMap<(String, u32, String), Arc<Vec<f32>>>,
+}
+
+impl SemanticVectorCache {
+    pub(crate) fn get(
+        &self,
+        embedding_model_id: &str,
+        dimensions: u32,
+        text: &str,
+    ) -> Option<Arc<Vec<f32>>> {
+        self.vectors
+            .get(&(embedding_model_id.to_string(), dimensions, text.to_string()))
+            .map(|e| e.clone())
+    }
+
+    pub(crate) fn insert(
+        &self,
+        embedding_model_id: &str,
+        dimensions: u32,
+        text: &str,
+        vec: Arc<Vec<f32>>,
+    ) {
+        self.vectors.insert(
+            (embedding_model_id.to_string(), dimensions, text.to_string()),
+            vec,
+        );
+    }
+}
+
+/// Resolve a semantic router to a single direct-model attempt + the name
+/// of the route that matched (`None` when the request fell through to
+/// `default`). The returned `Vec<AttemptModel>` always has exactly one
+/// element; the chat dispatch loop drives it like any routing target.
+pub(crate) async fn resolve(
+    state: &ProxyState,
+    snapshot: &AisixSnapshot,
+    router_entry: &ResourceEntry<Model>,
+    prompt: &str,
+    request_id: &str,
+) -> Result<(Vec<AttemptModel>, Option<String>), ProxyError> {
+    let semantic = router_entry
+        .value
+        .semantic
+        .as_ref()
+        .expect("resolve called on a non-semantic model");
+
+    // Resolve the embedding model + its modality metadata. A dangling or
+    // wrong-kind reference is a config error; degrade via the failure
+    // policy rather than 500.
+    let embed_entry = match snapshot.models.get_by_name(&semantic.embedding_model) {
+        Some(e) if e.value.is_embedding() => e,
+        other => {
+            tracing::warn!(
+                router = %router_entry.value.display_name,
+                embedding_model = %semantic.embedding_model,
+                found = other.is_some(),
+                "semantic router references a missing or non-embedding embedding_model; \
+                 applying on_embedding_failure",
+            );
+            return fallback(semantic, snapshot);
+        }
+    };
+    let dims = embed_entry
+        .value
+        .embedding
+        .as_ref()
+        .map(|e| e.dimensions)
+        .unwrap_or(0);
+
+    // Batch the prompt (index 0) with every uncached example text in one
+    // embedding call. Steady state: only the prompt is uncached.
+    let mut pending: Vec<String> = Vec::new();
+    for route in &semantic.routes {
+        for ex in &route.examples {
+            if state
+                .semantic_cache
+                .get(&embed_entry.id, dims, ex)
+                .is_none()
+                && !pending.iter().any(|p| p == ex)
+            {
+                pending.push(ex.clone());
+            }
+        }
+    }
+    let mut to_embed: Vec<String> = Vec::with_capacity(1 + pending.len());
+    to_embed.push(prompt.to_string());
+    to_embed.extend(pending.iter().cloned());
+
+    let vectors = match embed_texts(
+        state,
+        snapshot,
+        &embed_entry,
+        semantic,
+        request_id,
+        &to_embed,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                router = %router_entry.value.display_name,
+                error = %e,
+                "semantic embedding call failed; applying on_embedding_failure",
+            );
+            return fallback(semantic, snapshot);
+        }
+    };
+
+    let mut iter = vectors.into_iter();
+    let prompt_vec = iter
+        .next()
+        .expect("embed_texts returns at least the prompt vector");
+    for text in &pending {
+        if let Some(v) = iter.next() {
+            state
+                .semantic_cache
+                .insert(&embed_entry.id, dims, text, Arc::new(v));
+        }
+    }
+
+    let route_vecs: Vec<Vec<Arc<Vec<f32>>>> = semantic
+        .routes
+        .iter()
+        .map(|route| {
+            route
+                .examples
+                .iter()
+                .filter_map(|ex| state.semantic_cache.get(&embed_entry.id, dims, ex))
+                .collect()
+        })
+        .collect();
+
+    let decision = decide(semantic, &prompt_vec, &route_vecs);
+    let (target_alias, route_name): (&str, Option<String>) = match decision.winner {
+        Some(i) => (
+            semantic.routes[i].target.as_str(),
+            Some(semantic.routes[i].name.clone()),
+        ),
+        None => (semantic.default.as_str(), None),
+    };
+    tracing::debug!(
+        router = %router_entry.value.display_name,
+        resolved_route = ?route_name,
+        target = %target_alias,
+        "semantic routing decision",
+    );
+    let attempt = attempt_for_target(snapshot, target_alias)?;
+    Ok((vec![attempt], route_name))
+}
+
+/// Apply the `on_embedding_failure` policy: route to the fallback target,
+/// or surface `503` when the policy is `fail`.
+fn fallback(
+    semantic: &Semantic,
+    snapshot: &AisixSnapshot,
+) -> Result<(Vec<AttemptModel>, Option<String>), ProxyError> {
+    match embedding_failure_target(semantic) {
+        Some(alias) => Ok((vec![attempt_for_target(snapshot, alias)?], None)),
+        None => Err(ProxyError::ProviderUnavailable),
+    }
+}
+
+/// Resolve a direct-model alias to the single `AttemptModel` the dispatch
+/// loop will drive.
+fn attempt_for_target(snapshot: &AisixSnapshot, alias: &str) -> Result<AttemptModel, ProxyError> {
+    let entry = snapshot.models.get_by_name(alias).ok_or_else(|| {
+        ProxyError::InvalidRequest(format!(
+            "semantic router target {alias:?} does not resolve to a known model",
+        ))
+    })?;
+    Ok(AttemptModel {
+        id: entry.id.clone(),
+        model: entry.value.clone(),
+    })
+}
+
+/// Embed `texts` through the embedding model's bridge in one batched call,
+/// returning one float vector per input in input order.
+async fn embed_texts(
+    state: &ProxyState,
+    snapshot: &AisixSnapshot,
+    embed_entry: &ResourceEntry<Model>,
+    semantic: &Semantic,
+    request_id: &str,
+    texts: &[String],
+) -> Result<Vec<Vec<f32>>, ProxyError> {
+    let model = &embed_entry.value;
+    crate::dispatch::require_provider(model)?;
+    let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
+    let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
+        .ok_or(ProxyError::ProviderUnavailable)?;
+    let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
+    let dimensions = model.embedding.as_ref().map(|e| e.dimensions);
+
+    let req = EmbeddingRequest {
+        model: upstream_model,
+        input: texts.to_vec(),
+        input_was_single: texts.len() == 1,
+        encoding_format: Some("float".to_string()),
+        dimensions,
+    };
+    let ctx = {
+        let base = BridgeContext::new(
+            request_id,
+            Arc::new(model.clone()),
+            Arc::new(pk_entry.value.clone()),
+        );
+        match semantic.embedding_timeout() {
+            Some(d) => base.with_deadline(d),
+            None => base,
+        }
+    };
+
+    let resp = bridge.embed(&req, &ctx).await.map_err(ProxyError::Bridge)?;
+    let mut data = resp.data;
+    data.sort_by_key(|d| d.index);
+    let mut out = Vec::with_capacity(data.len());
+    for obj in data {
+        match obj.embedding {
+            EmbeddingVector::Float(v) => out.push(v),
+            EmbeddingVector::Base64(_) => {
+                return Err(ProxyError::InvalidRequest(
+                    "embedding endpoint returned base64 vectors; semantic routing needs \
+                     encoding_format=float support"
+                        .into(),
+                ));
+            }
+        }
+    }
+    if out.len() != texts.len() {
+        return Err(ProxyError::InvalidRequest(format!(
+            "embedding endpoint returned {} vectors for {} inputs",
+            out.len(),
+            texts.len(),
+        )));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn semantic(json: &str) -> Semantic {
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn arc(v: Vec<f32>) -> Arc<Vec<f32>> {
+        Arc::new(v)
+    }
+
+    #[test]
+    fn cosine_identical_is_one_orthogonal_is_zero() {
+        assert!((cosine_similarity(&[1.0, 0.0], &[1.0, 0.0]) - 1.0).abs() < 1e-6);
+        assert!(cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]).abs() < 1e-6);
+        // Opposite direction → -1.
+        assert!((cosine_similarity(&[1.0, 0.0], &[-1.0, 0.0]) + 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_degenerate_inputs_are_zero_not_nan() {
+        assert_eq!(cosine_similarity(&[0.0, 0.0], &[1.0, 1.0]), 0.0);
+        assert_eq!(cosine_similarity(&[1.0, 2.0, 3.0], &[1.0, 2.0]), 0.0); // length mismatch
+        assert!(!cosine_similarity(&[0.0], &[0.0]).is_nan());
+    }
+
+    #[test]
+    fn cosine_is_scale_invariant() {
+        // Same direction, different magnitude → still ~1.
+        let s = cosine_similarity(&[1.0, 1.0], &[5.0, 5.0]);
+        assert!((s - 1.0).abs() < 1e-6, "expected ~1, got {s}");
+    }
+
+    fn router() -> Semantic {
+        semantic(
+            r#"{
+                "embedding_model": "bge-m3",
+                "routes": [
+                    {"name": "legal", "target": "opus", "examples": ["a"], "threshold": 0.8},
+                    {"name": "code",  "target": "sonnet", "examples": ["b"]}
+                ],
+                "default": "gpt-4o",
+                "match": {"threshold": 0.5}
+            }"#,
+        )
+    }
+
+    #[test]
+    fn decide_picks_highest_route_clearing_its_threshold() {
+        let s = router();
+        let req = vec![1.0, 0.0];
+        // legal example == request (cos 1.0 ≥ 0.8 ✓); code example orthogonal (0.0 < 0.5).
+        let route_vecs = vec![vec![arc(vec![1.0, 0.0])], vec![arc(vec![0.0, 1.0])]];
+        let d = decide(&s, &req, &route_vecs);
+        assert_eq!(d.winner, Some(0));
+        assert!((d.scores[0] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn decide_falls_through_to_default_when_none_clear() {
+        let s = router();
+        let req = vec![1.0, 0.0];
+        // Both examples weakly aligned: legal 0.6 (< 0.8 own threshold),
+        // code 0.4 (< 0.5 router threshold) → no winner.
+        let route_vecs = vec![
+            vec![arc(vec![0.6, 0.8])],   // cos ≈ 0.6
+            vec![arc(vec![0.4, 0.917])], // cos ≈ 0.4
+        ];
+        let d = decide(&s, &req, &route_vecs);
+        assert_eq!(d.winner, None);
+    }
+
+    #[test]
+    fn decide_uses_router_threshold_when_route_has_no_override() {
+        let s = router();
+        let req = vec![1.0, 0.0];
+        // code route (no override → 0.5): give it cos ≈ 0.71 (clears 0.5).
+        // legal route (0.8): give it cos ≈ 0.71 (does NOT clear 0.8).
+        let route_vecs = vec![vec![arc(vec![1.0, 1.0])], vec![arc(vec![1.0, 1.0])]];
+        let d = decide(&s, &req, &route_vecs);
+        assert_eq!(
+            d.winner,
+            Some(1),
+            "only the code route clears its threshold"
+        );
+    }
+
+    #[test]
+    fn decide_max_aggregation_takes_best_example() {
+        let s = router();
+        let req = vec![1.0, 0.0];
+        // legal has two examples: one orthogonal (0.0), one identical (1.0).
+        // max → 1.0 clears 0.8.
+        let route_vecs = vec![
+            vec![arc(vec![0.0, 1.0]), arc(vec![1.0, 0.0])],
+            vec![arc(vec![0.0, 1.0])],
+        ];
+        let d = decide(&s, &req, &route_vecs);
+        assert_eq!(d.winner, Some(0));
+        assert!((d.scores[0] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn embedding_failure_target_maps_each_policy() {
+        let default_policy = router();
+        assert_eq!(embedding_failure_target(&default_policy), Some("gpt-4o"));
+
+        let fail = semantic(
+            r#"{"embedding_model":"e","routes":[{"name":"a","target":"m","examples":["x"]}],
+                "default":"d","match":{"threshold":0.5},"on_embedding_failure":"fail"}"#,
+        );
+        assert_eq!(embedding_failure_target(&fail), None);
+
+        let target = semantic(
+            r#"{"embedding_model":"e","routes":[{"name":"a","target":"m","examples":["x"]}],
+                "default":"d","match":{"threshold":0.5},"on_embedding_failure":{"target":"safe"}}"#,
+        );
+        assert_eq!(embedding_failure_target(&target), Some("safe"));
+    }
+
+    #[test]
+    fn cache_round_trips_and_dimension_change_invalidates() {
+        let cache = SemanticVectorCache::default();
+        assert!(cache.get("bge", 1024, "hello").is_none());
+        cache.insert("bge", 1024, "hello", arc(vec![1.0, 2.0]));
+        assert_eq!(
+            cache.get("bge", 1024, "hello").unwrap().as_slice(),
+            &[1.0, 2.0]
+        );
+        // Different dimensions → different key → miss (auto-invalidation).
+        assert!(cache.get("bge", 512, "hello").is_none());
+        // Different embedding model → miss.
+        assert!(cache.get("other", 1024, "hello").is_none());
+    }
+}

--- a/crates/aisix-proxy/src/semantic.rs
+++ b/crates/aisix-proxy/src/semantic.rs
@@ -150,6 +150,13 @@ pub(crate) async fn resolve(
         .as_ref()
         .expect("resolve called on a non-semantic model");
 
+    // No user text to classify (e.g. a system-only or tool-only request):
+    // route to `default` without an embedding call rather than embedding an
+    // empty string, which could spuriously match a route.
+    if prompt.trim().is_empty() {
+        return Ok((vec![attempt_for_target(snapshot, &semantic.default)?], None));
+    }
+
     // Resolve the embedding model + its modality metadata. A dangling or
     // wrong-kind reference is a config error; degrade via the failure
     // policy rather than 500.
@@ -321,10 +328,24 @@ async fn embed_texts(
     let resp = bridge.embed(&req, &ctx).await.map_err(ProxyError::Bridge)?;
     let mut data = resp.data;
     data.sort_by_key(|d| d.index);
+    let expected_dims = dimensions.map(|d| d as usize);
     let mut out = Vec::with_capacity(data.len());
     for obj in data {
         match obj.embedding {
-            EmbeddingVector::Float(v) => out.push(v),
+            EmbeddingVector::Float(v) => {
+                // Surface a wrong-dimension response explicitly instead of
+                // letting cosine_similarity fold the length mismatch into
+                // 0.0 (which would silently route every request to default).
+                if let Some(expected) = expected_dims {
+                    if v.len() != expected {
+                        return Err(ProxyError::InvalidRequest(format!(
+                            "embedding endpoint returned a {}-dim vector; expected {expected}",
+                            v.len(),
+                        )));
+                    }
+                }
+                out.push(v);
+            }
             EmbeddingVector::Base64(_) => {
                 return Err(ProxyError::InvalidRequest(
                     "embedding endpoint returned base64 vectors; semantic routing needs \

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -101,6 +101,10 @@ pub struct ProxyState {
     pub metrics: Arc<Metrics>,
     pub cache: Option<CacheBackends>,
     pub routing: Arc<RoutingRegistry>,
+    /// Per-instance cache of semantic-router example embeddings, populated
+    /// lazily on first use and reused across requests so semantic routing
+    /// costs one embedding call (the prompt) in steady state.
+    pub semantic_cache: Arc<crate::semantic::SemanticVectorCache>,
     /// Per-request guardrail index. Resolves the applicable chain from
     /// attachment scope + priority on each request. Rebuilds lazily
     /// when the snapshot version changes. Default is an empty index
@@ -146,6 +150,7 @@ impl ProxyState {
             metrics: Arc::new(Metrics::new(false)),
             cache: Some(CacheBackends::memory_only()),
             routing: Arc::new(RoutingRegistry::new()),
+            semantic_cache: Arc::new(crate::semantic::SemanticVectorCache::default()),
             guardrail_index,
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
@@ -174,6 +179,7 @@ impl ProxyState {
             metrics: Arc::new(Metrics::new(false)),
             cache: Some(CacheBackends::memory_only()),
             routing: Arc::new(RoutingRegistry::new()),
+            semantic_cache: Arc::new(crate::semantic::SemanticVectorCache::default()),
             guardrail_index,
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
@@ -205,6 +211,7 @@ impl ProxyState {
             metrics,
             cache,
             routing: Arc::new(RoutingRegistry::new()),
+            semantic_cache: Arc::new(crate::semantic::SemanticVectorCache::default()),
             guardrail_index,
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),

--- a/docs/semantic-routing.md
+++ b/docs/semantic-routing.md
@@ -1,0 +1,139 @@
+# Semantic routing
+
+Semantic routing lets one virtual model dispatch each request to a different
+upstream model based on the **meaning** of the request, instead of a fixed
+model name, a weight, or a health check. Callers always send the same
+`model`; the gateway reads the latest user message, embeds it, compares it to
+example utterances you attach to each route, and forwards the request to the
+best-matching route's target — or to a `default` model when nothing matches.
+
+It is a fourth virtual-model shape alongside direct models, routing groups
+(load balancing), and ensembles. Like those, it is just a `Model` with a
+config block — here, a `semantic` block.
+
+```
+caller sends  model: "prod-chat"
+   │
+   ├─ embed the latest user message  (via the configured embedding model)
+   ├─ cosine-score it against every route's example embeddings
+   ├─ aggregate per route (max), keep the highest route that clears its threshold
+   └─ dispatch to that route's target  ·  or to `default` when none clears
+```
+
+## Pieces you configure
+
+Semantic routing needs two model kinds:
+
+1. **An embedding model** — a normal direct model that points at an
+   OpenAI-compatible `/v1/embeddings` endpoint, plus an `embedding` block that
+   records its output dimensionality. It can also be called directly via
+   `/v1/embeddings`.
+2. **A semantic router** — a model with a `semantic` block that references the
+   embedding model and lists the routes.
+
+### Embedding model
+
+```jsonc
+{
+  "display_name": "bge-m3",
+  "provider": "openai",
+  "model_name": "bge-m3",            // the upstream model id
+  "provider_key_id": "<provider key for the embeddings endpoint>",
+  "embedding": {
+    "dimensions": 1024,               // required: output vector size
+    "normalize": true                 // default true; set false if the
+                                      // endpoint does not return unit vectors
+  }
+}
+```
+
+The endpoint must speak the OpenAI `/v1/embeddings` shape and return float
+vectors (`encoding_format: "float"`). Self-hosted runners such as
+[TEI](https://github.com/huggingface/text-embeddings-inference) and Ollama, as
+well as hosted providers, all qualify.
+
+### Semantic router
+
+```jsonc
+{
+  "display_name": "prod-chat",        // callers send model: "prod-chat"
+  "semantic": {
+    "embedding_model": "bge-m3",      // alias of the embedding model above
+    "routes": [
+      {
+        "name": "legal",              // surfaced in x-aisix-route + logs
+        "target": "claude-opus",      // a direct model alias
+        "description": "Contract & legal risk analysis",  // optional, docs only
+        "examples": [                 // >= 1; the route is matched on these
+          "analyze this contract for legal risk",
+          "review this NDA for liability exposure",
+          "这条赔偿条款合法吗"
+        ],
+        "threshold": 0.8              // optional per-route override
+      },
+      { "name": "translate", "target": "gpt-4o-mini", "examples": ["translate this"] }
+    ],
+    "default": "gpt-4o",              // used when no route clears its threshold
+    "match": {
+      "distance_metric": "cosine",   // default cosine (only value today)
+      "aggregation": "max",          // default max (a route's score is its best example)
+      "threshold": 0.75              // default threshold for routes without one
+    },
+    "embedding_timeout_ms": 500,     // optional per-call embedding deadline
+    "on_embedding_failure": "default" // see below
+  }
+}
+```
+
+## How matching works
+
+- Only the **latest user message** is embedded (multimodal text blocks are
+  concatenated; non-text content is ignored). System/assistant/tool turns do
+  not affect routing.
+- Each route's score is the **maximum** cosine similarity between the request
+  and that route's example utterances. Higher is more similar / stricter.
+- A route matches when its score is `>=` its effective threshold (its own
+  `threshold`, else `match.threshold`). Among matching routes, the highest
+  score wins. If none match, the request goes to `default`.
+- Example utterances are embedded once and cached in the data plane (keyed by
+  embedding model, dimensions, and text), so the steady-state cost of a
+  request is a single embedding call for the prompt plus local arithmetic.
+
+Cross-lingual matching works out of the box with a multilingual embedding
+model — a Chinese prompt can match English examples and vice-versa. Real
+cosine scores for related-but-not-identical text typically fall in the
+`0.4–0.65` range, so tune thresholds against your own examples rather than
+assuming high cutoffs.
+
+## What the caller sees
+
+The response body reports the **resolved** upstream model, and two headers
+expose the decision:
+
+- `x-aisix-route: <route name>` — the route that matched (absent when the
+  request fell through to `default`).
+- `x-aisix-served-by: <target display name>` — the direct model that served
+  the request.
+
+## When embedding fails
+
+If the embedding call errors or times out (or the `embedding_model` /
+`target` / `default` reference is missing), the router applies
+`on_embedding_failure`:
+
+| value             | behavior                                   |
+|-------------------|--------------------------------------------|
+| `"default"`       | route to the router's `default` model (the default) |
+| `"fail"`          | reject the request with `503`              |
+| `{ "target": "<alias>" }` | route to a specific safe model      |
+
+## Notes
+
+- A semantic router is mutually exclusive with the direct-upstream fields and
+  with `routing` / `ensemble`; the `embedding` block is only valid on a direct
+  model. The Admin API rejects invalid combinations.
+- Route example vectors are recomputed automatically when you change an
+  example's text, the embedding model, or its dimensions.
+- Routing decisions can be influenced by adversarial prompts, so run input
+  guardrails *before* routing (the gateway does) and treat similarity scores
+  as operator-only signals.

--- a/docs/semantic-routing.md
+++ b/docs/semantic-routing.md
@@ -11,7 +11,7 @@ It is a fourth virtual-model shape alongside direct models, routing groups
 (load balancing), and ensembles. Like those, it is just a `Model` with a
 config block — here, a `semantic` block.
 
-```
+```text
 caller sends  model: "prod-chat"
    │
    ├─ embed the latest user message  (via the configured embedding model)

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -11,13 +11,15 @@ schemas/
 └── resources/
     ├── api_key.schema.json
     ├── cache_policy.schema.json
+    ├── embedding.schema.json
     ├── guardrail.schema.json
     ├── model.schema.json
     ├── observability_exporter.schema.json
     ├── provider_key.schema.json
     ├── rate_limit.schema.json
     ├── rate_limit_policy.schema.json
-    └── routing.schema.json
+    ├── routing.schema.json
+    └── semantic.schema.json
 ```
 
 Each file is a self-contained JSON Schema draft-07 document. Nested

--- a/schemas/resources/embedding.schema.json
+++ b/schemas/resources/embedding.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "EmbeddingConfig",
+  "description": "Embedding-modality metadata for a direct Model.",
+  "type": "object",
+  "required": [
+    "dimensions"
+  ],
+  "properties": {
+    "dimensions": {
+      "description": "Output vector dimensionality. Used to validate vectors, key the example-vector cache, and (for endpoints that support it) request a reduced output size.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 1.0
+    },
+    "normalize": {
+      "description": "Whether the endpoint already returns L2-normalized vectors. When `false`, the gateway normalizes before computing cosine similarity. Defaults to `true`.",
+      "default": true,
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -2,6 +2,18 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
+    "Aggregation": {
+      "description": "How a request's per-example similarity scores collapse into one score for the route. v1 uses `max` (the single best-matching example), chosen for explainability — the UI surfaces \"the top matching example\" — over semantic-router's default sum/mean-over-top_k.",
+      "oneOf": [
+        {
+          "description": "Route score = the highest cosine across its examples.",
+          "enum": [
+            "max"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "BackgroundModelCheck": {
       "additionalProperties": false,
       "properties": {
@@ -104,6 +116,58 @@
       },
       "type": "object"
     },
+    "DistanceMetric": {
+      "description": "Distance metric used to compare the request embedding against route example embeddings. v1 supports cosine only.",
+      "oneOf": [
+        {
+          "description": "Cosine similarity — higher is more similar.",
+          "enum": [
+            "cosine"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "EmbeddingConfig": {
+      "additionalProperties": false,
+      "description": "Embedding-modality metadata for a direct Model.",
+      "properties": {
+        "dimensions": {
+          "description": "Output vector dimensionality. Used to validate vectors, key the example-vector cache, and (for endpoints that support it) request a reduced output size.",
+          "format": "uint32",
+          "minimum": 1.0,
+          "type": "integer"
+        },
+        "normalize": {
+          "default": true,
+          "description": "Whether the endpoint already returns L2-normalized vectors. When `false`, the gateway normalizes before computing cosine similarity. Defaults to `true`.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "dimensions"
+      ],
+      "type": "object"
+    },
+    "EmbeddingFailureMode": {
+      "description": "Mode for an enum-only failure policy: route to the router's `default`, or fail the request with `503`.",
+      "oneOf": [
+        {
+          "description": "Route to the semantic router's `default` model.",
+          "enum": [
+            "default"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Reject the request with `503`.",
+          "enum": [
+            "fail"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "EnsembleConfig": {
       "additionalProperties": false,
       "properties": {
@@ -203,6 +267,32 @@
           "type": "string"
         }
       ]
+    },
+    "OnEmbeddingFailure": {
+      "anyOf": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/definitions/EmbeddingFailureMode"
+            }
+          ],
+          "description": "`\"default\"` or `\"fail\"`."
+        },
+        {
+          "description": "`{ \"target\": \"<direct alias>\" }` — route to a specific safe model.",
+          "properties": {
+            "target": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "target"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "What the router does when the embedding call errors or times out.\n\nWire shape mirrors the proposal: the bare string `\"default\"` / `\"fail\"`, or an object `{ \"target\": \"<direct alias>\" }` to fall back to a specific safe model. Replicates the spirit of [`OnAllFilteredPolicy`](super::OnAllFilteredPolicy) with the added explicit-target option."
     },
     "PanelMember": {
       "additionalProperties": false,
@@ -380,6 +470,137 @@
         "model"
       ],
       "type": "object"
+    },
+    "Semantic": {
+      "additionalProperties": false,
+      "description": "Semantic-routing config: pick a target by request meaning.",
+      "properties": {
+        "default": {
+          "description": "Direct model alias used when no route clears its threshold.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "embedding_model": {
+          "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "embedding_timeout_ms": {
+          "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "match": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SemanticMatch"
+            }
+          ],
+          "description": "Shared matching parameters (metric, aggregation, default threshold)."
+        },
+        "on_embedding_failure": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/OnEmbeddingFailure"
+            }
+          ],
+          "description": "Behavior when the embedding call fails or times out. Defaults to routing to `default`."
+        },
+        "routes": {
+          "description": "Routes evaluated for each request. At least one is required.",
+          "items": {
+            "$ref": "#/definitions/SemanticRoute"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "default",
+        "embedding_model",
+        "match",
+        "routes"
+      ],
+      "type": "object"
+    },
+    "SemanticMatch": {
+      "additionalProperties": false,
+      "description": "Matching parameters shared across every route in a semantic router.",
+      "properties": {
+        "aggregation": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Aggregation"
+            }
+          ],
+          "default": "max",
+          "description": "Per-example score aggregation. v1: max."
+        },
+        "distance_metric": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/DistanceMetric"
+            }
+          ],
+          "default": "cosine",
+          "description": "Similarity metric. v1: cosine."
+        },
+        "threshold": {
+          "description": "Default similarity threshold for routes that do not set their own `threshold`. Higher is stricter.",
+          "format": "float",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "threshold"
+      ],
+      "type": "object"
+    },
+    "SemanticRoute": {
+      "additionalProperties": false,
+      "description": "One semantic route: a labeled set of example utterances whose embeddings define the route. A request that scores high enough against them dispatches to `target`.",
+      "properties": {
+        "description": {
+          "description": "Human-facing description. Documentation only — v1 matches on `examples`, not on this field.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "examples": {
+          "description": "Example utterances that define this route. The DP embeds each at apply time and caches the vector; a request is matched against these. At least one is required (description does not participate in matching).",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "name": {
+          "description": "Operator-facing route label. Surfaced in the `x-aisix-route` response header and access logs (e.g. `prod-chat -> route:legal`).",
+          "minLength": 1,
+          "type": "string"
+        },
+        "target": {
+          "description": "Direct model alias that receives traffic matching this route.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "threshold": {
+          "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level [`SemanticMatch::threshold`] applies.",
+          "format": "float",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "examples",
+        "name",
+        "target"
+      ],
+      "type": "object"
     }
   },
   "oneOf": [
@@ -415,6 +636,16 @@
             "required": [
               "ensemble"
             ]
+          },
+          {
+            "required": [
+              "semantic"
+            ]
+          },
+          {
+            "required": [
+              "embedding"
+            ]
           }
         ]
       },
@@ -433,6 +664,11 @@
           {
             "required": [
               "ensemble"
+            ]
+          },
+          {
+            "required": [
+              "semantic"
             ]
           }
         ]
@@ -475,11 +711,70 @@
             "required": [
               "cooldown"
             ]
+          },
+          {
+            "required": [
+              "semantic"
+            ]
+          },
+          {
+            "required": [
+              "embedding"
+            ]
           }
         ]
       },
       "required": [
         "ensemble"
+      ]
+    },
+    {
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "provider"
+            ]
+          },
+          {
+            "required": [
+              "model_name"
+            ]
+          },
+          {
+            "required": [
+              "provider_key_id"
+            ]
+          },
+          {
+            "required": [
+              "routing"
+            ]
+          },
+          {
+            "required": [
+              "ensemble"
+            ]
+          },
+          {
+            "required": [
+              "background_model_check"
+            ]
+          },
+          {
+            "required": [
+              "cooldown"
+            ]
+          },
+          {
+            "required": [
+              "embedding"
+            ]
+          }
+        ]
+      },
+      "required": [
+        "semantic"
       ]
     }
   ],
@@ -521,6 +816,14 @@
       "minLength": 1,
       "type": "string"
     },
+    "embedding": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/EmbeddingConfig"
+        }
+      ],
+      "description": "Embedding-modality metadata. Present on direct Models that serve an OpenAI-compatible `/v1/embeddings` endpoint (and can be referenced by a semantic router's `embedding_model`)."
+    },
     "ensemble": {
       "allOf": [
         {
@@ -561,6 +864,14 @@
         }
       ],
       "description": "Virtual routing configuration. When set, the gateway selects a target from `routing.targets` and uses that target model's `provider`, `model_name`, and `provider_key_id` fields for upstream dispatch."
+    },
+    "semantic": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Semantic"
+        }
+      ],
+      "description": "Semantic-routing configuration. When set, the gateway embeds the request and dispatches to the route whose examples it matches best, using that route's target Model for upstream dispatch."
     },
     "stream_timeout": {
       "description": "Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to `timeout`.",

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -282,6 +282,7 @@
           "description": "`{ \"target\": \"<direct alias>\" }` — route to a specific safe model.",
           "properties": {
             "target": {
+              "description": "Direct-model alias to route to when embedding fails.",
               "minLength": 1,
               "type": "string"
             }

--- a/schemas/resources/semantic.schema.json
+++ b/schemas/resources/semantic.schema.json
@@ -118,6 +118,7 @@
           ],
           "properties": {
             "target": {
+              "description": "Direct-model alias to route to when embedding fails.",
               "type": "string",
               "minLength": 1
             }

--- a/schemas/resources/semantic.schema.json
+++ b/schemas/resources/semantic.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Semantic",
+  "description": "Semantic-routing config: pick a target by request meaning.",
+  "type": "object",
+  "required": [
+    "default",
+    "embedding_model",
+    "match",
+    "routes"
+  ],
+  "properties": {
+    "default": {
+      "description": "Direct model alias used when no route clears its threshold.",
+      "type": "string",
+      "minLength": 1
+    },
+    "embedding_model": {
+      "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples.",
+      "type": "string",
+      "minLength": 1
+    },
+    "embedding_timeout_ms": {
+      "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "match": {
+      "description": "Shared matching parameters (metric, aggregation, default threshold).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SemanticMatch"
+        }
+      ]
+    },
+    "on_embedding_failure": {
+      "description": "Behavior when the embedding call fails or times out. Defaults to routing to `default`.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/OnEmbeddingFailure"
+        }
+      ]
+    },
+    "routes": {
+      "description": "Routes evaluated for each request. At least one is required.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SemanticRoute"
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Aggregation": {
+      "description": "How a request's per-example similarity scores collapse into one score for the route. v1 uses `max` (the single best-matching example), chosen for explainability — the UI surfaces \"the top matching example\" — over semantic-router's default sum/mean-over-top_k.",
+      "oneOf": [
+        {
+          "description": "Route score = the highest cosine across its examples.",
+          "type": "string",
+          "enum": [
+            "max"
+          ]
+        }
+      ]
+    },
+    "DistanceMetric": {
+      "description": "Distance metric used to compare the request embedding against route example embeddings. v1 supports cosine only.",
+      "oneOf": [
+        {
+          "description": "Cosine similarity — higher is more similar.",
+          "type": "string",
+          "enum": [
+            "cosine"
+          ]
+        }
+      ]
+    },
+    "EmbeddingFailureMode": {
+      "description": "Mode for an enum-only failure policy: route to the router's `default`, or fail the request with `503`.",
+      "oneOf": [
+        {
+          "description": "Route to the semantic router's `default` model.",
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        },
+        {
+          "description": "Reject the request with `503`.",
+          "type": "string",
+          "enum": [
+            "fail"
+          ]
+        }
+      ]
+    },
+    "OnEmbeddingFailure": {
+      "description": "What the router does when the embedding call errors or times out.\n\nWire shape mirrors the proposal: the bare string `\"default\"` / `\"fail\"`, or an object `{ \"target\": \"<direct alias>\" }` to fall back to a specific safe model. Replicates the spirit of [`OnAllFilteredPolicy`](super::OnAllFilteredPolicy) with the added explicit-target option.",
+      "anyOf": [
+        {
+          "description": "`\"default\"` or `\"fail\"`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EmbeddingFailureMode"
+            }
+          ]
+        },
+        {
+          "description": "`{ \"target\": \"<direct alias>\" }` — route to a specific safe model.",
+          "type": "object",
+          "required": [
+            "target"
+          ],
+          "properties": {
+            "target": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      ]
+    },
+    "SemanticMatch": {
+      "description": "Matching parameters shared across every route in a semantic router.",
+      "type": "object",
+      "required": [
+        "threshold"
+      ],
+      "properties": {
+        "aggregation": {
+          "description": "Per-example score aggregation. v1: max.",
+          "default": "max",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Aggregation"
+            }
+          ]
+        },
+        "distance_metric": {
+          "description": "Similarity metric. v1: cosine.",
+          "default": "cosine",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DistanceMetric"
+            }
+          ]
+        },
+        "threshold": {
+          "description": "Default similarity threshold for routes that do not set their own `threshold`. Higher is stricter.",
+          "type": "number",
+          "format": "float",
+          "maximum": 1.0,
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "SemanticRoute": {
+      "description": "One semantic route: a labeled set of example utterances whose embeddings define the route. A request that scores high enough against them dispatches to `target`.",
+      "type": "object",
+      "required": [
+        "examples",
+        "name",
+        "target"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-facing description. Documentation only — v1 matches on `examples`, not on this field.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "examples": {
+          "description": "Example utterances that define this route. The DP embeds each at apply time and caches the vector; a request is matched against these. At least one is required (description does not participate in matching).",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "name": {
+          "description": "Operator-facing route label. Surfaced in the `x-aisix-route` response header and access logs (e.g. `prod-chat -> route:legal`).",
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "description": "Direct model alias that receives traffic matching this route.",
+          "type": "string",
+          "minLength": 1
+        },
+        "threshold": {
+          "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level [`SemanticMatch::threshold`] applies.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float",
+          "maximum": 1.0,
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/e2e/src/cases/semantic-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/semantic-routing-e2e.test.ts
@@ -71,7 +71,15 @@ async function startEmbeddingMock(opts: { fail?: boolean } = {}): Promise<Embedd
         res.end(JSON.stringify({ error: { message: "embedding upstream down" } }));
         return;
       }
-      const body = JSON.parse(raw || "{}") as { input?: string | string[] };
+      let body: { input?: string | string[] };
+      try {
+        body = JSON.parse(raw || "{}") as { input?: string | string[] };
+      } catch {
+        res.statusCode = 400;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: { message: "invalid JSON payload" } }));
+        return;
+      }
       const inputs = Array.isArray(body.input)
         ? body.input
         : [body.input ?? ""];
@@ -140,6 +148,43 @@ describe("semantic routing e2e", () => {
     await admin.createApiKey({
       key_hash: CALLER_KEY_HASH,
       allowed_models: ["*"],
+    });
+
+    // Shared `prod-chat` fixture for the matched + default-fallthrough
+    // tests, so neither depends on the other's execution order.
+    const embed = await startEmbeddingMock();
+    const legal = await chatUpstreamReplying("served-by-legal");
+    const fallback = await chatUpstreamReplying("served-by-default");
+    embedMocks.push(embed);
+    upstreams.push(legal, fallback);
+
+    await createEmbeddingModel("bge-mock", embed);
+    await createDirectModel("legal-model", legal);
+    await createDirectModel("default-model", fallback);
+    await admin.createModel({
+      display_name: "prod-chat",
+      semantic: {
+        embedding_model: "bge-mock",
+        routes: [
+          {
+            name: "legal",
+            target: "legal-model",
+            examples: ["analyze this contract for legal risk"],
+            threshold: 0.5,
+          },
+        ],
+        default: "default-model",
+        match: { threshold: 0.5 },
+      },
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("prod-chat", "review the nda contract clauses");
+        return r.status === 200 && r.content === "served-by-legal";
+      } catch {
+        return false;
+      }
     });
   });
 
@@ -227,40 +272,7 @@ describe("semantic routing e2e", () => {
       ctx.skip();
       return;
     }
-    const embed = await startEmbeddingMock();
-    const legal = await chatUpstreamReplying("served-by-legal");
-    const fallback = await chatUpstreamReplying("served-by-default");
-    embedMocks.push(embed);
-    upstreams.push(legal, fallback);
-
-    await createEmbeddingModel("bge-mock", embed);
-    await createDirectModel("legal-model", legal);
-    await createDirectModel("default-model", fallback);
-    await admin.createModel({
-      display_name: "prod-chat",
-      semantic: {
-        embedding_model: "bge-mock",
-        routes: [
-          {
-            name: "legal",
-            target: "legal-model",
-            examples: ["analyze this contract for legal risk"],
-            threshold: 0.5,
-          },
-        ],
-        default: "default-model",
-        match: { threshold: 0.5 },
-      },
-    });
-
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("prod-chat", "review the nda contract clauses");
-        return r.status === 200 && r.content === "served-by-legal";
-      } catch {
-        return false;
-      }
-    });
+    // `prod-chat` is provisioned in beforeAll (shared, order-independent).
 
     const r = await chat("prod-chat", "please review the contract for risk");
     expect(r.status).toBe(200);

--- a/tests/e2e/src/cases/semantic-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/semantic-routing-e2e.test.ts
@@ -1,0 +1,374 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { pickFreePort } from "../harness/ports.js";
+
+// E2E: semantic routing (#641). A request to a `semantic` virtual model
+// embeds the latest user message, scores it against each route's example
+// embeddings, and dispatches to the best route's target — or to `default`
+// when none clears its threshold. No CP involved: real `aisix` binary +
+// etcd + a deterministic mock embedding endpoint + mock chat upstreams.
+//
+// The mock embedding endpoint maps each input string to a one-hot vector
+// by keyword, so routing decisions are fully deterministic and asserted:
+//   contains "contract"/"legal"/"nda" -> [0,0,1,0]  (legal route)
+//   contains "python"/"code"          -> [0,1,0,0]  (code route)
+//   contains "translate"              -> [1,0,0,0]  (translate route)
+//   anything else                     -> [0,0,0,1]  (orthogonal -> default)
+// A route example sharing a keyword with the prompt yields cosine 1.0;
+// an unrelated prompt yields cosine 0 against every example -> default.
+
+const CALLER_PLAINTEXT = "sk-semantic-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function keywordVector(text: string): number[] {
+  const t = text.toLowerCase();
+  if (t.includes("translate")) return [1, 0, 0, 0];
+  if (t.includes("python") || t.includes("code")) return [0, 1, 0, 0];
+  if (t.includes("contract") || t.includes("legal") || t.includes("nda"))
+    return [0, 0, 1, 0];
+  return [0, 0, 0, 1];
+}
+
+interface EmbeddingMock {
+  baseUrl: string;
+  callCount(): number;
+  close(): Promise<void>;
+}
+
+/**
+ * A minimal OpenAI-compatible `/v1/embeddings` mock that returns a
+ * deterministic keyword vector per input. When `fail` is set, every
+ * embeddings call returns 500 (to exercise `on_embedding_failure`).
+ */
+async function startEmbeddingMock(opts: { fail?: boolean } = {}): Promise<EmbeddingMock> {
+  let calls = 0;
+  const server: Server = createServer((req, res) => {
+    res.on("error", () => {});
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      if (!req.url?.includes("/embeddings")) {
+        res.statusCode = 404;
+        res.end("{}");
+        return;
+      }
+      calls++;
+      if (opts.fail) {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: { message: "embedding upstream down" } }));
+        return;
+      }
+      const body = JSON.parse(raw || "{}") as { input?: string | string[] };
+      const inputs = Array.isArray(body.input)
+        ? body.input
+        : [body.input ?? ""];
+      const data = inputs.map((text, index) => ({
+        object: "embedding",
+        index,
+        embedding: keywordVector(text),
+      }));
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          object: "list",
+          model: "embed-mock",
+          data,
+          usage: { prompt_tokens: inputs.length, total_tokens: inputs.length },
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    callCount: () => calls,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+function chatUpstreamReplying(content: string): Promise<OpenAiUpstream> {
+  return startOpenAiUpstream({
+    nonStreamBody: {
+      id: `cmpl-${content}`,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: "gpt-4o-mini",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  });
+}
+
+describe("semantic routing e2e", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+  const embedMocks: EmbeddingMock[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+    await Promise.all(embedMocks.map((m) => m.close()));
+  });
+
+  async function createDirectModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin not ready");
+    const pk = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+  }
+
+  async function createEmbeddingModel(
+    displayName: string,
+    mock: EmbeddingMock,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin not ready");
+    const pk = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${mock.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "embed-mock",
+      provider_key_id: pk.id,
+      embedding: { dimensions: 4, normalize: true },
+    });
+  }
+
+  interface ChatResult {
+    status: number;
+    content: string | undefined;
+    route: string | null;
+    servedBy: string | null;
+  }
+
+  async function chat(model: string, prompt: string): Promise<ChatResult> {
+    const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+    let content: string | undefined;
+    if (res.status === 200) {
+      const json = (await res.json()) as {
+        choices?: { message?: { content?: string } }[];
+      };
+      content = json.choices?.[0]?.message?.content;
+    } else {
+      await res.text();
+    }
+    return {
+      status: res.status,
+      content,
+      route: res.headers.get("x-aisix-route"),
+      servedBy: res.headers.get("x-aisix-served-by"),
+    };
+  }
+
+  test("routes a matching prompt to its route target and sets x-aisix-route", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+    const embed = await startEmbeddingMock();
+    const legal = await chatUpstreamReplying("served-by-legal");
+    const fallback = await chatUpstreamReplying("served-by-default");
+    embedMocks.push(embed);
+    upstreams.push(legal, fallback);
+
+    await createEmbeddingModel("bge-mock", embed);
+    await createDirectModel("legal-model", legal);
+    await createDirectModel("default-model", fallback);
+    await admin.createModel({
+      display_name: "prod-chat",
+      semantic: {
+        embedding_model: "bge-mock",
+        routes: [
+          {
+            name: "legal",
+            target: "legal-model",
+            examples: ["analyze this contract for legal risk"],
+            threshold: 0.5,
+          },
+        ],
+        default: "default-model",
+        match: { threshold: 0.5 },
+      },
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("prod-chat", "review the nda contract clauses");
+        return r.status === 200 && r.content === "served-by-legal";
+      } catch {
+        return false;
+      }
+    });
+
+    const r = await chat("prod-chat", "please review the contract for risk");
+    expect(r.status).toBe(200);
+    expect(r.content).toBe("served-by-legal");
+    expect(r.route).toBe("legal");
+    expect(r.servedBy).toBe("legal-model");
+  });
+
+  test("falls through to default when no route clears its threshold (no x-aisix-route)", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+    // Reuses the prod-chat router from the previous test. A prompt with no
+    // route keyword embeds orthogonal to every example -> default.
+    const r = await chat("prod-chat", "what time is the meeting tomorrow");
+    expect(r.status).toBe(200);
+    expect(r.content).toBe("served-by-default");
+    // No route matched -> the header is absent.
+    expect(r.route).toBeNull();
+  });
+
+  test("on_embedding_failure: default routes to the default model when embedding errors", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+    const brokenEmbed = await startEmbeddingMock({ fail: true });
+    const fallback = await chatUpstreamReplying("served-by-safe-default");
+    embedMocks.push(brokenEmbed);
+    upstreams.push(fallback);
+
+    await createEmbeddingModel("broken-embed", brokenEmbed);
+    await createDirectModel("safe-default-model", fallback);
+    await admin.createModel({
+      display_name: "degrading-router",
+      semantic: {
+        embedding_model: "broken-embed",
+        routes: [
+          {
+            name: "legal",
+            target: "safe-default-model",
+            examples: ["analyze this contract"],
+            threshold: 0.5,
+          },
+        ],
+        default: "safe-default-model",
+        match: { threshold: 0.5 },
+        on_embedding_failure: "default",
+      },
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("degrading-router", "anything at all");
+        return r.status === 200 && r.content === "served-by-safe-default";
+      } catch {
+        return false;
+      }
+    });
+
+    const r = await chat("degrading-router", "contract review please");
+    expect(r.status).toBe(200);
+    expect(r.content).toBe("served-by-safe-default");
+    // Embedding failed, so no route matched -> no route header.
+    expect(r.route).toBeNull();
+  });
+
+  test("on_embedding_failure: fail returns 503 when embedding errors", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+    const brokenEmbed = await startEmbeddingMock({ fail: true });
+    const target = await chatUpstreamReplying("should-not-be-reached");
+    embedMocks.push(brokenEmbed);
+    upstreams.push(target);
+
+    await createEmbeddingModel("broken-embed-2", brokenEmbed);
+    await createDirectModel("unreached-model", target);
+    await admin.createModel({
+      display_name: "strict-router",
+      semantic: {
+        embedding_model: "broken-embed-2",
+        routes: [
+          {
+            name: "legal",
+            target: "unreached-model",
+            examples: ["analyze this contract"],
+            threshold: 0.5,
+          },
+        ],
+        default: "unreached-model",
+        match: { threshold: 0.5 },
+        on_embedding_failure: "fail",
+      },
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("strict-router", "contract review");
+        return r.status === 503;
+      } catch {
+        return false;
+      }
+    });
+
+    const r = await chat("strict-router", "contract review please");
+    expect(r.status).toBe(503);
+  });
+});


### PR DESCRIPTION
## What

Adds **semantic routing** to the data plane: one virtual model that dispatches each request to a different upstream based on the *meaning* of the request. Callers always send the same `model`; the gateway embeds the latest user message, scores it against per-route example utterances, and forwards to the best-matching route's target — or to a `default` when none matches. It is a fourth virtual-model shape alongside direct / routing (load balancing) / ensemble.

## How

- **Config contract** (`aisix-core`): a `semantic` block on `Model` (`embedding_model`, `routes[]` with `name`/`target`/`examples`/optional `threshold`, `default`, `match` = `{distance_metric, aggregation, threshold}`, `embedding_timeout_ms`, `on_embedding_failure`), and an `embedding` modality block (`dimensions`, `normalize`) carried by a direct model that serves `/v1/embeddings`. The direct/routing/ensemble/semantic mutual-exclusion `oneOf` is extended; `embedding` is permitted only on the direct shape. `ModelKind` gains `Ensemble` + `Semantic`.
- **Runtime** (`aisix-proxy`): a semantic router resolves to a single target — embed the latest user message through the existing OpenAI embeddings bridge, cosine-score against each route's example embeddings (`max` aggregation), keep the highest route clearing its threshold, else `default`. The chosen target is then driven through the existing dispatch loop unchanged, so streaming / failover / telemetry are reused. Example vectors are cached in-process (keyed by embedding model + dimensions + text), so steady-state cost is one embedding call for the prompt.
- **Response surface**: `x-aisix-route: <route>` (the matched route; absent on a `default` fall-through) and `x-aisix-served-by: <target>`. The response body reports the resolved upstream model.
- **Failure handling**: `on_embedding_failure` = `"default"` (route to default), `"fail"` (503), or `{ target }` (named safe model). Dangling `embedding_model`/`target`/`default` references degrade via the same policy with a warning rather than 500.

## Matching notes

Only the latest user message is embedded (multimodal text blocks concatenated). Cross-lingual matching works with a multilingual embedding model. The embedding endpoint must speak the OpenAI `/v1/embeddings` shape and return float vectors.

## Tests

- Unit tests for the scoring core (cosine, `max` aggregation, per-route vs router threshold, winner-or-default, failure-policy mapping) and the vector cache.
- E2E (`tests/e2e/src/cases/semantic-routing-e2e.test.ts`): real `aisix` binary + etcd + a deterministic embedding mock + mock chat upstreams, covering a matching prompt → route target + headers, fall-through to default, `on_embedding_failure` default→default, and fail→503.

## Docs

`docs/semantic-routing.md` (linked from the README features list); admin OpenAPI + canonical JSON Schemas regenerated and kept in sync.

## Compatibility

Additive — existing models are unaffected. No migration required.

Fixes api7/AISIX-Cloud#641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic routing for chat requests, matching the latest user message against per-route examples and dispatching to the best match (or a default).
  * Added embedding-modality support (dimensions + optional normalization) to power semantic routing.
  * Exposed route attribution via `x-aisix-route` and updated `x-aisix-served-by` behavior for semantic requests.
  * Added documentation and published canonical JSON schemas for semantic routing and embedding config.

* **Bug Fixes**
  * Improved schema validation and exclusivity checks for semantic/embedding configurations, including clearer failure behavior (default fallback vs 503).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->