### PR TITLE
fix(messages): stop forwarding Anthropic-only fields to OpenAI-compatible upstreams

### DIFF
--- a/crates/aisix-provider-anthropic/src/lib.rs
+++ b/crates/aisix-provider-anthropic/src/lib.rs
@@ -31,5 +31,6 @@ pub use bridge::{AnthropicBridge, ANTHROPIC_DEFAULT_BASE, ANTHROPIC_VERSION};
 pub use wire::{
     chat_response_into_anthropic_json, parse_inbound_request,
     translate_anthropic_tool_choice_to_openai, translate_anthropic_tools_to_openai,
-    AnthropicInboundError, AnthropicSseEncoder, AnthropicSseEvent,
+    translate_extras_to_openai_shape, AnthropicInboundError, AnthropicSseEncoder,
+    AnthropicSseEvent,
 };

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -448,6 +448,80 @@ pub fn translate_anthropic_tool_choice_to_openai(
     }
 }
 
+/// Rewrite `extra` (as filled by [`parse_inbound_request`], i.e. raw
+/// Anthropic `/v1/messages` top-level fields) into the OpenAI chat shape
+/// that non-Anthropic bridges expect. Whitelist-translate what maps
+/// cleanly; drop everything else — Anthropic-only fields flattened onto
+/// an OpenAI-compatible upstream request are rejected as unknown
+/// parameters, e.g. 400 "Unknown parameter: 'context_management'"
+/// (AISIX-Cloud#953). Mirrors the `/v1/responses` bridge's
+/// whitelist-and-drop policy (#825) in the opposite direction.
+///
+/// Translations (matching LiteLLM's Anthropic→OpenAI adapter):
+///   tools / tool_choice   → OpenAI shapes (existing helpers)
+///   stop_sequences        → stop
+///   metadata.user_id      → user
+///   thinking              → reasoning_effort
+pub fn translate_extras_to_openai_shape(extra: &mut serde_json::Map<String, serde_json::Value>) {
+    let anthropic = std::mem::take(extra);
+    for (key, value) in anthropic {
+        match key.as_str() {
+            "tools" => {
+                if let Some(translated) = translate_anthropic_tools_to_openai(value) {
+                    extra.insert("tools".to_string(), translated);
+                }
+            }
+            "tool_choice" => {
+                if let Some(translated) = translate_anthropic_tool_choice_to_openai(value) {
+                    extra.insert("tool_choice".to_string(), translated);
+                }
+            }
+            "stop_sequences" => {
+                extra.insert("stop".to_string(), value);
+            }
+            "metadata" => {
+                if let Some(user_id) = value.get("user_id").and_then(|v| v.as_str()) {
+                    extra.insert("user".to_string(), user_id.into());
+                }
+            }
+            "thinking" => {
+                if let Some(effort) = reasoning_effort_from_thinking(&value) {
+                    extra.insert("reasoning_effort".to_string(), effort.into());
+                }
+            }
+            _ => {
+                tracing::debug!(
+                    field = %key,
+                    "dropping Anthropic-only request field on cross-provider dispatch"
+                );
+            }
+        }
+    }
+}
+
+/// Bucket Anthropic `thinking` into an OpenAI `reasoning_effort` label.
+/// Thresholds match LiteLLM's `reasoning_effort_from_thinking_budget`
+/// (budget_tokens ≥ 4096 → high, ≥ 2048 → medium, ≥ 1024 → low, below →
+/// minimal; `adaptive` → medium; `disabled`/unrecognised → None).
+fn reasoning_effort_from_thinking(thinking: &serde_json::Value) -> Option<&'static str> {
+    match thinking.get("type").and_then(|t| t.as_str())? {
+        "enabled" => {
+            let budget = thinking
+                .get("budget_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            Some(match budget {
+                b if b >= 4096 => "high",
+                b if b >= 2048 => "medium",
+                b if b >= 1024 => "low",
+                _ => "minimal",
+            })
+        }
+        "adaptive" => Some("medium"),
+        _ => None,
+    }
+}
+
 /// Non-streaming response shape from `/v1/messages`.
 #[derive(Debug, Deserialize)]
 pub struct AnthropicResponse {
@@ -2242,6 +2316,97 @@ mod tests {
             parse_inbound_request(&body).unwrap_err(),
             AnthropicInboundError::MissingModel,
         ));
