### PR TITLE
feat(mcp): apply rate-limit + budget governance to MCP tool calls

### DIFF
--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -170,13 +170,13 @@ mod tests {
         snapshot
     }
 
-    /// A `tools/call` request authenticated with `TOKEN`.
-    fn tools_call_request() -> HttpRequest<Body> {
+    /// A JSON-RPC request to `/mcp` for `method`, authenticated with `TOKEN`.
+    fn mcp_request(method: &str, params: serde_json::Value) -> HttpRequest<Body> {
         let body = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "tools/call",
-            "params": { "name": "ghost__tool", "arguments": {} }
+            "method": method,
+            "params": params
         });
         HttpRequest::post("/mcp")
             .header("host", "mcp.aisix.example.com")
@@ -185,6 +185,13 @@ mod tests {
             .header("authorization", format!("Bearer {TOKEN}"))
             .body(Body::from(body.to_string()))
             .unwrap()
+    }
+
+    fn tools_call_request() -> HttpRequest<Body> {
+        mcp_request(
+            "tools/call",
+            serde_json::json!({ "name": "ghost__tool", "arguments": {} }),
+        )
     }
 
     #[tokio::test]
@@ -217,8 +224,10 @@ mod tests {
             "second tool call should be rate-limited"
         );
 
-        // The handshake is never rate-limited, even with the key at its limit.
+        // Neither handshake nor discovery is rate-limited, even with the key at
+        // its tool-call limit — a client can always connect and enumerate.
         let handshake = router
+            .clone()
             .oneshot(initialize_request(Some(TOKEN)))
             .await
             .expect("router responds");
@@ -226,6 +235,16 @@ mod tests {
             handshake.status(),
             StatusCode::TOO_MANY_REQUESTS,
             "initialize must not be rate-limited"
+        );
+
+        let listed = router
+            .oneshot(mcp_request("tools/list", serde_json::json!({})))
+            .await
+            .expect("router responds");
+        assert_ne!(
+            listed.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "tools/list must not be rate-limited"
         );
     }
 

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -12,28 +12,69 @@
 //! traffic are layered on in subsequent steps; this step establishes the
 //! authenticated, snapshot-sourced endpoint.
 
-use axum::body::Body;
+use axum::body::{to_bytes, Body};
 use axum::extract::{Request, State};
-use axum::response::Response;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
 use tower::ServiceExt;
 
 use crate::auth::AuthenticatedKey;
 use crate::state::ProxyState;
 
+/// Just enough of a JSON-RPC request to tell a tool call apart from the MCP
+/// handshake / discovery methods. Unknown fields are ignored.
+#[derive(Deserialize)]
+struct JsonRpcPeek {
+    method: Option<String>,
+}
+
 /// Serve a `/mcp` request. The [`AuthenticatedKey`] extractor enforces a valid
