### PR TITLE
fix(telemetry): record applied_guardrails on non-chat usage events

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -17,6 +17,7 @@
 //! Auth and model authorisation follow the same rules as every other
 //! proxy endpoint.
 
+use aisix_core::AppliedGuardrail;
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::body::Bytes;
 use axum::extract::{Multipart, State};
@@ -243,7 +244,7 @@ pub async fn speech(
         .to_string();
 
     match speech_dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
-        Ok((resp, provider, model_id, provider_key_id)) => {
+        Ok((resp, provider, model_id, provider_key_id, applied_guardrails)) => {
             let elapsed = started.elapsed();
             emit_access_log(
                 "POST",
@@ -274,6 +275,7 @@ pub async fn speech(
                 &model_name,
                 &api_key_id,
                 &provider_key_id,
+                &applied_guardrails,
                 200,
                 elapsed,
                 0,
@@ -533,7 +535,7 @@ async fn speech_dispatch(
     mut body: Value,
     request_id: &str,
     source_ip: &str,
-) -> Result<(Response, String, String, String), ProxyError> {
+) -> Result<(Response, String, String, String, Vec<AppliedGuardrail>), ProxyError> {
     let model_name = body
         .get("model")
         .and_then(|v| v.as_str())
@@ -565,6 +567,9 @@ async fn speech_dispatch(
         team_id: auth.key().team_id.as_deref(),
     };
     let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    // Record which guardrails govern this request (#379 parity) for the emitted
+    // UsageEvent. Empty when none attached.
+    let applied_guardrails = resolved_chain.applied().to_vec();
     if !resolved_chain.is_empty() {
         let chat = speech_input_to_chat(&model_name, &body);
         if let aisix_guardrails::GuardrailVerdict::Block {
@@ -701,6 +706,7 @@ async fn speech_dispatch(
         provider_label,
         model_entry.id.to_string(),
         pk_entry.id.to_string(),
+        applied_guardrails,
     ))
 }
 
@@ -732,6 +738,8 @@ fn emit_audio_usage(
     client: &ClientContext,
 ) {
     let (prompt_tokens, completion_tokens) = success.usage.unwrap_or((0, 0));
+    // Transcriptions/translations (multipart) don't run input guardrails — the
+    // audio bytes aren't scannable text — so no applied set to record here.
     emit_usage_event(
         state,
         request_id,
@@ -739,6 +747,7 @@ fn emit_audio_usage(
         &success.model_name,
         api_key_id,
         &success.provider_key_id,
+        &[],
         200,
         elapsed,
         prompt_tokens,
@@ -762,6 +771,7 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    applied_guardrails: &[AppliedGuardrail],
     status_code: u16,
     elapsed: Duration,
     prompt_tokens: u32,
@@ -780,6 +790,7 @@ fn emit_usage_event(
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),
+        applied_guardrails: applied_guardrails.to_vec(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         ..Default::default()
@@ -965,6 +976,42 @@ mod tests {
             .header("content-type", "application/json")
             .body(axum::body::Body::from(body.to_string()))
             .unwrap()
+    }
+
+    /// #379 parity: a successful /v1/audio/speech whose input passes an attached
+    /// input guardrail records that guardrail's `{kind, hook}` in the emitted
+    /// UsageEvent's `applied_guardrails`.
+    #[tokio::test]
+    async fn speech_applied_guardrails_recorded_on_usage_event() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"AUDIO".to_vec()))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(tts_model("my-tts"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        // Benign input (no "BLOCKME") → passes the guardrail.
+        let req = speech_req(r#"{"model":"my-tts","input":"hello","voice":"alloy"}"#);
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert!(
+            !ev.applied_guardrails.is_empty(),
+            "the attached input guardrail must be recorded"
+        );
+        assert_eq!(ev.applied_guardrails[0].kind, "keyword");
+        assert_eq!(ev.applied_guardrails[0].hook, "input");
     }
 
     /// #545: a configured input guardrail must fire on /v1/audio/speech — a

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -14,6 +14,7 @@
 //! Providers that don't implement embeddings return a 501 with
 //! `"type": "not_implemented"`.
 
+use aisix_core::AppliedGuardrail;
 use aisix_gateway::{BridgeContext, BridgeError, ChatFormat, ChatMessage, EmbeddingRequest};
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::extract::State;
@@ -166,6 +167,7 @@ pub async fn embeddings(
                     &model_name,
                     &api_key_id,
                     &success.provider_key_id,
+                    &success.applied_guardrails,
                     status,
                     elapsed,
                     success.prompt_tokens,
@@ -222,6 +224,9 @@ struct EmbedDispatchSuccess {
     /// Resolved ProviderKey UUID — feeds the per-PK telemetry attribution
     /// tags on the emitted UsageEvent (AISIX-Cloud#867 parity).
     provider_key_id: String,
+    /// The `{kind, hook}` set of guardrails that governed this request (#379
+    /// parity) — surfaced on the emitted UsageEvent.
+    applied_guardrails: Vec<AppliedGuardrail>,
     prompt_tokens: u32,
     /// `true` when the dispatch produced a real 200 from the upstream
     /// (we have authoritative usage data to attribute). `false` for the
@@ -280,6 +285,10 @@ async fn dispatch(
         team_id: auth.key().team_id.as_deref(),
     };
     let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    // Record which guardrails govern this request (#379 parity) so the emitted
+    // UsageEvent surfaces them in Logs, like chat / messages. Empty when no
+    // guardrail is attached.
+    let applied_guardrails = resolved_chain.applied().to_vec();
     if !resolved_chain.is_empty() {
         let chat = embeddings_input_to_chat(&body.model, &body.input);
         if let aisix_guardrails::GuardrailVerdict::Block {
@@ -350,6 +359,7 @@ async fn dispatch(
                 provider: provider_label,
                 model_id: model_entry.id.to_string(),
                 provider_key_id: pk_entry.id.to_string(),
+                applied_guardrails: applied_guardrails.clone(),
                 prompt_tokens,
                 upstream_called: true,
             })
@@ -368,6 +378,7 @@ async fn dispatch(
                 provider: provider.to_ascii_lowercase(),
                 model_id: model_entry.id.to_string(),
                 provider_key_id: pk_entry.id.to_string(),
+                applied_guardrails: applied_guardrails.clone(),
                 prompt_tokens: 0,
                 // No upstream call happened — the handler reads this
                 // and skips UsageEvent emission. Distinguished from
@@ -443,6 +454,7 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    applied_guardrails: &[AppliedGuardrail],
     status_code: u16,
     elapsed: Duration,
     prompt_tokens: u32,
@@ -485,6 +497,7 @@ fn emit_usage_event(
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),
+        applied_guardrails: applied_guardrails.to_vec(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         ..Default::default()
@@ -620,6 +633,59 @@ mod tests {
         );
         let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
         ResourceEntry::new("g-1", g, 1)
+    }
+
+    /// #379 parity: a successful /v1/embeddings request whose input passes an
+    /// attached input guardrail records that guardrail's `{kind, hook}` in the
+    /// emitted UsageEvent's `applied_guardrails`. Before the fix the field was
+    /// left empty on the non-chat handlers.
+    #[tokio::test]
+    async fn applied_guardrails_recorded_on_usage_event() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1_f32]}],
+                "model": "text-embedding-3-small",
+                "usage": {"prompt_tokens": 3, "total_tokens": 3}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        // Benign input (does not contain "BLOCKME") → passes the guardrail.
+        let body = serde_json::json!({"model": "my-embed", "input": "hello world"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert!(
+            !ev.applied_guardrails.is_empty(),
+            "the attached input guardrail must be recorded"
+        );
+        assert_eq!(ev.applied_guardrails[0].kind, "keyword");
+        assert_eq!(ev.applied_guardrails[0].hook, "input");
     }
 
     /// #719: /v1/embeddings explicitly bypassed all guardrails, so a content

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -10,6 +10,7 @@
 //! 7. Call `bridge.generate_image(body, ctx)` → JSON response.
 //! 8. Providers that don't support image generation return 501.
 
+use aisix_core::AppliedGuardrail;
 use aisix_gateway::{BridgeContext, BridgeError};
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::extract::State;
@@ -37,6 +38,9 @@ struct ImageDispatchSuccess {
     /// Resolved ProviderKey UUID — feeds per-PK telemetry attribution
     /// (AISIX-Cloud#867 parity).
     provider_key_id: String,
+    /// The `{kind, hook}` set of guardrails that governed this request (#379
+    /// parity) — surfaced on the emitted UsageEvent.
+    applied_guardrails: Vec<AppliedGuardrail>,
     /// `(prompt_tokens, completion_tokens)` from the upstream `usage`
     /// block when the model returns one (gpt-image-1). `None` for
     /// models that don't (dall-e-3) — those still emit a zero-token
@@ -100,6 +104,7 @@ pub async fn image_generations(
                     &model_name,
                     &api_key_id,
                     &success.provider_key_id,
+                    &success.applied_guardrails,
                     200,
                     elapsed,
                     prompt_tokens,
@@ -193,6 +198,10 @@ async fn dispatch(
         team_id: auth.key().team_id.as_deref(),
     };
     let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    // Record which guardrails govern this request (#379 parity) so the emitted
+    // UsageEvent surfaces them in Logs, like chat / messages. Empty when no
+    // guardrail is attached.
+    let applied_guardrails = resolved_chain.applied().to_vec();
     if !resolved_chain.is_empty() {
         let chat = images_input_to_chat(model_name, &body);
         if let aisix_guardrails::GuardrailVerdict::Block {
@@ -264,6 +273,7 @@ async fn dispatch(
                 provider: provider_label,
                 model_id: model_entry.id.to_string(),
                 provider_key_id: pk_entry.id.to_string(),
+                applied_guardrails: applied_guardrails.clone(),
                 usage,
                 upstream_called: true,
             })
@@ -275,6 +285,7 @@ async fn dispatch(
                 provider: provider_label,
                 model_id: model_entry.id.to_string(),
                 provider_key_id: pk_entry.id.to_string(),
+                applied_guardrails: applied_guardrails.clone(),
                 usage: None,
                 // No upstream call happened → handler skips emit.
                 upstream_called: false,
@@ -319,6 +330,7 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    applied_guardrails: &[AppliedGuardrail],
     status_code: u16,
     elapsed: Duration,
     prompt_tokens: u32,
@@ -337,6 +349,7 @@ fn emit_usage_event(
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),
+        applied_guardrails: applied_guardrails.to_vec(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         ..Default::default()
@@ -921,6 +934,53 @@ mod tests {
         assert_eq!(
             ev.pk_label, "prod-images-key",
             "pk_label must mirror telemetry_tags.pk_label"
+        );
+    }
+
+    /// #379 parity: a successful /v1/images/generations 200 governed by a
+    /// configured input guardrail must surface the applied `{kind, hook}` set
+    /// on the emitted UsageEvent — exactly like chat / messages / embeddings.
+    /// A benign prompt that does NOT match the keyword guardrail passes through
+    /// (200), and the event records the guardrail that governed the request.
+    #[tokio::test]
+    async fn applied_guardrails_recorded_on_usage_event() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("dall-e"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        // Benign prompt — does not contain the blocked literal, so it passes
+        // the guardrail and reaches the upstream.
+        let req = serde_json::json!({"model": "dall-e", "prompt": "a serene landscape", "n": 1});
+        let resp = tower::ServiceExt::oneshot(app, make_req(req))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted for /v1/images/generations 200")
+            .expect("usage_sink sender dropped");
+        assert!(
+            !ev.applied_guardrails.is_empty(),
+            "the configured guardrail must be recorded on the UsageEvent"
+        );
+        assert_eq!(
+            ev.applied_guardrails[0].kind, "keyword",
+            "applied guardrail kind must mirror the configured guardrail"
+        );
+        assert_eq!(
+            ev.applied_guardrails[0].hook, "input",
+            "applied guardrail hook must mirror the configured hook_point"
         );
     }
 

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -9,6 +9,7 @@
 //! be configured with a `base_url` pointing to their rerank endpoint root.
 //! The gateway appends `/v1/rerank`.
 
+use aisix_core::AppliedGuardrail;
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::HeaderValue;
@@ -35,6 +36,9 @@ struct RerankDispatchSuccess {
     /// Resolved ProviderKey UUID — feeds per-PK telemetry attribution
     /// (AISIX-Cloud#867 parity).
     provider_key_id: String,
+    /// The `{kind, hook}` set of guardrails that governed this request (#379
+    /// parity) — surfaced on the emitted UsageEvent.
+    applied_guardrails: Vec<AppliedGuardrail>,
     /// Upstream-reported token count. `None` on a 200 with no
     /// recognisable usage field (provider returned malformed body,
     /// or a wire shape this gateway doesn't yet support). Handler
@@ -105,6 +109,7 @@ pub async fn rerank(
                     &model_name,
                     &api_key_id,
                     &success.provider_key_id,
+                    &success.applied_guardrails,
                     status,
                     elapsed,
                     &usage,
@@ -212,6 +217,10 @@ async fn dispatch(
         team_id: auth.key().team_id.as_deref(),
     };
     let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    // Record which guardrails govern this request (#379 parity) so the emitted
+    // UsageEvent surfaces them in Logs, like chat / messages. Empty when no
+    // guardrail is attached.
+    let applied_guardrails = resolved_chain.applied().to_vec();
     if !resolved_chain.is_empty() {
         let chat = rerank_input_to_chat(&model_name, &*body);
         if let aisix_guardrails::GuardrailVerdict::Block {
@@ -445,6 +454,7 @@ async fn dispatch(
         provider: provider_label,
         model_id: model_entry.id.to_string(),
         provider_key_id: pk_entry.id.to_string(),
+        applied_guardrails: applied_guardrails.clone(),
         usage,
     })
 }
@@ -501,6 +511,7 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    applied_guardrails: &[AppliedGuardrail],
     status_code: u16,
     elapsed: Duration,
     usage: &RerankUsage,
@@ -517,6 +528,7 @@ fn emit_usage_event(
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),
+        applied_guardrails: applied_guardrails.to_vec(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         ..Default::default()
@@ -1198,6 +1210,72 @@ mod tests {
         assert_eq!(event.inbound_protocol, "openai");
         assert!(!event.request_id.is_empty());
         assert!(!event.occurred_at.is_empty());
+    }
+
+    /// #379 parity: a successful /v1/rerank 200 whose request was governed by a
+    /// configured guardrail must surface that guardrail's `{kind, hook}` on the
+    /// emitted UsageEvent — exactly like /v1/embeddings. An env-scoped keyword
+    /// guardrail (literal the benign request never matches) is attached so the
+    /// request passes (200) but the applied set is non-empty. Pre-fix the rerank
+    /// handler left `applied_guardrails` at Default (empty), so Logs couldn't
+    /// show which guardrails ran on rerank traffic.
+    #[tokio::test]
+    async fn applied_guardrails_recorded_on_usage_event() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        // OpenAI-compat rerank: `usage.prompt_tokens` so the handler reaches
+        // the emit path (emission is gated on a recognisable usage field).
+        let upstream_body = serde_json::json!({
+            "id": "rerank-guarded",
+            "results": [{"index": 0, "relevance_score": 0.9}],
+            "model": "rerank-multilingual-v3.0",
+            "usage": {"prompt_tokens": 23, "total_tokens": 23}
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/rerank"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(openai_model("rerank-openai"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        // ALLOW guardrail: a literal the benign request below never matches, so
+        // it governs the request (non-empty applied set) without blocking it.
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let body = serde_json::json!({
+            "model": "rerank-openai",
+            "query": "a perfectly fine query",
+            "documents": ["Paris", "London", "Berlin"]
+        });
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted for /v1/rerank 200")
+            .expect("usage_sink sender dropped");
+        assert!(
+            !ev.applied_guardrails.is_empty(),
+            "the configured guardrail must surface on the UsageEvent's applied set",
+        );
+        assert_eq!(
+            ev.applied_guardrails[0].kind, "keyword",
+            "applied entry kind must mirror the configured guardrail's kind",
+        );
     }
 
     /// Issue #405 audit MEDIUM: Jina's wire shape only puts


### PR DESCRIPTION
## Problem

`chat` / `messages` attach the `{kind, hook}` set of guardrails that governed a request to the emitted `UsageEvent` (`applied_guardrails`, #379), so the dashboard Logs show **which** guardrails ran — not just the `guardrail_blocked` boolean. The non-chat handlers that run input guardrails — `/v1/embeddings`, `/v1/rerank`, `/v1/images/generations`, `/v1/audio/speech` — resolved a guardrail chain but never recorded the applied set, leaving the field empty.

## Fix

Capture `resolved_chain.applied()` in each handler's `dispatch` and thread it to the success `UsageEvent` (via the dispatch-success struct / speech's return tuple). Multipart audio (`transcriptions`/`translations`) runs no input guardrails — the audio bytes aren't scannable text — so it passes an empty set.

## Tests

Per-handler tests attach a keyword input guardrail that the benign request passes, then assert the emitted event carries it (`{kind:"keyword", hook:"input"}`). Each fails before the fix (empty applied set) and passes after. Full `aisix-proxy` suite green (497), clippy + fmt clean.

Origin: cross-API consistency audit after AISIX-Cloud#867.