### PR TITLE
feat(mcp): McpBridge — upstream MCP client over Streamable HTTP (DP-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "dashmap",
  "futures",
  "http 1.4.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -142,7 +142,7 @@ dependencies = [
  "chrono",
  "hmac 0.12.1",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha1",
@@ -151,6 +151,19 @@ dependencies = [
  "tracing",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "aisix-mcp"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -171,7 +184,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "object_store",
  "parking_lot",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -193,7 +206,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -214,7 +227,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 1.4.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -256,7 +269,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 1.4.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -278,7 +291,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "jsonwebtoken",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -307,7 +320,7 @@ dependencies = [
  "http-body-util",
  "ipnet",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -371,7 +384,7 @@ dependencies = [
  "etcd-client",
  "hostname",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls 0.23.38",
  "serde",
  "serde_json",
@@ -2629,7 +2642,7 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "uuid-simd",
@@ -3031,7 +3044,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.10.1",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
  "serde",
@@ -3131,6 +3144,12 @@ dependencies = [
  "structmeta",
  "syn",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"
@@ -3706,9 +3725,43 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -3723,6 +3776,37 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3871,7 +3955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
 ]
@@ -3894,8 +3978,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -3905,6 +3991,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4210,6 +4308,19 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -5028,6 +5139,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,6 +2602,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,6 +3453,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3744,15 +3794,21 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.38",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -3906,6 +3962,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.38",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.12",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3938,6 +4021,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -4252,6 +4344,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -5025,6 +5133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5193,6 +5311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,6 +5343,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/aisix-core",
     "crates/aisix-etcd",
     "crates/aisix-gateway",
+    "crates/aisix-mcp",
     "crates/aisix-provider-openai",
     "crates/aisix-provider-anthropic",
     "crates/aisix-provider-vertex",

--- a/crates/aisix-mcp/Cargo.toml
+++ b/crates/aisix-mcp/Cargo.toml
@@ -30,6 +30,12 @@ features = [
     "base64",
     "transport-streamable-http-client",
     "transport-streamable-http-client-reqwest",
+    # `transport-streamable-http-client-reqwest` only wires `dep:reqwest`
+    # with NO TLS backend; rmcp gates rustls behind its separate `reqwest`
+    # feature (`reqwest?/rustls`). Without this, `https://` upstreams — i.e.
+    # every real authenticated upstream — fail to connect. rustls matches the
+    # workspace TLS posture (reqwest 0.12 already uses rustls-tls elsewhere).
+    "reqwest",
 ]
 
 [dev-dependencies]

--- a/crates/aisix-mcp/Cargo.toml
+++ b/crates/aisix-mcp/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "aisix-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "aisix: MCP gateway — upstream MCP server client (Streamable HTTP) behind the McpBridge trait"
+
+[dependencies]
+tokio.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+# Official MCP Rust SDK. Pinned exactly: rmcp is <16 months old and still
+# ships breaking changes on a roughly-monthly cadence, so we hold a fixed
+# version and keep all rmcp types behind this crate's `McpBridge` trait to
+# absorb API drift. Production only needs the upstream-facing client; the
+# server side (used to stand up a real MCP server in tests, and later for the
+# DP `/mcp` endpoint) is a dev-dependency so the gateway binary does not link
+# it yet.
+[dependencies.rmcp]
+version = "=1.8.0"
+default-features = false
+features = [
+    "client",
+    "base64",
+    "transport-streamable-http-client",
+    "transport-streamable-http-client-reqwest",
+]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+axum.workspace = true
+
+# Server-side rmcp, dev-only: lets the integration test stand up a real MCP
+# server over real Streamable HTTP (no mock transport) for the client to talk
+# to end-to-end.
+[dev-dependencies.rmcp]
+version = "=1.8.0"
+default-features = false
+features = [
+    "server",
+    "transport-streamable-http-server",
+]

--- a/crates/aisix-mcp/src/bridge.rs
+++ b/crates/aisix-mcp/src/bridge.rs
@@ -11,6 +11,8 @@
 //! the rest of the data plane never depends on the SDK directly. That keeps
 //! rmcp's still-moving API contained to this file.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use rmcp::model::CallToolRequestParams;
 use rmcp::service::{RoleClient, RunningService};
@@ -20,13 +22,19 @@ use rmcp::ServiceExt;
 
 use crate::error::McpError;
 
+/// Default deadline for a single upstream operation (connect / list / call).
+/// rmcp's high-level client sets no request timeout and reqwest has no default
+/// one, so without this a hung or slow upstream pins the gateway request task
+/// indefinitely. Overridable per upstream via [`McpUpstream::with_timeout`].
+pub const DEFAULT_UPSTREAM_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// How the gateway authenticates to an upstream MCP server. The credential is
 /// held here on the gateway side and is never exposed to the calling agent —
 /// the agent presents only its AISIX key. The MCP authorization spec
 /// (2025-11-25) also requires that a downstream client token is never passed
 /// through to the upstream; a Bearer set here is a distinct, gateway-held
 /// credential.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum McpAuth {
     /// No upstream auth — the server is reachable as-is.
     None,
@@ -35,22 +43,49 @@ pub enum McpAuth {
     Bearer(String),
 }
 
+// Hand-written so the gateway-held token never lands in logs via `{:?}`. This
+// crate is the credential holder; a derived `Debug` would print the bearer in
+// plaintext the moment any caller logs an upstream.
+impl std::fmt::Debug for McpAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            McpAuth::None => f.write_str("None"),
+            McpAuth::Bearer(_) => f.write_str("Bearer(***redacted***)"),
+        }
+    }
+}
+
 /// Connection parameters for a single upstream MCP server.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct McpUpstream {
     /// The server's Streamable HTTP MCP endpoint, e.g.
     /// `https://api.example.com/mcp`.
     pub url: String,
     /// Upstream authentication, held gateway-side.
     pub auth: McpAuth,
+    /// Per-operation deadline. Defaults to [`DEFAULT_UPSTREAM_TIMEOUT`].
+    pub timeout: Duration,
+}
+
+// Manual so a `Bearer` token cannot leak through `McpUpstream`'s `Debug`
+// (delegates to the redacting `McpAuth` impl above).
+impl std::fmt::Debug for McpUpstream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpUpstream")
+            .field("url", &self.url)
+            .field("auth", &self.auth)
+            .field("timeout", &self.timeout)
+            .finish()
+    }
 }
 
 impl McpUpstream {
-    /// Build an unauthenticated upstream.
+    /// Build an unauthenticated upstream with the default timeout.
     pub fn new(url: impl Into<String>) -> Self {
         Self {
             url: url.into(),
             auth: McpAuth::None,
+            timeout: DEFAULT_UPSTREAM_TIMEOUT,
         }
     }
 
@@ -59,9 +94,19 @@ impl McpUpstream {
         self.auth = McpAuth::Bearer(token.into());
         self
     }
+
+    /// Override the per-operation deadline.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
 }
 
 /// One tool advertised by an upstream server, normalised off the wire shape.