-/// AISIX API key (responding `401` otherwise); the request is then handled by an
-/// MCP gateway built from the current snapshot's `mcp_servers`.
+/// AISIX API key (responding `401` otherwise). A `tools/call` is then subject to
+/// the same rate-limit and budget governance as an LLM request — keyed on the
+/// caller's API key — before being handled by an MCP gateway built from the
+/// current snapshot's `mcp_servers`. The `initialize` / `tools/list` handshake
+/// and discovery methods pass through ungated.
 pub async fn mcp_endpoint(
     auth: AuthenticatedKey,
     State(state): State<ProxyState>,
     request: Request,
 ) -> Response {
+    // Buffer the body so the JSON-RPC method can be inspected, then rebuilt for
+    // the gateway. The global body-limit layer has already capped the size.
+    let (parts, body) = request.into_parts();
+    let bytes = match to_bytes(body, state.request_body_limit_bytes).await {
+        Ok(bytes) => bytes,
+        Err(_) => return (StatusCode::BAD_REQUEST, "invalid request body").into_response(),
+    };
+
+    let is_tool_call = serde_json::from_slice::<JsonRpcPeek>(&bytes)
+        .ok()
+        .and_then(|peek| peek.method)
+        .as_deref()
+        == Some("tools/call");
+
+    // Reuse the LLM path's rate-limit + budget gate on the unit of work. The
+    // reservation is held for the duration of the call and dropped after (no
+    // tokens to commit — a tool call carries no token cost), which releases the
+    // concurrency slot. On 429 / budget-exceeded this returns before any
+    // upstream is contacted.
+    let _reservation = if is_tool_call {
+        match crate::quota::enforce(&state, &auth, None).await {
+            Ok(reservation) => Some(reservation),
+            Err(err) => return err.into_response(),
+        }
+    } else {
+        None
+    };
+
     let snapshot = state.snapshot.load();
     // Scope the gateway to the tools this caller's key permits, so MCP tool
     // access is governed by the same key object as LLM access.
     let acl = aisix_mcp::ToolAcl::from_allowed(auth.key().allowed_tools.as_deref());
     let gateway = aisix_mcp::McpGateway::from_snapshot(&snapshot).with_tool_acl(acl);
     let service = aisix_mcp::streamable_http_service(gateway);
+    let request = Request::from_parts(parts, Body::from(bytes));
     // `StreamableHttpService` is a tower service that dispatches on method and
     // never fails (`Error = Infallible`); map its boxed body back to axum's.
     match service.oneshot(request).await {
@@ -109,6 +150,83 @@ mod tests {
             builder = builder.header("authorization", format!("Bearer {token}"));
         }
         builder.body(Body::from(body.to_string())).unwrap()
+    }
+
+    /// A snapshot whose key carries an inline `rate_limit` of `rpm` requests
+    /// per minute and may call every tool.
+    fn snapshot_with_rate_limited_key(rpm: u32) -> AisixSnapshot {
+        let key_hash = ApiKey::hash_bearer(TOKEN);
+        let apikey: ApiKey = serde_json::from_value(serde_json::json!({
+            "key_hash": key_hash,
+            "allowed_models": ["*"],
+            "allowed_tools": ["*"],
+            "rate_limit": { "rpm": rpm },
+        }))
+        .expect("valid apikey");
+        let snapshot = AisixSnapshot::new();
+        snapshot
+            .apikeys
+            .insert(ResourceEntry::new("ak-1", apikey, 1));
+        snapshot
+    }
+
+    /// A `tools/call` request authenticated with `TOKEN`.
+    fn tools_call_request() -> HttpRequest<Body> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "ghost__tool", "arguments": {} }
+        });
+        HttpRequest::post("/mcp")
+            .header("host", "mcp.aisix.example.com")
+            .header("content-type", "application/json")
+            .header("accept", "application/json, text/event-stream")
+            .header("authorization", format!("Bearer {TOKEN}"))
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn rate_limit_applies_to_tool_calls_but_not_handshake() {
+        // rpm=1: the key may make one tools/call per minute.
+        let router = router_with(snapshot_with_rate_limited_key(1));
+
+        // First tool call passes the rate gate (status is whatever the gateway
+        // returns — there are no upstreams — but NOT 429).
+        let first = router
+            .clone()
+            .oneshot(tools_call_request())
+            .await
+            .expect("router responds");
+        assert_ne!(
+            first.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "first tool call should pass the rate gate"
+        );
+
+        // Second tool call within the same minute is rate-limited.
+        let second = router
+            .clone()
+            .oneshot(tools_call_request())
+            .await
+            .expect("router responds");
+        assert_eq!(
+            second.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "second tool call should be rate-limited"
+        );
+
+        // The handshake is never rate-limited, even with the key at its limit.
+        let handshake = router
+            .oneshot(initialize_request(Some(TOKEN)))
+            .await
+            .expect("router responds");
+        assert_ne!(
+            handshake.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "initialize must not be rate-limited"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

DP-4 slice 4 (governance reuse). An MCP `tools/call` now passes through the **same rate-limit and budget gate** as an LLM request — `quota::enforce(&state, &auth, None)`, keyed on the caller's API key. This is the core of the "single-pipeline same-governance" story: the same key, the same limiter, the same budget govern LLM *and* MCP work.

## How

- **Gate placement** — in the `/mcp` handler, after auth, before the gateway. `quota::enforce` applies the key's inline `rate_limit` (RPM/TPM/concurrency) **and** the budget pre-check (`budgets.check`). On 429 / budget-exceeded it returns before any upstream is contacted.
- **Scoped to the unit of work** — the handler peeks at the JSON-RPC `method` and only meters `tools/call`. `initialize` / `tools/list` (handshake + discovery) pass through ungated, so a client can always connect and enumerate even when the key is at its tool-call limit. (Reading the method means buffering the body — already size-capped by the global body-limit layer — and rebuilding the request for the gateway.)
- **No token cost** — a tool call carries no token figure (per-tool cost is a separate future concern), so the reservation is dropped after the call without committing tokens, which releases the concurrency slot. Budget is a gating check here, not a charge.

## Test plan

- [x] With an `rpm=1` key: first `tools/call` passes the gate (non-429), second `tools/call` within the minute → **429**, and `initialize` is **never** rate-limited (proves handshake/discovery bypass).
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p aisix-proxy` (508 pass), green.

## Scope / remaining

- This delivers **rate-limit + budget** reuse over MCP. The last slice — **guardrails over MCP** — is separate and meatier (guardrails are built around chat text, so MCP tool-call *arguments* and *results* need a JSON↔text adapter to flow through `guardrail_index.resolve` + `check_input`/`check_output`). And **UsageEvent** emission for MCP calls.

Refs AISIX-Cloud#894


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added rate-limit enforcement to MCP tool calls, helping prevent excessive usage before requests reach the backend.
  * MCP connection setup now respects existing request limits while leaving initial handshake and discovery steps unaffected.
  * Improved handling of incoming MCP requests so they continue to work reliably after being inspected for routing and limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->