### PR TITLE
feat(auth): API key lifecycle — expires_at + disabled enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "aisix-proxy",
  "async-trait",
  "axum",
+ "chrono",
  "dashmap",
  "etcd-client",
  "http 1.4.0",
@@ -78,6 +79,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "chrono",
  "config",
  "dashmap",
  "hex",
@@ -4055,6 +4057,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "schemars_derive 0.8.22",
  "serde",

--- a/crates/aisix-admin/Cargo.toml
+++ b/crates/aisix-admin/Cargo.toml
@@ -21,6 +21,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
+chrono.workspace = true
 async-trait.workspace = true
 dashmap.workspace = true
 etcd-client.workspace = true

--- a/crates/aisix-admin/src/apikeys_handlers.rs
+++ b/crates/aisix-admin/src/apikeys_handlers.rs
@@ -36,6 +36,16 @@ struct StandaloneApiKeyBody {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     allowed_tools: Option<Vec<String>>,
+    /// RFC 3339 timestamp after which the key stops authenticating.
+    /// Omitted or `null` means the key never expires.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Administratively disabled. A disabled key is rejected until it
+    /// is enabled again.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    disabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -46,6 +56,10 @@ pub struct PublicApiKey {
     pub rate_limit: Option<aisix_core::models::RateLimit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub disabled: bool,
 }
 
 impl From<ApiKey> for PublicApiKey {
@@ -55,6 +69,8 @@ impl From<ApiKey> for PublicApiKey {
             allowed_models: value.allowed_models,
             rate_limit: value.rate_limit,
             allowed_tools: value.allowed_tools,
+            expires_at: value.expires_at,
+            disabled: value.disabled,
         }
     }
 }

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3173,6 +3173,20 @@ const OPENAPI_JSON_BASE: &str = r##"{
               "type": "string"
             },
             "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted or set to `null`, the key has no MCP tool access."
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "RFC 3339 timestamp after which the key stops authenticating. Requests presenting an expired key are rejected with `401`. When omitted or set to `null`, the key never expires.",
+            "example": "2027-01-01T00:00:00Z"
+          },
+          "disabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Administratively disabled. A disabled key is rejected with `401` until it is enabled again; the key itself is preserved."
           }
         },
         "additionalProperties": false
@@ -3484,6 +3498,20 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "example": [
               "github__create_issue"
             ]
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "RFC 3339 timestamp after which the key stops authenticating. Requests presenting an expired key are rejected with `401`. When omitted or set to `null`, the key never expires.",
+            "example": "2027-01-01T00:00:00Z"
+          },
+          "disabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Administratively disabled. A disabled key is rejected with `401` until it is enabled again; the key itself is preserved."
           }
         },
         "additionalProperties": false,

--- a/crates/aisix-core/Cargo.toml
+++ b/crates/aisix-core/Cargo.toml
@@ -17,7 +17,10 @@ thiserror.workspace = true
 anyhow.workspace = true
 config.workspace = true
 jsonschema.workspace = true