+///
+/// Minimal for this step: tool annotations (`readOnlyHint` / `destructiveHint`)
+/// and `output_schema` are dropped here and will be carried when the per-tool
+/// ACL / guardrail layer (DP-4) needs them.
 #[derive(Debug, Clone, PartialEq)]
 pub struct McpTool {
     /// The tool's name, as the upstream advertises it (no gateway prefix yet).
@@ -79,6 +124,9 @@ pub struct McpToolResult {
     /// resource links, …). Left as raw JSON here; the downstream endpoint
     /// shapes it for the agent.
     pub content: serde_json::Value,
+    /// The tool's structured result, when it returns one (MCP `structuredContent`).
+    /// A tool may return only structured content with an empty `content` array.
+    pub structured_content: Option<serde_json::Value>,
     /// Whether the upstream flagged this result as a tool-level error.
     pub is_error: bool,
 }
@@ -105,11 +153,13 @@ pub trait McpBridge: Send + Sync {
 /// upstream. Dropping it tears the session down.
 pub struct RmcpBridge {
     running: RunningService<RoleClient, ()>,
+    timeout: Duration,
 }
 
 impl RmcpBridge {
     /// Open a session to `upstream`: build the Streamable HTTP transport
-    /// (injecting gateway-held auth) and run the `initialize` handshake.
+    /// (injecting gateway-held auth) and run the `initialize` handshake,
+    /// bounded by the upstream's timeout.
     pub async fn connect(upstream: &McpUpstream) -> Result<Self, McpError> {
         let transport = match &upstream.auth {
             McpAuth::None => StreamableHttpClientTransport::from_uri(upstream.url.clone()),
@@ -118,18 +168,23 @@ impl RmcpBridge {
                     .auth_header(token.clone()),
             ),
         };
-        let running = ().serve(transport).await.map_err(|e| McpError::Connect(e.to_string()))?;
-        Ok(Self { running })
+        let running = tokio::time::timeout(upstream.timeout, ().serve(transport))
+            .await
+            .map_err(|_| McpError::Connect("upstream MCP connect timed out".to_string()))?
+            .map_err(|e| McpError::Connect(e.to_string()))?;
+        Ok(Self {
+            running,
+            timeout: upstream.timeout,
+        })
     }
 }
 
 #[async_trait]
 impl McpBridge for RmcpBridge {
     async fn list_tools(&self) -> Result<Vec<McpTool>, McpError> {
-        let result = self
-            .running
-            .list_tools(None)
+        let result = tokio::time::timeout(self.timeout, self.running.list_tools(None))
             .await
+            .map_err(|_| McpError::Request("upstream tools/list timed out".to_string()))?
             .map_err(|e| McpError::Request(e.to_string()))?;
         Ok(result.tools.into_iter().map(into_mcp_tool).collect())
     }
@@ -149,15 +204,15 @@ impl McpBridge for RmcpBridge {
                 ))
             }
         };
