### PR TITLE
feat(metrics): add stream/fallback/client + readable-name dimensions (#890)

### DIFF
--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -41,6 +41,14 @@ pub struct ApiKey {
     #[schemars(length(min = 1))]
     pub user_id: Option<String>,
 
+    /// Readable display name of the owning member (#890 req-3). Synced by
+    /// cp-api solely so the proxy can stamp a human-readable `user_name`
+    /// metric label alongside `user_id`; never used for auth or routing.
+    /// Absent on older cp-api payloads → the metric label falls back to
+    /// `"unknown"` (DP-first rollout).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_name: Option<String>,
+
     /// etcd-key uuid. Filled by the loader and never included in the JSON payload.
     #[serde(skip)]
     pub(crate) runtime_id: String,
@@ -157,6 +165,7 @@ mod tests {
             rate_limit: None,
             team_id: None,
             user_id: None,
+            user_name: None,
             runtime_id: String::new(),
         };
         assert!(!k.can_access("my-gpt4"));
@@ -228,12 +237,14 @@ mod tests {
               "key_hash": "{SAMPLE_HASH}",
               "allowed_models": ["gpt-4o"],
               "team_id": "team-uuid-1",
-              "user_id": "member-uuid-1"
+              "user_id": "member-uuid-1",
+              "user_name": "Alice Example"
             }}"#
         ))
         .unwrap();
         assert_eq!(k.team_id.as_deref(), Some("team-uuid-1"));
         assert_eq!(k.user_id.as_deref(), Some("member-uuid-1"));
+        assert_eq!(k.user_name.as_deref(), Some("Alice Example"));
     }
 
     #[test]
@@ -241,5 +252,6 @@ mod tests {
         let k = sample();
         assert!(k.team_id.is_none());
         assert!(k.user_id.is_none());
+        assert!(k.user_name.is_none());
     }
 }

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -27,8 +27,8 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 pub use access_log::AccessLog;
 pub use metrics::{
-    BudgetGauges, BudgetLabels, DeploymentLabels, DeploymentState, LlmUsage, Metrics,
-    RequestLabels, RequestOutcome, UsageLabels,
+    client_type_from_user_agent, BudgetGauges, BudgetLabels, DeploymentLabels, DeploymentState,
+    LlmUsage, Metrics, RequestLabels, RequestOutcome, UsageLabels,
 };
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::{content_capture_cap, OtlpHttpFanOut, OtlpSink};

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -40,6 +40,12 @@ pub const M_LLM_REQUESTS_TOTAL: &str = "aisix_llm_requests_total";
 pub const M_LLM_REQUEST_DURATION: &str = "aisix_llm_request_duration_seconds";
 pub const M_LLM_API_LATENCY: &str = "aisix_llm_api_latency_seconds";
 pub const M_LLM_TTFT: &str = "aisix_llm_time_to_first_token_seconds";
+/// Issue #890 req-4: token volume sliced by inbound client type only — a
+/// DEDICATED low-cardinality series so the client dimension never multiplies
+/// the per-key `aisix_llm_*_tokens_total` families. `client_type` is
+/// normalised to a bounded allowlist by [`client_type_from_user_agent`]; the
+/// raw user-agent + client version stay in logs / `UsageEvent`, never here.
+pub const M_LLM_TOKENS_BY_CLIENT_TOTAL: &str = "aisix_llm_tokens_by_client_total";
 pub const M_PROXY_IN_FLIGHT: &str = "aisix_proxy_in_flight_requests";
 pub const M_PROXY_REQUESTS_TOTAL: &str = "aisix_proxy_requests_total";
 pub const M_PROXY_FAILED_REQUESTS_TOTAL: &str = "aisix_proxy_failed_requests_total";
@@ -253,9 +259,12 @@ impl Metrics {
                 "model" => labels.model.to_string(),
                 "upstream_model" => labels.upstream_model.to_string(),
                 "provider_key_id" => labels.provider_key_id.to_string(),
+                "provider_key_name" => labels.provider_key_name.to_string(),
                 "api_key_id" => labels.api_key_id.to_string(),
                 "team_id" => labels.team_id.to_string(),
                 "user_id" => labels.user_id.to_string(),
+                "user_name" => labels.user_name.to_string(),
+                "stream" => bool_str(labels.stream),
                 "status" => labels.status.to_string(),
                 "outcome" => labels.outcome.as_str().to_string(),
             )
@@ -277,9 +286,12 @@ impl Metrics {
                 "model" => labels.model.to_string(),
                 "upstream_model" => labels.upstream_model.to_string(),
                 "provider_key_id" => labels.provider_key_id.to_string(),
+                "provider_key_name" => labels.provider_key_name.to_string(),
                 "api_key_id" => labels.api_key_id.to_string(),
                 "team_id" => labels.team_id.to_string(),
                 "user_id" => labels.user_id.to_string(),
+                "user_name" => labels.user_name.to_string(),
+                "stream" => bool_str(labels.stream),
                 "status" => labels.status.to_string(),
                 "outcome" => labels.outcome.as_str().to_string(),
             )
@@ -320,11 +332,46 @@ impl Metrics {
                 "model" => labels.model.to_string(),
                 "upstream_model" => labels.upstream_model.to_string(),
                 "provider_key_id" => labels.provider_key_id.to_string(),
+                "provider_key_name" => labels.provider_key_name.to_string(),
                 "api_key_id" => labels.api_key_id.to_string(),
                 "team_id" => labels.team_id.to_string(),
                 "user_id" => labels.user_id.to_string(),
+                "user_name" => labels.user_name.to_string(),
             )
             .record(ttft.as_secs_f64());
+        });
+    }
+
+    /// #890 req-4: record token volume for the inbound `client_type` on the
+    /// dedicated [`M_LLM_TOKENS_BY_CLIENT_TOTAL`] series. `client_type` is a
+    /// `&'static str` from [`client_type_from_user_agent`] so cardinality is
+    /// bounded; zero dims are skipped to keep the series sparse.
+    pub fn record_llm_tokens_by_client(
+        &self,
+        client_type: &'static str,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) {
+        if input_tokens == 0 && output_tokens == 0 {
+            return;
+        }
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            if input_tokens > 0 {
+                metrics::counter!(
+                    M_LLM_TOKENS_BY_CLIENT_TOTAL,
+                    "client_type" => client_type,
+                    "token_type" => "input",
+                )
+                .increment(input_tokens);
+            }
+            if output_tokens > 0 {
+                metrics::counter!(
+                    M_LLM_TOKENS_BY_CLIENT_TOTAL,
+                    "client_type" => client_type,
+                    "token_type" => "output",
+                )
+                .increment(output_tokens);
+            }
         });
     }
 