+    }
+
+    // ─── translate_extras_to_openai_shape (AISIX-Cloud#953) ───────
+
+    #[test]
+    fn extras_shape_drops_anthropic_only_fields() {
+        let mut extra = serde_json::json!({
+            "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+            "top_k": 40,
+            "mcp_servers": [{"type": "url", "url": "https://example.com/mcp"}],
+            "container": "container_abc",
+            "service_tier": "standard_only",
+            "betas": ["context-management-2025-06-27"],
+            "anthropic_version": "2023-06-01",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        translate_extras_to_openai_shape(&mut extra);
+        assert!(extra.is_empty(), "expected all dropped, got: {extra:?}");
+    }
+
+    #[test]
+    fn extras_shape_translates_mappable_fields() {
+        let mut extra = serde_json::json!({
+            "stop_sequences": ["\n\nHuman:"],
+            "metadata": {"user_id": "user-123"},
+            "tools": [{"name": "get_time", "input_schema": {"type": "object"}}],
+            "tool_choice": {"type": "any"},
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        translate_extras_to_openai_shape(&mut extra);
+
+        assert_eq!(extra.get("stop"), Some(&serde_json::json!(["\n\nHuman:"])));
+        assert!(!extra.contains_key("stop_sequences"));
+        assert_eq!(extra.get("user"), Some(&serde_json::json!("user-123")));
+        assert!(!extra.contains_key("metadata"));
+        assert_eq!(
+            extra.get("tools").unwrap()[0]["function"]["name"],
+            serde_json::json!("get_time")
+        );
+        assert_eq!(
+            extra.get("tool_choice"),
+            Some(&serde_json::json!("required"))
+        );
+    }
+
+    #[test]
+    fn extras_shape_metadata_without_user_id_is_dropped() {
+        let mut extra = serde_json::json!({"metadata": {"foo": "bar"}})
+            .as_object()
+            .unwrap()
+            .clone();
+        translate_extras_to_openai_shape(&mut extra);
+        assert!(extra.is_empty());
+    }
+
+    #[test]
+    fn extras_shape_thinking_buckets_to_reasoning_effort() {
+        for (thinking, expected) in [
+            (
+                serde_json::json!({"type": "enabled", "budget_tokens": 8000}),
+                Some("high"),
+            ),
+            (
+                serde_json::json!({"type": "enabled", "budget_tokens": 2048}),
+                Some("medium"),
+            ),
+            (
+                serde_json::json!({"type": "enabled", "budget_tokens": 1024}),
+                Some("low"),
+            ),
+            (
+                serde_json::json!({"type": "enabled", "budget_tokens": 100}),
+                Some("minimal"),
+            ),
+            (serde_json::json!({"type": "adaptive"}), Some("medium")),
+            (serde_json::json!({"type": "disabled"}), None),
+        ] {
+            let mut extra = serde_json::Map::new();
+            extra.insert("thinking".to_string(), thinking.clone());
+            translate_extras_to_openai_shape(&mut extra);
+            assert_eq!(
+                extra.get("reasoning_effort").and_then(|v| v.as_str()),
+                expected,
+                "thinking = {thinking}"
+            );
+            assert!(!extra.contains_key("thinking"));
+        }
     }
 
     // ─── chat_response_into_anthropic_json ────────────────────────

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1363,8 +1363,7 @@ async fn cross_provider_dispatch(
 ) -> Result<DispatchOutcome, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
     use aisix_provider_anthropic::{
-        chat_response_into_anthropic_json, parse_inbound_request,
-        translate_anthropic_tool_choice_to_openai, translate_anthropic_tools_to_openai,
+        chat_response_into_anthropic_json, parse_inbound_request, translate_extras_to_openai_shape,
         AnthropicSseEncoder,
     };
     use std::sync::Arc;
@@ -1389,19 +1388,13 @@ async fn cross_provider_dispatch(
     // through `ctx.model.upstream_model()` exactly like chat.rs does.
     chat.model = model_name.to_string();
 
-    // Translate Anthropic-shape tools/tool_choice in `extra` to
-    // OpenAI shape so the non-Anthropic bridge receives the format
-    // it expects. Without this, tools are silently dropped (#236).
-    if let Some(tools) = chat.extra.remove("tools") {
-        if let Some(translated) = translate_anthropic_tools_to_openai(tools) {
-            chat.extra.insert("tools".to_string(), translated);
-        }
-    }
-    if let Some(tc) = chat.extra.remove("tool_choice") {
-        if let Some(translated) = translate_anthropic_tool_choice_to_openai(tc) {
-            chat.extra.insert("tool_choice".to_string(), translated);
-        }
-    }
+    // Rewrite Anthropic-shaped extras into the OpenAI chat shape the
+    // non-Anthropic bridges expect: tools/tool_choice (#236),
+    // stop_sequences/metadata/thinking are translated; Anthropic-only
+    // fields (context_management, top_k, mcp_servers, …) are dropped —
+    // flattened onto an OpenAI-compatible upstream they 400 as unknown
+    // parameters (AISIX-Cloud#953).
+    translate_extras_to_openai_shape(&mut chat.extra);
 
     let is_stream = chat.is_streaming();
     let model_arc = Arc::new(model.clone());

--- a/tests/e2e/src/cases/messages-cross-provider-extras-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-cross-provider-extras-e2e.test.ts
@@ -1,0 +1,312 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: Anthropic Messages client → OpenAI-compatible upstream —
+// Anthropic-only extras must not leak upstream (AISIX-Cloud#953).
+//
+// The cross-provider path preserves unknown Anthropic top-level fields
+// in ChatFormat.extra, and the OpenAI bridge flattens extras into the
+// upstream request body. Anthropic-only fields (`context_management`,
+// `thinking`, `top_k`, …) reached the OpenAI/Azure upstream verbatim,
+// which rejects them: 400 "Unknown parameter: 'context_management'".
+//
+// The gateway must translate what maps cleanly onto the OpenAI chat
+// shape and drop the rest — never forward Anthropic-only fields.
+
+// Every Anthropic-only /v1/messages field with no OpenAI equivalent,
+// including newer SDK fields like context_management (the #953 trigger).
+const ANTHROPIC_ONLY_FIELDS: Record<string, unknown> = {
+  context_management: {
+    edits: [{ type: "clear_tool_uses_20250919" }],
+  },
+  thinking: { type: "enabled", budget_tokens: 2048 },
+  top_k: 40,
+  mcp_servers: [
+    { type: "url", url: "https://example.com/mcp", name: "example" },
+  ],
+  container: "container_abc",
+  service_tier: "standard_only",
+  betas: ["context-management-2025-06-27"],
+  anthropic_version: "2023-06-01",
+};
+
+function expectNoAnthropicOnlyFields(sentBody: Record<string, unknown>) {
+  for (const key of Object.keys(ANTHROPIC_ONLY_FIELDS)) {
+    expect(sentBody[key], `\`${key}\` leaked to upstream`).toBeUndefined();
+  }
+}
+
+const CALLER_PLAINTEXT = "sk-anth-extras-xprov-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("Anthropic Messages → OpenAI upstream: Anthropic-only extras are not forwarded (#953)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "chatcmpl-extras-01",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "hello" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "anth-extras-xprov-pk",
+      secret: "sk-openai-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "anth-extras-xprov",
+      provider: "openai",
+      model_name: "gpt-4o",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["anth-extras-xprov"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("non-streaming: Anthropic-only fields are dropped, translatable fields survive", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      try {
+        const res = await fetch(`${app!.proxyUrl}/v1/messages`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": CALLER_PLAINTEXT,
+          },
+          body: JSON.stringify({
+            model: "anth-extras-xprov",
+            max_tokens: 100,
+            messages: [{ role: "user", content: "probe" }],
+          }),
+        });
+        return res.ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": CALLER_PLAINTEXT,
+      },
+      body: JSON.stringify({
+        model: "anth-extras-xprov",
+        max_tokens: 200,
+        temperature: 0.5,
+        metadata: { user_id: "user-123" },
+        stop_sequences: ["\\n\\nHuman:"],
+        tools: [
+          {
+            name: "get_time",
+            description: "Get the current time",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        tool_choice: { type: "auto" },
+        messages: [{ role: "user", content: "hello" }],
+        ...ANTHROPIC_ONLY_FIELDS,
+      }),
+    });
+    expect(res.ok).toBe(true);
+
+    const upstreamReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/chat/completions");
+    expect(upstreamReq).toBeDefined();
+    const sentBody = JSON.parse(upstreamReq!.body) as Record<string, unknown>;
+
+    // The #953 bug: none of these may reach an OpenAI-compatible upstream.
+    expectNoAnthropicOnlyFields(sentBody);
+    expect(sentBody.metadata, "`metadata` leaked to upstream").toBeUndefined();
+    expect(
+      sentBody.stop_sequences,
+      "`stop_sequences` leaked to upstream",
+    ).toBeUndefined();
+
+    // Translatable fields must still flow.
+    expect(sentBody.max_tokens).toBe(200);
+    expect(sentBody.temperature).toBe(0.5);
+    expect(sentBody.stop).toEqual(["\\n\\nHuman:"]);
+    expect(sentBody.user).toBe("user-123");
+    const tools = sentBody.tools as Array<{
+      type?: string;
+      function?: { name?: string };
+    }>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.type).toBe("function");
+    expect(tools[0]?.function?.name).toBe("get_time");
+    expect(sentBody.tool_choice).toBe("auto");
+  });
+});
+
+// ─── Streaming variant ──────────────────────────────────────────────
+
+const STREAM_CALLER_PLAINTEXT = "sk-anth-extras-stream-xprov";
+const STREAM_CALLER_KEY_HASH = createHash("sha256")
+  .update(STREAM_CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("Anthropic Messages → OpenAI upstream: streaming extras are not forwarded (#953)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      streamEvents: [
+        JSON.stringify({
+          id: "cmpl-extras-stream",
+          object: "chat.completion.chunk",
+          model: "gpt-4o",
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: "hi" },
+              finish_reason: null,
+            },
+          ],
+        }),
+        JSON.stringify({
+          id: "cmpl-extras-stream",
+          object: "chat.completion.chunk",
+          model: "gpt-4o",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        }),
+        "[DONE]",
+      ],
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "anth-extras-stream-xprov-pk",
+      secret: "sk-openai-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "anth-extras-stream-xprov",
+      provider: "openai",
+      model_name: "gpt-4o",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: STREAM_CALLER_KEY_HASH,
+      allowed_models: ["anth-extras-stream-xprov"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("streaming: Anthropic-only fields are dropped", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      try {
+        const res = await fetch(`${app!.proxyUrl}/v1/messages`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": STREAM_CALLER_PLAINTEXT,
+          },
+          body: JSON.stringify({
+            model: "anth-extras-stream-xprov",
+            max_tokens: 100,
+            stream: true,
+            messages: [{ role: "user", content: "probe" }],
+          }),
+        });
+        return res.ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": STREAM_CALLER_PLAINTEXT,
+      },
+      body: JSON.stringify({
+        model: "anth-extras-stream-xprov",
+        max_tokens: 200,
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+        ...ANTHROPIC_ONLY_FIELDS,
+      }),
+    });
+    expect(res.ok).toBe(true);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    await res.text();
+
+    const upstreamReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/chat/completions");
+    expect(upstreamReq).toBeDefined();
+    const sentBody = JSON.parse(upstreamReq!.body) as Record<string, unknown>;
+
+    expectNoAnthropicOnlyFields(sentBody);
+    expect(sentBody.stream).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

