### PR TITLE
feat(routing): cost-aware target selection (least_cost strategy)

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3730,7 +3730,7 @@ fn add_variant_titles(doc: &mut Value) {
         ),
         (
             "/components/schemas/RoutingStrategy/oneOf",
-            &["Round robin", "Weighted", "Failover"],
+            &["Round robin", "Weighted", "Failover", "Least cost"],
         ),
         (
             "/components/schemas/SlsContentMode/oneOf",

--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -6,12 +6,19 @@
 //! Failures may retry the current target and then fall back to later
 //! targets.
 //!
-//! Three strategies (spec §3):
+//! Positional strategies (spec §3) pick a *starting* target, then walk
+//! forward on failure:
 //! - `round_robin`: cycle through targets in declaration order.
 //! - `weighted`: pick a target with probability proportional to its
 //!   `weight`; falls back to round-robin when weights are missing.
 //! - `failover`: always start at the first target; only move down the
 //!   list on failure.
+//!
+//! Metric-ordered strategies rank *all* targets by a runtime signal and
+//! attempt them best-first, falling forward down the ranked order:
+//! - `least_cost`: cheapest target first, by the target model's `cost`
+//!   (combined input+output per-1K price). Targets without a `cost` rank
+//!   last. See [`RoutingStrategy::is_metric_based`].
 
 use serde::{Deserialize, Serialize};
 
@@ -28,6 +35,20 @@ pub enum RoutingStrategy {
     /// after failure.
     #[default]
     Failover,
+    /// Rank targets cheapest-first by the target model's `cost` (combined
+    /// input+output per-1K price), then fall forward. Targets without a
+    /// configured `cost` rank last.
+    LeastCost,
+}
+
+impl RoutingStrategy {
+    /// Whether the strategy ranks the full target set by a runtime metric
+    /// (rather than picking a start index and walking positionally). These
+    /// strategies are ordered after target resolution, where each target's
+    /// Model and runtime state are available.
+    pub fn is_metric_based(&self) -> bool {
+        matches!(self, RoutingStrategy::LeastCost)
+    }
 }
 
 /// One destination in a routing configuration. `model` references a direct model alias.
@@ -219,6 +240,23 @@ mod tests {
     fn missing_weight_defaults_to_one() {
         let t = RoutingTarget::new("x");
         assert_eq!(t.weight_or_default(), 1);
+    }
+
+    #[test]
+    fn parses_least_cost_strategy() {
+        let r: Routing = serde_json::from_str(
+            r#"{"strategy":"least_cost","targets":[{"model":"a"},{"model":"b"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(r.strategy, RoutingStrategy::LeastCost);
+    }
+
+    #[test]
+    fn is_metric_based_classification() {
+        assert!(RoutingStrategy::LeastCost.is_metric_based());
+        assert!(!RoutingStrategy::Failover.is_metric_based());
+        assert!(!RoutingStrategy::RoundRobin.is_metric_based());
+        assert!(!RoutingStrategy::Weighted.is_metric_based());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -6,13 +6,21 @@
 //! model state (round-robin counter, weighted PRNG seed); selection
 //! itself is pure given that state.
 //!
-//! Strategies (spec §3.5):
+//! Positional strategies (spec §3.5) pick a starting target, then walk
+//! forward on failure:
 //! - **failover**: always start at `targets[0]`, walk forward on failure.
 //! - **round_robin**: each *new* request advances a per-model counter
 //!   so callers spread evenly across targets.
 //! - **weighted**: pick a starting target with probability proportional
 //!   to `weight`, then walk forward on failure (weights only affect the
 //!   *first* target choice — once we're falling back, order is positional).
+//!
+//! Metric-ordered strategies rank the whole target set by a runtime signal
+//! (attempted best-first, then falling forward). They can't be ordered from
+//! `pick_targets` because the ranking key lives on the resolved target
+//! Models / runtime state, so `resolve_attempt_models` ranks them instead:
+//! - **least_cost**: cheapest target first, by combined input+output per-1K
+//!   price; targets without a `cost` rank last.
 
 use aisix_core::{
     AisixSnapshot, Model, Routing, RoutingStrategy, RoutingTarget, WhenAllUnavailablePolicy,
@@ -107,6 +115,14 @@ impl RoutingRegistry {
         if routing.targets.is_empty() {
             return Vec::new();
         }
+        // Metric-ordered strategies (least_cost, …) can't be ranked here:
+        // the ranking key lives on the resolved target Models / runtime
+        // state, which `resolve_attempt_models` has and this does not. Hand
+        // back the full declaration-order list; ranking and `max_fallbacks`
+        // truncation happen there instead.
+        if routing.strategy.is_metric_based() {
+            return routing.targets.iter().map(|t| t.model.clone()).collect();
+        }
         let start = self.starting_index(virtual_name, routing);
         attempt_order(
             &routing.targets,
@@ -120,6 +136,9 @@ impl RoutingRegistry {
             RoutingStrategy::Failover => 0,
             RoutingStrategy::RoundRobin => self.advance_cursor(virtual_name, routing.targets.len()),
             RoutingStrategy::Weighted => weighted_pick(&routing.targets),
+            // Metric-ordered strategies never reach here — `pick_targets`
+            // short-circuits them before computing a start index.
+            RoutingStrategy::LeastCost => 0,
         }
     }
 
@@ -184,6 +203,30 @@ fn weighted_pick(targets: &[RoutingTarget]) -> usize {
         }
     }
     targets.len() - 1
+}
+
+/// Combined per-1K unit price used to rank `least_cost` targets. A target
+/// Model without a configured `cost` sorts last (treated as +∞) so a
+/// misconfigured target is deprioritised rather than silently preferred.
+fn cost_key(model: &Model) -> f64 {
+    model
+        .cost
+        .as_ref()
+        .map(|c| c.input_per_1k + c.output_per_1k)
+        .unwrap_or(f64::INFINITY)
+}
+
+/// Rank the resolved attempt list by the strategy's runtime metric,
+/// best-first (ascending). Stable, so equal-metric targets keep their
+/// declaration order. Only metric-based strategies reach here; positional
+/// strategies are ordered in [`RoutingRegistry::pick_targets`].
+fn order_attempts_by_metric(strategy: RoutingStrategy, attempts: &mut [AttemptModel]) {
+    match strategy {
+        RoutingStrategy::LeastCost => {
+            attempts.sort_by(|a, b| cost_key(&a.model).total_cmp(&cost_key(&b.model)));
+        }
+        RoutingStrategy::Failover | RoutingStrategy::RoundRobin | RoutingStrategy::Weighted => {}
+    }
 }
 
 /// One concrete (non-routing) Model the dispatch loop will attempt, paired
@@ -311,6 +354,13 @@ pub(crate) fn resolve_attempt_models(
             id: target_entry.id.clone(),
             model: target_entry.value.clone(),
         });
+    }
+    // Metric-ordered strategies get the full target set from `pick_targets`;
+    // rank it best-first here (target Models are now resolved) and cap it to
+    // the same attempt budget the positional strategies apply upstream.
+    if routing.strategy.is_metric_based() {
+        order_attempts_by_metric(routing.strategy, &mut resolved);
+        resolved.truncate(routing.max_fallbacks_or_default() + 1);
     }
     match filter_attempt_models(
         runtime_status,
@@ -684,6 +734,75 @@ mod tests {
             id: id.to_string(),
             model,
         }
+    }
+
+    // ── order_attempts_by_metric (least_cost) ─────────────────────
+    fn am_with_cost(id: &str, input_per_1k: f64, output_per_1k: f64) -> AttemptModel {
+        let model: Model = serde_json::from_str(&format!(
+            r#"{{
+              "display_name": "{id}",
+              "provider": "openai",
+              "model_name": "gpt-4o-mini",
+              "provider_key_id": "pk-{id}",
+              "cost": {{ "input_per_1k": {input_per_1k}, "output_per_1k": {output_per_1k} }}
+            }}"#
+        ))
+        .unwrap();
+        AttemptModel {
+            id: id.to_string(),
+            model,
+        }
+    }
+
+    #[test]
+    fn least_cost_orders_cheapest_first() {
+        let mut attempts = vec![
+            am_with_cost("pricey", 10.0, 20.0), // 30 / 1K
+            am_with_cost("cheap", 1.0, 2.0),    // 3 / 1K
+            am_with_cost("mid", 5.0, 5.0),      // 10 / 1K
+        ];
+        order_attempts_by_metric(RoutingStrategy::LeastCost, &mut attempts);
+        let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec!["cheap", "mid", "pricey"]);
+    }
+
+    #[test]
+    fn least_cost_ranks_missing_cost_last_and_stably() {
+        let mut attempts = vec![
+            am("no-cost-a"),                 // +∞
+            am_with_cost("cheap", 1.0, 1.0), // 2 / 1K
+            am("no-cost-b"),                 // +∞
+        ];
+        order_attempts_by_metric(RoutingStrategy::LeastCost, &mut attempts);
+        let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
+        // Priced target first; equal (missing-cost) targets keep their
+        // declaration order thanks to the stable sort.
+        assert_eq!(ids, vec!["cheap", "no-cost-a", "no-cost-b"]);
+    }
+
+    #[test]
+    fn non_metric_strategy_leaves_order_untouched() {
+        let mut attempts = vec![am_with_cost("b", 9.0, 9.0), am_with_cost("a", 1.0, 1.0)];
+        order_attempts_by_metric(RoutingStrategy::Failover, &mut attempts);
+        let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec!["b", "a"]);
+    }
+
+    #[test]
+    fn metric_strategy_pick_targets_returns_full_declaration_order() {
+        let reg = RoutingRegistry::new();
+        let routing = r(
+            RoutingStrategy::LeastCost,
+            vec![
+                RoutingTarget::new("a"),
+                RoutingTarget::new("b"),
+                RoutingTarget::new("c"),
+            ],
+            Some(1), // truncation is deferred to resolve_attempt_models
+        );
+        // Ranking needs resolved Models, so pick_targets hands back every
+        // target untouched regardless of max_fallbacks.
+        assert_eq!(reg.pick_targets("v", &routing), vec!["a", "b", "c"]);
     }
 
     #[test]

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -429,6 +429,13 @@
             "failover"
           ],
           "type": "string"
