### PR TITLE
fix(obs): content capture on /v1/responses & /v1/completions; mask streaming capture buffers

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -3905,6 +3905,14 @@ where
                             let counts =
                                 crate::redact::redact_chat_chunks(ctx.chain.as_ref(), &mut pending);
                             if !counts.is_empty() {
+                                // The wire chunks were masked — mask the
+                                // content-capture accumulator too, or the
+                                // exported content would carry PII the client
+                                // never saw (#932 × AISIX-Cloud#947).
+                                crate::redact::redact_captured_output(
+                                    ctx.chain.as_ref(),
+                                    &mut guard.comp().response_text,
+                                );
                                 crate::redact::merge_counts(
                                     &mut guard.comp().redacted_entity_counts,
                                     counts,

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -17,7 +17,7 @@
 use aisix_gateway::{
     BridgeContext, BridgeError, ChatMessage, ChatResponse, FinishReason, UsageStats,
 };
-use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
+use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -62,6 +62,11 @@ struct CompletionDispatchSuccess {
     /// ledger + /logs from under-reporting spend the provider charged for
     /// — the output analog of chat.rs's UpstreamCharge / responses.rs #543.
     guardrail_blocked: bool,
+    /// Captured request/response content for content-capturing exporters
+    /// (AISIX-Cloud#947). `Some` only when an enabled exporter opted into
+    /// `content_mode = full`; threaded to `fan_out` via the handler's emit,
+    /// never to the CP sink.
+    captured_content: Option<CapturedContent>,
 }
 
 /// Subset of the OpenAI legacy /v1/completions response `usage`
@@ -135,6 +140,7 @@ pub async fn completions(
                     &client,
                     success.guardrail_blocked,
                     success.redactions.clone(),
+                    success.captured_content.as_ref(),
                 );
             }
             success.response
@@ -259,6 +265,18 @@ async fn dispatch(
     // block check passes, BEFORE the body is forwarded upstream.
     let mut redactions = crate::redact::redact_completions_request(&resolved_chain, &mut body);
 
+    // Content capture (AISIX-Cloud#947): the client-facing request body
+    // (post-redaction, so masked PII stays masked in the exported content),
+    // gated on an exporter actually wanting content.
+    let content_cap = content_capture_cap(
+        snapshot
+            .observability_exporters
+            .entries()
+            .iter()
+            .map(|e| &e.value),
+    );
+    let captured_prompt = content_cap.map(|_| serde_json::to_string(&body).unwrap_or_default());
+
     let model_rl =
         crate::quota::ModelRateLimit::from_model(model_name, &model_entry.id, &model_entry.value);
     let reservation = crate::quota::enforce(state, auth, Some(&model_rl)).await?;
@@ -345,6 +363,9 @@ async fn dispatch(
                         usage,
                         redactions,
                         guardrail_blocked: true,
+                        // Blocked responses never reached the client — no
+                        // content capture, matching the chat surface.
+                        captured_content: None,
                     });
                 }
             }
@@ -357,6 +378,18 @@ async fn dispatch(
                 crate::redact::redact_completions_response(&resolved_chain, &mut resp_json),
             );
 
