### PR TITLE
feat(health): add /readyz and return 503 (not 500) on graceful shutdown

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -75,6 +75,7 @@ pub fn build_router(state: AdminState) -> Router {
 
     let router = Router::new()
         .route("/livez", get(livez))
+        .route("/readyz", get(readyz))
         // OpenAPI scalar UI is unauthenticated like /livez — admin
         // listener is private in production.
         .route("/admin/openapi.json", get(openapi::openapi_json))
@@ -217,6 +218,21 @@ async fn livez(
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Response {
     aisix_proxy::health::livez_response(&state.livez_state, params.contains_key("verbose"))
+}
+
+async fn readyz(
+    axum::extract::State(state): axum::extract::State<AdminState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    let config_block = state
+        .watch_status
+        .as_ref()
+        .and_then(|ws| aisix_proxy::health::config_readiness_block(ws.snapshot().last_apply_age));
+    aisix_proxy::health::readyz_response(
+        &state.livez_state,
+        config_block,
+        params.contains_key("verbose"),
+    )
 }
 
 #[cfg(test)]
@@ -450,7 +466,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn livez_returns_500_when_shutting_down() {
+    async fn livez_returns_503_when_shutting_down() {
         let state = build_state();
         state.livez_state.mark_shutting_down();
         let app = build_router(state);
@@ -459,7 +475,7 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         let text = std::str::from_utf8(&bytes).unwrap();
         assert!(text.contains("livez check failed"));

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -68,8 +68,8 @@ const OPENAPI_JSON_BASE: &str = r##"{
               }
             }
           },
-          "500": {
-            "description": "Liveness checks failed during shutdown",
+          "503": {
+            "description": "Process is shutting down (graceful drain)",
             "content": {
               "text/plain": {
                 "schema": {
@@ -82,7 +82,51 @@ const OPENAPI_JSON_BASE: &str = r##"{
         "tags": [
           "Health"
         ],
-        "description": "Get the liveness status of the admin process."
+        "description": "Process liveness: 200 while the process is alive, 503 once graceful shutdown has begun (an expected drain, not a crash). Use /readyz for traffic eligibility (readiness)."
+      }
+    },
+    "/readyz": {
+      "get": {
+        "summary": "Get Readiness Status",
+        "security": [],
+        "parameters": [
+          {
+            "name": "verbose",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "When present, returns a detailed multi-line text report instead of the short `ok` response.",
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ready to receive traffic",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Not ready: shutting down (drain), still starting up, or the config watch is stale",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Health"
+        ],
+        "description": "Traffic eligibility (readiness): 200 when the instance can serve, 503 while draining, before the first config apply, or when the etcd config watch is stale. Distinct from /livez (process liveness)."
       }
     },
     "/admin/openapi.json": {
@@ -3671,6 +3715,7 @@ mod tests {
             .collect();
         let expected = BTreeSet::from([
             "/livez",
+            "/readyz",
             "/admin/openapi.json",
             "/admin/openapi-scalar",
             "/admin/v1/models",
@@ -4300,7 +4345,12 @@ mod tests {
             parsed["paths"]["/livez"]["get"]["parameters"][0]["name"],
             "verbose"
         );
-        assert!(parsed["paths"]["/livez"]["get"]["responses"]["500"].is_object());
+        // Graceful shutdown is documented as 503 (drain), not 500 (#591).
+        assert!(parsed["paths"]["/livez"]["get"]["responses"]["503"].is_object());
+        assert!(parsed["paths"]["/livez"]["get"]["responses"]["500"].is_null());
+        // /readyz is documented with 200 + 503 (readiness).
+        assert!(parsed["paths"]["/readyz"]["get"]["responses"]["200"].is_object());
+        assert!(parsed["paths"]["/readyz"]["get"]["responses"]["503"].is_object());
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -47,6 +47,31 @@ impl LivezState {
             Ok(())
         }
     }
+
+    /// Whether graceful shutdown has been signalled. Used by `/readyz` to
+    /// drain traffic before the process exits.
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::Relaxed)
+    }
+}
+
+/// A config snapshot older than this — or never applied — means the etcd
+/// watch isn't delivering fresh config, so the instance shouldn't be
+/// counted ready for traffic (#591). Matches the freshness threshold the
+/// admin health aggregate uses.
+pub const READYZ_STALE_AFTER: Duration = Duration::from_secs(300);
+
+/// Decide whether config freshness blocks readiness. `last_apply_age` is
+/// the time since the config watch last applied an event: `None` means no
+/// apply yet (still starting up / disconnected), `Some(age)` past the
+/// stale threshold means a wedged watch. Returns `Some(reason)` when the
+/// instance is not ready, `None` when config is fresh enough.
+pub fn config_readiness_block(last_apply_age: Option<Duration>) -> Option<&'static str> {
+    match last_apply_age {
+        None => Some("config not yet applied"),
+        Some(age) if age > READYZ_STALE_AFTER => Some("config watch is stale"),
+        Some(_) => None,
+    }
 }
 
 pub fn livez_response(livez: &LivezState, verbose: bool) -> Response {
@@ -68,8 +93,11 @@ pub fn livez_response(livez: &LivezState, verbose: bool) -> Response {
     ];
 
     if failed {
+        // Graceful shutdown is an expected drain, not an internal error —
+        // 503 so Kubernetes stops routing without treating it as a crash
+        // loop (#591).
         return (
-            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::SERVICE_UNAVAILABLE,
             headers,
             format!("{body}livez check failed"),
         )
@@ -84,6 +112,62 @@ pub fn livez_response(livez: &LivezState, verbose: bool) -> Response {
         StatusCode::OK,
         headers,
         format!("{body}livez check passed\n"),
+    )
+        .into_response()
+}
+
+/// `GET /readyz` — readiness (traffic eligibility), distinct from `/livez`
+/// (process liveness). Returns 503 while draining (graceful shutdown) or
+/// while config isn't fresh (still starting up, or a wedged watch), so
+/// Kubernetes keeps the instance out of the Service endpoints until it can
+/// actually serve. `config_block` is the result of
+/// [`config_readiness_block`]; pass `None` when no freshness signal is
+/// wired (readiness then gates on shutdown only).
+pub fn readyz_response(
+    livez: &LivezState,
+    config_block: Option<&'static str>,
+    verbose: bool,
+) -> Response {
+    let mut body = String::new();
+    let mut failed = false;
+
+    match livez.shutdown_check() {
+        Ok(()) => body.push_str("[+]shutdown ok\n"),
+        Err(_) => {
+            failed = true;
+            body.push_str("[-]shutdown failed: draining\n");
+        }
+    }
+    match config_block {
+        None => body.push_str("[+]config ok\n"),
+        Some(_) => {
+            failed = true;
+            body.push_str("[-]config failed: not ready\n");
+        }
+    }
+
+    let headers = [
+        (CONTENT_TYPE, TEXT_PLAIN_UTF8.clone()),
+        (X_CONTENT_TYPE_OPTIONS.clone(), NOSNIFF.clone()),
+    ];
+
+    if failed {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            headers,
+            format!("{body}readyz check failed"),
+        )
+            .into_response();
+    }
+
+    if !verbose {
+        return (StatusCode::OK, headers, "ok").into_response();
+    }
+
+    (
+        StatusCode::OK,
+        headers,
+        format!("{body}readyz check passed\n"),
     )
         .into_response()
 }
@@ -477,16 +561,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn livez_failure_returns_500_with_reason_withheld() {
+    async fn livez_failure_returns_503_with_reason_withheld() {
         let state = LivezState::new();
         state.mark_shutting_down();
         let resp = livez_response(&state, false);
 
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         let body = to_bytes(resp.into_body(), 1024).await.unwrap();
         let text = std::str::from_utf8(&body).unwrap();
         assert!(text.contains("[-]shutdown failed: reason withheld"));
         assert!(text.contains("livez check failed"));
+    }
+
+    #[test]
+    fn config_readiness_block_logic() {
+        // No apply yet → not ready (startup).
+        assert!(config_readiness_block(None).is_some());
+        // Fresh apply → ready.
+        assert!(config_readiness_block(Some(Duration::from_secs(5))).is_none());
+        // Beyond the stale threshold → not ready (wedged watch).
+        assert!(
+            config_readiness_block(Some(READYZ_STALE_AFTER + Duration::from_secs(1))).is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn readyz_ok_when_not_draining_and_config_fresh() {
+        let state = LivezState::new();
+        let resp = readyz_response(&state, None, false);
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn readyz_503_when_draining() {
+        let state = LivezState::new();
+        state.mark_shutting_down();
+        let resp = readyz_response(&state, None, false);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn readyz_503_when_config_not_ready() {
+        let state = LivezState::new();
+        let resp = readyz_response(&state, Some("config not yet applied"), true);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(text.contains("[-]config failed"));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -85,6 +85,7 @@ pub fn build_router(state: ProxyState) -> Router {
     let body_limit = state.request_body_limit_bytes;
     Router::new()
         .route("/livez", get(livez))
+        .route("/readyz", get(readyz))
         .route("/v1/models", get(models::list_models))
         .route("/v1/chat/completions", post(chat::chat_completions))
         .route("/v1/completions", post(completions::completions))
@@ -164,6 +165,7 @@ async fn record_in_flight_request(
 fn normalize_endpoint_label(path: &str) -> &'static str {
     match path {
         "/livez" => "/livez",
+        "/readyz" => "/readyz",
         "/v1/models" => "/v1/models",
         "/v1/chat/completions" => "/v1/chat/completions",
         "/v1/completions" => "/v1/completions",
@@ -325,6 +327,17 @@ async fn livez(
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Response {
     crate::health::livez_response(&state.livez, params.contains_key("verbose"))
+}
+
+async fn readyz(
+    State(state): State<ProxyState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    let config_block = state
+        .config_apply_age
+        .as_ref()
+        .and_then(|probe| crate::health::config_readiness_block(probe()));
+    crate::health::readyz_response(&state.livez, config_block, params.contains_key("verbose"))
 }
 
 #[cfg(test)]
@@ -823,7 +836,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn livez_returns_500_when_shutting_down() {
+    async fn livez_returns_503_when_shutting_down() {
         let hub = Arc::new(Hub::new());
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
         let state = build_state(snap, hub);
@@ -837,7 +850,7 @@ mod tests {
             .unwrap();
 
         let resp = run(app, req).await;
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
         let text = std::str::from_utf8(&bytes).unwrap();
         assert!(text.contains("livez check failed"));

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -138,6 +138,11 @@ pub struct ProxyState {
     /// client IP on each request (#492). Default = trust nothing → the
     /// logged source IP is the immediate TCP peer.
     pub real_ip: Arc<ResolvedRealIp>,
+    /// Optional config-freshness probe for `GET /readyz`: returns the time
+    /// since the etcd watch last applied config (`None` = never applied).
+    /// Wired from the watch supervisor in aisix-server; `None` here means
+    /// no freshness signal, so readiness gates on shutdown only (#591).
+    pub config_apply_age: Option<Arc<dyn Fn() -> Option<std::time::Duration> + Send + Sync>>,
 }
 
 impl ProxyState {
@@ -155,6 +160,7 @@ impl ProxyState {
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
+            config_apply_age: None,
             runtime_status: Arc::new(ModelRuntimeStatusTracker::new()),
             usage_sink: UsageSink::disabled(),
             otlp_fan_out: OtlpHttpFanOut::new(),
@@ -184,6 +190,7 @@ impl ProxyState {
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
+            config_apply_age: None,
             runtime_status: Arc::new(ModelRuntimeStatusTracker::new()),
             usage_sink: UsageSink::disabled(),
             otlp_fan_out: OtlpHttpFanOut::new(),
@@ -216,6 +223,7 @@ impl ProxyState {
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
+            config_apply_age: None,
             runtime_status: Arc::new(ModelRuntimeStatusTracker::new()),
             usage_sink: UsageSink::disabled(),
             otlp_fan_out: OtlpHttpFanOut::new(),
@@ -251,6 +259,16 @@ impl ProxyState {
     /// the disabled (allow-all) client used in self-hosted dev.
     pub fn with_budget_client(mut self, client: Arc<BudgetClient>) -> Self {
         self.budgets = client;
+        self
+    }
+
+    /// Wire the config-freshness probe used by `GET /readyz` (#591). The
+    /// closure returns the time since the etcd watch last applied config.
+    pub fn with_config_apply_age(
+        mut self,
+        probe: Arc<dyn Fn() -> Option<std::time::Duration> + Send + Sync>,
+    ) -> Self {
+        self.config_apply_age = Some(probe);
         self
     }
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -494,6 +494,12 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let background_hub = hub.clone();
     let background_runtime_status_tracker = runtime_status_tracker.clone();
     let background_cancel_rx = cancel_rx.clone();
+    // Wire the config-freshness probe so the proxy's /readyz reflects etcd
+    // watch staleness (and pre-first-apply startup), not just shutdown (#591).
+    let readyz_watch_status = supervisor.watch_status();
+    proxy_state = proxy_state.with_config_apply_age(Arc::new(move || {
+        readyz_watch_status.snapshot().last_apply_age
+    }));
     let proxy_router = aisix_proxy::build_router(proxy_state);
 
     let background_check_task = tokio::spawn(async move {

--- a/tests/e2e/src/cases/health-minimal-e2e.test.ts
+++ b/tests/e2e/src/cases/health-minimal-e2e.test.ts
@@ -39,6 +39,33 @@ describe("livez e2e: public liveness route is /livez and /health is gone", () =>
     await adminHealth.body.dump();
   });
 
+  test("proxy and admin /readyz report ready once config is applied (#591)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // Readiness gates on config freshness, so poll until the supervisor's
+    // first apply lands (a fresh spawn briefly reports 503 = starting up).
+    const deadline = Date.now() + 5000;
+    let proxyReady = false;
+    while (Date.now() < deadline) {
+      const r = await harnessRequest(`${app.proxyUrl}/readyz`, { method: "GET" });
+      const ok = r.statusCode === 200;
+      await r.body.dump();
+      if (ok) {
+        proxyReady = true;
+        break;
+      }
+      await new Promise((res) => setTimeout(res, 50));
+    }
+    expect(proxyReady).toBe(true);
+
+    const adminReadyz = await harnessRequest(`${app.adminUrl}/readyz`, { method: "GET" });
+    expect(adminReadyz.statusCode).toBe(200);
+    expect(await adminReadyz.body.text()).toBe("ok");
+  });
+
   test("proxy /livez turns unhealthy after SIGTERM before exit", async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();


### PR DESCRIPTION
## Problem

`/livez` represented intentional graceful shutdown as `500 Internal Server Error`. That fails Kubernetes probes (any non-2xx/3xx does), but it's semantically wrong — a drain is an expected state, not an internal crash — and it conflates liveness (restart me) with readiness (stop sending traffic).

## Change

Following LiteLLM (separate `/health/liveliness` + `/health/readiness`, both 503 on drain):

- **`/livez` returns 503, not 500, during graceful shutdown** (proxy + admin). Liveness otherwise stays 200.
- **New `/readyz` endpoint** (proxy + admin) for traffic eligibility, distinct from liveness. Returns 503 when:
  - draining (graceful shutdown),
  - the config watch hasn't applied yet (startup),
  - the config snapshot is stale (> 300s — a wedged watch),

  and 200 otherwise. The proxy reads config freshness through a probe wired from the watch supervisor (`with_config_apply_age`); the admin reads it from its existing watch status. When no freshness signal is wired, readiness gates on shutdown only.

OpenAPI documents `/livez` 503 and the new `/readyz` path.

## Tests

- Unit: `livez_response` 503 on shutdown (proxy + admin), `readyz_response` (ready / draining / config-not-ready), `config_readiness_block` thresholds, and the openapi path/response assertions.
- DP e2e (`health-minimal`): `/readyz` reports ready once config is applied on both listeners.

Verified locally: `cargo test -p aisix-proxy -p aisix-admin`, `cargo fmt --check`, `cargo clippy`, and the e2e (`vitest run health-minimal`) against a real `aisix` binary + etcd.

A paired `api7/docs` PR updates the health-check docs (liveness vs readiness).

Fixes #591
