### PR TITLE
feat(routing): tag/metadata conditional routing

### DIFF
--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -78,13 +78,27 @@ pub struct RoutingTarget {
     /// Target weight for `weighted` routing. Other strategies ignore this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub weight: Option<u32>,
+    /// Tags for tag/metadata-conditional routing. When a request carries
+    /// routing tags, only targets whose tags intersect the request's are
+    /// eligible; a target tagged `"default"` is the fallback used when nothing
+    /// matches and for untagged requests. Absent/empty means the target opts
+    /// out of tag filtering (eligible only via the default fallback once any
+    /// sibling target is tagged). The configured strategy then orders whatever
+    /// set survives.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(inner(length(min = 1)))]
+    pub tags: Option<Vec<String>>,
 }
+
+/// Reserved tag marking a target as the fallback when no tag matches.
+pub const DEFAULT_ROUTING_TAG: &str = "default";
 
 impl RoutingTarget {
     pub fn new(model: impl Into<String>) -> Self {
         Self {
             model: model.into(),
             weight: None,
+            tags: None,
         }
     }
 
@@ -93,8 +107,32 @@ impl RoutingTarget {
         self
     }
 
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = Some(tags);
+        self
+    }
+
     pub fn weight_or_default(&self) -> u32 {
         self.weight.unwrap_or(1)
+    }
+
+    /// True if this target carries at least one tag.
+    pub fn has_tags(&self) -> bool {
+        self.tags.as_ref().is_some_and(|t| !t.is_empty())
+    }
+
+    /// True if this target is the `"default"` fallback.
+    pub fn is_default_target(&self) -> bool {
+        self.tags
+            .as_ref()
+            .is_some_and(|t| t.iter().any(|tag| tag == DEFAULT_ROUTING_TAG))
+    }
+
+    /// True if any of this target's tags appears in `request_tags` (match-any).
+    pub fn matches_request_tags(&self, request_tags: &[String]) -> bool {
+        self.tags
+            .as_ref()
+            .is_some_and(|t| t.iter().any(|tag| request_tags.iter().any(|r| r == tag)))
     }
 }
 
@@ -257,6 +295,21 @@ mod tests {
     fn missing_weight_defaults_to_one() {
         let t = RoutingTarget::new("x");
         assert_eq!(t.weight_or_default(), 1);
+    }
+
+    #[test]
+    fn target_tags_parse_and_predicates() {
+        let r: Routing = serde_json::from_str(
+            r#"{"targets":[{"model":"a","tags":["eu","premium"]},{"model":"b","tags":["default"]},{"model":"c"}]}"#,
+        )
+        .unwrap();
+        assert!(r.targets[0].has_tags());
+        assert!(!r.targets[0].is_default_target());
+        assert!(r.targets[0].matches_request_tags(&["premium".into()]));
+        assert!(!r.targets[0].matches_request_tags(&["apac".into()]));
+        assert!(r.targets[1].is_default_target());
+        assert!(!r.targets[2].has_tags());
+        assert!(!r.targets[2].matches_request_tags(&["eu".into()]));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -902,6 +902,7 @@ async fn dispatch(
                 &req.model,
                 &virtual_entry.id,
                 &virtual_entry.value,
+                &client.routing_tags,
             )
             .map_err(&with_model)?;
             (attempts, None)

--- a/crates/aisix-proxy/src/client_ip.rs
+++ b/crates/aisix-proxy/src/client_ip.rs
@@ -114,12 +114,20 @@ fn parse_forwarded_token(tok: &str) -> Option<IpAddr> {
     None
 }
 
+/// Header carrying request-scoped routing tags for tag/metadata-conditional
+/// routing (comma-separated). Read out-of-band from the request headers so the
+/// tags never reach the upstream request body.
+pub const ROUTING_TAGS_HEADER: &str = "x-aisix-routing-tags";
+
 /// Per-request client attribution. Resolved once via the extractor and
 /// threaded into the usage event by each handler's emit fn.
 #[derive(Debug, Clone, Default)]
 pub struct ClientContext {
     pub source_ip: String,
     pub user_agent: String,
+    /// Routing tags from [`ROUTING_TAGS_HEADER`], used to select among a
+    /// routing model's tagged targets. Empty when the header is absent.
+    pub routing_tags: Vec<String>,
 }
 
 #[axum::async_trait]
@@ -154,11 +162,28 @@ where
             .map(|s| crate::chat::sanitize_tag(s.to_string()))
             .unwrap_or_default();
 
+        let routing_tags = parts
+            .headers
+            .get(ROUTING_TAGS_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(parse_routing_tags)
+            .unwrap_or_default();
+
         Ok(ClientContext {
             source_ip,
             user_agent,
+            routing_tags,
         })
     }
+}
+
+/// Split a comma-separated routing-tags header into trimmed, non-empty tags.
+fn parse_routing_tags(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_owned)
+        .collect()
 }
 
 #[cfg(test)]
