### PR TITLE
docs(admin): fix API key OpenAPI metadata

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -288,6 +288,12 @@ mod tests {
         json!({"key_hash": key_hash, "allowed_models": allowed})
     }
 
+    fn apikey_payload_with_tools(key: &str, allowed: &[&str], tools: Value) -> Value {
+        let mut payload = apikey_payload(key, allowed);
+        payload["allowed_tools"] = tools;
+        payload
+    }
+
     fn auth_req(method: &str, uri: &str, body: Option<Value>) -> Request<Body> {
         let body = match body {
             Some(v) => Body::from(v.to_string()),
@@ -1045,6 +1051,74 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn apikey_crud_round_trips_allowed_tools() {
+        let state = build_state();
+
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req(
+                "POST",
+                "/admin/v1/apikeys",
+                Some(apikey_payload_with_tools(
+                    "sk-mcp-tools",
+                    &["*"],
+                    json!(["github__create_issue"]),
+                )),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let created = body_json(resp).await;
+        let id = created["id"].as_str().unwrap().to_string();
+        assert_eq!(
+            created["value"]["allowed_tools"],
+            json!(["github__create_issue"])
+        );
+
+        let app = build_router(state.clone());
+        let resp = run(app, auth_req("GET", "/admin/v1/apikeys", None)).await;
+        let listed = body_json(resp).await;
+        assert_eq!(
+            listed[0]["value"]["allowed_tools"],
+            json!(["github__create_issue"])
+        );
+
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("GET", &format!("/admin/v1/apikeys/{id}"), None),
+        )
+        .await;
+        let fetched = body_json(resp).await;
+        assert_eq!(
+            fetched["value"]["allowed_tools"],
+            json!(["github__create_issue"])
+        );
+
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req(
+                "PUT",
+                &format!("/admin/v1/apikeys/{id}"),
+                Some(apikey_payload_with_tools(
+                    "sk-mcp-tools-2",
+                    &["*"],
+                    Value::Null,
+                )),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let updated = body_json(resp).await;
+        assert!(
+            updated["value"].get("allowed_tools").is_none(),
+            "explicit null should clear allowed_tools and be omitted from the response"
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3163,6 +3163,16 @@ const OPENAPI_JSON_BASE: &str = r##"{
           "rate_limit": {
             "$ref": "#/components/schemas/RateLimit",
             "description": "Request, token, and concurrency limits for this key."
+          },
+          "allowed_tools": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted, the key has no MCP tool access."
           }
         },
         "additionalProperties": false
@@ -3461,6 +3471,19 @@ const OPENAPI_JSON_BASE: &str = r##"{
           "rate_limit": {
             "$ref": "#/components/schemas/RateLimit",
             "description": "Request, token, and concurrency limits for this key."
+          },
+          "allowed_tools": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted, the key has no MCP tool access.",
+            "example": [
+              "github__create_issue"
+            ]
           }
         },
         "additionalProperties": false,
@@ -3703,7 +3726,7 @@ fn add_variant_titles(doc: &mut Value) {
         ),
         (
             "/components/schemas/WhenAllUnavailablePolicy/oneOf",
-            &["Fail", "Original order"],
+            &["Fail", "Try anyway"],
         ),
         (
             "/components/schemas/RoutingStrategy/oneOf",
@@ -4158,6 +4181,15 @@ mod tests {
         let request = &parsed["components"]["schemas"]["ApiKeyRequest"];
         assert_eq!(request["required"][0], "key_hash");
         assert_eq!(request["required"][1], "allowed_models");
+        assert!(
+            request["properties"].get("allowed_tools").is_some(),
+            "self-hosted API key requests must document MCP tool access"
+        );
+        let public = &parsed["components"]["schemas"]["PublicApiKey"];
+        assert!(
+            public["properties"].get("allowed_tools").is_some(),
+            "API key responses must document MCP tool access"
+        );
         assert!(request["properties"].get("team_id").is_none());
         assert!(request["properties"].get("user_id").is_none());
     }

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3172,7 +3172,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted, the key has no MCP tool access."
+            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted or set to `null`, the key has no MCP tool access."
           }
         },
         "additionalProperties": false
@@ -3480,7 +3480,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted, the key has no MCP tool access.",
+            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted or set to `null`, the key has no MCP tool access.",
             "example": [
               "github__create_issue"
             ]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -4185,10 +4185,24 @@ mod tests {
             request["properties"].get("allowed_tools").is_some(),
             "self-hosted API key requests must document MCP tool access"
         );
