### PR TITLE
feat(mcp): McpServer admin resource (registration + CRUD)

### DIFF
--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -19,7 +19,9 @@
 //! deterministic behaviour continue to use [`crate::InMemoryStore`].
 
 use aisix_core::resource::ResourceEntry;
-use aisix_core::{ApiKey, CachePolicy, Guardrail, Model, ObservabilityExporter, ProviderKey};
+use aisix_core::{
+    ApiKey, CachePolicy, Guardrail, McpServer, Model, ObservabilityExporter, ProviderKey,
+};
 use etcd_client::{Client, DeleteOptions, GetOptions};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -35,6 +37,7 @@ pub const PROVIDER_KEYS_SUBKEY: &str = "provider_keys";
 pub const GUARDRAILS_SUBKEY: &str = "guardrails";
 pub const CACHE_POLICIES_SUBKEY: &str = "cache_policies";
 pub const OBSERVABILITY_EXPORTERS_SUBKEY: &str = "observability_exporters";
+pub const MCP_SERVERS_SUBKEY: &str = "mcp_servers";
 
 pub struct EtcdConfigStore {
     client: Mutex<Client>,
@@ -332,6 +335,35 @@ impl ConfigStore for EtcdConfigStore {
     async fn delete_observability_exporter(&self, id: &str) -> Result<bool, StoreError> {
         self.delete_one(&self.key_for(OBSERVABILITY_EXPORTERS_SUBKEY, id))
             .await
+    }
+
+    async fn put_mcp_server(&self, entry: ResourceEntry<McpServer>) -> Result<(), StoreError> {
+        let key = self.key_for(MCP_SERVERS_SUBKEY, &entry.id);
+        self.put_json(&key, &entry.value).await
+    }
+
+    async fn get_mcp_server(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<McpServer>>, StoreError> {
+        let key = self.key_for(MCP_SERVERS_SUBKEY, id);
+        Ok(self
+            .get_one::<McpServer>(&key)
+            .await?
+            .map(|(v, rev)| ResourceEntry::new(id, v, rev)))
+    }
+
+    async fn list_mcp_servers(&self) -> Result<Vec<ResourceEntry<McpServer>>, StoreError> {
+        Ok(self
+            .list_range::<McpServer>(MCP_SERVERS_SUBKEY)
+            .await?
+            .into_iter()
+            .map(|(id, v, rev)| ResourceEntry::new(id, v, rev))
+            .collect())
+    }
+
+    async fn delete_mcp_server(&self, id: &str) -> Result<bool, StoreError> {
+        self.delete_one(&self.key_for(MCP_SERVERS_SUBKEY, id)).await
     }
 }
 

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -41,6 +41,7 @@ mod error;
 pub mod etcd_store;
 mod guardrails_handlers;
 mod health_handler;
+mod mcp_servers_handlers;
 mod models_handlers;
 mod models_status_handler;
 mod observability_exporters_handlers;
@@ -118,6 +119,17 @@ pub fn build_router(state: AdminState) -> Router {
             get(provider_keys_handlers::get_provider_key)
                 .put(provider_keys_handlers::update_provider_key)
                 .delete(provider_keys_handlers::delete_provider_key),
+        )
+        .route(
+            "/admin/v1/mcp_servers",
+            get(mcp_servers_handlers::list_mcp_servers)
+                .post(mcp_servers_handlers::create_mcp_server),
+        )
+        .route(
+            "/admin/v1/mcp_servers/:id",
+            get(mcp_servers_handlers::get_mcp_server)
+                .put(mcp_servers_handlers::update_mcp_server)
+                .delete(mcp_servers_handlers::delete_mcp_server),
         )
         .route(
             "/admin/v1/guardrails",

--- a/crates/aisix-admin/src/mcp_servers_handlers.rs
+++ b/crates/aisix-admin/src/mcp_servers_handlers.rs
@@ -1,0 +1,119 @@
+//! CRUD handlers for `/admin/v1/mcp_servers`.
+//!
+//! Same shape as the ProviderKeys handlers: validate against the JSON schema,
+//! reject duplicate display_names (409), generate a uuid v4 on POST, bump
+//! revision on PUT. Additionally rejects a display_name containing the reserved
+//! tool-namespace separator `__`, since the name prefixes the server's tools.
+
+use aisix_core::models::validate_mcp_server;
+use aisix_core::resource::ResourceEntry;
+use aisix_core::McpServer;
+use axum::extract::{Path, State};
+use axum::Json;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::auth::AdminAuth;
+use crate::error::AdminError;
+use crate::state::AdminState;
+
+const STARTING_REVISION: i64 = 1;
+
+/// Reserved separator between a server's name and a tool name in the gateway's
+/// aggregated namespace (`<display_name>__<tool>`). A server name must not
+/// contain it.
+const TOOL_NAMESPACE_SEPARATOR: &str = "__";
+
+pub async fn list_mcp_servers(
+    _auth: AdminAuth,
+    State(state): State<AdminState>,
+) -> Result<Json<Vec<ResourceEntry<McpServer>>>, AdminError> {
+    let entries = state.store.list_mcp_servers().await?;
+    Ok(Json(entries))
+}
+
+pub async fn get_mcp_server(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+) -> Result<Json<ResourceEntry<McpServer>>, AdminError> {
+    let entry = state
+        .store
+        .get_mcp_server(&id)
+        .await?
+        .ok_or(AdminError::NotFound)?;
+    Ok(Json(entry))
+}
+
+pub async fn create_mcp_server(
+    _auth: AdminAuth,
+    State(state): State<AdminState>,
+    Json(raw): Json<Value>,
+) -> Result<Json<ResourceEntry<McpServer>>, AdminError> {
+    let mcp_server = decode(&raw)?;
+    let all = state.store.list_mcp_servers().await?;
+    assert_unique_display_name(&all, &mcp_server.display_name, None)?;
+
+    let id = Uuid::new_v4().to_string();
+    let entry = ResourceEntry::new(&id, mcp_server, STARTING_REVISION);
+    state.store.put_mcp_server(entry.clone()).await?;
+    Ok(Json(entry))
+}
+
+pub async fn update_mcp_server(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+    Json(raw): Json<Value>,
+) -> Result<Json<ResourceEntry<McpServer>>, AdminError> {
+    let existing = state
+        .store
+        .get_mcp_server(&id)
+        .await?
+        .ok_or(AdminError::NotFound)?;
+    let mcp_server = decode(&raw)?;
+
+    let all = state.store.list_mcp_servers().await?;
+    assert_unique_display_name(&all, &mcp_server.display_name, Some(&id))?;
+
+    let entry = ResourceEntry::new(&id, mcp_server, existing.revision + 1);
+    state.store.put_mcp_server(entry.clone()).await?;
+    Ok(Json(entry))
+}
+
+pub async fn delete_mcp_server(
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+    State(state): State<AdminState>,
+) -> Result<Json<Value>, AdminError> {
+    let removed = state.store.delete_mcp_server(&id).await?;
+    if !removed {
+        return Err(AdminError::NotFound);
+    }
+    Ok(Json(serde_json::json!({"deleted": true, "id": id})))
+}
+
+fn decode(raw: &Value) -> Result<McpServer, AdminError> {
+    validate_mcp_server(raw)?;
+    let server: McpServer = serde_json::from_value(raw.clone())
+        .map_err(|e| AdminError::BadRequest(format!("malformed McpServer payload: {e}")))?;
+    if server.display_name.contains(TOOL_NAMESPACE_SEPARATOR) {
+        return Err(AdminError::BadRequest(format!(
+            "display_name must not contain the reserved separator `{TOOL_NAMESPACE_SEPARATOR}`"
+        )));
+    }
+    Ok(server)
+}
+
+fn assert_unique_display_name(
+    existing: &[ResourceEntry<McpServer>],
+    display_name: &str,
+    self_id: Option<&str>,
+) -> Result<(), AdminError> {
+    for e in existing {
+        if e.value.display_name == display_name && self_id.is_none_or(|sid| sid != e.id) {
+            return Err(AdminError::Conflict(display_name.to_string()));
+        }
+    }
+    Ok(())
+}

--- a/crates/aisix-admin/src/mcp_servers_handlers.rs
+++ b/crates/aisix-admin/src/mcp_servers_handlers.rs
@@ -7,7 +7,7 @@
 
 use aisix_core::models::validate_mcp_server;
 use aisix_core::resource::ResourceEntry;
-use aisix_core::McpServer;
+use aisix_core::{McpAuthType, McpServer};
 use axum::extract::{Path, State};
 use axum::Json;
 use serde_json::Value;
@@ -102,6 +102,13 @@ fn decode(raw: &Value) -> Result<McpServer, AdminError> {
             "display_name must not contain the reserved separator `{TOOL_NAMESPACE_SEPARATOR}`"
         )));
     }
