### PR TITLE
feat(mcp): downstream /mcp aggregating endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,11 +159,13 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
+ "futures",
  "rmcp",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/aisix-mcp/Cargo.toml
+++ b/crates/aisix-mcp/Cargo.toml
@@ -46,3 +46,4 @@ features = [
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 axum.workspace = true
+async-trait.workspace = true

--- a/crates/aisix-mcp/Cargo.toml
+++ b/crates/aisix-mcp/Cargo.toml
@@ -6,27 +6,31 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "aisix: MCP gateway — upstream MCP server client (Streamable HTTP) behind the McpBridge trait"
+description = "aisix: MCP gateway — upstream client + downstream-facing aggregating endpoint (Streamable HTTP)"
 
 [dependencies]
 tokio.workspace = true
 async-trait.workspace = true
+futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 # Official MCP Rust SDK. Pinned exactly: rmcp is <16 months old and still
 # ships breaking changes on a roughly-monthly cadence, so we hold a fixed
-# version and keep all rmcp types behind this crate's `McpBridge` trait to
-# absorb API drift. Production only needs the upstream-facing client; the
-# server side (used to stand up a real MCP server in tests, and later for the
-# DP `/mcp` endpoint) is a dev-dependency so the gateway binary does not link
-# it yet.
+# version and keep all rmcp types behind this crate's own surface (the
+# `McpBridge` trait and the gateway DTOs) to absorb API drift.
+#
+# The gateway is dual-role — an MCP client to upstream servers AND an MCP
+# server to downstream agents — so both the `client` and `server` halves are
+# production dependencies.
 [dependencies.rmcp]
 version = "=1.8.0"
 default-features = false
 features = [
     "client",
+    "server",
     "base64",
     "transport-streamable-http-client",
     "transport-streamable-http-client-reqwest",
@@ -36,19 +40,9 @@ features = [
     # every real authenticated upstream — fail to connect. rustls matches the
     # workspace TLS posture (reqwest 0.12 already uses rustls-tls elsewhere).
     "reqwest",
+    "transport-streamable-http-server",
 ]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 axum.workspace = true
-
-# Server-side rmcp, dev-only: lets the integration test stand up a real MCP
-# server over real Streamable HTTP (no mock transport) for the client to talk
-# to end-to-end.
-[dev-dependencies.rmcp]
-version = "=1.8.0"
-default-features = false
-features = [
-    "server",
-    "transport-streamable-http-server",
-]

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -1,0 +1,221 @@
+//! The downstream-facing MCP gateway endpoint.
+//!
+//! [`McpGateway`] makes AISIX look like a single MCP server to a downstream
+//! agent while fronting N registered upstream servers (each an [`McpBridge`]).
+//! It is the other half of the dual role: an MCP *client* to each upstream
+//! (via [`crate::RmcpBridge`]) and an MCP *server* to the agent (this type,
+//! served over Streamable HTTP by [`streamable_http_service`]).
+//!
+//! Two operations, mirroring the upstream surface:
+//! - `tools/list` fans out across every upstream and returns one aggregated
+//!   list, each tool namespaced `server<SEP>tool`. An upstream that fails to
+//!   list is skipped (its tools are simply absent), so one bad upstream does
+//!   not blind the agent to the rest.
+//! - `tools/call` strips the namespace prefix and routes to the owning
+//!   upstream.
+//!
+//! The aggregator holds no per-request or per-session state, so governance
+//! never depends on a transport session — which keeps it aligned with the
+//! stateless direction of the MCP 2026-07-28 revision.
+//!
+//! Wiring this endpoint behind the gateway's auth / per-tool ACL / quota /
+//! observability pipeline (and sourcing upstreams from the resource snapshot)
+//! is the next step; this type takes an explicit set of upstreams and is not
+//! yet mounted on any production listener.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ErrorData, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::{RoleServer, ServerHandler};
+
+use crate::bridge::McpBridge;
+
+/// Separator between an upstream server's registered name and a tool name in
+/// the aggregated namespace, e.g. `github__create_issue`. Server names must
+/// not contain it; tool names may (we split on the first occurrence).
+pub const TOOL_NAMESPACE_SEPARATOR: &str = "__";
+
+/// One registered upstream: its gateway-facing name and the live bridge to it.
+struct NamedUpstream {
+    name: String,
+    bridge: Arc<dyn McpBridge>,
+}
+
+/// Aggregates N upstream MCP servers behind one downstream MCP server surface.
+/// Cheap to clone (the upstream set is shared); the Streamable HTTP transport
+/// clones it per session.
+#[derive(Clone)]
+pub struct McpGateway {
+    upstreams: Arc<[NamedUpstream]>,
+}
+
+impl McpGateway {
+    /// Build a gateway over the given `(server_name, bridge)` upstreams.
+    /// Registration order is the order tools are listed in.
+    pub fn new(upstreams: impl IntoIterator<Item = (String, Arc<dyn McpBridge>)>) -> Self {
+        let upstreams: Vec<NamedUpstream> = upstreams
+            .into_iter()
+            .map(|(name, bridge)| NamedUpstream { name, bridge })
+            .collect();
+        Self {
+            upstreams: upstreams.into(),
+        }
+    }
+
+    fn find(&self, server: &str) -> Option<&Arc<dyn McpBridge>> {
+        self.upstreams
+            .iter()
+            .find(|u| u.name == server)
+            .map(|u| &u.bridge)
+    }
+}
+
+impl ServerHandler for McpGateway {
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        // Fan out concurrently; each upstream call is already deadline-bounded
+        // by its bridge, so a slow upstream cannot stall the aggregate.
+        let listed = futures::future::join_all(
+            self.upstreams
+                .iter()
+                .map(|u| async move { (u.name.as_str(), u.bridge.list_tools().await) }),
+        )
+        .await;
+
+        let mut tools = Vec::new();
+        for (server, result) in listed {
+            match result {
+                Ok(upstream_tools) => {
+                    tools.extend(upstream_tools.into_iter().map(|t| prefixed_tool(server, t)));
+                }
+                Err(error) => {
+                    // Degrade gracefully: drop this upstream's tools, keep the
+                    // rest. Detail is logged server-side (never client-visible).
+                    tracing::warn!(
+                        upstream = server,
+                        error = %error,
+                        "skipping upstream in tools/list: list_tools failed"
+                    );
+                }
+            }
+        }
+        Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (server, tool) = request
+            .name
+            .split_once(TOOL_NAMESPACE_SEPARATOR)
+            .ok_or_else(|| {
+                ErrorData::invalid_params(
+                    format!(
+                        "tool name '{}' is missing a 'server__tool' prefix",
+                        request.name
+                    ),
+                    None,
+                )
+            })?;
+
+        let bridge = self.find(server).ok_or_else(|| {
+            ErrorData::invalid_params(format!("unknown MCP server '{server}'"), None)
+        })?;
+
+        let arguments = request
+            .arguments
+            .map(serde_json::Value::Object)
+            .unwrap_or(serde_json::Value::Null);
+
+        let result = bridge.call_tool(tool, arguments).await.map_err(|error| {
+            // Generic client-facing message; the upstream's detail (which may
+            // include its URL) is logged server-side, not surfaced to the agent.
+            tracing::warn!(
+                upstream = server,
+                tool = tool,
+                error = %error,
+                "upstream tools/call failed"
+            );
+            ErrorData::internal_error(
+                format!("upstream MCP server '{server}' failed to call tool"),
+                None,
+            )
+        })?;
+
+        into_call_tool_result(result)
+    }
+
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::default();
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info.instructions = Some(
+            "AISIX MCP gateway: aggregates tools from registered upstream MCP \
+             servers, namespaced as `server__tool`."
+                .to_string(),
+        );
+        info
+    }
+}
+
+/// Build the Streamable HTTP service for this gateway, ready to nest in axum
+/// at `/mcp`.
+///
+/// Configured stateless (no sticky session, JSON responses): the aggregator
+/// keeps no per-session state, so the endpoint can sit behind a plain load
+/// balancer — matching the MCP 2026-07-28 transport direction.
+pub fn streamable_http_service(
+    gateway: McpGateway,
+) -> StreamableHttpService<McpGateway, LocalSessionManager> {
+    let mut config = StreamableHttpServerConfig::default();
+    config.stateful_mode = false;
+    config.json_response = true;
+    StreamableHttpService::new(
+        move || Ok(gateway.clone()),
+        Arc::new(LocalSessionManager::default()),
+        config,
+    )
+}
+
+/// Namespace an upstream tool: `server<SEP>tool`, preserving its schema and
+/// (optional) description.
+fn prefixed_tool(server: &str, tool: crate::McpTool) -> Tool {
+    let schema = match tool.input_schema {
+        serde_json::Value::Object(map) => map,
+        // A non-object schema is malformed per JSON Schema; advertise an empty
+        // object rather than dropping the tool.
+        _ => serde_json::Map::new(),
+    };
+    Tool::new_with_raw(
+        format!("{server}{TOOL_NAMESPACE_SEPARATOR}{}", tool.name),
+        tool.description.map(Cow::Owned),
+        schema,
+    )
+}
+
+/// Map our [`crate::McpToolResult`] back onto rmcp's `CallToolResult`,
+/// preserving the upstream's tool-level error flag (a tool-level error is
+/// propagated as `Ok(error_result)`, not turned into a protocol error).
+fn into_call_tool_result(result: crate::McpToolResult) -> Result<CallToolResult, ErrorData> {
+    let content: Vec<Content> = serde_json::from_value(result.content).map_err(|e| {
+        ErrorData::internal_error(format!("malformed tool content from upstream: {e}"), None)
+    })?;
+    let mut call_result = if result.is_error {
+        CallToolResult::error(content)
+    } else {
+        CallToolResult::success(content)
+    };
+    call_result.structured_content = result.structured_content;
+    Ok(call_result)
+}

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -59,13 +59,31 @@ pub struct McpGateway {
 impl McpGateway {
     /// Build a gateway over the given `(server_name, bridge)` upstreams.
     /// Registration order is the order tools are listed in.
+    ///
+    /// A name may only register once: a duplicate is dropped (the first
+    /// registration wins) with a warning, rather than silently shadowing the
+    /// later one and emitting duplicate tool names on the wire. Server names
+    /// must not contain [`TOOL_NAMESPACE_SEPARATOR`].
     pub fn new(upstreams: impl IntoIterator<Item = (String, Arc<dyn McpBridge>)>) -> Self {
-        let upstreams: Vec<NamedUpstream> = upstreams
-            .into_iter()
-            .map(|(name, bridge)| NamedUpstream { name, bridge })
-            .collect();
+        let mut seen = std::collections::HashSet::new();
+        let mut deduped = Vec::new();
+        for (name, bridge) in upstreams {
+            debug_assert!(
+                !name.contains(TOOL_NAMESPACE_SEPARATOR),
+                "upstream server name `{name}` must not contain the namespace \
+                 separator `{TOOL_NAMESPACE_SEPARATOR}`"
+            );
+            if !seen.insert(name.clone()) {
+                tracing::warn!(
+                    upstream = %name,
+                    "duplicate MCP upstream name; keeping the first registration, dropping this one"
+                );
+                continue;
+            }
+            deduped.push(NamedUpstream { name, bridge });
+        }
         Self {
-            upstreams: upstreams.into(),
+            upstreams: deduped.into(),
         }
     }
 

--- a/crates/aisix-mcp/src/lib.rs
+++ b/crates/aisix-mcp/src/lib.rs
@@ -15,6 +15,8 @@
 
 pub mod bridge;
 pub mod error;
+pub mod gateway;
 
 pub use bridge::{McpAuth, McpBridge, McpTool, McpToolResult, McpUpstream, RmcpBridge};
 pub use error::McpError;
+pub use gateway::{streamable_http_service, McpGateway, TOOL_NAMESPACE_SEPARATOR};

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -13,7 +13,10 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use aisix_mcp::{streamable_http_service, McpBridge, McpGateway, McpUpstream, RmcpBridge};
+use aisix_mcp::{
+    streamable_http_service, McpBridge, McpError, McpGateway, McpTool, McpToolResult, McpUpstream,
+    RmcpBridge,
+};
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, Content, ErrorData, ListToolsResult,
     PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
@@ -67,6 +70,11 @@ impl ServerHandler for LabeledEcho {
             .and_then(|m| m.get("text"))
             .and_then(|v| v.as_str())
             .unwrap_or_default();
+        // `fail` drives the tool-level-error path: a valid call whose tool
+        // reports failure, returned as `Ok(CallToolResult::error(..))`.
+        if text == "fail" {
+            return Ok(CallToolResult::error(vec![Content::text("boom")]));
+        }
         Ok(CallToolResult::success(vec![Content::text(format!(
             "{}:{text}",
             self.label
@@ -104,6 +112,24 @@ async fn serve(app: axum::Router) -> SocketAddr {
         axum::serve(listener, app).await.expect("serve");
     });
     addr
+}
+
+/// A bridge whose every operation fails — stands in for an unreachable or
+/// broken upstream so the graceful-skip path is deterministic.
+struct FailingBridge;
+
+#[async_trait::async_trait]
+impl McpBridge for FailingBridge {
+    async fn list_tools(&self) -> Result<Vec<McpTool>, McpError> {
+        Err(McpError::Request("simulated upstream failure".into()))
+    }
+    async fn call_tool(
+        &self,
+        _name: &str,
+        _arguments: serde_json::Value,
+    ) -> Result<McpToolResult, McpError> {
+        Err(McpError::Request("simulated upstream failure".into()))
+    }
 }
 
 /// Connect a bridge to a freshly-spawned labeled upstream.
@@ -175,6 +201,90 @@ async fn aggregates_and_routes_across_upstreams() {
     assert!(
         client.call_tool(call("echo", "x")).await.is_err(),
         "prefixless tool name must error"
+    );
+}
+
+#[tokio::test]
+async fn skips_failing_upstream_keeping_the_rest() {
+    // One healthy upstream + one that fails every call. tools/list must still
+    // return the healthy upstream's tools, not collapse to empty or error.
+    let gateway = McpGateway::new([
+        ("alpha".to_string(), bridge_to("alpha").await),
+        (
+            "down".to_string(),
+            Arc::new(FailingBridge) as Arc<dyn McpBridge>,
+        ),
+    ]);
+    let gw_addr = spawn_gateway(gateway).await;
+    let client = ()
+        .serve(StreamableHttpClientTransport::from_uri(format!(
+            "http://{gw_addr}/mcp"
+        )))
+        .await
+        .expect("connect");
+
+    let tools = client.list_all_tools().await.expect("list tools");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert_eq!(
+        tools.len(),
+        1,
+        "failing upstream's tools dropped, healthy one kept: {names:?}"
+    );
+    assert!(
+        names.contains(&"alpha__echo"),
+        "alpha tool missing: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn propagates_tool_level_error_as_ok() {
+    // An upstream tool that reports failure must reach the agent as a tool
+    // result with is_error=true — NOT as a transport/protocol Err.
+    let gateway = McpGateway::new([("alpha".to_string(), bridge_to("alpha").await)]);
+    let gw_addr = spawn_gateway(gateway).await;
+    let client = ()
+        .serve(StreamableHttpClientTransport::from_uri(format!(
+            "http://{gw_addr}/mcp"
+        )))
+        .await
+        .expect("connect");
+
+    let result = client
+        .call_tool(call("alpha__echo", "fail"))
+        .await
+        .expect("tool-level error must be Ok(error_result), not a protocol Err");
+    assert_eq!(result.is_error, Some(true), "tool-level error flag lost");
+    assert_eq!(first_text(&result), "boom");
+}
+
+#[tokio::test]
+async fn duplicate_upstream_name_keeps_first() {
+    // Two registrations under the same name: the first wins, the second is
+    // dropped — no duplicate tool names, all calls route to the first.
+    let gateway = McpGateway::new([
+        ("dup".to_string(), bridge_to("first").await),
+        ("dup".to_string(), bridge_to("second").await),
+    ]);
+    let gw_addr = spawn_gateway(gateway).await;
+    let client = ()
+        .serve(StreamableHttpClientTransport::from_uri(format!(
+            "http://{gw_addr}/mcp"
+        )))
+        .await
+        .expect("connect");
+
+    let tools = client.list_all_tools().await.expect("list tools");
+    assert_eq!(tools.len(), 1, "duplicate name should yield one tool");
+    assert_eq!(tools[0].name.as_ref(), "dup__echo");
+
+    let result = client
+        .call_tool(call("dup__echo", "hi"))
+        .await
+        .expect("call");
+    assert_eq!(
+        first_text(&result),
+        "first:hi",
+        "should route to first registration"
     );
 }
 

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -1,0 +1,185 @@
+//! End-to-end test of the dual-role gateway: AISIX as an MCP *server* to a
+//! downstream agent, fronting two *real* upstream MCP servers.
+//!
+//! Topology, all real Streamable HTTP over ephemeral ports (no mock transport):
+//!
+//!   downstream rmcp client  ──►  McpGateway (/mcp)  ──►  upstream "alpha" (echo)
+//!                                                   └──►  upstream "beta"  (echo)
+//!
+//! Each upstream labels its echo so routing is observable. Pins: aggregated +
+//! namespaced `tools/list`, `tools/call` routes to the owning upstream, and
+//! bad/prefixless names are rejected.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use aisix_mcp::{streamable_http_service, McpBridge, McpGateway, McpUpstream, RmcpBridge};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ErrorData, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::{RoleServer, ServerHandler, ServiceExt};
+
+/// A real upstream MCP server exposing one `echo` tool that prefixes its reply
+/// with `label`, so the test can tell which upstream actually handled a call.
+#[derive(Clone)]
+struct LabeledEcho {
+    label: &'static str,
+}
+
+impl ServerHandler for LabeledEcho {
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "text": { "type": "string" } },
+            "required": ["text"],
+        });
+        let tool = Tool::new(
+            "echo",
+            "Echo back the provided text",
+            schema.as_object().expect("schema is an object").clone(),
+        );
+        Ok(ListToolsResult::with_all_items(vec![tool]))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if request.name != "echo" {
+            return Err(ErrorData::invalid_params(
+                format!("unknown tool: {}", request.name),
+                None,
+            ));
+        }
+        let text = request
+            .arguments
+            .as_ref()
+            .and_then(|m| m.get("text"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{}:{text}",
+            self.label
+        ))]))
+    }
+
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::default();
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
+    }
+}
+
+/// Start a labeled upstream echo server; return its bound address.
+async fn spawn_upstream(label: &'static str) -> SocketAddr {
+    let service = StreamableHttpService::new(
+        move || Ok(LabeledEcho { label }),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default(),
+    );
+    serve(axum::Router::new().nest_service("/mcp", service)).await
+}
+
+/// Serve the gateway itself; return its bound address.
+async fn spawn_gateway(gateway: McpGateway) -> SocketAddr {
+    serve(axum::Router::new().nest_service("/mcp", streamable_http_service(gateway))).await
+}
+
+async fn serve(app: axum::Router) -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+    addr
+}
+
+/// Connect a bridge to a freshly-spawned labeled upstream.
+async fn bridge_to(label: &'static str) -> Arc<dyn McpBridge> {
+    let addr = spawn_upstream(label).await;
+    let bridge = RmcpBridge::connect(&McpUpstream::new(format!("http://{addr}/mcp")))
+        .await
+        .expect("connect upstream bridge");
+    Arc::new(bridge)
+}
+
+/// Decode the first text content block of a tool result.
+fn first_text(result: &CallToolResult) -> String {
+    let value = serde_json::to_value(&result.content).expect("encode content");
+    value[0]["text"].as_str().unwrap_or_default().to_string()
+}
+
+#[tokio::test]
+async fn aggregates_and_routes_across_upstreams() {
+    let gateway = McpGateway::new([
+        ("alpha".to_string(), bridge_to("alpha").await),
+        ("beta".to_string(), bridge_to("beta").await),
+    ]);
+    let gw_addr = spawn_gateway(gateway).await;
+
+    // The downstream agent talks to AISIX as if it were a single MCP server.
+    let client = ()
+        .serve(StreamableHttpClientTransport::from_uri(format!(
+            "http://{gw_addr}/mcp"
+        )))
+        .await
+        .expect("downstream client connects to gateway");
+
+    // tools/list is aggregated and namespaced `server__tool`.
+    let tools = client.list_all_tools().await.expect("list tools");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert_eq!(
+        tools.len(),
+        2,
+        "both upstreams' tools should appear: {names:?}"
+    );
+    assert!(
+        names.contains(&"alpha__echo"),
+        "missing alpha tool: {names:?}"
+    );
+    assert!(
+        names.contains(&"beta__echo"),
+        "missing beta tool: {names:?}"
+    );
+
+    // tools/call routes to the owning upstream — proven by the label prefix.
+    let from_alpha = client
+        .call_tool(call("alpha__echo", "hi"))
+        .await
+        .expect("call alpha");
+    assert_eq!(first_text(&from_alpha), "alpha:hi");
+
+    let from_beta = client
+        .call_tool(call("beta__echo", "hi"))
+        .await
+        .expect("call beta");
+    assert_eq!(first_text(&from_beta), "beta:hi");
+
+    // Unknown server and a prefixless name both error, not misroute.
+    assert!(
+        client.call_tool(call("ghost__echo", "x")).await.is_err(),
+        "unknown server must error"
+    );
+    assert!(
+        client.call_tool(call("echo", "x")).await.is_err(),
+        "prefixless tool name must error"
+    );
+}
+
+/// Build a `tools/call` for `name` with a single `text` argument.
+fn call(name: &'static str, text: &str) -> CallToolRequestParams {
+    let args = serde_json::json!({ "text": text });
+    CallToolRequestParams::new(name).with_arguments(args.as_object().unwrap().clone())
+}