+            // Content capture (AISIX-Cloud#947): the completion text from the
+            // POST-redaction body, so the exported content matches what the
+            // caller received.
+            let captured_content = match (&captured_prompt, content_cap) {
+                (Some(prompt), Some(cap)) => Some(CapturedContent::new(
+                    prompt,
+                    &completion_output_text(&resp_json),
+                    cap as usize,
+                )),
+                _ => None,
+            };
+
             Ok(CompletionDispatchSuccess {
                 response: Json(resp_json).into_response(),
                 provider: provider_label,
@@ -365,6 +398,7 @@ async fn dispatch(
                 usage,
                 redactions,
                 guardrail_blocked: false,
+                captured_content,
             })
         }
         Err(BridgeError::Config(msg)) if msg.contains("does not support text completions") => {
@@ -382,6 +416,7 @@ async fn dispatch(
                 usage: None,
                 redactions,
                 guardrail_blocked: false,
+                captured_content: None,
             })
         }
         Err(e) => {
@@ -465,6 +500,9 @@ fn emit_usage_event(
     guardrail_blocked: bool,
     // Per-detector PII mask counts (#932). Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Captured request/response content for content-capturing exporters
+    // (AISIX-Cloud#947). Forwarded only to `fan_out`, never to the CP sink.
+    content: Option<&CapturedContent>,
 ) {
     let snap = state.snapshot.load();
     let mut event = UsageEvent {
@@ -491,7 +529,7 @@ fn emit_usage_event(
     let exporters = snap.observability_exporters.entries();
     state
         .otlp_fan_out
-        .fan_out(&event, None, exporters.iter().map(|e| &e.value));
+        .fan_out(&event, content, exporters.iter().map(|e| &e.value));
 }
 
 fn emit_access_log(

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1883,6 +1883,13 @@ fn build_anthropic_sse_stream(
                 let counts =
                     crate::redact::redact_chat_chunks(chain.as_ref(), &mut held_chunks);
                 if !counts.is_empty() {
+                    // The wire chunks were masked — mask the content-capture
+                    // accumulator too, or the exported content would carry
+                    // PII the client never saw (#932 × AISIX-Cloud#947).
+                    crate::redact::redact_captured_output(
+                        chain.as_ref(),
+                        &mut guard.comp().response_text,
+                    );
                     crate::redact::merge_counts(
                         &mut guard.comp().redacted_entity_counts,
                         counts,
@@ -2617,6 +2624,15 @@ where
                 .and_then(|c| crate::redact::redact_anthropic_sse(c.as_ref(), &held))
             {
                 Some((rewritten, counts)) => {
+                    // The wire bytes were masked — mask the content-capture
+                    // accumulator too, or the exported content would carry
+                    // PII the client never saw (#932 × AISIX-Cloud#947).
+                    if let Some(c) = output_guardrail.as_ref() {
+                        crate::redact::redact_captured_output(
+                            c.as_ref(),
+                            &mut guard.usage().response_text,
+                        );
+                    }
                     crate::redact::merge_counts(
                         &mut guard.usage().redacted_entity_counts,
                         counts,

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -116,6 +116,19 @@ pub fn redact_value_strings(
     }
 }
 
+/// Mask-rewrite an already-assembled OUTPUT text buffer in place — the
+/// content-capture accumulator a streaming hold-back path hands to
+/// content-capturing exporters (#932 × AISIX-Cloud#947). The wire-side
+/// SSE/chunk redaction rewrites only the held bytes released to the client;
+/// the capture accumulator collects raw deltas, so without this the exported
+/// content would carry PII the client never saw. Counts are deliberately
+/// discarded — the wire-side redaction already tallied them, and tallying
+/// the same matches again would double-count.
+pub fn redact_captured_output(chain: &dyn Guardrail, text: &mut String) {
+    let mut discard = RedactionCounts::new();
+    apply_to_string(chain, Direction::Output, text, &mut discard);
+}
+
 /// Rewrite a JSON-*encoded* string (OpenAI `function.arguments`): parse,
 /// walk the string values, re-serialise — so a mask token can't corrupt
 /// the embedded document (e.g. a phone number as a JSON number value

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -13,7 +13,7 @@
 //! 400 with an explanatory message.
 
 use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse, FinishReason, UsageStats};
-use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
+use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
 use axum::response::{IntoResponse, Response};
@@ -71,6 +71,12 @@ struct ResponseDispatchSuccess {
     /// guard owns the UsageEvent emit (parsed from the terminal SSE event),
     /// so the top-level handler must NOT emit the winner event again (#808).
     usage_handled_by_stream: bool,
+    /// Captured request/response content for content-capturing exporters
+    /// (AISIX-Cloud#947). `Some` only when an enabled exporter opted into
+    /// `content_mode = full`; threaded to `fan_out` via the handler's emit,
+    /// never to the CP sink. `None` on the streaming paths, whose
+    /// end-of-stream emit owns the capture.
+    captured_content: Option<CapturedContent>,
     /// Per-detector PII mask counts applied to the response body (#932),
     /// non-streaming + buffered paths. Merged with the input-side counts by
     /// the handler before the terminal emit. Empty on the live streaming
@@ -223,6 +229,7 @@ pub async fn responses(
                         attempt,
                         success.guardrail_blocked,
                         redaction_counts.clone(),
+                        success.captured_content.as_ref(),
                     );
                 }
             }
@@ -700,6 +707,18 @@ async fn responses_to_target(
     // handler, which already holds them.
     input_redactions: crate::redact::RedactionCounts,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
+    // Largest content cap any enabled content-capturing exporter wants, or
+    // `None` when none do (AISIX-Cloud#947). The captured prompt is the
+    // client-facing request body (post-#932-redaction), taken BEFORE the
+    // upstream model rewrite below so the log shows what the caller sent.
+    let content_cap = content_capture_cap(
+        snapshot
+            .observability_exporters
+            .entries()
+            .iter()
+            .map(|e| &e.value),
+    );
+    let captured_prompt = content_cap.map(|_| serde_json::to_string(body).unwrap_or_default());
     let mut body = body.clone();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
     // Resolved PK id for per-PK telemetry attribution on the emitted
@@ -956,6 +975,17 @@ async fn responses_to_target(
             // terminal event for usage and let the handler emit (the body is
             // a single complete chunk now, not a live stream).
             let usage = responses_sse_usage(&buf);
+            // Content capture (AISIX-Cloud#947): the assembled output text,
+            // read from the POST-redaction buffer so masked PII stays masked
+            // in the exported content.
+            let captured_content = match (&captured_prompt, content_cap) {
+                (Some(prompt), Some(cap)) => Some(CapturedContent::new(
+                    prompt,
+                    &responses_sse_output_text(&buf),
+                    cap as usize,
+                )),
+                _ => None,
+            };
             let mut response = axum::response::Response::new(axum::body::Body::from(buf));
             apply_passthrough_headers(&mut response, &headers, request_id);
             return Ok(ResponseDispatchSuccess {
@@ -968,6 +998,7 @@ async fn responses_to_target(
                 guardrail_blocked: false,
                 usage_handled_by_stream: false,
                 output_redactions,
+                captured_content,
             });
         }
 
@@ -1040,38 +1071,50 @@ async fn responses_to_target(
         let post_stream_keys = reservation.as_ref().map(|r| r.keys()).unwrap_or_default();
         let stream_hold = reservation.take().map(|r| r.into_stream_hold());
         let limiter_c = std::sync::Arc::clone(&state.limiter);
-        let parsed_stream = build_responses_passthrough_stream(body_stream, move |usage| {
-            // Streams that reach here are committed 200s — the
-            // `!status.is_success()` guard above returned early on errors.
-            //
-            // #688: apply the terminal token cost to TPM/TPD and release the
-            // concurrency hold now the stream has ended (sync analog of the
-            // reservation's async `commit_tokens`, which this closure can't await).
-            let streamed_tokens =
-                u64::from(usage.prompt_tokens) + u64::from(usage.completion_tokens);
-            for key in &post_stream_keys {
-                limiter_c.add_tokens_post_stream(key, streamed_tokens);
-            }
-            drop(stream_hold);
-            emit_usage_event(
-                &state_c,
-                &request_id_c,
-                &model_id_c,
-                &requested_model_c,
-                &api_key_id_c,
-                &provider_key_id_c,
-                200,
-                started.elapsed(),
-                &usage,
-                &client_c,
-                attempt,
-                /* guardrail_blocked */ false,
-                // Live-forward path: no output masking possible (an
-                // output-masking guardrail forces the buffered branch),
-                // so only the input-side counts apply.
-                input_redactions.clone(),
-            );
-        });
+        let captured_prompt_c = captured_prompt.clone();
+        let parsed_stream =
+            build_responses_passthrough_stream(body_stream, content_cap, move |usage, out_text| {
+                // Streams that reach here are committed 200s — the
+                // `!status.is_success()` guard above returned early on errors.
+                //
+                // #688: apply the terminal token cost to TPM/TPD and release the
+                // concurrency hold now the stream has ended (sync analog of the
+                // reservation's async `commit_tokens`, which this closure can't await).
+                let streamed_tokens =
+                    u64::from(usage.prompt_tokens) + u64::from(usage.completion_tokens);
+                for key in &post_stream_keys {
+                    limiter_c.add_tokens_post_stream(key, streamed_tokens);
+                }
+                drop(stream_hold);
+                // Content capture (AISIX-Cloud#947): prompt captured up front,
+                // output text assembled by the stream wrapper (empty when no
+                // exporter wants content).
+                let captured_content = match (&captured_prompt_c, content_cap) {
+                    (Some(prompt), Some(cap)) => {
+                        Some(CapturedContent::new(prompt, &out_text, cap as usize))
+                    }
+                    _ => None,
+                };
+                emit_usage_event(
+                    &state_c,
+                    &request_id_c,
+                    &model_id_c,
+                    &requested_model_c,
+                    &api_key_id_c,
+                    &provider_key_id_c,
+                    200,
+                    started.elapsed(),
+                    &usage,
+                    &client_c,
+                    attempt,
+                    /* guardrail_blocked */ false,
+                    // Live-forward path: no output masking possible (an
+                    // output-masking guardrail forces the buffered branch),
+                    // so only the input-side counts apply.
+                    input_redactions.clone(),
+                    captured_content.as_ref(),
+                );
+            });
         let mut response =
             axum::response::Response::new(axum::body::Body::from_stream(Box::pin(parsed_stream)));
         apply_passthrough_headers(&mut response, &headers, request_id);
@@ -1088,6 +1131,8 @@ async fn responses_to_target(
             usage_handled_by_stream: true,
             // The Drop guard's emit carries the counts.
             output_redactions: crate::redact::RedactionCounts::new(),
+            // The Drop guard's emit carries the captured content too.
+            captured_content: None,
         })
     } else {
         let json_body: Value = upstream_resp
@@ -1146,6 +1191,9 @@ async fn responses_to_target(
                     guardrail_blocked: true,
                     usage_handled_by_stream: false,
                     output_redactions: crate::redact::RedactionCounts::new(),
+                    // Blocked responses never reached the client — no content
+                    // capture, matching the chat surface.
+                    captured_content: None,
                 });
             }
         }
@@ -1154,6 +1202,18 @@ async fn responses_to_target(
         // block check passes.
         let mut json_body = json_body;
         let output_redactions = crate::redact::redact_responses_response(chain, &mut json_body);
+
+        // Content capture (AISIX-Cloud#947): the assistant's assembled output
+        // text, read from the POST-redaction body so masked PII stays masked
+        // in the exported content.
+        let captured_content = match (&captured_prompt, content_cap) {
+            (Some(prompt), Some(cap)) => Some(CapturedContent::new(
+                prompt,
+                &responses_output_text(&json_body),
+                cap as usize,
+            )),
+            _ => None,
+        };
 
         Ok(ResponseDispatchSuccess {
             response: Json(json_body).into_response(),
@@ -1165,6 +1225,7 @@ async fn responses_to_target(
             guardrail_blocked: false,
             usage_handled_by_stream: false,
             output_redactions,
+            captured_content,
         })
     }
 }
@@ -1195,6 +1256,18 @@ async fn responses_cross_provider_to_target(
     input_redactions: crate::redact::RedactionCounts,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
+
+    // Content capture (AISIX-Cloud#947), same contract as the verbatim
+    // target: prompt = the client-facing Responses request body
+    // (post-#932-redaction), gated on an exporter actually wanting content.
+    let content_cap = content_capture_cap(
+        snapshot
+            .observability_exporters
+            .entries()
+            .iter()
+            .map(|e| &e.value),
+    );
+    let captured_prompt = content_cap.map(|_| serde_json::to_string(body).unwrap_or_default());
 
     let provider = model
         .provider
@@ -1316,6 +1389,7 @@ async fn responses_cross_provider_to_target(
         let post_stream_keys = reservation.as_ref().map(|r| r.keys()).unwrap_or_default();
         let stream_hold = reservation.take().map(|r| r.into_stream_hold());
         let limiter_c = std::sync::Arc::clone(&state.limiter);
+        let captured_prompt_c = captured_prompt.clone();
         let sse_body = crate::responses_bridge::build_responses_bridge_stream(
             upstream,
             encoder,
@@ -1323,6 +1397,7 @@ async fn responses_cross_provider_to_target(
             output_guardrail,
             max_buffer_bytes,
             requested_model.to_string(),
+            content_cap,
             move |comp| {
                 // #688: apply the terminal token cost to TPM/TPD and release the
                 // concurrency hold now the stream has ended (sync analog of the
@@ -1347,6 +1422,16 @@ async fn responses_cross_provider_to_target(
                 // recorded as a 422 marked guardrail_blocked, matching the
                 // non-streaming path so the Blocked tab + ledger see it.
                 let status = if comp.guardrail_blocked { 422 } else { 200 };
+                // Content capture (AISIX-Cloud#947): prompt captured up front,
+                // response assembled across the bridged stream into
+                // `comp.response_text` (empty when no exporter wants content
+                // or when the response was blocked before release).
+                let captured_content = match (&captured_prompt_c, content_cap) {
+                    (Some(prompt), Some(cap)) if !comp.guardrail_blocked => Some(
+                        CapturedContent::new(prompt, &comp.response_text, cap as usize),
+                    ),
+                    _ => None,
+                };
                 emit_usage_event(
                     &state_c,
                     &request_id_c,
@@ -1367,6 +1452,7 @@ async fn responses_cross_provider_to_target(
                         crate::redact::merge_counts(&mut merged, comp.redacted_entity_counts);
                         merged
                     },
+                    captured_content.as_ref(),
                 );
             },
         );
@@ -1395,6 +1481,8 @@ async fn responses_cross_provider_to_target(
             usage_handled_by_stream: true,
             // The stream's end-of-stream emit carries the counts.
             output_redactions: crate::redact::RedactionCounts::new(),
+            // The stream's end-of-stream emit carries the captured content.
+            captured_content: None,
         });
     }
 
@@ -1450,6 +1538,9 @@ async fn responses_cross_provider_to_target(
                 guardrail_blocked: true,
                 usage_handled_by_stream: false,
                 output_redactions: crate::redact::RedactionCounts::new(),
+                // Blocked responses never reached the client — no content
+                // capture, matching the chat surface.
+                captured_content: None,
             });
         }
     }
@@ -1464,6 +1555,17 @@ async fn responses_cross_provider_to_target(
         requested_model,
         created_at,
     );
+    // Content capture (AISIX-Cloud#947): the client-visible Responses JSON
+    // (post-redaction) is the source, so the exported text matches what the
+    // caller received.
+    let captured_content = match (&captured_prompt, content_cap) {
+        (Some(prompt), Some(cap)) => Some(CapturedContent::new(
+            prompt,
+            &responses_output_text(&json_body),
+            cap as usize,
+        )),
+        _ => None,
+    };
     let mut response = Json(json_body).into_response();
     if let Ok(hv) = HeaderValue::from_str(request_id) {
         response
@@ -1480,6 +1582,7 @@ async fn responses_cross_provider_to_target(
         guardrail_blocked: false,
         usage_handled_by_stream: false,
         output_redactions,
+        captured_content,
     })
 }
 
@@ -1570,11 +1673,16 @@ fn responses_sse_usage(bytes: &[u8]) -> Option<ResponseUsage> {
 }
 
 /// Drain every complete SSE frame from `buf`, updating `acc` with the latest
-/// terminal-event usage (#808). A frame ends at the first blank line; an
-/// incomplete trailing frame is left in `buf` for the next chunk. Reuses the
-/// shared SSE framing helpers from the `/v1/messages` passthrough so the two
-/// surfaces parse identically.
-fn drain_responses_sse_frames(buf: &mut Vec<u8>, acc: &mut Option<ResponseUsage>) {
+/// terminal-event usage (#808) and feeding each parsed event to the optional
+/// content capture (AISIX-Cloud#947). A frame ends at the first blank line;
+/// an incomplete trailing frame is left in `buf` for the next chunk. Reuses
+/// the shared SSE framing helpers from the `/v1/messages` passthrough so the
+/// two surfaces parse identically.
+fn drain_responses_sse_frames(
+    buf: &mut Vec<u8>,
+    acc: &mut Option<ResponseUsage>,
+    mut capture: Option<&mut SseTextCapture>,
+) {
     while let Some(end) = crate::messages::find_frame_end(buf) {
         let frame: Vec<u8> = buf.drain(..end).collect();
         if let Some(data) = crate::messages::extract_sse_data_line(&frame) {
@@ -1585,8 +1693,66 @@ fn drain_responses_sse_frames(buf: &mut Vec<u8>, acc: &mut Option<ResponseUsage>
                 if let Some(u) = parse_responses_terminal_usage(&json) {
                     *acc = Some(u);
                 }
+                if let Some(c) = capture.as_deref_mut() {
+                    c.observe(&json);
+                }
             }
         }
+    }
+}
+
+/// Streamed output-text accumulator for content-capturing exporters
+/// (AISIX-Cloud#947). Mirrors `responses_sse_output_text`'s precedence: a
+/// terminal `response.*` event's full output (incl. tool-call items) wins;
+/// concatenated `*.delta` text is the fallback for streams that abort before
+/// a terminal object. Delta accumulation is bounded to the capture cap so a
+/// long stream can't grow the buffer without limit.
+struct SseTextCapture {
+    cap: usize,
+    deltas: String,
+    terminal: Option<String>,
+}
+
+impl SseTextCapture {
+    fn new(cap: usize) -> Self {
+        Self {
+            cap,
+            deltas: String::new(),
+            terminal: None,
+        }
+    }
+
+    /// Feed one parsed SSE event's JSON.
+    fn observe(&mut self, json: &Value) {
+        match json.get("type").and_then(|t| t.as_str()) {
+            Some("response.completed" | "response.incomplete" | "response.failed") => {
+                if let Some(resp) = json.get("response") {
+                    let full = responses_output_text(resp);
+                    if !full.is_empty() {
+                        self.terminal = Some(full);
+                    }
+                }
+            }
+            Some(
+                "response.output_text.delta"
+                | "response.function_call_arguments.delta"
+                | "response.mcp_call_arguments.delta"
+                | "response.custom_tool_call_input.delta",
+            ) => {
+                if let Some(d) = json.get("delta").and_then(|d| d.as_str()) {
+                    if self.deltas.len() < self.cap {
+                        self.deltas.push_str(d);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// The captured output text: terminal full output when seen, else the
+    /// accumulated deltas. `CapturedContent::new` re-truncates to the cap.
+    fn into_text(self) -> String {
+        self.terminal.unwrap_or(self.deltas)
     }
 }
 
@@ -1596,43 +1762,55 @@ fn drain_responses_sse_frames(buf: &mut Vec<u8>, acc: &mut Option<ResponseUsage>
 /// point), mirroring the `/v1/messages` and chat.rs CompleteOnDrop pattern.
 /// `None` means no terminal usage was seen (e.g. an abort before completion);
 /// the emit then records a zero-token 200 so the request still appears in the
-/// dashboard Logs.
-struct ResponsesUsageGuard<F: FnOnce(ResponseUsage)> {
-    slot: Option<(F, Option<ResponseUsage>)>,
+/// dashboard Logs. The second callback argument is the captured output text
+/// (AISIX-Cloud#947) — empty when no exporter wants content.
+struct ResponsesUsageGuard<F: FnOnce(ResponseUsage, String)> {
+    slot: Option<(F, Option<ResponseUsage>, Option<SseTextCapture>)>,
 }
 
-impl<F: FnOnce(ResponseUsage)> ResponsesUsageGuard<F> {
-    fn usage(&mut self) -> &mut Option<ResponseUsage> {
-        &mut self
+impl<F: FnOnce(ResponseUsage, String)> ResponsesUsageGuard<F> {
+    fn parts(&mut self) -> (&mut Option<ResponseUsage>, Option<&mut SseTextCapture>) {
+        let slot = self
             .slot
             .as_mut()
-            .expect("ResponsesUsageGuard accessed after take")
-            .1
+            .expect("ResponsesUsageGuard accessed after take");
+        (&mut slot.1, slot.2.as_mut())
     }
 }
 
-impl<F: FnOnce(ResponseUsage)> Drop for ResponsesUsageGuard<F> {
+impl<F: FnOnce(ResponseUsage, String)> Drop for ResponsesUsageGuard<F> {
     fn drop(&mut self) {
-        if let Some((f, usage)) = self.slot.take() {
-            f(usage.unwrap_or_default());
+        if let Some((f, usage, capture)) = self.slot.take() {
+            f(
+                usage.unwrap_or_default(),
+                capture.map(SseTextCapture::into_text).unwrap_or_default(),
+            );
         }
     }
 }
 
 /// Wrap a Responses-API upstream byte stream so the terminal event's usage is
 /// parsed in-flight and `on_complete` fires once at end-of-stream (or
-/// client-disconnect) with the accumulated counts (#808). Bytes forward
-/// verbatim — the client sees the exact upstream SSE wire shape.
+/// client-disconnect) with the accumulated counts (#808) plus the captured
+/// output text (AISIX-Cloud#947, empty when `content_cap` is `None`). Bytes
+/// forward verbatim — the client sees the exact upstream SSE wire shape.
 fn build_responses_passthrough_stream<S, F>(
     upstream: S,
+    content_cap: Option<u32>,
     on_complete: F,
 ) -> impl futures::Stream<Item = reqwest::Result<bytes::Bytes>>
 where
     S: futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send + 'static,
-    F: FnOnce(ResponseUsage) + Send + 'static,
+    F: FnOnce(ResponseUsage, String) + Send + 'static,
 {
     async_stream::stream! {
-        let mut guard = ResponsesUsageGuard { slot: Some((on_complete, None)) };
+        let mut guard = ResponsesUsageGuard {
+            slot: Some((
+                on_complete,
+                None,
+                content_cap.map(|cap| SseTextCapture::new(cap as usize)),
+            )),
+        };
         futures::pin_mut!(upstream);
         let mut buf: Vec<u8> = Vec::new();
         while let Some(item) = upstream.next().await {
@@ -1640,7 +1818,8 @@ where
                 // Side-channel parse: copy into the frame buffer (the original
                 // `bytes` is yielded unchanged below) and drain complete frames.
                 buf.extend_from_slice(bytes);
-                drain_responses_sse_frames(&mut buf, guard.usage());
+                let (usage_acc, capture) = guard.parts();
+                drain_responses_sse_frames(&mut buf, usage_acc, capture);
                 // Bound the frame buffer: the happy path drains complete frames
                 // above so `buf` only holds a partial trailing frame. A
                 // non-conformant upstream streaming bytes without a blank-line
@@ -1847,6 +2026,9 @@ fn emit_usage_event(
     // Per-detector PII mask counts (#932), input + output merged. Detector
     // names only, never matched values. Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Captured request/response content for content-capturing exporters
+    // (AISIX-Cloud#947). Forwarded only to `fan_out`, never to the CP sink.
+    content: Option<&CapturedContent>,
 ) {
     let snap = state.snapshot.load();
     let tags = provider_telemetry_tags(&snap, provider_key_id);
@@ -1887,7 +2069,7 @@ fn emit_usage_event(
     let exporters = snap.observability_exporters.entries();
     state
         .otlp_fan_out
-        .fan_out(&event, None, exporters.iter().map(|e| &e.value));
+        .fan_out(&event, content, exporters.iter().map(|e| &e.value));
 }
 
 /// Emit a zero-token `UsageEvent` for a failed / pre-dispatch attempt
@@ -3887,5 +4069,61 @@ data: [DONE]\n\n";
             event.completion_tokens, 0,
             "missing output_tokens must default to 0, not drop the event"
         );
+    }
+
+    /// AISIX-Cloud#947: the streamed content capture prefers the terminal
+    /// `response.completed` event's full output over accumulated deltas —
+    /// the terminal object is authoritative (includes tool-call items the
+    /// deltas may have missed).
+    #[test]
+    fn sse_text_capture_prefers_terminal_full_output() {
+        let mut cap = super::SseTextCapture::new(1024);
+        cap.observe(&serde_json::json!({
+            "type": "response.output_text.delta",
+            "delta": "partial "
+        }));
+        cap.observe(&serde_json::json!({
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {"type": "message", "content": [{"type": "output_text", "text": "the full text"}]}
+                ]
+            }
+        }));
+        assert_eq!(cap.into_text(), "the full text");
+    }
+
+    /// AISIX-Cloud#947: a stream that aborts before any terminal event falls
+    /// back to the concatenated deltas — including tool-call argument deltas,
+    /// which stream via their own event type.
+    #[test]
+    fn sse_text_capture_falls_back_to_deltas_on_abort() {
+        let mut cap = super::SseTextCapture::new(1024);
+        cap.observe(&serde_json::json!({
+            "type": "response.output_text.delta",
+            "delta": "hello "
+        }));
+        cap.observe(&serde_json::json!({
+            "type": "response.function_call_arguments.delta",
+            "delta": "{\"city\":\"SF\"}"
+        }));
+        assert_eq!(cap.into_text(), "hello {\"city\":\"SF\"}");
+    }
+
+    /// AISIX-Cloud#947: delta accumulation is bounded to the capture cap so
+    /// a long stream can't grow the buffer without limit.
+    #[test]
+    fn sse_text_capture_bounds_delta_accumulation() {
+        let mut cap = super::SseTextCapture::new(10);
+        for _ in 0..100 {
+            cap.observe(&serde_json::json!({
+                "type": "response.output_text.delta",
+                "delta": "0123456789"
+            }));
+        }
+        let text = cap.into_text();
+        // One push may land after the buffer crosses the cap; the point is
+        // the accumulation stops near the cap instead of growing 100x.
+        assert!(text.len() <= 20, "delta buffer must stay near the cap");
     }
 }

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -901,6 +901,11 @@ pub struct ResponsesStreamCompletion {
     /// Per-detector PII mask counts applied to the held stream at release
     /// (#932). Merged with the input-side counts by the on_complete emit.
     pub redacted_entity_counts: crate::redact::RedactionCounts,
+    /// Assembled assistant text for content-capturing exporters
+    /// (AISIX-Cloud#947), accumulated across chunks ONLY when an exporter
+    /// wants full content (bounded to the capture cap). Empty otherwise.
+    /// Read by the on_complete telemetry closure; never reaches the CP sink.
+    pub response_text: String,
 }
 
 struct CompleteOnDrop<F: FnOnce(ResponsesStreamCompletion)> {
@@ -938,6 +943,7 @@ impl<F: FnOnce(ResponsesStreamCompletion)> Drop for CompleteOnDrop<F> {
 /// (not raw deltas), and the buffer is capped — an output guardrail must
 /// never release content it couldn't fully buffer to scan, so an overflow
 /// fails closed. With no output guardrail the bytes forward live.
+#[allow(clippy::too_many_arguments)]
 pub fn build_responses_bridge_stream(
     upstream: ChatChunkStream,
     encoder: ResponsesSseEncoder,
@@ -945,6 +951,9 @@ pub fn build_responses_bridge_stream(
     output_guardrail: Option<Arc<aisix_guardrails::GuardrailChain>>,
     max_buffer_bytes: usize,
     model_label: String,
+    // Largest content cap any content-capturing exporter wants
+    // (AISIX-Cloud#947); `None` skips response-text accumulation entirely.
+    content_cap: Option<u32>,
     on_complete: impl FnOnce(ResponsesStreamCompletion) + Send + 'static,
 ) -> axum::body::Body {
     use futures::StreamExt;
@@ -974,6 +983,18 @@ pub fn build_responses_bridge_stream(
                         let comp = guard.comp();
                         if let Some(fr) = chunk.finish_reason.as_ref() {
                             comp.finish_reason = finish_reason_label(fr);
+                        }
+                        // Content capture (AISIX-Cloud#947): assemble the
+                        // assistant text for the observability fan-out,
+                        // bounded to the cap so a long stream can't grow the
+                        // buffer without limit. Only when an exporter wants
+                        // full content — mirrors chat.rs's stream capture.
+                        if let (Some(cap), Some(text)) =
+                            (content_cap, chunk.delta.content.as_deref())
+                        {
+                            if comp.response_text.len() < cap as usize {
+                                comp.response_text.push_str(text);
+                            }
                         }
                         if let Some(u) = chunk.usage.as_ref() {
                             comp.prompt_tokens = comp.prompt_tokens.max(u.prompt_tokens);

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1106,6 +1106,13 @@ pub fn build_responses_bridge_stream(
             if let Some((rewritten, counts)) =
                 crate::redact::redact_responses_sse(chain.as_ref(), &joined)
             {
+                // The wire bytes were masked — mask the content-capture
+                // accumulator too, or the exported content would carry
+                // PII the client never saw (#932 × AISIX-Cloud#947).
+                crate::redact::redact_captured_output(
+                    chain.as_ref(),
+                    &mut guard.comp().response_text,
+                );
                 crate::redact::merge_counts(
                     &mut guard.comp().redacted_entity_counts,
                     counts,

--- a/tests/e2e/src/cases/aliyun-sls-content-capture-e2e.test.ts
+++ b/tests/e2e/src/cases/aliyun-sls-content-capture-e2e.test.ts
@@ -1,13 +1,15 @@
 import { createHash } from "node:crypto";
-import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   AdminClient,
+  decodedTextFor,
   EtcdClient,
-  pickFreePort,
   spawnApp,
+  startMockSls,
   startOpenAiUpstream,
   waitConfigPropagation,
+  waitForLogstore,
+  type MockSls,
   type OpenAiUpstream,
   type SpawnedApp,
 } from "../harness/index.js";
@@ -45,91 +47,6 @@ const STREAM_RESPONSE_TOKEN = "stream-response-tok-b22f70";
 // Anthropic-shape request streamed off an OpenAI upstream).
 const ANTHROPIC_PROMPT_TOKEN = "anthropic-prompt-tok-5d1f9c";
 const ANTHROPIC_RESPONSE_TOKEN = "anthropic-response-tok-a4e823";
-
-interface CapturedPutLogs {
-  logstore: string;
-  rawSize: number;
-  body: Buffer;
-}
-
-interface MockSls {
-  url: string;
-  requests: CapturedPutLogs[];
-  close(): Promise<void>;
-}
-
-/** Decompress an lz4 *block* (no frame header) given the raw output size. */
-function lz4DecompressBlock(src: Buffer, rawSize: number): Buffer {
-  const dest = Buffer.alloc(rawSize);
-  let s = 0;
-  let d = 0;
-  while (s < src.length) {
-    const token = src[s++];
-    let litLen = token >> 4;
-    if (litLen === 15) {
-      let b: number;
-      do {
-        b = src[s++];
-        litLen += b;
-      } while (b === 255);
-    }
-    src.copy(dest, d, s, s + litLen);
-    s += litLen;
-    d += litLen;
-    if (s >= src.length) break;
-    const offset = src[s] | (src[s + 1] << 8);
-    s += 2;
-    let matchLen = token & 0x0f;
-    if (matchLen === 15) {
-      let b: number;
-      do {
-        b = src[s++];
-        matchLen += b;
-      } while (b === 255);
-    }
-    matchLen += 4;
-    let m = d - offset;
-    for (let i = 0; i < matchLen; i++) {
-      dest[d++] = dest[m++];
-    }
-  }
-  return dest;
-}
-
-function logstoreFromPath(path: string): string {
-  // /logstores/<logstore>/shards/lb
-  const m = path.match(/^\/logstores\/([^/]+)\/shards\/lb$/);
-  return m ? m[1] : "";
-}
-
-async function startMockSls(): Promise<MockSls> {
-  const requests: CapturedPutLogs[] = [];
-  const server: Server = createServer((req, res) => {
-    const chunks: Buffer[] = [];
-    req.on("data", (c: Buffer) => chunks.push(c));
-    req.on("end", () => {
-      const logstore = logstoreFromPath((req.url ?? "").split("?")[0]);
-      if (logstore) {
-        const rawSizeHeader = req.headers["x-log-bodyrawsize"];
-        const rawSize = Number(Array.isArray(rawSizeHeader) ? rawSizeHeader[0] : rawSizeHeader);
-        requests.push({ logstore, rawSize, body: Buffer.concat(chunks) });
-      }
-      res.statusCode = 200;
-      res.end();
-    });
-  });
-  const port = await pickFreePort();
-  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
-  return {
-    url: `http://127.0.0.1:${port}`,
-    requests,
-    async close() {
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => (err ? reject(err) : resolve()));
-      });
-    },
-  };
-}
 
 async function seedRouting(
   admin: AdminClient,
@@ -227,23 +144,6 @@ async function chatStream(app: SpawnedApp): Promise<string> {
     }),
   });
   return res.text();
-}
-
-/** Decompress every PutLogs body for a logstore and join as one searchable string. */
-function decodedTextFor(sls: MockSls, logstore: string): string {
-  return sls.requests
-    .filter((r) => r.logstore === logstore && r.rawSize > 0 && r.body.length > 0)
-    .map((r) => lz4DecompressBlock(r.body, r.rawSize).toString("utf8"))
-    .join(" ");
-}
-
-async function waitForLogstore(sls: MockSls, logstore: string, timeoutMs = 10_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (sls.requests.some((r) => r.logstore === logstore)) return;
-    await new Promise((r) => setTimeout(r, 50));
-  }
-  throw new Error(`no PutLogs to logstore '${logstore}' within ${timeoutMs}ms`);
 }
 
 describe("aliyun_sls content capture e2e (#687): full vs metadata_only", () => {

--- a/tests/e2e/src/cases/sls-content-capture-masked-e2e.test.ts
+++ b/tests/e2e/src/cases/sls-content-capture-masked-e2e.test.ts
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  decodedTextFor,
+  EtcdClient,
+  spawnApp,
+  startMockSls,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  waitForToken,
+  type MockSls,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// #932 × AISIX-Cloud#947: on a streaming response with a mask-action PII
+// guardrail, the wire chunks released to the client are masked — and the
+// content handed to a `content_mode = full` exporter must be the SAME masked
+// text. Pre-fix, the capture accumulator collected raw deltas and only the
+// wire bytes were rewritten, so SLS received PII the client never saw. The
+// email value is split across two SSE deltas so only the assembled (capture)
+// text ever contains it whole — exactly the shape that leaked.
+
+const CALLER_PLAINTEXT = "sk-content-capture-masked-PLAINTEXT";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+const PROVIDER_SECRET = "sk-mock-content-capture-masked";
+
+const CREDENTIAL_REF = "mock";
+const SLS_PROJECT = "aisix-e2e-obs";
+const FULL_LOGSTORE = "full-events-masked";
+const META_LOGSTORE = "meta-events-masked";
+
+const EMAIL = "alice@example.com";
+const MASK = "[EMAIL_REDACTED]";
+const CHAT_PROMPT_TOKEN = "masked-chat-prompt-tok-1f2e3d";
+const BRIDGE_PROMPT_TOKEN = "masked-bridge-prompt-tok-4c5b6a";
+
+/** OpenAI chat chunks with the email split across two deltas (channel
+ * reassembly): neither wire chunk carries the whole value; only the
+ * assembled text does. */
+function chatStreamEvents(marker: string): string[] {
+  const split = EMAIL.indexOf("@") + 2; // "alice@e" | "xample.com"
+  return [
+    JSON.stringify({
+      id: "mock-masked-1",
+      object: "chat.completion.chunk",
+      model: "mock-model",
+      choices: [{ index: 0, delta: { role: "assistant" } }],
+    }),
+    JSON.stringify({
+      id: "mock-masked-1",
+      object: "chat.completion.chunk",
+      model: "mock-model",
+      choices: [{ index: 0, delta: { content: `${marker} reach me at ${EMAIL.slice(0, split)}` } }],
+    }),
+    JSON.stringify({
+      id: "mock-masked-1",
+      object: "chat.completion.chunk",
+      model: "mock-model",
+      choices: [
+        { index: 0, delta: { content: `${EMAIL.slice(split)} thanks` }, finish_reason: "stop" },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+    }),
+    "[DONE]",
+  ];
+}
+
+async function postJson(app: SpawnedApp, path: string, body: unknown): Promise<Response> {
+  return fetch(`${app.proxyUrl}${path}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("sls content capture e2e: streaming capture is post-mask (#932 × AISIX-Cloud#947)", () => {
+  let etcdReachable = false;
+  let chatUpstream: OpenAiUpstream | undefined;
+  let bridgeUpstream: OpenAiUpstream | undefined;
+  let sls: MockSls | undefined;
+  const apps: SpawnedApp[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    chatUpstream = await startOpenAiUpstream({ streamEvents: chatStreamEvents("chat-reply") });
+    // The /v1/responses cross-provider bridge consumes OpenAI chat chunks too.
+    bridgeUpstream = await startOpenAiUpstream({ streamEvents: chatStreamEvents("bridge-reply") });
+    sls = await startMockSls();
+  });
+
+  afterAll(async () => {
+    await Promise.all(apps.map((a) => a.exit()));
+    await chatUpstream?.close();
+    await bridgeUpstream?.close();
+    await sls?.close();
+  });
+
+  test(
+    "full-capture exporter receives the masked stream text, never the raw PII",
+    async (ctx) => {
+      if (!etcdReachable || !chatUpstream || !bridgeUpstream || !sls) {
+        ctx.skip();
+        return;
+      }
+      const app = await spawnApp({
+        extraEnv: {
+          [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: "mock-akid",
+          [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: "mock-secret",
+        },
+      });
+      apps.push(app);
+      const admin = new AdminClient(app.adminUrl, app.adminKey);
+      await admin.createObservabilityExporter({
+        name: "sls-full-masked",
+        enabled: true,
+        kind: "aliyun_sls",
+        endpoint: sls.url,
+        project: SLS_PROJECT,
+        logstore: FULL_LOGSTORE,
+        credential_ref: CREDENTIAL_REF,
+        content_mode: "full",
+      });
+      await admin.createObservabilityExporter({
+        name: "sls-meta-masked",
+        enabled: true,
+        kind: "aliyun_sls",
+        endpoint: sls.url,
+        project: SLS_PROJECT,
+        logstore: META_LOGSTORE,
+        credential_ref: CREDENTIAL_REF,
+        content_mode: "metadata_only",
+      });
+      const chatPk = await admin.createProviderKey({
+        display_name: "masked-chat-pk",
+        secret: PROVIDER_SECRET,
+        api_base: `${chatUpstream.baseUrl}/v1`,
+      });
+      await admin.createModel({
+        display_name: "masked-chat-model",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: chatPk.id,
+      });
+      const bridgePk = await admin.createProviderKey({
+        display_name: "masked-bridge-pk",
+        secret: PROVIDER_SECRET,
+        api_base: `${bridgeUpstream.baseUrl}/v1`,
+        provider: "deepseek",
+        adapter: "openai",
+      });
+      await admin.createModel({
+        display_name: "masked-bridge-model",
+        provider: "deepseek",
+        model_name: "gpt-4o-mini",
+        provider_key_id: bridgePk.id,
+      });
+      await admin.createApiKey({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: ["masked-chat-model", "masked-bridge-model"],
+      });
+      // Env-wide output-hook PII guardrail: email → mask. Its presence also
+      // forces the streaming hold-back (BufferFull) path — the path where
+      // the capture/wire divergence lived.
+      await admin.json("POST", "/admin/v1/guardrails", {
+        name: "masked-capture-guard",
+        enabled: true,
+        hook_point: "output",
+        kind: "pii",
+        detectors: [{ type: "email", action: "mask" }],
+      });
+
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await postJson(app, "/v1/chat/completions", {
+            model: "masked-chat-model",
+            stream: true,
+            messages: [{ role: "user", content: "warmup" }],
+          });
+          const body = await r.text();
+          // The guardrail must be live too, not just the model: wait until
+          // the masked form appears in the wire response.
+          return r.status === 200 && body.includes(MASK);
+        } catch {
+          return false;
+        }
+      });
+
+      // -- streaming chat (hold-back release path) --
+      const chatRes = await postJson(app, "/v1/chat/completions", {
+        model: "masked-chat-model",
+        stream: true,
+        messages: [{ role: "user", content: `note ${CHAT_PROMPT_TOKEN}` }],
+      });
+      expect(chatRes.status).toBe(200);
+      const chatBody = await chatRes.text();
+      expect(chatBody).toContain(MASK); // client got masked text
+      expect(chatBody).not.toContain(EMAIL);
+
+      await waitForToken(sls, FULL_LOGSTORE, CHAT_PROMPT_TOKEN);
+      let fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      expect(fullText).toContain(CHAT_PROMPT_TOKEN);
+      expect(fullText).toContain(MASK); // capture carries the masked reply
+      expect(fullText).not.toContain(EMAIL); // and never the raw PII
+
+      // -- streaming /v1/responses via the cross-provider bridge --
+      const bridgeRes = await postJson(app, "/v1/responses", {
+        model: "masked-bridge-model",
+        stream: true,
+        input: `note ${BRIDGE_PROMPT_TOKEN}`,
+      });
+      expect(bridgeRes.status).toBe(200);
+      const bridgeBody = await bridgeRes.text();
+      expect(bridgeBody).toContain(MASK);
+      expect(bridgeBody).not.toContain(EMAIL);
+
+      await waitForToken(sls, FULL_LOGSTORE, BRIDGE_PROMPT_TOKEN);
+      fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      expect(fullText).toContain(BRIDGE_PROMPT_TOKEN);
+      expect(fullText).not.toContain(EMAIL);
+
+      // metadata_only exporter never sees content at all.
+      const metaText = decodedTextFor(sls, META_LOGSTORE);
+      expect(metaText).not.toContain(EMAIL);
+      expect(metaText).not.toContain(MASK);
+      expect(metaText).not.toContain(CHAT_PROMPT_TOKEN);
+    },
+    120_000,
+  );
+});

--- a/tests/e2e/src/cases/sls-content-capture-responses-completions-e2e.test.ts
+++ b/tests/e2e/src/cases/sls-content-capture-responses-completions-e2e.test.ts
@@ -1,0 +1,365 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  decodedTextFor,
+  EtcdClient,
+  spawnApp,
+  startMockSls,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  waitForLogstore,
+  waitForToken,
+  type MockSls,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// AISIX-Cloud#947: a `content_mode = full` exporter must capture the request
+// prompt + response for /v1/responses and /v1/completions too — pre-fix those
+// handlers fanned out with `content: None`, so SLS received metadata only even
+// with "full (prompt + response)" selected in the console. This suite pins all
+// four /v1/responses paths that carry content (verbatim non-streaming,
+// verbatim streaming, cross-provider bridge non-streaming + streaming) plus
+// /v1/completions, and that a `metadata_only` exporter still receives none.
+
+const CALLER_PLAINTEXT = "sk-content-capture-947-PLAINTEXT";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+const PROVIDER_SECRET = "sk-mock-content-capture-947";
+
+const CREDENTIAL_REF = "mock";
+const MOCK_AK_ID = "mock-akid";
+const MOCK_AK_SECRET = "mock-secret";
+const SLS_PROJECT = "aisix-e2e-obs";
+const FULL_LOGSTORE = "full-events-947";
+const META_LOGSTORE = "meta-events-947";
+
+// Unique tokens per scenario, planted in the request input and the mock
+// upstream's output text.
+const RESP_PROMPT_TOKEN = "responses-prompt-tok-1a2b3c";
+const RESP_RESPONSE_TOKEN = "responses-response-tok-4d5e6f";
+const RESP_STREAM_PROMPT_TOKEN = "responses-stream-prompt-tok-7a8b9c";
+const RESP_STREAM_RESPONSE_TOKEN = "responses-stream-response-tok-0d1e2f";
+const BRIDGE_PROMPT_TOKEN = "responses-bridge-prompt-tok-3a4b5c";
+const BRIDGE_RESPONSE_TOKEN = "responses-bridge-response-tok-6d7e8f";
+const BRIDGE_STREAM_PROMPT_TOKEN = "responses-bridge-stream-prompt-tok-9a0b1c";
+const BRIDGE_STREAM_RESPONSE_TOKEN = "responses-bridge-stream-response-tok-2d3e4f";
+const COMPLETIONS_PROMPT_TOKEN = "completions-prompt-tok-5a6b7c";
+const COMPLETIONS_RESPONSE_TOKEN = "completions-response-tok-8d9e0f";
+
+/** Responses-API non-streaming body carrying the response token. */
+function responsesBody(text: string) {
+  return {
+    id: "resp_mock947",
+    object: "response",
+    status: "completed",
+    model: "mock-model",
+    output: [
+      {
+        type: "message",
+        id: "msg_mock947",
+        role: "assistant",
+        content: [{ type: "output_text", text }],
+      },
+    ],
+    usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+  };
+}
+
+/** Responses-API SSE events: the response token split across two deltas plus
+ * the terminal `response.completed` carrying the full output + usage. */
+function responsesStreamEvents(): string[] {
+  const half = Math.floor(RESP_STREAM_RESPONSE_TOKEN.length / 2);
+  return [
+    JSON.stringify({
+      type: "response.output_text.delta",
+      delta: `streamed ${RESP_STREAM_RESPONSE_TOKEN.slice(0, half)}`,
+    }),
+    JSON.stringify({
+      type: "response.output_text.delta",
+      delta: RESP_STREAM_RESPONSE_TOKEN.slice(half),
+    }),
+    JSON.stringify({
+      type: "response.completed",
+      response: responsesBody(`streamed ${RESP_STREAM_RESPONSE_TOKEN}`),
+    }),
+    "[DONE]",
+  ];
+}
+
+/** OpenAI chat-completions chunks for the cross-provider bridge stream. */
+function bridgeStreamEvents(): string[] {
+  return [
+    JSON.stringify({
+      id: "mock-bridge-1",
+      object: "chat.completion.chunk",
+      model: "mock-model",
+      choices: [{ index: 0, delta: { role: "assistant" } }],
+    }),
+    JSON.stringify({
+      id: "mock-bridge-1",
+      object: "chat.completion.chunk",
+      model: "mock-model",
+      choices: [{ index: 0, delta: { content: `bridged ${BRIDGE_STREAM_RESPONSE_TOKEN}` } }],
+    }),
+    JSON.stringify({
+      id: "mock-bridge-1",
+      object: "chat.completion.chunk",
+      model: "mock-model",
+      choices: [{ index: 0, delta: { content: " done" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+    }),
+    "[DONE]",
+  ];
+}
+
+async function postJson(app: SpawnedApp, path: string, body: unknown): Promise<Response> {
+  return fetch(`${app.proxyUrl}${path}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("sls content capture e2e (AISIX-Cloud#947): /v1/responses + /v1/completions", () => {
+  let etcdReachable = false;
+  let responsesUpstream: OpenAiUpstream | undefined;
+  let responsesStreamUpstream: OpenAiUpstream | undefined;
+  let bridgeUpstream: OpenAiUpstream | undefined;
+  let bridgeStreamUpstream: OpenAiUpstream | undefined;
+  let completionsUpstream: OpenAiUpstream | undefined;
+  let sls: MockSls | undefined;
+  const apps: SpawnedApp[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+    responsesUpstream = await startOpenAiUpstream({
+      nonStreamBody: responsesBody(`sure, ${RESP_RESPONSE_TOKEN} noted`),
+    });
+    responsesStreamUpstream = await startOpenAiUpstream({
+      streamEvents: responsesStreamEvents(),
+    });
+    // Cross-provider bridge (non-openai provider): the DP translates the
+    // Responses request into ChatFormat and calls the OpenAI-compatible
+    // family bridge, so the mock serves chat-completions wire shapes.
+    bridgeUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "mock-bridge-nonstream",
+        object: "chat.completion",
+        created: 1_700_000_000,
+        model: "mock-model",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: `bridged ${BRIDGE_RESPONSE_TOKEN}` },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+      },
+    });
+    bridgeStreamUpstream = await startOpenAiUpstream({
+      streamEvents: bridgeStreamEvents(),
+    });
+    completionsUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-mock947",
+        object: "text_completion",
+        created: 1_700_000_000,
+        model: "mock-model",
+        choices: [
+          { text: `ok ${COMPLETIONS_RESPONSE_TOKEN}`, index: 0, finish_reason: "stop" },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+      },
+    });
+    sls = await startMockSls();
+  });
+
+  afterAll(async () => {
+    await Promise.all(apps.map((a) => a.exit()));
+    await responsesUpstream?.close();
+    await responsesStreamUpstream?.close();
+    await bridgeUpstream?.close();
+    await bridgeStreamUpstream?.close();
+    await completionsUpstream?.close();
+    await sls?.close();
+  });
+
+  test(
+    "full-capture exporter logs prompt + response on every /v1/responses path and /v1/completions; metadata_only logs neither",
+    async (ctx) => {
+      if (
+        !etcdReachable ||
+        !responsesUpstream ||
+        !responsesStreamUpstream ||
+        !bridgeUpstream ||
+        !bridgeStreamUpstream ||
+        !completionsUpstream ||
+        !sls
+      ) {
+        ctx.skip();
+        return;
+      }
+      const app = await spawnApp({
+        extraEnv: {
+          [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: MOCK_AK_ID,
+          [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: MOCK_AK_SECRET,
+        },
+      });
+      apps.push(app);
+      const admin = new AdminClient(app.adminUrl, app.adminKey);
+      await admin.createObservabilityExporter({
+        name: "sls-full-947",
+        enabled: true,
+        kind: "aliyun_sls",
+        endpoint: sls.url,
+        project: SLS_PROJECT,
+        logstore: FULL_LOGSTORE,
+        credential_ref: CREDENTIAL_REF,
+        content_mode: "full",
+      });
+      await admin.createObservabilityExporter({
+        name: "sls-meta-947",
+        enabled: true,
+        kind: "aliyun_sls",
+        endpoint: sls.url,
+        project: SLS_PROJECT,
+        logstore: META_LOGSTORE,
+        credential_ref: CREDENTIAL_REF,
+        content_mode: "metadata_only",
+      });
+
+      const seedModel = async (name: string, provider: string, upstream: OpenAiUpstream) => {
+        const pk = await admin.createProviderKey({
+          display_name: `${name}-pk`,
+          secret: PROVIDER_SECRET,
+          api_base: `${upstream.baseUrl}/v1`,
+          provider,
+          adapter: "openai",
+        });
+        await admin.createModel({
+          display_name: name,
+          provider,
+          model_name: "gpt-4o-mini",
+          provider_key_id: pk.id,
+        });
+      };
+      await seedModel("cc947-responses", "openai", responsesUpstream);
+      await seedModel("cc947-responses-stream", "openai", responsesStreamUpstream);
+      await seedModel("cc947-bridge", "deepseek", bridgeUpstream);
+      await seedModel("cc947-bridge-stream", "deepseek", bridgeStreamUpstream);
+      await seedModel("cc947-completions", "openai", completionsUpstream);
+      await admin.createApiKey({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: [
+          "cc947-responses",
+          "cc947-responses-stream",
+          "cc947-bridge",
+          "cc947-bridge-stream",
+          "cc947-completions",
+        ],
+      });
+
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await postJson(app, "/v1/responses", {
+            model: "cc947-responses",
+            input: "warmup",
+          });
+          await r.text();
+          return r.status === 200;
+        } catch {
+          return false;
+        }
+      });
+
+      // -- /v1/responses, verbatim non-streaming --
+      const res = await postJson(app, "/v1/responses", {
+        model: "cc947-responses",
+        input: `note the token ${RESP_PROMPT_TOKEN}`,
+      });
+      expect(res.status).toBe(200);
+      await res.text();
+      await waitForToken(sls, FULL_LOGSTORE, RESP_PROMPT_TOKEN);
+      let fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      expect(fullText).toContain(RESP_PROMPT_TOKEN);
+      expect(fullText).toContain(RESP_RESPONSE_TOKEN);
+
+      // -- /v1/responses, verbatim streaming (live-forward Drop-guard emit) --
+      const streamRes = await postJson(app, "/v1/responses", {
+        model: "cc947-responses-stream",
+        stream: true,
+        input: `recall the token ${RESP_STREAM_PROMPT_TOKEN}`,
+      });
+      expect(streamRes.status).toBe(200);
+      const streamBody = await streamRes.text();
+      expect(streamBody).toContain(RESP_STREAM_RESPONSE_TOKEN); // client received it
+      await waitForToken(sls, FULL_LOGSTORE, RESP_STREAM_PROMPT_TOKEN);
+      fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      expect(fullText).toContain(RESP_STREAM_PROMPT_TOKEN);
+      expect(fullText).toContain(RESP_STREAM_RESPONSE_TOKEN);
+
+      // -- /v1/responses, cross-provider bridge non-streaming --
+      const bridgeRes = await postJson(app, "/v1/responses", {
+        model: "cc947-bridge",
+        input: `remember the token ${BRIDGE_PROMPT_TOKEN}`,
+      });
+      expect(bridgeRes.status).toBe(200);
+      await bridgeRes.text();
+      await waitForToken(sls, FULL_LOGSTORE, BRIDGE_PROMPT_TOKEN);
+      fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      expect(fullText).toContain(BRIDGE_PROMPT_TOKEN);
+      expect(fullText).toContain(BRIDGE_RESPONSE_TOKEN);
+
+      // -- /v1/responses, cross-provider bridge streaming --
+      const bridgeStreamRes = await postJson(app, "/v1/responses", {
+        model: "cc947-bridge-stream",
+        stream: true,
+        input: `keep the token ${BRIDGE_STREAM_PROMPT_TOKEN}`,
+      });
+      expect(bridgeStreamRes.status).toBe(200);
+      const bridgeStreamBody = await bridgeStreamRes.text();
+      expect(bridgeStreamBody).toContain(BRIDGE_STREAM_RESPONSE_TOKEN);
+      await waitForToken(sls, FULL_LOGSTORE, BRIDGE_STREAM_PROMPT_TOKEN);
+      fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      expect(fullText).toContain(BRIDGE_STREAM_PROMPT_TOKEN);
+      expect(fullText).toContain(BRIDGE_STREAM_RESPONSE_TOKEN);
+
+      // -- /v1/completions --
+      const cmplRes = await postJson(app, "/v1/completions", {
+        model: "cc947-completions",
+        prompt: `say the token ${COMPLETIONS_PROMPT_TOKEN}`,
+      });
+      expect(cmplRes.status).toBe(200);
+      await cmplRes.text();
+      await waitForToken(sls, FULL_LOGSTORE, COMPLETIONS_PROMPT_TOKEN);
+      fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      expect(fullText).toContain(COMPLETIONS_PROMPT_TOKEN);
+      expect(fullText).toContain(COMPLETIONS_RESPONSE_TOKEN);
+
+      // -- metadata_only exporter received events but never content --
+      await waitForLogstore(sls, META_LOGSTORE);
+      const metaText = decodedTextFor(sls, META_LOGSTORE);
+      for (const token of [
+        RESP_PROMPT_TOKEN,
+        RESP_RESPONSE_TOKEN,
+        RESP_STREAM_PROMPT_TOKEN,
+        RESP_STREAM_RESPONSE_TOKEN,
+        BRIDGE_PROMPT_TOKEN,
+        BRIDGE_RESPONSE_TOKEN,
+        BRIDGE_STREAM_PROMPT_TOKEN,
+        BRIDGE_STREAM_RESPONSE_TOKEN,
+        COMPLETIONS_PROMPT_TOKEN,
+        COMPLETIONS_RESPONSE_TOKEN,
+      ]) {
+        expect(metaText).not.toContain(token);
+      }
+    },
+    120_000,
+  );
+});

--- a/tests/e2e/src/harness/index.ts
+++ b/tests/e2e/src/harness/index.ts
@@ -4,3 +4,12 @@ export { ProxyClient } from "./proxy.js";
 export { EtcdClient } from "./etcd.js";
 export { startOpenAiUpstream, type OpenAiUpstream, type ReceivedRequest } from "./upstream-openai.js";
 export { pickFreePort, pickFreePorts } from "./ports.js";
+export {
+  startMockSls,
+  decodedTextFor,
+  waitForLogstore,
+  waitForToken,
+  lz4DecompressBlock,
+  type MockSls,
+  type CapturedPutLogs,
+} from "./sls-mock.js";

--- a/tests/e2e/src/harness/sls-mock.ts
+++ b/tests/e2e/src/harness/sls-mock.ts
@@ -1,0 +1,130 @@
+import { createServer, type Server } from "node:http";
+import { pickFreePort } from "./ports.js";
+
+/**
+ * Mock Aliyun SLS PutLogs endpoint shared by the content-capture e2e suites
+ * (#687 chat/messages, AISIX-Cloud#947 responses/completions). Captures each
+ * PutLogs body (lz4 block compressed) per logstore so tests can decompress
+ * and search for planted tokens.
+ */
+
+export interface CapturedPutLogs {
+  logstore: string;
+  rawSize: number;
+  body: Buffer;
+}
+
+export interface MockSls {
+  url: string;
+  requests: CapturedPutLogs[];
+  close(): Promise<void>;
+}
+
+/** Decompress an lz4 *block* (no frame header) given the raw output size. */
+export function lz4DecompressBlock(src: Buffer, rawSize: number): Buffer {
+  const dest = Buffer.alloc(rawSize);
+  let s = 0;
+  let d = 0;
+  while (s < src.length) {
+    const token = src[s++];
+    let litLen = token >> 4;
+    if (litLen === 15) {
+      let b: number;
+      do {
+        b = src[s++];
+        litLen += b;
+      } while (b === 255);
+    }
+    src.copy(dest, d, s, s + litLen);
+    s += litLen;
+    d += litLen;
+    if (s >= src.length) break;
+    const offset = src[s] | (src[s + 1] << 8);
+    s += 2;
+    let matchLen = token & 0x0f;
+    if (matchLen === 15) {
+      let b: number;
+      do {
+        b = src[s++];
+        matchLen += b;
+      } while (b === 255);
+    }
+    matchLen += 4;
+    let m = d - offset;
+    for (let i = 0; i < matchLen; i++) {
+      dest[d++] = dest[m++];
+    }
+  }
+  return dest;
+}
+
+function logstoreFromPath(path: string): string {
+  // /logstores/<logstore>/shards/lb
+  const m = path.match(/^\/logstores\/([^/]+)\/shards\/lb$/);
+  return m ? m[1] : "";
+}
+
+export async function startMockSls(): Promise<MockSls> {
+  const requests: CapturedPutLogs[] = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const logstore = logstoreFromPath((req.url ?? "").split("?")[0]);
+      if (logstore) {
+        const rawSizeHeader = req.headers["x-log-bodyrawsize"];
+        const rawSize = Number(Array.isArray(rawSizeHeader) ? rawSizeHeader[0] : rawSizeHeader);
+        requests.push({ logstore, rawSize, body: Buffer.concat(chunks) });
+      }
+      res.statusCode = 200;
+      res.end();
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${port}`,
+    requests,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+/** Decompress every PutLogs body for a logstore and join as one searchable string. */
+export function decodedTextFor(sls: MockSls, logstore: string): string {
+  return sls.requests
+    .filter((r) => r.logstore === logstore && r.rawSize > 0 && r.body.length > 0)
+    .map((r) => lz4DecompressBlock(r.body, r.rawSize).toString("utf8"))
+    .join(" ");
+}
+
+export async function waitForLogstore(
+  sls: MockSls,
+  logstore: string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (sls.requests.some((r) => r.logstore === logstore)) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`no PutLogs to logstore '${logstore}' within ${timeoutMs}ms`);
+}
+
+/** Poll until the decoded logstore text contains `token` (or time out). */
+export async function waitForToken(
+  sls: MockSls,
+  logstore: string,
+  token: string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (decodedTextFor(sls, logstore).includes(token)) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`token '${token}' not seen in logstore '${logstore}' within ${timeoutMs}ms`);
+}


### PR DESCRIPTION
## Problem

Two gaps in observability content capture (`content_mode = full`):

1. **/v1/responses and /v1/completions exported no content at all.** The SLS/Datadog/OTLP sinks write `prompt`/`response` only when the handler passes `CapturedContent` to `fan_out`, and both handlers passed `None` — so with "完整（提示词 + 响应）" selected, SLS received metadata only for Codex-style traffic. `/v1/chat/completions` and `/v1/messages` already captured correctly.
2. **Streaming capture buffers bypassed #932 PII masking.** On every streaming hold-back path, mask-action rules rewrote only the held wire bytes released to the client; the capture accumulator kept the raw pre-mask deltas, so a full-content exporter received PII the client never saw. The /v1/responses verbatim buffered path already captured post-redaction; the four siblings (chat BufferFull release, messages passthrough + bridge releases, responses bridge release) did not.

## Fix

**Content capture for /v1/responses + /v1/completions**, mirroring the chat/messages conventions (prompt = client-facing request JSON, response = client-visible output text, both post-redaction; blocked 422 responses capture nothing):

- /v1/responses verbatim non-streaming + buffered output-guardrail path — capture from the post-redaction body / SSE buffer.
- /v1/responses verbatim live-forward streaming — `build_responses_passthrough_stream` now accumulates output text side-channel (terminal `response.completed|incomplete|failed` full output preferred, cap-bounded delta fallback) and hands it to the Drop-guard emit alongside usage.
- /v1/responses cross-provider bridge (non-streaming + streaming) — `ResponsesStreamCompletion` gains a cap-bounded `response_text`.
- /v1/completions — capture from the post-redaction response body.

**Post-mask capture on all streaming hold-back paths**: new `redact::redact_captured_output` masks the capture accumulator in place at the same release point where the wire bytes are redacted (counts deliberately discarded — the wire-side redaction already tallied them). Applied at all four sites listed above.

LiteLLM baseline: its standard logging payload includes input + output content for both the Responses API and legacy text completions by default, so the capture scope matches the reference behavior.

## Tests

- `sls-content-capture-responses-completions-e2e.test.ts`: real `aisix` + etcd + mock SLS + mock upstreams; pins all four `/v1/responses` content paths + `/v1/completions` (full logstore receives planted prompt+response tokens; metadata_only receives none). Fails before the fix.
- `sls-content-capture-masked-e2e.test.ts`: streaming chat + streaming `/v1/responses` bridge with an email split across SSE deltas and a mask-action PII guardrail — the full logstore carries `[EMAIL_REDACTED]` and never the raw address. Fails before the fix.
- Mock-SLS helpers extracted to `tests/e2e/src/harness/sls-mock.ts` (shared with the existing #687 suite, unchanged behavior).
- Unit tests for the new `SseTextCapture` accumulator (terminal-preferred, delta fallback, cap bounding).

Fixes api7/AISIX-Cloud#947