### PR TITLE
fix(usage): harvest input/cache tokens from message_delta.usage

### DIFF
--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -645,6 +645,53 @@ data: {\"type\":\"message_stop\"}\n\n";
         assert_eq!(chunks[2].usage.as_ref().unwrap().completion_tokens, 5);
     }
 
+    /// AISIX-Cloud#952: some relay backends omit usage from
+    /// `message_start` and report input/cache counts only on the
+    /// terminal `message_delta`. The bridge must harvest them there
+    /// (pre-fix the final usage carried prompt_tokens=0).
+    #[tokio::test]
+    async fn streaming_harvests_input_tokens_from_message_delta() {
+        let server = MockServer::start().await;
+        let sse = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"gen_952\",\"model\":\"claude-sonnet-4-5\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null}}\n\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":37,\"cache_creation_input_tokens\":4,\"cache_read_input_tokens\":9,\"output_tokens\":5}}\n\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
+
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.unwrap());
+        }
+        let usage = chunks
+            .last()
+            .and_then(|c| c.usage.as_ref())
+            .expect("finish chunk must carry usage");
+        assert_eq!(
+            usage.prompt_tokens, 37,
+            "input_tokens reported only on message_delta must be harvested (#952)",
+        );
+        assert_eq!(usage.completion_tokens, 5);
+        assert_eq!(usage.cache_creation_tokens, 4);
+        assert_eq!(usage.cache_read_tokens, 9);
+    }
+
     #[tokio::test]
     async fn streaming_upstream_error_surfaces_before_stream_start() {
         let server = MockServer::start().await;

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -686,6 +686,17 @@ pub struct AnthropicStreamMessageDelta {
 pub struct AnthropicStreamUsage {
     #[serde(default)]
     pub output_tokens: Option<u32>,
+    /// Cumulative input/cache counts on the terminal `message_delta` —
+    /// newer Anthropic wire sends them there too, and for some relay
+    /// backends it is the ONLY frame that carries them (AISIX-Cloud#952:
+    /// `message_start` shipped no usable usage, so prompt tokens
+    /// recorded as 0).
+    #[serde(default)]
+    pub input_tokens: Option<u32>,
+    #[serde(default)]
+    pub cache_creation_input_tokens: Option<u32>,
+    #[serde(default)]
+    pub cache_read_input_tokens: Option<u32>,
 }
 
 /// Rolling state the Bridge carries across a stream so chunks can be
@@ -707,26 +718,46 @@ pub struct StreamState {
 
 impl StreamState {
     pub fn update(&mut self, event: &AnthropicStreamEvent) {
-        if let AnthropicStreamEvent::MessageStart { message } = event {
-            self.id = message.id.clone();
-            self.model = message.model.clone();
-            // Reset on every message_start so a later message_start without
-            // usage can't leave a stale prompt-token count from a prior one.
-            self.input_tokens = message
-                .usage
-                .as_ref()
-                .and_then(|u| u.input_tokens)
-                .unwrap_or(0);
-            self.cache_creation_tokens = message
-                .usage
-                .as_ref()
-                .and_then(|u| u.cache_creation_input_tokens)
-                .unwrap_or(0);
-            self.cache_read_tokens = message
-                .usage
-                .as_ref()
-                .and_then(|u| u.cache_read_input_tokens)
-                .unwrap_or(0);
+        match event {
+            AnthropicStreamEvent::MessageStart { message } => {
+                self.id = message.id.clone();
+                self.model = message.model.clone();
+                // Reset on every message_start so a later message_start without
+                // usage can't leave a stale prompt-token count from a prior one.
+                self.input_tokens = message
+                    .usage
+                    .as_ref()
+                    .and_then(|u| u.input_tokens)
+                    .unwrap_or(0);
+                self.cache_creation_tokens = message
+                    .usage
+                    .as_ref()
+                    .and_then(|u| u.cache_creation_input_tokens)
+                    .unwrap_or(0);
+                self.cache_read_tokens = message
+                    .usage
+                    .as_ref()
+                    .and_then(|u| u.cache_read_input_tokens)
+                    .unwrap_or(0);
+            }
+            // AISIX-Cloud#952: harvest cumulative input/cache counts from
+            // the terminal message_delta too (max-wins) — some backends
+            // report them only there. Runs before to_chunk() for the same
+            // event, so the emitted UsageStats picks these up.
+            AnthropicStreamEvent::MessageDelta {
+                usage: Some(usage), ..
+            } => {
+                if let Some(t) = usage.input_tokens {
+                    self.input_tokens = self.input_tokens.max(t);
+                }
+                if let Some(t) = usage.cache_creation_input_tokens {
+                    self.cache_creation_tokens = self.cache_creation_tokens.max(t);
+                }
+                if let Some(t) = usage.cache_read_input_tokens {
+                    self.cache_read_tokens = self.cache_read_tokens.max(t);
+                }
+            }
+            _ => {}
         }
     }
 

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -2315,20 +2315,40 @@ fn update_anthropic_usage(
             }
         }
         Some("message_delta") => {
-            if let Some(v) = json.get("usage").and_then(|u| u.get("output_tokens")) {
-                if let Some(t) = v.as_u64() {
-                    acc.completion_tokens = acc.completion_tokens.max(t as u32);
-                } else {
-                    // PR #436 audit LOW-1: a `usage` object present but
-                    // with a non-numeric `output_tokens` leaves
-                    // completion_tokens at the message_start floor
-                    // (often 1) — a silent under-count. Surface it so a
-                    // wire-shape drift is visible to operators.
-                    tracing::debug!(
-                        output_tokens = %v,
-                        "anthropic stream: message_delta usage.output_tokens \
-                         is non-numeric; completion_tokens left at floor"
-                    );
+            if let Some(usage) = json.get("usage") {
+                if let Some(v) = usage.get("output_tokens") {
+                    if let Some(t) = v.as_u64() {
+                        acc.completion_tokens = acc.completion_tokens.max(t as u32);
+                    } else {
+                        // PR #436 audit LOW-1: a `usage` object present but
+                        // with a non-numeric `output_tokens` leaves
+                        // completion_tokens at the message_start floor
+                        // (often 1) — a silent under-count. Surface it so a
+                        // wire-shape drift is visible to operators.
+                        tracing::debug!(
+                            output_tokens = %v,
+                            "anthropic stream: message_delta usage.output_tokens \
+                             is non-numeric; completion_tokens left at floor"
+                        );
+                    }
+                }
+                // AISIX-Cloud#952: newer Anthropic wire (and some relays)
+                // report cumulative input/cache counts on message_delta —
+                // for some backends that is the ONLY place they appear
+                // (message_start ships no usable usage), which recorded
+                // prompt_tokens=0. Harvest them here too, max-wins with
+                // the message_start values (LiteLLM reads both frames).
+                if let Some(t) = usage.get("input_tokens").and_then(Value::as_u64) {
+                    acc.prompt_tokens = acc.prompt_tokens.max(t as u32);
+                }
+                if let Some(t) = usage
+                    .get("cache_creation_input_tokens")
+                    .and_then(Value::as_u64)
+                {
+                    acc.cache_creation_tokens = acc.cache_creation_tokens.max(t as u32);
+                }
+                if let Some(t) = usage.get("cache_read_input_tokens").and_then(Value::as_u64) {
+                    acc.cache_read_tokens = acc.cache_read_tokens.max(t as u32);
                 }
             }
             if let Some(sr) = json
@@ -3889,6 +3909,71 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             "streaming /v1/messages telemetry must record TTFT",
         );
         assert!(rx.try_recv().is_err(), "usage event should be emitted once");
+    }
+
+    /// AISIX-Cloud#952: relay backends that ship NO usage on
+    /// `message_start` (id/model present) and report cumulative
+    /// input/cache counts only on the terminal `message_delta`. Pre-fix
+    /// the emitted UsageEvent carried prompt_tokens=0 (stored as NULL by
+    /// cp-api, shown as 0 in the dashboard).
+    #[tokio::test]
+    async fn anthropic_passthrough_streaming_harvests_input_tokens_from_message_delta() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        let sse = "\
+event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"gen_01REPRO952\",\"role\":\"assistant\",\"content\":[],\"model\":\"mco-5\",\"stop_reason\":null}}\n\n\
+event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n\
+event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":11504,\"cache_creation_input_tokens\":4,\"cache_read_input_tokens\":9,\"output_tokens\":136}}\n\n\
+event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        let snap = new_snap_anthropic(&upstream.uri());
+        snap.models.insert(anthropic_model("my-claude"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-claude",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 200,
+            "stream": true,
+        });
+        let resp = app.oneshot(make_req(body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        to_bytes(resp.into_body(), 65536).await.unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("streaming /v1/messages must emit a UsageEvent")
+            .expect("usage event sender dropped");
+        assert_eq!(
+            event.prompt_tokens, 11504,
+            "input_tokens reported only on message_delta must be harvested (#952)",
+        );
+        assert_eq!(event.completion_tokens, 136);
+        assert_eq!(event.cache_creation_tokens, 4);
+        assert_eq!(event.cache_read_tokens, 9);
+        assert_eq!(event.provider_request_id, "gen_01REPRO952");
+        assert_eq!(event.provider_model_version, "mco-5");
     }
 
     /// Issue #245: the SSE frame parser must reassemble events that

--- a/tests/e2e/src/cases/messages-stream-delta-only-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-stream-delta-only-usage-e2e.test.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: AISIX-Cloud#952 — streaming /v1/messages against a relay backend
+// that ships NO usage block on message_start (id/model present) and
+// reports cumulative input/cache counts only on the terminal
+// message_delta. Pre-fix the DP emitted prompt_tokens=0 for these
+// streams (cp-api stored NULL, the dashboard displayed 0 and the
+// request billed as zero input).
+//
+// Mirrors the wire shape observed in the POC: message_start carries a
+// `gen_*` id and the model but no usage; the final message_delta
+// carries the full cumulative usage.
+
+const CALLER_PLAINTEXT = "sk-anth-952-delta-usage-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const INPUT_TOKENS = 11504;
+const OUTPUT_TOKENS = 136;
+const STREAM_EVENTS = [
+  JSON.stringify({
+    type: "message_start",
+    message: {
+      id: "gen_01E2E952",
+      role: "assistant",
+      content: [],
+      model: "mco-5",
+      stop_reason: null,
+      // no usage block — the #952 relay-backend shape
+    },
+  }),
+  JSON.stringify({
+    type: "content_block_start",
+    index: 0,
+    content_block: { type: "text", text: "" },
+  }),
+  JSON.stringify({
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "text_delta", text: "hello there" },
+  }),
+  JSON.stringify({ type: "content_block_stop", index: 0 }),
+  JSON.stringify({
+    type: "message_delta",
+    delta: { stop_reason: "end_turn" },
+    usage: { input_tokens: INPUT_TOKENS, output_tokens: OUTPUT_TOKENS },
+  }),
+  JSON.stringify({ type: "message_stop" }),
+];
+
+describe("anthropic /v1/messages stream with usage only on message_delta (#952)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      streamEvents: STREAM_EVENTS,
+      eventDelayMs: 2,
+    });
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "anth-952-delta-pk",
+      secret: "sk-anth-mock",
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "anth-952-delta",
+      provider: "anthropic",
+      model_name: "mco-5",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["anth-952-delta"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("input tokens reported only on message_delta land in telemetry", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // Config propagation: retry until routed.
+    const deadline = Date.now() + 10_000;
+    let res: Response | undefined;
+    while (Date.now() < deadline) {
+      res = await fetch(`${app.proxyUrl}/v1/messages`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": CALLER_PLAINTEXT,
+        },
+        body: JSON.stringify({
+          model: "anth-952-delta",
+          max_tokens: 200,
+          stream: true,
+          messages: [{ role: "user", content: "repro 952" }],
+        }),
+      });
+      if (res.status === 200) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(res!.status).toBe(200);
+
+    // Bytes still pass through verbatim.
+    const body = await res!.text();
+    expect(body).toContain("gen_01E2E952");
+    expect(body).toContain("message_stop");
+
+    // Poll the DP's own /metrics until the token counters appear —
+    // pre-fix input stays 0 while output records, so assert both.
+    const scrapeDeadline = Date.now() + 5_000;
+    let inTokens = 0;
+    let outTokens = 0;
+    while (Date.now() < scrapeDeadline) {
+      const scrape = await fetch(`${app.metricsUrl}/metrics`).then((r) =>
+        r.text(),
+      );
+      inTokens = sumMetric(scrape, "aisix_llm_input_tokens_total", "/v1/messages");
+      outTokens = sumMetric(
+        scrape,
+        "aisix_llm_output_tokens_total",
+        "/v1/messages",
+      );
+      if (inTokens > 0 && outTokens > 0) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    expect(
+      inTokens,
+      "input_tokens reported only on message_delta must be harvested (#952)",
+    ).toBeGreaterThanOrEqual(INPUT_TOKENS);
+    expect(outTokens).toBeGreaterThanOrEqual(OUTPUT_TOKENS);
+  });
+});
+
+function sumMetric(scrape: string, metric: string, endpoint: string): number {
+  let total = 0;
+  for (const line of scrape.split("\n")) {
+    if (!line.startsWith(`${metric}{`)) continue;
+    if (!line.includes(`endpoint="${endpoint}"`)) continue;
+    const valueStr = line.split("}").at(-1)?.trim() ?? "";
+    const v = Number.parseFloat(valueStr);
+    if (!Number.isNaN(v)) total += v;
+  }
+  return total;
+}


### PR DESCRIPTION
## Problem

Some anthropic-protocol relay backends ship **no usage block on `message_start`** (id/model still present) and report cumulative input/cache counts **only on the terminal `message_delta`**. Our anthropic SSE parsers read `input_tokens` / cache counters exclusively from `message_start` and only `output_tokens` from `message_delta`, so those requests record `prompt_tokens=0` — cp-api stores that as NULL, the dashboard shows 0, and the request bills as zero input (AISIX-Cloud#952, observed on the POC with claude-code through a multi-backend relay: 10/10 affected events came from the one backend with this wire shape, 507/507 events from the other backends were fine).

## Fix

Harvest `input_tokens` / `cache_creation_input_tokens` / `cache_read_input_tokens` from `message_delta.usage` too, max-wins with the `message_start` values. Two sites (the whole family):

- `aisix-proxy/src/messages.rs` `update_anthropic_usage` — the `/v1/messages` passthrough streaming parser.
- `aisix-provider-anthropic/src/wire.rs` `AnthropicStreamUsage` + `StreamState::update` — the shared decoder behind the chat bridge, vertex anthropic streaming, and `/v1/responses` (via `chat_stream`).

Non-streaming paths have a single usage source and need no fallback. This matches LiteLLM, whose `_handle_message_delta` → `calculate_usage` reads `input_tokens` from both frames.

If the relay backend ships input usage on **neither** frame, the DP still records 0/NULL — that case is unrecoverable gateway-side and is with the customer to confirm against the relay operator.

## Tests

- `messages.rs`: router-level test — mock upstream streams the #952 wire shape, asserts the emitted UsageEvent carries the delta-reported counts (fails pre-fix with `prompt_tokens=0`, verified).
- `bridge.rs`: streaming test for the shared `StreamState` harvest (verified red pre-fix).
- `tests/e2e`: new vitest case driving the real `aisix` binary + mock upstream, asserting the `/metrics` input-token counter records the delta-only usage.

Fixes api7/AISIX-Cloud#952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming token accounting for Anthropic responses when usage details arrive only at the end of the stream.
  * Usage totals now correctly include input and cache token counts, and output tokens are preserved even when upstream values are incomplete or inconsistent.
  * End-to-end metrics now reflect the expected token usage for streamed `/v1/messages` requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->