When an Anthropic SDK / Claude Code client calls `/v1/messages` targeting a model whose upstream is OpenAI/Azure OpenAI, Anthropic-only top-level request fields leak into the upstream request body and the upstream rejects them:

```text
API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Unknown parameter: 'context_management'."}}
```

The chain: `parse_inbound_request()` copies every non-whitelisted top-level key into `ChatFormat.extra`; `cross_provider_dispatch()` only translates `tools`/`tool_choice`; `OpenAiRequest.extra` is `#[serde(flatten)]`, so `context_management` (and `thinking`, `top_k`, `mcp_servers`, …) land verbatim on the OpenAI wire.

## Fix

Replace the tools/tool_choice-only fixup in `cross_provider_dispatch` with a whitelist translation, `translate_extras_to_openai_shape()` in the anthropic provider crate:

- `tools` / `tool_choice` → existing OpenAI-shape translation (#236 behavior unchanged)
- `stop_sequences` → `stop`
- `metadata.user_id` → `user` (LiteLLM parity)
- `thinking` → `reasoning_effort` (LiteLLM-aligned buckets: budget_tokens ≥4096 high / ≥2048 medium / ≥1024 low / below minimal; `adaptive` → medium; `disabled` → omitted)
- everything else (`context_management`, `top_k`, `mcp_servers`, `container`, `service_tier`, `betas`, …) is **dropped** (debug-logged), so future Anthropic SDK fields cannot re-trigger the 400

This mirrors the whitelist-and-drop policy the `/v1/responses` bridge (#825) already applies in the opposite direction. Both streaming and non-streaming go through the same `ChatFormat` build, so one fix covers both.

## Behavior changes / compatibility

- Anthropic-native `/v1/messages` passthrough (Anthropic upstream) is untouched — bodies still forward verbatim, `context_management` keeps working there.
- Bedrock/Vertex bridges only ever read `tools`/`tool_choice` from extras, so dropping the rest changes nothing for them.
- LiteLLM baseline (HEAD `88e03e5`): its Anthropic→OpenAI adapter is also whitelist-based and maps `metadata.user_id`→`user` and `thinking`→`reasoning_effort`; it translates `context_management` into OpenAI Responses-API compaction (or polyfills it in-gateway on the chat path) rather than dropping — that fuller treatment is deferred to a follow-up issue. `stop_sequences`→`stop` goes beyond LiteLLM (which silently drops it) since chat/completions supports `stop` natively.

## Tests

- Unit tests for `translate_extras_to_openai_shape` (drop set, mappings, thinking buckets).
- New E2E `messages-cross-provider-extras-e2e.test.ts` (non-streaming + streaming): asserts Anthropic-only fields never reach the mock OpenAI upstream while translated fields survive. Fails before this fix (`context_management` leaked), passes after.

Fixes api7/AISIX-Cloud#953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded cross-provider request translation so Anthropic message extras are converted into an OpenAI-compatible shape more consistently.
  * Added support for mapping additional fields such as stop sequences, user metadata, and thinking-related settings.

* **Bug Fixes**
  * Removed Anthropic-only fields from upstream requests to prevent unsupported parameters from being forwarded.
  * Improved handling for both streaming and non-streaming message requests across providers.

* **Tests**
  * Added end-to-end coverage for cross-provider extras translation and field preservation/removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->