### PR TITLE
refactor(routing)!: rename on_all_filtered → when_all_unavailable (try_anyway)

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3313,7 +3313,7 @@ fn add_variant_titles(doc: &mut Value) {
             &["OTLP HTTP", "Aliyun SLS", "Object storage", "Datadog"],
         ),
         (
-            "/components/schemas/OnAllFilteredPolicy/oneOf",
+            "/components/schemas/WhenAllUnavailablePolicy/oneOf",
             &["Fail", "Original order"],
         ),
         (
@@ -3463,7 +3463,7 @@ fn add_schema_defaults(doc: &mut Value) {
             serde_json::json!({}),
         ),
         (
-            "/components/schemas/Routing/properties/on_all_filtered",
+            "/components/schemas/Routing/properties/when_all_unavailable",
             serde_json::json!("fail"),
         ),
     ] {
@@ -3989,7 +3989,7 @@ mod tests {
             "runtime default cooldown trigger statuses should be visible in OpenAPI"
         );
         assert_eq!(
-            schemas["Routing"]["properties"]["on_all_filtered"]["default"],
+            schemas["Routing"]["properties"]["when_all_unavailable"]["default"],
             serde_json::json!("fail"),
             "runtime default routing policy should be visible in OpenAPI"
         );

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -35,9 +35,10 @@ pub use models::{
     validate_observability_exporter, validate_provider_key, validate_rate_limit_policy, Adapter,
     AisixSnapshot, ApiKey, AppliedGuardrail, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
     GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern, Model, ObservabilityExporter,
-    OnAllFilteredPolicy, ParamConstraints, PolicyScope, PolicyWindow, ProviderKey, RateLimit,
-    RateLimitPolicy, RequestOverrides, ResponseOverrides, Routing, RoutingStrategy, RoutingTarget,
-    SchemaError, StreamDoneMarker, TelemetryKind, TelemetryTags, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
+    ParamConstraints, PolicyScope, PolicyWindow, ProviderKey, RateLimit, RateLimitPolicy,
+    RequestOverrides, ResponseOverrides, Routing, RoutingStrategy, RoutingTarget, SchemaError,
+    StreamDoneMarker, TelemetryKind, TelemetryTags, WhenAllUnavailablePolicy,
+    DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -53,7 +53,7 @@ pub use provider_key::{
 };
 pub use rate_limit::RateLimit;
 pub use rate_limit_policy::{PolicyScope, PolicyWindow, RateLimitPolicy};
-pub use routing::{OnAllFilteredPolicy, Routing, RoutingStrategy, RoutingTarget};
+pub use routing::{Routing, RoutingStrategy, RoutingTarget, WhenAllUnavailablePolicy};
 pub use schema::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_guardrail_attachment,
     validate_model, validate_observability_exporter, validate_provider_key,

--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -60,20 +60,20 @@ impl RoutingTarget {
     }
 }
 
-/// Behavior when every routing target is filtered out by runtime health or cooldown state.
+/// Behavior when every routing target is unavailable because of runtime health or cooldown state.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, schemars::JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
-pub enum OnAllFilteredPolicy {
+pub enum WhenAllUnavailablePolicy {
     /// Return `503` with a fixed `Retry-After` hint.
     #[default]
     Fail,
-    /// Route to the original candidate list in declaration order even
-    /// when all targets were filtered by health or cooldown status. Use
+    /// Try every target in declaration order even when all of them are
+    /// currently unavailable because of health or cooldown status. Use
     /// only when maintaining availability is preferred over avoiding
     /// recently unhealthy targets.
-    OriginalOrder,
+    TryAnyway,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -94,9 +94,9 @@ pub struct Routing {
     /// Whether upstream 429 participates in retries and failover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retry_on_429: Option<bool>,
-    /// Policy to apply when runtime status filtering removes every candidate.
+    /// Policy to apply when every target is unavailable because of runtime health or cooldown state.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub on_all_filtered: Option<OnAllFilteredPolicy>,
+    pub when_all_unavailable: Option<WhenAllUnavailablePolicy>,
 }
 
 impl Routing {
@@ -116,8 +116,8 @@ impl Routing {
         self.retry_on_429.unwrap_or(false)
     }
 
-    pub fn on_all_filtered_or_default(&self) -> OnAllFilteredPolicy {
-        self.on_all_filtered.unwrap_or_default()
+    pub fn when_all_unavailable_or_default(&self) -> WhenAllUnavailablePolicy {
+        self.when_all_unavailable.unwrap_or_default()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -169,7 +169,7 @@ mod tests {
             retries: Some(0),
             max_fallbacks: Some(0),
             retry_on_429: None,
-            on_all_filtered: None,
+            when_all_unavailable: None,
         };
         assert_eq!(r.max_fallbacks_or_default(), 0);
     }
@@ -182,33 +182,36 @@ mod tests {
             retries: None,
             max_fallbacks: Some(99),
             retry_on_429: None,
-            on_all_filtered: None,
+            when_all_unavailable: None,
         };
         assert_eq!(r.max_fallbacks_or_default(), 0);
     }
 
     #[test]
-    fn on_all_filtered_defaults_to_fail() {
+    fn when_all_unavailable_defaults_to_fail() {
         let r: Routing = serde_json::from_str(r#"{"targets":[{"model":"a"}]}"#).unwrap();
-        assert_eq!(r.on_all_filtered_or_default(), OnAllFilteredPolicy::Fail);
-    }
-
-    #[test]
-    fn on_all_filtered_parses_original_order() {
-        let r: Routing = serde_json::from_str(
-            r#"{"targets":[{"model":"a"}],"on_all_filtered":"original_order"}"#,
-        )
-        .unwrap();
         assert_eq!(
-            r.on_all_filtered_or_default(),
-            OnAllFilteredPolicy::OriginalOrder
+            r.when_all_unavailable_or_default(),
+            WhenAllUnavailablePolicy::Fail
         );
     }
 
     #[test]
-    fn on_all_filtered_rejects_unknown_value() {
+    fn when_all_unavailable_parses_try_anyway() {
+        let r: Routing = serde_json::from_str(
+            r#"{"targets":[{"model":"a"}],"when_all_unavailable":"try_anyway"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            r.when_all_unavailable_or_default(),
+            WhenAllUnavailablePolicy::TryAnyway
+        );
+    }
+
+    #[test]
+    fn when_all_unavailable_rejects_unknown_value() {
         let r: Result<Routing, _> =
-            serde_json::from_str(r#"{"targets":[{"model":"a"}],"on_all_filtered":"explode"}"#);
+            serde_json::from_str(r#"{"targets":[{"model":"a"}],"when_all_unavailable":"explode"}"#);
         assert!(r.is_err());
     }
 

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1138,36 +1138,36 @@ mod tests {
     }
 
     #[test]
-    fn routing_on_all_filtered_fail_passes() {
+    fn routing_when_all_unavailable_fail_passes() {
         let v = json!({
             "display_name": "router-1",
             "routing": {
                 "targets": [{"model": "a"}],
-                "on_all_filtered": "fail"
+                "when_all_unavailable": "fail"
             }
         });
         validate_model(&v).unwrap();
     }
 
     #[test]
-    fn routing_on_all_filtered_original_order_passes() {
+    fn routing_when_all_unavailable_try_anyway_passes() {
         let v = json!({
             "display_name": "router-1",
             "routing": {
                 "targets": [{"model": "a"}],
-                "on_all_filtered": "original_order"
+                "when_all_unavailable": "try_anyway"
             }
         });
         validate_model(&v).unwrap();
     }
 
     #[test]
-    fn routing_on_all_filtered_rejects_unknown_value() {
+    fn routing_when_all_unavailable_rejects_unknown_value() {
         let v = json!({
             "display_name": "router-1",
             "routing": {
                 "targets": [{"model": "a"}],
-                "on_all_filtered": "yolo"
+                "when_all_unavailable": "yolo"
             }
         });
         assert!(validate_model(&v).is_err());

--- a/crates/aisix-core/src/models/semantic.rs
+++ b/crates/aisix-core/src/models/semantic.rs
@@ -112,7 +112,7 @@ pub enum EmbeddingFailureMode {
 /// Wire shape mirrors the proposal: the bare string `"default"` / `"fail"`,
 /// or an object `{ "target": "<direct alias>" }` to fall back to a specific
 /// safe model. Replicates the spirit of
-/// [`OnAllFilteredPolicy`](super::OnAllFilteredPolicy) with the added
+/// [`WhenAllUnavailablePolicy`](super::WhenAllUnavailablePolicy) with the added
 /// explicit-target option.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(untagged)]

--- a/crates/aisix-core/tests/model_schema_characterization.rs
+++ b/crates/aisix-core/tests/model_schema_characterization.rs
@@ -120,7 +120,7 @@ fn accept_routing_full() {
                 "retries": 2,
                 "max_fallbacks": 1,
                 "retry_on_429": true,
-                "on_all_filtered": "original_order"
+                "when_all_unavailable": "try_anyway"
             },
             "timeout": 1000,
             "rate_limit": {"rpm": 10},
@@ -391,10 +391,10 @@ fn reject_routing_bad_strategy() {
 }
 
 #[test]
-fn reject_routing_bad_on_all_filtered() {
+fn reject_routing_bad_when_all_unavailable() {
     reject(
-        "routing invalid on_all_filtered",
-        json!({"display_name": "r", "routing": {"targets": [{"model": "x"}], "on_all_filtered": "shrug"}}),
+        "routing invalid when_all_unavailable",
+        json!({"display_name": "r", "routing": {"targets": [{"model": "x"}], "when_all_unavailable": "shrug"}}),
     );
 }
 

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -161,9 +161,9 @@ pub enum ProxyError {
     ProviderUnavailable,
     /// Every routing candidate was excluded by the runtime status layer
     /// (all in cooldown or background-unhealthy) and the routing model
-    /// is configured with `on_all_filtered: fail`. Caller-visible as
+    /// is configured with `when_all_unavailable: fail`. Caller-visible as
     /// 503 with a Retry-After hint derived from the nearest cooldown
-    /// expiry. See [`aisix_core::OnAllFilteredPolicy`].
+    /// expiry. See [`aisix_core::WhenAllUnavailablePolicy`].
     #[error("all routing candidates are unavailable")]
     AllCandidatesUnavailable { retry_after_secs: Option<u64> },
     /// Caller-visible message MUST NOT carry the matched-pattern detail.

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -15,7 +15,7 @@
 //!   *first* target choice — once we're falling back, order is positional).
 
 use aisix_core::{
-    AisixSnapshot, Model, OnAllFilteredPolicy, Routing, RoutingStrategy, RoutingTarget,
+    AisixSnapshot, Model, Routing, RoutingStrategy, RoutingTarget, WhenAllUnavailablePolicy,
 };
 use aisix_gateway::BridgeError;
 use dashmap::DashMap;
@@ -29,7 +29,7 @@ use crate::error::ProxyError;
 /// candidate is background-unhealthy and no cooldown timer is available
 /// to derive a more precise hint. Operators tune per-model cooldown
 /// TTLs via `cooldown.default_seconds`; this is only the all-unhealthy
-/// fallback for the `on_all_filtered: fail` path.
+/// fallback for the `when_all_unavailable: fail` path.
 const FALLBACK_ALL_UNHEALTHY_RETRY_AFTER: Duration = Duration::from_secs(30);
 
 /// Whether a Bridge error is retryable at all, optionally treating 429
@@ -204,7 +204,7 @@ pub(crate) enum FilterOutcome {
     /// minus the excluded entries.
     Selected(Vec<AttemptModel>),
     /// Every candidate is currently background-unhealthy and the
-    /// routing model is configured with `on_all_filtered: fail`. The
+    /// routing model is configured with `when_all_unavailable: fail`. The
     /// caller should surface a 503 with the supplied Retry-After hint
     /// (in seconds), if any.
     AllUnhealthy { retry_after_secs: Option<u64> },
@@ -213,7 +213,7 @@ pub(crate) enum FilterOutcome {
 pub(crate) fn filter_attempt_models(
     runtime_status: &crate::ModelRuntimeStatusTracker,
     attempts: Vec<AttemptModel>,
-    policy: OnAllFilteredPolicy,
+    policy: WhenAllUnavailablePolicy,
 ) -> FilterOutcome {
     let mut healthy = Vec::new();
     let mut cooldown_only = Vec::new();
@@ -263,10 +263,10 @@ pub(crate) fn filter_attempt_models(
     // by construction every candidate that reaches here is in the
     // background-unhealthy state and has no cooldown timer to read.
     match policy {
-        OnAllFilteredPolicy::Fail => FilterOutcome::AllUnhealthy {
+        WhenAllUnavailablePolicy::Fail => FilterOutcome::AllUnhealthy {
             retry_after_secs: Some(FALLBACK_ALL_UNHEALTHY_RETRY_AFTER.as_secs()),
         },
-        OnAllFilteredPolicy::OriginalOrder => FilterOutcome::Selected(attempts),
+        WhenAllUnavailablePolicy::TryAnyway => FilterOutcome::Selected(attempts),
     }
 }
 
@@ -315,7 +315,7 @@ pub(crate) fn resolve_attempt_models(
     match filter_attempt_models(
         runtime_status,
         resolved,
-        routing.on_all_filtered_or_default(),
+        routing.when_all_unavailable_or_default(),
     ) {
         FilterOutcome::Selected(list) => Ok(list),
         FilterOutcome::AllUnhealthy { retry_after_secs } => {
@@ -345,7 +345,7 @@ mod tests {
             retries: None,
             max_fallbacks,
             retry_on_429: None,
-            on_all_filtered: None,
+            when_all_unavailable: None,
         }
     }
 
@@ -690,7 +690,7 @@ mod tests {
     fn healthy_only_returns_all_healthy() {
         let t = crate::ModelRuntimeStatusTracker::new();
         let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+        match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
             FilterOutcome::Selected(list) => {
                 assert_eq!(list.len(), 2);
             }
@@ -706,7 +706,7 @@ mod tests {
         let t = crate::ModelRuntimeStatusTracker::new();
         t.mark_cooldown("a", Duration::from_secs(30), "retryable_failure");
         let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+        match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
             FilterOutcome::Selected(list) => {
                 assert_eq!(list.len(), 1);
                 assert_eq!(list[0].id, "b");
@@ -725,7 +725,7 @@ mod tests {
         t.mark_unhealthy("a", Some(503), "background_check_failed");
         t.mark_unhealthy("b", Some(503), "background_check_failed");
         let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+        match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
             FilterOutcome::AllUnhealthy { retry_after_secs } => {
                 assert_eq!(retry_after_secs, Some(30));
             }
@@ -743,7 +743,7 @@ mod tests {
         t.mark_unhealthy("b", Some(503), "background_check_failed");
         t.mark_cooldown("c", Duration::from_secs(30), "x");
         let attempts = vec![am("a"), am("b"), am("c")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+        match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
             FilterOutcome::Selected(list) => {
                 assert_eq!(list.len(), 1);
                 assert_eq!(list[0].id, "c");
@@ -753,17 +753,17 @@ mod tests {
     }
 
     #[test]
-    fn all_unhealthy_original_order_policy_returns_full_list() {
+    fn all_unhealthy_try_anyway_policy_returns_full_list() {
         // Legacy opt-in: send to all candidates regardless.
         let t = crate::ModelRuntimeStatusTracker::new();
         t.mark_unhealthy("a", Some(503), "background_check_failed");
         t.mark_unhealthy("b", Some(503), "background_check_failed");
         let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::OriginalOrder) {
+        match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::TryAnyway) {
             FilterOutcome::Selected(list) => {
                 assert_eq!(list.len(), 2);
             }
-            _ => panic!("expected Selected under OriginalOrder policy"),
+            _ => panic!("expected Selected under TryAnyway policy"),
         }
     }
 
@@ -776,7 +776,7 @@ mod tests {
         t.mark_cooldown("a", Duration::from_secs(30), "x");
         t.mark_cooldown("b", Duration::from_secs(30), "x");
         let attempts = vec![am("a"), am("b")];
-        match filter_attempt_models(&t, attempts, OnAllFilteredPolicy::Fail) {
+        match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
             FilterOutcome::Selected(list) => {
                 assert_eq!(list.len(), 2);
             }

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -249,25 +249,6 @@
       ],
       "type": "object"
     },
-    "OnAllFilteredPolicy": {
-      "description": "Behavior when every routing target is filtered out by runtime health or cooldown state.",
-      "oneOf": [
-        {
-          "description": "Return `503` with a fixed `Retry-After` hint.",
-          "enum": [
-            "fail"
-          ],
-          "type": "string"
-        },
-        {
-          "description": "Route to the original candidate list in declaration order even when all targets were filtered by health or cooldown status. Use only when maintaining availability is preferred over avoiding recently unhealthy targets.",
-          "enum": [
-            "original_order"
-          ],
-          "type": "string"
-        }
-      ]
-    },
     "OnEmbeddingFailure": {
       "anyOf": [
         {
@@ -293,7 +274,7 @@
           "type": "object"
         }
       ],
-      "description": "What the router does when the embedding call errors or times out.\n\nWire shape mirrors the proposal: the bare string `\"default\"` / `\"fail\"`, or an object `{ \"target\": \"<direct alias>\" }` to fall back to a specific safe model. Replicates the spirit of [`OnAllFilteredPolicy`](super::OnAllFilteredPolicy) with the added explicit-target option."
+      "description": "What the router does when the embedding call errors or times out.\n\nWire shape mirrors the proposal: the bare string `\"default\"` / `\"fail\"`, or an object `{ \"target\": \"<direct alias>\" }` to fall back to a specific safe model. Replicates the spirit of [`WhenAllUnavailablePolicy`](super::WhenAllUnavailablePolicy) with the added explicit-target option."
     },
     "PanelMember": {
       "additionalProperties": false,
@@ -385,14 +366,6 @@
           "minimum": 0.0,
           "type": "integer"
         },
-        "on_all_filtered": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/OnAllFilteredPolicy"
-            }
-          ],
-          "description": "Policy to apply when runtime status filtering removes every candidate."
-        },
         "retries": {
           "description": "Retry attempts on the current target before failing over.",
           "format": "uint32",
@@ -419,6 +392,14 @@
           },
           "minItems": 1,
           "type": "array"
+        },
+        "when_all_unavailable": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/WhenAllUnavailablePolicy"
+            }
+          ],
+          "description": "Policy to apply when every target is unavailable because of runtime health or cooldown state."
         }
       },
       "required": [
@@ -602,6 +583,25 @@
         "target"
       ],
       "type": "object"
+    },
+    "WhenAllUnavailablePolicy": {
+      "description": "Behavior when every routing target is unavailable because of runtime health or cooldown state.",
+      "oneOf": [
+        {
+          "description": "Return `503` with a fixed `Retry-After` hint.",
+          "enum": [
+            "fail"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Try every target in declaration order even when all of them are currently unavailable because of health or cooldown status. Use only when maintaining availability is preferred over avoiding recently unhealthy targets.",
+          "enum": [
+            "try_anyway"
+          ],
+          "type": "string"
+        }
+      ]
     }
   },
   "oneOf": [

--- a/schemas/resources/routing.schema.json
+++ b/schemas/resources/routing.schema.json
@@ -15,17 +15,6 @@
       "format": "uint32",
       "minimum": 0.0
     },
-    "on_all_filtered": {
-      "description": "Policy to apply when runtime status filtering removes every candidate.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/OnAllFilteredPolicy"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "retries": {
       "description": "Retry attempts on the current target before failing over.",
       "type": [
@@ -58,29 +47,21 @@
         "$ref": "#/definitions/RoutingTarget"
       },
       "minItems": 1
+    },
+    "when_all_unavailable": {
+      "description": "Policy to apply when every target is unavailable because of runtime health or cooldown state.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/WhenAllUnavailablePolicy"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "additionalProperties": false,
   "definitions": {
-    "OnAllFilteredPolicy": {
-      "description": "Behavior when every routing target is filtered out by runtime health or cooldown state.",
-      "oneOf": [
-        {
-          "description": "Return `503` with a fixed `Retry-After` hint.",
-          "type": "string",
-          "enum": [
-            "fail"
-          ]
-        },
-        {
-          "description": "Route to the original candidate list in declaration order even when all targets were filtered by health or cooldown status. Use only when maintaining availability is preferred over avoiding recently unhealthy targets.",
-          "type": "string",
-          "enum": [
-            "original_order"
-          ]
-        }
-      ]
-    },
     "RoutingStrategy": {
       "oneOf": [
         {
@@ -129,6 +110,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "WhenAllUnavailablePolicy": {
+      "description": "Behavior when every routing target is unavailable because of runtime health or cooldown state.",
+      "oneOf": [
+        {
+          "description": "Return `503` with a fixed `Retry-After` hint.",
+          "type": "string",
+          "enum": [
+            "fail"
+          ]
+        },
+        {
+          "description": "Try every target in declaration order even when all of them are currently unavailable because of health or cooldown status. Use only when maintaining availability is preferred over avoiding recently unhealthy targets.",
+          "type": "string",
+          "enum": [
+            "try_anyway"
+          ]
+        }
+      ]
     }
   }
 }

--- a/schemas/resources/semantic.schema.json
+++ b/schemas/resources/semantic.schema.json
@@ -100,7 +100,7 @@
       ]
     },
     "OnEmbeddingFailure": {
-      "description": "What the router does when the embedding call errors or times out.\n\nWire shape mirrors the proposal: the bare string `\"default\"` / `\"fail\"`, or an object `{ \"target\": \"<direct alias>\" }` to fall back to a specific safe model. Replicates the spirit of [`OnAllFilteredPolicy`](super::OnAllFilteredPolicy) with the added explicit-target option.",
+      "description": "What the router does when the embedding call errors or times out.\n\nWire shape mirrors the proposal: the bare string `\"default\"` / `\"fail\"`, or an object `{ \"target\": \"<direct alias>\" }` to fall back to a specific safe model. Replicates the spirit of [`WhenAllUnavailablePolicy`](super::WhenAllUnavailablePolicy) with the added explicit-target option.",
       "anyOf": [
         {
           "description": "`\"default\"` or `\"fail\"`.",

--- a/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
@@ -20,7 +20,7 @@ import {
  *  - H2: Retry-After header from upstream drives the cooldown TTL.
  *  - H3: When every routing candidate is filtered out, the proxy
  *        fails fast with 503 + Retry-After (default policy).
- *  - H3 escape hatch: `on_all_filtered: original_order` preserves the
+ *  - H3 escape hatch: `when_all_unavailable: try_anyway` preserves the
  *        legacy "send to known-bad" behavior for operators that
  *        explicitly opt in.
  *  - M1: 429 cools down regardless of `retry_on_429` — cooldown and
@@ -548,7 +548,7 @@ describe("filter contract (H3) — all candidates unhealthy returns 503", () => 
         stale_after_seconds: 120,
       },
     });
-    // Default on_all_filtered policy is "fail" — explicit here for
+    // Default when_all_unavailable policy is "fail" — explicit here for
     // clarity even though it's the default.
     await admin.createModel({
       display_name: "h3-router-fail",
@@ -556,7 +556,7 @@ describe("filter contract (H3) — all candidates unhealthy returns 503", () => 
         strategy: "failover",
         targets: [{ model: "h3-down-a" }, { model: "h3-down-b" }],
         max_fallbacks: 1,
-        on_all_filtered: "fail",
+        when_all_unavailable: "fail",
       },
     });
     await admin.createApiKey({
@@ -616,7 +616,7 @@ describe("filter contract (H3) — all candidates unhealthy returns 503", () => 
   });
 });
 
-describe("filter contract (H3 escape hatch) — original_order sends to known-bad", () => {
+describe("filter contract (H3 escape hatch) — try_anyway sends to known-bad", () => {
   let app: SpawnedApp | undefined;
   let admin: AdminClient | undefined;
   let etcdReachable = false;
@@ -661,7 +661,7 @@ describe("filter contract (H3 escape hatch) — original_order sends to known-ba
         strategy: "failover",
         targets: [{ model: "h3-escape-down" }],
         max_fallbacks: 0,
-        on_all_filtered: "original_order",
+        when_all_unavailable: "try_anyway",
       },
     });
     await admin.createApiKey({
@@ -675,7 +675,7 @@ describe("filter contract (H3 escape hatch) — original_order sends to known-ba
     await downUpstream?.close();
   });
 
-  test("with on_all_filtered=original_order, the proxy still tries the unhealthy target (legacy opt-in)", async (ctx) => {
+  test("with when_all_unavailable=try_anyway, the proxy still tries the unhealthy target (legacy opt-in)", async (ctx) => {
     if (!etcdReachable || !app || !admin || !downUpstream) {
       ctx.skip();
       return;
@@ -689,7 +689,7 @@ describe("filter contract (H3 escape hatch) — original_order sends to known-ba
 
     const baseline = downUpstream.receivedRequests.length;
 
-    // With original_order, the request goes out to the unhealthy
+    // With try_anyway, the request goes out to the unhealthy
     // target. The upstream still returns 503 and the SDK throws,
     // but the key point is that a request *was sent*.
     const resp = await fetch(`${app.proxyUrl}/v1/chat/completions`, {


### PR DESCRIPTION
## What

Rename the routing "every target removed by runtime health/cooldown" policy to intent-based names, **before** the control plane / dashboard surface it:

- field `on_all_filtered` → `when_all_unavailable`
- enum `OnAllFilteredPolicy` → `WhenAllUnavailablePolicy`
- variant `OriginalOrder` → `TryAnyway` (wire `original_order` → `try_anyway`; `fail` unchanged)
- de-jargoned the user-facing schema descriptions ("filtered out" → "unavailable")

## Why

The old name describes the internal filter mechanism, not the operator's intent. The dashboard will phrase this as *"when all targets are unavailable: fail fast vs try anyway"* — `on_all_filtered` / `original_order` leak implementation detail into the wire + generated API docs. Fixing it now is free.

## Breaking?

Wire-breaking (`on_all_filtered` → `when_all_unavailable`, `original_order` → `try_anyway`), but **no consumer exists today**: cp-api carries no such field (verified — no `on_all_filtered` anywhere in `internal/`) and the dashboard doesn't send it. The field is greenfield and unsurfaced, so nothing downstream breaks — this is the moment to rename, before PR 3 wires it through cp-api + the dashboard.

## Verification

- `cargo build --workspace` ✓ (no dependent crate referenced the renamed symbols)
- `cargo test -p aisix-core -p aisix-proxy -p aisix-admin` ✓ — **501 passed, 0 failed**
- `cargo clippy --all-targets` ✓, `cargo fmt` ✓
- Regenerated `schemas/resources/{model,routing,semantic}.schema.json` via `dump-schema` (exactly those 3 changed; the other resource schemas re-emit byte-identical)
- Updated the schema-characterization test and the `cooldown-contract` e2e to the new wire shape
- `git grep` confirms zero residual `on_all_filtered` / `OnAllFilteredPolicy` / `OriginalOrder` / `original_order`

## Next

PR for cp-api adds `when_all_unavailable` + `cooldown` to the control-plane resource and the dashboard control. Part of the routing-UX series (dashboard PR api7/AISIX-Cloud#899, design api7/AISIX-Cloud#895).
