### PR TITLE
feat(mcp): per-server wildcard in api_key MCP tool ACL

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3172,7 +3172,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted or set to `null`, the key has no MCP tool access."
+            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly."
           },
           "expires_at": {
             "type": [
@@ -3494,7 +3494,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names. A wildcard entry `\"*\"` grants every tool. When omitted or set to `null`, the key has no MCP tool access.",
+            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly.",
             "example": [
               "github__create_issue"
             ]
@@ -4232,6 +4232,10 @@ mod tests {
             request_allowed_tools.contains("omitted or set to `null`"),
             "self-hosted API key request schema must document null tool-access behavior"
         );
+        assert!(
+            request_allowed_tools.contains("<server>__*"),
+            "self-hosted API key request schema must document the per-server wildcard"
+        );
         let public = &parsed["components"]["schemas"]["PublicApiKey"];
         assert!(
             public["properties"].get("allowed_tools").is_some(),
@@ -4243,6 +4247,10 @@ mod tests {
         assert!(
             public_allowed_tools.contains("omitted or set to `null`"),
             "API key response schema must document null tool-access behavior"
+        );
+        assert!(
+            public_allowed_tools.contains("<server>__*"),
+            "API key response schema must document the per-server wildcard"
         );
         assert!(request["properties"].get("team_id").is_none());
         assert!(request["properties"].get("user_id").is_none());

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -49,9 +49,12 @@ pub struct ApiKey {
     pub user_name: Option<String>,
 
     /// MCP tools this key may call, as namespaced `<server>__<tool>` names
-    /// (the form the gateway exposes). A wildcard entry `"*"` grants every
-    /// tool. When omitted or set to `null`, the key has no MCP tool access —
-    /// access is granted explicitly, matching `allowed_models`.
+    /// (the form the gateway exposes). Entries are matched as single-`*`
+    /// globs, mirroring `allowed_models`: `"*"` grants every tool and
+    /// `"<server>__*"` grants every tool on one server (e.g. `"github__*"`);
+    /// an entry without a `*` matches one tool exactly. When omitted or set
+    /// to `null`, the key has no MCP tool access — access is granted
+    /// explicitly.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
 
@@ -109,13 +112,17 @@ impl ApiKey {
     /// True if this key may call the given MCP tool, named in the gateway's
     /// namespaced `<server>__<tool>` form.
     ///
-    /// A wildcard entry `"*"` grants every tool. A key with no `allowed_tools`
-    /// (or an empty list) may call no MCP tools — access is granted explicitly,
-    /// matching [`ApiKey::can_access`].
+    /// Entries are matched as single-`*` globs, so `"*"` grants every tool and
+    /// `"<server>__*"` grants every tool on that server (e.g. `"github__*"`
+    /// permits `github__create_issue`); entries without a `*` match exactly.
+    /// A key with no `allowed_tools` (or an empty list) may call no MCP tools —
+    /// access is granted explicitly, matching [`ApiKey::can_access`].
     pub fn can_access_tool(&self, tool: &str) -> bool {
         match &self.allowed_tools {
             None => false,
-            Some(allowed) => allowed.iter().any(|t| t == "*" || t == tool),
+            Some(allowed) => allowed
+                .iter()
+                .any(|t| crate::wildcard::wildcard_matches(t, tool)),
         }
     }
 
@@ -241,6 +248,18 @@ mod tests {
             serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["*"]}"#)
                 .unwrap();
         assert!(wildcard.can_access_tool("anything__at_all"));
+
+        // Per-server wildcard grants every tool on that server only.
+        let per_server: ApiKey = serde_json::from_str(
+            r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["github__*"]}"#,
+        )
+        .unwrap();
+        assert!(per_server.can_access_tool("github__create_issue"));
+        assert!(per_server.can_access_tool("github__delete_repo"));
+        // It must not leak across the server boundary: a different server,
+        // and a server whose name merely shares the prefix, are both denied.
+        assert!(!per_server.can_access_tool("slack__post_message"));
+        assert!(!per_server.can_access_tool("githubenterprise__create_issue"));
     }
 
     #[test]

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -117,6 +117,10 @@ impl ApiKey {
     /// permits `github__create_issue`); entries without a `*` match exactly.
     /// A key with no `allowed_tools` (or an empty list) may call no MCP tools —
     /// access is granted explicitly, matching [`ApiKey::can_access`].
+    ///
+    /// Currently exercised only by tests: the live MCP enforcement path builds
+    /// an `aisix_mcp::ToolAcl` from `allowed_tools` and uses the identical
+    /// matcher, so this method is kept in lockstep as the documented mirror.
     pub fn can_access_tool(&self, tool: &str) -> bool {
         match &self.allowed_tools {
             None => false,
@@ -260,6 +264,18 @@ mod tests {
         // and a server whose name merely shares the prefix, are both denied.
         assert!(!per_server.can_access_tool("slack__post_message"));
         assert!(!per_server.can_access_tool("githubenterprise__create_issue"));
+
+        // The glob is a single `*` anywhere, not only trailing (same as
+        // `allowed_models`): `"*__readonly"` is a genuine any-server grant of
+        // a same-named tool. Pinned so the breadth stays intentional.
+        let any_server: ApiKey = serde_json::from_str(
+            r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["*__readonly"]}"#,
+        )
+        .unwrap();
+        assert!(any_server.can_access_tool("github__readonly"));
+        assert!(any_server.can_access_tool("slack__readonly"));
+        // The suffix still anchors — a longer tool name doesn't match.
+        assert!(!any_server.can_access_tool("github__readonly_admin"));
     }
 
     #[test]

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -65,7 +65,8 @@ pub enum ToolAcl {
 impl ToolAcl {
     /// Build an ACL from an API key's `allowed_tools` list: `None` or an empty
     /// list grants no tools; a list containing `"*"` grants all; otherwise the
-    /// exact namespaced set. Mirrors `ApiKey::can_access_tool`.
+    /// listed patterns. Entries are matched as single-`*` globs (see
+    /// [`ToolAcl::permits`]), mirroring `ApiKey::can_access_tool`.
     pub fn from_allowed(allowed: Option<&[String]>) -> Self {
         match allowed {
             Some(list) if list.iter().any(|t| t == "*") => Self::AllowAll,
@@ -74,10 +75,16 @@ impl ToolAcl {
         }
     }
 
+    /// Whether `namespaced_tool` is permitted. Patterns are single-`*` globs:
+    /// `"<server>__*"` grants every tool on that server, a pattern without a
+    /// `*` matches exactly. (A bare `"*"` is folded into [`Self::AllowAll`] at
+    /// construction.) Uses the same matcher as `ApiKey::can_access_tool`.
     fn permits(&self, namespaced_tool: &str) -> bool {
         match self {
             Self::AllowAll => true,
-            Self::Allow(set) => set.contains(namespaced_tool),
+            Self::Allow(patterns) => patterns
+                .iter()
+                .any(|p| aisix_core::wildcard::wildcard_matches(p, namespaced_tool)),
         }
     }
 }

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -499,6 +499,12 @@ fn tool_acl_from_allowed_semantics() {
         ToolAcl::from_allowed(Some(&["a__b".to_string()])),
         ToolAcl::Allow(_)
     ));
+    // A per-server wildcard is a scoped Allow, not AllowAll — only a bare
+    // `"*"` opens everything.
+    assert!(matches!(
+        ToolAcl::from_allowed(Some(&["github__*".to_string()])),
+        ToolAcl::Allow(_)
+    ));
 }
 
 #[tokio::test]
@@ -548,6 +554,52 @@ async fn tool_acl_filters_list_and_rejects_calls() {
         !msg.contains("permitted") && !msg.contains("forbidden") && !msg.contains("exists"),
         "rejection must not reveal existence/permission detail, got: {msg}"
     );
+}
+
+#[tokio::test]
+async fn tool_acl_per_server_wildcard_scopes_to_one_server() {
+    // A `<server>__*` grant exposes every tool on that server and nothing
+    // from any other — the granularity an operator gets without a live tool
+    // list. Two real upstreams; the key is scoped to alpha only.
+    let gateway = McpGateway::new([
+        ("alpha".to_string(), bridge_to("alpha").await),
+        ("beta".to_string(), bridge_to("beta").await),
+    ])
+    .with_tool_acl(ToolAcl::from_allowed(Some(&["alpha__*".to_string()])));
+    let gw_addr = spawn_gateway(gateway).await;
+    let client = ()
+        .serve(StreamableHttpClientTransport::from_uri(format!(
+            "http://{gw_addr}/mcp"
+        )))
+        .await
+        .expect("connect");
+
+    // Every alpha tool is exposed; nothing from beta.
+    let tools = client.list_all_tools().await.expect("list tools");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(
+        names.iter().all(|n| n.starts_with("alpha__")),
+        "per-server wildcard must expose only alpha's tools, got: {names:?}"
+    );
+    assert!(
+        names.contains(&"alpha__echo"),
+        "alpha's tool should be visible, got: {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("beta__")),
+        "beta's tools must stay hidden, got: {names:?}"
+    );
+
+    // alpha is callable; beta is rejected by the same ACL (defense-in-depth).
+    let allowed = client
+        .call_tool(call("alpha__echo", "hi"))
+        .await
+        .expect("permitted call");
+    assert_eq!(first_text(&allowed), "alpha:hi");
+    client
+        .call_tool(call("beta__echo", "hi"))
+        .await
+        .expect_err("a tool outside the granted server must be rejected");
 }
 
 /// Build a `tools/call` for `name` with a single `text` argument.

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -81,7 +81,7 @@
       "type": "array"
     },
     "allowed_tools": {
-      "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). A wildcard entry `\"*\"` grants every tool. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly, matching `allowed_models`.",
+      "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly.",
       "items": {
         "type": "string"
       },


### PR DESCRIPTION
## What

An API key's `allowed_tools` (per-tool MCP ACL, #668) matched only a bare `"*"` (every tool) or exact `<server>__<tool>` names. Since the discovered tool list isn't surfaced anywhere yet, an operator can't know the exact names — so the only *usable* grant today is all-or-nothing (`"*"`).

This adds a **per-server wildcard**: entries are now matched as single-`*` globs (reusing the very same `wildcard::wildcard_matches` helper that `allowed_models` already uses), so `"<server>__*"` grants every tool on one server:

- `"github__*"` permits `github__create_issue`, `github__delete_repo`
- and does **not** leak across the boundary: `slack__post_message` and the prefix-sharing `githubenterprise__create_issue` are both denied.

A bare `"*"` and exact names keep their exact meaning. The change is **purely additive** — no existing grant shifts, because real composed tool names contain no `*`.

## Why this shape

- **Reuses the model matcher.** `allowed_models` already globs `openai/*`; tools now glob `github__*` through the identical helper, so the two ACLs stay semantically consistent and there's one source of truth.
- **Both matchers move together.** `ApiKey::can_access_tool` (core) and the proxy-path `ToolAcl::permits` (aisix-mcp) both delegate to `wildcard_matches`, preserving their documented "mirror" relationship. `ToolAcl::from_allowed` still folds a bare `"*"` into `AllowAll`; a `<server>__*` becomes a scoped `Allow`.
- **Server granularity is the granularity an operator can actually express** without a live tool list, and it maps directly onto the MCP servers they've already registered ("give this key the GitHub server's tools").

## Tests

- `can_access_tool_enforces_namespaced_allowlist` extended: `github__*` grants github tools, denies a different server and a prefix-sharing server name.
- `tool_acl_from_allowed_semantics`: a per-server wildcard is a scoped `Allow`, not `AllowAll`.
- `tool_acl_per_server_wildcard_scopes_to_one_server` (new, full gateway): `alpha__*` over two real upstreams exposes only alpha's tools in `tools/list`, calls alpha, and rejects beta (defense-in-depth) — exercises `permits` end-to-end.

`cargo fmt` / `clippy -D warnings` / `aisix-core` + `aisix-mcp` suites green; `dump-schema` regenerated `api_key.schema.json` (description only) and is idempotent.

## Control-plane pairing

This exposes a richer matching semantics on an existing field; the field itself still needs to become **reachable** — the CP api_key resource has no `allowed_tools` today. The paired **AISIX-Cloud PR** adds `allowed_tools` to the api_key model/validation/projection + a dashboard tool-ACL picker that composes `<server>__*` grants from the org's registered MCP servers (plus a global-`*` toggle and an exact-name escape hatch). Refs AISIX-Cloud#894 (Phase 2, per-key tool ACL). The live individual-tool list (via a DP→CP report) is a separate fast-follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool access rules now support wildcard patterns, including server-scoped grants like `<server>__*`.
  * API keys can now allow all tools, a single tool, or all tools for one server using pattern-based access.

* **Bug Fixes**
  * Tightened tool listing and tool call permissions so access is limited to the intended server or tool names.
  * Keys without tool अनुमति remain unable to access MCP tools unless explicitly granted.

* **Documentation**
  * Updated access descriptions to clearly explain wildcard and exact-match behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Independent audit response

A cold audit returned **FIX-FIRST** (no BLOCK): it traced the matcher character-by-character and confirmed `github__*` matches github tools while correctly rejecting the prefix-sharing `githubenterprise__*`, no privilege-widening for existing data, and that `tools/list` filter + `tools/call` reject both go through the same `permits`. Two MEDIUMs, both fixed in `eb8ff95`:

- **MEDIUM-1 — stale admin OpenAPI description.** The hand-maintained `allowed_tools` descriptions in `openapi.rs` (request + public schemas) still carried the pre-wildcard wording, so `GET /admin/openapi.json` disagreed with the shipped behavior. Updated both to match the code doc and `api_key.schema.json`; the schema-guard tests now assert the `<server>__*` wording so future drift fails CI. (No separate generated artifact exists — `openapi.rs` is the source of truth; verified the generator propagates the new wording.)
- **MEDIUM-2 — leading/middle-`*` breadth untested.** Entries are single-`*` globs *anywhere*, mirroring `allowed_models` — so `"*__readonly"` is a genuine any-server grant of a same-named tool. Pinned with a test (asserting cross-server match + suffix anchoring) and kept the "single-`*` globs, mirroring `allowed_models`" framing that states the general rule. This is intentional and consistent with the model ACL, not an accident.

LOWs: added a one-line note that `can_access_tool` is test-only (the live path is `ToolAcl::permits`); the literal-`*`-in-name and `debug_assert!` server-name notes are benign/pre-existing (no real grant flips, since composed tool names contain no `*`).