+    if matches!(server.auth_type, McpAuthType::Bearer)
+        && server.secret.as_deref().unwrap_or_default().is_empty()
+    {
+        return Err(AdminError::BadRequest(
+            "secret is required and must be non-empty when auth_type is `bearer`".to_string(),
+        ));
+    }
     Ok(server)
 }
 
@@ -116,4 +123,41 @@ fn assert_unique_display_name(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn decode_rejects_separator_in_display_name() {
+        let err = decode(&json!({"display_name": "a__b", "url": "https://x/mcp"}))
+            .expect_err("`__` in display_name must be rejected");
+        assert!(matches!(err, AdminError::BadRequest(_)));
+    }
+
+    #[test]
+    fn decode_rejects_bearer_without_secret() {
+        let err = decode(&json!({
+            "display_name": "gh",
+            "url": "https://x/mcp",
+            "auth_type": "bearer"
+        }))
+        .expect_err("bearer auth without a secret must be rejected");
+        assert!(matches!(err, AdminError::BadRequest(_)));
+    }
+
+    #[test]
+    fn decode_accepts_valid_server() {
+        let server = decode(&json!({
+            "display_name": "github",
+            "url": "https://api.example.com/mcp",
+            "auth_type": "bearer",
+            "secret": "tok"
+        }))
+        .expect("valid server should decode");
+        assert_eq!(server.display_name, "github");
+        assert_eq!(server.secret.as_deref(), Some("tok"));
+    }
 }

