### PR TITLE
fix(health): mark cooldown on completions/embeddings/images/passthrough failures

### DIFF
--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -300,6 +300,10 @@ async fn dispatch(
 
     match bridge.complete(&body, &ctx).await {
         Ok(resp_json) => {
+            // #701: clear any cooldown/unhealthy mark now the upstream
+            // answered — same recovery signal as rerank/audio/chat.
+            state.health.record_success(model_name);
+            state.runtime_status.mark_healthy(&model_entry.id);
             // Extract usage BEFORE moving resp_json into the Response
             // so the success struct carries typed counters rather
             // than re-parsing JSON downstream.
@@ -421,6 +425,16 @@ async fn dispatch(
         }
         Err(e) => {
             reservation.commit_tokens(0).await;
+            // #701: mark the failure on the runtime status so the cooldown /
+            // circuit-breaker sees flapping upstreams reached only via this
+            // endpoint — same policy as rerank/audio/chat. `note_failure` is
+            // a no-op for non-triggering categories (e.g. Config errors).
+            let e = crate::cooldown::note_failure(
+                &state.runtime_status,
+                &model_entry.id,
+                model.cooldown.as_ref(),
+                e,
+            );
             Err(ProxyError::Bridge(e))
         }
     }
@@ -1225,5 +1239,41 @@ mod tests {
         assert!(ev.provider_featured);
         assert_eq!(ev.branded_provider, "openai");
         assert_eq!(ev.pk_label, "prod-completions-key");
+    }
+
+    /// #701: an upstream 5xx must mark the model's runtime status (cooldown)
+    /// so a flapping upstream reached only via /v1/completions trips the
+    /// circuit breaker like rerank/audio/chat. Pre-#701 the status stayed
+    /// Healthy.
+    #[tokio::test]
+    async fn upstream_5xx_marks_cooldown_issue_701() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/completions"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("instruct"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg()).without_cache();
+        let app = crate::build_router(state.clone());
+
+        let body = serde_json::json!({"model": "instruct", "prompt": "x"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+        let status = state.runtime_status.status("m-1");
+        assert!(
+            status.cooldown_until.is_some(),
+            "a 500 must mark the model in cooldown, got {status:?}"
+        );
     }
 }

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -371,6 +371,10 @@ async fn dispatch(
 
     match bridge.embed(&req, &ctx).await {
         Ok(embed_resp) => {
+            // #701: clear any cooldown/unhealthy mark now the upstream
+            // answered — same recovery signal as rerank/audio/chat.
+            state.health.record_success(&body.model);
+            state.runtime_status.mark_healthy(&model_entry.id);
             // Commit the reservation — release the concurrency permit
             // and finalise RPM. Embeddings do report prompt_tokens via
             // EmbeddingResponse.usage; thread it through so TPM works
@@ -420,6 +424,16 @@ async fn dispatch(
         }
         Err(e) => {
             reservation.commit_tokens(0).await;
+            // #701: mark the failure on the runtime status so the cooldown /
+            // circuit-breaker sees flapping upstreams reached only via this
+            // endpoint — same policy as rerank/audio/chat. `note_failure` is
+            // a no-op for non-triggering categories (e.g. Config errors).
+            let e = crate::cooldown::note_failure(
+                &state.runtime_status,
+                &model_entry.id,
+                model.cooldown.as_ref(),
+                e,
+            );
             Err(ProxyError::Bridge(e))
         }
     }
@@ -1539,6 +1553,40 @@ mod tests {
         assert_eq!(
             v["error"]["type"], "invalid_request_error",
             "envelope must be OpenAI-shape invalid_request_error — #401",
+        );
+    }
+
+    /// #701: an upstream 5xx must mark the model's runtime status (cooldown)
+    /// — /v1/embeddings previously never touched it.
+    #[tokio::test]
+    async fn upstream_5xx_marks_cooldown_issue_701() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("embed-model"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg()).without_cache();
+        let app = crate::build_router(state.clone());
+
+        let body = serde_json::json!({"model": "embed-model", "input": "hi"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+        let status = state.runtime_status.status("m-1");
+        assert!(
+            status.cooldown_until.is_some(),
+            "a 500 must mark the model in cooldown, got {status:?}"
         );
     }
 }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -264,6 +264,10 @@ async fn dispatch(
 
     match bridge.generate_image(&body, &ctx).await {
         Ok(resp_json) => {
+            // #701: clear any cooldown/unhealthy mark now the upstream
+            // answered — same recovery signal as rerank/audio/chat.
+            state.health.record_success(model_name);
+            state.runtime_status.mark_healthy(&model_entry.id);
             // Extract usage tokens (gpt-image-1 returns a `usage` block;
             // dall-e-3 doesn't) BEFORE moving resp_json into the
             // Response, so the success struct carries typed counters.
@@ -302,6 +306,16 @@ async fn dispatch(
         }
         Err(e) => {
             reservation.commit_tokens(0).await;
+            // #701: mark the failure on the runtime status so the cooldown /
+            // circuit-breaker sees flapping upstreams reached only via this
+            // endpoint — same policy as rerank/audio/chat. `note_failure` is
+            // a no-op for non-triggering categories (e.g. Config errors).
+            let e = crate::cooldown::note_failure(
+                &state.runtime_status,
+                &model_entry.id,
+                model.cooldown.as_ref(),
+                e,
+            );
             Err(ProxyError::Bridge(e))
         }
     }
@@ -1036,6 +1050,40 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "exactly one event per failed request"
+        );
+    }
+
+    /// #701: an upstream 5xx must mark the model's runtime status (cooldown)
+    /// — /v1/images/generations previously never touched it.
+    #[tokio::test]
+    async fn upstream_5xx_marks_cooldown_issue_701() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("img"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg()).without_cache();
+        let app = crate::build_router(state.clone());
+
+        let body = serde_json::json!({"model": "img", "prompt": "a cat"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+        let status = state.runtime_status.status("m-1");
+        assert!(
+            status.cooldown_until.is_some(),
+            "a 500 must mark the model in cooldown, got {status:?}"
         );
     }
 }

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -426,10 +426,22 @@ async fn dispatch(
         builder = builder.timeout(d);
     }
 
+    // #701: transport/decode failures against the shared upstream mark the
+    // borrowed model's runtime status (same borrowed-model basis as the
+    // #911 [6] guardrail chain), so a dead upstream reached only via the raw
+    // tunnel still trips the cooldown. Forwarded HTTP statuses stay the
+    // caller's business — the tunnel relays them verbatim.
     let upstream_resp = builder
         .send()
         .await
-        .map_err(|e| aisix_gateway::BridgeError::Transport(e.to_string()))
+        .map_err(|e| {
+            crate::cooldown::note_failure(
+                &state.runtime_status,
+                &model_entry.id,
+                model.cooldown.as_ref(),
+                aisix_gateway::BridgeError::Transport(e.to_string()),
+            )
+        })
         .map_err(ProxyError::Bridge)?;
 
     let status = upstream_resp.status();
@@ -437,7 +449,14 @@ async fn dispatch(
     let resp_body = upstream_resp
         .bytes()
         .await
-        .map_err(|e| aisix_gateway::BridgeError::UpstreamDecode(e.to_string()))
+        .map_err(|e| {
+            crate::cooldown::note_failure(
+                &state.runtime_status,
+                &model_entry.id,
+                model.cooldown.as_ref(),
+                aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
+            )
+        })
         .map_err(ProxyError::Bridge)?;
 
     // #911 [6]: run OUTPUT guardrails on the passthrough response body — the


### PR DESCRIPTION
## Problem

Audit finding #701 (parent: api7/AISIX-Cloud#950). `mark_cooldown`/`note_failure` fired on chat, messages, responses, audio, rerank and count_tokens — but not on completions, embeddings, images or passthrough. A flapping upstream reached only via those endpoints kept a Healthy runtime status and never tripped the cooldown/circuit-breaker, while the same upstream failing via rerank (also single-target) did.

## Fix

- completions / embeddings / images: wire the shared `cooldown::note_failure` into each bridge-dispatch `Err` arm. It is a no-op for `BridgeError::Config`, so the 501 not-implemented branches stay uncooled (config mismatches aren't upstream health). The `Ok` arms now `record_success` + `mark_healthy` (recovery parity with rerank/audio).
- passthrough: transport/decode failures mark the borrowed model's runtime status (same borrowed-model basis as the #911 [6] guardrail chain). Forwarded HTTP statuses stay untouched — the raw tunnel relays them verbatim to the caller.

## Tests

One per handler: upstream 500 → response maps to 502 AND `state.runtime_status.status(model)` reports a cooldown. Verified fail-before/pass-after (wiring removed → all three fail).

Fixes #701