### PR TITLE
feat(mcp): emit usage events for MCP tool calls

### DIFF
--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -313,6 +313,19 @@ pub struct UsageEvent {
     /// Empty when the client sent none. cp-api stores empty as NULL.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub client_user_agent: String,
+
+    // ─── MCP gateway attribution ───
+    /// Registered name of the upstream MCP server a `tools/call` was routed
+    /// to (the namespace prefix of the requested tool). Empty for non-MCP
+    /// events; cp-api stores empty as NULL. Older cp-api images that predate
+    /// this field ignore it (DP-first rollout).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub mcp_server_name: String,
+
+    /// Name of the MCP tool invoked, without the server prefix. Empty for
+    /// non-MCP events; cp-api stores empty as NULL.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub mcp_tool_name: String,
 }
 
 #[inline]
@@ -405,6 +418,7 @@ impl UsageSink {
         let bounded_protocol: &'static str = match event.inbound_protocol.as_str() {
             "openai" => "openai",
             "anthropic" => "anthropic",
+            "mcp" => "mcp",
             _ => "other",
         };
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2875,6 +2875,8 @@ fn emit_usage_event(
         // extractor (control-char strip + cap); IP is a formatted addr.
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
+        // MCP attribution does not apply to the chat path.
+        ..Default::default()
     };
     // Handler label "chat" matches the documented enumeration for
     // `aisix_usage_events_emitted_total` (#408). Keep `&'static str`

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -12,6 +12,9 @@
 //! traffic are layered on in subsequent steps; this step establishes the
 //! authenticated, snapshot-sourced endpoint.
 
+use std::time::{Duration, Instant};
+
+use aisix_obs::UsageEvent;
 use axum::body::{to_bytes, Body};
 use axum::extract::{Request, State};
 use axum::http::StatusCode;
@@ -23,18 +26,27 @@ use crate::auth::AuthenticatedKey;
 use crate::state::ProxyState;
 
 /// Just enough of a JSON-RPC request to tell a tool call apart from the MCP
-/// handshake / discovery methods. Unknown fields are ignored.
+/// handshake / discovery methods, and to recover the called tool's name.
+/// Unknown fields are ignored.
 #[derive(Deserialize)]
 struct JsonRpcPeek {
     method: Option<String>,
+    params: Option<PeekParams>,
+}
+
+#[derive(Deserialize)]
+struct PeekParams {
+    /// The namespaced `<server>__<tool>` name on a `tools/call`.
+    name: Option<String>,
 }
 
 /// Serve a `/mcp` request. The [`AuthenticatedKey`] extractor enforces a valid
 /// AISIX API key (responding `401` otherwise). A `tools/call` is then subject to
 /// the same rate-limit and budget governance as an LLM request — keyed on the
 /// caller's API key — before being handled by an MCP gateway built from the