### PR DESCRIPTION
## What

The downstream-facing half of the MCP gateway runtime ([AISIX-Cloud#894](https://github.com/api7/AISIX-Cloud/issues/894)). With the upstream `McpBridge` (already merged, [#660](https://github.com/api7/aisix/pull/660)), the runtime is now complete end-to-end: AISIX is an MCP **client** to each upstream **and** an MCP **server** to the agent.

```
downstream agent ──► McpGateway (/mcp) ──► upstream "alpha"
                                      └──► upstream "beta"
```

- **`tools/list`** — fans out concurrently across upstreams → one aggregated list, each tool namespaced `server__tool`. A failing upstream is skipped (logged), so one bad upstream doesn't blind the agent to the rest.
- **`tools/call`** — strips the prefix, routes to the owning upstream. Unknown server / prefixless names error; an upstream **tool-level error** is propagated faithfully as `Ok(error_result)`, not collapsed to a protocol error.
- **Stateless transport** — `stateful_mode=false` + `json_response=true`; the aggregator holds no per-session state (governance never depends on a session), matching the MCP `2026-07-28` direction. Verified with a real downstream rmcp client.
- **No error bleed** — upstream failure detail (which may carry the upstream URL) is logged server-side, never in the client-visible error.
- **Duplicate upstream names** are deduped at construction (first wins + warn), so no duplicate tool names reach the wire.

`rmcp`'s server half moves from dev-dependency → production dependency (the gateway is now genuinely dual-role).

> Supersedes #661, which GitHub auto-closed when its stacked base branch was deleted on the #660 squash-merge. This branch is rebased onto `main`; the diff is the same DP-3 changes, plus the audit fixes.

## Scope / not in this PR

`McpGateway` is **not mounted on any production listener**. Wiring it behind the gateway auth (AISIX key) / per-tool ACL / quota / observability pipeline, and sourcing upstreams from the resource snapshot, is the next step. No unauthenticated production endpoint is introduced here.

## Independent audit (CLAUDE.md §8)

A fresh audit agent reviewed this cold; it returned BLOCK with 2 MEDIUM, both fixed in this branch:
- Missing test coverage for graceful-skip + tool-level-error propagation → added 3 tests.
- Duplicate upstream names silently shadowed → `McpGateway::new` now dedups (first-wins + warn) + `debug_assert` no separator in name.

## Test plan

Integration tests (`tests/gateway_aggregation.rs`), all real Streamable HTTP, no mock transport: real labeled upstream echo servers behind the gateway, driven by a **real downstream rmcp client**.

- [x] aggregated, namespaced `tools/list` (`alpha__echo`, `beta__echo`).
- [x] `tools/call` routes to the correct upstream (proven by each upstream's label prefix).
- [x] unknown server (`ghost__echo`) and prefixless name (`echo`) both error.
- [x] a failing upstream is skipped, the healthy one still listed.
- [x] a tool-level error reaches the agent as `Ok` with `is_error=true`.
- [x] duplicate upstream name keeps the first registration.
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p aisix-mcp` (7/7) green.

Refs AISIX-Cloud#894