-        let result = self
-            .running
-            .call_tool(params)
+        let result = tokio::time::timeout(self.timeout, self.running.call_tool(params))
             .await
+            .map_err(|_| McpError::Request("upstream tools/call timed out".to_string()))?
             .map_err(|e| McpError::Request(e.to_string()))?;
         let content = serde_json::to_value(&result.content)
             .map_err(|e| McpError::Request(format!("failed to encode tool result: {e}")))?;
         Ok(McpToolResult {
             content,
+            structured_content: result.structured_content,
             is_error: result.is_error.unwrap_or(false),
         })
     }

--- a/crates/aisix-mcp/src/bridge.rs
+++ b/crates/aisix-mcp/src/bridge.rs
@@ -1,0 +1,173 @@
+//! The upstream MCP client, behind the [`McpBridge`] trait.
+//!
+//! A bridge owns one live MCP session to a single upstream server (Streamable
+//! HTTP transport) and exposes just the two operations the gateway needs in
+//! this first cut: enumerate the server's tools, and invoke one. Aggregating
+//! many bridges into the downstream-facing `/mcp` endpoint, tool namespacing,
+//! and wiring into the shared guardrail/quota pipeline come in later steps —
+//! this layer only proves a governed tunnel to one real upstream.
+//!
+//! All `rmcp` types are converted to this crate's own DTOs at the boundary so
+//! the rest of the data plane never depends on the SDK directly. That keeps
+//! rmcp's still-moving API contained to this file.
+
+use async_trait::async_trait;
+use rmcp::model::CallToolRequestParams;
+use rmcp::service::{RoleClient, RunningService};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt;
+
+use crate::error::McpError;
+
+/// How the gateway authenticates to an upstream MCP server. The credential is
+/// held here on the gateway side and is never exposed to the calling agent —
+/// the agent presents only its AISIX key. The MCP authorization spec
+/// (2025-11-25) also requires that a downstream client token is never passed
+/// through to the upstream; a Bearer set here is a distinct, gateway-held
+/// credential.
+#[derive(Debug, Clone)]
+pub enum McpAuth {
+    /// No upstream auth — the server is reachable as-is.
+    None,
+    /// Send `Authorization: Bearer <token>` on every upstream request. The
+    /// token is the raw value, without the `Bearer ` prefix.
+    Bearer(String),
+}
+
+/// Connection parameters for a single upstream MCP server.
+#[derive(Debug, Clone)]
+pub struct McpUpstream {
+    /// The server's Streamable HTTP MCP endpoint, e.g.
+    /// `https://api.example.com/mcp`.
+    pub url: String,
+    /// Upstream authentication, held gateway-side.
+    pub auth: McpAuth,
+}
+
+impl McpUpstream {
+    /// Build an unauthenticated upstream.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            auth: McpAuth::None,
+        }
+    }
+
+    /// Set Bearer auth (raw token, no `Bearer ` prefix).
+    pub fn with_bearer(mut self, token: impl Into<String>) -> Self {
+        self.auth = McpAuth::Bearer(token.into());
+        self
+    }
+}
+
+/// One tool advertised by an upstream server, normalised off the wire shape.
+#[derive(Debug, Clone, PartialEq)]
+pub struct McpTool {
+    /// The tool's name, as the upstream advertises it (no gateway prefix yet).
+    pub name: String,
+    /// Human-readable description, if the server provides one.
+    pub description: Option<String>,
+    /// JSON Schema for the tool's arguments, as a JSON object.
+    pub input_schema: serde_json::Value,
+}
+
+/// The outcome of a `tools/call`, normalised off the wire shape.
+#[derive(Debug, Clone, PartialEq)]
+pub struct McpToolResult {
+    /// The content blocks the tool returned, as a JSON array (text, images,
+    /// resource links, …). Left as raw JSON here; the downstream endpoint
+    /// shapes it for the agent.
+    pub content: serde_json::Value,
+    /// Whether the upstream flagged this result as a tool-level error.
+    pub is_error: bool,
+}
+
+/// The gateway's view of one upstream MCP server. Implemented by
+/// [`RmcpBridge`]; kept as a trait so the rest of the data plane depends on
+/// this surface rather than on `rmcp`, and so the upstream can be stubbed in
+/// higher-layer tests.
+#[async_trait]
+pub trait McpBridge: Send + Sync {
+    /// List the tools the upstream currently exposes.
+    async fn list_tools(&self) -> Result<Vec<McpTool>, McpError>;
+
+    /// Invoke a tool by name with the given JSON arguments. `arguments` must
+    /// be a JSON object or `null` (no arguments); anything else is rejected.
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<McpToolResult, McpError>;
+}
+
+/// `rmcp`-backed [`McpBridge`]: holds one running client session to the
+/// upstream. Dropping it tears the session down.
+pub struct RmcpBridge {
+    running: RunningService<RoleClient, ()>,
+}
+
+impl RmcpBridge {
+    /// Open a session to `upstream`: build the Streamable HTTP transport
+    /// (injecting gateway-held auth) and run the `initialize` handshake.
+    pub async fn connect(upstream: &McpUpstream) -> Result<Self, McpError> {
+        let transport = match &upstream.auth {
+            McpAuth::None => StreamableHttpClientTransport::from_uri(upstream.url.clone()),
+            McpAuth::Bearer(token) => StreamableHttpClientTransport::from_config(
+                StreamableHttpClientTransportConfig::with_uri(upstream.url.clone())
+                    .auth_header(token.clone()),
+            ),
+        };
+        let running = ().serve(transport).await.map_err(|e| McpError::Connect(e.to_string()))?;
+        Ok(Self { running })
+    }
+}
+
+#[async_trait]
+impl McpBridge for RmcpBridge {
+    async fn list_tools(&self) -> Result<Vec<McpTool>, McpError> {
+        let result = self
+            .running
+            .list_tools(None)
+            .await
+            .map_err(|e| McpError::Request(e.to_string()))?;
+        Ok(result.tools.into_iter().map(into_mcp_tool).collect())
+    }
+
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<McpToolResult, McpError> {
+        let mut params = CallToolRequestParams::new(name.to_string());
+        params = match arguments {
+            serde_json::Value::Null => params,
+            serde_json::Value::Object(map) => params.with_arguments(map),
+            _ => {
+                return Err(McpError::Request(
+                    "tool arguments must be a JSON object or null".to_string(),
+                ))
+            }
+        };
+        let result = self
+            .running
+            .call_tool(params)
+            .await
+            .map_err(|e| McpError::Request(e.to_string()))?;
+        let content = serde_json::to_value(&result.content)
+            .map_err(|e| McpError::Request(format!("failed to encode tool result: {e}")))?;
+        Ok(McpToolResult {
+            content,
+            is_error: result.is_error.unwrap_or(false),
+        })
+    }
+}
+
+/// Normalise an `rmcp` `Tool` into our [`McpTool`] DTO.
+fn into_mcp_tool(tool: rmcp::model::Tool) -> McpTool {
+    McpTool {
+        name: tool.name.into_owned(),
+        description: tool.description.map(|d| d.into_owned()),
+        input_schema: serde_json::Value::Object((*tool.input_schema).clone()),
+    }
+}