--- a/crates/aisix-admin/src/store.rs
+++ b/crates/aisix-admin/src/store.rs
@@ -7,7 +7,9 @@
 //! in the handler layer so the store stays dumb and fast.
 
 use aisix_core::resource::ResourceEntry;
-use aisix_core::{ApiKey, CachePolicy, Guardrail, Model, ObservabilityExporter, ProviderKey};
+use aisix_core::{
+    ApiKey, CachePolicy, Guardrail, McpServer, Model, ObservabilityExporter, ProviderKey,
+};
 use dashmap::DashMap;
 use std::sync::Arc;
 
@@ -65,6 +67,14 @@ pub trait ConfigStore: Send + Sync + 'static {
         &self,
     ) -> Result<Vec<ResourceEntry<ObservabilityExporter>>, StoreError>;
     async fn delete_observability_exporter(&self, id: &str) -> Result<bool, StoreError>;
+
+    async fn put_mcp_server(&self, entry: ResourceEntry<McpServer>) -> Result<(), StoreError>;
+    async fn get_mcp_server(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<McpServer>>, StoreError>;
+    async fn list_mcp_servers(&self) -> Result<Vec<ResourceEntry<McpServer>>, StoreError>;
+    async fn delete_mcp_server(&self, id: &str) -> Result<bool, StoreError>;
 }
 
 /// In-memory store. Thread-safe via DashMap; mainly used by tests, but