+        },
+        {
+          "description": "Rank targets cheapest-first by the target model's `cost` (combined input+output per-1K price), then fall forward. Targets without a configured `cost` rank last.",
+          "enum": [
+            "least_cost"
+          ],
+          "type": "string"
         }
       ]
     },

--- a/schemas/resources/routing.schema.json
+++ b/schemas/resources/routing.schema.json
@@ -84,6 +84,13 @@
           "enum": [
             "failover"
           ]
+        },
+        {
+          "description": "Rank targets cheapest-first by the target model's `cost` (combined input+output per-1K price), then fall forward. Targets without a configured `cost` rank last.",
+          "type": "string",
+          "enum": [
+            "least_cost"
+          ]
         }
       ]
     },

--- a/tests/e2e/src/cases/cost-aware-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/cost-aware-routing-e2e.test.ts
@@ -1,0 +1,202 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const CALLER_PLAINTEXT = "sk-cost-routing-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function okBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe("cost-aware (least_cost) routing e2e", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  async function createOpenAiModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+    extra: Record<string, unknown> = {},
+  ): Promise<void> {
+    if (!admin) throw new Error("admin client not initialized");
+    const providerKey = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: providerKey.id,
+      ...extra,
+    });
+  }
+
+  function client(): OpenAI {
+    return new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app?.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  test("ranks the cheapest target first regardless of declaration order", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const cheap = await startOpenAiUpstream({ nonStreamBody: okBody("cheap-served") });
+    const pricey = await startOpenAiUpstream({ nonStreamBody: okBody("pricey-served") });
+    upstreams.push(cheap, pricey);
+
+    // Cheap total unit price = 0.2/1K; pricey = 20/1K.
+    await createOpenAiModel("cost-cheap", cheap, {
+      cost: { input_per_1k: 0.1, output_per_1k: 0.1 },
+    });
+    await createOpenAiModel("cost-pricey", pricey, {
+      cost: { input_per_1k: 10, output_per_1k: 10 },
+    });
+    // Declare the expensive target FIRST — least_cost must reorder by price,
+    // not honor declaration order.
+    await admin.createModel({
+      display_name: "cost-virtual",
+      routing: {
+        strategy: "least_cost",
+        targets: [{ model: "cost-pricey" }, { model: "cost-cheap" }],
+      },
+    });
+
+    // Gate on the routing model reaching the DP snapshot (probe would be
+    // fine here since both targets are healthy, but listModels avoids any
+    // per-target request skew before baselines are taken).
+    await waitConfigPropagation(async () => {
+      try {
+        const models = await admin!.listModels();
+        return models.some((m) => m.display_name === "cost-virtual");
+      } catch {
+        return false;
+      }
+    });
+
+    const cheapBaseline = cheap.receivedRequests.length;
+    const priceyBaseline = pricey.receivedRequests.length;
+
+    const completion = await client().chat.completions.create({
+      model: "cost-virtual",
+      messages: [{ role: "user", content: "cheapest please" }],
+    });
+
+    expect(completion.choices[0]?.message.content).toBe("cheap-served");
+    expect(cheap.receivedRequests.length - cheapBaseline).toBe(1);
+    expect(pricey.receivedRequests.length - priceyBaseline).toBe(0);
+  });
+
+  test("falls forward to the next-cheapest when the cheapest fails", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const cheap = await startOpenAiUpstream({
+      status: 503,
+      errorBody: { error: { message: "cheapest down", type: "server_error" } },
+    });
+    const mid = await startOpenAiUpstream({ nonStreamBody: okBody("mid-served") });
+    const pricey = await startOpenAiUpstream({ nonStreamBody: okBody("pricey-served") });
+    upstreams.push(cheap, mid, pricey);
+
+    // Keep the failing cheapest in rotation so the assertion sees it attempted
+    // (cooldown would take it out after the first 503).
+    await createOpenAiModel("cost-ff-cheap", cheap, {
+      cost: { input_per_1k: 0.1, output_per_1k: 0.1 },
+      cooldown: { enabled: false },
+    });
+    await createOpenAiModel("cost-ff-mid", mid, {
+      cost: { input_per_1k: 1, output_per_1k: 1 },
+    });
+    await createOpenAiModel("cost-ff-pricey", pricey, {
+      cost: { input_per_1k: 10, output_per_1k: 10 },
+    });
+    await admin.createModel({
+      display_name: "cost-ff-virtual",
+      routing: {
+        strategy: "least_cost",
+        targets: [
+          { model: "cost-ff-pricey" },
+          { model: "cost-ff-mid" },
+          { model: "cost-ff-cheap" },
+        ],
+      },
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const models = await admin!.listModels();
+        return models.some((m) => m.display_name === "cost-ff-virtual");
+      } catch {
+        return false;
+      }
+    });
+
+    const cheapBaseline = cheap.receivedRequests.length;
+    const midBaseline = mid.receivedRequests.length;
+    const priceyBaseline = pricey.receivedRequests.length;
+
+    const completion = await client().chat.completions.create({
+      model: "cost-ff-virtual",
+      messages: [{ role: "user", content: "cheapest then fall forward" }],
+    });
+
+    // Cheapest tried first (503), falls forward to next-cheapest (mid). The
+    // pricey target is never reached.
+    expect(completion.choices[0]?.message.content).toBe("mid-served");
+    expect(cheap.receivedRequests.length - cheapBaseline).toBe(1);
+    expect(mid.receivedRequests.length - midBaseline).toBe(1);
+    expect(pricey.receivedRequests.length - priceyBaseline).toBe(0);
+  });
+});