+        let request_allowed_tools = request["properties"]["allowed_tools"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            request_allowed_tools.contains("omitted or set to `null`"),
+            "self-hosted API key request schema must document null tool-access behavior"
+        );
         let public = &parsed["components"]["schemas"]["PublicApiKey"];
         assert!(
             public["properties"].get("allowed_tools").is_some(),
             "API key responses must document MCP tool access"
+        );
+        let public_allowed_tools = public["properties"]["allowed_tools"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            public_allowed_tools.contains("omitted or set to `null`"),
+            "API key response schema must document null tool-access behavior"
         );
         assert!(request["properties"].get("team_id").is_none());
         assert!(request["properties"].get("user_id").is_none());

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -198,6 +198,12 @@ mod tests {
             serde_json::from_str(r#"{"key_hash":"h","allowed_models":["*"]}"#).unwrap();
         assert!(!none.can_access_tool("github__create_issue"));
 
+        // Explicit null has the same no-access behavior as omission.
+        let null: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_models":["*"],"allowed_tools":null}"#)
+                .unwrap();
+        assert!(!null.can_access_tool("github__create_issue"));
+
         // Empty list also denies everything.
         let empty: ApiKey =
             serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"allowed_tools":[]}"#)

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -49,8 +49,8 @@ pub struct ApiKey {
 
     /// MCP tools this key may call, as namespaced `<server>__<tool>` names
     /// (the form the gateway exposes). A wildcard entry `"*"` grants every
-    /// tool. When omitted, the key has no MCP tool access — access is granted
-    /// explicitly, matching `allowed_models`.
+    /// tool. When omitted or set to `null`, the key has no MCP tool access —
+    /// access is granted explicitly, matching `allowed_models`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
 

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -41,11 +41,9 @@ pub struct ApiKey {
     #[schemars(length(min = 1))]
     pub user_id: Option<String>,
 
-    /// Readable display name of the owning member (#890 req-3). Synced by
-    /// cp-api solely so the proxy can stamp a human-readable `user_name`
-    /// metric label alongside `user_id`; never used for auth or routing.
-    /// Absent on older cp-api payloads → the metric label falls back to
-    /// `"unknown"` (DP-first rollout).
+    /// Readable display name of the owning member. Used only for telemetry
+    /// labels alongside `user_id`; never used for authentication or routing.
+    /// When omitted, telemetry reports the user name as `"unknown"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_name: Option<String>,
 

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -81,7 +81,7 @@
       "type": "array"
     },
     "allowed_tools": {
-      "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). A wildcard entry `\"*\"` grants every tool. When omitted, the key has no MCP tool access — access is granted explicitly, matching `allowed_models`.",
+      "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). A wildcard entry `\"*\"` grants every tool. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly, matching `allowed_models`.",
       "items": {
         "type": "string"
       },

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -123,7 +123,7 @@
       ]
     },
     "user_name": {
-      "description": "Readable display name of the owning member (#890 req-3). Synced by cp-api solely so the proxy can stamp a human-readable `user_name` metric label alongside `user_id`; never used for auth or routing. Absent on older cp-api payloads → the metric label falls back to `\"unknown\"` (DP-first rollout).",
+      "description": "Readable display name of the owning member. Used only for telemetry labels alongside `user_id`; never used for authentication or routing. When omitted, telemetry reports the user name as `\"unknown\"`.",
       "type": [
         "string",
         "null"


### PR DESCRIPTION
## Summary

- document self-hosted API key MCP tool access in the Admin API request and response schemas
- rename the `try_anyway` ReDoc variant title from `Original order` to `Try anyway`
- remove internal rollout/review wording from the generated `ApiKey.user_name` description

## Runtime impact

No runtime behavior change. The self-hosted API key handler already accepts and returns `allowed_tools`; this PR fixes the generated Admin API reference metadata.

## Validation

- cargo run -p aisix-core --bin dump-schema
- cargo test -p aisix-admin openapi_
- cargo run -p aisix-admin --bin dump-openapi > /tmp/admin-api.openapi.reviewfix.json
- cargo fmt --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key settings now document an `allowed_tools` option, including support for allowing all tools with `*` or leaving the field unset.

* **Documentation**
  * Clarified API key field descriptions for both request and response formats.
  * Improved guidance on how display names are used in telemetry when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->