@@ -77,6 +87,7 @@ pub struct InMemoryStore {
     guardrails: DashMap<String, ResourceEntry<Guardrail>>,
     cache_policies: DashMap<String, ResourceEntry<CachePolicy>>,
     observability_exporters: DashMap<String, ResourceEntry<ObservabilityExporter>>,
+    mcp_servers: DashMap<String, ResourceEntry<McpServer>>,
 }
 
 impl InMemoryStore {
@@ -208,6 +219,26 @@ impl ConfigStore for InMemoryStore {
 
     async fn delete_observability_exporter(&self, id: &str) -> Result<bool, StoreError> {
         Ok(self.observability_exporters.remove(id).is_some())
+    }
+
+    async fn put_mcp_server(&self, entry: ResourceEntry<McpServer>) -> Result<(), StoreError> {
+        self.mcp_servers.insert(entry.id.clone(), entry);
+        Ok(())
+    }
+
+    async fn get_mcp_server(
+        &self,
+        id: &str,
+    ) -> Result<Option<ResourceEntry<McpServer>>, StoreError> {
+        Ok(self.mcp_servers.get(id).map(|r| r.clone()))
+    }
+
+    async fn list_mcp_servers(&self) -> Result<Vec<ResourceEntry<McpServer>>, StoreError> {
+        Ok(self.mcp_servers.iter().map(|r| r.clone()).collect())
+    }
+
+    async fn delete_mcp_server(&self, id: &str) -> Result<bool, StoreError> {
+        Ok(self.mcp_servers.remove(id).is_some())
     }
 }
 

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -197,6 +197,27 @@ async fn provider_keys_round_trip_through_real_etcd() {
 }
 
 #[tokio::test]
+async fn mcp_servers_round_trip_through_real_etcd() {
+    let Some(url) = etcd_url() else {
+        eprintln!("skipping: ADMIN_TEST_ETCD_URL not set");
+        return;
+    };
+    let prefix = unique_prefix();
+    let state = build_state_with_real_etcd(&url, &prefix).await;
+    admin_crud_round_trip(
+        state,
+        "/admin/v1/mcp_servers",
+        json!({
+            "display_name": "github-it",
+            "url": "https://api.example.com/mcp",
+            "auth_type": "bearer",
+            "secret": "tok-it"
+        }),
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn guardrails_round_trip_through_real_etcd() {
     let Some(url) = etcd_url() else {
         eprintln!("skipping: ADMIN_TEST_ETCD_URL not set");
@@ -317,6 +338,10 @@ async fn loader_picks_up_every_admin_write() {
                 "endpoint": "https://otel.example.com/v1/traces"
             }),
         ),
+        (
+            "/admin/v1/mcp_servers",
+            json!({"display_name": "loader-mcp", "url": "https://api.example.com/mcp"}),
+        ),
     ];
     for (uri, body) in writes {
         let app = build_router(state.clone());
@@ -363,7 +388,7 @@ async fn loader_picks_up_every_admin_write() {
          likely a subkey-constant drift between EtcdConfigStore::*_SUBKEY \
          and the match arms in aisix_etcd::loader: {stats:?}"
     );
-    assert_eq!(stats.accepted, 6, "expected 6 entries; got {stats:?}");
+    assert_eq!(stats.accepted, 7, "expected 7 entries; got {stats:?}");
 
     // Each resource table should now have exactly one entry.
     assert_eq!(snap.models.len(), 1);
@@ -372,4 +397,5 @@ async fn loader_picks_up_every_admin_write() {
     assert_eq!(snap.guardrails.len(), 1);
     assert_eq!(snap.cache_policies.len(), 1);
     assert_eq!(snap.observability_exporters.len(), 1);
+    assert_eq!(snap.mcp_servers.len(), 1);
 }

--- a/crates/aisix-core/src/bin/dump-schema.rs
+++ b/crates/aisix-core/src/bin/dump-schema.rs
@@ -62,6 +62,7 @@ fn main() {
         "guardrail_attachment",
         schema::guardrail_attachment_root_schema(),
     );
+    dump_value(&out_dir, "mcp_server", schema::mcp_server_root_schema());
 
     dump::<EnsembleConfig>(&out_dir, "ensemble");
     dump::<RateLimit>(&out_dir, "rate_limit");

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -31,10 +31,11 @@ pub use error::{
     AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,
 };
 pub use models::{
-    validate_apikey, validate_cache_policy, validate_guardrail, validate_model,
-    validate_observability_exporter, validate_provider_key, validate_rate_limit_policy, Adapter,
-    AisixSnapshot, ApiKey, AppliedGuardrail, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
-    GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern, Model, ObservabilityExporter,
+    validate_apikey, validate_cache_policy, validate_guardrail, validate_mcp_server,
+    validate_model, validate_observability_exporter, validate_provider_key,
+    validate_rate_limit_policy, Adapter, AisixSnapshot, ApiKey, AppliedGuardrail, CachePolicy,
+    CooldownConfig, ExporterKind, Guardrail, GuardrailHookPoint, GuardrailKind, KeywordConfig,
+    KeywordPattern, McpAuthType, McpServer, McpTransport, Model, ObservabilityExporter,
     ParamConstraints, PolicyScope, PolicyWindow, ProviderKey, RateLimit, RateLimitPolicy,
     RequestOverrides, ResponseOverrides, Routing, RoutingStrategy, RoutingTarget, SchemaError,
     StreamDoneMarker, TelemetryKind, TelemetryTags, WhenAllUnavailablePolicy,

--- a/crates/aisix-core/src/models/mcp_server.rs
+++ b/crates/aisix-core/src/models/mcp_server.rs
@@ -1,0 +1,185 @@
+//! `McpServer` entity — a registered upstream MCP server.
+//!
+//! Registers an upstream Model Context Protocol (MCP) server so the gateway can
+//! front it: its tools are aggregated into the gateway's own MCP endpoint under
+//! the namespace `<display_name>__<tool>`, and tool calls are routed back to it.
+//! The upstream credential is held by the gateway and is never exposed to the
+//! calling client.
+//!
+//! etcd path: `{prefix}/mcp_servers/{uuid}`. Secondary index on `display_name`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::resource::Resource;
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct McpServer {
+    /// Operator-facing label, unique within the gateway. It is used as the
+    /// namespace prefix for this server's tools, which are exposed to clients as
+    /// `<display_name>__<tool>`, so it must not contain the reserved separator
+    /// `__`.
+    #[schemars(length(min = 1))]
+    pub display_name: String,
+
+    /// The upstream server's MCP endpoint URL, reached over the Streamable HTTP
+    /// transport, such as `https://api.example.com/mcp`.
+    #[schemars(length(min = 1))]
+    pub url: String,
+
+    /// Transport used to reach the upstream server. Streamable HTTP is the only
+    /// supported transport.
+    #[serde(default)]
+    pub transport: McpTransport,
+
+    /// How the gateway authenticates to the upstream server. The credential is
+    /// held by the gateway and is never forwarded from or exposed to the calling
+    /// client.
+    #[serde(default)]
+    pub auth_type: McpAuthType,
+
+    /// Authentication credential for the upstream server. Required when
+    /// `auth_type` is `bearer`, where it is sent as `Authorization: Bearer
+    /// <secret>` on every upstream request. Leave unset when `auth_type` is
+    /// `none`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
+
+    /// Maximum time, in milliseconds, to wait for a single upstream operation
+    /// (establishing the session, listing tools, or calling a tool). When
+    /// omitted, the gateway applies a built-in default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+
+    /// Whether this server is active. When `false`, its tools are not listed and
+    /// cannot be called.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Filled in by the snapshot loader from the etcd key path.
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+/// Transport used to reach an upstream MCP server.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum McpTransport {
+    /// Streamable HTTP transport: a single endpoint that serves both POST and
+    /// GET.
+    #[default]
+    StreamableHttp,
+}
+
+/// How the gateway authenticates to an upstream MCP server.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum McpAuthType {
+    /// No authentication; the server is reached as-is.
+    #[default]
+    None,
+    /// Bearer token authentication. The token is supplied in `secret` and sent
+    /// as `Authorization: Bearer <secret>`.
+    Bearer,
+}
+
+impl Resource for McpServer {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    fn name(&self) -> &str {
+        &self.display_name
+    }
+
+    fn kind() -> &'static str {
+        "mcp_servers"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_minimal_mcp_server() {
+        let s: McpServer = serde_json::from_str(
+            r#"{"display_name":"github","url":"https://api.example.com/mcp"}"#,
+        )
+        .unwrap();
+        assert_eq!(s.display_name, "github");
+        assert_eq!(s.url, "https://api.example.com/mcp");
+        // Defaults.
+        assert_eq!(s.transport, McpTransport::StreamableHttp);
+        assert_eq!(s.auth_type, McpAuthType::None);
+        assert!(s.secret.is_none());
+        assert!(s.timeout_ms.is_none());
+        assert!(s.enabled);
+    }
+
+    #[test]
+    fn deserialises_with_bearer_auth() {
+        let s: McpServer = serde_json::from_str(
+            r#"{"display_name":"gh","url":"https://x/mcp","auth_type":"bearer","secret":"tok","timeout_ms":5000,"enabled":false}"#,
+        )
+        .unwrap();
+        assert_eq!(s.auth_type, McpAuthType::Bearer);
+        assert_eq!(s.secret.as_deref(), Some("tok"));
+        assert_eq!(s.timeout_ms, Some(5000));
+        assert!(!s.enabled);
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let r: Result<McpServer, _> =
+            serde_json::from_str(r#"{"display_name":"x","url":"u","extra":1}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_transport_and_auth_type() {
+        assert!(serde_json::from_str::<McpServer>(
+            r#"{"display_name":"x","url":"u","transport":"stdio"}"#
+        )
+        .is_err());
+        assert!(serde_json::from_str::<McpServer>(
+            r#"{"display_name":"x","url":"u","auth_type":"oauth"}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn resource_trait_routes_through_display_name() {
+        let mut s: McpServer =
+            serde_json::from_str(r#"{"display_name":"github","url":"https://x/mcp"}"#).unwrap();
+        s.runtime_id = "uuid-mcp-1".into();
+        assert_eq!(<McpServer as Resource>::kind(), "mcp_servers");
+        assert_eq!(s.id(), "uuid-mcp-1");
+        assert_eq!(s.name(), "github");
+    }
+
+    #[test]
+    fn round_trip_omits_default_optionals() {
+        let original = McpServer {
+            display_name: "github".into(),
+            url: "https://x/mcp".into(),
+            transport: McpTransport::StreamableHttp,
+            auth_type: McpAuthType::None,
+            secret: None,
+            timeout_ms: None,
+            enabled: true,
+            runtime_id: String::new(),
+        };
+        let s = serde_json::to_string(&original).unwrap();
+        let back: McpServer = serde_json::from_str(&s).unwrap();
+        assert_eq!(original, back);
+    }
+}

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -20,6 +20,7 @@ pub mod cache_policy;
 pub mod embedding;
 pub mod ensemble;
 pub mod guardrail;
+pub mod mcp_server;
 pub mod model;
 pub mod observability_exporter;
 pub mod provider_key;
@@ -40,6 +41,7 @@ pub use guardrail::{
     BedrockLatencyMode, Guardrail, GuardrailAttachment, GuardrailHookPoint, GuardrailKind,
     GuardrailScopeType, KeywordConfig, KeywordPattern,
 };
+pub use mcp_server::{McpAuthType, McpServer, McpTransport};
 pub use model::{
     Adapter, BackgroundModelCheck, CooldownConfig, Model, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
@@ -56,7 +58,7 @@ pub use rate_limit_policy::{PolicyScope, PolicyWindow, RateLimitPolicy};
 pub use routing::{Routing, RoutingStrategy, RoutingTarget, WhenAllUnavailablePolicy};
 pub use schema::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_guardrail_attachment,
-    validate_model, validate_observability_exporter, validate_provider_key,
+    validate_mcp_server, validate_model, validate_observability_exporter, validate_provider_key,
     validate_rate_limit_policy, SchemaError,
 };
 pub use semantic::{

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -30,6 +30,7 @@ pub struct Schemas {
     pub cache_policy: Validator,
     pub observability_exporter: Validator,
     pub rate_limit_policy: Validator,
+    pub mcp_server: Validator,
 }
 
 pub static SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::compile()));
@@ -61,6 +62,9 @@ impl Schemas {
             rate_limit_policy: jsonschema::options()
                 .build(&rate_limit_policy_root_schema())
                 .expect("rate_limit_policy schema is well-formed"),
+            mcp_server: jsonschema::options()
+                .build(&mcp_server_root_schema())
+                .expect("mcp_server schema is well-formed"),
         }
     }
 }
@@ -117,6 +121,10 @@ pub fn validate_guardrail_attachment(value: &Value) -> Result<(), SchemaError> {
     validate(&SCHEMAS.guardrail_attachment, value)
 }
 
+pub fn validate_mcp_server(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.mcp_server, value)
+}
+
 /// Build a resource's canonical JSON Schema from its struct via `schemars`,
 /// the single source of field shapes and per-field constraints.
 ///
@@ -171,6 +179,17 @@ pub fn apikey_root_schema() -> Value {
 /// keeping all optionals nullable matches the resource's wire contract.
 pub fn provider_key_root_schema() -> Value {
     struct_root_schema::<crate::models::ProviderKey>(true)
+}
+
+/// Canonical JSON Schema for the `mcp_server` resource, derived from the
+/// [`McpServer`](crate::models::McpServer) struct. Uses the nullable `Option`
+/// representation (`true`) so the optional `secret` / `timeout_ms` fields accept
+/// an explicit `null` as well as being absent, matching the resource's wire
+/// contract. The `transport` / `auth_type` closed sets come from the
+/// [`McpTransport`](crate::models::McpTransport) /
+/// [`McpAuthType`](crate::models::McpAuthType) enums.
+pub fn mcp_server_root_schema() -> Value {
+    struct_root_schema::<crate::models::McpServer>(true)
 }
 
 /// Canonical JSON Schema for the `guardrail` resource, derived from the

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -7,6 +7,7 @@
 use super::apikey::ApiKey;
 use super::cache_policy::CachePolicy;
 use super::guardrail::{Guardrail, GuardrailAttachment};
+use super::mcp_server::McpServer;
 use super::model::Model;
 use super::observability_exporter::ObservabilityExporter;
 use super::provider_key::ProviderKey;
@@ -34,6 +35,10 @@ pub struct AisixSnapshot {
     /// fan-out POST per chat completion (see `aisix-obs::OtlpHttpFanOut`).
     pub observability_exporters: ResourceTable<ObservabilityExporter>,
     pub rate_limit_policies: ResourceTable<RateLimitPolicy>,
+    /// Registered upstream MCP servers: `/aisix/<env>/mcp_servers/<uuid>`. The
+    /// MCP gateway endpoint aggregates each enabled server's tools and routes
+    /// tool calls back to the owning server.
+    pub mcp_servers: ResourceTable<McpServer>,
 }
 
 impl AisixSnapshot {
@@ -52,6 +57,7 @@ impl AisixSnapshot {
             + self.cache_policies.len()
             + self.observability_exporters.len()
             + self.rate_limit_policies.len()
+            + self.mcp_servers.len()
     }
 }
 

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -13,9 +13,9 @@
 
 use aisix_core::models::{
     validate_apikey, validate_cache_policy, validate_guardrail, validate_guardrail_attachment,
-    validate_model, validate_observability_exporter, validate_provider_key,
-    validate_rate_limit_policy, ApiKey, CachePolicy, Guardrail, GuardrailAttachment, Model,
-    ObservabilityExporter, ProviderKey, RateLimitPolicy, SchemaError,
+    validate_mcp_server, validate_model, validate_observability_exporter, validate_provider_key,
+    validate_rate_limit_policy, ApiKey, CachePolicy, Guardrail, GuardrailAttachment, McpServer,
+    Model, ObservabilityExporter, ProviderKey, RateLimitPolicy, SchemaError,
 };
 use aisix_core::resource::ResourceEntry;
 use aisix_core::AisixSnapshot;
@@ -242,6 +242,18 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
                     &mut stats,
                 ) {
                     snapshot.rate_limit_policies.insert(entry);
+                }
+            }
+            "mcp_servers" => {
+                if let Some(entry) = validate_and_parse::<McpServer>(
+                    &raw.key,
+                    raw.revision,
+                    parsed,
+                    &value,
+                    validate_mcp_server,
+                    &mut stats,
+                ) {
+                    snapshot.mcp_servers.insert(entry);
                 }
             }
             other => {

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -376,6 +376,9 @@ impl<P: ConfigProvider> Supervisor<P> {
             for e in tiny.rate_limit_policies.entries() {
                 new.rate_limit_policies.insert(clone_entry(&e));
             }
+            for e in tiny.mcp_servers.entries() {
+                new.mcp_servers.insert(clone_entry(&e));
+            }
             new
         });
         self.remove_rejection_for_key(&entry.key);
@@ -430,6 +433,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                 snap.observability_exporters.get_by_id(parsed.id).is_some()
             }
             "rate_limit_policies" => snap.rate_limit_policies.get_by_id(parsed.id).is_some(),
+            "mcp_servers" => snap.mcp_servers.get_by_id(parsed.id).is_some(),
             _ => false,
         };
         let removed_rejection = self.remove_rejection_for_key(key_str);
