### PR TITLE
feat(mcp): per-tool ACL — govern MCP tools by the caller's API key

### DIFF
--- a/crates/aisix-admin/src/apikeys_handlers.rs
+++ b/crates/aisix-admin/src/apikeys_handlers.rs
@@ -32,6 +32,10 @@ struct StandaloneApiKeyBody {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     rate_limit: Option<aisix_core::models::RateLimit>,
+    /// MCP tools this key may call (namespaced `<server>__<tool>`, or `"*"`).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_tools: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -40,6 +44,8 @@ pub struct PublicApiKey {
     pub allowed_models: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<aisix_core::models::RateLimit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
 }
 
 impl From<ApiKey> for PublicApiKey {
@@ -48,6 +54,7 @@ impl From<ApiKey> for PublicApiKey {
             key_hash: value.key_hash,
             allowed_models: value.allowed_models,
             rate_limit: value.rate_limit,
+            allowed_tools: value.allowed_tools,
         }
     }
 }

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -175,7 +175,11 @@ async fn apikeys_round_trip_through_real_etcd() {
     admin_crud_round_trip(
         state,
         "/admin/v1/apikeys",
-        json!({"key_hash": key_hash, "allowed_models": ["it-gpt4"]}),
+        json!({
+            "key_hash": key_hash,
+            "allowed_models": ["it-gpt4"],
+            "allowed_tools": ["github__create_issue", "*"]
+        }),
     )
     .await;
 }

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -49,6 +49,13 @@ pub struct ApiKey {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_name: Option<String>,
 
+    /// MCP tools this key may call, as namespaced `<server>__<tool>` names
+    /// (the form the gateway exposes). A wildcard entry `"*"` grants every
+    /// tool. When omitted, the key has no MCP tool access — access is granted
+    /// explicitly, matching `allowed_models`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+
     /// etcd-key uuid. Filled by the loader and never included in the JSON payload.
     #[serde(skip)]
     pub(crate) runtime_id: String,
@@ -76,6 +83,19 @@ impl ApiKey {
         self.allowed_models
             .iter()
             .any(|n| n == "*" || n == model_name)
+    }
+
+    /// True if this key may call the given MCP tool, named in the gateway's
+    /// namespaced `<server>__<tool>` form.
+    ///
+    /// A wildcard entry `"*"` grants every tool. A key with no `allowed_tools`
+    /// (or an empty list) may call no MCP tools — access is granted explicitly,
+    /// matching [`ApiKey::can_access`].
+    pub fn can_access_tool(&self, tool: &str) -> bool {
+        match &self.allowed_tools {
+            None => false,
+            Some(allowed) => allowed.iter().any(|t| t == "*" || t == tool),
+        }
     }
 
     /// Iterate over the names of models this key may access, filtering
@@ -166,10 +186,39 @@ mod tests {
             team_id: None,
             user_id: None,
             user_name: None,
+            allowed_tools: None,
             runtime_id: String::new(),
         };
         assert!(!k.can_access("my-gpt4"));
         assert!(!k.can_access("anything"));
+    }
+
+    #[test]
+    fn can_access_tool_enforces_namespaced_allowlist() {
+        // No `allowed_tools` configured → no MCP tool access.
+        let none: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_models":["*"]}"#).unwrap();
+        assert!(!none.can_access_tool("github__create_issue"));
+
+        // Empty list also denies everything.
+        let empty: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"allowed_tools":[]}"#)
+                .unwrap();
+        assert!(!empty.can_access_tool("github__create_issue"));
+
+        // Exact namespaced names.
+        let specific: ApiKey = serde_json::from_str(
+            r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["github__create_issue"]}"#,
+        )
+        .unwrap();
+        assert!(specific.can_access_tool("github__create_issue"));
+        assert!(!specific.can_access_tool("github__delete_repo"));
+
+        // Wildcard grants every tool.
+        let wildcard: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["*"]}"#)
+                .unwrap();
+        assert!(wildcard.can_access_tool("anything__at_all"));
     }
 
     #[test]

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -99,6 +99,11 @@ impl McpGateway {
     /// registration wins) with a warning, rather than silently shadowing the
     /// later one and emitting duplicate tool names on the wire. Server names
     /// must not contain [`TOOL_NAMESPACE_SEPARATOR`].
+    ///
+    /// The gateway is **unrestricted** ([`ToolAcl::AllowAll`]) until scoped with
+    /// [`McpGateway::with_tool_acl`]. Any caller that serves external traffic
+    /// MUST scope it to the caller's key — the proxy `/mcp` mount is the single
+    /// enforcement point and always does.
     pub fn new(upstreams: impl IntoIterator<Item = (String, Arc<dyn McpBridge>)>) -> Self {
         let mut seen = std::collections::HashSet::new();
         let mut deduped = Vec::new();

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -50,12 +50,45 @@ struct NamedUpstream {
     bridge: Arc<dyn McpBridge>,
 }
 
+/// Which tools a gateway instance may expose and call, in the namespaced
+/// `<server>__<tool>` form. Built per request from the caller's API key so MCP
+/// tool access is governed by the same key object as LLM access.
+#[derive(Clone)]
+pub enum ToolAcl {
+    /// No restriction — every aggregated tool is exposed.
+    AllowAll,
+    /// Only these namespaced tool names are exposed; any other is hidden from
+    /// `tools/list` and rejected by `tools/call`.
+    Allow(std::collections::HashSet<String>),
+}
+
+impl ToolAcl {
+    /// Build an ACL from an API key's `allowed_tools` list: `None` or an empty
+    /// list grants no tools; a list containing `"*"` grants all; otherwise the
+    /// exact namespaced set. Mirrors `ApiKey::can_access_tool`.
+    pub fn from_allowed(allowed: Option<&[String]>) -> Self {
+        match allowed {
+            Some(list) if list.iter().any(|t| t == "*") => Self::AllowAll,
+            Some(list) => Self::Allow(list.iter().cloned().collect()),
+            None => Self::Allow(std::collections::HashSet::new()),
+        }
+    }
+
+    fn permits(&self, namespaced_tool: &str) -> bool {
+        match self {
+            Self::AllowAll => true,
+            Self::Allow(set) => set.contains(namespaced_tool),
+        }
+    }
+}
+
 /// Aggregates N upstream MCP servers behind one downstream MCP server surface.
 /// Cheap to clone (the upstream set is shared); the Streamable HTTP transport
 /// clones it per session.
 #[derive(Clone)]
 pub struct McpGateway {
     upstreams: Arc<[NamedUpstream]>,
+    tool_acl: ToolAcl,
 }
 
 impl McpGateway {
@@ -86,7 +119,16 @@ impl McpGateway {
         }
         Self {
             upstreams: deduped.into(),
+            tool_acl: ToolAcl::AllowAll,
         }
+    }
+
+    /// Scope this gateway to a per-tool [`ToolAcl`]: `tools/list` returns only
+    /// permitted tools and `tools/call` rejects the rest. The mount builds this
+    /// from the caller's API key.
+    pub fn with_tool_acl(mut self, acl: ToolAcl) -> Self {
+        self.tool_acl = acl;
+        self
     }
 
     /// Build a gateway whose upstreams are the **enabled** `mcp_servers` in the
@@ -149,6 +191,8 @@ impl ServerHandler for McpGateway {
                 }
             }
         }
