### PR TITLE
fix(guardrails): make pii mask real on rerank/images/audio; scan+mask audio transcripts

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -427,16 +427,18 @@ async fn multipart_dispatch(
     let applied_guardrails = resolved_chain.applied().to_vec();
     let mut redactions = crate::redact::RedactionCounts::new();
     if !resolved_chain.is_empty() {
-        let prompt_text = fields
+        // EVERY `prompt` field: multipart allows repeated names and the form
+        // is rebuilt with all of them, so all are scanned — an empty first
+        // field must not skip a later one.
+        let prompt_messages: Vec<ChatMessage> = fields
             .iter()
-            .find(|(name, ..)| name == "prompt")
-            .and_then(|(.., data)| std::str::from_utf8(data).ok())
-            .unwrap_or("");
-        if !prompt_text.is_empty() {
-            let chat = aisix_gateway::ChatFormat::new(
-                &model_name,
-                vec![ChatMessage::user(prompt_text.to_string())],
-            );
+            .filter(|(name, ..)| name == "prompt")
+            .filter_map(|(.., data)| std::str::from_utf8(data).ok())
+            .filter(|s| !s.is_empty())
+            .map(|s| ChatMessage::user(s.to_string()))
+            .collect();
+        if !prompt_messages.is_empty() {
+            let chat = aisix_gateway::ChatFormat::new(&model_name, prompt_messages);
             if let aisix_guardrails::GuardrailVerdict::Block {
                 reason,
                 guardrail_name,
@@ -453,18 +455,18 @@ async fn multipart_dispatch(
                     crate::error::guardrail_block_message("request", guardrail_name.as_deref()),
                 ));
             }
-            if aisix_guardrails::Guardrail::redacts_input(&resolved_chain) {
-                for (name, _, _, data) in fields.iter_mut() {
-                    if name != "prompt" {
-                        continue;
-                    }
-                    if let Ok(text) = std::str::from_utf8(data) {
-                        if let Some(r) =
-                            aisix_guardrails::Guardrail::redact_input_text(&resolved_chain, text)
-                        {
-                            *data = Bytes::from(r.text.into_bytes());
-                            crate::redact::merge_counts(&mut redactions, r.counts);
-                        }
+        }
+        if aisix_guardrails::Guardrail::redacts_input(&resolved_chain) {
+            for (name, _, _, data) in fields.iter_mut() {
+                if name != "prompt" {
+                    continue;
+                }
+                if let Ok(text) = std::str::from_utf8(data) {
+                    if let Some(r) =
+                        aisix_guardrails::Guardrail::redact_input_text(&resolved_chain, text)
+                    {
+                        *data = Bytes::from(r.text.into_bytes());
+                        crate::redact::merge_counts(&mut redactions, r.counts);
                     }
                 }
             }
@@ -687,15 +689,24 @@ async fn multipart_dispatch(
 }
 
 /// The caller-visible transcript text for output-guardrail scanning (#696):
-/// the JSON `text` field (`json` / `verbose_json` response formats) or the
-/// raw body for the plain-text formats (`text` / `srt` / `vtt`).
+/// the JSON `text` field plus `segments[].text` (`json` / `verbose_json`
+/// response formats — segments are scanned too so a response carrying text
+/// only in segments can't bypass the check), or the raw body for the
+/// plain-text formats (`text` / `srt` / `vtt`).
 fn transcription_output_text(body: &[u8]) -> String {
     if let Ok(json) = serde_json::from_slice::<Value>(body) {
-        return json
-            .get("text")
-            .and_then(|t| t.as_str())
-            .unwrap_or_default()
-            .to_string();
+        let mut parts: Vec<&str> = Vec::new();
+        if let Some(t) = json.get("text").and_then(|t| t.as_str()) {
+            parts.push(t);
+        }
+        if let Some(segments) = json.get("segments").and_then(|s| s.as_array()) {
+            parts.extend(
+                segments
+                    .iter()
+                    .filter_map(|s| s.get("text").and_then(|t| t.as_str())),
+            );
+        }
+        return parts.join("\n");
     }
     String::from_utf8_lossy(body).into_owned()
 }

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -18,6 +18,7 @@
 //! proxy endpoint.
 
 use aisix_core::AppliedGuardrail;
+use aisix_gateway::{ChatMessage, ChatResponse, FinishReason, UsageStats};
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::body::Bytes;
 use axum::extract::{Multipart, State};
@@ -51,6 +52,19 @@ struct AudioDispatchSuccess {
     /// whisper-1 (no usage block) — those still emit a zero-token event
     /// so the request is visible + attributed.
     usage: Option<(u32, u32)>,
+    /// The `{kind, hook}` set of guardrails that governed this request
+    /// (#379 parity, wired with #696) — surfaced on the emitted UsageEvent.
+    applied_guardrails: Vec<AppliedGuardrail>,
+    /// Per-detector PII mask counts (#932/#696): the multipart `prompt`
+    /// field (input side) + the transcript (output side), merged. Attached
+    /// to the emitted UsageEvent. Empty = no redaction.
+    redactions: crate::redact::RedactionCounts,
+    /// #696: set when an OUTPUT guardrail blocked the transcript AFTER the
+    /// upstream billed for it. The response body is the redacted 422, but
+    /// `usage` keeps the billed counts so the UsageEvent (marked
+    /// `guardrail_blocked`) doesn't under-report spend — same convention as
+    /// completions #911 [23] / responses #543.
+    guardrail_blocked: bool,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -81,24 +95,35 @@ pub async fn transcriptions(
     {
         Ok(success) => {
             let elapsed = started.elapsed();
+            // Actual status, not a hardcoded 200 — the #696 billed-then-
+            // output-blocked path returns Ok(success) carrying a 422.
+            let status = success.response.status().as_u16();
             emit_access_log(
                 "POST",
                 "/v1/audio/transcriptions",
                 &success.model_name,
                 &success.provider,
                 &api_key_id,
-                200,
+                status,
                 elapsed,
                 &request_id,
             );
             state.metrics.record_request(
                 &success.provider,
                 &success.model_name,
-                200,
-                RequestOutcome::Success,
+                status,
+                RequestOutcome::from_status(status),
                 elapsed,
             );
-            emit_audio_usage(&state, &request_id, &success, &api_key_id, elapsed, &client);
+            emit_audio_usage(
+                &state,
+                &request_id,
+                &success,
+                &api_key_id,
+                status,
+                elapsed,
+                &client,
+            );
             success.response
         }
         Err(err) => {
@@ -167,24 +192,35 @@ pub async fn translations(
     {
         Ok(success) => {
             let elapsed = started.elapsed();
+            // Actual status, not a hardcoded 200 — the #696 billed-then-
+            // output-blocked path returns Ok(success) carrying a 422.
+            let status = success.response.status().as_u16();
             emit_access_log(
                 "POST",
                 "/v1/audio/translations",
                 &success.model_name,
                 &success.provider,
                 &api_key_id,
-                200,
+                status,
                 elapsed,
                 &request_id,
             );
             state.metrics.record_request(
                 &success.provider,
                 &success.model_name,
-                200,
-                RequestOutcome::Success,
+                status,
+                RequestOutcome::from_status(status),
                 elapsed,
             );
-            emit_audio_usage(&state, &request_id, &success, &api_key_id, elapsed, &client);
+            emit_audio_usage(
+                &state,
+                &request_id,
+                &success,
+                &api_key_id,
+                status,
+                elapsed,
+                &client,
+            );
             success.response
         }
         Err(err) => {
@@ -244,7 +280,7 @@ pub async fn speech(
         .to_string();
 
     match speech_dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
-        Ok((resp, provider, model_id, provider_key_id, applied_guardrails)) => {
+        Ok((resp, provider, model_id, provider_key_id, applied_guardrails, redactions)) => {
             let elapsed = started.elapsed();
             emit_access_log(
                 "POST",
@@ -281,6 +317,8 @@ pub async fn speech(
                 0,
                 0,
                 &client,
+                redactions,
+                /* guardrail_blocked */ false,
             );
             resp
         }
@@ -374,6 +412,64 @@ async fn multipart_dispatch(
 
     // Client-IP allowlist gate (#557): reject before quota / upstream.
     crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+
+    // #696: transcriptions/translations run the guardrail chain too. The
+    // audio bytes aren't scannable text, but the optional `prompt` form
+    // field IS caller text forwarded verbatim to the provider — scan it
+    // (input hook, before the reservation per #542) and mask it (#932).
+    // The transcript RESPONSE is scanned/masked after the upstream call.
+    let guardrail_ctx = aisix_guardrails::RequestContext {
+        model_id: &model_entry.id,
+        api_key_id: &auth.entry.id,
+        team_id: auth.key().team_id.as_deref(),
+    };
+    let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
+    let applied_guardrails = resolved_chain.applied().to_vec();
+    let mut redactions = crate::redact::RedactionCounts::new();
+    if !resolved_chain.is_empty() {
+        let prompt_text = fields
+            .iter()
+            .find(|(name, ..)| name == "prompt")
+            .and_then(|(.., data)| std::str::from_utf8(data).ok())
+            .unwrap_or("");
+        if !prompt_text.is_empty() {
+            let chat = aisix_gateway::ChatFormat::new(
+                &model_name,
+                vec![ChatMessage::user(prompt_text.to_string())],
+            );
+            if let aisix_guardrails::GuardrailVerdict::Block {
+                reason,
+                guardrail_name,
+            } = aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+            {
+                // Per #153 the matched-pattern detail stays in ops logs only.
+                tracing::warn!(
+                    guardrail_hook = "input",
+                    model = %model_name,
+                    reason = %reason,
+                    "guardrail blocked audio request (prompt field)",
+                );
+                return Err(ProxyError::ContentFiltered(
+                    crate::error::guardrail_block_message("request", guardrail_name.as_deref()),
+                ));
+            }
+            if aisix_guardrails::Guardrail::redacts_input(&resolved_chain) {
+                for (name, _, _, data) in fields.iter_mut() {
+                    if name != "prompt" {
+                        continue;
+                    }
+                    if let Ok(text) = std::str::from_utf8(data) {
+                        if let Some(r) =
+                            aisix_guardrails::Guardrail::redact_input_text(&resolved_chain, text)
+                        {
+                            *data = Bytes::from(r.text.into_bytes());
+                            crate::redact::merge_counts(&mut redactions, r.counts);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
@@ -517,6 +613,64 @@ async fn multipart_dispatch(
         .unwrap_or(0);
     reservation.commit_tokens(total_tokens).await;
 
+    // #696: run the output guardrail chain on the transcript — it is
+    // caller-visible model output, scanned like chat's replies. Pre-fix an
+    // output block/mask enforced on /v1/chat/completions was bypassable by
+    // transcribing audio. The upstream already billed (tokens committed
+    // above), so a block returns the redacted 422 while keeping the billed
+    // usage marked `guardrail_blocked` — same as completions #911 [23].
+    if aisix_guardrails::Guardrail::runs_on_output(&resolved_chain) {
+        let transcript = transcription_output_text(&body_bytes);
+        if !transcript.is_empty() {
+            let synth = ChatResponse {
+                id: String::new(),
+                model: model_name.clone(),
+                message: ChatMessage::assistant(transcript),
+                finish_reason: FinishReason::Stop,
+                usage: UsageStats::default(),
+            };
+            if let aisix_guardrails::GuardrailVerdict::Block {
+                reason,
+                guardrail_name,
+            } = aisix_guardrails::Guardrail::check_output(&resolved_chain, &synth).await
+            {
+                // Per #153 the matched-pattern detail stays in ops logs only.
+                tracing::warn!(
+                    guardrail_hook = "output",
+                    model = %model_name,
+                    reason = %reason,
+                    "guardrail blocked audio transcript response",
+                );
+                return Ok(AudioDispatchSuccess {
+                    response: ProxyError::ContentFiltered(crate::error::guardrail_block_message(
+                        "response",
+                        guardrail_name.as_deref(),
+                    ))
+                    .into_response(),
+                    model_name,
+                    provider: provider_label,
+                    model_id: model_entry.id.to_string(),
+                    provider_key_id: pk_entry.id.to_string(),
+                    usage,
+                    applied_guardrails,
+                    redactions,
+                    guardrail_blocked: true,
+                });
+            }
+        }
+    }
+
+    // #932/#696: mask-action PII rules rewrite the transcript AFTER the
+    // block check passes, BEFORE it reaches the caller.
+    let body_bytes =
+        match crate::redact::redact_transcription_response(&resolved_chain, &body_bytes) {
+            Some((rewritten, counts)) => {
+                crate::redact::merge_counts(&mut redactions, counts);
+                Bytes::from(rewritten)
+            }
+            None => body_bytes,
+        };
+
     let mut out = axum::response::Response::new(axum::body::Body::from(body_bytes));
     copy_response_header(&upstream_headers, &mut out, header::CONTENT_TYPE);
     Ok(AudioDispatchSuccess {
@@ -526,7 +680,24 @@ async fn multipart_dispatch(
         model_id: model_entry.id.to_string(),
         provider_key_id: pk_entry.id.to_string(),
         usage,
+        applied_guardrails,
+        redactions,
+        guardrail_blocked: false,
     })
+}
+
+/// The caller-visible transcript text for output-guardrail scanning (#696):
+/// the JSON `text` field (`json` / `verbose_json` response formats) or the
+/// raw body for the plain-text formats (`text` / `srt` / `vtt`).
+fn transcription_output_text(body: &[u8]) -> String {
+    if let Ok(json) = serde_json::from_slice::<Value>(body) {
+        return json
+            .get("text")
+            .and_then(|t| t.as_str())
+            .unwrap_or_default()
+            .to_string();
+    }
+    String::from_utf8_lossy(body).into_owned()
 }
 
 /// JSON passthrough for `/v1/audio/speech` — returns binary audio bytes.
@@ -542,13 +713,24 @@ fn speech_input_to_chat(model: &str, body: &Value) -> aisix_gateway::ChatFormat 
     aisix_gateway::ChatFormat::new(model, messages)
 }
 
+#[allow(clippy::type_complexity)]
 async fn speech_dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
     mut body: Value,
     request_id: &str,
     source_ip: &str,
-) -> Result<(Response, String, String, String, Vec<AppliedGuardrail>), ProxyError> {
+) -> Result<
+    (
+        Response,
+        String,
+        String,
+        String,
+        Vec<AppliedGuardrail>,
+        crate::redact::RedactionCounts,
+    ),
+    ProxyError,
+> {
     let model_name = body
         .get("model")
         .and_then(|v| v.as_str())
@@ -600,6 +782,11 @@ async fn speech_dispatch(
             ));
         }
     }
+
+    // #932/#696: mask-action PII rules rewrite the `input` text in place
+    // AFTER the block check passes, BEFORE the body is forwarded upstream.
+    // Pre-#696 a mask-action detector was a silent no-op here.
+    let redactions = crate::redact::redact_speech_request(&resolved_chain, &mut body);
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
@@ -730,6 +917,7 @@ async fn speech_dispatch(
         model_entry.id.to_string(),
         pk_entry.id.to_string(),
         applied_guardrails,
+        redactions,
     ))
 }
 
@@ -757,12 +945,11 @@ fn emit_audio_usage(
     request_id: &str,
     success: &AudioDispatchSuccess,
     api_key_id: &str,
+    status: u16,
     elapsed: Duration,
     client: &ClientContext,
 ) {
     let (prompt_tokens, completion_tokens) = success.usage.unwrap_or((0, 0));
-    // Transcriptions/translations (multipart) don't run input guardrails — the
-    // audio bytes aren't scannable text — so no applied set to record here.
     emit_usage_event(
         state,
         request_id,
@@ -770,12 +957,14 @@ fn emit_audio_usage(
         &success.model_name,
         api_key_id,
         &success.provider_key_id,
-        &[],
-        200,
+        &success.applied_guardrails,
+        status,
         elapsed,
         prompt_tokens,
         completion_tokens,
         client,
+        success.redactions.clone(),
+        success.guardrail_blocked,
     );
 }
 
@@ -800,6 +989,10 @@ fn emit_usage_event(
     prompt_tokens: u32,
     completion_tokens: u32,
     client: &ClientContext,
+    // Per-detector PII mask counts (#932/#696). Empty = no redaction.
+    redacted_entity_counts: crate::redact::RedactionCounts,
+    // #696: transcript blocked by an output guardrail after upstream billing.
+    guardrail_blocked: bool,
 ) {
     let snap = state.snapshot.load();
     let mut event = UsageEvent {
@@ -816,6 +1009,8 @@ fn emit_usage_event(
         applied_guardrails: applied_guardrails.to_vec(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
+        redacted_entity_counts,
+        guardrail_blocked,
         ..Default::default()
     };
     // Per-PK telemetry attribution, same lookup as chat / messages /
@@ -1543,5 +1738,249 @@ mod tests {
             .unwrap();
         let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    fn pii_guardrail(hook: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"pii","enabled":true,"hook_point":"{hook}","kind":"pii","detectors":[{{"type":"email","action":"mask"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-pii", g, 1)
+    }
+
+    fn keyword_output_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"t-out","enabled":true,"hook_point":"output","fail_open":false,"kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-out", g, 1)
+    }
+
+    /// Multipart body carrying `model` + an optional text `prompt` field +
+    /// a tiny fake audio `file` — for the #696 prompt-field guardrail tests.
+    fn transcription_multipart_with_prompt(
+        model: &str,
+        prompt: &str,
+    ) -> (String, axum::body::Body) {
+        let body = format!(
+            "--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n{model}\r\n\
+             --b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\n{prompt}\r\n\
+             --b\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.mp3\"\r\n\
+             Content-Type: audio/mpeg\r\n\r\nID3fakeaudio\r\n--b--\r\n"
+        );
+        (
+            "multipart/form-data; boundary=b".to_string(),
+            axum::body::Body::from(body),
+        )
+    }
+
+    /// #696: a mask-action PII detector must rewrite the TTS `input` text
+    /// before the body reaches the upstream. Pre-#696 the mask action was a
+    /// silent no-op on /v1/audio/speech.
+    #[tokio::test]
+    async fn speech_pii_mask_rewrites_input_before_upstream_issue_696() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"fakeaudio".to_vec()))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(tts_model("my-tts"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(pii_guardrail("input"));
+
+        let app = build_app(snap);
+        let body = serde_json::json!({
+            "model": "my-tts",
+            "input": "read out a@x.com please",
+            "voice": "alloy"
+        });
+        let resp = tower::ServiceExt::oneshot(app, speech_req(&body.to_string()))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let reqs = upstream.received_requests().await.unwrap();
+        let sent = String::from_utf8_lossy(&reqs[0].body).into_owned();
+        assert!(sent.contains("[EMAIL_REDACTED]"), "sent: {sent}");
+        assert!(
+            !sent.contains("a@x.com"),
+            "raw PII forwarded upstream: {sent}"
+        );
+    }
+
+    /// #696: the transcription `prompt` form field is caller text forwarded
+    /// verbatim — an input guardrail must scan it. A blocked literal returns
+    /// 422 and the upstream is never contacted.
+    #[tokio::test]
+    async fn transcription_prompt_field_input_guardrail_blocks_issue_696() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"text":"x"})))
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-whisper"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let app = build_app(snap);
+        let (ct, body) = transcription_multipart_with_prompt("my-whisper", "please BLOCKME now");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    /// #696: a mask-action PII detector must rewrite the transcription
+    /// `prompt` form field before the form is forwarded upstream.
+    #[tokio::test]
+    async fn transcription_prompt_field_pii_masked_before_upstream_issue_696() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"text":"x"})))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-whisper"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(pii_guardrail("input"));
+
+        let app = build_app(snap);
+        let (ct, body) =
+            transcription_multipart_with_prompt("my-whisper", "the speaker is a@x.com");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let reqs = upstream.received_requests().await.unwrap();
+        let sent = String::from_utf8_lossy(&reqs[0].body).into_owned();
+        assert!(sent.contains("[EMAIL_REDACTED]"), "sent: {sent}");
+        assert!(
+            !sent.contains("a@x.com"),
+            "raw PII forwarded upstream: {sent}"
+        );
+    }
+
+    /// #696: a mask-action PII detector on the OUTPUT hook must rewrite the
+    /// transcript text before it reaches the caller. Pre-#696 the transcript
+    /// was returned raw. Counts must land on the emitted UsageEvent.
+    #[tokio::test]
+    async fn transcription_output_pii_masked_issue_696() {
+        let upstream = MockServer::start().await;
+        let body = serde_json::json!({
+            "text": "my address is a@x.com thanks",
+            "usage": {"type": "tokens", "input_tokens": 9, "output_tokens": 6, "total_tokens": 15}
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-whisper"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(pii_guardrail("output"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = transcription_multipart("my-whisper");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let text = v["text"].as_str().unwrap();
+        assert!(text.contains("[EMAIL_REDACTED]"), "client got: {text}");
+        assert!(
+            !text.contains("a@x.com"),
+            "raw PII reached the caller: {text}"
+        );
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.redacted_entity_counts.get("email"), Some(&1));
+    }
+
+    /// #696: an OUTPUT keyword guardrail must block a transcript carrying a
+    /// blocked literal — the caller gets the 422 content_filter envelope,
+    /// but the UsageEvent keeps the billed tokens marked guardrail_blocked
+    /// (the upstream already charged for the transcription) — same
+    /// convention as completions #911 [23].
+    #[tokio::test]
+    async fn transcription_output_guardrail_blocks_with_billed_usage_issue_696() {
+        let upstream = MockServer::start().await;
+        let body = serde_json::json!({
+            "text": "the secret word is BLOCKME",
+            "usage": {"type": "tokens", "input_tokens": 21, "output_tokens": 7, "total_tokens": 28}
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-whisper"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = transcription_multipart("my-whisper");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        assert!(!v["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("BLOCKME"));
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted for the billed-then-blocked transcript")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.status_code, 422);
+        assert!(event.guardrail_blocked, "event must be marked blocked");
+        assert_eq!(event.prompt_tokens, 21, "billed tokens must be kept");
+        assert_eq!(event.completion_tokens, 7);
     }
 }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -51,6 +51,9 @@ struct ImageDispatchSuccess {
     /// not-implemented path stays out of /logs (same convention as
     /// embeddings #402).
     upstream_called: bool,
+    /// Per-detector PII mask counts (#932/#696) applied to the prompt.
+    /// Attached to the emitted UsageEvent. Empty = no redaction.
+    redactions: crate::redact::RedactionCounts,
 }
 
 pub async fn image_generations(
@@ -110,6 +113,7 @@ pub async fn image_generations(
                     prompt_tokens,
                     completion_tokens,
                     &client,
+                    success.redactions.clone(),
                 );
             }
             success.response
@@ -165,14 +169,18 @@ fn images_input_to_chat(model: &str, body: &Value) -> aisix_gateway::ChatFormat 
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
-    body: Value,
+    mut body: Value,
     request_id: &str,
     source_ip: &str,
 ) -> Result<ImageDispatchSuccess, ProxyError> {
+    // Owned so the #696 in-place prompt masking below can borrow `body`
+    // mutably.
     let model_name = body
         .get("model")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| ProxyError::InvalidRequest("missing `model` field".into()))?;
+        .ok_or_else(|| ProxyError::InvalidRequest("missing `model` field".into()))?
+        .to_string();
+    let model_name = model_name.as_str();
 
     let snapshot = state.snapshot.load();
 
@@ -221,6 +229,11 @@ async fn dispatch(
             ));
         }
     }
+
+    // #932/#696: mask-action PII rules rewrite the `prompt` in place AFTER
+    // the block check passes, BEFORE the body is forwarded upstream.
+    // Pre-#696 a mask-action detector was a silent no-op here.
+    let redactions = crate::redact::redact_images_request(&resolved_chain, &mut body);
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(model_name, &model_entry.id, &model_entry.value);
@@ -283,6 +296,7 @@ async fn dispatch(
                 applied_guardrails: applied_guardrails.clone(),
                 usage,
                 upstream_called: true,
+                redactions,
             })
         }
         Err(BridgeError::Config(msg)) if msg.contains("does not support image generation") => {
@@ -298,6 +312,7 @@ async fn dispatch(
                 usage: None,
                 // No upstream call happened → handler skips emit.
                 upstream_called: false,
+                redactions,
             })
         }
         Err(e) => {
@@ -348,6 +363,8 @@ fn emit_usage_event(
     prompt_tokens: u32,
     completion_tokens: u32,
     client: &ClientContext,
+    // Per-detector PII mask counts (#932/#696). Empty = no redaction.
+    redacted_entity_counts: crate::redact::RedactionCounts,
 ) {
     let snap = state.snapshot.load();
     let mut event = UsageEvent {
@@ -364,6 +381,7 @@ fn emit_usage_event(
         applied_guardrails: applied_guardrails.to_vec(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
+        redacted_entity_counts,
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, &snap, provider_key_id);
@@ -1036,6 +1054,64 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "exactly one event per failed request"
+        );
+    }
+
+    fn pii_mask_guardrail() -> ResourceEntry<aisix_core::Guardrail> {
+        let json = r#"{"name":"pii","enabled":true,"hook_point":"input","kind":"pii","detectors":[{"type":"email","action":"mask"}]}"#;
+        let g: aisix_core::Guardrail = serde_json::from_str(json).unwrap();
+        ResourceEntry::new("g-pii", g, 1)
+    }
+
+    /// #696: a mask-action PII detector must rewrite the `prompt` before the
+    /// body reaches the upstream. Pre-#696 the mask action was a silent
+    /// no-op on /v1/images/generations — the raw text was forwarded. Also
+    /// pins the counts on the emitted UsageEvent.
+    #[tokio::test]
+    async fn pii_mask_rewrites_prompt_before_upstream_issue_696() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "created": 1_700_000_000,
+                "data": [{"url": "https://img.example/1.png"}]
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("img"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(pii_mask_guardrail());
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let body = serde_json::json!({
+            "model": "img",
+            "prompt": "a portrait of a@x.com at sunset"
+        });
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let reqs = upstream.received_requests().await.unwrap();
+        let sent = String::from_utf8_lossy(&reqs[0].body).into_owned();
+        assert!(sent.contains("[EMAIL_REDACTED]"), "sent: {sent}");
+        assert!(
+            !sent.contains("a@x.com"),
+            "raw PII forwarded upstream: {sent}"
+        );
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(
+            event.redacted_entity_counts.get("email"),
+            Some(&1),
+            "mask counts must reach the UsageEvent"
         );
     }
 }

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -397,6 +397,98 @@ pub fn redact_completions_request(chain: &dyn Guardrail, body: &mut Value) -> Re
     counts
 }
 
+/// Mask a `/v1/rerank` request body in place: `query` plus `documents[]`
+/// (plain strings or `{"text": ...}` objects) — the same surface
+/// `check_input` scans via `rerank_input_to_chat` (#696).
+pub fn redact_rerank_request(chain: &dyn Guardrail, body: &mut Value) -> RedactionCounts {
+    let mut counts = RedactionCounts::new();
+    if !chain.redacts_input() {
+        return counts;
+    }
+    if let Some(q) = body.get_mut("query") {
+        apply_to_value_string(chain, Direction::Input, q, &mut counts);
+    }
+    if let Some(Value::Array(docs)) = body.get_mut("documents") {
+        for doc in docs {
+            match doc {
+                Value::String(_) => {
+                    apply_to_value_string(chain, Direction::Input, doc, &mut counts)
+                }
+                Value::Object(_) => {
+                    if let Some(text) = doc.get_mut("text") {
+                        apply_to_value_string(chain, Direction::Input, text, &mut counts);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    counts
+}
+
+/// Mask a `/v1/images/generations` request body in place: the `prompt`
+/// field — the same surface `check_input` scans via `images_input_to_chat`
+/// (#696).
+pub fn redact_images_request(chain: &dyn Guardrail, body: &mut Value) -> RedactionCounts {
+    let mut counts = RedactionCounts::new();
+    if !chain.redacts_input() {
+        return counts;
+    }
+    if let Some(p) = body.get_mut("prompt") {
+        apply_to_value_string(chain, Direction::Input, p, &mut counts);
+    }
+    counts
+}
+
+/// Mask a `/v1/audio/speech` request body in place: the `input` field (the
+/// text to synthesize) — the same surface `check_input` scans via
+/// `speech_input_to_chat` (#696).
+pub fn redact_speech_request(chain: &dyn Guardrail, body: &mut Value) -> RedactionCounts {
+    let mut counts = RedactionCounts::new();
+    if !chain.redacts_input() {
+        return counts;
+    }
+    if let Some(input) = body.get_mut("input") {
+        apply_to_value_string(chain, Direction::Input, input, &mut counts);
+    }
+    counts
+}
+
+/// Mask an audio transcription/translation RESPONSE in place (#696). The
+/// wire body is either JSON (`json` / `verbose_json` response_format:
+/// top-level `text` + per-segment `segments[].text`) or raw text
+/// (`text` / `srt` / `vtt` formats). Returns the rewritten bytes + counts,
+/// or `None` when nothing matched (caller keeps the original body). A
+/// non-UTF-8 body is left untouched.
+pub fn redact_transcription_response(
+    chain: &dyn Guardrail,
+    body: &[u8],
+) -> Option<(Vec<u8>, RedactionCounts)> {
+    if !chain.redacts_output() {
+        return None;
+    }
+    let mut counts = RedactionCounts::new();
+    if let Ok(mut json) = serde_json::from_slice::<Value>(body) {
+        if let Some(text) = json.get_mut("text") {
+            apply_to_value_string(chain, Direction::Output, text, &mut counts);
+        }
+        if let Some(Value::Array(segments)) = json.get_mut("segments") {
+            for seg in segments {
+                if let Some(text) = seg.get_mut("text") {
+                    apply_to_value_string(chain, Direction::Output, text, &mut counts);
+                }
+            }
+        }
+        if counts.is_empty() {
+            return None;
+        }
+        return serde_json::to_vec(&json).ok().map(|b| (b, counts));
+    }
+    let text = std::str::from_utf8(body).ok()?;
+    let r = chain.redact_output_text(text)?;
+    Some((r.text.into_bytes(), r.counts))
+}
+
 /// Mask a legacy `/v1/completions` RESPONSE body in place: `choices[].text`.
 pub fn redact_completions_response(chain: &dyn Guardrail, body: &mut Value) -> RedactionCounts {
     let mut counts = RedactionCounts::new();
@@ -1381,5 +1473,71 @@ mod tests {
         redact_json_encoded(chain.as_ref(), Direction::Output, &mut encoded, &mut counts);
         assert_eq!(encoded, "not json but has [EMAIL_REDACTED] inside");
         assert_eq!(counts.get("email"), Some(&1));
+    }
+
+    /// #696: rerank request masking covers `query` + both document shapes.
+    #[test]
+    fn rerank_request_masks_query_and_documents() {
+        let chain = both();
+        let mut body = json!({
+            "model": "m",
+            "query": "who is a@x.com",
+            "documents": ["contact b@y.org", {"text": "reach c@z.io"}, 42]
+        });
+        let counts = redact_rerank_request(chain.as_ref(), &mut body);
+        assert_eq!(body["query"], "who is [EMAIL_REDACTED]");
+        assert_eq!(body["documents"][0], "contact [EMAIL_REDACTED]");
+        assert_eq!(body["documents"][1]["text"], "reach [EMAIL_REDACTED]");
+        assert_eq!(counts.get("email"), Some(&3));
+    }
+
+    /// #696: images request masking covers `prompt`.
+    #[test]
+    fn images_request_masks_prompt() {
+        let chain = both();
+        let mut body = json!({"model": "m", "prompt": "portrait of a@x.com"});
+        let counts = redact_images_request(chain.as_ref(), &mut body);
+        assert_eq!(body["prompt"], "portrait of [EMAIL_REDACTED]");
+        assert_eq!(counts.get("email"), Some(&1));
+    }
+
+    /// #696: speech (TTS) request masking covers `input`.
+    #[test]
+    fn speech_request_masks_input() {
+        let chain = both();
+        let mut body = json!({"model": "m", "input": "read a@x.com aloud", "voice": "alloy"});
+        let counts = redact_speech_request(chain.as_ref(), &mut body);
+        assert_eq!(body["input"], "read [EMAIL_REDACTED] aloud");
+        assert_eq!(counts.get("email"), Some(&1));
+    }
+
+    /// #696: transcription response masking rewrites the JSON `text` +
+    /// `segments[].text` (verbose_json) and reports counts.
+    #[test]
+    fn transcription_response_masks_json_text_and_segments() {
+        let chain = both();
+        let body = json!({
+            "text": "mail a@x.com",
+            "segments": [{"id": 0, "text": "mail a@x.com"}]
+        });
+        let (rewritten, counts) =
+            redact_transcription_response(chain.as_ref(), &serde_json::to_vec(&body).unwrap())
+                .expect("must rewrite");
+        let v: Value = serde_json::from_slice(&rewritten).unwrap();
+        assert_eq!(v["text"], "mail [EMAIL_REDACTED]");
+        assert_eq!(v["segments"][0]["text"], "mail [EMAIL_REDACTED]");
+        assert_eq!(counts.get("email"), Some(&2));
+    }
+
+    /// #696: the raw-text response formats (`text` / `srt` / `vtt`) are
+    /// masked as plain text; a clean body returns None (kept as-is).
+    #[test]
+    fn transcription_response_masks_raw_text_formats() {
+        let chain = both();
+        let (rewritten, counts) =
+            redact_transcription_response(chain.as_ref(), b"speaker: a@x.com\n").expect("rewrite");
+        assert_eq!(rewritten, b"speaker: [EMAIL_REDACTED]\n");
+        assert_eq!(counts.get("email"), Some(&1));
+        assert!(redact_transcription_response(chain.as_ref(), b"all clean\n").is_none());
     }
 }

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -44,6 +44,9 @@ struct RerankDispatchSuccess {
     /// or a wire shape this gateway doesn't yet support). Handler
     /// gates UsageEvent emission on this being `Some`.
     usage: Option<RerankUsage>,
+    /// Per-detector PII mask counts (#932/#696) applied to the request.
+    /// Attached to the emitted UsageEvent. Empty = no redaction.
+    redactions: crate::redact::RedactionCounts,
 }
 
 /// Rerank has no completion side — only the input (query + docs)
@@ -114,6 +117,7 @@ pub async fn rerank(
                     elapsed,
                     &usage,
                     &client,
+                    success.redactions.clone(),
                 );
             }
             success.response
@@ -240,6 +244,11 @@ async fn dispatch(
             ));
         }
     }
+
+    // #932/#696: mask-action PII rules rewrite `query` + `documents[]` in
+    // place AFTER the block check passes, BEFORE the body is forwarded
+    // upstream. Pre-#696 a mask-action detector was a silent no-op here.
+    let redactions = crate::redact::redact_rerank_request(&resolved_chain, body);
 
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&model_name, &model_entry.id, &model_entry.value);
@@ -465,6 +474,7 @@ async fn dispatch(
         provider_key_id: pk_entry.id.to_string(),
         applied_guardrails: applied_guardrails.clone(),
         usage,
+        redactions,
     })
 }
 
@@ -525,6 +535,8 @@ fn emit_usage_event(
     elapsed: Duration,
     usage: &RerankUsage,
     client: &ClientContext,
+    // Per-detector PII mask counts (#932/#696). Empty = no redaction.
+    redacted_entity_counts: crate::redact::RedactionCounts,
 ) {
     let snap = state.snapshot.load();
     let mut event = UsageEvent {
@@ -540,6 +552,7 @@ fn emit_usage_event(
         applied_guardrails: applied_guardrails.to_vec(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
+        redacted_entity_counts,
         ..Default::default()
     };
     // Per-PK attribution tags (provider_kind / provider_featured /
@@ -1631,5 +1644,69 @@ mod tests {
         // The mock only matches when both the injected body field and header
         // are present — a 200 proves the PK request overrides were applied.
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    fn pii_mask_guardrail() -> ResourceEntry<aisix_core::Guardrail> {
+        let json = r#"{"name":"pii","enabled":true,"hook_point":"input","kind":"pii","detectors":[{"type":"email","action":"mask"}]}"#;
+        let g: aisix_core::Guardrail = serde_json::from_str(json).unwrap();
+        ResourceEntry::new("g-pii", g, 1)
+    }
+
+    /// #696: a mask-action PII detector must rewrite `query` + `documents[]`
+    /// (plain strings AND `{text}` objects) before the body reaches the
+    /// upstream. Pre-#696 the mask action was a silent no-op on /v1/rerank —
+    /// the raw text was forwarded. Also pins the counts on the UsageEvent.
+    #[tokio::test]
+    async fn pii_mask_rewrites_query_and_documents_before_upstream_issue_696() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/rerank"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "results": [],
+                "usage": {"total_tokens": 3}
+            })))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(openai_model("rr"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(pii_mask_guardrail());
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(aisix_obs::UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let body = serde_json::json!({
+            "model": "rr",
+            "query": "who is a@x.com",
+            "documents": ["contact b@y.org now", {"text": "reach c@z.io"}]
+        });
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let reqs = upstream.received_requests().await.unwrap();
+        let sent = String::from_utf8_lossy(&reqs[0].body).into_owned();
+        assert!(sent.contains("[EMAIL_REDACTED]"), "sent: {sent}");
+        for raw in ["a@x.com", "b@y.org", "c@z.io"] {
+            assert!(!sent.contains(raw), "raw PII forwarded upstream: {sent}");
+        }
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(
+            event.redacted_entity_counts.get("email"),
+            Some(&3),
+            "mask counts must reach the UsageEvent"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Audit finding #696 (parent: api7/AISIX-Cloud#950). A `kind: pii` detector configured with the **mask** action was a silent no-op on `/v1/rerank`, `/v1/images/generations` and `/v1/audio/*`: `check_input` ran (so **block** worked), but no `redact_*` call existed on these handlers, so the raw matched text was forwarded upstream with no error and no counts. The audio transcript **response** additionally bypassed output guardrails entirely — an output block/mask enforced on `/v1/chat/completions` was escapable by transcribing audio.

## Fix

- `redact.rs`: four new helpers — `redact_rerank_request` (`query` + `documents[]`, plain-string and `{text}` shapes), `redact_images_request` (`prompt`), `redact_speech_request` (`input`), `redact_transcription_response` (JSON `text` + `segments[].text`, or the raw `text`/`srt`/`vtt` body).
- rerank / images / speech: mask in place after the input block check (same #932 ordering as embeddings), counts threaded onto the emitted UsageEvent's `redacted_entity_counts`.
- transcriptions / translations: the multipart `prompt` form field (caller text forwarded verbatim, previously unscanned) now runs the input chain — block + mask; the transcript response runs the output chain — a block returns the standard 422 `content_filter` envelope while keeping the billed usage marked `guardrail_blocked` (the completions #911 [23] convention: the upstream already charged for the transcription), and mask rewrites the transcript before the caller sees it. `applied_guardrails` is now recorded on these events (#379 parity).
- The transcription/translation handlers now log/emit the actual response status (the billed-then-blocked path is a 422, previously hardcoded 200).

LiteLLM baseline: presidio-based PII masking in LiteLLM applies through pre/post-call hooks across call types (embedding, transcription, image generation included), so enforcing mask semantics on these endpoints matches the reference behavior.

## Tests

- Handler-level (wiremock, real router): masked text asserted **on the upstream-received body** for rerank (query + both document shapes) / images / speech / transcription-prompt-field; transcript output mask asserted on the client response; prompt-field block (422, upstream never contacted); output block keeps billed tokens + `guardrail_blocked` on the UsageEvent. Verified fail-before/pass-after (wiring removed → test fails).
- Unit tests for the four new redact helpers.

Fixes #696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PII masking support for audio, image, and rerank requests.
  * Audio transcription and translation responses can now be filtered when guardrails block content.
  * Audio and image usage reporting now includes redaction counts.

* **Bug Fixes**
  * Audio endpoints now report the correct upstream HTTP status instead of always showing success.
  * Transcription responses now handle both structured and plain-text formats more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->