### PR TITLE
feat(admin): make /admin/v1/health status a real aggregate

### DIFF
--- a/crates/aisix-admin/src/health_handler.rs
+++ b/crates/aisix-admin/src/health_handler.rs
@@ -65,15 +65,48 @@ pub struct ConfigStatus {
 
 #[derive(Debug, Serialize)]
 pub struct HealthResponse {
-    /// Fixed success marker for this response. Successful responses currently
-    /// always return "ok"; operators should use individual model health levels
-    /// and configuration freshness for actionable signal.
+    /// Aggregate health summary — `"ok"`, `"degraded"`, or `"unhealthy"`,
+    /// derived from per-model health (`models[].health`) and config
+    /// freshness (`config`). See [`aggregate_status`]. `models[].health`
+    /// and `config` remain the per-dimension detail.
     pub status: &'static str,
     pub models: Vec<ModelHealth>,
     /// Etcd watch supervisor freshness. Omitted when the supervisor
     /// isn't wired into AdminState.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<ConfigStatus>,
+}
+
+/// A snapshot older than this (or never applied) means the etcd watch is
+/// not delivering fresh config, so the gateway may be serving a frozen
+/// snapshot — reflected as `degraded` (#114, #618).
+const SNAPSHOT_STALE_SECS: u64 = 300;
+
+/// Aggregate the top-level `status` from per-model health and config
+/// freshness so a single glance reflects real state instead of a fixed
+/// `"ok"` marker (#618):
+///
+/// - `"unhealthy"` — at least one model is Down (health level 2).
+/// - `"degraded"` — at least one model is Degraded (level 1), or the
+///   config watch is stale / not yet applied.
+/// - `"ok"` — every model is Healthy and config is fresh (or the watch
+///   supervisor isn't wired, so freshness can't be assessed).
+fn aggregate_status(models: &[ModelHealth], config: Option<&ConfigStatus>) -> &'static str {
+    if models.iter().any(|m| m.health >= 2) {
+        return "unhealthy";
+    }
+    let degraded_model = models.iter().any(|m| m.health == 1);
+    let stale_config = match config {
+        Some(c) => match c.snapshot_age_seconds {
+            None => true,
+            Some(age) => age > SNAPSHOT_STALE_SECS,
+        },
+        None => false,
+    };
+    if degraded_model || stale_config {
+        return "degraded";
+    }
+    "ok"
 }
 
 pub async fn get_health(
@@ -113,8 +146,10 @@ pub async fn get_health(
         }
     });
 
+    let status = aggregate_status(&models, config.as_ref());
+
     Ok(Json(HealthResponse {
-        status: "ok",
+        status,
         models,
         config,
     }))