+        // Per-tool ACL: expose only the tools this caller's key permits.
+        tools.retain(|tool| self.tool_acl.permits(tool.name.as_ref()));
         Ok(ListToolsResult::with_all_items(tools))
     }
 
@@ -169,6 +213,17 @@ impl ServerHandler for McpGateway {
                     None,
                 )
             })?;
+
+        // Per-tool ACL: reject a call the caller's key doesn't permit. A
+        // disallowed tool is also absent from `tools/list`, so this is
+        // defense-in-depth; the message stays neutral and does not reveal
+        // whether the tool exists upstream.
+        if !self.tool_acl.permits(request.name.as_ref()) {
+            return Err(ErrorData::invalid_params(
+                format!("tool '{}' is not available", request.name),
+                None,
+            ));
+        }
 
         let bridge = self.find(server).ok_or_else(|| {
             ErrorData::invalid_params(format!("unknown MCP server '{server}'"), None)

--- a/crates/aisix-mcp/src/lib.rs
+++ b/crates/aisix-mcp/src/lib.rs
@@ -22,4 +22,4 @@ pub use bridge::{
     McpUpstream, RmcpBridge,
 };
 pub use error::McpError;
-pub use gateway::{streamable_http_service, McpGateway, TOOL_NAMESPACE_SEPARATOR};
+pub use gateway::{streamable_http_service, McpGateway, ToolAcl, TOOL_NAMESPACE_SEPARATOR};

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -414,10 +414,20 @@ async fn tool_acl_filters_list_and_rejects_calls() {
         .expect("permitted call");
     assert_eq!(first_text(&allowed), "alpha:hi");
 
-    // A non-permitted tool is rejected (defense-in-depth), not routed upstream.
+    // A non-permitted tool is rejected (defense-in-depth), not routed upstream,
+    // with a neutral message that doesn't reveal whether the tool/server exists.
+    let err = client
+        .call_tool(call("beta__echo", "hi"))
+        .await
+        .expect_err("non-permitted tool call must be rejected");
+    let msg = format!("{err:?}");
     assert!(
-        client.call_tool(call("beta__echo", "hi")).await.is_err(),
-        "non-permitted tool call must be rejected"
+        msg.contains("not available"),
+        "rejection should use the neutral message, got: {msg}"
+    );
+    assert!(
+        !msg.contains("permitted") && !msg.contains("forbidden") && !msg.contains("exists"),
+        "rejection must not reveal existence/permission detail, got: {msg}"
     );
 }
 

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use aisix_core::{AisixSnapshot, McpServer, ResourceEntry};
 use aisix_mcp::{
     streamable_http_service, upstream_from_mcp_server, McpAuth, McpBridge, McpError, McpGateway,
-    McpTool, McpToolResult, McpUpstream, RmcpBridge,
+    McpTool, McpToolResult, McpUpstream, RmcpBridge, ToolAcl,
 };
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, Content, ErrorData, ListToolsResult,
@@ -363,6 +363,62 @@ async fn from_snapshot_sources_only_enabled_upstreams() {
         .await
         .expect("call");
     assert_eq!(first_text(&result), "alpha:hi");
+}
+
+#[test]
+fn tool_acl_from_allowed_semantics() {
+    // No allowed_tools / empty → deny all.
+    assert!(matches!(ToolAcl::from_allowed(None), ToolAcl::Allow(ref s) if s.is_empty()));
+    assert!(matches!(ToolAcl::from_allowed(Some(&[])), ToolAcl::Allow(ref s) if s.is_empty()));
+    // Wildcard → allow all.
+    assert!(matches!(
+        ToolAcl::from_allowed(Some(&["*".to_string()])),
+        ToolAcl::AllowAll
+    ));
+    // Exact set.
+    assert!(matches!(
+        ToolAcl::from_allowed(Some(&["a__b".to_string()])),
+        ToolAcl::Allow(_)
+    ));
+}
+
+#[tokio::test]
+async fn tool_acl_filters_list_and_rejects_calls() {
+    // Two real upstreams; the key permits only alpha's tool.
+    let gateway = McpGateway::new([
+        ("alpha".to_string(), bridge_to("alpha").await),
+        ("beta".to_string(), bridge_to("beta").await),
+    ])
+    .with_tool_acl(ToolAcl::from_allowed(Some(&["alpha__echo".to_string()])));
+    let gw_addr = spawn_gateway(gateway).await;
+    let client = ()
+        .serve(StreamableHttpClientTransport::from_uri(format!(
+            "http://{gw_addr}/mcp"
+        )))
+        .await
+        .expect("connect");
+
+    // tools/list exposes only the permitted tool — beta's is hidden.
+    let tools = client.list_all_tools().await.expect("list tools");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert_eq!(
+        names,
+        vec!["alpha__echo"],
+        "ACL must hide non-permitted tools"
+    );
+
+    // The permitted tool is callable.
+    let allowed = client
+        .call_tool(call("alpha__echo", "hi"))
+        .await
+        .expect("permitted call");
+    assert_eq!(first_text(&allowed), "alpha:hi");
+
+    // A non-permitted tool is rejected (defense-in-depth), not routed upstream.
+    assert!(
+        client.call_tool(call("beta__echo", "hi")).await.is_err(),
+        "non-permitted tool call must be rejected"
+    );
 }
 
 /// Build a `tools/call` for `name` with a single `text` argument.

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -24,12 +24,15 @@ use crate::state::ProxyState;
 /// AISIX API key (responding `401` otherwise); the request is then handled by an
 /// MCP gateway built from the current snapshot's `mcp_servers`.
 pub async fn mcp_endpoint(
-    _auth: AuthenticatedKey,
+    auth: AuthenticatedKey,
     State(state): State<ProxyState>,
     request: Request,
 ) -> Response {
     let snapshot = state.snapshot.load();
-    let gateway = aisix_mcp::McpGateway::from_snapshot(&snapshot);
+    // Scope the gateway to the tools this caller's key permits, so MCP tool
+    // access is governed by the same key object as LLM access.
+    let acl = aisix_mcp::ToolAcl::from_allowed(auth.key().allowed_tools.as_deref());
+    let gateway = aisix_mcp::McpGateway::from_snapshot(&snapshot).with_tool_acl(acl);
     let service = aisix_mcp::streamable_http_service(gateway);
     // `StreamableHttpService` is a tower service that dispatches on method and
     // never fails (`Error = Infallible`); map its boxed body back to axum's.

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -80,6 +80,16 @@
       },
       "type": "array"
     },
+    "allowed_tools": {
+      "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). A wildcard entry `\"*\"` grants every tool. When omitted, the key has no MCP tool access — access is granted explicitly, matching `allowed_models`.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
     "key_hash": {
       "description": "SHA-256 hexadecimal hash of the plaintext bearer. The proxy hashes incoming bearer tokens before lookup.",
       "minLength": 1,


### PR DESCRIPTION
## What

DP-4 slice 3. Scopes the MCP gateway to the tools the caller's AISIX API key permits — so MCP tool access is governed by the **same key object** as LLM access (the "single-pipeline same-governance" differentiation). Builds on the mounted, authenticated `/mcp` endpoint (#667) and the snapshot-sourced gateway (#665).

## How

- **aisix-core** — `ApiKey.allowed_tools: Option<Vec<String>>` (namespaced `<server>__<tool>` names; `"*"` = all) + `can_access_tool`, mirroring `allowed_models` / `can_access`. **Deny-by-default**: a key with no `allowed_tools` may call no MCP tools — access is granted explicitly (consistent with `allowed_models`).
- **aisix-mcp** — `ToolAcl` (`AllowAll` / `Allow(set)`, built from a key's `allowed_tools`) + `McpGateway::with_tool_acl`. `tools/list` exposes only permitted tools; `tools/call` rejects the rest with a **neutral** message (defense-in-depth — doesn't reveal whether the tool exists upstream).
- **aisix-proxy** — the `/mcp` handler builds the gateway scoped to `auth.key().allowed_tools` (per request; the handler already holds the resolved key, so no rmcp request-context plumbing is needed).
- **aisix-admin** — the self-hosted apikeys API (`StandaloneApiKeyBody` + `PublicApiKey`) round-trips `allowed_tools`; `api_key.schema.json` regenerated (so the loader + admin validation accept it).

## Test plan

- [x] `can_access_tool` semantics (none/empty → deny, `["*"]` → all, exact names).
- [x] `ToolAcl::from_allowed` mapping.
- [x] **end-to-end** (real upstreams): a key permitting only `alpha__echo` → `beta__echo` is hidden from `tools/list` and its call is rejected; `alpha__echo` lists and calls. (`tool_acl_filters_list_and_rejects_calls`)
- [x] apikeys etcd round-trip carries `allowed_tools`.
- [x] `fmt`, `clippy --workspace --all-targets -D warnings`, `cargo test` (core/mcp/proxy/admin) green.

## Scope notes

- ACL behavior lives in `aisix-mcp` and is e2e-tested there (the real-upstream harness); the proxy is one-line wiring (`ToolAcl::from_allowed(key.allowed_tools)`), covered by compile + the existing `/mcp` auth tests.
- OpenAPI doc for the new `allowed_tools` request/response field is not added (consistent with how the resource OpenAPI was handled in #663/#664; the field IS accepted by the admin API via the regenerated schema). Can fold into the #663 OpenAPI follow-up.
- Remaining DP-4 slices: ④ guardrail / rate-limit / budget reuse over MCP; ⑤ UsageEvent for MCP calls.

Refs AISIX-Cloud#894
