### PR TITLE
fix(cache,ratelimit): scope Redis keys by env_id so a shared Redis can't leak across environments

### DIFF
--- a/crates/aisix-cache/src/redis.rs
+++ b/crates/aisix-cache/src/redis.rs
@@ -76,6 +76,19 @@ impl RedisCache {
         self
     }
 
+    /// Namespace the prefix by the DP's environment id. The response-cache
+    /// key is a content-only fingerprint (`CacheKey`, no caller/env in it),
+    /// so two environments pointed at the same (user-provided) Redis would
+    /// otherwise serve each other's cached answers for an identical request.
+    /// Scoping the prefix to `<prefix>:<env_id>` keeps them isolated. Empty
+    /// `env_id` (standalone / v2 — no env cert) leaves the prefix unchanged.
+    pub fn with_env_namespace(mut self, env_id: &str) -> Self {
+        if !env_id.is_empty() {
+            self.prefix = format!("{}:{}", self.prefix, env_id);
+        }
+        self
+    }
+
     fn full_key(&self, key: &str) -> String {
         format!("{}:{}", self.prefix, key)
     }

--- a/crates/aisix-cache/tests/redis_integration.rs
+++ b/crates/aisix-cache/tests/redis_integration.rs
@@ -224,6 +224,69 @@ async fn put_then_get_round_trips_against_sentinel() {
     assert_eq!(got.message.content_str(), "via-master");
 }
 
+#[tokio::test]
+async fn env_namespace_isolates_identical_fingerprints() {
+    // Two environments pointed at the same (user-provided) Redis must not
+    // share cache entries even for a byte-identical request — the key is a
+    // content-only fingerprint, so `with_env_namespace` is the only thing
+    // keeping them apart.
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: CACHE_TEST_REDIS_URL not set");
+        return;
+    };
+    // Same base prefix for both handles, so any isolation is due to the env
+    // segment alone (not a stray unique prefix).
+    let base = format!("aisix:test:{}", uuid_like());
+
+    let env_a = RedisCache::connect(&single(&url))
+        .await
+        .expect("redis connect")
+        .with_prefix(base.clone())
+        .with_env_namespace("env-a");
+    let env_b = RedisCache::connect(&single(&url))
+        .await
+        .expect("redis connect")
+        .with_prefix(base.clone())
+        .with_env_namespace("env-b");
+
+    let key = "identical-fingerprint";
+    env_a.put(key, sample("answer for A")).await.unwrap();
+
+    // env-b must NOT see env-a's entry under the identical fingerprint.
+    assert!(
+        env_b.get(key).await.unwrap().is_none(),
+        "distinct env namespaces must not share cache entries"
+    );
+    // env-a still reads its own.
+    assert_eq!(
+        env_a
+            .get(key)
+            .await
+            .unwrap()
+            .expect("hit")
+            .message
+            .content_str(),
+        "answer for A"
+    );
+
+    // Control: empty env_id leaves the prefix unchanged, so a bare handle
+    // shares the base namespace (standalone / v2 behaviour is preserved).
+    let bare = RedisCache::connect(&single(&url))
+        .await
+        .expect("redis connect")
+        .with_prefix(base.clone());
+    let bare_ns = RedisCache::connect(&single(&url))
+        .await
+        .expect("redis connect")
+        .with_prefix(base.clone())
+        .with_env_namespace("");
+    bare.put("empty-env", sample("shared")).await.unwrap();
+    assert!(
+        bare_ns.get("empty-env").await.unwrap().is_some(),
+        "empty env_id must not change the namespace"
+    );
+}
+
 /// Cheap unique-ish suffix to keep tests from clobbering each other.
 /// We don't need cryptographic uniqueness — `cargo test` runs each test
 /// file in a single process, so nanos + thread-id give plenty of spread.

--- a/crates/aisix-ratelimit/src/store/redis.rs
+++ b/crates/aisix-ratelimit/src/store/redis.rs
@@ -236,6 +236,21 @@ impl RedisStore {
         self
     }
 
