### PR TITLE
feat(routing): sticky weighted routing (A/B / canary)

### DIFF
--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -173,11 +173,24 @@ pub struct Routing {
     /// Policy to apply when every target is unavailable because of runtime health or cooldown state.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub when_all_unavailable: Option<WhenAllUnavailablePolicy>,
+    /// Sticky (deterministic) target selection for `weighted` routing — the
+    /// A/B / canary knob. When `true`, a request's target is chosen by hashing a
+    /// stability key (the `x-aisix-routing-key` header, else the caller's API
+    /// key) into the weight distribution, so the same key consistently lands on
+    /// the same target while the aggregate split still honors the weights. When
+    /// absent/`false`, `weighted` samples independently per request (the
+    /// default). Ignored by non-`weighted` strategies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sticky: Option<bool>,
 }
 
 impl Routing {
     pub fn retries_or_default(&self) -> usize {
         self.retries.unwrap_or(0) as usize
+    }
+
+    pub fn sticky_or_default(&self) -> bool {
+        self.sticky.unwrap_or(false)
     }
 
     pub fn max_fallbacks_or_default(&self) -> usize {
@@ -246,6 +259,7 @@ mod tests {
             max_fallbacks: Some(0),
             retry_on_429: None,
             when_all_unavailable: None,
+            sticky: None,
         };
         assert_eq!(r.max_fallbacks_or_default(), 0);
     }
@@ -259,6 +273,7 @@ mod tests {
             max_fallbacks: Some(99),
             retry_on_429: None,
             when_all_unavailable: None,
+            sticky: None,
         };
         assert_eq!(r.max_fallbacks_or_default(), 0);
     }