--- a/crates/aisix-mcp/src/error.rs
+++ b/crates/aisix-mcp/src/error.rs
@@ -1,0 +1,22 @@
+//! Typed errors for the MCP upstream client.
+//!
+//! These are deliberately coarse for the first cut: the gateway only needs to
+//! distinguish "could not establish the session" from "the session is up but
+//! the RPC failed" so the proxy layer can pick a client-visible status. Finer
+//! mapping (per-JSON-RPC-error-code) lands when the `/mcp` endpoint wires MCP
+//! traffic into the shared error-translation path.
+
+/// Error surfaced by an [`crate::McpBridge`].
+#[derive(Debug, thiserror::Error)]
+pub enum McpError {
+    /// The upstream MCP session could not be established — DNS/TCP/TLS
+    /// failure, the `initialize` handshake was rejected, or the URL/auth is
+    /// wrong. Non-retryable without operator action.
+    #[error("failed to connect to upstream MCP server: {0}")]
+    Connect(String),
+
+    /// The session is established but an MCP request (`tools/list`,
+    /// `tools/call`) failed at the protocol layer.
+    #[error("upstream MCP request failed: {0}")]
+    Request(String),
+}

--- a/crates/aisix-mcp/src/lib.rs
+++ b/crates/aisix-mcp/src/lib.rs
@@ -1,0 +1,20 @@
+//! aisix-mcp — the MCP gateway data-plane crate.
+//!
+//! First step (DP-2): a governed client tunnel to a single upstream MCP server
+//! over Streamable HTTP, exposed through the [`McpBridge`] trait. Later steps
+//! aggregate many upstreams behind the downstream-facing `/mcp` endpoint and
+//! route MCP tool traffic through the same auth / ACL / guardrail / quota
+//! pipeline as LLM traffic.
+//!
+//! The official `rmcp` SDK does the JSON-RPC + Streamable HTTP plumbing; this
+//! crate keeps every rmcp type behind [`McpBridge`] so the SDK's still-moving
+//! API stays contained here.
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+pub mod bridge;
+pub mod error;
+
+pub use bridge::{McpAuth, McpBridge, McpTool, McpToolResult, McpUpstream, RmcpBridge};
+pub use error::McpError;