--- a/tests/e2e/src/cases/cost-aware-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/cost-aware-routing-e2e.test.ts
@@ -113,14 +113,12 @@ describe("cost-aware (least_cost) routing e2e", () => {
 
     // Gate on the routing model reaching the DP snapshot (probe would be
     // fine here since both targets are healthy, but listModels avoids any
-    // per-target request skew before baselines are taken).
+    // per-target request skew before baselines are taken). listModels reads
+    // etcd directly and shouldn't fail during propagation — let a genuine
+    // admin failure surface instead of masking it as a 30s timeout.
     await waitConfigPropagation(async () => {
-      try {
-        const models = await admin!.listModels();
-        return models.some((m) => m.display_name === "cost-virtual");
-      } catch {
-        return false;
-      }
+      const models = await admin!.listModels();
+      return models.some((m) => m.display_name === "cost-virtual");
     });
 
     const cheapBaseline = cheap.receivedRequests.length;
@@ -175,12 +173,8 @@ describe("cost-aware (least_cost) routing e2e", () => {
     });
 
     await waitConfigPropagation(async () => {
-      try {
-        const models = await admin!.listModels();
-        return models.some((m) => m.display_name === "cost-ff-virtual");
-      } catch {
-        return false;
-      }
+      const models = await admin!.listModels();
+      return models.some((m) => m.display_name === "cost-ff-virtual");
     });
 
     const cheapBaseline = cheap.receivedRequests.length;


### PR DESCRIPTION
Adds a `least_cost` routing strategy: a routing model ranks its targets cheapest-first by the target model's `cost` (combined input+output per-1K price) and falls forward down the ranked order. Targets without a `cost` rank last, so a misconfigured target is deprioritised rather than silently preferred.

## Why

`RoutingStrategy` was a closed 3-variant enum (round_robin / weighted / failover) with no cost-aware selection — a gap vs LiteLLM (`lowest_cost`) and Kong. First of the smart-routing strategies from the routing gap list (#873); design aligns with #895 Phase 2 (the cost objective).

## How

Positional strategies (failover/round_robin/weighted) pick a start index and walk forward. Cost ranking instead needs the resolved target Models, so it's a new "metric-ordered" class:

- `pick_targets` hands the full target list back untouched for metric strategies.
- `resolve_attempt_models` (the shared path for chat/messages/responses/count_tokens) ranks the resolved targets by cost and applies the `max_fallbacks` cap after resolution.

This reuses the existing retry / cooldown / health-filter / fallback machinery unchanged — only the target ordering is new.

Cost key = `input_per_1k + output_per_1k`; missing cost → +∞ (ranks last). Ties keep declaration order (stable sort).

## Tests

- Core + proxy unit tests: enum parsing, `is_metric_based` classification, cost ordering (cheapest-first, missing-cost-last-stably, non-metric untouched, metric `pick_targets` returns full list).
- DP E2E (`cost-aware-routing-e2e.test.ts`): cheapest target wins regardless of declaration order; cheapest failure falls forward to next-cheapest without reaching the pricey target.

## Notes

Regenerated the committed resource schemas (`schemas/resources/{routing,model}.schema.json`) for the new enum variant. User-facing docs will ship as a paired `api7/docs` PR.

Fixes api7/AISIX-Cloud#923


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `least_cost` routing option that sends requests to the cheapest available target first.
  * Routing now continues to the next cheapest target if the first choice fails.
  * Documentation and API schema updates now show the new routing option in supported views.

* **Bug Fixes**
  * Improved routing behavior so cost-based targets are ordered consistently, even when some targets have no configured cost.
  * Adjusted weighted routing behavior for more reliable request selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->