@@ -295,6 +310,17 @@ mod tests {
     fn missing_weight_defaults_to_one() {
         let t = RoutingTarget::new("x");
         assert_eq!(t.weight_or_default(), 1);
+    }
+
+    #[test]
+    fn sticky_parses_and_defaults_false() {
+        let off: Routing = serde_json::from_str(r#"{"targets":[{"model":"a"}]}"#).unwrap();
+        assert!(!off.sticky_or_default());
+        let on: Routing = serde_json::from_str(
+            r#"{"strategy":"weighted","sticky":true,"targets":[{"model":"a"},{"model":"b"}]}"#,
+        )
+        .unwrap();
+        assert!(on.sticky_or_default());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -41,7 +41,7 @@ use crate::client_ip::ClientContext;
 use crate::error::ProxyError;
 use crate::render::{render_chunk, render_response};
 use crate::request_id::new_request_id;
-use crate::routing::{is_retryable, resolve_attempt_models, AttemptModel};
+use crate::routing::{is_retryable, resolve_attempt_models, AttemptModel, RoutingRequest};
 use crate::state::ProxyState;
 
 /// Header set on every non-streaming response indicating whether the
@@ -902,7 +902,15 @@ async fn dispatch(
                 &req.model,
                 &virtual_entry.id,
                 &virtual_entry.value,
-                &client.routing_tags,
+                RoutingRequest {
+                    tags: &client.routing_tags,
+                    stability_key: Some(
+                        client
+                            .routing_key
+                            .as_deref()
+                            .unwrap_or(auth.entry.id.as_str()),
+                    ),
+                },
             )
             .map_err(&with_model)?;
             (attempts, None)

--- a/crates/aisix-proxy/src/client_ip.rs
+++ b/crates/aisix-proxy/src/client_ip.rs
@@ -119,6 +119,11 @@ fn parse_forwarded_token(tok: &str) -> Option<IpAddr> {
 /// tags never reach the upstream request body.
 pub const ROUTING_TAGS_HEADER: &str = "x-aisix-routing-tags";
 
+/// Header carrying the stability key for sticky (A/B / canary) weighted
+/// routing. When present, a request consistently maps to the same weighted
+/// target; absent, the caller's API key is used as the key instead.
+pub const ROUTING_KEY_HEADER: &str = "x-aisix-routing-key";
+
 /// Per-request client attribution. Resolved once via the extractor and
 /// threaded into the usage event by each handler's emit fn.
 #[derive(Debug, Clone, Default)]
@@ -128,6 +133,9 @@ pub struct ClientContext {
     /// Routing tags from [`ROUTING_TAGS_HEADER`], used to select among a
     /// routing model's tagged targets. Empty when the header is absent.
     pub routing_tags: Vec<String>,
+    /// Stability key from [`ROUTING_KEY_HEADER`] for sticky weighted routing.
+    /// `None` when the header is absent (the caller's API key is used instead).
+    pub routing_key: Option<String>,
 }
 
 #[axum::async_trait]
@@ -169,10 +177,19 @@ where
             .map(parse_routing_tags)
             .unwrap_or_default();
 
+        let routing_key = parts
+            .headers
+            .get(ROUTING_KEY_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+
         Ok(ClientContext {
             source_ip,
             user_agent,
             routing_tags,
+            routing_key,
         })
     }
 }

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -176,7 +176,15 @@ async fn dispatch(
         &model_name,
         &model_entry.id,
         &model_entry.value,
-        &client.routing_tags,
+        crate::routing::RoutingRequest {
+            tags: &client.routing_tags,
+            stability_key: Some(
+                client
+                    .routing_key
+                    .as_deref()
+                    .unwrap_or(auth.entry.id.as_str()),
+            ),
+        },
     )?;
     let retry_on_429 = model_entry
         .value

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -485,7 +485,15 @@ async fn dispatch(
         &model_name,
         &model_entry.id,
         &model_entry.value,
-        &client.routing_tags,
+        crate::routing::RoutingRequest {
+            tags: &client.routing_tags,
+            stability_key: Some(
+                client
+                    .routing_key
+                    .as_deref()
+                    .unwrap_or(auth.entry.id.as_str()),
+            ),
+        },
     )?;
 
     let retry_on_429 = model_entry

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -356,7 +356,15 @@ async fn dispatch(
         &model_name,
         &model_entry.id,
         &model_entry.value,
-        &client.routing_tags,
+        crate::routing::RoutingRequest {
+            tags: &client.routing_tags,
+            stability_key: Some(
+                client
+                    .routing_key
+                    .as_deref()
+                    .unwrap_or(auth.entry.id.as_str()),
+            ),
+        },
     )?;
     let retry_on_429 = model_entry
         .value

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -416,7 +416,9 @@ pub(crate) fn filter_attempt_models(
 
 /// Per-request routing inputs threaded into [`resolve_attempt_models`]: the
 /// tags that gate tag/metadata routing and the stability key for sticky
-/// (A/B / canary) weighted selection. Both come from request headers.
+/// (A/B / canary) weighted selection. Tags come from request headers; the
+/// stability key is the routing-key header when present, otherwise the
+/// caller's API key id.
 #[derive(Clone, Copy, Default)]
 pub(crate) struct RoutingRequest<'a> {
     pub tags: &'a [String],

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -114,7 +114,12 @@ impl RoutingRegistry {
     /// initial target; subsequent elements are later fallback targets (in
     /// declaration order, wrapping if needed). Length is bounded by the
     /// initial target plus `routing.max_fallbacks_or_default()`.
-    pub fn pick_targets(&self, virtual_name: &str, routing: &Routing) -> Vec<String> {
+    pub fn pick_targets(
+        &self,
+        virtual_name: &str,
+        routing: &Routing,
+        stability_key: Option<&str>,
+    ) -> Vec<String> {
         if routing.targets.is_empty() {
             return Vec::new();
         }
@@ -126,7 +131,7 @@ impl RoutingRegistry {
         if routing.strategy.is_metric_based() {
             return routing.targets.iter().map(|t| t.model.clone()).collect();
         }
-        let start = self.starting_index(virtual_name, routing);
+        let start = self.starting_index(virtual_name, routing, stability_key);
         attempt_order(
             &routing.targets,
             start,
@@ -134,11 +139,25 @@ impl RoutingRegistry {
         )
     }
 
-    fn starting_index(&self, virtual_name: &str, routing: &Routing) -> usize {
+    fn starting_index(
+        &self,
+        virtual_name: &str,
+        routing: &Routing,
+        stability_key: Option<&str>,
+    ) -> usize {
         match routing.strategy {
             RoutingStrategy::Failover => 0,
             RoutingStrategy::RoundRobin => self.advance_cursor(virtual_name, routing.targets.len()),
-            RoutingStrategy::Weighted => weighted_pick(&routing.targets),
+            RoutingStrategy::Weighted => {
+                // Sticky (A/B / canary) routing makes the weighted pick
+                // deterministic in the request's stability key; otherwise each
+                // request samples the weight distribution independently.
+                let sticky_key = routing
+                    .sticky_or_default()
+                    .then_some(stability_key)
+                    .flatten();
+                weighted_pick(&routing.targets, sticky_key)
+            }
             // Metric-ordered strategies never reach here — `pick_targets`
             // short-circuits them before computing a start index.
             RoutingStrategy::LeastCost
@@ -231,12 +250,19 @@ fn attempt_order(targets: &[RoutingTarget], start_idx: usize, limit: usize) -> V
 /// from OS entropy on first use and is independent across calls; the
 /// distribution converges to the configured weights over a finite
 /// sample (per the spec the e2e pins).
-fn weighted_pick(targets: &[RoutingTarget]) -> usize {
+///
+/// With a `sticky_key` (A/B / canary routing) the pick is instead a
+/// deterministic function of that key, so the same key always resolves to the
+/// same target while the aggregate split still honors the weights.
+fn weighted_pick(targets: &[RoutingTarget], sticky_key: Option<&str>) -> usize {
     let total: u64 = targets.iter().map(|t| t.weight_or_default() as u64).sum();
     if total == 0 {
         return 0;
     }
-    let pick = rand::thread_rng().gen_range(0..total);
+    let pick = match sticky_key {
+        Some(key) => stable_hash(key) % total,
+        None => rand::thread_rng().gen_range(0..total),
+    };
     let mut acc: u64 = 0;
     for (i, t) in targets.iter().enumerate() {
         acc += t.weight_or_default() as u64;
@@ -245,6 +271,18 @@ fn weighted_pick(targets: &[RoutingTarget]) -> usize {
         }
     }
     targets.len() - 1
+}
+
+/// Stable 64-bit FNV-1a hash used to map a sticky-routing key into the weight
+/// distribution. Deterministic across processes and toolchains by design (the
+/// std hasher is not), so a given key always resolves to the same target.
+fn stable_hash(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a offset basis
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3); // FNV-1a prime
+    }
+    h
 }
 
 /// Combined per-1K unit price used to rank `least_cost` targets. A target
@@ -376,6 +414,15 @@ pub(crate) fn filter_attempt_models(
     }
 }
 
+/// Per-request routing inputs threaded into [`resolve_attempt_models`]: the
+/// tags that gate tag/metadata routing and the stability key for sticky
+/// (A/B / canary) weighted selection. Both come from request headers.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct RoutingRequest<'a> {
+    pub tags: &'a [String],
+    pub stability_key: Option<&'a str>,
+}
+
 /// Resolve the ordered list of concrete Models a request will attempt.
 ///
 /// For a routing model (Model Group), walk `routing.targets` per the
@@ -392,7 +439,7 @@ pub(crate) fn resolve_attempt_models(
     virtual_name: &str,
     virtual_id: &str,
     virtual_model: &Model,
-    request_tags: &[String],
+    req: RoutingRequest<'_>,
 ) -> Result<Vec<AttemptModel>, ProxyError> {
     let Some(routing) = virtual_model.routing.as_ref() else {
         return Ok(vec![AttemptModel {
@@ -404,10 +451,11 @@ pub(crate) fn resolve_attempt_models(
     // Tag/metadata pre-filter: narrow the targets to those eligible for this
     // request's routing tags, then let the configured strategy order whatever
     // survives. A no-op when no target is tagged.
-    let eligible = eligible_targets(&routing.targets, request_tags);
+    let eligible = eligible_targets(&routing.targets, req.tags);
     if eligible.is_empty() {
         return Err(ProxyError::InvalidRequest(format!(
-            "no routing target matches request tags {request_tags:?}"
+            "no routing target matches request tags {:?}",
+            req.tags
         )));
     }
     let filtered_routing = Routing {
@@ -416,7 +464,7 @@ pub(crate) fn resolve_attempt_models(
     };
     let routing = &filtered_routing;
 
-    let names = routing_registry.pick_targets(virtual_name, routing);
+    let names = routing_registry.pick_targets(virtual_name, routing, req.stability_key);
     if names.is_empty() {
         return Err(ProxyError::InvalidRequest(
             "routing model has no targets".into(),
@@ -475,6 +523,7 @@ mod tests {
             max_fallbacks,
             retry_on_429: None,
             when_all_unavailable: None,
+            sticky: None,
         }
     }
 
@@ -484,6 +533,69 @@ mod tests {
 
     fn model_names(targets: &[RoutingTarget]) -> Vec<&str> {
         targets.iter().map(|t| t.model.as_str()).collect()
+    }
+
+    #[test]
+    fn stable_hash_is_deterministic() {
+        assert_eq!(stable_hash("session-abc"), stable_hash("session-abc"));
+        assert_ne!(stable_hash("a"), stable_hash("b"));
+    }
+
+    #[test]
+    fn sticky_weighted_pick_is_deterministic_per_key() {
+        let targets = vec![
+            RoutingTarget::new("a").with_weight(50),
+            RoutingTarget::new("b").with_weight(50),
+        ];
+        let first = weighted_pick(&targets, Some("session-1"));
+        for _ in 0..50 {
+            assert_eq!(weighted_pick(&targets, Some("session-1")), first);
+        }
+    }
+
+    #[test]
+    fn sticky_weighted_pick_spreads_distinct_keys() {
+        // Distinct keys shouldn't all funnel to one target.
+        let targets = vec![
+            RoutingTarget::new("a").with_weight(50),
+            RoutingTarget::new("b").with_weight(50),
+        ];
+        let mut seen = [false; 2];
+        for i in 0..200 {
+            seen[weighted_pick(&targets, Some(&format!("k{i}")))] = true;
+        }
+        assert!(seen[0] && seen[1]);
+    }
+
+    #[test]
+    fn sticky_weighted_pick_honors_extreme_weights() {
+        // A 100/0 canary split lands every key on the weighted target.
+        let targets = vec![
+            RoutingTarget::new("stable").with_weight(100),
+            RoutingTarget::new("canary").with_weight(0),
+        ];
+        for i in 0..50 {
+            assert_eq!(weighted_pick(&targets, Some(&format!("k{i}"))), 0);
+        }
+    }
+
+    #[test]
+    fn sticky_routing_pins_a_key_to_one_target() {
+        let reg = RoutingRegistry::new();
+        let mut routing = r(
+            RoutingStrategy::Weighted,
+            vec![
+                RoutingTarget::new("stable").with_weight(90),
+                RoutingTarget::new("canary").with_weight(10),
+            ],
+            Some(0), // only the chosen start target
+        );
+        routing.sticky = Some(true);
+        let first = reg.pick_targets("v", &routing, Some("user-42"));
+        assert_eq!(first.len(), 1);
+        for _ in 0..20 {
+            assert_eq!(reg.pick_targets("v", &routing, Some("user-42")), first);
+        }
     }
 
     #[test]
@@ -552,7 +664,7 @@ mod tests {
             None,
         );
         for _ in 0..5 {
-            let order = reg.pick_targets("v", &routing);
+            let order = reg.pick_targets("v", &routing, None);
             assert_eq!(order, vec!["primary", "secondary", "tertiary"]);
         }
     }
@@ -571,7 +683,7 @@ mod tests {
         );
         let mut firsts = Vec::new();
         for _ in 0..6 {
-            let order = reg.pick_targets("v", &routing);
+            let order = reg.pick_targets("v", &routing, None);
             firsts.push(order[0].clone());
         }
         // Two full cycles of a→b→c.
@@ -587,10 +699,10 @@ mod tests {
             Some(1),
         );
         // Two distinct virtual models advance independently.
-        assert_eq!(reg.pick_targets("v1", &routing)[0], "a");
-        assert_eq!(reg.pick_targets("v2", &routing)[0], "a");
-        assert_eq!(reg.pick_targets("v1", &routing)[0], "b");
-        assert_eq!(reg.pick_targets("v2", &routing)[0], "b");
+        assert_eq!(reg.pick_targets("v1", &routing, None)[0], "a");
+        assert_eq!(reg.pick_targets("v2", &routing, None)[0], "a");
+        assert_eq!(reg.pick_targets("v1", &routing, None)[0], "b");
+        assert_eq!(reg.pick_targets("v2", &routing, None)[0], "b");
     }
 
     #[test]
@@ -606,9 +718,9 @@ mod tests {
             Some(2),
         );
         // First call starts at a → a, b, c
-        assert_eq!(reg.pick_targets("v", &routing), vec!["a", "b", "c"]);
+        assert_eq!(reg.pick_targets("v", &routing, None), vec!["a", "b", "c"]);
         // Second call starts at b → b, c, a
-        assert_eq!(reg.pick_targets("v", &routing), vec!["b", "c", "a"]);
+        assert_eq!(reg.pick_targets("v", &routing, None), vec!["b", "c", "a"]);
     }
 
     #[test]
@@ -626,7 +738,7 @@ mod tests {
         // exactly two attempts, distinct targets, both targets covered.
         // (Aggregate distribution is pinned by the dedicated tests
         // below.)
-        let order = reg.pick_targets("v", &routing);
+        let order = reg.pick_targets("v", &routing, None);
         assert_eq!(order.len(), 2);
         assert!(order.iter().any(|t| t == "a"));
         assert!(order.iter().any(|t| t == "b"));
@@ -638,7 +750,7 @@ mod tests {
             RoutingTarget::new("a").with_weight(0),
             RoutingTarget::new("b").with_weight(0),
         ];
-        assert_eq!(weighted_pick(&targets), 0);
+        assert_eq!(weighted_pick(&targets, None), 0);
     }
 
     /// Aggregate-distribution property: across many trials, a 100/1
@@ -656,7 +768,9 @@ mod tests {
             RoutingTarget::new("b").with_weight(1),
         ];
         let n = 5_000;
-        let a_count = (0..n).filter(|_| weighted_pick(&targets) == 0).count();
+        let a_count = (0..n)
+            .filter(|_| weighted_pick(&targets, None) == 0)
+            .count();
         // Uniform 50/50 → ~2500. Weighted 100/1 → ~4950 in theory.
         // 95% threshold (4750) rejects both a weight-blind impl
         // (~50%) AND a half-sensitivity regression (~75% would also
@@ -681,7 +795,9 @@ mod tests {
             RoutingTarget::new("b").with_weight(100),
         ];
         let n = 5_000;
-        let b_count = (0..n).filter(|_| weighted_pick(&targets) == 1).count();
+        let b_count = (0..n)
+            .filter(|_| weighted_pick(&targets, None) == 1)
+            .count();
         assert!(
             b_count * 100 / n >= 95,
             "weight=100 target at index 1 should dominate aggregate picks; got {b_count}/{n}",
@@ -705,7 +821,9 @@ mod tests {
             RoutingTarget::new("b").with_weight(30),
         ];
         let n = 1_000;
-        let a_count = (0..n).filter(|_| weighted_pick(&targets) == 0).count();
+        let a_count = (0..n)
+            .filter(|_| weighted_pick(&targets, None) == 0)
+            .count();
         // Expected ~700; tolerance window [650, 750] (≈±3.45σ).
         assert!(
             (650..=750).contains(&a_count),
@@ -732,7 +850,7 @@ mod tests {
         let n = 2_000;
         let mut counts = [0_usize; 3];
         for _ in 0..n {
-            counts[weighted_pick(&targets)] += 1;
+            counts[weighted_pick(&targets, None)] += 1;
         }
         // Expected 1000/600/400. ±100 window catches a weight-blind
         // 2-target collapse (where the 3rd bin would be 0) AND
@@ -765,7 +883,9 @@ mod tests {
             RoutingTarget::new("c").with_weight(10),
         ];
         let n = 2_000;
-        let b_count = (0..n).filter(|_| weighted_pick(&targets) == 1).count();
+        let b_count = (0..n)
+            .filter(|_| weighted_pick(&targets, None) == 1)
+            .count();
         assert_eq!(
             b_count, 0,
             "weight=0 target must never be picked; got {b_count}/{n}",
@@ -780,7 +900,7 @@ mod tests {
             vec![RoutingTarget::new("a"), RoutingTarget::new("b")],
             Some(0),
         );
-        let order = reg.pick_targets("v", &routing);
+        let order = reg.pick_targets("v", &routing, None);
         assert_eq!(order, vec!["a"]);
     }
 
@@ -788,7 +908,7 @@ mod tests {
     fn empty_targets_yields_empty_order() {
         let reg = RoutingRegistry::new();
         let routing = r(RoutingStrategy::Failover, vec![], None);
-        assert!(reg.pick_targets("v", &routing).is_empty());
+        assert!(reg.pick_targets("v", &routing, None).is_empty());
     }
 
     #[test]
@@ -1019,7 +1139,7 @@ mod tests {
         );
         // Ranking needs resolved Models, so pick_targets hands back every
         // target untouched regardless of max_fallbacks.
-        assert_eq!(reg.pick_targets("v", &routing), vec!["a", "b", "c"]);
+        assert_eq!(reg.pick_targets("v", &routing, None), vec!["a", "b", "c"]);
     }
 
     #[test]

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -376,6 +376,10 @@
           "description": "Whether upstream 429 participates in retries and failover.",
           "type": "boolean"
         },
+        "sticky": {
+          "description": "Sticky (deterministic) target selection for `weighted` routing — the A/B / canary knob. When `true`, a request's target is chosen by hashing a stability key (the `x-aisix-routing-key` header, else the caller's API key) into the weight distribution, so the same key consistently lands on the same target while the aggregate split still honors the weights. When absent/`false`, `weighted` samples independently per request (the default). Ignored by non-`weighted` strategies.",
+          "type": "boolean"
+        },
         "strategy": {
           "allOf": [
             {

--- a/schemas/resources/routing.schema.json
+++ b/schemas/resources/routing.schema.json
@@ -31,6 +31,13 @@
         "null"
       ]
     },
+    "sticky": {
+      "description": "Sticky (deterministic) target selection for `weighted` routing — the A/B / canary knob. When `true`, a request's target is chosen by hashing a stability key (the `x-aisix-routing-key` header, else the caller's API key) into the weight distribution, so the same key consistently lands on the same target while the aggregate split still honors the weights. When absent/`false`, `weighted` samples independently per request (the default). Ignored by non-`weighted` strategies.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "strategy": {
       "description": "Strategy used to select a target for each request.",
       "default": "failover",

--- a/tests/e2e/src/cases/canary-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/canary-routing-e2e.test.ts
@@ -1,0 +1,135 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const CALLER_PLAINTEXT = "sk-canary-routing-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function okBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe("sticky (A/B / canary) weighted routing e2e", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  async function createOpenAiModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!admin) throw new Error("admin client not initialized");
+    const providerKey = await admin.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: providerKey.id,
+    });
+  }
+
+  function client(): OpenAI {
+    return new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app?.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  async function askWithKey(key: string): Promise<string | null> {
+    const completion = await client().chat.completions.create(
+      { model: "canary-router", messages: [{ role: "user", content: "hi" }] },
+      { headers: { "x-aisix-routing-key": key } },
+    );
+    return completion.choices[0]?.message.content ?? null;
+  }
+
+  test("pins a stability key to one target while splitting across keys", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const stable = await startOpenAiUpstream({ nonStreamBody: okBody("stable-served") });
+    const canary = await startOpenAiUpstream({ nonStreamBody: okBody("canary-served") });
+    upstreams.push(stable, canary);
+    await createOpenAiModel("canary-stable", stable);
+    await createOpenAiModel("canary-new", canary);
+    await admin.createModel({
+      display_name: "canary-router",
+      routing: {
+        strategy: "weighted",
+        sticky: true,
+        targets: [
+          { model: "canary-stable", weight: 50 },
+          { model: "canary-new", weight: 50 },
+        ],
+      },
+    });
+
+    await waitConfigPropagation(async () => {
+      const models = await admin!.listModels();
+      return models.some((m) => m.display_name === "canary-router");
+    });
+
+    // Same key → same target on every request (sticky).
+    const repeated = await Promise.all(
+      Array.from({ length: 6 }, () => askWithKey("user-A")),
+    );
+    expect(new Set(repeated).size).toBe(1);
+
+    // Distinct keys spread across both targets (the split is honored, not a
+    // single funnel). Deterministic hashing keeps this stable across runs.
+    const served = new Set<string | null>();
+    for (let i = 0; i < 32; i++) {
+      served.add(await askWithKey(`user-${i}`));
+    }
+    expect(served).toEqual(new Set(["stable-served", "canary-served"]));
+  });
+});


### PR DESCRIPTION
Adds sticky weighted routing — the A/B / canary knob. Weighted routing already splits traffic by weight, but samples independently per request, so a caller bounces between variants and can't form stable A/B cohorts. `sticky: true` makes the weighted pick deterministic in a per-request stability key, so the same key always lands on the same target while the aggregate split still honors the weights. Closes the A/B / canary gap vs Portkey / Kong (routing gap list #873).

## How

`Routing` gains an optional `sticky: bool` (default `false`, so existing weighted models are unchanged). When set, `weighted_pick` maps a stability key into the weight distribution via a stable FNV-1a hash (`hash(key) % total_weight`) instead of drawing a random sample — deterministic across processes and toolchains, so a key's target never drifts.

The stability key is the `x-aisix-routing-key` request header (read out-of-band by the existing `ClientContext` extractor), falling back to the caller's API key id when absent — so canary assignment is per-session when the client supplies a key, and per-API-key otherwise. `sticky` only affects `weighted`; other strategies ignore it.

Example — 5% canary, stable per session:

```yaml
routing:
  strategy: weighted
  sticky: true
  targets:
    - { model: stable-v1, weight: 95 }
    - { model: canary-v2, weight: 5 }
```

The two per-request routing inputs (tags from #927 and this stability key) are threaded into `resolve_attempt_models` as one small `RoutingRequest` bundle rather than loose arguments.

## LiteLLM baseline

LiteLLM's router has weighted routing but no per-session sticky / canary assignment (weighted is random per call), so there's no LiteLLM equivalent to mirror here — this goes beyond its routing feature set.

## Tests

- Proxy unit: `stable_hash` determinism; sticky `weighted_pick` is deterministic per key, spreads distinct keys across targets, and honors extreme (100/0) weights; `pick_targets` pins a key to one target under `sticky`.
- Core unit: `sticky` parsing + default.
- DP E2E (`canary-routing-e2e.test.ts`): a 50/50 sticky router — the same `x-aisix-routing-key` returns one target across repeated requests, while 32 distinct keys split across both targets.

## Notes

Regenerated the committed resource schemas (`routing`/`model`). User-facing docs ship as one consolidated `api7/docs` routing-strategies page for the whole routing family.

Fixes api7/AISIX-Cloud#928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional sticky routing for weighted target selection, making requests with the same routing key consistently choose the same upstream.
  * Introduced support for a routing key header to improve request consistency across retries and related calls.

* **Bug Fixes**
  * Improved model-attempt resolution to use routing context more accurately across chat, messages, responses, and token-count requests.

* **Tests**
  * Added coverage for sticky routing behavior and updated existing routing tests for the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->