--- a/crates/aisix-mcp/tests/upstream_roundtrip.rs
+++ b/crates/aisix-mcp/tests/upstream_roundtrip.rs
@@ -59,6 +59,10 @@ impl ServerHandler for EchoServer {
             .and_then(|m| m.get("text"))
             .and_then(|v| v.as_str())
             .unwrap_or_default();
+        // A `sleep` argument lets the timeout test drive a slow upstream.
+        if text == "sleep" {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 
@@ -141,9 +145,9 @@ async fn lists_and_calls_tools_over_streamable_http() {
         .await
         .expect("call echo tool");
     assert!(!result.is_error, "echo should not be a tool error");
-    assert!(
-        result.content.to_string().contains("hello mcp"),
-        "echoed content should carry the input, got: {}",
+    assert_eq!(
+        result.content[0]["text"], "hello mcp",
+        "echoed text block should equal the input, got: {}",
         result.content
     );
 
@@ -175,4 +179,23 @@ async fn forwards_gateway_held_bearer_to_upstream() {
     let tools = bridge.list_tools().await.expect("list tools");
     assert_eq!(tools.len(), 1);
     assert_eq!(tools[0].name, "echo");
+}
+
+#[tokio::test]
+async fn upstream_call_times_out_instead_of_hanging() {
+    let addr = spawn_echo_server(None).await;
+    let upstream = McpUpstream::new(format!("http://{addr}/mcp"))
+        .with_timeout(std::time::Duration::from_millis(200));
+    let bridge = RmcpBridge::connect(&upstream).await.expect("connect");
+
+    // The server sleeps 2s on this call; the 200ms deadline must fire first.
+    let started = std::time::Instant::now();
+    let result = bridge
+        .call_tool("echo", serde_json::json!({ "text": "sleep" }))
+        .await;
+    assert!(result.is_err(), "a call exceeding the deadline must error");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(1),
+        "call should give up at the ~200ms deadline, not wait out the 2s server sleep"
+    );
 }

--- a/crates/aisix-mcp/tests/upstream_roundtrip.rs
+++ b/crates/aisix-mcp/tests/upstream_roundtrip.rs
@@ -1,0 +1,178 @@
+//! End-to-end test of [`RmcpBridge`] against a *real* MCP server.
+//!
+//! No mock transport: we stand up an actual `rmcp` Streamable HTTP server
+//! (an "echo" tool) on an ephemeral port, nested in axum, and drive it through
+//! the public `McpBridge` surface over real HTTP — the same path a production
+//! upstream takes. Two contracts are pinned:
+//!   1. `initialize` → `tools/list` → `tools/call` round-trips correctly.
+//!   2. The gateway-held Bearer is sent to the upstream (and its absence is
+//!      rejected), per the MCP authorization no-passthrough model.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use aisix_mcp::{McpBridge, McpUpstream, RmcpBridge};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ListToolsResult, PaginatedRequestParams,
+    ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::{ErrorData, RoleServer, ServerHandler};
+
+/// A minimal real MCP server exposing one tool, `echo`, that returns its
+/// `text` argument back as a text content block.
+#[derive(Clone, Default)]
+struct EchoServer;
+
+impl ServerHandler for EchoServer {
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "text": { "type": "string" } },
+            "required": ["text"],
+        });
+        let schema_obj = schema.as_object().expect("schema is an object").clone();
+        let tool = Tool::new("echo", "Echo back the provided text", schema_obj);
+        Ok(ListToolsResult::with_all_items(vec![tool]))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if request.name != "echo" {
+            return Err(ErrorData::invalid_params(
+                format!("unknown tool: {}", request.name),
+                None,
+            ));
+        }
+        let text = request
+            .arguments
+            .as_ref()
+            .and_then(|m| m.get("text"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::default();
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
+    }
+}
+
+/// Reject any request whose `Authorization` header is not `Bearer <expected>`,
+/// when an expected token is configured. Lets the test assert that the
+/// gateway-held credential actually reaches the upstream on every request.
+async fn require_bearer(
+    axum::extract::State(expected): axum::extract::State<Option<String>>,
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    if let Some(expected) = expected.as_deref() {
+        let presented = request
+            .headers()
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok());
+        if presented != Some(&format!("Bearer {expected}")) {
+            return (axum::http::StatusCode::UNAUTHORIZED, "missing bearer").into_response();
+        }
+    }
+    next.run(request).await
+}
+
+/// Start the echo server on an ephemeral port; return its bound address.
+async fn spawn_echo_server(require_bearer_token: Option<&str>) -> SocketAddr {
+    let service = StreamableHttpService::new(
+        || Ok(EchoServer),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default(),
+    );
+    let expected = require_bearer_token.map(str::to_string);
+    let app = axum::Router::new().nest_service("/mcp", service).layer(
+        axum::middleware::from_fn_with_state(expected, require_bearer),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+    addr
+}
+
+#[tokio::test]
+async fn lists_and_calls_tools_over_streamable_http() {
+    let addr = spawn_echo_server(None).await;
+    let upstream = McpUpstream::new(format!("http://{addr}/mcp"));
+    let bridge = RmcpBridge::connect(&upstream)
+        .await
+        .expect("connect to upstream MCP server");
+
+    // tools/list surfaces the echo tool with its schema.
+    let tools = bridge.list_tools().await.expect("list tools");
+    assert_eq!(tools.len(), 1, "expected exactly one tool");
+    let echo = &tools[0];
+    assert_eq!(echo.name, "echo");
+    assert_eq!(
+        echo.description.as_deref(),
+        Some("Echo back the provided text")
+    );
+    assert!(
+        echo.input_schema["properties"]["text"].is_object(),
+        "schema should describe the `text` argument, got: {}",
+        echo.input_schema
+    );
+
+    // tools/call echoes the argument back.
+    let result = bridge
+        .call_tool("echo", serde_json::json!({ "text": "hello mcp" }))
+        .await
+        .expect("call echo tool");
+    assert!(!result.is_error, "echo should not be a tool error");
+    assert!(
+        result.content.to_string().contains("hello mcp"),
+        "echoed content should carry the input, got: {}",
+        result.content
+    );
+
+    // An unknown tool surfaces as an error, not a silent empty result.
+    let unknown = bridge
+        .call_tool("does_not_exist", serde_json::Value::Null)
+        .await;
+    assert!(unknown.is_err(), "unknown tool must error");
+}
+
+#[tokio::test]
+async fn forwards_gateway_held_bearer_to_upstream() {
+    let addr = spawn_echo_server(Some("s3cret-token")).await;
+    let url = format!("http://{addr}/mcp");
+
+    // Without the gateway-held credential, the upstream rejects the session.
+    let unauth = RmcpBridge::connect(&McpUpstream::new(url.clone())).await;
+    assert!(
+        unauth.is_err(),
+        "connect without bearer must fail against an auth-required upstream"
+    );
+
+    // With it, the session establishes and tools are reachable — proving the
+    // gateway-held Bearer is forwarded to the upstream.
+    let upstream = McpUpstream::new(url).with_bearer("s3cret-token");
+    let bridge = RmcpBridge::connect(&upstream)
+        .await
+        .expect("connect with gateway-held bearer");
+    let tools = bridge.list_tools().await.expect("list tools");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "echo");
+}


