### PR TITLE
ci(docker-image): sign published images with cosign (keyless OIDC)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,6 +39,7 @@ env:
 permissions:
   contents: read
   packages: write
+  id-token: write # keyless cosign signing via GitHub OIDC
 
 concurrency:
   group: docker-image-${{ github.ref }}
@@ -108,6 +109,7 @@ jobs:
         run: echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -119,6 +121,31 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false   # keep manifest format compatible with older clients
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless (GitHub OIDC) signature over the pushed image digest, same
+      # scheme as api7-ee-3-gateway. Tags sharing a digest collapse to one
+      # signature; signatures land in a sibling <registry>/api7/notary repo,
+      # so `cosign verify` must set COSIGN_REPOSITORY to the same value.
+      - name: Sign images with cosign
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          signed=""
+          for ref in ${TAGS}; do
+            repo="${ref%:*}"
+            case " ${signed} " in *" ${repo} "*) continue ;; esac
+            signed="${signed} ${repo}"
+            registry="${repo%%/*}"
+            echo "Signing ${repo}@${DIGEST} (notary: ${registry}/api7/notary)"
+            COSIGN_REPOSITORY="${registry}/api7/notary" \
+              cosign sign --yes --recursive "${repo}@${DIGEST}"
+          done
 
       - name: Check OpenAPI publishing secrets
         id: openapi-secrets


### PR DESCRIPTION
## What

Sign every published `aisix` container image with [cosign](https://github.com/sigstore/cosign), using **keyless GitHub OIDC** signing (no private key to store/rotate). This mirrors the signing scheme already used by `api7-ee-3-gateway`.

## Why

Images pushed to GHCR (and Docker Hub on release) are currently unsigned, so downstream/private-deployment consumers can't verify provenance. Cosign signatures let anyone cryptographically confirm an image was built by this repo's CI.

## How

- `permissions: id-token: write` — lets the job request the GitHub OIDC token cosign uses (Fulcio/Rekor keyless flow).
- Install `sigstore/cosign-installer`, then sign the digest emitted by `docker/build-push-action` (`steps.build.outputs.digest`).
- Signing is by **digest**, and the tag set is collapsed to **one signature per `repo@digest`** — so `dev`/`poc`/`sha-*` and every release tag are covered without re-signing a shared digest.
- Signatures are stored in a sibling `<registry>/api7/notary` repo (`COSIGN_REPOSITORY`): `ghcr.io/api7/notary` on every push, plus `docker.io/api7/notary` on release tags.

## Scope / behavior

- Signs all **pushed** images (dev/poc/sha + release), matching the reference pipeline.
- Pull-request builds are unaffected: they don't push, so the install/sign steps are skipped (`if: github.event_name != 'pull_request'`).

## Config

No new secrets. `ghcr.io/api7/notary` already grants this repo Actions write access; `docker.io/api7/notary` uses the same Docker Hub credentials already configured for release mirroring.

## Verify

```bash
COSIGN_REPOSITORY=ghcr.io/api7/notary \
cosign verify \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  --certificate-identity-regexp '^https://github.com/api7/ai-gateway/' \
  ghcr.io/api7/aisix:<tag>
```

## Testing

CI-workflow-only change with no unit-testable surface; it is exercised by the `docker-image` workflow run itself on the next push to `main`. The tag→digest collapse logic was validated locally under bash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images are now signed after publishing, adding stronger verification for released builds.
  * Automated signing uses a keyless trust flow for supported release events.

* **Bug Fixes**
  * Improved the release pipeline so image digests can be reliably tracked and signed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->