-schemars.workspace = true
+schemars = { workspace = true, features = ["chrono"] }
+# ApiKey::expires_at parses RFC 3339 timestamps for key-expiry
+# enforcement in the proxy auth path (#933).
+chrono.workspace = true
 once_cell.workspace = true
 # ApiKey::hash_bearer (prd-09a §9A.7B.4) is the canonical SHA-256 the
 # proxy uses to compare an incoming Authorization: Bearer <plaintext>

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -9,6 +9,7 @@
 //! looks up by the hash. Net security win: no plaintext API key
 //! ever sits in the DB or KV.
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::rate_limit::RateLimit;
@@ -54,6 +55,17 @@ pub struct ApiKey {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
 
+    /// RFC 3339 timestamp after which the key stops authenticating.
+    /// Requests presenting an expired key are rejected with `401`.
+    /// When omitted or set to `null`, the key never expires.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+
+    /// Administratively disabled. A disabled key is rejected with `401`
+    /// until it is enabled again; the key itself is preserved.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub disabled: bool,
+
     /// etcd-key uuid. Filled by the loader and never included in the JSON payload.
     #[serde(skip)]
     pub(crate) runtime_id: String,
@@ -71,6 +83,12 @@ impl ApiKey {
         let mut h = Sha256::new();
         h.update(plaintext.as_bytes());
         hex::encode(h.finalize())
+    }
+
+    /// True if the key's `expires_at` deadline has passed at `now`.
+    /// Keys without a deadline never expire.
+    pub fn is_expired_at(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at.is_some_and(|deadline| deadline <= now)
     }
 
     /// True if this key is allowed to call the given Model.
@@ -180,6 +198,8 @@ mod tests {
             user_id: None,
             user_name: None,
             allowed_tools: None,
+            expires_at: None,
+            disabled: false,
             runtime_id: String::new(),
         };
         assert!(!k.can_access("my-gpt4"));
@@ -321,5 +341,62 @@ mod tests {
         assert!(k.team_id.is_none());
         assert!(k.user_id.is_none());
         assert!(k.user_name.is_none());
+    }
+
+    #[test]
+    fn absent_lifecycle_fields_mean_active_forever() {
+        // Every pre-existing key payload lacks `expires_at`/`disabled`;
+        // they must keep authenticating unchanged.
+        let k = sample();
+        assert!(k.expires_at.is_none());
+        assert!(!k.disabled);
+        assert!(!k.is_expired_at(chrono::Utc::now()));
+    }
+
+    #[test]
+    fn explicit_null_expires_at_means_never_expires() {
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"expires_at":null}"#)
+                .unwrap();
+        assert!(k.expires_at.is_none());
+        assert!(!k.is_expired_at(chrono::Utc::now()));
+    }
+
+    #[test]
+    fn is_expired_at_honors_deadline() {
+        let k: ApiKey = serde_json::from_str(
+            r#"{"key_hash":"h","allowed_models":[],"expires_at":"2030-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+        let before = "2029-12-31T23:59:59Z".parse().unwrap();
+        let at = "2030-01-01T00:00:00Z".parse().unwrap();
+        let after = "2030-01-01T00:00:01Z".parse().unwrap();
+        assert!(!k.is_expired_at(before));
+        // The deadline itself is exclusive: a key is valid strictly
+        // before `expires_at`, expired from that instant on.
+        assert!(k.is_expired_at(at));
+        assert!(k.is_expired_at(after));
+    }
+
+    #[test]
+    fn rejects_malformed_expires_at() {
+        // A non-RFC3339 string must fail deserialization so the loader
+        // rejects the row (fail closed) instead of silently treating
+        // the key as never-expiring.
+        let r: Result<ApiKey, _> =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"expires_at":"tomorrow"}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn disabled_roundtrips_and_defaults_false() {
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"disabled":true}"#)
+                .unwrap();
+        assert!(k.disabled);
+        // `disabled: false` is the default and stays off the wire.
+        let v = serde_json::to_value(sample()).unwrap();
+        assert!(v.get("disabled").is_none());
+        assert!(v.get("expires_at").is_none());
     }
 }

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -86,9 +86,11 @@ impl ApiKey {
     }
 
     /// True if the key's `expires_at` deadline has passed at `now`.
-    /// Keys without a deadline never expire.
+    /// Keys without a deadline never expire. The comparison is strict
+    /// (`<`): the key is still valid at the deadline instant itself,
+    /// matching the established gateway-ecosystem semantics.
     pub fn is_expired_at(&self, now: DateTime<Utc>) -> bool {
-        self.expires_at.is_some_and(|deadline| deadline <= now)
+        self.expires_at.is_some_and(|deadline| deadline < now)
     }
 
     /// True if this key is allowed to call the given Model.
