### PR TITLE
feat(docker): non-root image binds :80/:443 via CAP_NET_BIND_SERVICE file capability

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -114,6 +114,9 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          # PR builds aren't pushed; load them into the local daemon so
+          # the smoke test below can run the image.
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -121,6 +124,45 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false   # keep manifest format compatible with older clients
+
+      # The image contract customers rely on for hostNetwork/:80
+      # deployments: the default non-root user (uid 10001) must be able
+      # to bind privileged ports via the CAP_NET_BIND_SERVICE file
+      # capability set in the Dockerfile. Runs the container on the host
+      # network with the proxy on :80 — without the file capability the
+      # bind fails and /livez never answers.
+      - name: Smoke test — non-root binds :80
+        if: github.event_name == 'pull_request'
+        run: |
+          set -eux
+          IMAGE="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)"
+          docker run -d --name smoke-etcd -p 2379:2379 quay.io/coreos/etcd:v3.5.18 \
+            etcd --listen-client-urls=http://0.0.0.0:2379 \
+                 --advertise-client-urls=http://127.0.0.1:2379
+          cat > /tmp/smoke.yaml <<'EOF'
+          etcd:
+            endpoints: ["http://127.0.0.1:2379"]
+          proxy:
+            addr: "0.0.0.0:80"
+          admin:
+            addr: "127.0.0.1:3001"
+            admin_keys: ["smoke-only"]
+          observability:
+            service_name: "aisix-smoke"
+            log_level: "info"
+            metrics:
+              prometheus:
+                enabled: false
+          EOF
+          docker run -d --name smoke-aisix --network host \
+            -v /tmp/smoke.yaml:/etc/aisix/config.yaml:ro "$IMAGE"
+          ok=""
+          for _ in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:80/livez > /dev/null; then ok=1; break; fi
+            sleep 1
+          done
+          docker logs smoke-aisix
+          test -n "$ok"
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,22 @@ RUN apt-get update \
     && mkdir -p /etc/aisix/tls /var/lib/aisix \
     && chown -R aisix:aisix /etc/aisix /var/lib/aisix
 
-COPY --from=builder /usr/local/bin/aisix /usr/local/bin/aisix
+# Install the binary and grant CAP_NET_BIND_SERVICE as a file
+# capability so the non-root user can bind privileged ports (e.g.
+# listening on :80/:443 with Kubernetes hostNetwork). Install + setcap
+# happen in one RUN (bind-mount, no COPY) so the binary isn't
+# duplicated across layers by the xattr change. Caveat: with the
+# effective bit set, exec fails outright if NET_BIND_SERVICE is
+# missing from the container's bounding set — it is in the default
+# Docker/containerd cap set, but `capabilities: {drop: [ALL]}` pod
+# specs must add NET_BIND_SERVICE back.
+RUN --mount=type=bind,from=builder,source=/usr/local/bin/aisix,target=/mnt/aisix \
+    apt-get update \
+    && apt-get install -y --no-install-recommends libcap2-bin \
+    && install -m 0755 /mnt/aisix /usr/local/bin/aisix \
+    && setcap 'cap_net_bind_service=+ep' /usr/local/bin/aisix \
+    && apt-get purge -y --auto-remove libcap2-bin \
+    && rm -rf /var/lib/apt/lists/*
 
 # Bake the managed-mode bootstrap config so aisix.cloud tenants can
 # `docker run` without mounting anything — env vars carry the per-DP


### PR DESCRIPTION
Customers deploying the DP on Kubernetes with `hostNetwork: true` want the proxy listener directly on node port 80. The image runs as uid 10001, so binding a privileged port previously required running the container as root (or shipping a separate root image variant).

Instead, the Dockerfile now sets the `cap_net_bind_service=+ep` file capability on the binary. The image stays non-root and can bind 80/443 in plain Docker, in hostNetwork pods, and under the restricted Pod Security Standard (`drop: [ALL]` + `add: [NET_BIND_SERVICE]`). Same approach as Traefik/Envoy images. No separate root image, no release-workflow changes.

Implementation notes:

- install + `setcap` happen in one bind-mount `RUN` (no `COPY --from` for the binary) so the xattr change doesn't duplicate the ~large binary into a second layer, and because `COPY` does not reliably carry `security.capability` xattrs;
- `libcap2-bin` is purged again in the same layer.

Behavior change / compatibility: `NET_BIND_SERVICE` is in the default Docker/containerd capability set, so default deployments are unaffected. The one caveat: a pod that drops ALL capabilities without adding `NET_BIND_SERVICE` back now fails at exec (`Operation not permitted`) instead of starting — with the effective bit set, the kernel refuses to exec a binary whose file capabilities cannot be granted. Documented in the paired docs PR (api7/docs#1766).

Testing: `docker-image.yml` PR builds now `load` the image and smoke-test the contract — run the container with the default non-root user on the host network with `proxy.addr: 0.0.0.0:80` and require `/livez` to answer. The test fails on the pre-fix image (`proxy serve error: Permission denied (os error 13)`) and passes with this change. Also locally verified: `--cap-drop ALL` fails exec as documented, `--cap-drop ALL --cap-add NET_BIND_SERVICE` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
