### PR TITLE
fix(ratelimit): enforce TPM/TPD + concurrency on streamed /v1/messages and /v1/responses

### DIFF
--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -463,7 +463,10 @@ async fn dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
+    // `Option` so the winning streaming attempt can `take()` the reservation
+    // and carry it into the end-of-stream guard (#688); non-streaming / failed
+    // attempts leave it in place for the post-dispatch commit or a retry.
+    let mut reservation = Some(crate::quota::enforce(state, auth, Some(&model_rl)).await?);
 
     // Budget pre-check via cp-api (mirrors /v1/chat/completions).
     let budget_decision = state.budgets.check(&auth.entry.id).await;
@@ -569,6 +572,7 @@ async fn dispatch(
                     model: target_model.clone(),
                     ..Default::default()
                 },
+                &mut reservation,
             )
             .await
             {
@@ -592,15 +596,16 @@ async fn dispatch(
                     // #911 [21]: commit the reserved layers with the actual
                     // token cost so TPM/TPD is enforced for /v1/messages like
                     // chat + embeddings. The non-streaming path carries the
-                    // counts in `outcome.metrics`; the verbatim streaming path
-                    // sets `usage_handled_by_stream` (its Drop guard owns end-
-                    // of-stream emission) and its post-stream token accounting
-                    // is tracked in #688 — its reservation still releases the
-                    // concurrency slot on drop, and budget ($) already gated it.
+                    // counts in `outcome.metrics` and commits here; the
+                    // streaming path already `take()`-d the reservation into its
+                    // end-of-stream guard (#688), so `reservation` is `None` and
+                    // this is skipped.
                     if !outcome.usage_handled_by_stream {
-                        let total = u64::from(outcome.metrics.prompt_tokens)
-                            + u64::from(outcome.metrics.completion_tokens);
-                        reservation.commit_tokens(total).await;
+                        if let Some(r) = reservation.take() {
+                            let total = u64::from(outcome.metrics.prompt_tokens)
+                                + u64::from(outcome.metrics.completion_tokens);
+                            r.commit_tokens(total).await;
+                        }
                     }
                     return Ok(outcome);
                 }
@@ -668,6 +673,10 @@ async fn dispatch_to_target(
     // whose Drop guard owns the UsageEvent emit. Non-streaming paths emit
     // from the handler and ignore it.
     attempt: AttemptInfo,
+    // #688: the streaming paths `take()` this to carry the concurrency hold +
+    // post-stream token accounting into the end-of-stream guard. Left in place
+    // on the non-streaming / error paths for the handler to commit or retry.
+    reservation: &mut Option<aisix_ratelimit::MultiReservation>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let model = &target.model;
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
@@ -689,6 +698,7 @@ async fn dispatch_to_target(
             resolved_chain,
             client,
             attempt,
+            reservation,
         )
         .await;
     }
@@ -710,6 +720,7 @@ async fn dispatch_to_target(
         resolved_chain,
         client,
         attempt,
+        reservation,
     )
     .await
 }