@@ -372,17 +374,21 @@ mod tests {
         let at = "2030-01-01T00:00:00Z".parse().unwrap();
         let after = "2030-01-01T00:00:01Z".parse().unwrap();
         assert!(!k.is_expired_at(before));
-        // The deadline itself is exclusive: a key is valid strictly
-        // before `expires_at`, expired from that instant on.
-        assert!(k.is_expired_at(at));
+        // Strict comparison: still valid at the deadline instant,
+        // expired strictly after it (ecosystem-aligned boundary).
+        assert!(!k.is_expired_at(at));
         assert!(k.is_expired_at(after));
     }
 
     #[test]
     fn rejects_malformed_expires_at() {
         // A non-RFC3339 string must fail deserialization so the loader
-        // rejects the row (fail closed) instead of silently treating
-        // the key as never-expiring.
+        // rejects the row instead of silently treating the key as
+        // never-expiring. Note the rejection is fail-closed on full
+        // loads/resyncs (the key is absent from the snapshot); on the
+        // incremental watch path a rejected UPDATE keeps the previous
+        // version serving until the next resync (pre-existing
+        // supervisor behavior shared by every resource kind).
         let r: Result<ApiKey, _> =
             serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"expires_at":"tomorrow"}"#);
         assert!(r.is_err());

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -62,7 +62,8 @@ pub struct ApiKey {
     pub expires_at: Option<DateTime<Utc>>,
 
     /// Administratively disabled. A disabled key is rejected with `401`
-    /// until it is enabled again; the key itself is preserved.
+    /// until it is enabled again; the key itself is preserved. Treated
+    /// as `false` when omitted.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub disabled: bool,
 

--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -49,6 +49,17 @@ where
             .apikeys
             .get_by_name(&ApiKey::hash_bearer(&token))
             .ok_or(ProxyError::InvalidApiKey)?;
+        // Lifecycle enforcement (#933): a known key that is disabled or
+        // past its expiry deadline must be rejected here, at the single
+        // auth choke point, so every proxy surface (chat, messages,
+        // responses, embeddings, audio, passthrough, MCP, …) inherits
+        // the same 401 without per-handler checks.
+        if entry.value.disabled {
+            return Err(ProxyError::ApiKeyDisabled);
+        }
+        if entry.value.is_expired_at(chrono::Utc::now()) {
+            return Err(ProxyError::ApiKeyExpired);
+        }
         Ok(AuthenticatedKey { entry })
     }
 }

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -144,6 +144,17 @@ pub enum ProxyError {
     MissingAuth,
     #[error("invalid API key")]
     InvalidApiKey,
+    /// The presented key exists but its `expires_at` deadline has
+    /// passed (#933). Deliberately caller-visible as "expired" (not a
+    /// generic invalid-key 401): the caller already holds the secret,
+    /// so naming the reason leaks nothing and tells them to request a
+    /// fresh key instead of debugging a typo.
+    #[error("API key has expired")]
+    ApiKeyExpired,
+    /// The presented key exists but was administratively disabled
+    /// (#933). Same disclosure reasoning as [`Self::ApiKeyExpired`].
+    #[error("API key has been disabled")]
+    ApiKeyDisabled,
     #[error("model {0:?} not found")]
     ModelNotFound(String),
     #[error("API key is not allowed to use model {0:?}")]
@@ -222,7 +233,10 @@ pub(crate) fn guardrail_block_message(side: &str, guardrail_name: Option<&str>) 
 impl ProxyError {
     pub fn status(&self) -> StatusCode {
         match self {
-            ProxyError::MissingAuth | ProxyError::InvalidApiKey => StatusCode::UNAUTHORIZED,
+            ProxyError::MissingAuth
+            | ProxyError::InvalidApiKey
+            | ProxyError::ApiKeyExpired
+            | ProxyError::ApiKeyDisabled => StatusCode::UNAUTHORIZED,
             ProxyError::ModelForbidden(_) => StatusCode::FORBIDDEN,
             ProxyError::ModelIpRestricted(_) => StatusCode::FORBIDDEN,
             ProxyError::ModelNotFound(_) => StatusCode::NOT_FOUND,
@@ -241,7 +255,10 @@ impl ProxyError {
 
     pub fn kind(&self) -> &'static str {
         match self {
-            ProxyError::MissingAuth | ProxyError::InvalidApiKey => "invalid_api_key",
+            ProxyError::MissingAuth
+            | ProxyError::InvalidApiKey
+            | ProxyError::ApiKeyExpired
+            | ProxyError::ApiKeyDisabled => "invalid_api_key",
             ProxyError::ModelForbidden(_) => "permission_denied",
             ProxyError::ModelIpRestricted(_) => "permission_denied",
             ProxyError::ModelNotFound(_) => "model_not_found",
@@ -310,6 +327,11 @@ impl ProxyError {
             // from the generic `permission_denied` type shared with
             // ModelForbidden (#557 AC-1).
             ProxyError::ModelIpRestricted(_) => env.with_code("ip_restricted"),
+            // Stable machine-readable codes so SDKs can branch on the
+            // lifecycle reason without parsing the message, while the
+            // `error.type` stays the family-wide `invalid_api_key`.
+            ProxyError::ApiKeyExpired => env.with_code("api_key_expired"),
+            ProxyError::ApiKeyDisabled => env.with_code("api_key_disabled"),
             _ => env,
         }
     }

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -91,7 +91,7 @@
       ]
     },
     "disabled": {
-      "description": "Administratively disabled. A disabled key is rejected with `401` until it is enabled again; the key itself is preserved.",
+      "description": "Administratively disabled. A disabled key is rejected with `401` until it is enabled again; the key itself is preserved. Treated as `false` when omitted.",
       "type": "boolean"
     },
     "expires_at": {

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -90,6 +90,18 @@
         "null"
       ]
     },
+    "disabled": {
+      "description": "Administratively disabled. A disabled key is rejected with `401` until it is enabled again; the key itself is preserved.",
+      "type": "boolean"
+    },
+    "expires_at": {
+      "description": "RFC 3339 timestamp after which the key stops authenticating. Requests presenting an expired key are rejected with `401`. When omitted or set to `null`, the key never expires.",
+      "format": "date-time",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "key_hash": {
       "description": "SHA-256 hexadecimal hash of the plaintext bearer. The proxy hashes incoming bearer tokens before lookup.",
       "minLength": 1,

--- a/tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts
@@ -214,17 +214,25 @@ describe("api key lifecycle e2e: expired/disabled keys fail closed, rotate swaps
 
     const plaintext = "sk-lifecycle-deadline";
     // Expires well after propagation completes (seedKey asserts a 200
-    // first), but soon enough for the test to observe the flip.
-    const expiresAt = new Date(Date.now() + 8_000).toISOString();
+    // first), but soon enough for the test to observe the flip. The
+    // runway must outlast worst-case propagation on shared-etcd CI
+    // runners — if propagation eats it anyway, the "no config change"
+    // premise is void, so skip rather than fail unrecoverably.
+    const runwayMs = 15_000;
+    const expiresAt = new Date(Date.now() + runwayMs).toISOString();
     await seedKey(plaintext, { expires_at: expiresAt }, is200);
+    if (Date.now() >= Date.parse(expiresAt)) {
+      ctx.skip();
+      return;
+    }
 
     // No admin writes from here on: the ONLY thing that changes is the
     // wall clock. Poll until the gateway starts rejecting.
     await waitConfigPropagation(
       async () => isLifecycle401("api_key_expired")(await chat(plaintext, "deadline probe")),
-      20_000,
+      runwayMs + 15_000,
     );
-  }, 40_000);
+  }, 60_000);
 
   test("Anthropic surface rejects a disabled key with the Anthropic envelope", async (ctx) => {
     if (!etcdReachable || !app) {
@@ -284,5 +292,34 @@ describe("api key lifecycle e2e: expired/disabled keys fail closed, rotate swaps
     const res = await chat(plaintext, "old secret after rotate");
     expect(res.status).toBe(401);
     await res.text();
+  });
+
+  test("rotate preserves lifecycle fields: a disabled key's new secret is still disabled", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const plaintext = "sk-lifecycle-rotate-disabled";
+    const expiresAt = "2099-01-01T00:00:00Z";
+    const { id } = await seedKey(
+      plaintext,
+      { disabled: true, expires_at: expiresAt },
+      isLifecycle401("api_key_disabled"),
+    );
+
+    const rotated = await admin!.json<{
+      entry: { id: string; value: { disabled?: boolean; expires_at?: string } };
+      plaintext: string;
+    }>("POST", `/admin/v1/apikeys/${id}/rotate`);
+
+    // Rotation swaps ONLY the secret — a regression that rebuilt the
+    // entry from a partial body would silently re-enable a disabled
+    // key under its fresh plaintext.
+    expect(rotated.entry.value.disabled).toBe(true);
+    expect(Date.parse(rotated.entry.value.expires_at ?? "")).toBe(Date.parse(expiresAt));
+    await waitConfigPropagation(async () =>
+      isLifecycle401("api_key_disabled")(await chat(rotated.plaintext, "rotated but disabled")),
+    );
   });
 });