+    /// Namespace the prefix by the DP's environment id. Most bucket keys are
+    /// globally-unique CP UUIDs (api_key / policy ids), but the model inline
+    /// limit buckets on the env-local model alias (`model:<name>`), so two
+    /// environments sharing one (user-provided) Redis would otherwise merge
+    /// their `model:<alias>` counters. Scoping the prefix to `<prefix>:<env_id>`
+    /// isolates every bucket. Empty `env_id` (standalone / v2) leaves it
+    /// unchanged. The env segment sits before the `{bucket}` hash tag, so
+    /// Redis Cluster slot placement (by bucket) is unaffected.
+    pub fn with_env_namespace(mut self, env_id: &str) -> Self {
+        if !env_id.is_empty() {
+            self.prefix = format!("{}:{}", self.prefix, env_id);
+        }
+        self
+    }
+
     /// `aisix:rl:{<bucket>}` — the hash tag co-locates every key for the
     /// bucket on one Redis Cluster slot.
     fn bucket_prefix(&self, key: &str) -> String {

--- a/crates/aisix-ratelimit/tests/redis_integration.rs
+++ b/crates/aisix-ratelimit/tests/redis_integration.rs
@@ -316,3 +316,55 @@ async fn sentinel_shared_counter_round_trips() {
         "got {err:?}"
     );
 }
+
+#[tokio::test]
+async fn env_namespace_isolates_model_alias_bucket() {
+    // The model inline rate limit buckets on the env-local alias
+    // (`model:<name>`), which is NOT a globally-unique id. Two environments
+    // sharing one Redis must keep independent counters for the same alias —
+    // `with_env_namespace` is what separates them. (The api_key / policy
+    // buckets are UUIDs and never collided; the prefix just covers them too.)
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: RATELIMIT_TEST_REDIS_URL not set");
+        return;
+    };
+    // A shared run tag keeps the test hermetic; the env-a / env-b suffixes are
+    // what must isolate the two counters.
+    let run = unique_key("modelns");
+    let env_a_ns = format!("{run}:env-a");
+    let env_b_ns = format!("{run}:env-b");
+
+    let env_a = store(&url).await.with_env_namespace(&env_a_ns);
+    let env_b = store(&url).await.with_env_namespace(&env_b_ns);
+
+    // Identical alias bucket in both environments.
+    let key = "model:gpt-4o";
+    let limits = RateLimit {
+        rpm: Some(1),
+        ..rl()
+    };
+
+    // env-a burns its single rpm slot for the alias.
+    env_a
+        .acquire(key, &limits, "a-1")
+        .await
+        .expect("env-a first allowed");
+    env_a
+        .acquire(key, &limits, "a-2")
+        .await
+        .expect_err("env-a is now at its own limit");
+
+    // env-b, identical alias bucket, is unaffected — a distinct counter.
+    env_b
+        .acquire(key, &limits, "b-1")
+        .await
+        .expect("different env must not share the model:<alias> counter");
+
+    // Control: a second handle in env-a shares the exhausted counter, proving
+    // the isolation comes from the env namespace, not the handle identity.
+    let env_a2 = store(&url).await.with_env_namespace(&env_a_ns);
+    env_a2
+        .acquire(key, &limits, "a-3")
+        .await
+        .expect_err("same env shares the counter");
+}

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -400,7 +400,8 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 .map_err(|e| {
                     anyhow::anyhow!("redis rate-limit connect failed (ratelimit.redis): {e}")
                 })?
-                .with_conc_ttl(cfg.ratelimit.concurrency_ttl_secs);
+                .with_conc_ttl(cfg.ratelimit.concurrency_ttl_secs)
+                .with_env_namespace(&cfg.etcd.env_id);
             Limiter::with_store(Arc::new(store))
         }
         RateLimitBackend::Memory => Limiter::new(),