@@ -736,6 +747,7 @@ async fn anthropic_passthrough_dispatch(
     resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
     client_ctx: &ClientContext,
     attempt: AttemptInfo,
+    reservation: &mut Option<aisix_ratelimit::MultiReservation>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let mut body = body.clone();
     let api_key = crate::dispatch::require_secret(pk_value, model)?;
@@ -985,6 +997,14 @@ async fn anthropic_passthrough_dispatch(
         );
         let captured_prompt_c =
             content_cap.map(|_| serde_json::to_string(&body).unwrap_or_default());
+        // #688: carry the rate-limit reservation into the end-of-stream guard.
+        // The winning streaming attempt owns it now; the keys drive post-stream
+        // TPM/TPD accounting and `into_stream_hold` keeps the concurrency slot(s)
+        // until the stream ends (mirrors chat.rs). `take()` leaves the handler's
+        // `reservation` as `None`, so it won't also `commit_tokens`.
+        let post_stream_keys = reservation.as_ref().map(|r| r.keys()).unwrap_or_default();
+        let stream_hold = reservation.take().map(|r| r.into_stream_hold());
+        let limiter_c = std::sync::Arc::clone(&state.limiter);
         let parsed_stream = build_anthropic_passthrough_stream(
             body_stream,
             started,
@@ -995,6 +1015,19 @@ async fn anthropic_passthrough_dispatch(
                 // Streaming responses that got this far are 200 — the
                 // !status.is_success() guard above returned early on
                 // upstream errors.
+                //
+                // #688: apply the terminal token cost to TPM/TPD and release the
+                // concurrency hold now the stream has ended. `add_tokens_post_stream`
+                // is the sync analog of the reservation's async `commit_tokens`
+                // (this end-of-stream closure can't await); dropping the hold frees
+                // the concurrency slot(s) held for the stream's full lifetime.
+                let streamed_tokens =
+                    u64::from(usage.prompt_tokens) + u64::from(usage.completion_tokens);
+                for key in &post_stream_keys {
+                    limiter_c.add_tokens_post_stream(key, streamed_tokens);
+                }
+                drop(stream_hold);
+
                 let metrics = AnthropicUsageMetrics {
                     prompt_tokens: usage.prompt_tokens,
                     completion_tokens: usage.completion_tokens,
@@ -1274,6 +1307,7 @@ async fn cross_provider_dispatch(
     resolved_chain: std::sync::Arc<aisix_guardrails::GuardrailChain>,
     client: &ClientContext,
     attempt: AttemptInfo,
+    reservation: &mut Option<aisix_ratelimit::MultiReservation>,
 ) -> Result<DispatchOutcome, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
     use aisix_provider_anthropic::{
@@ -1430,6 +1464,13 @@ async fn cross_provider_dispatch(
         );
         let captured_prompt_for_telem =
             content_cap.map(|_| serde_json::to_string(body).unwrap_or_default());
+        // #688: carry the rate-limit reservation into the end-of-stream guard —
+        // keys drive post-stream TPM/TPD accounting, the hold keeps the
+        // concurrency slot(s) until the stream ends. `take()` leaves the
+        // handler's `reservation` as `None` so it won't also `commit_tokens`.
+        let post_stream_keys = reservation.as_ref().map(|r| r.keys()).unwrap_or_default();
+        let stream_hold = reservation.take().map(|r| r.into_stream_hold());
+        let limiter_for_stream = std::sync::Arc::clone(&state.limiter);
         let sse_body = build_anthropic_sse_stream(
             upstream,
             encoder,
@@ -1438,6 +1479,17 @@ async fn cross_provider_dispatch(
             model_name.to_string(),
             content_cap,
             move |comp| {
+                // #688: apply the terminal token cost to TPM/TPD and release the
+                // concurrency hold now the stream has ended (sync analog of the
+                // reservation's async `commit_tokens`, which this closure can't
+                // await).
+                let streamed_tokens =
+                    u64::from(comp.prompt_tokens) + u64::from(comp.completion_tokens);
+                for key in &post_stream_keys {
+                    limiter_for_stream.add_tokens_post_stream(key, streamed_tokens);
+                }
+                drop(stream_hold);
+
                 let metrics = AnthropicUsageMetrics {
                     prompt_tokens: comp.prompt_tokens,
                     completion_tokens: comp.completion_tokens,

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -344,7 +344,10 @@ async fn dispatch(
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
-    let reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
+    // `Option` so the winning streaming attempt can `take()` the reservation
+    // and carry it into the end-of-stream guard (#688); non-streaming / failed
+    // attempts leave it in place for the post-dispatch commit or a retry.
+    let mut reservation = Some(crate::quota::enforce(state, auth, Some(&model_rl)).await?);
 
     // Resolve the attempt list (routing-aware). A Model Group walks its
     // targets in order; a direct model resolves to itself (#471). OpenAI
@@ -434,6 +437,7 @@ async fn dispatch(
                     &auth.entry.id,
                     client,
                     attempt,
+                    &mut reservation,
                 )
                 .await
             } else {
@@ -450,6 +454,7 @@ async fn dispatch(
                     &auth.entry.id,
                     client,
                     attempt,
+                    &mut reservation,
                 )
                 .await
             };
@@ -474,18 +479,21 @@ async fn dispatch(
                     // #911 [21]: commit the reserved layers with the actual
                     // token cost so TPM/TPD is enforced for /v1/responses like
                     // chat + embeddings. The buffered / non-streaming paths
-                    // carry `usage` here; the verbatim streaming path reports
-                    // `usage_handled_by_stream` (its Drop guard owns end-of-
-                    // stream emission) and its post-stream token accounting is
-                    // tracked in #688 — its reservation still releases the
-                    // concurrency slot on drop, and budget ($) already gated it.
+                    // carry `usage` here and commit now; the streaming path
+                    // already `take()`-d the reservation into its end-of-stream
+                    // guard (#688), so `reservation` is `None` and this is
+                    // skipped.
                     if !success.usage_handled_by_stream {
-                        let total = success
-                            .usage
-                            .as_ref()
-                            .map(|u| u64::from(u.prompt_tokens) + u64::from(u.completion_tokens))
-                            .unwrap_or(0);
-                        reservation.commit_tokens(total).await;
+                        if let Some(r) = reservation.take() {
+                            let total = success
+                                .usage
+                                .as_ref()
+                                .map(|u| {
+                                    u64::from(u.prompt_tokens) + u64::from(u.completion_tokens)
+                                })
+                                .unwrap_or(0);
+                            r.commit_tokens(total).await;
+                        }
                     }
                     return Ok(success);
                 }
@@ -646,6 +654,7 @@ async fn responses_to_target(
     api_key_id: &str,
     client_ctx: &ClientContext,
     attempt: AttemptInfo,
+    reservation: &mut Option<aisix_ratelimit::MultiReservation>,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
     let mut body = body.clone();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
@@ -969,9 +978,26 @@ async fn responses_to_target(
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let client_c = client_ctx.clone();
+        // #688: carry the reservation into the end-of-stream guard — keys drive
+        // post-stream TPM/TPD accounting, the hold keeps the concurrency slot(s)
+        // until the stream ends. `take()` leaves the handler's `reservation` as
+        // `None` so it won't also `commit_tokens`.
+        let post_stream_keys = reservation.as_ref().map(|r| r.keys()).unwrap_or_default();
+        let stream_hold = reservation.take().map(|r| r.into_stream_hold());
+        let limiter_c = std::sync::Arc::clone(&state.limiter);
         let parsed_stream = build_responses_passthrough_stream(body_stream, move |usage| {
             // Streams that reach here are committed 200s — the
             // `!status.is_success()` guard above returned early on errors.
+            //
+            // #688: apply the terminal token cost to TPM/TPD and release the
+            // concurrency hold now the stream has ended (sync analog of the
+            // reservation's async `commit_tokens`, which this closure can't await).
+            let streamed_tokens =
+                u64::from(usage.prompt_tokens) + u64::from(usage.completion_tokens);
+            for key in &post_stream_keys {
+                limiter_c.add_tokens_post_stream(key, streamed_tokens);
+            }
+            drop(stream_hold);
             emit_usage_event(
                 &state_c,
                 &request_id_c,
@@ -1095,6 +1121,7 @@ async fn responses_cross_provider_to_target(
     api_key_id: &str,
     client_ctx: &ClientContext,
     attempt: AttemptInfo,
+    reservation: &mut Option<aisix_ratelimit::MultiReservation>,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
 
@@ -1211,6 +1238,13 @@ async fn responses_cross_provider_to_target(
         let provider_key_id_c = provider_key_id.clone();
         let client_c = client_ctx.clone();
         let attempt_c = attempt.clone();
+        // #688: carry the reservation into the end-of-stream guard — keys drive
+        // post-stream TPM/TPD accounting, the hold keeps the concurrency slot(s)
+        // until the stream ends. `take()` leaves the handler's `reservation` as
+        // `None` so it won't also `commit_tokens`.
+        let post_stream_keys = reservation.as_ref().map(|r| r.keys()).unwrap_or_default();
+        let stream_hold = reservation.take().map(|r| r.into_stream_hold());
+        let limiter_c = std::sync::Arc::clone(&state.limiter);
         let sse_body = crate::responses_bridge::build_responses_bridge_stream(
             upstream,
             encoder,
@@ -1219,6 +1253,16 @@ async fn responses_cross_provider_to_target(
             max_buffer_bytes,
             requested_model.to_string(),
             move |comp| {
+                // #688: apply the terminal token cost to TPM/TPD and release the
+                // concurrency hold now the stream has ended (sync analog of the
+                // reservation's async `commit_tokens`). Tokens count even on an
+                // output-guardrail block — the upstream still billed them.
+                let streamed_tokens =
+                    u64::from(comp.prompt_tokens) + u64::from(comp.completion_tokens);
+                for key in &post_stream_keys {
+                    limiter_c.add_tokens_post_stream(key, streamed_tokens);
+                }
+                drop(stream_hold);
                 let usage = ResponseUsage {
                     prompt_tokens: comp.prompt_tokens,
                     completion_tokens: comp.completion_tokens,

--- a/tests/e2e/src/cases/streaming-tpm-commit-e2e.test.ts
+++ b/tests/e2e/src/cases/streaming-tpm-commit-e2e.test.ts
@@ -1,0 +1,233 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for #688: streamed /v1/messages and /v1/responses skipped post-stream
+// token accounting — their reservation dropped at handler return without ever
+// committing the terminal token cost, so the TPM/TPD counters never moved and a
+// caller could bypass token-rate limits (and hold more than N concurrent
+// streams) simply by streaming. The fix carries the reservation into the
+// end-of-stream guard and commits the terminal usage via
+// `add_tokens_post_stream`, matching the chat streaming path.
+//
+// Both endpoints use a TPM cap of 10 against an upstream that reports 16 tokens
+// per stream: the first streamed call must succeed (committing 16) and the next
+// call must be rejected 429. Pre-fix the counter stayed 0 and the next call
+// also succeeded. Covers the two dispatch families — /v1/messages via the
+// cross-provider bridge and /v1/responses via the verbatim passthrough.
+
+const TPM = 10;
+const PROMPT_TOKENS = 8;
+const COMPLETION_TOKENS = 8; // 8 + 8 = 16 > TPM → one stream exhausts it
+
+const MSG_CALLER = "sk-688-msg-caller";
+const RESP_CALLER = "sk-688-resp-caller";
+const hash = (s: string) => createHash("sha256").update(s).digest("hex");
+
+// /v1/messages cross-provider: the request is bridged to the OpenAI-protocol
+// upstream, so the mock speaks chat.completion.chunk with a trailing usage
+// frame (OpenAI's real include_usage shape).
+function chunk(json: Record<string, unknown>): string {
+  return JSON.stringify({
+    id: "chatcmpl-688",
+    object: "chat.completion.chunk",
+    created: 0,
+    model: "up-688",
+    ...json,
+  });
+}
+const MSG_STREAM = [
+  chunk({ choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }),
+  chunk({ choices: [{ index: 0, delta: { content: "hi from 688" }, finish_reason: null }] }),
+  chunk({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+  chunk({
+    choices: [],
+    usage: {
+      prompt_tokens: PROMPT_TOKENS,
+      completion_tokens: COMPLETION_TOKENS,
+      total_tokens: PROMPT_TOKENS + COMPLETION_TOKENS,
+    },
+  }),
+  "[DONE]",
+];
+
+// /v1/responses verbatim passthrough: the upstream speaks the Responses-API SSE
+// wire shape, terminal `response.completed` carrying the authoritative usage.
+const RESP_STREAM = [
+  JSON.stringify({ type: "response.created", response: { id: "resp_688" } }),
+  JSON.stringify({ type: "response.output_text.delta", delta: "hi from 688" }),
+  JSON.stringify({
+    type: "response.completed",
+    response: {
+      id: "resp_688",
+      status: "completed",
+      usage: { input_tokens: PROMPT_TOKENS, output_tokens: COMPLETION_TOKENS },
+    },
+  }),
+  "[DONE]",
+];
+
+/**
+ * Send `make()` repeatedly until it returns 429 or the deadline passes. The
+ * post-stream token commit fires when the streamed response body is dropped on
+ * the server, a tick after the client finishes reading, so the first follow-up
+ * call can race ahead of it — retrying absorbs that tick. Pre-fix the counter
+ * never moves, so this exhausts the deadline and returns the last (200) status,
+ * failing the caller's `toBe(429)`.
+ */
+async function nextCallEventually429(make: () => Promise<Response>): Promise<number> {
+  const deadline = Date.now() + 5_000;
+  let last = 0;
+  while (Date.now() < deadline) {
+    const res = await make();
+    last = res.status;
+    await res.text();
+    if (last === 429) return 429;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return last;
+}
+
+describe("streaming TPM commit (#688)", () => {
+  let app: SpawnedApp | undefined;
+  let upstreamMsg: OpenAiUpstream | undefined;
+  let upstreamResp: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstreamMsg = await startOpenAiUpstream({ streamEvents: MSG_STREAM, eventDelayMs: 2 });
+    upstreamResp = await startOpenAiUpstream({ streamEvents: RESP_STREAM, eventDelayMs: 2 });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pkMsg = await admin.createProviderKey({
+      display_name: "688-msg-pk",
+      secret: "sk-mock",
+      api_base: `${upstreamMsg.baseUrl}/v1`,
+    });
+    const pkResp = await admin.createProviderKey({
+      display_name: "688-resp-pk",
+      secret: "sk-mock",
+      api_base: `${upstreamResp.baseUrl}/v1`,
+    });
+    // Both models are OpenAI-protocol: /v1/messages bridges to it
+    // (cross_provider_dispatch), /v1/responses forwards verbatim
+    // (responses_to_target).
+    await admin.createModel({
+      display_name: "msg-tpm",
+      provider: "openai",
+      model_name: "up-688",
+      provider_key_id: pkMsg.id,
+    });
+    await admin.createModel({
+      display_name: "resp-tpm",
+      provider: "openai",
+      model_name: "up-688",
+      provider_key_id: pkResp.id,
+    });
+    // Separate caller keys so each endpoint's TPM counter is independent.
+    await admin.createApiKey({
+      key_hash: hash(MSG_CALLER),
+      allowed_models: ["msg-tpm"],
+      rate_limit: { tpm: TPM },
+    });
+    await admin.createApiKey({
+      key_hash: hash(RESP_CALLER),
+      allowed_models: ["resp-tpm"],
+      rate_limit: { tpm: TPM },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstreamMsg?.close();
+    await upstreamResp?.close();
+  });
+
+  function postMessages(): Promise<Response> {
+    return fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": MSG_CALLER,
+      },
+      body: JSON.stringify({
+        model: "msg-tpm",
+        max_tokens: 200,
+        stream: true,
+        messages: [{ role: "user", content: "trip the tpm" }],
+      }),
+    });
+  }
+
+  function postResponses(): Promise<Response> {
+    return fetch(`${app!.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${RESP_CALLER}`,
+      },
+      body: JSON.stringify({ model: "resp-tpm", input: "trip the tpm", stream: true }),
+    });
+  }
+
+  test("streamed /v1/messages commits tokens post-stream and the next call is 429", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // listModels doesn't consume the token budget, so it's a safe readiness
+    // probe that leaves the TPM quota intact for the measured stream.
+    const probe = new ProxyClient(app.proxyUrl, MSG_CALLER);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "msg-tpm");
+    });
+
+    // First streamed call succeeds and commits its 16 tokens against TPM=10.
+    const first = await postMessages();
+    expect(first.status).toBe(200);
+    expect(await first.text()).toContain("message_stop");
+
+    // The next call is rejected once those streamed tokens are committed.
+    // Pre-fix (no post-stream commit) the counter stayed 0 and this stayed 200.
+    expect(await nextCallEventually429(postMessages)).toBe(429);
+  });
+
+  test("streamed /v1/responses commits tokens post-stream and the next call is 429", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const probe = new ProxyClient(app.proxyUrl, RESP_CALLER);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "resp-tpm");
+    });
+
+    const first = await postResponses();
+    expect(first.status).toBe(200);
+    expect(await first.text()).toContain("response.completed");
+
+    expect(await nextCallEventually429(postResponses)).toBe(429);
+  });
+});


### PR DESCRIPTION
Streamed `/v1/messages` and `/v1/responses` reserved the rate-limit layers but, when `usage_handled_by_stream` was set, dropped the reservation at handler return without ever committing the terminal token cost. Two consequences:

1. **TPM/TPD wasn't enforced for streaming.** The terminal token counts are only known inside the stream's end-of-stream guard, so `commit_tokens` never ran — the token-rate counter never moved. A caller could exceed TPM/TPD by streaming through these two endpoints.
2. **The concurrency permit was released at handler return, not stream end.** Because the reservation dropped when `dispatch()` returned (the streaming body outlives it), a key capped at N concurrent could run more than N simultaneous streams — the streaming analog of the `/v1/chat/completions` fix in #450.

RPM (counted at `pre_commit`) and the `$` budget (via the cp-api ledger fed by the post-stream UsageEvent) were unaffected, so the residual gap was token-rate + concurrent-stream count.

### Fix

Thread the reservation into the per-attempt dispatch as `&mut Option<MultiReservation>`. The winning streaming attempt `take()`s it, derives the layer keys, and converts it into a `StreamConcurrencyGuard` moved into the end-of-stream guard. There:

- the terminal usage is applied to TPM/TPD via `limiter.add_tokens_post_stream(key, total)` — the sync analog of the reservation's async `commit_tokens`, which the end-of-stream closure can't await;
- the hold keeps the concurrency slot(s) until the stream ends (or is cancelled), then drops.

Non-streaming and failed attempts leave the reservation in place for the handler to commit or a retry to reuse. This mirrors the existing chat.rs streaming path (`reservation.keys()` + `into_stream_hold()` + `add_tokens_post_stream`), extending it to the two endpoints that were still on the pre-#450 behavior. It also matches LiteLLM's post-completion TPM accounting (`parallel_request_limiter` increments `current_tpm` from the response usage in `async_log_success_event`, streaming included).

Covers all four streaming dispatch closures: `/v1/messages` (Anthropic verbatim passthrough + cross-provider bridge) and `/v1/responses` (verbatim passthrough + cross-provider bridge).

### Behavior / compatibility

- Streamed requests now count their tokens against TPM/TPD and hold their concurrency slot for the stream's lifetime, matching non-streaming and `/v1/chat/completions`. A tenant relying on the old gap to stream past a token-rate or concurrency cap will now be limited.
- No wire-shape or config change.

### Tests

New DP E2E `streaming-tpm-commit-e2e.test.ts`: with TPM=10 and an upstream reporting 16 tokens per stream, the first streamed call commits 16 and the next call is rejected 429, for both `/v1/messages` (cross-provider bridge) and `/v1/responses` (verbatim passthrough). Fails before the fix (the next call stays 200), passes after.

Fixes #688
