### PR TITLE
fix(mcp): reject mcp_server timeout_ms = 0

### DIFF
--- a/crates/aisix-core/src/models/mcp_server.rs
+++ b/crates/aisix-core/src/models/mcp_server.rs
@@ -46,9 +46,10 @@ pub struct McpServer {
     pub secret: Option<String>,
 
     /// Maximum time, in milliseconds, to wait for a single upstream operation
-    /// (establishing the session, listing tools, or calling a tool). When
-    /// omitted, the gateway applies a built-in default.
+    /// (establishing the session, listing tools, or calling a tool). Must be at
+    /// least `1` when set. When omitted, the gateway applies a built-in default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
     pub timeout_ms: Option<u64>,
 
     /// Whether this server is active. When `false`, its tools are not listed and

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -2140,4 +2140,39 @@ mod tests {
         });
         assert!(validate_provider_key(&v).is_err());
     }
+
+    // ---- mcp_server schema tests (#666 timeout_ms guard) ----
+
+    #[test]
+    fn mcp_server_minimal_passes() {
+        // `timeout_ms` is optional; omitting it must validate.
+        let v = json!({
+            "display_name": "github",
+            "url": "https://api.example.com/mcp"
+        });
+        validate_mcp_server(&v).unwrap();
+    }
+
+    #[test]
+    fn mcp_server_accepts_positive_timeout_ms() {
+        let v = json!({
+            "display_name": "github",
+            "url": "https://api.example.com/mcp",
+            "timeout_ms": 1
+        });
+        validate_mcp_server(&v).unwrap();
+    }
+
+    #[test]
+    fn mcp_server_rejects_zero_timeout_ms() {
+        // A zero deadline times out every upstream op instantly and silently
+        // drops the server from `tools/list`; reject it at the schema layer
+        // (enforced on both the Admin write-path and the etcd loader).
+        let v = json!({
+            "display_name": "github",
+            "url": "https://api.example.com/mcp",
+            "timeout_ms": 0
+        });
+        assert!(validate_mcp_server(&v).is_err());
+    }
 }

--- a/schemas/resources/mcp_server.schema.json
+++ b/schemas/resources/mcp_server.schema.json
@@ -65,9 +65,9 @@
       ]
     },
     "timeout_ms": {
-      "description": "Maximum time, in milliseconds, to wait for a single upstream operation (establishing the session, listing tools, or calling a tool). When omitted, the gateway applies a built-in default.",
+      "description": "Maximum time, in milliseconds, to wait for a single upstream operation (establishing the session, listing tools, or calling a tool). Must be at least `1` when set. When omitted, the gateway applies a built-in default.",
       "format": "uint64",
-      "minimum": 0.0,
+      "minimum": 1.0,
       "type": [
         "integer",
         "null"


### PR DESCRIPTION
`McpServer.timeout_ms` accepts `0`, which maps to a zero-duration per-operation deadline: every upstream op then times out instantly and the server is silently dropped from `tools/list` (graceful, logged, no crash).

## Fix

Guard it at the schema layer with `#[schemars(range(min = 1))]` on the `timeout_ms` field — the same mechanism as the existing `length(min = 1)` guards on `display_name`/`url` — so `validate_mcp_server` enforces it on **both** the Admin write-path (`mcp_servers_handlers`) and the etcd loader (`validate_and_parse`). Regenerated `mcp_server.schema.json` (`minimum` 0 → 1) and added validation tests (zero rejected, positive accepted, omitted still valid).

**Behavior change (called out for review):** a stored `mcp_server` with `timeout_ms = 0` is now rejected by the loader — but `build_snapshot` is infallible, so a rejected resource is skipped individually (bumps `schema_rejected`) without aborting the snapshot or taking down healthy resources, exactly as an empty `display_name` already is. `0` was never a usable value (instant timeout), so this rejects a previously-silently-broken config rather than a working one.

## Scope note

This PR originally also carried the `mcp_servers` Admin OpenAPI reference (#663). That was implemented independently and merged first as #675 (a different mechanism — variant titles baked into the generated schema via `title_single_value_enum_variants`). This branch was rebased onto that work and now carries **only** the `timeout_ms` validation; the regenerated schema correctly combines #675's variant titles with this PR's `minimum: 1`.

## Verification

`cargo test -p aisix-core` (incl. 3 new validation tests) + `-p aisix-admin` (19 openapi tests) green; `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean; `dump-schema` produces zero drift.

Closes #666.