@@ -420,12 +421,15 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let redis_cache: Option<Arc<dyn Cache>> = match cfg.cache.redis.as_ref() {
         Some(redis_cfg) => {
             tracing::info!(target: "aisix::cache", backend = "redis", "connecting cache backend");
-            let redis = RedisCache::connect(redis_cfg).await.map_err(|e| {
-                // Deliberately no URL in the message: redis URLs carry
-                // credentials (redis://user:pass@host) and this error
-                // lands in logs that may ship to centralized sinks.
-                anyhow::anyhow!("redis cache connect failed (cache.redis): {e}")
-            })?;
+            let redis = RedisCache::connect(redis_cfg)
+                .await
+                .map_err(|e| {
+                    // Deliberately no URL in the message: redis URLs carry
+                    // credentials (redis://user:pass@host) and this error
+                    // lands in logs that may ship to centralized sinks.
+                    anyhow::anyhow!("redis cache connect failed (cache.redis): {e}")
+                })?
+                .with_env_namespace(&cfg.etcd.env_id);
             Some(Arc::new(redis) as Arc<dyn Cache>)
         }
         None => None,

--- a/tests/e2e/src/cases/cache-env-namespace-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-env-namespace-e2e.test.ts
@@ -1,0 +1,236 @@
+import { createHash, randomUUID } from "node:crypto";
+import { connect } from "node:net";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the response cache is isolated per environment on a shared Redis
+// (api7/AISIX-Cloud#788, P1-1).
+//
+// The cache key is a content-only fingerprint (model + messages + params,
+// no env/caller). Redis is user-provided infrastructure our chart does
+// not manage, so a user can point the DPs of two different environments
+// at ONE Redis. Without env-scoping, a byte-identical request in env-b
+// would hit env-a's cached entry and receive env-a's answer.
+// `with_env_namespace` scopes the redis key prefix by `env_id`.
+//
+// Repro: two apps on one shared etcd base + one shared Redis, but with
+// distinct `env_id` (so `effective_prefix` isolates their config too).
+// Each has a redis-backed `applies_to:all` cache policy. An identical
+// request is a HIT within its own env yet a MISS in the peer env, and
+// the peer env returns its OWN upstream body — proving no cross-env
+// leak. Before the fix the peer request would be a HIT with env-a's body.
+
+const CALLER_PLAINTEXT = "sk-cache-envns-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const ETCD_ENDPOINT = process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379";
+const REDIS_URL = process.env.AISIX_E2E_REDIS ?? "redis://127.0.0.1:6379";
+
+// Both envs use the SAME model alias so the request fingerprints collide
+// across environments — the env namespace is the only thing keeping their
+// cache entries apart.
+const MODEL = "cache-envns";
+
+/** RESP-level PING so the suite skips honestly when no redis is reachable
+ *  (CI provisions redis:7-alpine on :6379). */
+async function redisPing(url: string): Promise<boolean> {
+  const m = /^redis:\/\/(?:[^@/]*@)?([^:/]+)(?::(\d+))?/.exec(url);
+  if (!m) return false;
+  const host = m[1];
+  const port = m[2] ? Number(m[2]) : 6379;
+  return new Promise((resolve) => {
+    const sock = connect({ host, port });
+    const done = (ok: boolean) => {
+      sock.destroy();
+      resolve(ok);
+    };
+    sock.once("connect", () => sock.write("PING\r\n"));
+    sock.once("data", (buf: Buffer) => done(buf.toString().startsWith("+PONG")));
+    sock.once("error", () => done(false));
+    sock.setTimeout(1000, () => done(false));
+  });
+}
+
+/** A shared etcd base prefix, but each app carries its own `env_id`, so
+ *  `effective_prefix` (`<prefix>/<env_id>/`) keeps their config namespaces
+ *  apart while both still point at ONE Redis. */
+function envEtcd(prefix: string, envId: string) {
+  return {
+    endpoints: [ETCD_ENDPOINT],
+    prefix,
+    env_id: envId,
+    dial_timeout_ms: 5000,
+    request_timeout_ms: 5000,
+  };
+}
+
+/** An OpenAI chat.completion body with a distinguishable assistant content,
+ *  so a cross-env cache hit is caught by comparing the returned text. */
+function completionBody(content: string) {
+  return {
+    id: `mock-${content}`,
+    object: "chat.completion",
+    created: 0,
+    model: "mock-model",
+    choices: [
+      { index: 0, message: { role: "assistant", content }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+  };
+}
+
+function chatRequest(proxyUrl: string): Promise<Response> {
+  return fetch(`${proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+}
+
+/** Seed one model (→ this env's own upstream), a permissive ApiKey, and a
+ *  redis-backed `applies_to:all` cache policy via this app's admin API. */
+async function seed(app: SpawnedApp, upstreamBase: string) {
+  const admin = new AdminClient(app.adminUrl, app.adminKey);
+  const pk = await admin.createProviderKey({
+    display_name: `${MODEL}-pk`,
+    secret: "sk-mock",
+    api_base: `${upstreamBase}/v1`,
+  });
+  await admin.createModel({
+    display_name: MODEL,
+    provider: "openai",
+    model_name: "gpt-4o-mini",
+    provider_key_id: pk.id,
+  });
+  await admin.createApiKey({
+    key_hash: CALLER_KEY_HASH,
+    allowed_models: [MODEL],
+  });
+  await admin.json("POST", "/admin/v1/cache_policies", {
+    name: `${MODEL}-redis-policy`,
+    enabled: true,
+    backend: "redis",
+    ttl_seconds: 300,
+    applies_to: "all",
+  });
+}
+
+/** Wait until `MODEL` is visible on `proxyUrl` (config propagation). */
+async function waitModelLive(proxyUrl: string) {
+  const probe = new ProxyClient(proxyUrl, CALLER_PLAINTEXT);
+  await waitConfigPropagation(async () => {
+    const res = await probe.listModels();
+    if (res.status !== 200) return false;
+    const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+    return data.some((m) => m.id === MODEL);
+  });
+}
+
+describe("response cache is isolated per env on a shared Redis (#788 P1-1)", () => {
+  let appA: SpawnedApp | undefined;
+  let appB: SpawnedApp | undefined;
+  let upstreamA: OpenAiUpstream | undefined;
+  let upstreamB: OpenAiUpstream | undefined;
+  let infraReady = false;
+  const prefix = `/aisix-e2e-cache-envns-${randomUUID()}`;
+  // Unique env ids per run so the redis namespace never collides with a
+  // prior run on a shared CI redis.
+  const envA = `env-a-${randomUUID()}`;
+  const envB = `env-b-${randomUUID()}`;
+
+  beforeAll(async () => {
+    infraReady = (await new EtcdClient().ping()) && (await redisPing(REDIS_URL));
+    if (!infraReady) return;
+
+    upstreamA = await startOpenAiUpstream({
+      nonStreamBody: completionBody("answer-from-env-a"),
+    });
+    upstreamB = await startOpenAiUpstream({
+      nonStreamBody: completionBody("answer-from-env-b"),
+    });
+
+    const cache = { backend: "memory", redis: { url: REDIS_URL } };
+    appA = await spawnApp({ extra: { etcd: envEtcd(prefix, envA), cache } });
+    appB = await spawnApp({ extra: { etcd: envEtcd(prefix, envB), cache } });
+
+    await seed(appA, upstreamA.baseUrl);
+    await seed(appB, upstreamB.baseUrl);
+    await waitModelLive(appA.proxyUrl);
+    await waitModelLive(appB.proxyUrl);
+  });
+
+  afterAll(async () => {
+    await appA?.exit();
+    await appB?.exit();
+    await upstreamA?.close();
+    await upstreamB?.close();
+    // The harness cleans the unique prefixes it generated, not our shared
+    // override — drop it ourselves (range delete covers both env scopes).
+    if (infraReady) await new EtcdClient().deletePrefix(prefix);
+  });
+
+  test("identical request hits within its env but misses in the peer env", async (ctx) => {
+    if (!infraReady || !appA || !appB || !upstreamA || !upstreamB) {
+      ctx.skip();
+      return;
+    }
+
+    const baseA = upstreamA.receivedRequests.length;
+    const baseB = upstreamB.receivedRequests.length;
+
+    // env-a: first request → MISS, served by env-a's upstream.
+    const a1 = await chatRequest(appA.proxyUrl);
+    expect(a1.status).toBe(200);
+    expect(a1.headers.get("x-aisix-cache")).toBe("miss");
+    const a1body = (await a1.json()) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    expect(a1body.choices[0].message.content).toBe("answer-from-env-a");
+    expect(upstreamA.receivedRequests.length).toBe(baseA + 1);
+
+    // env-a: same request again → HIT (proves caching is active in env-a,
+    // so a peer MISS below is due to isolation, not caching being off).
+    const a2 = await chatRequest(appA.proxyUrl);
+    expect(a2.status).toBe(200);
+    expect(a2.headers.get("x-aisix-cache")).toBe("hit");
+    await a2.body?.cancel();
+    expect(upstreamA.receivedRequests.length).toBe(baseA + 1);
+
+    // env-b: byte-identical request on the SAME shared Redis → MISS, because
+    // the cache namespace is env-scoped. It returns env-b's OWN upstream
+    // body — NOT env-a's. Before the fix this was a HIT with env-a's body
+    // and env-b's upstream would never be called.
+    const b1 = await chatRequest(appB.proxyUrl);
+    expect(b1.status).toBe(200);
+    expect(b1.headers.get("x-aisix-cache")).toBe("miss");
+    const b1body = (await b1.json()) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    expect(b1body.choices[0].message.content).toBe("answer-from-env-b");
+    expect(upstreamB.receivedRequests.length).toBe(baseB + 1);
+
+    // env-b: same request again → HIT within env-b's own namespace.
+    const b2 = await chatRequest(appB.proxyUrl);
+    expect(b2.status).toBe(200);
+    expect(b2.headers.get("x-aisix-cache")).toBe("hit");
+    await b2.body?.cancel();
+    expect(upstreamB.receivedRequests.length).toBe(baseB + 1);
+  });
+});


### PR DESCRIPTION
## Problem

The response-cache key is a content-only fingerprint (`CacheKey` — model + messages + params, no caller/env), and the model inline rate-limit bucket keys on the env-local model alias (`model:<name>`). Neither carries the environment.

Redis is user-provided infrastructure the Helm chart does not manage, so a user can point the DPs of two environments at one Redis. Today that means:

- **Cache**: a byte-identical request in env B is served env A's cached response (cross-env leak).
- **Rate limit**: two envs' `model:<alias>` counters merge, so one env's traffic eats into the other's model limit.

## Fix

Scope both Redis stores' key prefix by the DP's `env_id`:

- cache → `aisix:cache:<env_id>:<fingerprint>`
- rate limit → `aisix:rl:<env_id>:{<bucket>}:…`

`env_id` is already known at boot — parsed from the cert URI SAN in managed mode, set from config in self-managed mode — and is the same value that already scopes the DP's etcd reads via `effective_prefix()`. An empty `env_id` (standalone / v2, no env cert) leaves the prefix unchanged, so single-deployment setups are untouched. For the rate limiter the env segment sits **before** the `{bucket}` hash tag, so Redis Cluster slot placement (by bucket) is unaffected.

## Scope

- The other rate-limit buckets (api_key / policy ids) are globally-unique UUIDs and never collided; the prefix covers them harmlessly too.
- The in-process memory cache and the semantic vector cache are per-process (`DashMap`) and were never shared across envs — no change needed.

## Compatibility

On upgrade, any existing shared-Redis cache entries and rate-limit counters under the old bare prefix become unreachable (cold start): cache entries expire by TTL and short rate-limit windows reset. No data migration; self-healing.

## Tests

- Live-Redis integration tests for both stores: two env namespaces don't share a cache entry / a `model:<alias>` counter, with a same-env control proving the isolation comes from the namespace.
- Standalone E2E (`cache-env-namespace-e2e`): two DPs with distinct `env_id` against one Redis — an identical request is a hit within its own env but a miss in the peer env, and each returns its own upstream body.

Part of api7/AISIX-Cloud#788 (P1-1).