@@ -212,5 +247,69 @@ mod tests {
         // success resets
         t.record_success("m");
         assert_eq!(t.level("m"), aisix_proxy::health::HealthLevel::Healthy);
+    }
+
+    fn mh(health: u8) -> super::ModelHealth {
+        super::ModelHealth {
+            id: "id".into(),
+            name: "m".into(),
+            health,
+        }
+    }
+
+    fn cfg(age: Option<u64>) -> super::ConfigStatus {
+        super::ConfigStatus {
+            snapshot_revision: 1,
+            snapshot_age_seconds: age,
+        }
+    }
+
+    #[test]
+    fn aggregate_ok_when_all_healthy_and_fresh() {
+        let models = vec![mh(0), mh(0)];
+        assert_eq!(super::aggregate_status(&models, Some(&cfg(Some(5)))), "ok");
+    }
+
+    #[test]
+    fn aggregate_ok_when_watch_status_unwired() {
+        // No supervisor → freshness can't be assessed, base on models only.
+        let models = vec![mh(0)];
+        assert_eq!(super::aggregate_status(&models, None), "ok");
+    }
+
+    #[test]
+    fn aggregate_degraded_when_a_model_degraded() {
+        let models = vec![mh(0), mh(1)];
+        assert_eq!(
+            super::aggregate_status(&models, Some(&cfg(Some(5)))),
+            "degraded"
+        );
+    }
+
+    #[test]
+    fn aggregate_unhealthy_when_a_model_down_even_if_config_stale() {
+        let models = vec![mh(0), mh(2)];
+        assert_eq!(
+            super::aggregate_status(&models, Some(&cfg(Some(9999)))),
+            "unhealthy"
+        );
+    }
+
+    #[test]
+    fn aggregate_degraded_when_config_stale() {
+        let models = vec![mh(0)];
+        assert_eq!(
+            super::aggregate_status(&models, Some(&cfg(Some(super::SNAPSHOT_STALE_SECS + 1)))),
+            "degraded"
+        );
+    }
+
+    #[test]
+    fn aggregate_degraded_when_config_never_applied() {
+        let models = vec![mh(0)];
+        assert_eq!(
+            super::aggregate_status(&models, Some(&cfg(None))),
+            "degraded"
+        );
     }
 }

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -2991,9 +2991,11 @@ const OPENAPI_JSON_BASE: &str = r##"{
           "status": {
             "type": "string",
             "enum": [
-              "ok"
+              "ok",
+              "degraded",
+              "unhealthy"
             ],
-            "description": "Fixed success marker for this response. Successful responses currently always return `ok`. This field does not summarize model health. Use `models[].health` and `config` for actionable health details.",
+            "description": "Aggregate health summary derived from per-model health and config freshness. `ok` = all models healthy and config fresh; `degraded` = at least one model degraded or the config watch is stale/not yet applied; `unhealthy` = at least one model is down. Use `models[].health` and `config` for the per-dimension detail.",
             "example": "ok"
           },
           "models": {
@@ -3929,7 +3931,7 @@ mod tests {
         );
         assert_eq!(
             schemas["HealthResponse"]["properties"]["status"]["description"],
-            "Fixed success marker for this response. Successful responses currently always return `ok`. This field does not summarize model health. Use `models[].health` and `config` for actionable health details."
+            "Aggregate health summary derived from per-model health and config freshness. `ok` = all models healthy and config fresh; `degraded` = at least one model degraded or the config watch is stale/not yet applied; `unhealthy` = at least one model is down. Use `models[].health` and `config` for the per-dimension detail."
         );
         assert_eq!(
             schemas["ObservabilityExporter"]["oneOf"][0]["properties"]["sample_rate"]["default"],

--- a/tests/e2e/src/cases/health-minimal-e2e.test.ts
+++ b/tests/e2e/src/cases/health-minimal-e2e.test.ts
@@ -39,6 +39,28 @@ describe("livez e2e: public liveness route is /livez and /health is gone", () =>
     await adminHealth.body.dump();
   });
 
+  test("admin /admin/v1/health reports an aggregate status (#618)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await harnessRequest(`${app.adminUrl}/admin/v1/health`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${app.adminKey}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = (await res.body.json()) as { status: string; models: unknown[] };
+
+    // #618: the top-level status is now a real aggregate of model health +
+    // config freshness, not a fixed "ok" marker.
+    expect(["ok", "degraded", "unhealthy"]).toContain(body.status);
+    // A freshly spawned gateway has no upstream failures, so no model is
+    // down — it must never be "unhealthy".
+    expect(body.status).not.toBe("unhealthy");
+    expect(Array.isArray(body.models)).toBe(true);
+  });
+
   test("proxy /livez turns unhealthy after SIGTERM before exit", async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();


### PR DESCRIPTION
## Problem

`GET /admin/v1/health` returned a top-level `status` hardcoded to `"ok"` on every success. A client glancing at `status` could read the gateway as healthy while individual models were degraded/down, or while the etcd config watch had stalled and the gateway was serving a frozen snapshot.

LiteLLM never hardcodes a health status — its `/health` and `/health/readiness` return values that reflect actual state. We agreed to do the same here (make it a real aggregate) rather than keep it a fixed marker or remove it.

## Change

`status` is now derived from the per-model health levels and the config watch freshness already present in the response:

- `"unhealthy"` — at least one model is Down (health level 2).
- `"degraded"` — at least one model is Degraded (level 1), or the config snapshot is stale (`> 300s`) or not yet applied.
- `"ok"` — every model is Healthy and config is fresh (or the watch supervisor isn't wired, so freshness can't be assessed).

The per-dimension detail (`models[].health`, `config`) is unchanged, and the endpoint still returns HTTP 200 — it's an authenticated detail endpoint, not a probe. The OpenAPI `status` enum is widened to `ok | degraded | unhealthy`.

## Tests

- `aggregate_status` unit tests: every branch (ok / degraded-by-model / degraded-by-stale-config / degraded-by-never-applied / unhealthy-beats-stale / ok-when-watch-unwired).
- `health-minimal` DP e2e: `/admin/v1/health` returns a status within the aggregate enum and never `unhealthy` for a freshly spawned gateway.

Verified locally: `cargo test -p aisix-admin`, `cargo fmt --check`, `cargo clippy -p aisix-admin --all-targets`, and the DP e2e (`vitest run health-minimal`) against a real `aisix` binary + etcd.

A paired `api7/docs` PR updates the admin health-check docs to describe the aggregate values.

Fixes #618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The admin health endpoint now reports a more detailed overall status: `ok`, `degraded`, or `unhealthy`.
  * Health responses now reflect both model health and configuration freshness when available.

* **Bug Fixes**
  * The health status is no longer always reported as `ok`, improving visibility into partial or stale system states.

* **Tests**
  * Added coverage for health status aggregation and end-to-end validation of the admin health response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->