### PR TITLE
test(core): lock inline rate_limit rps/rph acceptance (models & api keys)

### DIFF
--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -473,6 +473,25 @@ mod tests {
     }
 
     #[test]
+    fn model_rate_limit_accepts_all_request_windows_incl_rps_rph() {
+        // Regression for #644: the inline rate_limit schema is derived from the
+        // RateLimit struct (#638), so every request-count window — rps/rpm/rph/
+        // rpd — alongside the token windows and concurrency must be accepted,
+        // not just rpm/rpd/tpm/tpd/concurrency.
+        let v = json!({
+            "display_name": "my-gpt4",
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111",
+            "rate_limit": {
+                "rps": 10, "rpm": 100, "rph": 1000, "rpd": 10000,
+                "tpm": 100000, "tpd": 1000000, "concurrency": 5
+            }
+        });
+        validate_model(&v).unwrap();
+    }
+
+    #[test]
     fn model_ensemble_with_direct_fields_fails() {
         // ensemble is mutually exclusive with the direct upstream triple.
         let v = json!({
@@ -972,6 +991,19 @@ mod tests {
             "allowed_models":["gpt-4o"],
             "team_id": null,
             "user_id": null
+        });
+        validate_apikey(&v).unwrap();
+    }
+
+    #[test]
+    fn apikey_rate_limit_accepts_rps_and_rph() {
+        // Regression for #644: inline rate_limit on a caller API key must accept
+        // the per-second and per-hour request windows too, not only
+        // rpm/rpd/tpm/tpd/concurrency.
+        let v = json!({
+            "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
+            "allowed_models":["gpt-4o"],
+            "rate_limit": {"rps": 5, "rph": 500}
         });
         validate_apikey(&v).unwrap();
     }


### PR DESCRIPTION
## Context

#644 reported that the Admin API validation schema rejects inline `rate_limit.rps` / `rate_limit.rph` for models and API keys, even though the generated OpenAPI and the `RateLimit` struct advertise them.

That was accurate for the **old hand-written** validation schema, but it was already resolved by #638 (merged the day before the issue was filed). #638 made the resource structs the single source of truth: `model_root_schema()` / `apikey_root_schema()` now derive from the `Model` / `ApiKey` structs via `schemars`, and `RateLimit` carries all seven windows (`rps` / `rpm` / `rph` / `rpd` + `tpm` / `tpd` + `concurrency`). So `rps` / `rph` are already accepted today.

## Change

No production change is needed. This adds the regression tests the issue asked for, so the per-second and per-hour request windows can't silently drop out of the derived schema again:

- `model_rate_limit_accepts_all_request_windows_incl_rps_rph`
- `apikey_rate_limit_accepts_rps_and_rph`

Both pass on current `main`, confirming the fix is in place.

This is a schema-validation regression guard, tested at its own boundary (`aisix-core` validators), so no separate data-plane E2E is added — there is no new end-to-end runtime behavior, the schema shipped in #638.

Verified locally: `cargo test -p aisix-core`, `cargo fmt --all -- --check`, `cargo clippy -p aisix-core --all-targets`.

Fixes #644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for JSON schema validation of inline rate limits.
  * Expanded validation checks to confirm supported request windows are accepted for models and API keys, including per-second, per-minute, per-hour, and per-day cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->