--- a/tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts
@@ -1,0 +1,288 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: API key lifecycle enforcement (#933). Pins the contract that a
+// key which EXISTS in the snapshot is still rejected when it is
+// expired or administratively disabled — distinct from the
+// unknown-token 401 covered by auth-baseline-e2e.
+//
+// Pinned scenarios:
+//
+//   1. `expires_at` in the past → 401 `api_key_expired`, upstream untouched
+//   2. `expires_at` in the future → authenticates normally
+//   3. `disabled: true` → 401 `api_key_disabled`, upstream untouched
+//   4. live transition: disable an in-use key → 401 after propagation,
+//      re-enable → 200 again (key preserved, no re-issue)
+//   5. a key crosses its expiry deadline while the gateway is running →
+//      401 without any config change (expiry is evaluated per request,
+//      not at load time)
+//   6. the Anthropic surface (`/v1/messages`) rejects a disabled key
+//      with the Anthropic-shaped 401 envelope
+//   7. rotate: the old plaintext stops working, the returned new
+//      plaintext works, and the resource id is unchanged
+//
+// Reference: OpenAI authentication doc
+// <https://platform.openai.com/docs/api-reference/authentication>,
+// RFC 6750 §3 <https://datatracker.ietf.org/doc/html/rfc6750#section-3>.
+
+const MODEL = "apikey-lifecycle";
+
+function sha256(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+describe("api key lifecycle e2e: expired/disabled keys fail closed, rotate swaps the secret", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "apikey-lifecycle-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  function chat(plaintext: string, content: string): Promise<Response> {
+    return fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${plaintext}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        messages: [{ role: "user", content }],
+      }),
+    });
+  }
+
+  /** Seed a key and wait until the gateway's snapshot can see it.
+   * Lifecycle-rejected keys never return 200, so propagation is
+   * confirmed by the response being the expected lifecycle 401
+   * (`error.code`) rather than the unknown-token 401 (no code). */
+  async function seedKey(
+    plaintext: string,
+    extra: Record<string, unknown>,
+    propagated: (res: Response) => Promise<boolean>,
+  ): Promise<{ id: string }> {
+    const created = await admin!.createApiKey({
+      key_hash: sha256(plaintext),
+      allowed_models: [MODEL],
+      ...extra,
+    });
+    await waitConfigPropagation(async () => propagated(await chat(plaintext, "probe")));
+    return { id: created.id };
+  }
+
+  const isLifecycle401 = (code: string) => async (res: Response) => {
+    const body = (await res.json()) as { error?: { code?: unknown } };
+    return res.status === 401 && body.error?.code === code;
+  };
+
+  const is200 = async (res: Response) => {
+    await res.text();
+    return res.status === 200;
+  };
+
+  test("expired key → 401 api_key_expired, upstream untouched", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const plaintext = "sk-lifecycle-expired";
+    await seedKey(
+      plaintext,
+      { expires_at: "2020-01-01T00:00:00Z" },
+      isLifecycle401("api_key_expired"),
+    );
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    const res = await chat(plaintext, "expired key");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as {
+      error?: { type?: unknown; code?: unknown; message?: unknown };
+    };
+    expect(body.error?.type).toBe("invalid_api_key");
+    expect(body.error?.code).toBe("api_key_expired");
+    // The message names the reason: the caller holds the secret
+    // already, so telling them it expired (vs a generic invalid-key
+    // message) leaks nothing and is actionable.
+    expect(String(body.error?.message).toLowerCase()).toContain("expired");
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+  });
+
+  test("future expires_at authenticates normally", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const plaintext = "sk-lifecycle-future";
+    await seedKey(plaintext, { expires_at: "2099-01-01T00:00:00Z" }, is200);
+
+    const res = await chat(plaintext, "future expiry");
+    expect(res.status).toBe(200);
+    await res.text();
+  });
+
+  test("disabled key → 401 api_key_disabled, upstream untouched", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const plaintext = "sk-lifecycle-disabled";
+    await seedKey(plaintext, { disabled: true }, isLifecycle401("api_key_disabled"));
+
+    const upstreamHitsBefore = upstream.receivedRequests.length;
+    const res = await chat(plaintext, "disabled key");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as {
+      error?: { type?: unknown; code?: unknown };
+    };
+    expect(body.error?.type).toBe("invalid_api_key");
+    expect(body.error?.code).toBe("api_key_disabled");
+    expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+  });
+
+  test("disable then re-enable an in-use key without re-issuing it", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const plaintext = "sk-lifecycle-toggle";
+    const keyHash = sha256(plaintext);
+    const { id } = await seedKey(plaintext, {}, is200);
+
+    // Disable: same key_hash, flipped flag — the credential the
+    // caller holds is unchanged, only its status moves.
+    await admin.json("PUT", `/admin/v1/apikeys/${id}`, {
+      key_hash: keyHash,
+      allowed_models: [MODEL],
+      disabled: true,
+    });
+    await waitConfigPropagation(async () =>
+      isLifecycle401("api_key_disabled")(await chat(plaintext, "post-disable probe")),
+    );
+
+    // Re-enable: the original plaintext works again — proving disable
+    // is reversible and did not rotate or delete the credential.
+    await admin.json("PUT", `/admin/v1/apikeys/${id}`, {
+      key_hash: keyHash,
+      allowed_models: [MODEL],
+    });
+    await waitConfigPropagation(async () => is200(await chat(plaintext, "post-enable probe")));
+  });
+
+  test("key crossing its expiry deadline at runtime starts failing without any config change", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const plaintext = "sk-lifecycle-deadline";
+    // Expires well after propagation completes (seedKey asserts a 200
+    // first), but soon enough for the test to observe the flip.
+    const expiresAt = new Date(Date.now() + 8_000).toISOString();
+    await seedKey(plaintext, { expires_at: expiresAt }, is200);
+
+    // No admin writes from here on: the ONLY thing that changes is the
+    // wall clock. Poll until the gateway starts rejecting.
+    await waitConfigPropagation(
+      async () => isLifecycle401("api_key_expired")(await chat(plaintext, "deadline probe")),
+      20_000,
+    );
+  }, 40_000);
+
+  test("Anthropic surface rejects a disabled key with the Anthropic envelope", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const plaintext = "sk-lifecycle-disabled-anthropic";
+    await seedKey(plaintext, { disabled: true }, isLifecycle401("api_key_disabled"));
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "x-api-key": plaintext,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 16,
+        messages: [{ role: "user", content: "disabled key via anthropic" }],
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as {
+      type?: unknown;
+      error?: { type?: unknown; message?: unknown };
+    };
+    // Anthropic error envelope: top-level discriminator + canonical
+    // per-status error type, per
+    // <https://docs.anthropic.com/en/api/errors>.
+    expect(body.type).toBe("error");
+    expect(body.error?.type).toBe("authentication_error");
+  });
+
+  test("rotate swaps the secret in place: old plaintext dies, new one works, id unchanged", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const plaintext = "sk-lifecycle-rotate";
+    const { id } = await seedKey(plaintext, {}, is200);
+
+    const rotated = await admin.json<{
+      entry: { id: string };
+      plaintext: string;
+    }>("POST", `/admin/v1/apikeys/${id}/rotate`);
+    expect(rotated.entry.id).toBe(id);
+    expect(rotated.plaintext).not.toBe(plaintext);
+
+    // New secret authenticates…
+    await waitConfigPropagation(async () => is200(await chat(rotated.plaintext, "rotated probe")));
+    // …and the old one is invalid (unknown-token 401), so a leaked
+    // pre-rotation secret is worthless immediately after rotation.
+    const res = await chat(plaintext, "old secret after rotate");
+    expect(res.status).toBe(401);
+    await res.text();
+  });
+});


