### PR TITLE
feat(embeddings): native Vertex/Gemini :predict + Bedrock Titan/Cohere embed (close the non-OpenAI 501)

### DIFF
--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -18,7 +18,8 @@
 
 use aisix_gateway::{
     Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream, ChatDelta, ChatFormat,
-    ChatMessage, ChatResponse, FinishReason, Role, UsageStats,
+    ChatMessage, ChatResponse, EmbeddingObject, EmbeddingRequest, EmbeddingResponse,
+    EmbeddingUsage, EmbeddingVector, FinishReason, Role, UsageStats,
 };
 use async_trait::async_trait;
 use aws_credential_types::provider::SharedCredentialsProvider;
@@ -661,6 +662,117 @@ impl Bridge for BedrockBridge {
         let _ = publisher;
         self.chat_converse_stream(req, ctx, upstream_id).await
     }
+
+    /// Native Bedrock embeddings (#723), LiteLLM `litellm/llms/bedrock/embed/`
+    /// parity: `amazon.titan-embed-*` (Titan G1/V2 — the model embeds ONE
+    /// text per InvokeModel, so batch inputs loop; LiteLLM iterates the
+    /// same way) and `cohere.embed-*` (whole batch in one call). Other
+    /// publishers expose no embedding models on Bedrock.
+    async fn embed(
+        &self,
+        req: &EmbeddingRequest,
+        ctx: &BridgeContext,
+    ) -> Result<EmbeddingResponse, BridgeError> {
+        let upstream_id = upstream_model(ctx)?;
+        validate_model_id_chars(upstream_id)?;
+        let client = self.build_client_from_ctx(ctx)?;
+        let started = Instant::now();
+        let deadline = ctx.deadline;
+
+        let mut data = Vec::with_capacity(req.input.len());
+        let mut prompt_tokens: u64 = 0;
+
+        let base_id = strip_region_prefix(upstream_id);
+        if base_id.starts_with("amazon.titan-embed") {
+            for (i, text) in req.input.iter().enumerate() {
+                let mut body = serde_json::json!({"inputText": text});
+                // `dimensions` is a Titan V2 knob; G1 rejects unknown keys.
+                if let Some(dims) = req.dimensions {
+                    if base_id.contains("v2") {
+                        body["dimensions"] = dims.into();
+                    }
+                }
+                let body_bytes = serde_json::to_vec(&body)
+                    .map_err(|e| BridgeError::Config(format!("serialize Titan embed body: {e}")))?;
+                let resp = client
+                    .invoke_model()
+                    .model_id(upstream_id)
+                    .content_type("application/json")
+                    .accept("application/json")
+                    .body(Blob::new(body_bytes))
+                    .send()
+                    .await
+                    .map_err(|e| map_sdk_error(e, started, deadline))?;
+                let parsed: TitanEmbedResponse = serde_json::from_slice(resp.body().as_ref())
+                    .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+                prompt_tokens += parsed.input_text_token_count;
+                data.push(EmbeddingObject {
+                    index: i as u32,
+                    object: "embedding".to_string(),
+                    embedding: EmbeddingVector::Float(parsed.embedding),
+                });
+            }
+        } else if base_id.starts_with("cohere.embed") {
+            let body = serde_json::json!({
+                "texts": req.input,
+                // LiteLLM's default when the caller gives no input_type.
+                "input_type": "search_document",
+            });
+            let body_bytes = serde_json::to_vec(&body)
+                .map_err(|e| BridgeError::Config(format!("serialize Cohere embed body: {e}")))?;
+            let resp = client
+                .invoke_model()
+                .model_id(upstream_id)
+                .content_type("application/json")
+                .accept("application/json")
+                .body(Blob::new(body_bytes))
+                .send()
+                .await
+                .map_err(|e| map_sdk_error(e, started, deadline))?;
+            let parsed: CohereEmbedResponse = serde_json::from_slice(resp.body().as_ref())
+                .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+            for (i, values) in parsed.embeddings.into_iter().enumerate() {
+                data.push(EmbeddingObject {
+                    index: i as u32,
+                    object: "embedding".to_string(),
+                    embedding: EmbeddingVector::Float(values),
+                });
+            }
+            // Cohere-on-Bedrock returns no token statistics; usage stays 0
+            // (LiteLLM surfaces the same absence).
+        } else {
+            return Err(BridgeError::Config(format!(
+                "bedrock embeddings support amazon.titan-embed-* and cohere.embed-* \
+                 model ids; got {upstream_id:?}"
+            )));
+        }
+
+        let tokens = prompt_tokens.min(u32::MAX as u64) as u32;
+        Ok(EmbeddingResponse {
+            object: "list".to_string(),
+            model: req.model.clone(),
+            data,
+            usage: EmbeddingUsage {
+                prompt_tokens: tokens,
+                total_tokens: tokens,
+            },
+        })
+    }
+}
+
+/// Titan embed response per the Amazon Titan Embeddings docs
+/// (`embedding` + `inputTextTokenCount`).
+#[derive(Debug, Deserialize)]
+struct TitanEmbedResponse {
+    embedding: Vec<f32>,
+    #[serde(rename = "inputTextTokenCount", default)]
+    input_text_token_count: u64,
+}
+
+/// Cohere-on-Bedrock embed response (`embeddings` = one vector per text).
+#[derive(Debug, Deserialize)]
+struct CohereEmbedResponse {
+    embeddings: Vec<Vec<f32>>,
 }
 
 impl BedrockBridge {
@@ -4002,5 +4114,163 @@ mod tests {
             Some(1.0),
             "stream-path Converse temperature must be clamped to temperature_max; body={body}",
         );
+    }
+
+    // ─── #723: native embeddings via InvokeModel ──────────────────────
+
+    #[tokio::test]
+    async fn titan_embed_loops_one_invoke_per_input() {
+        use wiremock::matchers::{method as wm_method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(wm_method("POST"))
+            .and(wm_path("/model/amazon.titan-embed-text-v1/invoke"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "embedding": [0.25, 0.5],
+                "inputTextTokenCount": 4
+            })))
+            .mount(&server)
+            .await;
+
+        let bridge = BedrockBridge::new().with_endpoint_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("amazon.titan-embed-text-v1"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let req = EmbeddingRequest {
+            model: "customer-facing-name".into(),
+            input: vec!["a".into(), "b".into()],
+            input_was_single: false,
+            encoding_format: None,
+            dimensions: None,
+        };
+        let resp = bridge.embed(&req, &ctx).await.expect("titan embed");
+        assert_eq!(resp.data.len(), 2);
+        assert_eq!(resp.data[1].index, 1);
+        assert_eq!(resp.usage.prompt_tokens, 8, "4 tokens per input, summed");
+
+        // Titan embeds ONE text per call -> two upstream invokes, in order.
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 2);
+        let first: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(first, serde_json::json!({"inputText": "a"}));
+        // SigV4 signing ran (SDK path) — the Authorization header carries
+        // the AWS algorithm marker.
+        assert!(received[0]
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .contains("AWS4-HMAC-SHA256"));
+    }
+
+    #[tokio::test]
+    async fn titan_v2_embed_forwards_dimensions_but_g1_does_not() {
+        use wiremock::matchers::method as wm_method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(wm_method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "embedding": [0.1],
+                "inputTextTokenCount": 1
+            })))
+            .mount(&server)
+            .await;
+
+        let bridge = BedrockBridge::new().with_endpoint_override(server.uri());
+        let req = EmbeddingRequest {
+            model: "customer-facing-name".into(),
+            input: vec!["a".into()],
+            input_was_single: true,
+            encoding_format: None,
+            dimensions: Some(512),
+        };
+
+        // V2: dimensions forwards.
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("amazon.titan-embed-text-v2:0"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        bridge.embed(&req, &ctx).await.expect("v2 embed");
+        // G1: dimensions must be omitted (Titan G1 rejects unknown keys).
+        let ctx = BridgeContext::new(
+            "req-2",
+            sample_model_with("amazon.titan-embed-text-v1"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        bridge.embed(&req, &ctx).await.expect("g1 embed");
+
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 2);
+        let v2_body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(v2_body["dimensions"], 512);
+        let g1_body: serde_json::Value = serde_json::from_slice(&received[1].body).unwrap();
+        assert!(g1_body.get("dimensions").is_none());
+    }
+
+    #[tokio::test]
+    async fn cohere_embed_sends_whole_batch_in_one_call() {
+        use wiremock::matchers::{method as wm_method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(wm_method("POST"))
+            .and(wm_path("/model/cohere.embed-english-v3/invoke"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "embeddings": [[0.1, 0.2], [0.3, 0.4]]
+            })))
+            .mount(&server)
+            .await;
+
+        let bridge = BedrockBridge::new().with_endpoint_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("cohere.embed-english-v3"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let req = EmbeddingRequest {
+            model: "customer-facing-name".into(),
+            input: vec!["a".into(), "b".into()],
+            input_was_single: false,
+            encoding_format: None,
+            dimensions: None,
+        };
+        let resp = bridge.embed(&req, &ctx).await.expect("cohere embed");
+        assert_eq!(resp.data.len(), 2);
+
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1, "cohere batches in a single call");
+        let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(body["texts"], serde_json::json!(["a", "b"]));
+        assert_eq!(body["input_type"], "search_document");
+    }
+
+    #[tokio::test]
+    async fn embed_rejects_non_embedding_publishers() {
+        let bridge = BedrockBridge::new();
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let req = EmbeddingRequest {
+            model: "customer-facing-name".into(),
+            input: vec!["a".into()],
+            input_was_single: true,
+            encoding_format: None,
+            dimensions: None,
+        };
+        let err = bridge.embed(&req, &ctx).await.unwrap_err();
+        match err {
+            BridgeError::Config(msg) => {
+                assert!(msg.contains("amazon.titan-embed-"));
+                assert!(msg.contains("cohere.embed-"));
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
     }
 }

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -25,7 +25,8 @@
 use aisix_gateway::{
     sse::{SseDecoder, SseEvent},
     Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream, ChatDelta, ChatFormat,
-    ChatMessage, ChatResponse, FinishReason, Role, UsageStats,
+    ChatMessage, ChatResponse, EmbeddingObject, EmbeddingRequest, EmbeddingResponse,
+    EmbeddingUsage, EmbeddingVector, FinishReason, Role, UsageStats,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -644,6 +645,121 @@ impl Bridge for VertexBridge {
             }
         }
     }