@@ -497,6 +544,72 @@ fn status_bucket(status: u16) -> &'static str {
     }
 }
 
+/// Render a boolean metric dimension as a stable `"true"`/`"false"` label
+/// value (#890 reqs 1 & 2: `stream`, `is_fallback`).
+fn bool_str(value: bool) -> &'static str {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+
+/// Normalise a raw inbound `User-Agent` into a BOUNDED `client_type` label
+/// for [`M_LLM_TOKENS_BY_CLIENT_TOTAL`] (#890 req-4).
+///
+/// The result is always one of a fixed allowlist (plus `"other"` /
+/// `"unknown"`), returned as `&'static str`, so a client-controlled header
+/// can never grow prometheus cardinality. Matching is case-insensitive and
+/// substring-based, most-specific first (SDK/tool names win over the generic
+/// HTTP-library buckets, whose UA a higher-level SDK often embeds). The full
+/// user-agent and its version are preserved on the `UsageEvent`/logs — only
+/// this coarse, bounded type ever becomes a metric label.
+pub fn client_type_from_user_agent(user_agent: &str) -> &'static str {
+    let ua = user_agent.trim().to_ascii_lowercase();
+    if ua.is_empty() {
+        return "unknown";
+    }
+    // (substring, label) — ordered: products/SDKs before generic libs.
+    const TABLE: &[(&str, &str)] = &[
+        ("claude-cli", "claude-code"),
+        ("claude-code", "claude-code"),
+        ("codex", "codex"),
+        ("cline", "cline"),
+        ("aider", "aider"),
+        ("openai-python", "openai-python"),
+        ("openai/python", "openai-python"),
+        ("openai-node", "openai-node"),
+        ("openai/js", "openai-node"),
+        ("anthropic-sdk-python", "anthropic-python"),
+        ("anthropic/python", "anthropic-python"),
+        ("anthropic-sdk-typescript", "anthropic-typescript"),
+        ("anthropic/js", "anthropic-typescript"),
+        ("langchain", "langchain"),
+        ("llama-index", "llamaindex"),
+        ("llama_index", "llamaindex"),
+        ("llamaindex", "llamaindex"),
+        ("litellm", "litellm"),
+        ("curl", "curl"),
+        ("python-requests", "python-requests"),
+        ("python-httpx", "httpx"),
+        ("httpx", "httpx"),
+        ("aiohttp", "aiohttp"),
+        ("okhttp", "okhttp"),
+        ("go-http-client", "go-http-client"),
+        ("node-fetch", "node"),
+        ("undici", "node"),
+        ("axios", "node"),
+        ("postmanruntime", "postman"),
+        ("mozilla", "browser"),
+    ];
+    for (needle, label) in TABLE {
+        if ua.contains(needle) {
+            return label;
+        }
+    }
+    "other"
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct RequestLabels<'a> {
     pub endpoint: &'a str,
@@ -505,9 +618,26 @@ pub struct RequestLabels<'a> {
     pub model: &'a str,
     pub upstream_model: &'a str,
     pub provider_key_id: &'a str,
+    /// Readable provider-key name (#890 req-3). 1:1 with `provider_key_id`
+    /// so it adds no new series; `"unknown"` when unresolved.
+    pub provider_key_name: &'a str,
     pub api_key_id: &'a str,
     pub team_id: &'a str,
     pub user_id: &'a str,
+    /// Readable user display name (#890 req-3). 1:1 with `user_id`;
+    /// `"unknown"` until cp-api syncs it onto the api-key config.
+    pub user_name: &'a str,
+    /// Whether the client requested a streaming (SSE) response (#890 req-1).
+    /// Emitted on the request counter AND duration histogram so a
+    /// TTFT-vs-E2E comparison can restrict the E2E latency to the same
+    /// streaming-only sample TTFT is measured on.
+    pub stream: bool,
+    /// Whether serving this request involved a fallback to a different
+    /// routing target (#890 req-2). Emitted on the request COUNTERS only
+    /// (a success-rate dimension — kept off the bucketed histograms to
+    /// avoid ×2 per latency bucket) so a success rate can exclude fallback
+    /// requests from the denominator.
+    pub is_fallback: bool,
     pub status: u16,
     pub outcome: RequestOutcome,
 }
@@ -521,9 +651,13 @@ impl Default for RequestLabels<'_> {
             model: "unknown",
             upstream_model: "unknown",
             provider_key_id: "unknown",
+            provider_key_name: "unknown",
             api_key_id: "unknown",
             team_id: "unknown",
             user_id: "unknown",
+            user_name: "unknown",
+            stream: false,
+            is_fallback: false,
             status: 0,
             outcome: RequestOutcome::UpstreamError,
         }
@@ -540,9 +674,13 @@ impl RequestLabels<'_> {
             "model" => self.model.to_string(),
             "upstream_model" => self.upstream_model.to_string(),
             "provider_key_id" => self.provider_key_id.to_string(),
+            "provider_key_name" => self.provider_key_name.to_string(),
             "api_key_id" => self.api_key_id.to_string(),
             "team_id" => self.team_id.to_string(),
             "user_id" => self.user_id.to_string(),
+            "user_name" => self.user_name.to_string(),
+            "stream" => bool_str(self.stream),
+            "is_fallback" => bool_str(self.is_fallback),
             "status" => self.status.to_string(),
             "outcome" => self.outcome.as_str().to_string(),
         )
@@ -558,9 +696,13 @@ pub struct UsageLabels<'a> {
     pub model: &'a str,
     pub upstream_model: &'a str,
     pub provider_key_id: &'a str,
+    /// Readable provider-key name (#890 req-3). 1:1 with `provider_key_id`.
+    pub provider_key_name: &'a str,
     pub api_key_id: &'a str,
     pub team_id: &'a str,
     pub user_id: &'a str,
+    /// Readable user display name (#890 req-3). 1:1 with `user_id`.
+    pub user_name: &'a str,
 }
 
 impl Default for UsageLabels<'_> {