### PR DESCRIPTION
## What

Adds lifecycle management to caller API keys (data-plane half of the feature):

- **`expires_at`** (RFC 3339, optional): the key stops authenticating once the deadline passes — rejected with 401, `error.code: api_key_expired`. Absent or `null` means the key never expires, so **all existing keys keep working unchanged**.
- **`disabled`** (bool, default `false`): an administratively disabled key is rejected with 401, `error.code: api_key_disabled`, without deleting it — flipping the flag back restores the original credential.

## How

- Both fields live on the `ApiKey` resource (`aisix-core`), regenerated into `schemas/resources/api_key.schema.json`.
- Enforcement sits in the single shared `AuthenticatedKey` extractor (`aisix-proxy/src/auth.rs`), so every proxy surface (chat, completions, messages, count_tokens, responses, embeddings, rerank, audio, images, passthrough, MCP, models) inherits the same check — no per-handler drift. The Anthropic-envelope surfaces render the same 401 as `authentication_error` via the existing status mapping.
- Expiry is evaluated per request against the wall clock, so a key crosses its deadline without any config write.
- The standalone Admin API (`/admin/v1/apikeys`) accepts and echoes both fields; the existing `rotate` endpoint (one-operation secret reset) now round-trips them.
- `disabled: false` and absent `expires_at` stay off the wire, so payloads for keys that don't use lifecycle features are byte-identical to before (older gateways never see unknown fields).