+
+    /// Native Vertex embeddings (#723): google-publisher `:predict`
+    /// with the text-embedding `instances` shape — LiteLLM
+    /// `VertexEmbedding` (`vertex_embeddings/embedding_handler.py`)
+    /// parity. Every embedding model on this adapter is a
+    /// google-publisher surface (the Claude / MaaS publishers expose
+    /// no embeddings), so there is no publisher dispatch here.
+    async fn embed(
+        &self,
+        req: &EmbeddingRequest,
+        ctx: &BridgeContext,
+    ) -> Result<EmbeddingResponse, BridgeError> {
+        let upstream_id = upstream_model(ctx)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        validate_url_token("project", &creds.project)?;
+        validate_url_token("region", &creds.region)?;
+        validate_url_token("upstream_id", upstream_id)?;
+
+        let base = self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
+        let url = format!(
+            "{base}/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:predict",
+            project = creds.project,
+            region = creds.region,
+            model = upstream_id,
+        );
+
+        let instances: Vec<serde_json::Value> = req
+            .input
+            .iter()
+            .map(|text| serde_json::json!({"content": text}))
+            .collect();
+        let mut body = serde_json::json!({"instances": instances});
+        if let Some(dims) = req.dimensions {
+            body["parameters"] = serde_json::json!({"outputDimensionality": dims});
+        }
+        apply_body_overrides(&mut body, ctx);
+
+        let access_token = creds.resolve_access_token(&self.token_minter).await?;
+        let headers = build_request_headers(
+            &access_token,
+            &ctx.request_id,
+            ctx.provider_key.request.as_ref(),
+        )?;
+        let client = self.client.clone();
+        let started = Instant::now();
+        let model_echo = req.model.clone();
+
+        with_deadline(ctx.deadline, started, async move {
+            let resp = client
+                .post(&url)
+                .headers(headers)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| BridgeError::Transport(e.to_string()))?;
+            let status = resp.status();
+            if !status.is_success() {
+                return Err(map_http_error(status, resp).await);
+            }
+            let parsed: VertexPredictEmbeddingsResponse = resp
+                .json()
+                .await
+                .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+
+            let mut data = Vec::with_capacity(parsed.predictions.len());
+            let mut prompt_tokens: u64 = 0;
+            for (i, p) in parsed.predictions.into_iter().enumerate() {
+                if let Some(stats) = &p.embeddings.statistics {
+                    prompt_tokens += stats.token_count;
+                }
+                data.push(EmbeddingObject {
+                    index: i as u32,
+                    object: "embedding".to_string(),
+                    embedding: EmbeddingVector::Float(p.embeddings.values),
+                });
+            }
+            let tokens = prompt_tokens.min(u32::MAX as u64) as u32;
+            Ok(EmbeddingResponse {
+                object: "list".to_string(),
+                model: model_echo,
+                data,
+                usage: EmbeddingUsage {
+                    prompt_tokens: tokens,
+                    total_tokens: tokens,
+                },
+            })
+        })
+        .await
+    }
+}
+
+/// `:predict` response for text-embedding models, per
+/// <https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings>.
+#[derive(Debug, Deserialize)]
+struct VertexPredictEmbeddingsResponse {
+    #[serde(default)]
+    predictions: Vec<VertexEmbeddingPrediction>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VertexEmbeddingPrediction {
+    embeddings: VertexEmbeddingsPayload,
+}
+
+#[derive(Debug, Deserialize)]
+struct VertexEmbeddingsPayload {
+    values: Vec<f32>,
+    #[serde(default)]
+    statistics: Option<VertexEmbeddingStatistics>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VertexEmbeddingStatistics {
+    #[serde(default)]
+    token_count: u64,
 }
 
 impl VertexBridge {
@@ -4803,5 +4919,109 @@ mod tests {
             Some("abc"),
             "response.content_list_to_string must flatten array content to a string on the outbound body; got {body}",
         );
+    }
+
+    // ─── #723: native embeddings via :predict ─────────────────────────
+
+    #[tokio::test]
+    async fn embed_dispatches_predict_and_sums_usage() {
+        use wiremock::matchers::{method as wm_method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(wm_method("POST"))
+            .and(wm_path(
+                "/v1/projects/my-proj/locations/us-central1/publishers/google/models/text-embedding-005:predict",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "predictions": [
+                    {"embeddings": {"values": [0.1, 0.2], "statistics": {"token_count": 3}}},
+                    {"embeddings": {"values": [0.3, 0.4], "statistics": {"token_count": 2}}}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let bridge = VertexBridge::new().with_api_base_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("text-embedding-005"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let req = EmbeddingRequest {
+            model: "customer-facing-name".into(),
+            input: vec!["hello".into(), "world".into()],
+            input_was_single: false,
+            encoding_format: None,
+            dimensions: None,
+        };
+        let resp = bridge.embed(&req, &ctx).await.expect("embed dispatch");
+        assert_eq!(resp.object, "list");
+        assert_eq!(resp.model, "customer-facing-name");
+        assert_eq!(resp.data.len(), 2);
+        assert_eq!(resp.data[0].index, 0);
+        match &resp.data[0].embedding {
+            EmbeddingVector::Float(v) => assert_eq!(v, &vec![0.1, 0.2]),
+            other => panic!("expected float vector, got {other:?}"),
+        }
+        assert_eq!(
+            resp.usage.prompt_tokens, 5,
+            "token_count sums across predictions"
+        );
+
+        // Upstream body: one instance per input, in order, plus the
+        // OAuth bearer from the PK secret.
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(
+            body["instances"],
+            serde_json::json!([{"content": "hello"}, {"content": "world"}])
+        );
+        assert!(
+            body.get("parameters").is_none(),
+            "no dims -> no parameters key"
+        );
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer ya29.test")
+        );
+    }
+
+    #[tokio::test]
+    async fn embed_forwards_output_dimensionality() {
+        use wiremock::matchers::method as wm_method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(wm_method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "predictions": [
+                    {"embeddings": {"values": [0.5], "statistics": {"token_count": 1}}}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let bridge = VertexBridge::new().with_api_base_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("gemini-embedding-001"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let req = EmbeddingRequest {
+            model: "customer-facing-name".into(),
+            input: vec!["hello".into()],
+            input_was_single: true,
+            encoding_format: None,
+            dimensions: Some(256),
+        };
+        bridge.embed(&req, &ctx).await.expect("embed dispatch");
+        let received = server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(body["parameters"]["outputDimensionality"], 256);
     }
 }

--- a/tests/e2e/src/cases/embeddings-native-providers-e2e.test.ts
+++ b/tests/e2e/src/cases/embeddings-native-providers-e2e.test.ts
@@ -1,0 +1,201 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: /v1/embeddings native provider translation (#723,
+// AISIX-Cloud#873 §⑤ "跨厂商 embeddings"). Pre-#723 only OpenAI-shaped
+// upstreams worked — a Vertex/Gemini or Bedrock Model on /v1/embeddings
+// returned 501. These cases drive the real `aisix` binary through the
+// OpenAI SDK and pin the provider-native upstream wire:
+//
+//   1. Vertex/Gemini: google-publisher `:predict` with the
+//      `instances[{content}]` body and OAuth bearer; per-prediction
+//      `statistics.token_count` sums into OpenAI-shape usage.
+//   2. Bedrock Titan: one SigV4-signed InvokeModel per input text
+//      (`{"inputText": …}`), vectors reassembled in input order.
+
+const CALLER_PLAINTEXT = "sk-nembed-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+interface RecordingUpstream {
+  baseUrl: string;
+  received: { method: string; path: string; body: string; headers: Record<string, string> }[];
+  close(): Promise<void>;
+}
+
+async function startJsonUpstream(
+  reply: (path: string, body: string) => unknown,
+): Promise<RecordingUpstream> {
+  const received: RecordingUpstream["received"] = [];
+  const server: Server = createServer((req, res) => {
+    res.on("error", () => {});
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString("utf8");
+      const path = (req.url ?? "/").split("?")[0];
+      received.push({
+        method: req.method ?? "GET",
+        path,
+        body,
+        headers: Object.fromEntries(
+          Object.entries(req.headers).map(([k, v]) => [
+            k,
+            Array.isArray(v) ? v.join(",") : (v ?? ""),
+          ]),
+        ),
+      });
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(reply(path, body)));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  if (addr === null || typeof addr === "string") throw new Error("no port");
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    received,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((e) => (e ? reject(e) : resolve())),
+      ),
+  };
+}
+
+describe("native-provider embeddings e2e (#723)", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  const upstreams: RecordingUpstream[] = [];
+  let client: OpenAI;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("vertex/gemini model embeds via :predict with OAuth bearer + summed usage", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startJsonUpstream(() => ({
+      predictions: [
+        { embeddings: { values: [0.11, 0.22], statistics: { token_count: 3 } } },
+        { embeddings: { values: [0.33, 0.44], statistics: { token_count: 2 } } },
+      ],
+    }));
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "vertex-embed-pk",
+      provider: "google",
+      adapter: "vertex",
+      secret: JSON.stringify({
+        access_token: "ya29.e2e-test",
+        project: "proj-e2e",
+        region: "us-central1",
+      }),
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "vertex-embed-model",
+      provider: "google",
+      model_name: "text-embedding-005",
+      provider_key_id: pk.id,
+    });
+
+    const resp = await client.embeddings.create({
+      model: "vertex-embed-model",
+      input: ["hello", "world"],
+    });
+    expect(resp.data.length).toBe(2);
+    expect(resp.data[0].embedding).toEqual([0.11, 0.22]);
+    expect(resp.data[1].embedding).toEqual([0.33, 0.44]);
+    expect(resp.usage.prompt_tokens).toBe(5);
+
+    const seen = upstream.received[0];
+    expect(seen.path).toBe(
+      "/v1/projects/proj-e2e/locations/us-central1/publishers/google/models/text-embedding-005:predict",
+    );
+    expect(seen.headers.authorization).toBe("Bearer ya29.e2e-test");
+    const sent = JSON.parse(seen.body) as { instances: { content: string }[] };
+    expect(sent.instances).toEqual([{ content: "hello" }, { content: "world" }]);
+  });
+
+  test("bedrock titan model embeds via one SigV4 InvokeModel per input", async (ctx) => {
+    if (!etcdReachable || !app || !admin) {
+      ctx.skip();
+      return;
+    }
+
+    let call = 0;
+    const upstream = await startJsonUpstream(() => {
+      call += 1;
+      return { embedding: [call * 0.1, call * 0.2], inputTextTokenCount: 4 };
+    });
+    upstreams.push(upstream);
+
+    const pk = await admin.createProviderKey({
+      display_name: "bedrock-embed-pk",
+      provider: "bedrock",
+      adapter: "bedrock",
+      secret: JSON.stringify({
+        access_key_id: "AKIA-e2e",
+        secret_access_key: "sk-e2e",
+        region: "us-west-2",
+      }),
+      api_base: upstream.baseUrl,
+    });
+    await admin.createModel({
+      display_name: "bedrock-embed-model",
+      provider: "bedrock",
+      model_name: "amazon.titan-embed-text-v1",
+      provider_key_id: pk.id,
+    });
+
+    const resp = await client.embeddings.create({
+      model: "bedrock-embed-model",
+      input: ["a", "b"],
+    });
+    expect(resp.data.length).toBe(2);
+    expect(resp.usage.prompt_tokens).toBe(8);
+
+    // Titan embeds one text per call: two invokes on the model URL,
+    // SigV4-signed, bodies in input order.
+    const invokes = upstream.received.filter((r) =>
+      r.path.includes("/model/amazon.titan-embed-text-v1/invoke"),
+    );
+    expect(invokes.length).toBe(2);
+    expect(JSON.parse(invokes[0].body)).toEqual({ inputText: "a" });
+    expect(JSON.parse(invokes[1].body)).toEqual({ inputText: "b" });
+    expect(invokes[0].headers.authorization).toContain("AWS4-HMAC-SHA256");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the "跨厂商 embeddings" gap of AISIX-Cloud#873 §⑤: `/v1/embeddings` on a Vertex/Gemini or Bedrock Model no longer 501s. The Bridge trait's `embed()` had a 501 default that only the OpenAI bridge overrode — this adds the two missing native implementations. No proxy-layer changes (the handler already dispatches through `bridge.embed()`), and Anthropic keeps the 501 default (no embeddings API — n/a in LiteLLM too).

Fixes #723

## Vertex / Gemini (LiteLLM `VertexEmbedding` parity)

Google-publisher `:predict` (`…/publishers/google/models/<model>:predict`) with the text-embedding `instances[{content}]` shape; OpenAI `dimensions` maps to `parameters.outputDimensionality`; per-prediction `statistics.token_count` sums into OpenAI-shape usage. Reuses the chat path's plumbing verbatim: OAuth bearer (pre-minted or SA-minted), `api_base` override, URL-token validation, PK body overrides, deadline wrapper. Embeddings on Vertex are a google-publisher surface, so there is no publisher dispatch.

## Bedrock (LiteLLM `litellm/llms/bedrock/embed/` parity)

- **Titan G1/V2** (`amazon.titan-embed-*`): one `InvokeModel` per input text — the model embeds a single text per call, LiteLLM loops identically; vectors reassemble in input order; `inputTextTokenCount` sums into usage. `dimensions` forwards on **V2 only** (G1 rejects unknown keys).
- **Cohere-on-Bedrock** (`cohere.embed-*`): whole batch in one call (`texts` + LiteLLM's `input_type: "search_document"` default). No token statistics on this response — usage stays 0, same absence LiteLLM surfaces.
- SigV4 via the existing per-request SDK client; cross-region inference-profile prefixes (`us.` / `eu.` / `apac.`) honored; other publishers get a clear Config error naming the supported families.

## Tests

- 6 unit tests (wiremock): vertex `:predict` URL/body/bearer + usage summing + `outputDimensionality`; bedrock titan per-input loop + SigV4 marker, V2-vs-G1 dimensions gating, cohere single-batch body, unsupported-publisher error.
- DP e2e `embeddings-native-providers-e2e.test.ts` (real binary + etcd, OpenAI SDK client): vertex `:predict` round-trip with OAuth bearer + summed usage; bedrock titan two-invoke round-trip with SigV4-signed requests.