### PR DESCRIPTION
## What

First implementation step of the **MCP gateway** ([AISIX-Cloud#894](https://github.com/api7/AISIX-Cloud/issues/894), `Revision 2026-06-29` → DP-2). Adds a new `aisix-mcp` crate that opens a governed session to **one** upstream MCP server over **Streamable HTTP** and exposes it behind an `McpBridge` trait:

- `list_tools()` → normalised `Vec<McpTool>`
- `call_tool(name, args)` → normalised `McpToolResult`
- upstream auth (`None` / `Bearer`) is **held gateway-side**, never sourced from the downstream caller.

This is the highest-risk slice of the feature (does the official Rust SDK actually work for our client needs over Streamable HTTP, on our toolchain?), so it ships first as a foundation. Aggregating N upstreams behind the downstream-facing `/mcp` endpoint, tool namespacing, per-tool ACL, and wiring MCP traffic into the shared guardrail/quota pipeline are the next steps (DP-3/DP-4) and are **not** in this PR.

## How

- Built on the official MCP Rust SDK **`rmcp`, pinned `=1.8.0`** (targets MCP spec `2025-11-25`). rmcp does the JSON-RPC + Streamable HTTP + session plumbing; we own the aggregation/governance layer (later).
- **API-drift containment:** all rmcp types are converted to this crate's own DTOs (`McpTool`, `McpToolResult`, `McpUpstream`, `McpAuth`) at the boundary. The rest of the data plane depends only on the `McpBridge` trait, not on rmcp. rmcp is <16 months old with ~monthly breaking changes, hence the exact pin + the trait seam.
- **Minimal dependency surface:** production links only rmcp's **client**; the **server** side is a `dev-dependency`, used solely to stand up a real upstream in the test.
- `rmcp` relationship is a **pure in-process Rust library** (compiled into the binary) — no sidecar, no extra network hop.

## Reference implementations studied (per repo CLAUDE.md §7)

- **rmcp** (official Rust SDK) — chosen build-on; its gap (no high-level proxy/aggregation) is exactly the layer we must own.
- **LiteLLM / Kong** MCP gateways — confirmed the intersection feature set; upstream-auth-held-server-side + no-token-passthrough is both their behaviour and a spec `MUST` (MCP authorization 2025-11-25).
- **MCP spec 2025-11-25** transports + authorization (primary source). Note: the `2026-07-28` RC removes the session header → the `/mcp` *server* endpoint (DP-3) will be built stateless; this client step is unaffected.

## Test plan

Integration test (`tests/upstream_roundtrip.rs`) runs against a **real** rmcp Streamable HTTP server on an ephemeral port (no mock transport):

- [x] `initialize` → `tools/list` → `tools/call` round-trips; echo tool returns its argument; schema surfaced.
- [x] unknown tool surfaces as an **error**, not a silent empty result.
- [x] gateway-held **Bearer is forwarded** to the upstream on every request; **absence is rejected** (401 at `initialize`).
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p aisix-mcp` all green locally.

Refs AISIX-Cloud#894


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new MCP client crate to connect to an upstream server over Streamable HTTP.
  * Exposed tool discovery and tool invocation through a simple bridge interface.
  * Added support for optional bearer-token authentication when connecting upstream.
  * Introduced a structured error type for connection and request failures.

* **Tests**
  * Added end-to-end coverage for listing tools, calling tools, and verifying bearer-token forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->