Behavior matches established gateway ecosystems: absolute expiry timestamp with null = never, expired/blocked keys → 401 with a named reason, rotation swaps the secret in place while preserving the key record.

## Tests

New `tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts` (real `aisix` binary + etcd + mock upstream):

1. expired key → 401 `api_key_expired`, upstream untouched
2. future `expires_at` → authenticates
3. `disabled: true` → 401 `api_key_disabled`, upstream untouched
4. live disable → 401 after propagation; re-enable → same plaintext works again
5. key crosses its deadline at runtime → starts failing with no config change
6. `/v1/messages` rejects a disabled key with the Anthropic envelope
7. rotate: old plaintext dies, new plaintext works, resource id unchanged

Plus unit tests for the expiry boundary, fail-closed malformed timestamps, and back-compat defaults.

## Cross-plane note

This is the DP half of api7/AISIX-Cloud#933; the CP PR (API + dashboard exposure: set expiry, disable, reset) follows once the dev image is built.

Fixes api7/AISIX-Cloud#933

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys can now be created/managed with an `expires_at` expiration time (or never expire) and an administratively `disabled` flag.
  * API key responses and API documentation now expose these fields.
* **Bug Fixes**
  * Requests using expired or disabled keys are rejected with `401` and distinct error codes (`api_key_expired`, `api_key_disabled`).
  * Lifecycle changes apply immediately; keys can be re-enabled or expire over time without additional configuration.
  * API key rotation preserves the key’s lifecycle status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->