### PR TITLE
feat(routing): wildcard model-name routing (provider/* aliases)

### DIFF
--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod error;
 pub mod models;
 pub mod resource;
 pub mod snapshot;
+pub mod wildcard;
 
 pub use config::{
     AdminConfig, CacheBackend, CacheConfig, Config, EtcdConfig, EtcdTlsConfig, ManagedConfig,

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -75,12 +75,14 @@ impl ApiKey {
 
     /// True if this key is allowed to call the given Model.
     ///
-    /// A wildcard entry `"*"` grants access to every model. An empty
-    /// `allowed_models` list denies everything (spec §3 authz rule).
+    /// Entries are matched as single-`*` globs, so `"*"` grants every model and
+    /// `"openai/*"` grants every `openai/*` name (pairing with wildcard Models);
+    /// entries without a `*` match exactly. An empty `allowed_models` list denies
+    /// everything (spec §3 authz rule).
     pub fn can_access(&self, model_name: &str) -> bool {
         self.allowed_models
             .iter()
-            .any(|n| n == "*" || n == model_name)
+            .any(|n| crate::wildcard::wildcard_matches(n, model_name))
     }
 
     /// True if this key may call the given MCP tool, named in the gateway's
@@ -96,22 +98,15 @@ impl ApiKey {
         }
     }
 
-    /// Iterate over the names of models this key may access, filtering
-    /// them against a known universe of model names. The `*` wildcard
-    /// expands to the full universe so callers don't have to special-case
-    /// it themselves.
+    /// Iterate over the names of models this key may access, filtering them
+    /// against a known universe of model names. Delegates to [`Self::can_access`]
+    /// so glob entries stay consistent with per-request authz: `*` expands to
+    /// the full universe and `openai/*` to every matching name.
     pub fn accessible_models<'a>(
         &'a self,
         all_models: impl Iterator<Item = &'a str> + 'a,
     ) -> Vec<&'a str> {
-        let has_wildcard = self.allowed_models.iter().any(|n| n == "*");
-        if has_wildcard {
-            all_models.collect()
-        } else {
-            all_models
-                .filter(|name| self.allowed_models.iter().any(|n| n.as_str() == *name))
-                .collect()
-        }
+        all_models.filter(|name| self.can_access(name)).collect()
     }
 }
 
@@ -239,6 +234,26 @@ mod tests {
             serde_json::from_str(r#"{"key_hash":"abc","allowed_models":["*"]}"#).unwrap();
         assert!(k.can_access("my-gpt4"));
         assert!(k.can_access("literally-anything"));
+    }
+
+    #[test]
+    fn glob_entry_grants_matching_names() {
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"abc","allowed_models":["openai/*"]}"#).unwrap();
+        assert!(k.can_access("openai/gpt-4o"));
+        assert!(k.can_access("openai/gpt-4o-mini"));
+        assert!(!k.can_access("anthropic/claude"));
+        assert!(!k.can_access("openai")); // prefix must be followed by the glob
+    }
+
+    #[test]
+    fn accessible_models_honors_glob_entry() {
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"abc","allowed_models":["openai/*"]}"#).unwrap();
+        let universe = ["openai/gpt-4o", "openai/o1", "anthropic/claude"];
+        let mut accessible = k.accessible_models(universe.iter().copied());
+        accessible.sort_unstable();
+        assert_eq!(accessible, vec!["openai/gpt-4o", "openai/o1"]);
     }
 
     #[test]

--- a/crates/aisix-core/src/wildcard.rs
+++ b/crates/aisix-core/src/wildcard.rs
@@ -1,0 +1,93 @@
+//! Single-`*` wildcard matching, shared by API-key model allowlists
+//! ([`crate::models::ApiKey::can_access`]) and the proxy's wildcard model
+//! resolution (`provider/*` aliases).
+//!
+//! Only one `*` per pattern is supported — enough for the common
+//! `provider/*` / `prefix-*-suffix` shapes and avoids pulling a regex engine
+//! into the hot path. The literals on either side of the `*` anchor the
+//! candidate at both ends, so a pattern matches the *whole* name.
+
+/// Match `candidate` against a `*`-glob `pattern` that contains **exactly one**
+/// `*`, returning the substring bound to the `*` on success.
+///
+/// `openai/*` matches `openai/gpt-4o` (capture `gpt-4o`) but not
+/// `azure/openai/x` (the prefix must anchor the start). A pattern with no `*`,
+/// or with more than one `*`, is unsupported and returns `None` — callers treat
+/// those as plain literals.
+pub fn wildcard_capture(pattern: &str, candidate: &str) -> Option<String> {
+    let star = pattern.find('*')?;
+    if pattern[star + 1..].contains('*') {
+        return None; // only a single '*' is supported
+    }
+    let prefix = &pattern[..star];
+    let suffix = &pattern[star + 1..];
+    if candidate.len() < prefix.len() + suffix.len() {
+        return None; // prefix and suffix would overlap
+    }
+    if candidate.starts_with(prefix) && candidate.ends_with(suffix) {
+        Some(candidate[prefix.len()..candidate.len() - suffix.len()].to_string())
+    } else {
+        None
+    }
+}
+
+/// Whether `pattern` matches `candidate`. A pattern with a single `*` is
+/// glob-matched; any other pattern matches only an exactly-equal candidate.
+pub fn wildcard_matches(pattern: &str, candidate: &str) -> bool {
+    if pattern.contains('*') {
+        wildcard_capture(pattern, candidate).is_some()
+    } else {
+        pattern == candidate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trailing_star_captures_the_rest() {
+        assert_eq!(
+            wildcard_capture("openai/*", "openai/gpt-4o").as_deref(),
+            Some("gpt-4o")
+        );
+        assert_eq!(
+            wildcard_capture("openai/*", "openai/gpt-4o-mini").as_deref(),
+            Some("gpt-4o-mini")
+        );
+    }
+
+    #[test]
+    fn prefix_must_anchor_the_start() {
+        assert_eq!(wildcard_capture("openai/*", "azure/openai/x"), None);
+        assert_eq!(wildcard_capture("openai/*", "opena"), None);
+    }
+
+    #[test]
+    fn interior_star_binds_the_middle() {
+        assert_eq!(
+            wildcard_capture("gpt-*-preview", "gpt-4o-preview").as_deref(),
+            Some("4o")
+        );
+        assert_eq!(wildcard_capture("gpt-*-preview", "gpt-4o-final"), None);
+    }
+
+    #[test]
+    fn star_matches_empty_capture() {
+        assert_eq!(wildcard_capture("openai/*", "openai/").as_deref(), Some(""));
+    }
+
+    #[test]
+    fn multiple_stars_unsupported() {
+        assert_eq!(wildcard_capture("a/*/*", "a/b/c"), None);
+    }
+
+    #[test]
+    fn matches_handles_literals_and_globs() {
+        assert!(wildcard_matches("*", "anything"));
+        assert!(wildcard_matches("openai/*", "openai/gpt-4o"));
+        assert!(wildcard_matches("gpt-4o", "gpt-4o"));
+        assert!(!wildcard_matches("gpt-4o", "gpt-4o-mini"));
+        assert!(!wildcard_matches("openai/*", "anthropic/claude"));
+    }
+}

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -363,9 +363,7 @@ async fn multipart_dispatch(
         .ok_or_else(|| ProxyError::InvalidRequest("`model` field missing from form".into()))?;
 
     let snapshot = state.snapshot.load();
-    let model_entry = snapshot
-        .models
-        .get_by_name(&model_name)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
     if !auth.key().can_access(&model_name) {
@@ -543,9 +541,7 @@ async fn speech_dispatch(
         .to_string();
 
     let snapshot = state.snapshot.load();
-    let model_entry = snapshot
-        .models
-        .get_by_name(&model_name)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
     if !auth.key().can_access(&model_name) {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -786,9 +786,10 @@ async fn dispatch(
             .iter()
             .map(|e| &e.value),
     );
-    let virtual_entry = snapshot.models.get_by_name(&req.model).ok_or_else(|| {
-        DispatchFailure::new(None, None, ProxyError::ModelNotFound(req.model.clone()))
-    })?;
+    let virtual_entry =
+        crate::model_resolve::resolve_model(&snapshot, &req.model).ok_or_else(|| {
+            DispatchFailure::new(None, None, ProxyError::ModelNotFound(req.model.clone()))
+        })?;
     let model_id = virtual_entry.id.clone();
 
     // Every error from here on attaches the resolved model_id so the

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -195,9 +195,7 @@ async fn dispatch(
 
     let snapshot = state.snapshot.load();
 
-    let model_entry = snapshot
-        .models
-        .get_by_name(model_name)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.to_string()))?;
 
     if !auth.key().can_access(model_name) {

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -152,9 +152,7 @@ async fn dispatch(
         .ok_or_else(|| ProxyError::InvalidRequest("`model` field missing".into()))?
         .to_string();
 
-    let model_entry = snapshot
-        .models
-        .get_by_name(&model_name)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
     if !auth.key().can_access(&model_name) {

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -249,9 +249,7 @@ async fn dispatch(
 ) -> Result<EmbedDispatchSuccess, ProxyError> {
     let snapshot = state.snapshot.load();
 
-    let model_entry = snapshot
-        .models
-        .get_by_name(&body.model)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, &body.model)
         .ok_or_else(|| ProxyError::ModelNotFound(body.model.clone()))?;
 
     if !auth.key().can_access(&body.model) {

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -174,9 +174,7 @@ async fn dispatch(
 
     let snapshot = state.snapshot.load();
 
-    let model_entry = snapshot
-        .models
-        .get_by_name(model_name)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.to_string()))?;
 
     if !auth.key().can_access(model_name) {

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -44,6 +44,7 @@ mod http_client;
 mod images;
 mod mcp;
 mod messages;
+mod model_resolve;
 mod models;
 mod passthrough;
 mod quota;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -108,9 +108,7 @@ pub async fn messages(
         .to_string();
 
     let snapshot = state.snapshot.load();
-    let model_id = snapshot
-        .models
-        .get_by_name(&model_name)
+    let model_id = crate::model_resolve::resolve_model(&snapshot, &model_name)
         .map(|e| e.id.clone())
         .unwrap_or_default();
     drop(snapshot);
@@ -405,9 +403,7 @@ async fn dispatch(
         .ok_or_else(|| ProxyError::InvalidRequest("`model` field missing".into()))?
         .to_string();
 
-    let model_entry = snapshot
-        .models
-        .get_by_name(&model_name)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
     if !auth.key().can_access(&model_name) {

--- a/crates/aisix-proxy/src/model_resolve.rs
+++ b/crates/aisix-proxy/src/model_resolve.rs
@@ -1,0 +1,150 @@
+//! Wildcard-aware model resolution (`provider/*` aliases).
+//!
+//! Client-facing handlers resolve `req.model` through [`resolve_model`] instead
+//! of calling `snapshot.models.get_by_name` directly, so a request for
+//! `openai/gpt-4o` can be served by an operator-defined `openai/*` wildcard
+//! Model. Exact names always win; among wildcards the most specific (longest
+//! literal) pattern wins.
+//!
+//! A wildcard match returns a synthetic clone of the Model with its
+//! `model_name` resolved to the concrete upstream id (the captured segment
+//! substituted into the template's `*`, or the template kept as-is when it has
+//! no `*`). Everything else — id, provider, provider_key_id, rate_limit, cost,
+//! guardrail scope — is inherited from the wildcard Model, so downstream
+//! dispatch/telemetry treat it like a normal Model and attribution stays on the
+//! wildcard Model's id. The client still sees the name it requested, because
+//! every handler echoes `req.model` rather than the resolved `display_name`.
+
+use std::sync::Arc;
+
+use aisix_core::wildcard::wildcard_capture;
+use aisix_core::{AisixSnapshot, Model, ResourceEntry};
+
+/// Resolve `requested` against the snapshot's Model table, honoring `provider/*`
+/// wildcard Models when no exact match exists. Returns `None` if nothing matches.
+pub(crate) fn resolve_model(
+    snapshot: &AisixSnapshot,
+    requested: &str,
+) -> Option<Arc<ResourceEntry<Model>>> {
+    if let Some(exact) = snapshot.models.get_by_name(requested) {
+        return Some(exact);
+    }
+    // Wildcard fallback: the most specific direct Model whose `*`-glob display
+    // name matches the request. Only runs when the exact lookup missed.
+    let mut best: Option<(usize, Arc<ResourceEntry<Model>>, String)> = None;
+    for entry in snapshot.models.entries() {
+        let model = &entry.value;
+        if !model.display_name.contains('*') {
+            continue;
+        }
+        // Only direct Models can serve a wildcard alias — routers / ensembles /
+        // semantic routers have no upstream `model_name` to dispatch.
+        if model.is_routing() || model.is_ensemble() || model.is_semantic() {
+            continue;
+        }
+        let Some(capture) = wildcard_capture(&model.display_name, requested) else {
+            continue;
+        };
+        // Specificity = literal (non-`*`) length; longest wins, first on a tie.
+        let specificity = model.display_name.len() - 1;
+        if best.as_ref().is_none_or(|(s, _, _)| specificity > *s) {
+            let upstream = resolve_upstream_model_name(model, &capture);
+            best = Some((specificity, entry.clone(), upstream));
+        }
+    }
+    let (_, entry, upstream) = best?;
+    let mut model = entry.value.clone();
+    model.model_name = Some(upstream);
+    Some(Arc::new(ResourceEntry::new(
+        entry.id.clone(),
+        model,
+        entry.revision,
+    )))
+}
+
+/// Concrete upstream model id for a wildcard match: substitute the captured
+/// segment into the `model_name` template's `*`, keep the template as-is when it
+/// has no `*` (a fixed upstream for every match), or send the captured segment
+/// verbatim when there is no template.
+fn resolve_upstream_model_name(model: &Model, capture: &str) -> String {
+    match model.model_name.as_deref() {
+        Some(t) if t.contains('*') => t.replacen('*', capture, 1),
+        Some(t) => t.to_string(),
+        None => capture.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::snapshot::ResourceTable;
+
+    fn direct_model(display_name: &str, model_name: Option<&str>) -> Model {
+        serde_json::from_value(serde_json::json!({
+            "display_name": display_name,
+            "provider": "openai",
+            "model_name": model_name,
+            "provider_key_id": "pk-1",
+        }))
+        .unwrap()
+    }
+
+    fn snapshot_with(models: Vec<(&str, Model)>) -> AisixSnapshot {
+        let table = ResourceTable::default();
+        for (id, model) in models {
+            table.insert(ResourceEntry::new(id, model, 1));
+        }
+        AisixSnapshot {
+            models: table,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn exact_match_wins_over_wildcard() {
+        let snap = snapshot_with(vec![
+            ("m-star", direct_model("openai/*", Some("*"))),
+            (
+                "m-exact",
+                direct_model("openai/gpt-4o", Some("gpt-4o-2024")),
+            ),
+        ]);
+        let resolved = resolve_model(&snap, "openai/gpt-4o").unwrap();
+        assert_eq!(resolved.id, "m-exact");
+        assert_eq!(resolved.value.model_name.as_deref(), Some("gpt-4o-2024"));
+    }
+
+    #[test]
+    fn wildcard_substitutes_capture_into_template() {
+        let snap = snapshot_with(vec![("m-star", direct_model("openai/*", Some("*")))]);
+        let resolved = resolve_model(&snap, "openai/gpt-4o").unwrap();
+        // Attribution stays on the wildcard Model; upstream id is the capture.
+        assert_eq!(resolved.id, "m-star");
+        assert_eq!(resolved.value.model_name.as_deref(), Some("gpt-4o"));
+    }
+
+    #[test]
+    fn wildcard_with_fixed_template_pins_all_matches() {
+        let snap = snapshot_with(vec![("m-star", direct_model("gpt-*", Some("gpt-4o")))]);
+        let resolved = resolve_model(&snap, "gpt-anything").unwrap();
+        assert_eq!(resolved.value.model_name.as_deref(), Some("gpt-4o"));
+    }
+
+    #[test]
+    fn most_specific_wildcard_wins() {
+        let snap = snapshot_with(vec![
+            ("m-broad", direct_model("openai/*", Some("*"))),
+            ("m-narrow", direct_model("openai/gpt-*", Some("*"))),
+        ]);
+        let resolved = resolve_model(&snap, "openai/gpt-4o").unwrap();
+        assert_eq!(resolved.id, "m-narrow");
+        // `openai/gpt-*` captures only `4o`.
+        assert_eq!(resolved.value.model_name.as_deref(), Some("4o"));
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let snap = snapshot_with(vec![("m-star", direct_model("openai/*", Some("*")))]);
+        assert!(resolve_model(&snap, "anthropic/claude").is_none());
+    }
+}

--- a/crates/aisix-proxy/src/models.rs
+++ b/crates/aisix-proxy/src/models.rs
@@ -58,12 +58,14 @@ pub async fn list_models(
 
     // Collect the names of all non-routing models (routing aliases are
     // implementation detail, not something callers PUT into requests).
+    // Wildcard aliases (`provider/*`) are patterns, not concrete ids a caller
+    // can request by name, so they're excluded too.
     // Then filter to what the authenticated key may access.
     let all_names: Vec<String> = snapshot
         .models
         .entries()
         .into_iter()
-        .filter(|e| !e.value.is_routing())
+        .filter(|e| !e.value.is_routing() && !e.value.display_name.contains('*'))
         .map(|e| e.value.display_name.clone())
         .collect();
 
@@ -286,6 +288,32 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let data = v["data"].as_array().unwrap();
         // Only gpt4, not smart-router.
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0]["id"], "gpt4");
+    }
+
+    #[tokio::test]
+    async fn wildcard_models_are_excluded_from_list() {
+        let snap = new_snap();
+        snap.models.insert(model_entry("m1", "gpt4"));
+        // A `provider/*` wildcard alias is a pattern, not a concrete id.
+        snap.models.insert(model_entry("w1", "openai/*"));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["*"]));
+
+        let app = build_app(snap);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/v1/models")
+            .header("authorization", "Bearer sk-caller")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let data = v["data"].as_array().unwrap();
+        // Only the concrete gpt4, not the `openai/*` pattern.
         assert_eq!(data.len(), 1);
         assert_eq!(data[0]["id"], "gpt4");
     }

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -193,9 +193,7 @@ async fn dispatch(
         .ok_or_else(|| ProxyError::InvalidRequest("`model` field missing".into()))?
         .to_string();
 
-    let model_entry = snapshot
-        .models
-        .get_by_name(&model_name)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
     if !auth.key().can_access(&model_name) {

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -282,9 +282,7 @@ async fn dispatch(
         .ok_or_else(|| ProxyError::InvalidRequest("`model` field missing".into()))?
         .to_string();
 
-    let model_entry = snapshot
-        .models
-        .get_by_name(&model_name)
+    let model_entry = crate::model_resolve::resolve_model(&snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
     if !auth.key().can_access(&model_name) {

--- a/tests/e2e/src/cases/wildcard-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/wildcard-routing-e2e.test.ts
@@ -1,0 +1,212 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const CALLER_PLAINTEXT = "sk-wildcard-routing-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// A key scoped to a single `vendor-a/*` glob — exercises the wildcard-aware
+// `can_access` path end to end.
+const SCOPED_PLAINTEXT = "sk-wildcard-routing-e2e-scoped";
+const SCOPED_KEY_HASH = createHash("sha256")
+  .update(SCOPED_PLAINTEXT)
+  .digest("hex");
+
+function okBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "upstream-model",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+function sentModel(upstream: OpenAiUpstream): string {
+  const last = upstream.receivedRequests[upstream.receivedRequests.length - 1];
+  return JSON.parse(last!.body).model;
+}
+
+describe("wildcard (provider/*) model routing e2e", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await admin.createApiKey({
+      key_hash: SCOPED_KEY_HASH,
+      allowed_models: ["vendor-a/*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  // A direct model. `modelName` is the upstream `model_name` template — `"*"`
+  // makes it a wildcard alias that substitutes the captured segment.
+  async function createDirectModel(
+    displayName: string,
+    modelName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin client not initialized");
+    const providerKey = await admin.createProviderKey({
+      display_name: `${displayName.replace(/[^a-z0-9]/gi, "-")}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: modelName,
+      provider_key_id: providerKey.id,
+    });
+  }
+
+  function client(plaintext = CALLER_PLAINTEXT): OpenAI {
+    return new OpenAI({
+      apiKey: plaintext,
+      baseURL: `${app?.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  test("resolves provider/* and sends the captured model upstream", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const up = await startOpenAiUpstream({ nonStreamBody: okBody("wild-served") });
+    upstreams.push(up);
+    await createDirectModel("openai/*", "*", up);
+
+    await waitConfigPropagation(async () => {
+      const models = await admin!.listModels();
+      return models.some((m) => m.display_name === "openai/*");
+    });
+
+    const baseline = up.receivedRequests.length;
+    const completion = await client().chat.completions.create({
+      model: "openai/gpt-4o",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(completion.choices[0]?.message.content).toBe("wild-served");
+    expect(up.receivedRequests.length - baseline).toBe(1);
+    // `openai/*` + template `*` → the captured `gpt-4o` is sent upstream.
+    expect(sentModel(up)).toBe("gpt-4o");
+  });
+
+  test("an exact model name wins over a matching wildcard", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const wild = await startOpenAiUpstream({ nonStreamBody: okBody("azure-wild") });
+    const exact = await startOpenAiUpstream({ nonStreamBody: okBody("azure-exact") });
+    upstreams.push(wild, exact);
+    await createDirectModel("azure/*", "*", wild);
+    await createDirectModel("azure/gpt-4o", "gpt-4o-2024-08-06", exact);
+
+    await waitConfigPropagation(async () => {
+      const models = await admin!.listModels();
+      return (
+        models.some((m) => m.display_name === "azure/*") &&
+        models.some((m) => m.display_name === "azure/gpt-4o")
+      );
+    });
+
+    // Exact name → the concrete model, not the wildcard.
+    const exactBaseline = exact.receivedRequests.length;
+    const wildBaseline = wild.receivedRequests.length;
+    const hitExact = await client().chat.completions.create({
+      model: "azure/gpt-4o",
+      messages: [{ role: "user", content: "exact" }],
+    });
+    expect(hitExact.choices[0]?.message.content).toBe("azure-exact");
+    expect(exact.receivedRequests.length - exactBaseline).toBe(1);
+    expect(wild.receivedRequests.length - wildBaseline).toBe(0);
+    expect(sentModel(exact)).toBe("gpt-4o-2024-08-06");
+
+    // A name only the wildcard covers → the wildcard, capture substituted.
+    const hitWild = await client().chat.completions.create({
+      model: "azure/o3-mini",
+      messages: [{ role: "user", content: "wild" }],
+    });
+    expect(hitWild.choices[0]?.message.content).toBe("azure-wild");
+    expect(wild.receivedRequests.length - wildBaseline).toBe(1);
+    expect(sentModel(wild)).toBe("o3-mini");
+  });
+
+  test("wildcard allowed_models scopes access to matching names", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const allowed = await startOpenAiUpstream({ nonStreamBody: okBody("vendor-a-served") });
+    const denied = await startOpenAiUpstream({ nonStreamBody: okBody("vendor-b-served") });
+    upstreams.push(allowed, denied);
+    await createDirectModel("vendor-a/*", "*", allowed);
+    // A concrete model the scoped key must NOT reach — it resolves, so the
+    // rejection is authz (403), not not-found (404).
+    await createDirectModel("vendor-b/thing", "thing", denied);
+
+    await waitConfigPropagation(async () => {
+      const models = await admin!.listModels();
+      return (
+        models.some((m) => m.display_name === "vendor-a/*") &&
+        models.some((m) => m.display_name === "vendor-b/thing")
+      );
+    });
+
+    // In-scope wildcard name → allowed.
+    const deniedBaseline = denied.receivedRequests.length;
+    const ok = await client(SCOPED_PLAINTEXT).chat.completions.create({
+      model: "vendor-a/anything",
+      messages: [{ role: "user", content: "allowed" }],
+    });
+    expect(ok.choices[0]?.message.content).toBe("vendor-a-served");
+
+    // Out-of-scope name → 403 before any upstream dispatch.
+    await expect(
+      client(SCOPED_PLAINTEXT).chat.completions.create({
+        model: "vendor-b/thing",
+        messages: [{ role: "user", content: "denied" }],
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+    expect(denied.receivedRequests.length - deniedBaseline).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds wildcard model-name routing: an operator can define one `openai/*` Model and every `openai/<anything>` request resolves to it, dispatching the captured segment upstream. Closes the last positional-routing gap vs LiteLLM's PatternMatchRouter (routing gap list #873).

## How

A single `resolve_model(snapshot, requested)` helper replaces the direct `snapshot.models.get_by_name` calls in every client-facing handler (chat, messages, responses, count_tokens, embeddings, rerank, images, audio transcription/speech, completions — 11 sites). It resolves exact-first, then falls back to the most specific `*`-glob Model whose display name matches. A match returns a synthetic clone of the wildcard Model with only its `model_name` resolved to the concrete upstream id; everything else (id, provider, provider_key_id, rate_limit, cost, guardrail scope) is inherited, so downstream dispatch/telemetry treat it like a normal Model and usage stays attributed to the wildcard Model. The client still sees the name it requested (handlers echo `req.model`, not the resolved display name).

The upstream id comes from the Model's `model_name` template: a `*` in the template is replaced with the captured segment (`openai/*` + template `*` → request `openai/gpt-4o` sends `gpt-4o`); a template without `*` pins every match to one fixed upstream model.

`ApiKey::can_access` (and `accessible_models`, which now delegates to it) match `allowed_models` entries as the same globs, so a key scoped to `["openai/*"]` can call any `openai/*` name. `GET /v1/models` omits wildcard Models — they're patterns, not concrete ids a caller requests by name (same rationale as the existing routing-alias exclusion).

## Semantics

- Exact model names always win over a wildcard.
- Among wildcards the most specific (longest literal) pattern wins.
- One `*` per pattern, anchored at both ends (full match) — covers `provider/*` and `prefix-*-suffix`. This matches LiteLLM's PatternMatchRouter for the `provider/*` shape; it does not implement LiteLLM's multi-`*` patterns, and it full-matches rather than start-anchor-matches (stricter — a name matches the whole pattern). No new dependency: a small manual matcher rather than a regex engine in the hot path.

## Tests

- Core unit: the `*`-glob matcher (anchoring, interior `*`, empty capture, multi-`*` rejected), `can_access`/`accessible_models` glob scoping.
- Proxy unit: `resolve_model` exact-precedence, capture substitution, fixed-template pinning, most-specific-wins; `/v1/models` wildcard exclusion.
- DP E2E (`wildcard-routing-e2e.test.ts`): `openai/*` resolves and sends the captured model upstream; exact wins over wildcard while the wildcard still serves uncovered names; a `["vendor-a/*"]`-scoped key is allowed in-scope and 403'd out-of-scope before dispatch.

## Notes

No schema change (display/model names already permit `*`). User-facing docs ship as one consolidated `api7/docs` routing-strategies page for the whole smart-routing family.

Fixes api7/AISIX-Cloud#926