@@ -572,9 +714,11 @@ impl Default for UsageLabels<'_> {
             model: "unknown",
             upstream_model: "unknown",
             provider_key_id: "unknown",
+            provider_key_name: "unknown",
             api_key_id: "unknown",
             team_id: "unknown",
             user_id: "unknown",
+            user_name: "unknown",
         }
     }
 }
@@ -589,9 +733,11 @@ impl UsageLabels<'_> {
             "model" => self.model.to_string(),
             "upstream_model" => self.upstream_model.to_string(),
             "provider_key_id" => self.provider_key_id.to_string(),
+            "provider_key_name" => self.provider_key_name.to_string(),
             "api_key_id" => self.api_key_id.to_string(),
             "team_id" => self.team_id.to_string(),
             "user_id" => self.user_id.to_string(),
+            "user_name" => self.user_name.to_string(),
         )
         .increment(value);
     }
@@ -612,9 +758,11 @@ impl UsageLabels<'_> {
             "model" => self.model.to_string(),
             "upstream_model" => self.upstream_model.to_string(),
             "provider_key_id" => self.provider_key_id.to_string(),
+            "provider_key_name" => self.provider_key_name.to_string(),
             "api_key_id" => self.api_key_id.to_string(),
             "team_id" => self.team_id.to_string(),
             "user_id" => self.user_id.to_string(),
+            "user_name" => self.user_name.to_string(),
         )
         .increment(micro_usd as u64);
     }
