### PR TITLE
test(harness): de-collide e2e ports — per-fork ranges + AddrInUse respawn

### DIFF
--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -65,8 +65,41 @@ const SHUTDOWN_GRACE_MS = 3_000;
  * on the proxy, `/admin/v1/health` on the admin listener, and the scrape
  * path on the metrics listener to respond 200. `exit()` issues SIGTERM
  * and waits up to 3s, escalating to SIGKILL.
+ *
+ * A startup that dies to a port collision (an external process bound one
+ * of the picked ports in the pick→bind window; see `ports.ts`) is retried
+ * with fresh ports rather than failing the test.
  */
 export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp> {
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await spawnAppOnce(overrides);
+    } catch (err) {
+      if (attempt < MAX_ATTEMPTS && isAddrInUseStartupFailure(err)) {
+        console.warn(
+          `spawnApp: aisix died to a port collision (attempt ${attempt}/${MAX_ATTEMPTS}), retrying with fresh ports`,
+        );
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * True when the spawn failure is `aisix` exiting at startup because one
+ * of its listeners hit AddrInUse — the only failure class `spawnApp`
+ * retries (anything else is a real bug the test must surface).
+ */
+export function isAddrInUseStartupFailure(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  // Matches both the OS error text ("Address already in use (os error
+  // 98)") and Rust's ErrorKind rendering ("AddrInUse").
+  return msg.includes("exited early") && /addr(?:ess)?\s*(?:already\s*)?in\s*use/i.test(msg);
+}
+
+async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   const etcd = new EtcdClient();
   if (!(await etcd.ping())) {
     throw new Error(
@@ -178,11 +211,17 @@ export async function spawnApp(overrides: AppOverrides = {}): Promise<SpawnedApp
     ]);
   } catch (err) {
     const detail = exitErr ?? "still running";
-    const stderr = stderrBuf.slice(-2000);
+    // Keep the head too — a startup error (anyhow's `Error: …` line)
+    // prints before its backtrace, and a tail-only excerpt used to cut
+    // exactly the line that says what went wrong.
+    const stderr =
+      stderrBuf.length <= 3000
+        ? stderrBuf
+        : `${stderrBuf.slice(0, 1500)}\n  […]\n${stderrBuf.slice(-1500)}`;
     await terminate(child);
     await cleanup(etcd, etcdPrefix, dir);
     throw new Error(
-      `${(err as Error).message}\n  binary state: ${detail}\n  stderr tail:\n${stderr}`,
+      `${(err as Error).message}\n  binary state: ${detail}\n  stderr:\n${stderr}`,
     );
   }
 

--- a/tests/e2e/src/harness/ports.test.ts
+++ b/tests/e2e/src/harness/ports.test.ts
@@ -1,0 +1,75 @@
+import { createServer, type Server } from "node:net";
+import { describe, expect, test } from "vitest";
+import { isAddrInUseStartupFailure } from "./app.js";
+import { pickFreePort, pickFreePorts } from "./ports.js";
+
+function listen(port: number): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(port, "127.0.0.1", () => resolve(srv));
+  });
+}
+
+function close(srv: Server): Promise<void> {
+  return new Promise((resolve, reject) =>
+    srv.close((err) => (err ? reject(err) : resolve())),
+  );
+}
+
+describe("harness port allocator", () => {
+  test("hands out distinct, immediately bindable ports from the fork's range", async () => {
+    const ports = await pickFreePorts(10);
+    expect(new Set(ports).size).toBe(ports.length);
+    for (const p of ports) {
+      expect(p).toBeGreaterThanOrEqual(21000);
+      expect(p).toBeLessThan(32200);
+      const srv = await listen(p); // must not be handed out already bound
+      await close(srv);
+    }
+  });
+
+  test("skips a port that is currently bound", async () => {
+    // The cursor is monotonic, so the next pick is deterministic within
+    // this process: occupy it and assert the allocator steps over it.
+    const probe = await pickFreePort();
+    const next = probe + 1;
+    const squatter = await listen(next);
+    try {
+      const picked = await pickFreePort();
+      expect(picked).not.toBe(next);
+    } finally {
+      await close(squatter);
+    }
+  });
+});
+
+describe("isAddrInUseStartupFailure", () => {
+  const tail = "  binary state: aisix exited early with code=1 signal=null\n  stderr:\n";
+
+  test("matches the OS error text and Rust's ErrorKind rendering", () => {
+    expect(
+      isAddrInUseStartupFailure(
+        new Error(`${tail}Error: failed to bind proxy listener: Address already in use (os error 98)`),
+      ),
+    ).toBe(true);
+    expect(
+      isAddrInUseStartupFailure(new Error(`${tail}Error: AddrInUse binding 127.0.0.1:21001`)),
+    ).toBe(true);
+  });
+
+  test("does not match other startup failures or a still-running binary", () => {
+    expect(
+      isAddrInUseStartupFailure(
+        new Error(`${tail}Error: etcd initial sync failed: deadline exceeded`),
+      ),
+    ).toBe(false);
+    expect(
+      isAddrInUseStartupFailure(
+        new Error(
+          "timed out waiting for /livez\n  binary state: still running\n  stderr:\nAddress already in use",
+        ),
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/e2e/src/harness/ports.ts
+++ b/tests/e2e/src/harness/ports.ts
@@ -1,25 +1,64 @@
 import { createServer } from "node:net";
 
-/**
- * Ask the OS for a free TCP port by binding to :0, reading the assigned
- * port, and closing the socket. There is a tiny race between close and
- * the caller binding, but in practice the test process grabs the port
- * fast enough that collisions are extremely rare.
- */
-export async function pickFreePort(): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
+// Port allocation for everything the harness binds (spawned `aisix`
+// listeners and mock upstreams).
+//
+// The old implementation asked the OS for an ephemeral port (bind :0,
+// read, close) and handed it to the caller to re-bind. That is a
+// check-then-use race: with vitest running two forks, a port picked in
+// fork A could be re-issued by the kernel to fork B (or grabbed by a
+// mock server) before `aisix` — whose bind happens a spawn later —
+// got to it. Observed as startup flakes where `aisix` exits 1 with
+// AddrInUse while the readiness probe sees a *different* instance
+// answer 404 on the stolen port, then ECONNREFUSED.
+//
+// Instead, carve a disjoint port range per vitest fork
+// (`VITEST_POOL_ID`; pid fallback outside vitest) and hand out ports
+// from a monotonic cursor within that range, verifying each is
+// actually bindable. No two in-run processes can be issued the same
+// port, and within a process a port is never re-issued while a
+// previous owner may still be starting up. The only remaining
+// collision source is an unrelated external process, which the
+// bind-probe skips when static and `spawnApp`'s AddrInUse retry
+// absorbs when racing. The range sits below Linux's default ephemeral
+// range (32768+) so the kernel never assigns from it.
+
+const RANGE_BASE = 21000;
+const RANGE_SIZE = 800;
+const RANGE_SLOTS = 14; // 21000..32199, below the ephemeral range
+
+function rangeSlot(): number {
+  const poolId = Number(process.env.VITEST_POOL_ID);
+  if (Number.isFinite(poolId) && poolId >= 0) return poolId % RANGE_SLOTS;
+  return process.pid % RANGE_SLOTS;
+}
+
+let cursor = 0;
+
+/** True when the port can be bound on 127.0.0.1 right now. */
+function canBind(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
     const srv = createServer();
-    srv.once("error", reject);
-    srv.listen(0, "127.0.0.1", () => {
-      const address = srv.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("unexpected unix-socket address"));
-        return;
-      }
-      const port = address.port;
-      srv.close((err) => (err ? reject(err) : resolve(port)));
+    srv.once("error", () => resolve(false));
+    srv.listen(port, "127.0.0.1", () => {
+      srv.close(() => resolve(true));
     });
   });
+}
+
+/**
+ * Hand out the next free port from this process's dedicated range.
+ * See the module comment for why this is not "ask the OS for :0".
+ */
+export async function pickFreePort(): Promise<number> {
+  const base = RANGE_BASE + rangeSlot() * RANGE_SIZE;
+  for (let i = 0; i < RANGE_SIZE; i++) {
+    const port = base + (cursor++ % RANGE_SIZE);
+    if (await canBind(port)) return port;
+  }
+  throw new Error(
+    `no free port in range ${base}-${base + RANGE_SIZE - 1} after ${RANGE_SIZE} attempts`,
+  );
 }
 
 /** Pick N free ports in sequence. */


### PR DESCRIPTION
## Problem

Recurring e2e startup flake (twice in two days: `sls-content-capture-responses-completions` on #710's run, `datadog-exporter` on main run 28595570164):

```text
timed out waiting for http://127.0.0.1:46453/metrics after 99 attempts (lastStatus=404): connect ECONNREFUSED
  binary state: aisix exited early with code=1 signal=null
```

`pickFreePort` binds `:0`, reads the assignment, closes the socket, and hands the port to `aisix` to re-bind **a process spawn later**. Under vitest's two parallel forks that check-then-use window races: the kernel can re-issue the port to the other fork (or a mock server) first. The `lastStatus=404`-then-`ECONNREFUSED` probe shape is the tell — the probe was answered by a *different* instance that had stolen the port, while our `aisix` died to AddrInUse.

## Fix

- **`ports.ts`**: allocate from a disjoint per-fork port range (`VITEST_POOL_ID`, pid fallback outside vitest) with a monotonic in-process cursor and a bind-verify probe. Ranges sit below the kernel's ephemeral range (32768+), so `:0` assignments can never overlap them. No call-site changes.
- **`app.ts`**: `spawnApp` respawns with fresh ports (max 3 attempts) only when `aisix` exited at startup with AddrInUse — the residual race vs unrelated external processes. Any other startup failure still fails the test immediately.
- **`app.ts` diagnostics**: keep the stderr **head** in the failure excerpt. anyhow prints `Error: …` before its backtrace; the old tail-only slice cut exactly the line naming the failure, which is why the CI flake logs only showed backtrace frames.

## Tests

- `src/harness/ports.test.ts`: allocator range/uniqueness/bindability, occupied-port skip, and the AddrInUse failure classifier (positive + negative).
- The respawn path's race itself can't be triggered deterministically (concurrency timing) — classifier is unit-tested instead.
- Full local e2e suite with the new allocator: 117 files / 225 tests, all green.