@@ -170,6 +195,16 @@ mod tests {
     }
     fn ip(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    #[test]
+    fn parse_routing_tags_splits_trims_and_drops_empties() {
+        assert_eq!(
+            parse_routing_tags("eu, premium ,,us"),
+            vec!["eu", "premium", "us"]
+        );
+        assert!(parse_routing_tags("").is_empty());
+        assert!(parse_routing_tags("  ,  ").is_empty());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -91,7 +91,7 @@ pub async fn count_tokens(
         .unwrap_or("")
         .to_string();
 
-    match dispatch(&state, &auth, &body, &request_id, &client.source_ip).await {
+    match dispatch(&state, &auth, &body, &request_id, &client).await {
         Ok((resp, provider)) => {
             let elapsed = started.elapsed();
             let status = resp.status().as_u16();
@@ -142,7 +142,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: &Value,
     request_id: &str,
-    source_ip: &str,
+    client: &ClientContext,
 ) -> Result<(Response, String), ProxyError> {
     let snapshot = state.snapshot.load();
 
@@ -160,7 +160,7 @@ async fn dispatch(
     }
 
     // Client-IP allowlist gate (#557): reject before quota / upstream.
-    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+    crate::dispatch::check_ip_access(&model_entry.value, &client.source_ip)?;
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
@@ -176,6 +176,7 @@ async fn dispatch(
         &model_name,
         &model_entry.id,
         &model_entry.value,
+        &client.routing_tags,
     )?;
     let retry_on_429 = model_entry
         .value

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -485,6 +485,7 @@ async fn dispatch(
         &model_name,
         &model_entry.id,
         &model_entry.value,
+        &client.routing_tags,
     )?;
 
     let retry_on_429 = model_entry

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -356,6 +356,7 @@ async fn dispatch(
         &model_name,
         &model_entry.id,
         &model_entry.value,
+        &client.routing_tags,
     )?;
     let retry_on_429 = model_entry
         .value

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -162,6 +162,43 @@ impl std::fmt::Debug for RoutingRegistry {
     }
 }
 
+/// Narrow a routing model's targets to those eligible for this request's
+/// routing tags, mirroring LiteLLM's tag-based routing:
+///   * No target is tagged → tag routing isn't in use; every target eligible.
+///   * Request carries tags → targets whose tags intersect it (match-any); if
+///     none match, fall back to `"default"`-tagged targets.
+///   * Request has no tags → `"default"`-tagged targets if any, else all.
+///
+/// Returns owned clones so the caller runs the normal strategy over the
+/// surviving subset. An empty result means the request asked for a tag tier
+/// with no matching target and no default — the caller turns that into an error.
+fn eligible_targets(targets: &[RoutingTarget], request_tags: &[String]) -> Vec<RoutingTarget> {
+    if !targets.iter().any(RoutingTarget::has_tags) {
+        return targets.to_vec();
+    }
+    let defaults = || -> Vec<RoutingTarget> {
+        targets
+            .iter()
+            .filter(|t| t.is_default_target())
+            .cloned()
+            .collect()
+    };
+    if request_tags.is_empty() {
+        let d = defaults();
+        return if d.is_empty() { targets.to_vec() } else { d };
+    }
+    let matched: Vec<RoutingTarget> = targets
+        .iter()
+        .filter(|t| t.matches_request_tags(request_tags))
+        .cloned()
+        .collect();
+    if matched.is_empty() {
+        defaults()
+    } else {
+        matched
+    }
+}
+
 /// Build the target-order vector starting at `start_idx`, walking forward
 /// (wrap-around) for `limit` distinct entries.
 fn attempt_order(targets: &[RoutingTarget], start_idx: usize, limit: usize) -> Vec<String> {
@@ -355,6 +392,7 @@ pub(crate) fn resolve_attempt_models(
     virtual_name: &str,
     virtual_id: &str,
     virtual_model: &Model,
+    request_tags: &[String],
 ) -> Result<Vec<AttemptModel>, ProxyError> {
     let Some(routing) = virtual_model.routing.as_ref() else {
         return Ok(vec![AttemptModel {
@@ -362,6 +400,21 @@ pub(crate) fn resolve_attempt_models(
             model: virtual_model.clone(),
         }]);
     };
+
+    // Tag/metadata pre-filter: narrow the targets to those eligible for this
+    // request's routing tags, then let the configured strategy order whatever
+    // survives. A no-op when no target is tagged.
+    let eligible = eligible_targets(&routing.targets, request_tags);
+    if eligible.is_empty() {
+        return Err(ProxyError::InvalidRequest(format!(
+            "no routing target matches request tags {request_tags:?}"
+        )));
+    }
+    let filtered_routing = Routing {
+        targets: eligible,
+        ..routing.clone()
+    };
+    let routing = &filtered_routing;
 
     let names = routing_registry.pick_targets(virtual_name, routing);
     if names.is_empty() {
@@ -423,6 +476,67 @@ mod tests {
             retry_on_429: None,
             when_all_unavailable: None,
         }
+    }
+
+    fn tagged(model: &str, tags: &[&str]) -> RoutingTarget {
+        RoutingTarget::new(model).with_tags(tags.iter().map(|s| s.to_string()).collect())
+    }
+
+    fn model_names(targets: &[RoutingTarget]) -> Vec<&str> {
+        targets.iter().map(|t| t.model.as_str()).collect()
+    }
+
+    #[test]
+    fn eligible_no_tagged_target_returns_all() {
+        // No target is tagged → tag routing isn't in use, even with request tags.
+        let targets = vec![RoutingTarget::new("a"), RoutingTarget::new("b")];
+        assert_eq!(
+            model_names(&eligible_targets(&targets, &["x".into()])),
+            vec!["a", "b"]
+        );
+    }
+
+    #[test]
+    fn eligible_matches_any_overlapping_tag() {
+        let targets = vec![tagged("eu", &["eu"]), tagged("us", &["us"])];
+        assert_eq!(
+            model_names(&eligible_targets(&targets, &["eu".into()])),
+            vec!["eu"]
+        );
+    }
+
+    #[test]
+    fn eligible_tagged_no_match_falls_back_to_default() {
+        let targets = vec![tagged("eu", &["eu"]), tagged("fallback", &["default"])];
+        assert_eq!(
+            model_names(&eligible_targets(&targets, &["apac".into()])),
+            vec!["fallback"]
+        );
+    }
+
+    #[test]
+    fn eligible_untagged_request_prefers_default() {
+        let targets = vec![tagged("eu", &["eu"]), tagged("fallback", &["default"])];
+        assert_eq!(
+            model_names(&eligible_targets(&targets, &[])),
+            vec!["fallback"]
+        );
+    }
+
+    #[test]
+    fn eligible_untagged_request_without_default_returns_all() {
+        let targets = vec![tagged("eu", &["eu"]), tagged("us", &["us"])];
+        assert_eq!(
+            model_names(&eligible_targets(&targets, &[])),
+            vec!["eu", "us"]
+        );
+    }
+
+    #[test]
+    fn eligible_tagged_no_match_no_default_is_empty() {
+        // The caller turns an empty result into a "no target matches tags" error.
+        let targets = vec![tagged("eu", &["eu"]), tagged("us", &["us"])];
+        assert!(eligible_targets(&targets, &["apac".into()]).is_empty());
     }
 
     #[test]

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -462,6 +462,14 @@
           "minLength": 1,
           "type": "string"
         },
+        "tags": {
+          "description": "Tags for tag/metadata-conditional routing. When a request carries routing tags, only targets whose tags intersect the request's are eligible; a target tagged `\"default\"` is the fallback used when nothing matches and for untagged requests. Absent/empty means the target opts out of tag filtering (eligible only via the default fallback once any sibling target is tagged). The configured strategy then orders whatever set survives.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
         "weight": {
           "description": "Target weight for `weighted` routing. Other strategies ignore this field.",
           "format": "uint32",

--- a/schemas/resources/routing.schema.json
+++ b/schemas/resources/routing.schema.json
@@ -120,6 +120,17 @@
           "type": "string",
           "minLength": 1
         },
+        "tags": {
+          "description": "Tags for tag/metadata-conditional routing. When a request carries routing tags, only targets whose tags intersect the request's are eligible; a target tagged `\"default\"` is the fallback used when nothing matches and for untagged requests. Absent/empty means the target opts out of tag filtering (eligible only via the default fallback once any sibling target is tagged). The configured strategy then orders whatever set survives.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
         "weight": {
           "description": "Target weight for `weighted` routing. Other strategies ignore this field.",
           "type": [

--- a/tests/e2e/src/cases/tag-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/tag-routing-e2e.test.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const CALLER_PLAINTEXT = "sk-tag-routing-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function okBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe("tag/metadata conditional routing e2e", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  async function createOpenAiModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin client not initialized");
+    const providerKey = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: providerKey.id,
+    });
+  }
+
+  function client(): OpenAI {
+    return new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app?.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  async function askWithTags(tags: string | undefined): Promise<string | null> {
+    const opts = tags ? { headers: { "x-aisix-routing-tags": tags } } : undefined;
+    const completion = await client().chat.completions.create(
+      { model: "tag-router", messages: [{ role: "user", content: "hi" }] },
+      opts,
+    );
+    return completion.choices[0]?.message.content ?? null;
+  }
+
+  test("selects the tagged target, defaulting when unmatched or untagged", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const eu = await startOpenAiUpstream({ nonStreamBody: okBody("eu-served") });
+    const us = await startOpenAiUpstream({ nonStreamBody: okBody("us-served") });
+    const def = await startOpenAiUpstream({ nonStreamBody: okBody("default-served") });
+    upstreams.push(eu, us, def);
+    await createOpenAiModel("tag-eu", eu);
+    await createOpenAiModel("tag-us", us);
+    await createOpenAiModel("tag-default", def);
+    // failover keeps target selection deterministic: whatever the tag filter
+    // leaves, the first survivor is attempted.
+    await admin.createModel({
+      display_name: "tag-router",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "tag-eu", tags: ["eu"] },
+          { model: "tag-us", tags: ["us"] },
+          { model: "tag-default", tags: ["default"] },
+        ],
+      },
+    });
+
+    await waitConfigPropagation(async () => {
+      const models = await admin!.listModels();
+      return models.some((m) => m.display_name === "tag-router");
+    });
+
+    // Matching tags route to their target.
+    expect(await askWithTags("eu")).toBe("eu-served");
+    expect(await askWithTags("us")).toBe("us-served");
+    // An untagged request uses the `default`-tagged target.
+    expect(await askWithTags(undefined)).toBe("default-served");
+    // A tag matching no target also falls back to default.
+    expect(await askWithTags("apac")).toBe("default-served");
+    // The routing header is out-of-band and must never reach the upstream body.
+    const lastEu = JSON.parse(eu.receivedRequests[eu.receivedRequests.length - 1]!.body);
+    expect(lastEu.metadata).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds tag/metadata-conditional routing: a routing model's targets can carry `tags`, and a request selects among them by the routing tags it carries. Closes the conditional/tag-routing gap vs LiteLLM / Portkey / Kong (routing gap list #873).

## How

Request tags come from an out-of-band header, `x-aisix-routing-tags` (comma-separated), resolved once by the existing `ClientContext` extractor alongside client IP / User-Agent. They're read from the headers, never the body, so they never reach the upstream request payload.

Filtering happens in the shared `resolve_attempt_models`, as a pre-filter that narrows the target set before the configured strategy orders it — so tag routing composes with round-robin / weighted / failover / least-*, rather than being a new strategy. `eligible_targets` mirrors LiteLLM's `tag_based_routing`:

- No target is tagged → tag routing isn't in use; every target is eligible.
- Request carries tags → targets whose tags intersect it (match-any); if none match, fall back to `"default"`-tagged targets.
- Request has no tags → `"default"`-tagged targets if any, else all.
- Tags that match nothing with no `default` configured → a "no target matches tags" error.

`RoutingTarget` gains an optional `tags: Vec<String>` (additive, serde-default, so existing configs are unaffected). `count_tokens`'s `dispatch` now takes the whole `ClientContext` (it previously took just `source_ip`), matching the other three routing-capable endpoints.

## LiteLLM baseline

Semantics follow `litellm/router_strategy/tag_based_routing.py` (match-any intersect + `default` fallback). One deliberate divergence: LiteLLM sources tags from the request body (`metadata.tags`); we use a header. Our bridges serialize the whole request body (including passthrough `extra`) to the upstream, so a body `metadata` field would be forwarded and rejected by providers that constrain `metadata` (OpenAI requires string values). A header keeps the routing signal out of the upstream payload without a body-stripping layer. The matching/fallback behavior is unchanged from LiteLLM.

## Tests

- Core unit: `RoutingTarget` tag predicates + `tags` deserialization.
- Proxy unit: `eligible_targets` across all branches (no-tags passthrough, match-any, tagged-no-match→default, untagged→default, untagged-no-default→all, tagged-no-match-no-default→empty), and header parsing.
- DP E2E (`tag-routing-e2e.test.ts`): a routing model with `eu` / `us` / `default` targets — `x-aisix-routing-tags` selects the matching upstream, an untagged request and an unmatched tag both fall back to default, and the header is asserted absent from the upstream body.

## Notes

Regenerated the committed resource schemas (`routing`/`model`). User-facing docs ship as one consolidated `api7/docs` routing-strategies page for the whole routing family.

Fixes api7/AISIX-Cloud#927


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag-based routing for requests, letting traffic be directed by request tags.
  * Support for a default routing target was added for untagged or unmatched requests.
  * Requests can now include routing tags via a new header, and matching behavior is covered end-to-end.

* **Bug Fixes**
  * Routing now falls back more predictably when no tag match is found.
  * Untagged requests are handled consistently using default-target behavior when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->