@@ -857,26 +1005,33 @@ mod tests {
             model: "gpt",
             upstream_model: "gpt-4o",
             provider_key_id: "pk-1",
+            provider_key_name: "my-openai-key",
             api_key_id: "ak-1",
             team_id: "team-1",
             user_id: "user-1",
+            user_name: "alice",
+            stream: true,
+            is_fallback: true,
             status: 200,
             outcome: RequestOutcome::Success,
+        };
+        let usage_labels = UsageLabels {
+            endpoint: "/v1/chat/completions",
+            inbound_protocol: "openai",
+            provider: "openai",
+            model: "gpt",
+            upstream_model: "gpt-4o",
+            provider_key_id: "pk-1",
+            provider_key_name: "my-openai-key",
+            api_key_id: "ak-1",
+            team_id: "team-1",
+            user_id: "user-1",
+            user_name: "alice",
         };
         m.record_proxy_request(labels, Duration::from_millis(25));
         m.record_llm_request(labels, Duration::from_millis(20));
         m.record_llm_usage(
-            UsageLabels {
-                endpoint: "/v1/chat/completions",
-                inbound_protocol: "openai",
-                provider: "openai",
-                model: "gpt",
-                upstream_model: "gpt-4o",
-                provider_key_id: "pk-1",
-                api_key_id: "ak-1",
-                team_id: "team-1",
-                user_id: "user-1",
-            },
+            usage_labels,
             LlmUsage {
                 input_tokens: 5,
                 output_tokens: 7,
@@ -884,20 +1039,7 @@ mod tests {
                 spend_usd: 0.001,
             },
         );
-        m.record_time_to_first_token(
-            UsageLabels {
-                endpoint: "/v1/chat/completions",
-                inbound_protocol: "openai",
-                provider: "openai",
-                model: "gpt",
-                upstream_model: "gpt-4o",
-                provider_key_id: "pk-1",
-                api_key_id: "ak-1",
-                team_id: "team-1",
-                user_id: "user-1",
-            },
-            Duration::from_millis(42),
-        );
+        m.record_time_to_first_token(usage_labels, Duration::from_millis(42));
 
         let rendered = m.render();
         assert!(rendered.contains(M_PROXY_REQUESTS_TOTAL));
@@ -911,6 +1053,72 @@ mod tests {
         assert!(rendered.contains("endpoint=\"/v1/chat/completions\""));
         assert!(rendered.contains("team_id=\"team-1\""));
         assert!(rendered.contains("user_id=\"user-1\""));
+        // #890 req-3: readable names ride alongside the ids (1:1).
+        assert!(rendered.contains("provider_key_name=\"my-openai-key\""));
+        assert!(rendered.contains("user_name=\"alice\""));
+        // #890 req-1/req-2: stream on counter + duration; is_fallback on
+        // the counter only (verified absent from the duration below).
+        assert!(rendered.contains("stream=\"true\""));
+        assert!(rendered.contains("is_fallback=\"true\""));
+        // is_fallback must NOT appear on the duration histogram series.
+        for line in rendered.lines() {
+            if line.starts_with(M_LLM_REQUEST_DURATION)
+                || line.starts_with(M_PROXY_REQUEST_DURATION)
+            {
+                assert!(
+                    !line.contains("is_fallback="),
+                    "is_fallback must stay off the duration histogram: {line}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tokens_by_client_records_bounded_client_type() {
+        let m = Metrics::new(false);
+        m.record_llm_tokens_by_client("openai-python", 100, 40);
+        m.record_llm_tokens_by_client("openai-python", 10, 0);
+        // Zero/zero is a no-op (keeps the series sparse).
+        m.record_llm_tokens_by_client("curl", 0, 0);
+        let rendered = m.render();
+        assert!(rendered.contains(M_LLM_TOKENS_BY_CLIENT_TOTAL));
+        assert!(rendered.contains("client_type=\"openai-python\""));
+        assert!(rendered.contains("token_type=\"input\""));
+        assert!(rendered.contains("token_type=\"output\""));
+        // The zero/zero curl call recorded nothing.
+        assert!(!rendered.contains("client_type=\"curl\""));
+    }
+
+    #[test]
+    fn client_type_from_user_agent_normalises_to_allowlist() {
+        // Known SDKs/tools normalise to a stable bounded label.
+        assert_eq!(
+            client_type_from_user_agent("OpenAI/Python 1.30.1"),
+            "openai-python"
+        );
+        assert_eq!(
+            client_type_from_user_agent("openai-node/4.20.0"),
+            "openai-node"
+        );
+        assert_eq!(
+            client_type_from_user_agent("claude-cli/1.2.3"),
+            "claude-code"
+        );
+        assert_eq!(client_type_from_user_agent("curl/8.4.0"), "curl");
+        // Version differences collapse to the SAME bounded type — no
+        // per-version cardinality blowup.
+        assert_eq!(
+            client_type_from_user_agent("OpenAI/Python 1.0.0"),
+            client_type_from_user_agent("OpenAI/Python 2.99.9"),
+        );
+        // Empty → unknown; unrecognised → other (the only unbounded inputs
+        // both collapse into bounded buckets).
+        assert_eq!(client_type_from_user_agent(""), "unknown");
+        assert_eq!(client_type_from_user_agent("   "), "unknown");
+        assert_eq!(
+            client_type_from_user_agent("SomeRandomBespokeClient/9.9"),
+            "other"
+        );
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -144,6 +144,13 @@ pub async fn chat_completions(
         Ok(mut success) => {
             let status = 200;
             let elapsed = started.elapsed();
+            // #890 req-3/req-4: resolve the readable provider-key name from the
+            // snapshot and normalise the inbound client type once.
+            let provider_key_name = {
+                let snap = state.snapshot.load();
+                crate::usage_attr::provider_key_metric_name(&snap, &success.provider_key_id)
+            };
+            let client_type = aisix_obs::client_type_from_user_agent(&client.user_agent);
             record_success(
                 &state.metrics,
                 &success.provider,
@@ -151,6 +158,11 @@ pub async fn chat_completions(
                 &api_key_id,
                 auth.key().team_id.as_deref(),
                 auth.key().user_id.as_deref(),
+                auth.key().user_name.as_deref(),
+                &provider_key_name,
+                client_type,
+                req.is_streaming(),
+                success.routing.fallback_count() > 0,
                 status,
                 &success,
                 elapsed,
@@ -342,6 +354,32 @@ pub async fn chat_completions(
                 .map(|c| c.routing.clone())
                 .filter(|r| !r.attempts.is_empty())
                 .unwrap_or(routing);
+            // #890 req-2: record the FAILED request on the same rich request
+            // metrics successes use, so a success rate is computable
+            // (numerator outcome="success" over a denominator that includes
+            // failures — previously these series were success-path-only).
+            // Provider / upstream_model / provider_key are unknown on the
+            // failure path; identity + status + outcome + stream + is_fallback
+            // are what the success-rate query needs.
+            let fail_labels = RequestLabels {
+                endpoint: "/v1/chat/completions",
+                inbound_protocol: "openai",
+                provider: "unknown",
+                model: &model_name,
+                upstream_model: "unknown",
+                provider_key_id: "unknown",
+                provider_key_name: "unknown",
+                api_key_id: &api_key_id,
+                team_id: auth.key().team_id.as_deref().unwrap_or("unknown"),
+                user_id: auth.key().user_id.as_deref().unwrap_or("unknown"),
+                user_name: auth.key().user_name.as_deref().unwrap_or("unknown"),
+                stream: req.is_streaming(),
+                is_fallback: routing.fallback_count() > 0,
+                status,
+                outcome: RequestOutcome::from_status(status),
+            };
+            state.metrics.record_proxy_request(fail_labels, elapsed);
+            state.metrics.record_llm_request(fail_labels, elapsed);
             emit_access_log(
                 method,
                 path,
@@ -1149,6 +1187,15 @@ async fn dispatch(
         let provider_for_metrics = provider.to_ascii_lowercase();
         let model_for_metrics = req.model.clone();
         let provider_key_id_for_metrics = pk_id.clone();
+        // #890 req-3/req-4: readable provider-key name + normalised inbound
+        // client type, captured for the streaming on_complete metric emission
+        // (mirrors the non-streaming `record_success` path).
+        let provider_key_name_for_metrics = {
+            let snap = state.snapshot.load();
+            crate::usage_attr::provider_key_metric_name(&snap, &pk_id)
+        };
+        let user_name_for_metrics = auth.key().user_name.clone();
+        let client_type_for_metrics = aisix_obs::client_type_from_user_agent(&client.user_agent);
         // Captured for the stream-end telemetry closure so
         // emit_usage_event can look up `telemetry_tags` for per-PK
         // attribution (#302 M17 / AISIX-Cloud#436). The metrics
@@ -1295,9 +1342,11 @@ async fn dispatch(
                         model: &model_for_metrics,
                         upstream_model: &upstream_model_for_metrics,
                         provider_key_id: &provider_key_id_for_metrics,
+                        provider_key_name: &provider_key_name_for_metrics,
                         api_key_id: &api_key_id_for_telem,
                         team_id: team_id_for_metrics.as_deref().unwrap_or("unknown"),
                         user_id: user_id_for_metrics.as_deref().unwrap_or("unknown"),
+                        user_name: user_name_for_metrics.as_deref().unwrap_or("unknown"),
                     },
                     LlmUsage {
                         input_tokens: comp.prompt_tokens,
@@ -1305,6 +1354,12 @@ async fn dispatch(
                         total_tokens: comp.total_tokens.min(u64::from(u32::MAX)) as u32,
                         spend_usd: 0.0,
                     },
+                );
+                // #890 req-4: streaming token volume by inbound client type.
+                metrics_for_stream.record_llm_tokens_by_client(
+                    client_type_for_metrics,
+                    u64::from(comp.prompt_tokens),
+                    u64::from(comp.completion_tokens),
                 );
                 metrics_for_stream.record_time_to_first_token(
                     UsageLabels {
@@ -1314,9 +1369,11 @@ async fn dispatch(
                         model: &model_for_metrics,
                         upstream_model: &upstream_model_for_metrics,
                         provider_key_id: &provider_key_id_for_metrics,
+                        provider_key_name: &provider_key_name_for_metrics,
                         api_key_id: &api_key_id_for_telem,
                         team_id: team_id_for_metrics.as_deref().unwrap_or("unknown"),
                         user_id: user_id_for_metrics.as_deref().unwrap_or("unknown"),
+                        user_name: user_name_for_metrics.as_deref().unwrap_or("unknown"),
                     },
                     Duration::from_millis(u64::from(comp.ttft_ms)),
                 );
@@ -2638,6 +2695,12 @@ fn record_success(
     api_key_id: &str,
     team_id: Option<&str>,
     user_id: Option<&str>,
+    // #890 req-3 readable name + req-4 client type + req-1/req-2 dimensions.
+    user_name: Option<&str>,
+    provider_key_name: &str,
+    client_type: &'static str,
+    stream: bool,
+    is_fallback: bool,
     status: u16,
     s: &Success,
     elapsed: Duration,
@@ -2651,9 +2714,13 @@ fn record_success(
         model,
         upstream_model: &s.upstream_model,
         provider_key_id: &s.provider_key_id,
+        provider_key_name,
         api_key_id,
         team_id: team_id.unwrap_or("unknown"),
         user_id: user_id.unwrap_or("unknown"),
+        user_name: user_name.unwrap_or("unknown"),
+        stream,
+        is_fallback,
         status,
         outcome,
     };
@@ -2670,9 +2737,11 @@ fn record_success(
             model,
             upstream_model: &s.upstream_model,
             provider_key_id: &s.provider_key_id,
+            provider_key_name,
             api_key_id,
             team_id: team_id.unwrap_or("unknown"),
             user_id: user_id.unwrap_or("unknown"),
+            user_name: user_name.unwrap_or("unknown"),
         },
         LlmUsage {
             input_tokens: s.prompt_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
@@ -2680,6 +2749,14 @@ fn record_success(
             total_tokens: s.total_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
             spend_usd: s.cost_usd,
         },
+    );
+    // #890 req-4: token volume by inbound client type (non-streaming path;
+    // streaming tokens arrive in the SSE on_complete and are recorded there).
+    // No-op when both counts are zero (e.g. the streaming branch here).
+    metrics.record_llm_tokens_by_client(
+        client_type,
+        s.prompt_tokens.unwrap_or(0),
+        s.completion_tokens.unwrap_or(0),
     );
 }
 

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -119,6 +119,12 @@ pub async fn messages(
     // read below to attach `applied_guardrails` to the telemetry event on both
     // the success and failure (input-block) paths (#379).
     let mut applied_guardrails: Vec<AppliedGuardrail> = Vec::new();
+    // #890 req-1: capture the client's streaming intent before dispatch
+    // (which mutates the body).
+    let stream_requested = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     match dispatch(
         &state,
         &auth,
@@ -159,6 +165,11 @@ pub async fn messages(
                 elapsed,
             );
             let outcome = RequestOutcome::from_status(status);
+            // #890 req-3: readable provider-key name resolved from the snapshot.
+            let provider_key_name = {
+                let snap = state.snapshot.load();
+                crate::usage_attr::provider_key_metric_name(&snap, &provider_key_id)
+            };
             let labels = RequestLabels {
                 endpoint: "/v1/messages",
                 inbound_protocol: "anthropic",
@@ -166,9 +177,13 @@ pub async fn messages(
                 model: &model_name,
                 upstream_model: &upstream_model,
                 provider_key_id: &provider_key_id,
+                provider_key_name: &provider_key_name,
                 api_key_id: &api_key_id,
                 team_id: auth.key().team_id.as_deref().unwrap_or("unknown"),
                 user_id: auth.key().user_id.as_deref().unwrap_or("unknown"),
+                user_name: auth.key().user_name.as_deref().unwrap_or("unknown"),
+                stream: stream_requested,
+                is_fallback: routing.fallback_count() > 0,
                 status,
                 outcome,
             };
@@ -186,6 +201,7 @@ pub async fn messages(
                 &upstream_model,
                 auth.key().team_id.as_deref(),
                 auth.key().user_id.as_deref(),
+                auth.key().user_name.as_deref(),
                 &client,
                 &applied_guardrails,
                 &routing,
@@ -213,6 +229,7 @@ pub async fn messages(
                     &upstream_model,
                     auth.key().team_id.as_deref(),
                     auth.key().user_id.as_deref(),
+                    auth.key().user_name.as_deref(),
                     status,
                     elapsed,
                     metrics,
@@ -243,6 +260,28 @@ pub async fn messages(
                 RequestOutcome::from_status(status),
                 elapsed,
             );
+            // #890 req-2: count the FAILED request on the rich request metrics
+            // so a success rate is computable (denominator incl. failures).
+            // Provider/upstream/provider_key are unknown on the failure path.
+            let fail_labels = RequestLabels {
+                endpoint: "/v1/messages",
+                inbound_protocol: "anthropic",
+                provider: "unknown",
+                model: &model_name,
+                upstream_model: "unknown",
+                provider_key_id: "unknown",
+                provider_key_name: "unknown",
+                api_key_id: &api_key_id,
+                team_id: auth.key().team_id.as_deref().unwrap_or("unknown"),
+                user_id: auth.key().user_id.as_deref().unwrap_or("unknown"),
+                user_name: auth.key().user_name.as_deref().unwrap_or("unknown"),
+                stream: stream_requested,
+                is_fallback: routing.fallback_count() > 0,
+                status,
+                outcome: RequestOutcome::from_status(status),
+            };
+            state.metrics.record_proxy_request(fail_labels, elapsed);
+            state.metrics.record_llm_request(fail_labels, elapsed);
             // Per #655: emit one zero-token UsageEvent per FAILED attempt so
             // the dashboard's Logs tab surfaces each failed upstream try.
             emit_failed_attempts_anthropic(
@@ -254,6 +293,7 @@ pub async fn messages(
                 "unknown",
                 auth.key().team_id.as_deref(),
                 auth.key().user_id.as_deref(),
+                auth.key().user_name.as_deref(),
                 &client,
                 &applied_guardrails,
                 &routing,
@@ -274,6 +314,7 @@ pub async fn messages(
                     "unknown",
                     auth.key().team_id.as_deref(),
                     auth.key().user_id.as_deref(),
+                    auth.key().user_name.as_deref(),
                     status,
                     elapsed,
                     AnthropicUsageMetrics::default(),
@@ -310,6 +351,7 @@ fn emit_failed_attempts_anthropic(
     upstream_model: &str,
     team_id: Option<&str>,
     user_id: Option<&str>,
+    user_name: Option<&str>,
     client: &ClientContext,
     applied_guardrails: &[AppliedGuardrail],
     routing: &RoutingTelemetry,
@@ -328,6 +370,7 @@ fn emit_failed_attempts_anthropic(
             upstream_model,
             team_id,
             user_id,
+            user_name,
             rec.status,
             Duration::from_millis(u64::from(rec.latency_ms)),
             AnthropicUsageMetrics::default(),
@@ -510,6 +553,7 @@ async fn dispatch(
                 &auth.entry.id,
                 auth.key().team_id.clone(),
                 auth.key().user_id.clone(),
+                auth.key().user_name.clone(),
                 resolved_chain.clone(),
                 client,
                 AttemptInfo {
@@ -594,6 +638,7 @@ async fn dispatch_to_target(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
+    user_name: Option<String>,
     resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
     client: &ClientContext,
     // Winning-attempt classification (#655) — used by the streaming paths
@@ -617,6 +662,7 @@ async fn dispatch_to_target(
             api_key_id,
             team_id,
             user_id,
+            user_name,
             resolved_chain,
             client,
             attempt,
@@ -637,6 +683,7 @@ async fn dispatch_to_target(
         api_key_id,
         team_id,
         user_id,
+        user_name,
         resolved_chain,
         client,
         attempt,
@@ -662,6 +709,7 @@ async fn anthropic_passthrough_dispatch(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
+    user_name: Option<String>,
     resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
     client_ctx: &ClientContext,
     attempt: AttemptInfo,
@@ -886,6 +934,7 @@ async fn anthropic_passthrough_dispatch(
         let upstream_model_c = upstream_model.clone();
         let team_id_c = team_id.clone();
         let user_id_c = user_id.clone();
+        let user_name_c = user_name.clone();
         // #492: log the same client IP/UA on streamed responses.
         let client_ctx_c = client_ctx.clone();
         // Winning-attempt classification (#655) for the stream-end emit.
@@ -944,6 +993,7 @@ async fn anthropic_passthrough_dispatch(
                     &upstream_model_c,
                     team_id_c.as_deref(),
                     user_id_c.as_deref(),
+                    user_name_c.as_deref(),
                     200,
                     started.elapsed(),
                     metrics,
@@ -1197,6 +1247,7 @@ async fn cross_provider_dispatch(
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
+    user_name: Option<String>,
     resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
     client: &ClientContext,
     attempt: AttemptInfo,
@@ -1329,6 +1380,7 @@ async fn cross_provider_dispatch(
         let upstream_model_for_telem = upstream_model.clone();
         let team_id_for_telem = team_id;
         let user_id_for_telem = user_id;
+        let user_name_for_telem = user_name;
         let started_for_telem = started;
         // #492: log the same client IP/UA on streamed responses.
         let client_for_telem = client.clone();
@@ -1384,6 +1436,7 @@ async fn cross_provider_dispatch(
                     &upstream_model_for_telem,
                     team_id_for_telem.as_deref(),
                     user_id_for_telem.as_deref(),
+                    user_name_for_telem.as_deref(),
                     200,
                     started_for_telem.elapsed(),
                     metrics,
@@ -1800,6 +1853,8 @@ fn emit_anthropic_usage_event(
     upstream_model: &str,
     team_id: Option<&str>,
     user_id: Option<&str>,
+    // #890 req-3: readable owner name (1:1 with user_id) for the metric label.
+    user_name: Option<&str>,
     status_code: u16,
     elapsed: Duration,
     metrics: AnthropicUsageMetrics,
@@ -1824,6 +1879,9 @@ fn emit_anthropic_usage_event(
     } else {
         Default::default()
     };
+    // #890 req-3: readable provider-key name for the metric label (shared
+    // resolver so chat + messages can't drift).
+    let provider_key_name = crate::usage_attr::provider_key_metric_name(&snap, provider_key_id);
     let event = UsageEvent {
         request_id: request_id.to_string(),
         occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
@@ -1873,9 +1931,11 @@ fn emit_anthropic_usage_event(
             model,
             upstream_model,
             provider_key_id,
+            provider_key_name: &provider_key_name,
             api_key_id,
             team_id: team_id.unwrap_or("unknown"),
             user_id: user_id.unwrap_or("unknown"),
+            user_name: user_name.unwrap_or("unknown"),
         },
         LlmUsage {
             input_tokens: metrics.prompt_tokens,
@@ -1886,6 +1946,13 @@ fn emit_anthropic_usage_event(
             spend_usd: 0.0,
         },
     );
+    // #890 req-4: token volume by inbound client type (covers streaming and
+    // non-streaming — every /v1/messages usage event flows through here).
+    state.metrics.record_llm_tokens_by_client(
+        aisix_obs::client_type_from_user_agent(&client.user_agent),
+        u64::from(metrics.prompt_tokens),
+        u64::from(metrics.completion_tokens),
+    );
     if metrics.ttft_ms > 0 {
         state.metrics.record_time_to_first_token(
             UsageLabels {
@@ -1895,9 +1962,11 @@ fn emit_anthropic_usage_event(
                 model,
                 upstream_model,
                 provider_key_id,
+                provider_key_name: &provider_key_name,
                 api_key_id,
                 team_id: team_id.unwrap_or("unknown"),
                 user_id: user_id.unwrap_or("unknown"),
+                user_name: user_name.unwrap_or("unknown"),
             },
             Duration::from_millis(u64::from(metrics.ttft_ms)),
         );

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -33,6 +33,28 @@ pub(crate) fn provider_telemetry_tags(
         .unwrap_or_default()
 }
 
+/// Resolve the readable provider-key NAME for the #890 req-3 metric label
+/// (`provider_key_name`). Returns the ProviderKey's `display_name`
+/// (control-char stripped + length-capped via [`sanitize_tag`]) or
+/// `"unknown"` when the id is empty / unresolved / blank. 1:1 with the
+/// `provider_key_id`, so it adds no metric series. Shared by the chat +
+/// messages metric emitters so the value can't drift between handlers.
+pub(crate) fn provider_key_metric_name(snap: &AisixSnapshot, provider_key_id: &str) -> String {
+    if provider_key_id.is_empty() {
+        return "unknown".to_string();
+    }
+    let name = snap
+        .provider_keys
+        .get_by_id(provider_key_id)
+        .map(|e| sanitize_tag(e.value.display_name.clone()))
+        .unwrap_or_default();
+    if name.is_empty() {
+        "unknown".to_string()
+    } else {
+        name
+    }
+}
+
 /// Stamp the five per-PK attribution fields onto an in-progress UsageEvent,
 /// sanitising the operator-controlled tag strings (control-char strip + length
 /// cap) before they hit the wire. One source of truth for the mapping so the

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -111,6 +111,13 @@
         "string",
         "null"
       ]
+    },
+    "user_name": {
+      "description": "Readable display name of the owning member (#890 req-3). Synced by cp-api solely so the proxy can stamp a human-readable `user_name` metric label alongside `user_id`; never used for auth or routing. Absent on older cp-api payloads → the metric label falls back to `\"unknown\"` (DP-first rollout).",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "required": [

--- a/tests/e2e/src/cases/metrics-dimensions-890-e2e.test.ts
+++ b/tests/e2e/src/cases/metrics-dimensions-890-e2e.test.ts
@@ -1,0 +1,319 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// Issue #890: extra metric dimensions —
+//  req-1 `stream` label on the request/duration series,
+//  req-2 `is_fallback` label + the request counter now also counting
+//        FAILED requests (so a success rate is computable),
+//  req-3 readable `provider_key_name` + `user_name` alongside the ids,
+//  req-4 a dedicated bounded `aisix_llm_tokens_by_client_total{client_type}`.
+const CALLER_PLAINTEXT = "sk-dims-890-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const PK_NAME = "prom890-pk";
+const USER_NAME = "alice-890";
+const USER_ID = "member-890";
+const NONSTREAM_MODEL = "dims890-nonstream";
+const STREAM_MODEL = "dims890-stream";
+const ERROR_MODEL = "dims890-error";
+
+describe("metrics dimensions #890 e2e", () => {
+  let app: SpawnedApp | undefined;
+  let nonStreamUpstream: OpenAiUpstream | undefined;
+  let streamUpstream: OpenAiUpstream | undefined;
+  let errorUpstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    nonStreamUpstream = await startOpenAiUpstream({ nonStreamBody: responseBody() });
+    streamUpstream = await startOpenAiUpstream({
+      streamEvents: streamEvents(),
+      // Small per-event delay so the stream is genuinely incremental and
+      // TTFT is measurable (> 0).
+      eventDelayMs: 2,
+    });
+    errorUpstream = await startOpenAiUpstream({
+      status: 500,
+      errorBody: { error: { message: "boom" } },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const nsPk = await admin.createProviderKey({
+      display_name: PK_NAME,
+      secret: "sk-mock",
+      api_base: `${nonStreamUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: NONSTREAM_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: nsPk.id,
+    });
+
+    const stPk = await admin.createProviderKey({
+      display_name: `${PK_NAME}-stream`,
+      secret: "sk-mock",
+      api_base: `${streamUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: STREAM_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stPk.id,
+    });
+
+    const errPk = await admin.createProviderKey({
+      display_name: `${PK_NAME}-error`,
+      secret: "sk-mock",
+      api_base: `${errorUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: ERROR_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: errPk.id,
+    });
+
+    // The api-key payload carries user_id + user_name — the DP stamps the
+    // readable name onto metric labels (req-3), proving cp-api's pushed name
+    // flows end-to-end. The DP standalone admin API intentionally only
+    // accepts key_hash/allowed_models/rate_limit (member/team identity is a
+    // cp-api concern), so we write the full ApiKey straight to etcd — the
+    // real production path (cp-api → etcd → DP loader).
+    await new EtcdClient().put(
+      `${app.etcdPrefix}/api_keys/${randomUUID()}`,
+      JSON.stringify({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: [NONSTREAM_MODEL, STREAM_MODEL, ERROR_MODEL],
+        user_id: USER_ID,
+        user_name: USER_NAME,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await nonStreamUpstream?.close();
+    await streamUpstream?.close();
+    await errorUpstream?.close();
+  });
+
+  // req-3 (names) + req-4 (client_type) + req-1 (stream="false" on a
+  // non-streaming request) + req-2 (is_fallback label present, off the
+  // bucketed histogram).
+  test("non-streaming request carries readable names, client_type, stream=false, is_fallback=false", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const probe = await proxy.chat({
+        model: NONSTREAM_MODEL,
+        messages: [{ role: "user", content: "ready" }],
+      });
+      return probe.status === 200;
+    });
+
+    // Raw fetch so we can set a recognised SDK User-Agent — the ProxyClient
+    // wrapper hardcodes its headers. The DP normalises this to a bounded
+    // `client_type` (req-4); the full UA never becomes a label.
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+        "user-agent": "openai-python/1.30.1",
+      },
+      body: JSON.stringify({
+        model: NONSTREAM_MODEL,
+        messages: [{ role: "user", content: "dims" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const text = await scrape(app);
+
+    // req-3: readable names ride alongside the ids (1:1, cardinality-neutral).
+    expect(text).toContain(`provider_key_name="${PK_NAME}"`);
+    expect(text).toContain(`user_name="${USER_NAME}"`);
+    expect(text).toContain(`user_id="${USER_ID}"`);
+
+    // req-1: a non-streaming request is labelled stream="false" on the E2E
+    // latency histogram, so a TTFT-vs-E2E comparison can exclude it.
+    expect(text).toMatch(
+      /aisix_llm_request_duration_seconds\{[^}]*stream="false"[^}]*\}/,
+    );
+
+    // req-2: is_fallback is present on the request counter (no fallback here).
+    expect(text).toMatch(
+      /aisix_llm_requests_total\{[^}]*is_fallback="false"[^}]*\}/,
+    );
+
+    // req-4: dedicated bounded client metric; client_type normalised from UA.
+    expect(text).toContain("aisix_llm_tokens_by_client_total");
+    expect(text).toMatch(
+      /aisix_llm_tokens_by_client_total\{[^}]*client_type="openai-python"[^}]*\}/,
+    );
+
+    // is_fallback must NOT leak onto the (bucketed) duration histogram — it
+    // is a success-rate dimension, kept off the per-bucket series.
+    for (const line of text.split("\n")) {
+      if (line.startsWith("aisix_llm_request_duration_seconds")) {
+        expect(line).not.toContain("is_fallback=");
+      }
+    }
+  });
+
+  // req-1: a streaming request is labelled stream="true" on the E2E latency
+  // histogram, and TTFT (streaming-only by nature) is recorded — so the two
+  // can be compared on the same streaming-only sample.
+  test('streaming request carries stream="true" and records TTFT', async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const probe = await proxy.chat({
+        model: STREAM_MODEL,
+        messages: [{ role: "user", content: "ready" }],
+        stream: true,
+      });
+      return probe.status === 200;
+    });
+
+    const r = await proxy.chat({
+      model: STREAM_MODEL,
+      messages: [{ role: "user", content: "stream" }],
+      stream: true,
+    });
+    expect(r.status).toBe(200);
+
+    // TTFT is recorded from the SSE on_complete callback, which may land a
+    // beat after the client finishes reading the body — poll briefly.
+    let text = "";
+    for (let i = 0; i < 60; i++) {
+      text = await scrape(app);
+      const hasStreamTrue =
+        /aisix_llm_request_duration_seconds\{[^}]*stream="true"[^}]*\}/.test(
+          text,
+        );
+      if (hasStreamTrue && text.includes("aisix_llm_time_to_first_token_seconds")) {
+        break;
+      }
+      await new Promise((res) => setTimeout(res, 50));
+    }
+
+    expect(text).toMatch(
+      /aisix_llm_request_duration_seconds\{[^}]*stream="true"[^}]*\}/,
+    );
+    expect(text).toContain("aisix_llm_time_to_first_token_seconds");
+  });
+
+  // req-2: the request counter previously only counted successes, so a
+  // success rate was not computable from it. A FAILED upstream request must
+  // now also increment aisix_llm_requests_total (outcome != success) and
+  // populate aisix_proxy_failed_requests_total.
+  test("a failed upstream request increments the request counter (success rate is computable)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      // Once the model has propagated, dispatch reaches the upstream and the
+      // forced 500 surfaces as a 5xx — distinguishes "ready" from the 404
+      // model-not-found of an un-propagated snapshot.
+      const probe = await proxy.chat({
+        model: ERROR_MODEL,
+        messages: [{ role: "user", content: "ready" }],
+      });
+      return probe.status >= 500;
+    });
+
+    const r = await proxy.chat({
+      model: ERROR_MODEL,
+      messages: [{ role: "user", content: "fail" }],
+    });
+    expect(r.status).toBeGreaterThanOrEqual(500);
+
+    const text = await scrape(app);
+    // The failure is counted on the rich request counter with a non-success
+    // outcome — the denominator now includes failures.
+    expect(text).toMatch(
+      /aisix_llm_requests_total\{[^}]*outcome="upstream_error"[^}]*\}/,
+    );
+    // The previously-dead failed-requests counter is now populated too.
+    expect(text).toContain("aisix_proxy_failed_requests_total");
+  });
+});
+
+async function scrape(app: SpawnedApp): Promise<string> {
+  const res = await fetch(`${app.metricsUrl}/metrics`);
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+function responseBody() {
+  return {
+    id: "chatcmpl-dims-890",
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: "hello" },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 11, completion_tokens: 13, total_tokens: 24 },
+  };
+}
+
+function streamEvents(): string[] {
+  return [
+    JSON.stringify({
+      id: "chatcmpl-dims-890-stream",
+      object: "chat.completion.chunk",
+      model: "gpt-4o-mini",
+      choices: [{ index: 0, delta: { role: "assistant" } }],
+    }),
+    JSON.stringify({
+      id: "chatcmpl-dims-890-stream",
+      object: "chat.completion.chunk",
+      model: "gpt-4o-mini",
+      choices: [{ index: 0, delta: { content: "hello" } }],
+    }),
+    JSON.stringify({
+      id: "chatcmpl-dims-890-stream",
+      object: "chat.completion.chunk",
+      model: "gpt-4o-mini",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 7, completion_tokens: 5, total_tokens: 12 },
+    }),
+    "[DONE]",
+  ];
+}


### PR DESCRIPTION
Adds the extra metric dimensions requested in api7/AISIX-Cloud#890. Scoped to the `/v1/chat/completions` and `/v1/messages` handlers — the two that emit the `aisix_proxy_*` / `aisix_llm_*` request+usage series.

## What changed

- **req-1 `stream` label** on the request counter and the E2E duration metric (`aisix_llm_request_duration_seconds`). TTFT is streaming-only by nature, so a P90 comparison against the E2E latency was apples-to-oranges; `stream` lets the E2E side be restricted to the same streaming-only sample.
- **req-2 success rate** — added an `is_fallback` label on the request counters, and the request counters now also count **failed** requests. Previously `aisix_llm_requests_total` / `aisix_proxy_requests_total` were emitted only on the success path, so a success rate (`success / all-outcomes`) was not computable from them and `aisix_proxy_failed_requests_total` had no live increment. The failure path now records them with the right `outcome` (`client_error` / `upstream_error` / `rate_limited`). `is_fallback` distinguishes requests served via a fallback target so they can be excluded from the denominator. It is kept **off** the bucketed duration histogram (a success-rate dimension, not a latency one) to avoid doubling every latency bucket.
- **req-3 readable names** — `provider_key_name` and `user_name` ride alongside the existing `provider_key_id` / `user_id`. They are 1:1 with the ids, so they add **no** new time series. `provider_key_name` resolves from the snapshot (shared resolver so chat + messages can't drift). `user_name` is a new optional field on the api-key config that cp-api syncs; it defaults to `unknown` until then (DP-first rollout — the field is additive on a `deny_unknown_fields` struct, so the DP must ship before cp-api emits it).
- **req-4 client dimension** — a dedicated low-cardinality series `aisix_llm_tokens_by_client_total{client_type,token_type}`. `client_type` is normalised from the inbound `User-Agent` into a bounded allowlist of known SDKs/tools (+ `other` / `unknown`) returned as `&'static str`, so a client-controlled header can never grow Prometheus cardinality, and it lives on its own metric rather than multiplying the per-key token series. The full user-agent and its version stay in logs / `UsageEvent` (the high-cardinality analytics path), never as a label.

## Compatibility

- `req-3 user_name` is cross-plane: this DP PR must merge and build a new image before the paired cp-api PR starts emitting `user_name` on the api-key config (the DP would otherwise reject the unknown field). Until cp-api emits it, `user_name="unknown"`.
- New labels widen existing series. `stream` × `is_fallback` add a bounded 2×2 to the request counters; the readable names are cardinality-neutral; the client metric is independent and bounded.

## Tests

- Unit: label rendering for all new dimensions, the UA→`client_type` allowlist normalisation (incl. version-collapse and the empty/unknown buckets), and `is_fallback` staying off the duration histogram.
- E2E (`tests/e2e/src/cases/metrics-dimensions-890-e2e.test.ts`): a real `aisix` + etcd + mock upstreams exercising all four dimensions end-to-end — readable names, `client_type` from a spoofed SDK UA, `stream="false"/"true"`, and a failed upstream request incrementing the request counter.

Fixes api7/AISIX-Cloud#890

🤖 Generated with [Claude Code](https://claude.com/claude-code)