@@ -474,6 +478,9 @@ impl<P: ConfigProvider> Supervisor<P> {
                 }
                 "rate_limit_policies" => {
                     new.rate_limit_policies.remove(parsed.id);
+                }
+                "mcp_servers" => {
+                    new.mcp_servers.remove(parsed.id);
                 }
                 _ => {}
             }
@@ -707,6 +714,9 @@ fn clone_snapshot(src: &AisixSnapshot) -> AisixSnapshot {
     }
     for e in src.rate_limit_policies.entries() {
         out.rate_limit_policies.insert(clone_entry(&e));
+    }
+    for e in src.mcp_servers.entries() {
+        out.mcp_servers.insert(clone_entry(&e));
     }
     out
 }

--- a/schemas/resources/mcp_server.schema.json
+++ b/schemas/resources/mcp_server.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "McpAuthType": {
+      "description": "How the gateway authenticates to an upstream MCP server.",
+      "oneOf": [
+        {
+          "description": "No authentication; the server is reached as-is.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Bearer token authentication. The token is supplied in `secret` and sent as `Authorization: Bearer <secret>`.",
+          "enum": [
+            "bearer"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "McpTransport": {
+      "description": "Transport used to reach an upstream MCP server.",
+      "oneOf": [
+        {
+          "description": "Streamable HTTP transport: a single endpoint that serves both POST and GET.",
+          "enum": [
+            "streamable_http"
+          ],
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "auth_type": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/McpAuthType"
+        }
+      ],
+      "default": "none",
+      "description": "How the gateway authenticates to the upstream server. The credential is held by the gateway and is never forwarded from or exposed to the calling client."
+    },
+    "display_name": {
+      "description": "Operator-facing label, unique within the gateway. It is used as the namespace prefix for this server's tools, which are exposed to clients as `<display_name>__<tool>`, so it must not contain the reserved separator `__`.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "enabled": {
+      "default": true,
+      "description": "Whether this server is active. When `false`, its tools are not listed and cannot be called.",
+      "type": "boolean"
+    },
+    "secret": {
+      "description": "Authentication credential for the upstream server. Required when `auth_type` is `bearer`, where it is sent as `Authorization: Bearer <secret>` on every upstream request. Leave unset when `auth_type` is `none`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "timeout_ms": {
+      "description": "Maximum time, in milliseconds, to wait for a single upstream operation (establishing the session, listing tools, or calling a tool). When omitted, the gateway applies a built-in default.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "transport": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/McpTransport"
+        }
+      ],
+      "default": "streamable_http",
+      "description": "Transport used to reach the upstream server. Streamable HTTP is the only supported transport."
+    },
+    "url": {
+      "description": "The upstream server's MCP endpoint URL, reached over the Streamable HTTP transport, such as `https://api.example.com/mcp`.",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "display_name",
+    "url"
+  ],
+  "title": "McpServer",
+  "type": "object"
+}


### PR DESCRIPTION
## What

Adds **`McpServer`** as a first-class Admin resource (parallel to `ProviderKey`): an upstream MCP server registration that the MCP gateway endpoint will source its upstreams from, instead of the explicit list it takes today. This is the control-plane prerequisite for wiring the gateway behind the governance pipeline.

Fields (customer-facing, rendered into the Admin API reference): `display_name` (unique; namespace prefix for the server's tools, so `__` is rejected), `url` (Streamable HTTP endpoint), `transport` (enum, `streamable_http`), `auth_type` (`none`/`bearer`) + `secret` (gateway-held), `timeout_ms`, `enabled`.

## How (mirrors the existing resource scaffolding)

- **aisix-core** — `McpServer` struct + `McpTransport`/`McpAuthType` enums + `Resource` impl (`kind = "mcp_servers"`); schema validator built through the same `struct_root_schema` producer the other resources use, so the **published schema == the enforced schema**; registered in `dump-schema`; new `mcp_servers` snapshot table.
- **aisix-etcd** — loader decode arm + supervisor merge / present-check / delete / clone dispatch for the new kind.
- **aisix-admin** — `ConfigStore` get/put/list/delete on both `InMemoryStore` and `EtcdConfigStore` (etcd subkey `mcp_servers`); `/admin/v1/mcp_servers[/:id]` handlers (schema-validate, dup-name 409, reject reserved `__`, uuid on POST, revision bump on PUT) + routes.

## Test plan

- [x] Resource unit tests (defaults, bearer auth, unknown-field/enum rejection, Resource trait, round-trip).
- [x] `mcp_servers_round_trip_through_real_etcd` — full Admin CRUD over a real etcd.
- [x] `loader_picks_up_every_admin_write` extended to seed an `mcp_servers` row and assert the loader accepts it — this catches **subkey-constant drift** between `EtcdConfigStore` and `aisix_etcd::loader` (the most likely wiring bug).
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p aisix-core -p aisix-etcd -p aisix-admin` all green; `schemas/resources/mcp_server.schema.json` regenerated via `dump-schema`.

## Scope / explicitly deferred

- **OpenAPI reference** for the two new routes is deferred to **#663**. Verified that no test or CI check enforces it (both OpenAPI coverage tests use hardcoded path/schema lists, not the live router; the `generate admin openapi` CI step validates structure, not a committed snapshot). The routes are fully functional; only the generated OpenAPI omits them. Called out here per the merge gate so it's a tracked gap, not a silent one.
- Wiring the gateway endpoint to source upstreams from this snapshot + per-tool ACL / quota / guardrail reuse is the next step (depends on this).

Refs AISIX-Cloud#894


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing MCP server resources in the admin UI and API, including create, view, update, delete, and list actions.
  * Introduced MCP server configuration fields for connection, authentication, enablement, and timeout settings.
  * Added MCP server schema support and snapshot/loader handling so these resources are included in exports and imports.

* **Bug Fixes**
  * Enforced unique display names and rejected invalid names with reserved separators to prevent conflicts.
  * Improved persistence and watch handling so MCP server changes are consistently stored and reflected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->