-/// current snapshot's `mcp_servers`. The `initialize` / `tools/list` handshake
-/// and discovery methods pass through ungated.
+/// current snapshot's `mcp_servers`, and a usage event is emitted into the same
+/// pipeline as LLM calls. The `initialize` / `tools/list` handshake and discovery
+/// methods pass through ungated and unmetered.
 pub async fn mcp_endpoint(
     auth: AuthenticatedKey,
     State(state): State<ProxyState>,
@@ -48,21 +60,41 @@ pub async fn mcp_endpoint(
         Err(_) => return (StatusCode::BAD_REQUEST, "invalid request body").into_response(),
     };
 
-    let is_tool_call = serde_json::from_slice::<JsonRpcPeek>(&bytes)
-        .ok()
-        .and_then(|peek| peek.method)
-        .as_deref()
-        == Some("tools/call");
+    let peek = serde_json::from_slice::<JsonRpcPeek>(&bytes).ok();
+    let is_tool_call = peek.as_ref().and_then(|p| p.method.as_deref()) == Some("tools/call");
+    // Split the namespaced tool name into (server, tool) up front, owned, so it
+    // survives the body being consumed when the request is rebuilt.
+    let (mcp_server, mcp_tool) = if is_tool_call {
+        peek.as_ref()
+            .and_then(|p| p.params.as_ref())
+            .and_then(|p| p.name.as_deref())
+            .and_then(|name| name.split_once(aisix_mcp::TOOL_NAMESPACE_SEPARATOR))
+            .map(|(server, tool)| (server.to_string(), tool.to_string()))
+            .unwrap_or_default()
+    } else {
+        (String::new(), String::new())
+    };
 
     // Reuse the LLM path's rate-limit + budget gate on the unit of work. The
     // reservation is held for the duration of the call and dropped after (no
     // tokens to commit — a tool call carries no token cost), which releases the
     // concurrency slot. On 429 / budget-exceeded this returns before any
-    // upstream is contacted.
+    // upstream is contacted — and the rejected call is still recorded.
     let _reservation = if is_tool_call {
         match crate::quota::enforce(&state, &auth, None).await {
             Ok(reservation) => Some(reservation),
-            Err(err) => return err.into_response(),
+            Err(err) => {
+                let response = err.into_response();
+                emit_tool_call_usage(
+                    &state,
+                    &auth,
+                    &mcp_server,
+                    &mcp_tool,
+                    response.status().as_u16(),
+                    Duration::ZERO,
+                );
+                return response;
+            }
         }
     } else {
         None
@@ -77,10 +109,48 @@ pub async fn mcp_endpoint(
     let request = Request::from_parts(parts, Body::from(bytes));
     // `StreamableHttpService` is a tower service that dispatches on method and
     // never fails (`Error = Infallible`); map its boxed body back to axum's.
-    match service.oneshot(request).await {
+    let started = Instant::now();
+    let response = match service.oneshot(request).await {
         Ok(response) => response.map(Body::new),
         Err(infallible) => match infallible {},
+    };
+
+    if is_tool_call {
+        emit_tool_call_usage(
+            &state,
+            &auth,
+            &mcp_server,
+            &mcp_tool,
+            response.status().as_u16(),
+            started.elapsed(),
+        );
     }
+    response
+}
+
+/// Emit a usage event for a single MCP tool call into the same sink as LLM
+/// usage. MCP calls carry no token cost yet, so token/cost fields stay zero;
+/// the event records who called which tool, the outcome, and the latency.
+fn emit_tool_call_usage(
+    state: &ProxyState,
+    auth: &AuthenticatedKey,
+    mcp_server: &str,
+    mcp_tool: &str,
+    status_code: u16,
+    latency: Duration,
+) {
+    let event = UsageEvent {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        api_key_id: auth.entry.id.clone(),
+        status_code,
+        latency_ms: latency.as_millis().min(u32::MAX as u128) as u32,
+        inbound_protocol: "mcp".to_string(),
+        mcp_server_name: mcp_server.to_string(),
+        mcp_tool_name: mcp_tool.to_string(),
+        ..Default::default()
+    };
+    state.usage_sink.try_emit("mcp", event);
 }
 
 #[cfg(test)]
@@ -337,6 +407,46 @@ mod tests {
         assert!(
             text.contains("serverInfo") || text.contains("protocolVersion"),
             "initialize result should carry the server info, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn emits_usage_event_for_tool_call_only() {
+        use aisix_obs::{UsageEvent, UsageSink};
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<UsageEvent>(8);
+        let handle = SnapshotHandle::new(snapshot_with_key());
+        let hub = Arc::new(aisix_gateway::Hub::new());
+        let state = ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let router = build_router(state);
+
+        // A tools/call emits one usage event into the same sink as LLM calls,
+        // carrying the MCP attribution (server + tool, parsed from the
+        // namespaced name `ghost__tool`).
+        let _ = router
+            .clone()
+            .oneshot(tools_call_request())
+            .await
+            .expect("router responds");
+        let event = rx
+            .try_recv()
+            .expect("a usage event was emitted for the tool call");
+        assert_eq!(event.inbound_protocol, "mcp");
+        assert_eq!(event.mcp_server_name, "ghost");
+        assert_eq!(event.mcp_tool_name, "tool");
+        assert_eq!(event.api_key_id, "ak-1");
+        assert_eq!(event.prompt_tokens, 0, "MCP calls carry no token cost");
+
+        // The handshake does NOT emit a usage event.
+        let _ = router
+            .oneshot(initialize_request(Some(TOKEN)))
+            .await
+            .expect("router responds");
+        assert!(
+            rx.try_recv().is_err(),
+            "initialize must not emit a usage event"
         );
     }
 }

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -438,6 +438,10 @@ mod tests {
         assert_eq!(event.mcp_tool_name, "tool");
         assert_eq!(event.api_key_id, "ak-1");
         assert_eq!(event.prompt_tokens, 0, "MCP calls carry no token cost");
+        assert!(
+            rx.try_recv().is_err(),
+            "exactly one usage event per tool call"
+        );
 
         // The handshake does NOT emit a usage event.
         let _ = router
@@ -448,5 +452,40 @@ mod tests {
             rx.try_recv().is_err(),
             "initialize must not emit a usage event"
         );
+    }
+
+    #[tokio::test]
+    async fn rate_limited_tool_call_still_emits_usage_event() {
+        use aisix_obs::{UsageEvent, UsageSink};
+
+        // rpm=1: the second tool call is rate-limited (429) but still recorded —
+        // the reject path emits before returning.
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<UsageEvent>(8);
+        let handle = SnapshotHandle::new(snapshot_with_rate_limited_key(1));
+        let hub = Arc::new(aisix_gateway::Hub::new());
+        let state = ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let router = build_router(state);
+
+        let _ = router
+            .clone()
+            .oneshot(tools_call_request())
+            .await
+            .expect("router responds");
+        let _ = rx.try_recv().expect("first (allowed) call emits");
+
+        let second = router
+            .oneshot(tools_call_request())
+            .await
+            .expect("router responds");
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+        let event = rx
+            .try_recv()
+            .expect("the rate-limited call is still recorded");
+        assert_eq!(event.status_code, 429);
+        assert_eq!(event.inbound_protocol, "mcp");
+        assert_eq!(event.mcp_server_name, "ghost");
+        assert_eq!(event.mcp_tool_name, "tool");
     }
 }


### PR DESCRIPTION
## What

DP-4 slice ⑤b (observability). Each MCP `tools/call` now emits a **UsageEvent into the same sink/pipeline as LLM usage**, so MCP activity lands in the unified usage record — matching how the leading gateways log MCP calls (Kong: MCP audit log + metrics; Portkey: unified MCP+LLM traces), framed AISIX's way: *the same usage pipeline*, not a separate MCP surface.

## How

- The `/mcp` handler peeks the JSON-RPC `params.name` (it already buffers the body for rate-limit), splits the namespaced `<server>__<tool>`, and after the gateway call emits a `UsageEvent` via `state.usage_sink.try_emit("mcp", ..)` (non-blocking, fire-and-forget — same as LLM handlers).
- Event fields: `api_key_id`, `status_code`, `latency_ms`, `inbound_protocol="mcp"`, and two new `mcp_server_name` / `mcp_tool_name`. **Rate-limited calls are recorded too** (the 429 path emits before returning). `initialize` / `tools/list` are **not** metered.
- **No token cost**: MCP tool calls carry no token figure yet (per-tool cost is deferred, #894 Phase 3), so token/cost fields stay zero — consistent with Kong/Portkey, who also log MCP calls without a per-call cost.
- `UsageEvent` gains two optional, skip-when-empty fields. Non-MCP events leave them empty (the chat path now uses `..Default::default()`). **DP-first rollout** like `user_name`: older cp-api ignores the unknown fields until the CP migration lands — filed as **[AISIX-Cloud#908](https://github.com/api7/AISIX-Cloud/issues/908)**.

## Reference implementations (CLAUDE.md §7)

Re-verified against primary sources (2026-06-30): **all three** mainstream gateways log MCP calls — LiteLLM (same spend-log table, `mcp_namespaced_tool_name`, `call_type=call_mcp_tool`), Kong (MCP audit log + Prometheus metrics, 3.12+), Portkey (unified MCP+LLM logs/traces). So MCP usage logging is table-stakes; AISIX's framing is unifying it into the *same* `UsageEvent` as LLM. **Per-tool cost**: only LiteLLM has it — we defer, like Kong/Portkey.

## Test plan

- [x] `emits_usage_event_for_tool_call_only`: a `tools/call` emits exactly one event with `inbound_protocol="mcp"`, `mcp_server_name`/`mcp_tool_name` parsed from the namespaced name, the right `api_key_id`, and zero tokens; `initialize` emits **none**. (Injects a real `UsageSink` with a receiver and asserts on the channel.)
- [x] `fmt`, `clippy --workspace --all-targets -D warnings`, `cargo test -p aisix-obs -p aisix-proxy` green.

## Remaining

Slice ⑤a — **guardrails over MCP** (the differentiator: Kong won't, Portkey "coming soon", LiteLLM experimental+buggy) — is the next and final DP-4 PR.

Refs AISIX-Cloud#894


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tool calls are now tracked as usage events, including server/tool attribution and request latency.
  * MCP-related usage is labeled distinctly, improving reporting and visibility.

* **Bug Fixes**
  * MCP handshake/discovery traffic no longer appears as billable tool usage.
  * Usage events now include default values consistently, preventing missing data in non-MCP chat flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->