### PR TITLE
test(etcd): de-collide watch_integration prefixes (pid + per-process seq)

### DIFF
--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -16,11 +16,20 @@ fn etcd_url() -> Option<String> {
 }
 
 fn unique_prefix() -> String {
+    // The timestamp alone is NOT unique: tests in this binary run
+    // concurrently, and a coarse CI clock can hand two of them the same
+    // nanosecond reading — their watches then share one prefix and each
+    // sees the other's events (observed as a flake: the single-put test
+    // received the batch test's `/batch/0`). A per-process counter
+    // disambiguates tests within the binary; the pid covers concurrent
+    // binaries against the same etcd.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or_default();
-    format!("/aisix-etcd-it/{nanos:x}")
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    format!("/aisix-etcd-it/{nanos:x}-{}-{seq}", std::process::id())
 }
 
 /// The core regression test for issue #237: after `watch()` returns,


### PR DESCRIPTION
CI flake seen on #695's `rust unit + coverage` job: `watch_stream_delivers_events_after_put` received the batch test's `/batch/0` event instead of its own `/models/watch-test` put.

Root cause: `unique_prefix()` derives the per-test etcd prefix from the `SystemTime` nanosecond reading alone. The three watch tests run concurrently in one binary, and a coarse CI clock can hand two of them the same reading — both providers then watch the SAME prefix, so each sees the other's events. The failure output shows both keys under one identical run-prefix (`/aisix-etcd-it/18be76822704dfe0/batch/0` vs `/aisix-etcd-it/18be76822704dfe0/models/watch-test`).

Fix: append `std::process::id()` + a per-process atomic sequence to the prefix, so concurrent tests (and concurrent test binaries sharing one etcd) can never collide. Verified locally against a real etcd (3 consecutive runs green).

Test-infra-only change — no product code touched.