### PR TITLE
feat(guardrails): surface monitor-mode hits on usage events

### DIFF
--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -36,11 +36,11 @@ pub use models::{
     validate_mcp_server, validate_model, validate_observability_exporter, validate_provider_key,
     validate_rate_limit_policy, A2aAgent, A2aAuthType, A2aProtocolVersion, Adapter, AisixSnapshot,
     ApiKey, AppliedGuardrail, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
-    GuardrailHookPoint, GuardrailKind, KeywordConfig, KeywordPattern, McpAuthType, McpServer,
-    McpTransport, Model, ObservabilityExporter, ParamConstraints, PolicyScope, PolicyWindow,
-    ProviderKey, RateLimit, RateLimitPolicy, RequestOverrides, ResponseOverrides, Routing,
-    RoutingStrategy, RoutingTarget, SchemaError, StreamDoneMarker, TelemetryKind, TelemetryTags,
-    WhenAllUnavailablePolicy, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
+    GuardrailHookPoint, GuardrailKind, GuardrailMonitorHit, KeywordConfig, KeywordPattern,
+    McpAuthType, McpServer, McpTransport, Model, ObservabilityExporter, ParamConstraints,
+    PolicyScope, PolicyWindow, ProviderKey, RateLimit, RateLimitPolicy, RequestOverrides,
+    ResponseOverrides, Routing, RoutingStrategy, RoutingTarget, SchemaError, StreamDoneMarker,
+    TelemetryKind, TelemetryTags, WhenAllUnavailablePolicy, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -734,6 +734,33 @@ pub struct AppliedGuardrail {
     pub hook: String,
 }
 
+/// One monitor-mode observation: what an `enforcement_mode: monitor`
+/// guardrail WOULD have done to this request had it been enforcing
+/// (AISIX-Cloud#562). Carried on the telemetry UsageEvent so operators can
+/// stage a policy, watch its hit rate in the dashboard, and only then flip
+/// it to `block`.
+///
+/// `reason` and `counts` carry detector/entity/category NAMES only — never
+/// matched content (#153 no-leak criterion).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GuardrailMonitorHit {
+    /// The configured (row) name of the monitor-mode guardrail that fired.
+    pub guardrail_name: String,
+    /// Which side observed the hit: `input` or `output`.
+    pub hook: String,
+    /// `would_block` (a Block verdict was downgraded) or `would_mask`
+    /// (maskable spans were observed but not rewritten).
+    pub action: String,
+    /// The suppressed Block's operator-facing reason (`would_block` only;
+    /// empty for `would_mask`).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub reason: String,
+    /// detector/entity name → span count the guardrail would have masked
+    /// (`would_mask` only; empty for `would_block`).
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub counts: std::collections::BTreeMap<String, u32>,
+}
+
 /// Content policy evaluated before or after upstream calls.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct Guardrail {

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -41,8 +41,9 @@ pub use guardrail::{
     AliyunTextModerationConfig, AppliedGuardrail, AzureContentSafetyConfig,
     AzureContentSafetyTextModerationConfig, BedrockAWSCredentials, BedrockConfig,
     BedrockLatencyMode, Guardrail, GuardrailAttachment, GuardrailHookPoint, GuardrailKind,
-    GuardrailScopeType, KeywordConfig, KeywordPattern, LakeraConfig, OpenaiModerationConfig,
-    PiiConfig, PiiCustomPattern, PiiDetectorConfig, PresidioConfig, PresidioEntityConfig,
+    GuardrailMonitorHit, GuardrailScopeType, KeywordConfig, KeywordPattern, LakeraConfig,
+    OpenaiModerationConfig, PiiConfig, PiiCustomPattern, PiiDetectorConfig, PresidioConfig,
+    PresidioEntityConfig,
 };
 pub use mcp_server::{McpAuthType, McpServer, McpTransport};
 pub use model::{

--- a/crates/aisix-guardrails/src/bedrock.rs
+++ b/crates/aisix-guardrails/src/bedrock.rs
@@ -262,6 +262,7 @@ impl BedrockGuardrail {
                             verdict: GuardrailVerdict::Allow,
                             masked: Some(outputs),
                             counts: anonymized_counts(&resp),
+                            monitor_hits: Vec::new(),
                         }
                     } else {
                         tracing::warn!(

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 
 use aisix_core::models::{
     AisixSnapshot, AppliedGuardrail, Guardrail as DomainGuardrail, GuardrailAttachment,
-    GuardrailHookPoint, GuardrailKind, GuardrailScopeType, KeywordPattern,
+    GuardrailHookPoint, GuardrailKind, GuardrailMonitorHit, GuardrailScopeType, KeywordPattern,
 };
 use aisix_core::snapshot::ResourceTable;
 use aisix_core::SnapshotHandle;
@@ -25,7 +25,9 @@ use async_trait::async_trait;
 use crate::index::{GuardrailIndex, RequestContext, ScopeKind};
 use crate::keyword::{KeywordBlocklist, KeywordRule};
 use crate::pii::{builtin_rule, PiiAction, PiiGuardrail, PiiRule};
-use crate::{Guardrail, GuardrailChain, GuardrailVerdict, Redaction, StreamOutputPolicy};
+use crate::{
+    Guardrail, GuardrailChain, GuardrailVerdict, Redaction, SegmentsOutcome, StreamOutputPolicy,
+};
 
 /// A snapshot table's guardrail entries in deterministic chain order:
 /// `created_at` ascending (RFC3339 strings in a fixed offset compare
@@ -498,6 +500,92 @@ impl MonitorGuardrail {
             other => other,
         }
     }
+
+    /// `would_block` telemetry hit for a downgraded Block (AISIX-Cloud#562).
+    fn would_block_hit(&self, hook: &'static str, reason: &str) -> GuardrailMonitorHit {
+        GuardrailMonitorHit {
+            guardrail_name: self.row_name.clone(),
+            hook: hook.to_owned(),
+            action: "would_block".to_owned(),
+            reason: reason.to_owned(),
+            counts: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// `would_mask` telemetry hit for suppressed mask counts.
+    fn would_mask_hit(
+        &self,
+        hook: &'static str,
+        counts: std::collections::BTreeMap<String, u32>,
+    ) -> GuardrailMonitorHit {
+        GuardrailMonitorHit {
+            guardrail_name: self.row_name.clone(),
+            hook: hook.to_owned(),
+            action: "would_mask".to_owned(),
+            reason: String::new(),
+            counts,
+        }
+    }
+
+    /// Downgrade a verdict, recording a `would_block` hit alongside the
+    /// existing ops-log line.
+    fn observe_hit(
+        &self,
+        hook: &'static str,
+        verdict: GuardrailVerdict,
+        hits: &mut Vec<GuardrailMonitorHit>,
+    ) -> GuardrailVerdict {
+        if let GuardrailVerdict::Block { ref reason, .. } = verdict {
+            hits.push(self.would_block_hit(hook, reason));
+        }
+        self.observe(hook, verdict)
+    }
+
+    /// Observe a segment outcome (AISIX-Cloud#562): a Block downgrades to
+    /// Allow with a `would_block` hit; an inner mask is suppressed (never
+    /// written back) with a `would_mask` hit carrying the provider's
+    /// entity counts. Bypass passes through — monitor mode doesn't change
+    /// availability semantics.
+    fn observe_segments(&self, hook: &'static str, outcome: SegmentsOutcome) -> SegmentsOutcome {
+        let mut hits = outcome.monitor_hits;
+        if outcome.masked.is_some() {
+            tracing::info!(
+                guardrail_name = %self.row_name,
+                hook,
+                counts = ?outcome.counts,
+                "guardrail in monitor mode observed maskable spans; not redacting (enforcement_mode=monitor)",
+            );
+            hits.push(self.would_mask_hit(hook, outcome.counts));
+        }
+        let verdict = self.observe_hit(hook, outcome.verdict, &mut hits);
+        SegmentsOutcome {
+            verdict,
+            masked: None,
+            counts: std::collections::BTreeMap::new(),
+            monitor_hits: hits,
+        }
+    }
+
+    /// Probe the inner SYNC redactor (kind=pii) with the hook's scan text
+    /// and record what it would have masked. Redaction stays suppressed —
+    /// this only recovers the counts for telemetry. Segment moderators
+    /// (bedrock/lakera/presidio) report through the segment pass instead.
+    fn probe_redaction(
+        &self,
+        hook: &'static str,
+        redacts: bool,
+        redact: impl FnOnce() -> Option<Redaction>,
+        hits: &mut Vec<GuardrailMonitorHit>,
+    ) {
+        if !redacts {
+            return;
+        }
+        let r = redact();
+        if let Some(ref red) = r {
+            hits.push(self.would_mask_hit(hook, red.counts.clone()));
+        }
+        self.observe_redaction(hook, r);
+    }
 }
 
 #[async_trait]
@@ -516,6 +604,63 @@ impl Guardrail for MonitorGuardrail {
 
     async fn check_output(&self, resp: &ChatResponse) -> GuardrailVerdict {
         self.observe("output", self.inner.check_output(resp).await)
+    }
+
+    async fn check_input_observed(
+        &self,
+        req: &ChatFormat,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        let mut hits = Vec::new();
+        let verdict = self.observe_hit("input", self.inner.check_input(req).await, &mut hits);
+        // Recover the would-mask counts the suppressed sync redactor
+        // (kind=pii) would have produced, from the same text its
+        // check_input scans.
+        let text: String = req
+            .messages
+            .iter()
+            .map(crate::message_scan_text)
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+        self.probe_redaction(
+            "input",
+            self.inner.redacts_input() && !text.is_empty(),
+            || self.inner.redact_input_text(&text),
+            &mut hits,
+        );
+        (verdict, hits)
+    }
+
+    async fn check_output_observed(
+        &self,
+        resp: &ChatResponse,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        let mut hits = Vec::new();
+        let verdict = self.observe_hit("output", self.inner.check_output(resp).await, &mut hits);
+        let text = resp.guardrail_output_text();
+        self.probe_redaction(
+            "output",
+            self.inner.redacts_output() && !text.is_empty(),
+            || self.inner.redact_output_text(&text),
+            &mut hits,
+        );
+        (verdict, hits)
+    }
+
+    /// Delegate so a monitored segment moderator (bedrock/lakera/presidio)
+    /// is consulted through the segment pass — ONE provider call whose
+    /// verdict AND mask are observed with full fidelity — instead of the
+    /// blob path, where a maskable outcome degrades to a would-block.
+    fn moderates_segments(&self) -> bool {
+        self.inner.moderates_segments()
+    }
+
+    async fn moderate_input_segments(&self, texts: &[String]) -> SegmentsOutcome {
+        self.observe_segments("input", self.inner.moderate_input_segments(texts).await)
+    }
+
+    async fn moderate_output_segments(&self, texts: &[String]) -> SegmentsOutcome {
+        self.observe_segments("output", self.inner.moderate_output_segments(texts).await)
     }
 
     fn stream_output_policy(&self) -> StreamOutputPolicy {
@@ -1078,6 +1223,131 @@ mod tests {
             usage: aisix_gateway::UsageStats::new(0, 0),
         };
         assert!(!chain.check_output(&resp).await.is_block());
+    }
+
+    /// AISIX-Cloud#562: the observed check surfaces what monitor mode
+    /// suppressed — a downgraded Block becomes a `would_block` hit and a
+    /// suppressed pii mask becomes a `would_mask` hit with the detector
+    /// counts. Verdicts stay downgraded; names only, never values.
+    #[tokio::test]
+    async fn monitor_mode_observed_check_reports_hits() {
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "watch-pii",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "watch-pii",
+                    "enforcement_mode": "monitor",
+                    "kind": "pii",
+                    "detectors": [
+                        { "type": "email", "action": "mask" },
+                        { "type": "us_ssn", "action": "block" }
+                    ]
+                }"#,
+            ),
+        ));
+        let chain = build_chain_from_snapshot(&table, None);
+
+        // mask-action detector match → would_mask hit with counts.
+        let (v, hits) = chain
+            .check_input_observed(&req("mail alice@example.com ok"))
+            .await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+        assert_eq!(hits.len(), 1, "hits: {hits:?}");
+        assert_eq!(hits[0].guardrail_name, "watch-pii");
+        assert_eq!(hits[0].hook, "input");
+        assert_eq!(hits[0].action, "would_mask");
+        assert_eq!(hits[0].counts.get("email"), Some(&1));
+        assert!(
+            !format!("{hits:?}").contains("alice@example.com"),
+            "matched value must never ride a hit",
+        );
+
+        // block-action detector match → would_block hit carrying the reason.
+        let (v, hits) = chain.check_input_observed(&req("ssn 123-45-6789")).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+        assert_eq!(hits.len(), 1, "hits: {hits:?}");
+        assert_eq!(hits[0].action, "would_block");
+        assert!(
+            hits[0].reason.contains("us_ssn"),
+            "reason: {}",
+            hits[0].reason
+        );
+        assert!(!hits[0].reason.contains("123-45-6789"));
+
+        // clean input → no hits.
+        let (v, hits) = chain.check_input_observed(&req("all fine")).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+        assert!(hits.is_empty(), "hits: {hits:?}");
+    }
+
+    /// An ENFORCING (block-mode) guardrail must not produce monitor hits —
+    /// its Block is real and already carried by the verdict.
+    #[tokio::test]
+    async fn enforcing_guardrail_produces_no_monitor_hits() {
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "hard-block",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "hard-block",
+                    "kind": "keyword",
+                    "patterns": [{ "kind": "literal", "value": "AKIA" }]
+                }"#,
+            ),
+        ));
+        let chain = build_chain_from_snapshot(&table, None);
+        let (v, hits) = chain
+            .check_input_observed(&req("here is AKIAEXAMPLE"))
+            .await;
+        assert!(v.is_block());
+        assert!(hits.is_empty(), "hits: {hits:?}");
+    }
+
+    /// A monitor-mode hit made BEFORE an enforcing peer blocks must survive
+    /// the short-circuit — the chain collects hits as it folds.
+    #[tokio::test]
+    async fn monitor_hit_survives_enforcing_peer_block() {
+        let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        table.insert(entry(
+            "watch-first",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "watch-first",
+                    "enforcement_mode": "monitor",
+                    "kind": "keyword",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "patterns": [{ "kind": "literal", "value": "AKIA" }]
+                }"#,
+            ),
+        ));
+        table.insert(entry(
+            "block-second",
+            "g-2",
+            parse(
+                r#"{
+                    "name": "block-second",
+                    "kind": "keyword",
+                    "created_at": "2024-01-02T00:00:00Z",
+                    "patterns": [{ "kind": "literal", "value": "AKIA" }]
+                }"#,
+            ),
+        ));
+        let chain = build_chain_from_snapshot(&table, None);
+        let (v, hits) = chain
+            .check_input_observed(&req("here is AKIAEXAMPLE"))
+            .await;
+        assert!(v.is_block(), "enforcing peer still blocks");
+        assert_eq!(
+            hits.len(),
+            1,
+            "monitor hit collected before the block: {hits:?}"
+        );
+        assert_eq!(hits[0].guardrail_name, "watch-first");
+        assert_eq!(hits[0].action, "would_block");
     }
 
     /// A monitor-mode guardrail must not force streamed output to hold back —

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -13,6 +13,8 @@ use aisix_core::AppliedGuardrail;
 use aisix_gateway::{ChatFormat, ChatResponse};
 use async_trait::async_trait;
 
+use aisix_core::models::GuardrailMonitorHit;
+
 use crate::{Guardrail, GuardrailVerdict, Redaction, SegmentsOutcome, StreamOutputPolicy};
 
 /// One chain member: the runtime guardrail plus the operator-facing name
@@ -205,6 +207,126 @@ impl Guardrail for GuardrailChain {
         }
     }
 
+    // Observed folds (AISIX-Cloud#562): same short-circuit semantics as the
+    // plain folds, but every member's monitor-mode observations are
+    // collected — including the ones made before an enforcing member
+    // blocks, so a monitored rule's hit isn't erased by a peer's Block.
+    async fn check_input_observed(
+        &self,
+        req: &ChatFormat,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        let mut bypass: Option<String> = None;
+        let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
+        for m in &self.members {
+            let (verdict, member_hits) = m.guardrail.check_input_observed(req).await;
+            hits.extend(member_hits);
+            match verdict {
+                GuardrailVerdict::Allow => continue,
+                GuardrailVerdict::Block {
+                    reason,
+                    guardrail_name,
+                } => return (attribute_block(&m.name, reason, guardrail_name), hits),
+                GuardrailVerdict::Bypass { reason } => {
+                    if bypass.is_none() {
+                        bypass = Some(reason);
+                    }
+                }
+            }
+        }
+        let verdict = match bypass {
+            Some(reason) => GuardrailVerdict::Bypass { reason },
+            None => GuardrailVerdict::Allow,
+        };
+        (verdict, hits)
+    }
+
+    async fn check_output_observed(
+        &self,
+        resp: &ChatResponse,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        let mut bypass: Option<String> = None;
+        let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
+        for m in &self.members {
+            let (verdict, member_hits) = m.guardrail.check_output_observed(resp).await;
+            hits.extend(member_hits);
+            match verdict {
+                GuardrailVerdict::Allow => continue,
+                GuardrailVerdict::Block {
+                    reason,
+                    guardrail_name,
+                } => return (attribute_block(&m.name, reason, guardrail_name), hits),
+                GuardrailVerdict::Bypass { reason } => {
+                    if bypass.is_none() {
+                        bypass = Some(reason);
+                    }
+                }
+            }
+        }
+        let verdict = match bypass {
+            Some(reason) => GuardrailVerdict::Bypass { reason },
+            None => GuardrailVerdict::Allow,
+        };
+        (verdict, hits)
+    }
+
+    async fn check_input_non_segment_observed(
+        &self,
+        req: &ChatFormat,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        let mut bypass: Option<String> = None;
+        let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
+        for m in &self.members {
+            let (verdict, member_hits) = m.guardrail.check_input_non_segment_observed(req).await;
+            hits.extend(member_hits);
+            match verdict {
+                GuardrailVerdict::Allow => continue,
+                GuardrailVerdict::Block {
+                    reason,
+                    guardrail_name,
+                } => return (attribute_block(&m.name, reason, guardrail_name), hits),
+                GuardrailVerdict::Bypass { reason } => {
+                    if bypass.is_none() {
+                        bypass = Some(reason);
+                    }
+                }
+            }
+        }
+        let verdict = match bypass {
+            Some(reason) => GuardrailVerdict::Bypass { reason },
+            None => GuardrailVerdict::Allow,
+        };
+        (verdict, hits)
+    }
+
+    async fn check_output_non_segment_observed(
+        &self,
+        resp: &ChatResponse,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        let mut bypass: Option<String> = None;
+        let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
+        for m in &self.members {
+            let (verdict, member_hits) = m.guardrail.check_output_non_segment_observed(resp).await;
+            hits.extend(member_hits);
+            match verdict {
+                GuardrailVerdict::Allow => continue,
+                GuardrailVerdict::Block {
+                    reason,
+                    guardrail_name,
+                } => return (attribute_block(&m.name, reason, guardrail_name), hits),
+                GuardrailVerdict::Bypass { reason } => {
+                    if bypass.is_none() {
+                        bypass = Some(reason);
+                    }
+                }
+            }
+        }
+        let verdict = match bypass {
+            Some(reason) => GuardrailVerdict::Bypass { reason },
+            None => GuardrailVerdict::Allow,
+        };
+        (verdict, hits)
+    }
+
     fn moderates_segments(&self) -> bool {
         self.members
             .iter()
@@ -312,27 +434,30 @@ async fn fold_segments(members: &[ChainMember], texts: &[String], input: bool) -
     let mut masked: Option<Vec<String>> = None;
     let mut counts = std::collections::BTreeMap::new();
     let mut bypass: Option<String> = None;
+    let mut monitor_hits: Vec<GuardrailMonitorHit> = Vec::new();
     for m in members {
         if !m.guardrail.moderates_segments() {
             continue;
         }
         let src: &[String] = masked.as_deref().unwrap_or(texts);
-        let outcome = if input {
+        let mut outcome = if input {
             m.guardrail.moderate_input_segments(src).await
         } else {
             m.guardrail.moderate_output_segments(src).await
         };
+        monitor_hits.append(&mut outcome.monitor_hits);
         match outcome.verdict {
             GuardrailVerdict::Allow => {}
             GuardrailVerdict::Block {
                 reason,
                 guardrail_name,
             } => {
-                return SegmentsOutcome::from_verdict(attribute_block(
-                    &m.name,
-                    reason,
-                    guardrail_name,
-                ))
+                return SegmentsOutcome {
+                    verdict: attribute_block(&m.name, reason, guardrail_name),
+                    masked: None,
+                    counts: std::collections::BTreeMap::new(),
+                    monitor_hits,
+                }
             }
             GuardrailVerdict::Bypass { reason } => {
                 if bypass.is_none() {
@@ -366,6 +491,7 @@ async fn fold_segments(members: &[ChainMember], texts: &[String], input: bool) -
         },
         masked,
         counts,
+        monitor_hits,
     }
 }
 
@@ -682,6 +808,7 @@ mod tests {
                     .mask
                     .then(|| texts.iter().map(|t| t.to_uppercase()).collect()),
                 counts,
+                monitor_hits: Vec::new(),
             }
         }
     }
@@ -789,6 +916,7 @@ mod tests {
                     verdict: GuardrailVerdict::Allow,
                     masked: Some(vec!["only-one".to_owned()]),
                     counts,
+                    monitor_hits: Vec::new(),
                 }
             }
         }

--- a/crates/aisix-guardrails/src/lakera.rs
+++ b/crates/aisix-guardrails/src/lakera.rs
@@ -254,6 +254,7 @@ impl LakeraGuardrail {
                         verdict: GuardrailVerdict::Allow,
                         masked: Some(masked),
                         counts,
+                        monitor_hits: Vec::new(),
                     }
                 }
             },

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -38,6 +38,7 @@ mod prompt_shield;
 #[cfg(feature = "azure-content-safety")]
 mod text_moderation;
 
+use aisix_core::models::GuardrailMonitorHit;
 use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse};
 use async_trait::async_trait;
 
@@ -329,6 +330,10 @@ pub struct SegmentsOutcome {
     pub verdict: GuardrailVerdict,
     pub masked: Option<Vec<String>>,
     pub counts: std::collections::BTreeMap<String, u32>,
+    /// Monitor-mode observations made during this pass (what an
+    /// `enforcement_mode: monitor` member WOULD have done). Callers merge
+    /// them into the request's `guardrail_monitor_hits` telemetry.
+    pub monitor_hits: Vec<GuardrailMonitorHit>,
 }
 
 impl SegmentsOutcome {
@@ -338,6 +343,7 @@ impl SegmentsOutcome {
             verdict: GuardrailVerdict::Allow,
             masked: None,
             counts: std::collections::BTreeMap::new(),
+            monitor_hits: Vec::new(),
         }
     }
 
@@ -347,6 +353,7 @@ impl SegmentsOutcome {
             verdict,
             masked: None,
             counts: std::collections::BTreeMap::new(),
+            monitor_hits: Vec::new(),
         }
     }
 }
@@ -485,6 +492,56 @@ pub trait Guardrail: Send + Sync + 'static {
             GuardrailVerdict::Allow
         } else {
             self.check_output(resp).await
+        }
+    }
+
+    // --- monitor-hit observation (AISIX-Cloud#562) -------------------------
+    //
+    // `enforcement_mode: monitor` downgrades Blocks and suppresses masks,
+    // which erases the observation from the plain check return value. The
+    // `*_observed` variants return the verdict PLUS the monitor hits made
+    // during the check, so call sites can attach them to the request's
+    // telemetry. Defaults delegate to the plain checks with no hits — only
+    // the monitor decorator and the chain override these, so concrete
+    // guardrail kinds never need to.
+
+    /// [`Self::check_input`] plus any monitor-mode observations.
+    async fn check_input_observed(
+        &self,
+        req: &ChatFormat,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        (self.check_input(req).await, Vec::new())
+    }
+
+    /// [`Self::check_output`] plus any monitor-mode observations.
+    async fn check_output_observed(
+        &self,
+        resp: &ChatResponse,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        (self.check_output(resp).await, Vec::new())
+    }
+
+    /// [`Self::check_input_non_segment`] plus any monitor-mode observations.
+    async fn check_input_non_segment_observed(
+        &self,
+        req: &ChatFormat,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        if self.moderates_segments() {
+            (GuardrailVerdict::Allow, Vec::new())
+        } else {
+            self.check_input_observed(req).await
+        }
+    }
+
+    /// [`Self::check_output_non_segment`] plus any monitor-mode observations.
+    async fn check_output_non_segment_observed(
+        &self,
+        resp: &ChatResponse,
+    ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
+        if self.moderates_segments() {
+            (GuardrailVerdict::Allow, Vec::new())
+        } else {
+            self.check_output_observed(resp).await
         }
     }
 }

--- a/crates/aisix-guardrails/src/presidio.rs
+++ b/crates/aisix-guardrails/src/presidio.rs
@@ -317,6 +317,7 @@ impl PresidioGuardrail {
             verdict: GuardrailVerdict::Allow,
             masked: Some(masked),
             counts,
+            monitor_hits: Vec::new(),
         }
     }
 

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -27,7 +27,7 @@
 //! batch contract (5s interval / 100-event ceiling) lives in the worker
 //! (aisix-server), not here.
 
-use aisix_core::AppliedGuardrail;
+use aisix_core::{AppliedGuardrail, GuardrailMonitorHit};
 use serde::Serialize;
 
 /// One usage event. Emitted at end-of-request (success / upstream error /
@@ -171,6 +171,18 @@ pub struct UsageEvent {
     /// binds JSON leniently, so older CP images ignore the unknown field.
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub redacted_entity_counts: std::collections::BTreeMap<String, u32>,
+
+    /// What each `enforcement_mode: monitor` guardrail WOULD have done to
+    /// this request (AISIX-Cloud#562): one entry per suppressed Block
+    /// (`would_block`, with the operator-facing reason) or suppressed mask
+    /// (`would_mask`, with per-detector counts). Names only — never matched
+    /// content (#153). Lets operators stage a policy and audit its hit rate
+    /// in the dashboard before flipping it to `block`. Empty (no
+    /// monitor-mode guardrail fired) is omitted from the wire; cp-api's
+    /// `/dp/telemetry` binds JSON leniently, so older CP images ignore the
+    /// unknown field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub guardrail_monitor_hits: Vec<GuardrailMonitorHit>,
 
     /// Cache outcome on this request. One of:
     ///

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -59,6 +59,9 @@ struct AudioDispatchSuccess {
     /// field (input side) + the transcript (output side), merged. Attached
     /// to the emitted UsageEvent. Empty = no redaction.
     redactions: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations (AISIX-Cloud#562), input +
+    /// output merged.
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     /// #696: set when an OUTPUT guardrail blocked the transcript AFTER the
     /// upstream billed for it. The response body is the redacted 422, but
     /// `usage` keeps the billed counts so the UsageEvent (marked
@@ -293,6 +296,7 @@ pub async fn speech(
             provider_key_id,
             applied_guardrails,
             redactions,
+            monitor_hits,
             captured,
         )) => {
             let elapsed = started.elapsed();
@@ -332,6 +336,7 @@ pub async fn speech(
                 0,
                 &client,
                 redactions,
+                monitor_hits,
                 /* guardrail_blocked */ false,
                 captured.as_ref(),
             );
@@ -441,6 +446,7 @@ async fn multipart_dispatch(
     let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
     let applied_guardrails = resolved_chain.applied().to_vec();
     let mut redactions = crate::redact::RedactionCounts::new();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if !resolved_chain.is_empty() {
         // EVERY `prompt` field: multipart allows repeated names and the form
         // is rebuilt with all of them, so all are scanned — an empty first
@@ -454,10 +460,13 @@ async fn multipart_dispatch(
             .collect();
         if !prompt_messages.is_empty() {
             let chat = aisix_gateway::ChatFormat::new(&model_name, prompt_messages);
+            let (verdict, hits) =
+                aisix_guardrails::Guardrail::check_input_observed(&resolved_chain, &chat).await;
+            monitor_hits.extend(hits);
             if let aisix_guardrails::GuardrailVerdict::Block {
                 reason,
                 guardrail_name,
-            } = aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+            } = verdict
             {
                 // Per #153 the matched-pattern detail stays in ops logs only.
                 tracing::warn!(
@@ -691,10 +700,13 @@ async fn multipart_dispatch(
                 finish_reason: FinishReason::Stop,
                 usage: UsageStats::default(),
             };
+            let (verdict, hits) =
+                aisix_guardrails::Guardrail::check_output_observed(&resolved_chain, &synth).await;
+            monitor_hits.extend(hits);
             if let aisix_guardrails::GuardrailVerdict::Block {
                 reason,
                 guardrail_name,
-            } = aisix_guardrails::Guardrail::check_output(&resolved_chain, &synth).await
+            } = verdict
             {
                 // Per #153 the matched-pattern detail stays in ops logs only.
                 tracing::warn!(
@@ -716,6 +728,7 @@ async fn multipart_dispatch(
                     usage,
                     applied_guardrails,
                     redactions,
+                    monitor_hits: monitor_hits.clone(),
                     guardrail_blocked: true,
                     // The blocked transcript never reached the client — no
                     // content capture, matching the chat surface.
@@ -759,6 +772,7 @@ async fn multipart_dispatch(
         usage,
         applied_guardrails,
         redactions,
+        monitor_hits,
         guardrail_blocked: false,
         captured_content,
     })
@@ -815,6 +829,7 @@ async fn speech_dispatch(
         String,
         Vec<AppliedGuardrail>,
         crate::redact::RedactionCounts,
+        Vec<aisix_core::GuardrailMonitorHit>,
         Option<CapturedContent>,
     ),
     ProxyError,
@@ -851,12 +866,16 @@ async fn speech_dispatch(
     // Record which guardrails govern this request (#379 parity) for the emitted
     // UsageEvent. Empty when none attached.
     let applied_guardrails = resolved_chain.applied().to_vec();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if !resolved_chain.is_empty() {
         let chat = speech_input_to_chat(&model_name, &body);
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_input_observed(&resolved_chain, &chat).await;
+        monitor_hits.extend(hits);
         if let aisix_guardrails::GuardrailVerdict::Block {
             reason,
             guardrail_name,
-        } = aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        } = verdict
         {
             // Per #153 the matched-pattern detail stays in ops logs only.
             tracing::warn!(
@@ -1024,6 +1043,7 @@ async fn speech_dispatch(
         pk_entry.id.to_string(),
         applied_guardrails,
         redactions,
+        monitor_hits,
         captured_content,
     ))
 }
@@ -1071,6 +1091,7 @@ fn emit_audio_usage(
         completion_tokens,
         client,
         success.redactions.clone(),
+        success.monitor_hits.clone(),
         success.guardrail_blocked,
         success.captured_content.as_ref(),
     );
@@ -1099,6 +1120,8 @@ fn emit_usage_event(
     client: &ClientContext,
     // Per-detector PII mask counts (#932/#696). Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Monitor-mode guardrail observations (AISIX-Cloud#562).
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     // #696: transcript blocked by an output guardrail after upstream billing.
     guardrail_blocked: bool,
     // Captured request/response content (#700). Forwarded only to `fan_out`,
@@ -1121,6 +1144,7 @@ fn emit_usage_event(
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         redacted_entity_counts,
+        guardrail_monitor_hits,
         guardrail_blocked,
         ..Default::default()
     };

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -132,6 +132,9 @@ pub async fn chat_completions(
     // Filled by `dispatch` with per-detector PII mask counts (#932), same
     // dual-path lifecycle as `applied_guardrails`.
     let mut redaction_counts = crate::redact::RedactionCounts::new();
+    // Filled by `dispatch` with monitor-mode guardrail observations
+    // (AISIX-Cloud#562), same dual-path lifecycle as `applied_guardrails`.
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     let outcome = dispatch(
         &state,
         &auth,
@@ -141,6 +144,7 @@ pub async fn chat_completions(
         &client,
         &mut applied_guardrails,
         &mut redaction_counts,
+        &mut monitor_hits,
     )
     .await;
 
@@ -251,6 +255,7 @@ pub async fn chat_completions(
                         applied_guardrails: applied_guardrails.clone(),
                         provider_key_id: success.provider_key_id.clone(),
                         redacted_entity_counts: redaction_counts.clone(),
+                        guardrail_monitor_hits: monitor_hits.clone(),
                     },
                     success.cost_usd,
                     /* guardrail_blocked */ false,
@@ -480,6 +485,7 @@ pub async fn chat_completions(
                             // Input-side masking happened before the output
                             // block — the audit trail keeps it.
                             redacted_entity_counts: redaction_counts.clone(),
+                            guardrail_monitor_hits: monitor_hits.clone(),
                         },
                         /* cost_usd */ 0.0,
                         guardrail_blocked,
@@ -509,6 +515,7 @@ pub async fn chat_completions(
                             applied_guardrails: applied_guardrails.clone(),
                             // Input masking may have fired before the failure.
                             redacted_entity_counts: redaction_counts.clone(),
+                            guardrail_monitor_hits: monitor_hits.clone(),
                             ..UsageExtras::default()
                         },
                         /* cost_usd */ 0.0,
@@ -794,6 +801,9 @@ async fn dispatch(
     // output counts travel via `StreamCompletion` instead (the event is
     // emitted at end-of-stream).
     redactions_out: &mut crate::redact::RedactionCounts,
+    // Out-param: monitor-mode guardrail observations (AISIX-Cloud#562),
+    // same lifecycle as `redactions_out`.
+    monitor_hits_out: &mut Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<Success, DispatchFailure> {
     if req.messages.is_empty() {
         return Err(DispatchFailure::new(
@@ -866,12 +876,14 @@ async fn dispatch(
     // Split moderation: local/blob members check first (on the original
     // text), then the segment pass runs the Bedrock call and writes
     // ANONYMIZE masks back into `req` (#932 bedrock follow-up).
-    let input_verdict = resolved_chain.check_input_non_segment(req).await;
+    let (input_verdict, hits) = resolved_chain.check_input_non_segment_observed(req).await;
+    monitor_hits_out.extend(hits);
     let input_verdict = crate::redact::moderate_body(
         resolved_chain.as_ref(),
         crate::redact::Direction::Input,
         input_verdict,
         redactions_out,
+        monitor_hits_out,
         |g| crate::redact::redact_chat_format(g, req),
     )
     .await;
@@ -1023,6 +1035,7 @@ async fn dispatch(
             &auth.entry.id,
             client,
             redactions_out.clone(),
+            monitor_hits_out.clone(),
         )
         .await;
     }
@@ -1283,6 +1296,9 @@ async fn dispatch(
         // the end-of-stream event merges them with the output-side counts
         // accumulated in `comp.redacted_entity_counts`.
         let input_redactions_for_telem = redactions_out.clone();
+        // Input-side monitor hits (AISIX-Cloud#562), merged with the
+        // output-side hits accumulated in `comp.monitor_hits`.
+        let input_monitor_hits_for_telem = monitor_hits_out.clone();
         // Downstream client attribution (#492) moved into the on_complete
         // closure so streamed responses log the same IP/UA as non-streaming.
         let client_for_telem = client.clone();
@@ -1397,6 +1413,11 @@ async fn dispatch(
                         redacted_entity_counts: {
                             let mut merged = input_redactions_for_telem.clone();
                             crate::redact::merge_counts(&mut merged, comp.redacted_entity_counts);
+                            merged
+                        },
+                        guardrail_monitor_hits: {
+                            let mut merged = input_monitor_hits_for_telem.clone();
+                            merged.extend(comp.monitor_hits);
                             merged
                         },
                     },
@@ -1580,12 +1601,16 @@ async fn dispatch(
                 // #448: a cache hit is client-visible output just like a
                 // fresh upstream response, so it must run output guardrails
                 // before being returned — not bypass them.
-                let cached_verdict = resolved_chain.check_output_non_segment(&cached).await;
+                let (cached_verdict, hits) = resolved_chain
+                    .check_output_non_segment_observed(&cached)
+                    .await;
+                monitor_hits_out.extend(hits);
                 let cached_verdict = crate::redact::moderate_body(
                     resolved_chain.as_ref(),
                     crate::redact::Direction::Output,
                     cached_verdict,
                     redactions_out,
+                    monitor_hits_out,
                     |g| crate::redact::redact_chat_response(g, &mut cached),
                 )
                 .await;
@@ -1934,12 +1959,16 @@ async fn dispatch(
     // ingesting telemetry; the DP just records 0.0 on the wire.
     let cost_usd = 0.0;
 
-    let output_verdict = resolved_chain.check_output_non_segment(&upstream).await;
+    let (output_verdict, hits) = resolved_chain
+        .check_output_non_segment_observed(&upstream)
+        .await;
+    monitor_hits_out.extend(hits);
     let output_verdict = crate::redact::moderate_body(
         resolved_chain.as_ref(),
         crate::redact::Direction::Output,
         output_verdict,
         redactions_out,
+        monitor_hits_out,
         |g| crate::redact::redact_chat_response(g, &mut upstream),
     )
     .await;
@@ -2135,6 +2164,9 @@ async fn dispatch_ensemble(
     // function (the handler's main emit is skipped), so the counts ride
     // the judge event — the ensemble's terminal event.
     input_redactions: crate::redact::RedactionCounts,
+    // Input-side monitor hits (AISIX-Cloud#562), same lifecycle as
+    // `input_redactions`.
+    input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<Success, DispatchFailure> {
     let started = Instant::now();
     let with_model = |e: ProxyError| DispatchFailure::new(Some(model_id.to_string()), None, e);
@@ -2453,6 +2485,8 @@ async fn dispatch_ensemble(
         // Input-side PII mask counts (#932); merged with the streamed judge's
         // output-side counts on the terminal (judge) event.
         let input_redactions_for_telem = input_redactions.clone();
+        // Input-side monitor hits (AISIX-Cloud#562), merged the same way.
+        let input_monitor_hits_for_telem = input_monitor_hits.clone();
 
         // Hold concurrency for the stream's full lifetime (#450). Snapshot the
         // keys BEFORE consuming the reservation into the owned guard.
@@ -2558,6 +2592,11 @@ async fn dispatch_ensemble(
                         redacted_entity_counts: {
                             let mut merged = input_redactions_for_telem.clone();
                             crate::redact::merge_counts(&mut merged, comp.redacted_entity_counts);
+                            merged
+                        },
+                        guardrail_monitor_hits: {
+                            let mut merged = input_monitor_hits_for_telem.clone();
+                            merged.extend(comp.monitor_hits);
                             merged
                         },
                         ..UsageExtras::default()
@@ -2686,7 +2725,8 @@ async fn dispatch_ensemble(
     let emit_subcalls = |outcome: &crate::ensemble::EnsembleOutcome,
                          blocked: bool,
                          bypass: &str,
-                         redactions: &crate::redact::RedactionCounts| {
+                         redactions: &crate::redact::RedactionCounts,
+                         hits: &[aisix_core::GuardrailMonitorHit]| {
         for (index, member) in outcome.panel.iter().enumerate() {
             emit_panel_member(member, index, blocked, bypass);
         }
@@ -2717,6 +2757,7 @@ async fn dispatch_ensemble(
                 applied_guardrails: applied_guardrails.to_vec(),
                 provider_key_id: judge_provider_key_id,
                 redacted_entity_counts: redactions.clone(),
+                guardrail_monitor_hits: hits.to_vec(),
                 ..UsageExtras::default()
             },
             /* cost_usd */ 0.0,
@@ -2733,14 +2774,17 @@ async fn dispatch_ensemble(
     // `charge: None` rather than a judge-only `UpstreamCharge`, which
     // would double-count the judge AND still miss the panel.
     let mut ensemble_redactions = input_redactions.clone();
-    let ensemble_verdict = resolved_chain
-        .check_output_non_segment(&outcome.response)
+    let mut ensemble_monitor_hits = input_monitor_hits.clone();
+    let (ensemble_verdict, hits) = resolved_chain
+        .check_output_non_segment_observed(&outcome.response)
         .await;
+    ensemble_monitor_hits.extend(hits);
     let ensemble_verdict = crate::redact::moderate_body(
         resolved_chain.as_ref(),
         crate::redact::Direction::Output,
         ensemble_verdict,
         &mut ensemble_redactions,
+        &mut ensemble_monitor_hits,
         |g| crate::redact::redact_chat_response(g, &mut outcome.response),
     )
     .await;
@@ -2763,6 +2807,7 @@ async fn dispatch_ensemble(
                 true,
                 &bypass_reason.clone().unwrap_or_default(),
                 &input_redactions,
+                &ensemble_monitor_hits,
             );
             return Err(DispatchFailure::new(
                 Some(model_id.to_string()),
@@ -2793,6 +2838,7 @@ async fn dispatch_ensemble(
         false,
         &bypass_reason.clone().unwrap_or_default(),
         &ensemble_redactions,
+        &ensemble_monitor_hits,
     );
 
     // The synthesized answer is the client-facing response, rendered with
@@ -3019,6 +3065,7 @@ fn emit_usage_event(
         guardrail_bypassed_reason: extras.bypass_reason,
         applied_guardrails: extras.applied_guardrails,
         redacted_entity_counts: extras.redacted_entity_counts,
+        guardrail_monitor_hits: extras.guardrail_monitor_hits,
         cache_status: extras.cache_status,
         cache_hit_saved_input_tokens: extras.cache_hit_saved_input_tokens,
         cache_hit_saved_output_tokens: extras.cache_hit_saved_output_tokens,
@@ -3165,6 +3212,10 @@ struct UsageExtras {
     /// merged (#932). Lands on `usage_events.redacted_entity_counts`.
     /// Detector names only, never matched values. Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations for this request, input +
+    /// output merged (AISIX-Cloud#562). Lands on
+    /// `usage_events.guardrail_monitor_hits`. Empty = no monitor hit.
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 }
 
 /// Emit one zero-token `UsageEvent` per FAILED attempt of a request
@@ -3354,6 +3405,10 @@ struct StreamCompletion {
     /// (#932). Merged with the input-side counts by the on_complete
     /// telemetry closure. Detector names only, never matched values.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations made by the end-of-stream
+    /// output checks (AISIX-Cloud#562). Merged with the input-side hits
+    /// by the on_complete telemetry closure.
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 }
 
 /// Parameters needed to run output-guardrail evaluation at
@@ -3751,7 +3806,10 @@ where
                                         ),
                                     }
                                 };
-                                match ctx.chain.check_output(&synthesized).await {
+                                let (verdict, hits) =
+                                    ctx.chain.check_output_observed(&synthesized).await;
+                                guard.comp().monitor_hits.extend(hits);
+                                match verdict {
                                     aisix_guardrails::GuardrailVerdict::Block { reason, guardrail_name } => {
                                         tracing::warn!(
                                             guardrail_hook = "output",
@@ -3906,16 +3964,23 @@ where
                                 ),
                             }
                         };
-                        let verdict = ctx.chain.check_output_non_segment(&synthesized).await;
+                        let (verdict, hits) = ctx
+                            .chain
+                            .check_output_non_segment_observed(&synthesized)
+                            .await;
+                        guard.comp().monitor_hits.extend(hits);
                         let mut seg_counts = crate::redact::RedactionCounts::new();
+                        let mut seg_hits = Vec::new();
                         let verdict = crate::redact::moderate_body(
                             ctx.chain.as_ref(),
                             crate::redact::Direction::Output,
                             verdict,
                             &mut seg_counts,
+                            &mut seg_hits,
                             |g| crate::redact::redact_chat_chunks(g, &mut pending),
                         )
                         .await;
+                        guard.comp().monitor_hits.extend(seg_hits);
                         if !seg_counts.is_empty() {
                             // Bedrock masked the held chunks — rebuild the
                             // content-capture accumulator from the masked
@@ -4021,7 +4086,9 @@ where
                         guard.comp().completion_tokens,
                     ),
                 };
-                match ctx.chain.check_output(&synthesized).await {
+                let (verdict, hits) = ctx.chain.check_output_observed(&synthesized).await;
+                guard.comp().monitor_hits.extend(hits);
+                match verdict {
                     aisix_guardrails::GuardrailVerdict::Block { reason, guardrail_name } => {
                         // Mirror the non-streaming path's #153
                         // redaction contract: the wire-level message

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -55,6 +55,9 @@ struct CompletionDispatchSuccess {
     /// Per-detector PII mask counts (#932), input + output merged.
     /// Attached to the emitted UsageEvent. Empty = no redaction.
     redactions: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations (AISIX-Cloud#562), input +
+    /// output merged. Attached to the emitted UsageEvent.
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     /// True when the response leg was blocked by an OUTPUT guardrail
     /// AFTER the upstream billed for it (#911 [23]). The response body is
     /// the redacted 422, but `usage` still carries the billed counts so
@@ -140,6 +143,7 @@ pub async fn completions(
                     &client,
                     success.guardrail_blocked,
                     success.redactions.clone(),
+                    success.monitor_hits.clone(),
                     success.captured_content.as_ref(),
                 );
             }
@@ -242,10 +246,13 @@ async fn dispatch(
     };
     let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
     let mut input_seg_counts = crate::redact::RedactionCounts::new();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if !resolved_chain.is_empty() {
         let chat = completions_input_to_chat(model_name, &body);
-        let verdict =
-            aisix_guardrails::Guardrail::check_input_non_segment(&resolved_chain, &chat).await;
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_input_non_segment_observed(&resolved_chain, &chat)
+                .await;
+        monitor_hits.extend(hits);
         // Segment pass: one Bedrock call over the prompt slots; an
         // ANONYMIZE disposition writes the masked text back into the body
         // (#932 bedrock follow-up).
@@ -254,6 +261,7 @@ async fn dispatch(
             crate::redact::Direction::Input,
             verdict,
             &mut input_seg_counts,
+            &mut monitor_hits,
             |g| crate::redact::redact_completions_request(g, &mut body),
         )
         .await;
@@ -351,14 +359,19 @@ async fn dispatch(
                     finish_reason: FinishReason::Stop,
                     usage: UsageStats::default(),
                 };
-                let verdict =
-                    aisix_guardrails::Guardrail::check_output_non_segment(&resolved_chain, &synth)
-                        .await;
+                let (verdict, hits) =
+                    aisix_guardrails::Guardrail::check_output_non_segment_observed(
+                        &resolved_chain,
+                        &synth,
+                    )
+                    .await;
+                monitor_hits.extend(hits);
                 let verdict = crate::redact::moderate_body(
                     &resolved_chain,
                     crate::redact::Direction::Output,
                     verdict,
                     &mut redactions,
+                    &mut monitor_hits,
                     |g| crate::redact::redact_completions_response(g, &mut resp_json),
                 )
                 .await;
@@ -393,6 +406,7 @@ async fn dispatch(
                         provider_key_id: pk_entry.id.to_string(),
                         usage,
                         redactions,
+                        monitor_hits,
                         guardrail_blocked: true,
                         // Blocked responses never reached the client — no
                         // content capture, matching the chat surface.
@@ -427,6 +441,7 @@ async fn dispatch(
                 provider_key_id: pk_entry.id.to_string(),
                 usage,
                 redactions,
+                monitor_hits,
                 guardrail_blocked: false,
                 captured_content,
             })
@@ -445,6 +460,7 @@ async fn dispatch(
                 // out of /logs noise (same convention as #402).
                 usage: None,
                 redactions,
+                monitor_hits,
                 guardrail_blocked: false,
                 captured_content: None,
             })
@@ -540,6 +556,8 @@ fn emit_usage_event(
     guardrail_blocked: bool,
     // Per-detector PII mask counts (#932). Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Monitor-mode guardrail observations (AISIX-Cloud#562).
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     // Captured request/response content for content-capturing exporters
     // (AISIX-Cloud#947). Forwarded only to `fan_out`, never to the CP sink.
     content: Option<&CapturedContent>,
@@ -562,6 +580,7 @@ fn emit_usage_event(
         // dashboard's Blocked tab while still carrying its billed token counts.
         guardrail_blocked,
         redacted_entity_counts,
+        guardrail_monitor_hits,
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, &snap, provider_key_id);

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -173,6 +173,7 @@ pub async fn embeddings(
                     success.prompt_tokens,
                     &client,
                     success.redactions.clone(),
+                    success.monitor_hits.clone(),
                     success.captured_content.as_ref(),
                 );
             }
@@ -233,6 +234,8 @@ struct EmbedDispatchSuccess {
     applied_guardrails: Vec<AppliedGuardrail>,
     /// Per-detector PII mask counts (#932) applied to the input.
     redactions: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations (AISIX-Cloud#562).
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     /// Captured request/response content for content-capturing exporters
     /// (#700, LiteLLM parity: the full response JSON — vectors included —
     /// truncated at the capture cap). `Some` only when an exporter opted
@@ -298,12 +301,16 @@ async fn dispatch(
     // UsageEvent surfaces them in Logs, like chat / messages. Empty when no
     // guardrail is attached.
     let applied_guardrails = resolved_chain.applied().to_vec();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if !resolved_chain.is_empty() {
         let chat = embeddings_input_to_chat(&body.model, &body.input);
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_input_observed(&resolved_chain, &chat).await;
+        monitor_hits.extend(hits);
         if let aisix_guardrails::GuardrailVerdict::Block {
             reason,
             guardrail_name,
-        } = aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        } = verdict
         {
             // Per #153 keep the matched-pattern detail in ops logs only; the
             // wire envelope names only the guardrail that fired (#519 B.4b).
@@ -424,6 +431,7 @@ async fn dispatch(
                 provider_key_id: pk_entry.id.to_string(),
                 applied_guardrails: applied_guardrails.clone(),
                 redactions: redactions.clone(),
+                monitor_hits: monitor_hits.clone(),
                 prompt_tokens,
                 upstream_called: true,
                 captured_content,
@@ -445,6 +453,7 @@ async fn dispatch(
                 provider_key_id: pk_entry.id.to_string(),
                 applied_guardrails: applied_guardrails.clone(),
                 redactions: redactions.clone(),
+                monitor_hits: monitor_hits.clone(),
                 prompt_tokens: 0,
                 captured_content: None,
                 // No upstream call happened — the handler reads this
@@ -538,6 +547,8 @@ fn emit_usage_event(
     client: &ClientContext,
     // Per-detector PII mask counts (#932) applied to the input.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Monitor-mode guardrail observations (AISIX-Cloud#562).
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     // Captured request/response content (#700). Forwarded only to `fan_out`,
     // never to the CP sink.
     content: Option<&CapturedContent>,
@@ -581,6 +592,7 @@ fn emit_usage_event(
         inbound_protocol: "openai".to_string(),
         applied_guardrails: applied_guardrails.to_vec(),
         redacted_entity_counts,
+        guardrail_monitor_hits,
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         ..Default::default()

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -54,6 +54,8 @@ struct ImageDispatchSuccess {
     /// Per-detector PII mask counts (#932/#696) applied to the prompt.
     /// Attached to the emitted UsageEvent. Empty = no redaction.
     redactions: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations (AISIX-Cloud#562).
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     /// Captured request/response content for content-capturing exporters
     /// (#700, LiteLLM parity: the full image response JSON — url or
     /// b64_json — truncated at the capture cap). `Some` only when an
@@ -119,6 +121,7 @@ pub async fn image_generations(
                     completion_tokens,
                     &client,
                     success.redactions.clone(),
+                    success.monitor_hits.clone(),
                     success.captured_content.as_ref(),
                 );
             }
@@ -216,12 +219,16 @@ async fn dispatch(
     // UsageEvent surfaces them in Logs, like chat / messages. Empty when no
     // guardrail is attached.
     let applied_guardrails = resolved_chain.applied().to_vec();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if !resolved_chain.is_empty() {
         let chat = images_input_to_chat(model_name, &body);
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_input_observed(&resolved_chain, &chat).await;
+        monitor_hits.extend(hits);
         if let aisix_guardrails::GuardrailVerdict::Block {
             reason,
             guardrail_name,
-        } = aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        } = verdict
         {
             // Per #153 the matched-pattern detail stays in ops logs only.
             tracing::warn!(
@@ -330,6 +337,7 @@ async fn dispatch(
                 usage,
                 upstream_called: true,
                 redactions,
+                monitor_hits: monitor_hits.clone(),
                 captured_content,
             })
         }
@@ -347,6 +355,7 @@ async fn dispatch(
                 // No upstream call happened → handler skips emit.
                 upstream_called: false,
                 redactions,
+                monitor_hits: monitor_hits.clone(),
                 captured_content: None,
             })
         }
@@ -410,6 +419,8 @@ fn emit_usage_event(
     client: &ClientContext,
     // Per-detector PII mask counts (#932/#696). Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Monitor-mode guardrail observations (AISIX-Cloud#562).
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     // Captured request/response content (#700). Forwarded only to `fan_out`,
     // never to the CP sink.
     content: Option<&CapturedContent>,
@@ -430,6 +441,7 @@ fn emit_usage_event(
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         redacted_entity_counts,
+        guardrail_monitor_hits,
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, &snap, provider_key_id);

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -400,6 +400,7 @@ async fn scan_input_blob(
     auth: &AuthenticatedKey,
     target: &JobTarget,
     blob: &[u8],
+    monitor_hits: &mut Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<(), ProxyError> {
     let ctx = aisix_guardrails::RequestContext {
         model_id: &target.model_entry.id,
@@ -416,10 +417,12 @@ async fn scan_input_blob(
             String::from_utf8_lossy(blob).into_owned(),
         )],
     );
+    let (verdict, hits) = aisix_guardrails::Guardrail::check_input_observed(&chain, &chat).await;
+    monitor_hits.extend(hits);
     if let aisix_guardrails::GuardrailVerdict::Block {
         reason,
         guardrail_name,
-    } = aisix_guardrails::Guardrail::check_input(&chain, &chat).await
+    } = verdict
     {
         tracing::warn!(
             guardrail_hook = "input",
@@ -440,6 +443,7 @@ async fn scan_output_blob(
     auth: &AuthenticatedKey,
     target: &JobTarget,
     blob: &[u8],
+    monitor_hits: &mut Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<(), ProxyError> {
     let ctx = aisix_guardrails::RequestContext {
         model_id: &target.model_entry.id,
@@ -457,10 +461,12 @@ async fn scan_output_blob(
         finish_reason: aisix_gateway::FinishReason::Stop,
         usage: aisix_gateway::UsageStats::default(),
     };
+    let (verdict, hits) = aisix_guardrails::Guardrail::check_output_observed(&chain, &synth).await;
+    monitor_hits.extend(hits);
     if let aisix_guardrails::GuardrailVerdict::Block {
         reason,
         guardrail_name,
-    } = aisix_guardrails::Guardrail::check_output(&chain, &synth).await
+    } = verdict
     {
         tracing::warn!(
             guardrail_hook = "output",
@@ -526,6 +532,7 @@ fn emit_job_usage_event(
     status_code: u16,
     elapsed: Duration,
     client: &ClientContext,
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) {
     let snap = state.snapshot.load();
     let mut event = UsageEvent {
@@ -539,6 +546,7 @@ fn emit_job_usage_event(
         inbound_protocol: "openai".to_string(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
+        guardrail_monitor_hits,
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, &snap, &target.pk_entry.id);
@@ -590,6 +598,7 @@ fn finish(
     started: Instant,
     request_id: String,
     result: Result<(Response, JobTarget), ProxyError>,
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Response {
     let elapsed = started.elapsed();
     match result {
@@ -620,6 +629,7 @@ fn finish(
                 status,
                 elapsed,
                 client,
+                monitor_hits,
             );
             if let Ok(hv) = HeaderValue::from_str(&request_id) {
                 resp.headers_mut().insert("x-aisix-request-id", hv);
@@ -711,6 +721,7 @@ pub(crate) async fn create_file(
 ) -> Response {
     let started = Instant::now();
     let request_id = new_request_id();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
 
     let result = async {
         // Re-build the outbound multipart form, extracting the gateway-only
@@ -766,7 +777,7 @@ pub(crate) async fn create_file(
 
         // Batch/fine-tune input files carry end-user content — scan them
         // like any other inbound payload.
-        scan_input_blob(&state, &auth, &target, &file_bytes).await?;
+        scan_input_blob(&state, &auth, &target, &file_bytes, &mut monitor_hits).await?;
         let _reservation = crate::quota::enforce(
             &state,
             &auth,
@@ -788,7 +799,7 @@ pub(crate) async fn create_file(
             &request_id,
         )
         .await?;
-        scan_output_blob(&state, &auth, &target, &bytes).await?;
+        scan_output_blob(&state, &auth, &target, &bytes, &mut monitor_hits).await?;
         let model = target.display_name().to_string();
         Ok((
             json_response(status, &resp_headers, bytes, Some(&model)),
@@ -807,6 +818,7 @@ pub(crate) async fn create_file(
         started,
         request_id,
         result,
+        monitor_hits,
     )
 }
 
@@ -941,6 +953,7 @@ pub(crate) async fn create_batch(
 ) -> Response {
     let started = Instant::now();
     let request_id = new_request_id();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
 
     let result = async {
         let mut req_json: Value = serde_json::from_slice(&body)
@@ -981,7 +994,7 @@ pub(crate) async fn create_batch(
         }
         let out_body = Bytes::from(serde_json::to_vec(&req_json).unwrap_or_default());
 
-        scan_input_blob(&state, &auth, &target, &out_body).await?;
+        scan_input_blob(&state, &auth, &target, &out_body, &mut monitor_hits).await?;
         let _reservation = crate::quota::enforce(
             &state,
             &auth,
@@ -1003,7 +1016,7 @@ pub(crate) async fn create_batch(
             &request_id,
         )
         .await?;
-        scan_output_blob(&state, &auth, &target, &bytes).await?;
+        scan_output_blob(&state, &auth, &target, &bytes, &mut monitor_hits).await?;
         let model = target.display_name().to_string();
         Ok((
             json_response(status, &resp_headers, bytes, Some(&model)),
@@ -1022,6 +1035,7 @@ pub(crate) async fn create_batch(
         started,
         request_id,
         result,
+        monitor_hits,
     )
 }
 
@@ -1036,6 +1050,7 @@ pub(crate) async fn get_batch(
     let started = Instant::now();
     let request_id = new_request_id();
     let (raw, embedded) = routed_model_hint(&id, &params, &headers);
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
 
     let result = async {
         require_safe_upstream_id(&raw)?;
@@ -1062,7 +1077,7 @@ pub(crate) async fn get_batch(
             &request_id,
         )
         .await?;
-        scan_output_blob(&state, &auth, &target, &bytes).await?;
+        scan_output_blob(&state, &auth, &target, &bytes, &mut monitor_hits).await?;
 
         // Batch cost attribution (#720): first observation of a completed
         // batch downloads the output JSONL and emits real token usage.
@@ -1090,6 +1105,7 @@ pub(crate) async fn get_batch(
         started,
         request_id,
         result,
+        monitor_hits,
     )
 }
 
@@ -1164,6 +1180,7 @@ pub(crate) async fn create_ft_job(
 ) -> Response {
     let started = Instant::now();
     let request_id = new_request_id();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
 
     let result = async {
         let mut req_json: Value = serde_json::from_slice(&body)
@@ -1201,7 +1218,7 @@ pub(crate) async fn create_ft_job(
         }
         let out_body = Bytes::from(serde_json::to_vec(&req_json).unwrap_or_default());
 
-        scan_input_blob(&state, &auth, &target, &out_body).await?;
+        scan_input_blob(&state, &auth, &target, &out_body, &mut monitor_hits).await?;
         let _reservation = crate::quota::enforce(
             &state,
             &auth,
@@ -1223,7 +1240,7 @@ pub(crate) async fn create_ft_job(
             &request_id,
         )
         .await?;
-        scan_output_blob(&state, &auth, &target, &bytes).await?;
+        scan_output_blob(&state, &auth, &target, &bytes, &mut monitor_hits).await?;
         let model = target.display_name().to_string();
         Ok((
             json_response(status, &resp_headers, bytes, Some(&model)),
@@ -1242,6 +1259,7 @@ pub(crate) async fn create_ft_job(
         started,
         request_id,
         result,
+        monitor_hits,
     )
 }
 
@@ -1365,6 +1383,7 @@ async fn forward_simple(
     let method = spec.method.clone();
     let log_path = spec.log_path.clone();
     let label = spec.label;
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
 
     let result = async {
         let embedded = match &spec.id {
@@ -1378,7 +1397,7 @@ async fn forward_simple(
         let target = resolve_target(&state, &auth, wanted.as_deref(), &client.source_ip)?;
 
         if let Some(body) = &spec.body {
-            scan_input_blob(&state, &auth, &target, body).await?;
+            scan_input_blob(&state, &auth, &target, body, &mut monitor_hits).await?;
         }
         let _reservation = crate::quota::enforce(
             &state,
@@ -1399,7 +1418,7 @@ async fn forward_simple(
         };
         let (status, resp_headers, bytes) =
             send_upstream(&state, &target, spec.method, &url, body, &request_id).await?;
-        scan_output_blob(&state, &auth, &target, &bytes).await?;
+        scan_output_blob(&state, &auth, &target, &bytes, &mut monitor_hits).await?;
 
         let resp = if spec.relay_raw_body {
             let mut resp = Response::builder()
@@ -1419,7 +1438,16 @@ async fn forward_simple(
     .await;
 
     finish(
-        &state, label, method, log_path, &auth, &client, started, request_id, result,
+        &state,
+        label,
+        method,
+        log_path,
+        &auth,
+        &client,
+        started,
+        request_id,
+        result,
+        monitor_hits,
     )
 }
 

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -152,6 +152,7 @@ async fn dispatch(
                     response.status().as_u16(),
                     Duration::ZERO,
                     false,
+                    Vec::new(),
                 );
                 return response;
             }
@@ -179,6 +180,7 @@ async fn dispatch(
         .filter(|chain| !chain.is_empty());
 
     // Input guardrails: scan the tool arguments.
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if let Some(chain) = &guardrail_chain {
         let args_text = peek
             .as_ref()
@@ -188,10 +190,12 @@ async fn dispatch(
             .unwrap_or_default();
         let chat =
             aisix_gateway::ChatFormat::new("", vec![aisix_gateway::ChatMessage::user(args_text)]);
+        let (verdict, hits) = aisix_guardrails::Guardrail::check_input_observed(chain, &chat).await;
+        monitor_hits.extend(hits);
         if let aisix_guardrails::GuardrailVerdict::Block {
             reason,
             guardrail_name,
-        } = aisix_guardrails::Guardrail::check_input(chain, &chat).await
+        } = verdict
         {
             tracing::warn!(
                 guardrail_hook = "input",
@@ -208,6 +212,7 @@ async fn dispatch(
                 StatusCode::OK.as_u16(),
                 Duration::ZERO,
                 true,
+                monitor_hits,
             );
             return jsonrpc_guardrail_block(rpc_id, "tool call", guardrail_name.as_deref());
         }
@@ -239,7 +244,9 @@ async fn dispatch(
                 return (StatusCode::BAD_GATEWAY, "invalid upstream response").into_response()
             }
         };
-        if let Some(guardrail_name) = output_guardrail_block(chain, &resp_bytes, &mcp_tool).await {
+        if let Some(guardrail_name) =
+            output_guardrail_block(chain, &resp_bytes, &mcp_tool, &mut monitor_hits).await
+        {
             emit_tool_call_usage(
                 state,
                 &auth,
@@ -249,6 +256,7 @@ async fn dispatch(
                 StatusCode::OK.as_u16(),
                 latency,
                 true,
+                monitor_hits,
             );
             return jsonrpc_guardrail_block(rpc_id, "tool result", guardrail_name.as_deref());
         }
@@ -267,6 +275,7 @@ async fn dispatch(
             response.status().as_u16(),
             latency,
             false,
+            monitor_hits,
         );
     }
     response
@@ -282,6 +291,7 @@ async fn output_guardrail_block(
     chain: &aisix_guardrails::GuardrailChain,
     response_bytes: &[u8],
     tool: &str,
+    monitor_hits: &mut Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Option<Option<String>> {
     // Fail closed on an unparseable body. The `/mcp` gateway is configured
     // `json_response = true`, so a `tools/call` returns a single
@@ -321,7 +331,9 @@ async fn output_guardrail_block(
         finish_reason: aisix_gateway::FinishReason::Stop,
         usage: aisix_gateway::UsageStats::new(0, 0),
     };
-    match aisix_guardrails::Guardrail::check_output(chain, &resp).await {
+    let (verdict, hits) = aisix_guardrails::Guardrail::check_output_observed(chain, &resp).await;
+    monitor_hits.extend(hits);
+    match verdict {
         aisix_guardrails::GuardrailVerdict::Block {
             reason,
             guardrail_name,
@@ -351,6 +363,7 @@ fn emit_tool_call_usage(
     status_code: u16,
     latency: Duration,
     guardrail_blocked: bool,
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) {
     let event = UsageEvent {
         request_id: request_id.to_string(),
@@ -362,6 +375,7 @@ fn emit_tool_call_usage(
         mcp_server_name: mcp_server.to_string(),
         mcp_tool_name: mcp_tool.to_string(),
         guardrail_blocked,
+        guardrail_monitor_hits,
         ..Default::default()
     };
     state.usage_sink.try_emit("mcp", event.clone());
@@ -858,7 +872,7 @@ mod tests {
         // A tool result whose content carries the forbidden token is blocked.
         let blocked = br#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"forbidden-token here"}]}}"#;
         assert!(
-            output_guardrail_block(&chain, blocked, "echo")
+            output_guardrail_block(&chain, blocked, "echo", &mut Vec::new())
                 .await
                 .is_some(),
             "a result containing the forbidden token must be blocked"
@@ -868,7 +882,7 @@ mod tests {
         let clean =
             br#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"all good"}]}}"#;
         assert!(
-            output_guardrail_block(&chain, clean, "echo")
+            output_guardrail_block(&chain, clean, "echo", &mut Vec::new())
                 .await
                 .is_none(),
             "a clean result must not be blocked"
@@ -877,7 +891,7 @@ mod tests {
         // An error response (no `result`) has nothing to scan.
         let errored = br#"{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"x"}}"#;
         assert!(
-            output_guardrail_block(&chain, errored, "echo")
+            output_guardrail_block(&chain, errored, "echo", &mut Vec::new())
                 .await
                 .is_none(),
             "an error response has no tool result to scan"
@@ -887,7 +901,7 @@ mod tests {
         // regression) fails closed — block, never pass an unscanned result.
         let sse_body = b"event: message\ndata: {\"jsonrpc\":\"2.0\",\"result\":{}}\n\n";
         assert!(
-            output_guardrail_block(&chain, sse_body, "echo")
+            output_guardrail_block(&chain, sse_body, "echo", &mut Vec::new())
                 .await
                 .is_some(),
             "an unparseable response body must fail closed (block)"
@@ -912,7 +926,7 @@ mod tests {
         // the decoded tool text ("hello world"), so the field name must NOT fire.
         let clean = br#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"hello world"}]}}"#;
         assert!(
-            output_guardrail_block(&chain, clean, "echo")
+            output_guardrail_block(&chain, clean, "echo", &mut Vec::new())
                 .await
                 .is_none(),
             "scanning the decoded text must ignore envelope field names"
@@ -922,7 +936,9 @@ mod tests {
         // proving it is active here, not simply absent.
         let hit = br#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"this has content in it"}]}}"#;
         assert!(
-            output_guardrail_block(&chain, hit, "echo").await.is_some(),
+            output_guardrail_block(&chain, hit, "echo", &mut Vec::new())
+                .await
+                .is_some(),
             "decoded text containing the pattern must still block"
         );
     }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -123,6 +123,9 @@ pub async fn messages(
     // dual-path lifecycle as `applied_guardrails`. Streaming output counts
     // travel via the stream builders' end-of-stream emit instead.
     let mut redaction_counts = crate::redact::RedactionCounts::new();
+    // Filled by `dispatch` with monitor-mode guardrail observations
+    // (AISIX-Cloud#562), same lifecycle as `redaction_counts`.
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     // #890 req-1: capture the client's streaming intent before dispatch
     // (which mutates the body).
     let stream_requested = body
@@ -138,6 +141,7 @@ pub async fn messages(
         &client,
         &mut applied_guardrails,
         &mut redaction_counts,
+        &mut monitor_hits,
     )
     .await
     {
@@ -151,10 +155,12 @@ pub async fn messages(
             routing,
             captured_content,
             output_redactions,
+            output_monitor_hits,
         }) => {
             // #932: fold the non-streaming response-side mask counts into
             // the per-request total before the terminal emit below.
             crate::redact::merge_counts(&mut redaction_counts, output_redactions);
+            monitor_hits.extend(output_monitor_hits);
             let elapsed = started.elapsed();
             let status = response.status().as_u16();
             emit_access_log(
@@ -246,6 +252,7 @@ pub async fn messages(
                     attempt,
                     applied_guardrails.clone(),
                     redaction_counts.clone(),
+                    monitor_hits.clone(),
                     captured_content,
                 );
             }
@@ -339,6 +346,7 @@ pub async fn messages(
                     applied_guardrails.clone(),
                     // Input masking may have fired before the failure.
                     redaction_counts.clone(),
+                    monitor_hits.clone(),
                     /* content */ None,
                 );
             }
@@ -394,6 +402,7 @@ fn emit_failed_attempts_anthropic(
             // Failed attempts carry no per-request redaction detail; the
             // terminal (winner / pre-dispatch) event does.
             crate::redact::RedactionCounts::new(),
+            Vec::new(),
             /* content */ None,
         );
     }
@@ -417,6 +426,9 @@ async fn dispatch(
     // `applied_out`. Streaming output counts travel via the stream
     // builders' own end-of-stream emit instead.
     redactions_out: &mut crate::redact::RedactionCounts,
+    // Out-param: monitor-mode guardrail observations (AISIX-Cloud#562),
+    // same lifecycle as `redactions_out`.
+    monitor_hits_out: &mut Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<DispatchOutcome, MessagesDispatchError> {
     let snapshot = state.snapshot.load();
 
@@ -461,11 +473,12 @@ async fn dispatch(
     *applied_out = resolved_chain.applied().to_vec();
     if !resolved_chain.is_empty() {
         if let Ok(chat) = aisix_provider_anthropic::parse_inbound_request(body) {
-            let verdict = aisix_guardrails::Guardrail::check_input_non_segment(
+            let (verdict, hits) = aisix_guardrails::Guardrail::check_input_non_segment_observed(
                 resolved_chain.as_ref(),
                 &chat,
             )
             .await;
+            monitor_hits_out.extend(hits);
             // Segment pass: one Bedrock call over the body's text slots;
             // an ANONYMIZE disposition writes the masked text back into
             // the Anthropic-native body (#932 bedrock follow-up).
@@ -474,6 +487,7 @@ async fn dispatch(
                 crate::redact::Direction::Input,
                 verdict,
                 redactions_out,
+                monitor_hits_out,
                 |g| crate::redact::redact_anthropic_request(g, body),
             )
             .await;
@@ -620,6 +634,7 @@ async fn dispatch(
                 },
                 &mut reservation,
                 redactions_out.clone(),
+                monitor_hits_out.clone(),
             )
             .await
             {
@@ -728,6 +743,9 @@ async fn dispatch_to_target(
     // into their end-of-stream telemetry emit (the non-streaming emit
     // happens in `messages()`, which already holds them).
     input_redactions: crate::redact::RedactionCounts,
+    // Input-side monitor hits (AISIX-Cloud#562), same lifecycle as
+    // `input_redactions`.
+    input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let model = &target.model;
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
@@ -751,6 +769,7 @@ async fn dispatch_to_target(
             attempt,
             reservation,
             input_redactions,
+            input_monitor_hits,
         )
         .await;
     }
@@ -774,6 +793,7 @@ async fn dispatch_to_target(
         attempt,
         reservation,
         input_redactions,
+        input_monitor_hits,
     )
     .await
 }
@@ -802,6 +822,7 @@ async fn anthropic_passthrough_dispatch(
     attempt: AttemptInfo,
     reservation: &mut Option<aisix_ratelimit::MultiReservation>,
     input_redactions: crate::redact::RedactionCounts,
+    input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let mut body = body.clone();
     let api_key = crate::dispatch::require_secret(pk_value, model)?;
@@ -1126,6 +1147,11 @@ async fn anthropic_passthrough_dispatch(
                         crate::redact::merge_counts(&mut merged, usage.redacted_entity_counts);
                         merged
                     },
+                    {
+                        let mut merged = input_monitor_hits.clone();
+                        merged.extend(usage.monitor_hits);
+                        merged
+                    },
                     // Prompt captured up front; response assembled by the frame
                     // parser into `usage.response_text`. Both gated on the cap.
                     match (&captured_prompt_c, content_cap) {
@@ -1180,6 +1206,7 @@ async fn anthropic_passthrough_dispatch(
             captured_content: None,
             // Streaming: the end-of-stream closure owns the counts.
             output_redactions: crate::redact::RedactionCounts::new(),
+            output_monitor_hits: Vec::new(),
         })
     } else {
         // Non-streaming: deserialise and re-serialise as JSON. Decode
@@ -1206,6 +1233,7 @@ async fn anthropic_passthrough_dispatch(
         // blocks + the raw content array, which covers tool_use args) into
         // a synthetic ChatResponse for inspection before returning it.
         let mut output_seg_counts = crate::redact::RedactionCounts::new();
+        let mut output_monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
         if !resolved_chain.is_empty() {
             if let Some(content) = json_body.get("content").and_then(|v| v.as_array()) {
                 let mut out_text = String::new();
@@ -1229,16 +1257,19 @@ async fn anthropic_passthrough_dispatch(
                     finish_reason: aisix_gateway::FinishReason::Stop,
                     usage: aisix_gateway::UsageStats::new(0, 0),
                 };
-                let verdict = aisix_guardrails::Guardrail::check_output_non_segment(
-                    resolved_chain.as_ref(),
-                    &synth,
-                )
-                .await;
+                let (verdict, hits) =
+                    aisix_guardrails::Guardrail::check_output_non_segment_observed(
+                        resolved_chain.as_ref(),
+                        &synth,
+                    )
+                    .await;
+                output_monitor_hits.extend(hits);
                 let verdict = crate::redact::moderate_body(
                     resolved_chain.as_ref(),
                     crate::redact::Direction::Output,
                     verdict,
                     &mut output_seg_counts,
+                    &mut output_monitor_hits,
                     |g| crate::redact::redact_anthropic_response(g, &mut json_body),
                 )
                 .await;
@@ -1308,6 +1339,7 @@ async fn anthropic_passthrough_dispatch(
             routing: RoutingTelemetry::default(),
             captured_content,
             output_redactions,
+            output_monitor_hits,
         })
     }
 }
@@ -1400,6 +1432,7 @@ async fn cross_provider_dispatch(
     attempt: AttemptInfo,
     reservation: &mut Option<aisix_ratelimit::MultiReservation>,
     input_redactions: crate::redact::RedactionCounts,
+    input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<DispatchOutcome, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
     use aisix_provider_anthropic::{
@@ -1620,6 +1653,11 @@ async fn cross_provider_dispatch(
                         crate::redact::merge_counts(&mut merged, comp.redacted_entity_counts);
                         merged
                     },
+                    {
+                        let mut merged = input_monitor_hits.clone();
+                        merged.extend(comp.monitor_hits);
+                        merged
+                    },
                     // Prompt captured up front, response assembled across the
                     // stream into `comp.response_text`; both gated on the cap.
                     match (&captured_prompt_for_telem, content_cap) {
@@ -1660,6 +1698,7 @@ async fn cross_provider_dispatch(
             captured_content: None,
             // Streaming: the end-of-stream closure owns the counts.
             output_redactions: crate::redact::RedactionCounts::new(),
+            output_monitor_hits: Vec::new(),
         });
     }
 
@@ -1678,15 +1717,20 @@ async fn cross_provider_dispatch(
     // before rendering it back as Anthropic JSON — the response is
     // client-visible output just like /v1/chat/completions.
     let mut output_seg_counts = crate::redact::RedactionCounts::new();
+    let mut output_monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if !resolved_chain.is_empty() {
-        let verdict =
-            aisix_guardrails::Guardrail::check_output_non_segment(resolved_chain.as_ref(), &resp)
-                .await;
+        let (verdict, hits) = aisix_guardrails::Guardrail::check_output_non_segment_observed(
+            resolved_chain.as_ref(),
+            &resp,
+        )
+        .await;
+        output_monitor_hits.extend(hits);
         let verdict = crate::redact::moderate_body(
             resolved_chain.as_ref(),
             crate::redact::Direction::Output,
             verdict,
             &mut output_seg_counts,
+            &mut output_monitor_hits,
             |g| crate::redact::redact_chat_response(g, &mut resp),
         )
         .await;
@@ -1753,6 +1797,7 @@ async fn cross_provider_dispatch(
         routing: RoutingTelemetry::default(),
         captured_content,
         output_redactions,
+        output_monitor_hits,
     })
 }
 
@@ -1913,18 +1958,25 @@ fn build_anthropic_sse_stream(
                     finish_reason: aisix_gateway::FinishReason::Stop,
                     usage: aisix_gateway::UsageStats::new(0, 0),
                 };
-                let verdict =
-                    aisix_guardrails::Guardrail::check_output_non_segment(chain.as_ref(), &synth)
-                        .await;
+                let (verdict, hits) =
+                    aisix_guardrails::Guardrail::check_output_non_segment_observed(
+                        chain.as_ref(),
+                        &synth,
+                    )
+                    .await;
+                guard.comp().monitor_hits.extend(hits);
                 let mut seg_counts = crate::redact::RedactionCounts::new();
+                let mut seg_hits = Vec::new();
                 let verdict = crate::redact::moderate_body(
                     chain.as_ref(),
                     crate::redact::Direction::Output,
                     verdict,
                     &mut seg_counts,
+                    &mut seg_hits,
                     |g| crate::redact::redact_chat_chunks(g, &mut held_chunks),
                 )
                 .await;
+                guard.comp().monitor_hits.extend(seg_hits);
                 if !seg_counts.is_empty() {
                     // Bedrock masked the held chunks — rebuild the content-
                     // capture accumulator from the masked content channel
@@ -2052,6 +2104,10 @@ struct AnthropicStreamCompletion {
     /// Per-detector PII mask counts applied to the held stream at release
     /// (#932). Merged with the input-side counts by the on_complete emit.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations made by the end-of-stream output
+    /// check (AISIX-Cloud#562). Merged with the input-side hits by the
+    /// on_complete emit.
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 }
 
 struct CompleteAnthropicStreamOnDrop<F: FnOnce(AnthropicStreamCompletion)> {
@@ -2100,6 +2156,9 @@ struct DispatchOutcome {
     /// before the terminal emit. Empty on the streaming paths — their
     /// end-of-stream closures own the output-side counts.
     output_redactions: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations on the response side
+    /// (AISIX-Cloud#562), same lifecycle as `output_redactions`.
+    output_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 }
 
 /// Dispatch error carrying the per-attempt telemetry accumulated before
@@ -2177,6 +2236,9 @@ fn emit_anthropic_usage_event(
     // Per-detector PII mask counts (#932), input + output merged. Detector
     // names only, never matched values. Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Monitor-mode guardrail observations (AISIX-Cloud#562), input +
+    // output merged.
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     content: Option<CapturedContent>,
 ) {
     // Per-PK telemetry attribution (#302 M17 / AISIX-Cloud#436).
@@ -2229,6 +2291,7 @@ fn emit_anthropic_usage_event(
         client_user_agent: client.user_agent.clone(),
         applied_guardrails,
         redacted_entity_counts,
+        guardrail_monitor_hits,
         ..Default::default()
     };
     // Handler label "messages" — Anthropic /v1/messages inbound
@@ -2331,6 +2394,10 @@ struct AnthropicStreamUsage {
     /// Per-detector PII mask counts applied to the held stream at release
     /// (#932). Merged with the input-side counts by the on_complete emit.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations made by the end-of-stream output
+    /// check (AISIX-Cloud#562). Merged with the input-side hits by the
+    /// on_complete emit.
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 }
 
 /// Update the accumulator from one parsed SSE `data:` JSON object.
@@ -2711,19 +2778,25 @@ where
                     finish_reason: aisix_gateway::FinishReason::Stop,
                     usage: aisix_gateway::UsageStats::new(0, 0),
                 };
-                let verdict =
-                    aisix_guardrails::Guardrail::check_output_non_segment(chain.as_ref(), &synth)
-                        .await;
+                let (verdict, hits) =
+                    aisix_guardrails::Guardrail::check_output_non_segment_observed(
+                        chain.as_ref(),
+                        &synth,
+                    )
+                    .await;
+                guard.usage().monitor_hits.extend(hits);
                 // Segment pass over the held SSE bytes. Only meaningful in
                 // hold-back mode (`held` is empty otherwise — and a chain
                 // with a segment member always folds to BufferFull, so a
                 // live-forward stream never carries one).
                 let mut seg_counts = crate::redact::RedactionCounts::new();
+                let mut seg_hits = Vec::new();
                 let verdict = crate::redact::moderate_body(
                     chain.as_ref(),
                     crate::redact::Direction::Output,
                     verdict,
                     &mut seg_counts,
+                    &mut seg_hits,
                     |g| match crate::redact::redact_anthropic_sse(g, &held) {
                         Some((rewritten, counts)) => {
                             held = rewritten;
@@ -2733,6 +2806,7 @@ where
                     },
                 )
                 .await;
+                guard.usage().monitor_hits.extend(seg_hits);
                 if !seg_counts.is_empty() {
                     // Bedrock masked the held bytes — rebuild the content-
                     // capture accumulator from the masked text channels

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -141,6 +141,7 @@ pub async fn passthrough(
     let method = req.method().clone();
     let path = format!("/passthrough/{provider}/{rest}");
 
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     match dispatch(
         state.clone(),
         &auth,
@@ -149,6 +150,7 @@ pub async fn passthrough(
         req,
         &request_id,
         &client.source_ip,
+        &mut monitor_hits,
     )
     .await
     {
@@ -187,6 +189,7 @@ pub async fn passthrough(
                 status,
                 elapsed,
                 &client,
+                monitor_hits,
             );
             resp
         }
@@ -237,6 +240,7 @@ async fn dispatch(
     req: Request,
     request_id: &str,
     source_ip: &str,
+    monitor_hits_out: &mut Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<(Response, String, String), ProxyError> {
     let snapshot = state.snapshot.load();
 
@@ -366,10 +370,13 @@ async fn dispatch(
                 String::from_utf8_lossy(&body_bytes).into_owned(),
             )],
         );
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_input_observed(&resolved_chain, &chat).await;
+        monitor_hits_out.extend(hits);
         if let aisix_guardrails::GuardrailVerdict::Block {
             reason,
             guardrail_name,
-        } = aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        } = verdict
         {
             // Per #153 the matched-pattern detail stays in ops logs only.
             tracing::warn!(
@@ -520,10 +527,13 @@ async fn dispatch(
             finish_reason: aisix_gateway::FinishReason::Stop,
             usage: aisix_gateway::UsageStats::default(),
         };
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_output_observed(&resolved_chain, &synth).await;
+        monitor_hits_out.extend(hits);
         if let aisix_guardrails::GuardrailVerdict::Block {
             reason,
             guardrail_name,
-        } = aisix_guardrails::Guardrail::check_output(&resolved_chain, &synth).await
+        } = verdict
         {
             // Per #153 the matched-pattern detail stays in ops logs only.
             tracing::warn!(
@@ -562,6 +572,7 @@ async fn dispatch(
 /// who lent which provider's credentials (per-PK attribution tags), the
 /// relayed status, and the latency. `inbound_protocol = "passthrough"`
 /// distinguishes these rows from typed-endpoint traffic in /logs.
+#[allow(clippy::too_many_arguments)]
 fn emit_usage_event(
     state: &ProxyState,
     request_id: &str,
@@ -570,6 +581,7 @@ fn emit_usage_event(
     status_code: u16,
     elapsed: Duration,
     client: &crate::client_ip::ClientContext,
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) {
     let snap = state.snapshot.load();
     let mut event = aisix_obs::UsageEvent {
@@ -581,6 +593,7 @@ fn emit_usage_event(
         inbound_protocol: "passthrough".to_string(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
+        guardrail_monitor_hits,
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, &snap, provider_key_id);

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -422,6 +422,7 @@ async fn run_session(
     let (mut up_tx, mut up_rx) = upstream.split();
 
     let mut usage = SessionUsage::default();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     let mut close_status: u16 = 200;
     // Operator-configured stream idle deadline (stream_timeout on the
     // Model). Absent → no idle cap; realtime sessions are long-lived by
@@ -461,6 +462,7 @@ async fn run_session(
                             &model_entry.value.display_name,
                             &text,
                             true,
+                            &mut monitor_hits,
                         )
                         .await
                         {
@@ -503,6 +505,7 @@ async fn run_session(
                             &model_entry.value.display_name,
                             &text,
                             false,
+                            &mut monitor_hits,
                         )
                         .await
                         {
@@ -595,6 +598,7 @@ async fn run_session(
         inbound_protocol: "realtime".to_string(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
+        guardrail_monitor_hits: monitor_hits,
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, &snap, &pk_id);
@@ -617,13 +621,14 @@ async fn guardrail_block_event(
     model_name: &str,
     text: &str,
     input_side: bool,
+    monitor_hits: &mut Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Option<String> {
-    let verdict = if input_side {
+    let (verdict, hits) = if input_side {
         let chat = aisix_gateway::ChatFormat::new(
             model_name,
             vec![aisix_gateway::ChatMessage::user(text.to_string())],
         );
-        aisix_guardrails::Guardrail::check_input(chain, &chat).await
+        aisix_guardrails::Guardrail::check_input_observed(chain, &chat).await
     } else {
         let synth = aisix_gateway::ChatResponse {
             id: String::new(),
@@ -632,8 +637,9 @@ async fn guardrail_block_event(
             finish_reason: aisix_gateway::FinishReason::Stop,
             usage: aisix_gateway::UsageStats::default(),
         };
-        aisix_guardrails::Guardrail::check_output(chain, &synth).await
+        aisix_guardrails::Guardrail::check_output_observed(chain, &synth).await
     };
+    monitor_hits.extend(hits);
     if let aisix_guardrails::GuardrailVerdict::Block {
         reason,
         guardrail_name,

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -203,6 +203,7 @@ pub async fn moderate_body(
     dir: Direction,
     non_segment_verdict: aisix_guardrails::GuardrailVerdict,
     counts_out: &mut RedactionCounts,
+    monitor_hits_out: &mut Vec<aisix_core::models::GuardrailMonitorHit>,
     mut walk: impl FnMut(&dyn Guardrail) -> RedactionCounts,
 ) -> aisix_guardrails::GuardrailVerdict {
     if non_segment_verdict.is_block() || !chain.moderates_segments() {
@@ -214,10 +215,11 @@ pub async fn moderate_body(
     if texts.is_empty() {
         return non_segment_verdict;
     }
-    let outcome = match dir {
+    let mut outcome = match dir {
         Direction::Input => chain.moderate_input_segments(&texts).await,
         Direction::Output => chain.moderate_output_segments(&texts).await,
     };
+    monitor_hits_out.append(&mut outcome.monitor_hits);
     if !outcome.verdict.is_block() {
         if let Some(masked) = outcome.masked {
             let applier = SegmentApplier::new(masked);
@@ -1850,6 +1852,7 @@ mod tests {
                         .collect()
                 }),
                 counts,
+                monitor_hits: Vec::new(),
             }
         }
     }
@@ -1884,6 +1887,7 @@ mod tests {
             Direction::Input,
             GuardrailVerdict::Allow,
             &mut counts,
+            &mut Vec::new(),
             |g| redact_chat_format(g, &mut req),
         )
         .await;
@@ -1933,6 +1937,7 @@ mod tests {
             Direction::Input,
             GuardrailVerdict::Allow,
             &mut counts,
+            &mut Vec::new(),
             |g| redact_chat_format(g, &mut req),
         )
         .await;
@@ -1962,6 +1967,7 @@ mod tests {
             Direction::Input,
             GuardrailVerdict::block("already blocked"),
             &mut counts,
+            &mut Vec::new(),
             |g| redact_chat_format(g, &mut req),
         )
         .await;
@@ -1974,6 +1980,7 @@ mod tests {
             Direction::Input,
             GuardrailVerdict::Allow,
             &mut counts,
+            &mut Vec::new(),
             |_| panic!("walk must not run when no segment member exists"),
         )
         .await;
@@ -2001,6 +2008,7 @@ mod tests {
             Direction::Output,
             GuardrailVerdict::Allow,
             &mut counts,
+            &mut Vec::new(),
             |g| match redact_anthropic_sse(g, &held) {
                 Some((rewritten, c)) => {
                     held = rewritten;

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -47,6 +47,8 @@ struct RerankDispatchSuccess {
     /// Per-detector PII mask counts (#932/#696) applied to the request.
     /// Attached to the emitted UsageEvent. Empty = no redaction.
     redactions: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations (AISIX-Cloud#562).
+    monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     /// Captured request/response content for content-capturing exporters
     /// (#700, LiteLLM parity: the full rerank response JSON). `Some` only
     /// when an exporter opted into `content_mode = full`.
@@ -122,6 +124,7 @@ pub async fn rerank(
                     &usage,
                     &client,
                     success.redactions.clone(),
+                    success.monitor_hits.clone(),
                     success.captured_content.as_ref(),
                 );
             }
@@ -230,12 +233,16 @@ async fn dispatch(
     // UsageEvent surfaces them in Logs, like chat / messages. Empty when no
     // guardrail is attached.
     let applied_guardrails = resolved_chain.applied().to_vec();
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if !resolved_chain.is_empty() {
         let chat = rerank_input_to_chat(&model_name, &*body);
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_input_observed(&resolved_chain, &chat).await;
+        monitor_hits.extend(hits);
         if let aisix_guardrails::GuardrailVerdict::Block {
             reason,
             guardrail_name,
-        } = aisix_guardrails::Guardrail::check_input(&resolved_chain, &chat).await
+        } = verdict
         {
             // Per #153 the matched-pattern detail stays in ops logs only.
             tracing::warn!(
@@ -503,6 +510,7 @@ async fn dispatch(
         applied_guardrails: applied_guardrails.clone(),
         usage,
         redactions,
+        monitor_hits,
         captured_content,
     })
 }
@@ -566,6 +574,8 @@ fn emit_usage_event(
     client: &ClientContext,
     // Per-detector PII mask counts (#932/#696). Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Monitor-mode guardrail observations (AISIX-Cloud#562).
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     // Captured request/response content (#700). Forwarded only to `fan_out`,
     // never to the CP sink.
     content: Option<&CapturedContent>,
@@ -585,6 +595,7 @@ fn emit_usage_event(
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         redacted_entity_counts,
+        guardrail_monitor_hits,
         ..Default::default()
     };
     // Per-PK attribution tags (provider_kind / provider_featured /

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -82,6 +82,9 @@ struct ResponseDispatchSuccess {
     /// the handler before the terminal emit. Empty on the live streaming
     /// paths — their end-of-stream closures own the output-side counts.
     output_redactions: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations on the response side
+    /// (AISIX-Cloud#562), same lifecycle as `output_redactions`.
+    output_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 }
 
 /// Dispatch error carrying the per-attempt telemetry accumulated before
@@ -150,6 +153,9 @@ pub async fn responses(
     // Filled by `dispatch` with per-detector PII mask counts (#932); attached
     // to the terminal usage event on both the success and failure paths.
     let mut redaction_counts = crate::redact::RedactionCounts::new();
+    // Filled by `dispatch` with monitor-mode guardrail observations
+    // (AISIX-Cloud#562), same lifecycle as `redaction_counts`.
+    let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     match dispatch(
         &state,
         &auth,
@@ -158,6 +164,7 @@ pub async fn responses(
         started,
         &client,
         &mut redaction_counts,
+        &mut monitor_hits,
     )
     .await
     {
@@ -165,6 +172,7 @@ pub async fn responses(
             // #932: fold the non-streaming response-side mask counts into
             // the per-request total before the terminal emit below.
             crate::redact::merge_counts(&mut redaction_counts, success.output_redactions.clone());
+            monitor_hits.extend(success.output_monitor_hits.clone());
             let elapsed = started.elapsed();
             let status = success.response.status().as_u16();
             emit_access_log(
@@ -229,6 +237,7 @@ pub async fn responses(
                         attempt,
                         success.guardrail_blocked,
                         redaction_counts.clone(),
+                        monitor_hits.clone(),
                         success.captured_content.as_ref(),
                     );
                 }
@@ -289,6 +298,7 @@ pub async fn responses(
                     },
                     // Input masking may have fired before the failure.
                     redaction_counts.clone(),
+                    monitor_hits.clone(),
                 );
             }
             err.into_response()
@@ -296,6 +306,7 @@ pub async fn responses(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn dispatch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
@@ -313,6 +324,9 @@ async fn dispatch(
     // arrives via `ResponseDispatchSuccess::output_redactions`; streaming
     // output counts travel via the stream completion instead.
     redactions_out: &mut crate::redact::RedactionCounts,
+    // Out-param: monitor-mode guardrail observations (AISIX-Cloud#562),
+    // same lifecycle as `redactions_out`.
+    monitor_hits_out: &mut Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<ResponseDispatchSuccess, ResponsesDispatchError> {
     let snapshot = state.snapshot.load();
 
@@ -355,9 +369,12 @@ async fn dispatch(
     let resolved_chain = Arc::new(state.guardrail_index.resolve(&guardrail_ctx));
     if !resolved_chain.is_empty() {
         let chat = responses_input_to_chat(&model_name, body);
-        let verdict =
-            aisix_guardrails::Guardrail::check_input_non_segment(resolved_chain.as_ref(), &chat)
-                .await;
+        let (verdict, hits) = aisix_guardrails::Guardrail::check_input_non_segment_observed(
+            resolved_chain.as_ref(),
+            &chat,
+        )
+        .await;
+        monitor_hits_out.extend(hits);
         // Segment pass: one Bedrock call over the body's text slots; an
         // ANONYMIZE disposition writes the masked text back into the
         // Responses body (#932 bedrock follow-up).
@@ -366,6 +383,7 @@ async fn dispatch(
             crate::redact::Direction::Input,
             verdict,
             redactions_out,
+            monitor_hits_out,
             |g| crate::redact::redact_responses_request(g, body),
         )
         .await;
@@ -498,6 +516,7 @@ async fn dispatch(
                     attempt,
                     &mut reservation,
                     redactions_out.clone(),
+                    monitor_hits_out.clone(),
                 )
                 .await
             } else {
@@ -516,6 +535,7 @@ async fn dispatch(
                     attempt,
                     &mut reservation,
                     redactions_out.clone(),
+                    monitor_hits_out.clone(),
                 )
                 .await
             };
@@ -720,6 +740,9 @@ async fn responses_to_target(
     // end-of-stream emit; the non-streaming/buffered emits happen in the
     // handler, which already holds them.
     input_redactions: crate::redact::RedactionCounts,
+    // Input-side monitor hits (AISIX-Cloud#562), same lifecycle as
+    // `input_redactions`.
+    input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
     // Largest content cap any enabled content-capturing exporter wants, or
     // `None` when none do (AISIX-Cloud#947). The captured prompt is the
@@ -965,8 +988,9 @@ async fn responses_to_target(
             }
             let out_text = responses_sse_output_text(&buf);
             let synth = synth_chat_response(&upstream_model, out_text);
-            let verdict =
-                aisix_guardrails::Guardrail::check_output_non_segment(chain, &synth).await;
+            let (verdict, hits) =
+                aisix_guardrails::Guardrail::check_output_non_segment_observed(chain, &synth).await;
+            let mut output_monitor_hits = hits;
             // Segment pass over the held SSE frames: one Bedrock call; an
             // ANONYMIZE disposition rewrites `buf` in place (#932 bedrock
             // follow-up). The capture below reads the post-mask buffer.
@@ -976,6 +1000,7 @@ async fn responses_to_target(
                 crate::redact::Direction::Output,
                 verdict,
                 &mut output_redactions,
+                &mut output_monitor_hits,
                 |g| match crate::redact::redact_responses_sse(g, &buf) {
                     Some((rewritten, counts)) => {
                         buf = rewritten;
@@ -1037,6 +1062,7 @@ async fn responses_to_target(
                 guardrail_blocked: false,
                 usage_handled_by_stream: false,
                 output_redactions,
+                output_monitor_hits,
                 captured_content,
             });
         }
@@ -1154,6 +1180,7 @@ async fn responses_to_target(
                     // output-masking guardrail forces the buffered branch),
                     // so only the input-side counts apply.
                     input_redactions.clone(),
+                    input_monitor_hits.clone(),
                     captured_content.as_ref(),
                 );
             });
@@ -1173,6 +1200,7 @@ async fn responses_to_target(
             usage_handled_by_stream: true,
             // The Drop guard's emit carries the counts.
             output_redactions: crate::redact::RedactionCounts::new(),
+            output_monitor_hits: Vec::new(),
             // The Drop guard's emit carries the captured content too.
             captured_content: None,
         })
@@ -1202,15 +1230,18 @@ async fn responses_to_target(
         // output-hook guardrail is attached; otherwise this is a no-op.
         let mut json_body = json_body;
         let mut output_seg_counts = crate::redact::RedactionCounts::new();
+        let mut output_monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
         if aisix_guardrails::Guardrail::runs_on_output(chain) {
             let synth = synth_chat_response(&upstream_model, responses_output_text(&json_body));
-            let verdict =
-                aisix_guardrails::Guardrail::check_output_non_segment(chain, &synth).await;
+            let (verdict, hits) =
+                aisix_guardrails::Guardrail::check_output_non_segment_observed(chain, &synth).await;
+            output_monitor_hits.extend(hits);
             let verdict = crate::redact::moderate_body(
                 chain,
                 crate::redact::Direction::Output,
                 verdict,
                 &mut output_seg_counts,
+                &mut output_monitor_hits,
                 |g| crate::redact::redact_responses_response(g, &mut json_body),
             )
             .await;
@@ -1245,6 +1276,8 @@ async fn responses_to_target(
                     guardrail_blocked: true,
                     usage_handled_by_stream: false,
                     output_redactions: crate::redact::RedactionCounts::new(),
+                    // Hits observed by the blocking check still count.
+                    output_monitor_hits,
                     // Blocked responses never reached the client — no content
                     // capture, matching the chat surface.
                     captured_content: None,
@@ -1279,6 +1312,7 @@ async fn responses_to_target(
             guardrail_blocked: false,
             usage_handled_by_stream: false,
             output_redactions,
+            output_monitor_hits,
             captured_content,
         })
     }
@@ -1308,6 +1342,9 @@ async fn responses_cross_provider_to_target(
     // Input-side PII mask counts (#932), merged into the streamed judge
     // path's end-of-stream emit; non-streaming emits happen in the handler.
     input_redactions: crate::redact::RedactionCounts,
+    // Input-side monitor hits (AISIX-Cloud#562), same lifecycle as
+    // `input_redactions`.
+    input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
     use aisix_gateway::{Bridge, BridgeContext};
 
@@ -1516,6 +1553,11 @@ async fn responses_cross_provider_to_target(
                         crate::redact::merge_counts(&mut merged, comp.redacted_entity_counts);
                         merged
                     },
+                    {
+                        let mut merged = input_monitor_hits.clone();
+                        merged.extend(comp.monitor_hits);
+                        merged
+                    },
                     captured_content.as_ref(),
                 );
             },
@@ -1545,6 +1587,7 @@ async fn responses_cross_provider_to_target(
             usage_handled_by_stream: true,
             // The stream's end-of-stream emit carries the counts.
             output_redactions: crate::redact::RedactionCounts::new(),
+            output_monitor_hits: Vec::new(),
             // The stream's end-of-stream emit carries the captured content.
             captured_content: None,
         });
@@ -1574,14 +1617,18 @@ async fn responses_cross_provider_to_target(
     // it as Responses JSON — the assistant text + tool calls are
     // client-visible output, scanned the same way /v1/chat/completions does.
     let mut output_seg_counts = crate::redact::RedactionCounts::new();
+    let mut output_monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if aisix_guardrails::Guardrail::runs_on_output(chain.as_ref()) {
-        let verdict =
-            aisix_guardrails::Guardrail::check_output_non_segment(chain.as_ref(), &resp).await;
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_output_non_segment_observed(chain.as_ref(), &resp)
+                .await;
+        output_monitor_hits.extend(hits);
         let verdict = crate::redact::moderate_body(
             chain.as_ref(),
             crate::redact::Direction::Output,
             verdict,
             &mut output_seg_counts,
+            &mut output_monitor_hits,
             |g| crate::redact::redact_chat_response(g, &mut resp),
         )
         .await;
@@ -1613,6 +1660,8 @@ async fn responses_cross_provider_to_target(
                 guardrail_blocked: true,
                 usage_handled_by_stream: false,
                 output_redactions: crate::redact::RedactionCounts::new(),
+                // Hits observed by the blocking check still count.
+                output_monitor_hits,
                 // Blocked responses never reached the client — no content
                 // capture, matching the chat surface.
                 captured_content: None,
@@ -1658,6 +1707,7 @@ async fn responses_cross_provider_to_target(
         guardrail_blocked: false,
         usage_handled_by_stream: false,
         output_redactions,
+        output_monitor_hits,
         captured_content,
     })
 }
@@ -2102,6 +2152,9 @@ fn emit_usage_event(
     // Per-detector PII mask counts (#932), input + output merged. Detector
     // names only, never matched values. Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Monitor-mode guardrail observations (AISIX-Cloud#562), input +
+    // output merged.
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     // Captured request/response content for content-capturing exporters
     // (AISIX-Cloud#947). Forwarded only to `fan_out`, never to the CP sink.
     content: Option<&CapturedContent>,
@@ -2139,6 +2192,7 @@ fn emit_usage_event(
         client_user_agent: client.user_agent.clone(),
         guardrail_blocked,
         redacted_entity_counts,
+        guardrail_monitor_hits,
         ..Default::default()
     };
     state.usage_sink.try_emit("responses", event.clone());
@@ -2165,6 +2219,9 @@ fn emit_zero_token_event(
     // Per-detector PII mask counts (#932): input masking may have fired
     // before the failure. Empty for most failure classes.
     redacted_entity_counts: crate::redact::RedactionCounts,
+    // Monitor-mode guardrail observations (AISIX-Cloud#562) that fired
+    // before the failure.
+    guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) {
     let snap = state.snapshot.load();
     let tags = provider_telemetry_tags(&snap, provider_key_id);
@@ -2175,6 +2232,7 @@ fn emit_zero_token_event(
         api_key_id: api_key_id.to_string(),
         requested_model: requested_model.to_string(),
         redacted_entity_counts,
+        guardrail_monitor_hits,
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),
@@ -2228,6 +2286,7 @@ fn emit_failed_attempts(
             // Failed attempts carry no per-request redaction detail; the
             // terminal event does.
             crate::redact::RedactionCounts::new(),
+            Vec::new(),
         );
     }
 }

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -901,6 +901,10 @@ pub struct ResponsesStreamCompletion {
     /// Per-detector PII mask counts applied to the held stream at release
     /// (#932). Merged with the input-side counts by the on_complete emit.
     pub redacted_entity_counts: crate::redact::RedactionCounts,
+    /// Monitor-mode guardrail observations made by the end-of-stream output
+    /// check (AISIX-Cloud#562). Merged with the input-side hits by the
+    /// on_complete emit.
+    pub monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     /// Assembled assistant text for content-capturing exporters
     /// (AISIX-Cloud#947), accumulated across chunks ONLY when an exporter
     /// wants full content (bounded to the capture cap). Empty otherwise.
@@ -1082,13 +1086,18 @@ pub fn build_responses_bridge_stream(
                 finish_reason: FinishReason::Stop,
                 usage: UsageStats::new(0, 0),
             };
-            let verdict =
-                aisix_guardrails::Guardrail::check_output_non_segment(chain.as_ref(), &synth)
-                    .await;
+            let (verdict, hits) =
+                aisix_guardrails::Guardrail::check_output_non_segment_observed(
+                    chain.as_ref(),
+                    &synth,
+                )
+                .await;
+            guard.comp().monitor_hits.extend(hits);
             // Segment pass over the held SSE frames: one Bedrock call; an
             // ANONYMIZE disposition rewrites the held bytes (#932 bedrock
             // follow-up).
             let mut seg_counts = crate::redact::RedactionCounts::new();
+            let mut seg_hits = Vec::new();
             let mut joined: Vec<u8> = Vec::with_capacity(held_bytes);
             for b in &held {
                 joined.extend_from_slice(b);
@@ -1099,6 +1108,7 @@ pub fn build_responses_bridge_stream(
                 crate::redact::Direction::Output,
                 verdict,
                 &mut seg_counts,
+                &mut seg_hits,
                 |g| match crate::redact::redact_responses_sse(g, &joined) {
                     Some((rewritten, counts)) => {
                         joined = rewritten;
@@ -1109,6 +1119,7 @@ pub fn build_responses_bridge_stream(
                 },
             )
             .await;
+            guard.comp().monitor_hits.extend(seg_hits);
             if !seg_counts.is_empty() {
                 // Bedrock masked the held bytes — rebuild the content-
                 // capture accumulator from the masked text channels,

--- a/tests/e2e/src/cases/guardrail-monitor-telemetry-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-monitor-telemetry-e2e.test.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  decodedTextFor,
+  EtcdClient,
+  spawnApp,
+  startMockSls,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type MockSls,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// AISIX-Cloud#562: an `enforcement_mode: monitor` guardrail must surface
+// what it WOULD have done on the request's usage event
+// (`guardrail_monitor_hits`), not just in gateway logs — that record is
+// what lets an operator stage a policy, audit its hit rate in the
+// dashboard, and only then flip it to `block`. We attach a monitor-mode
+// kind=pii guardrail (email → mask, china_id_card → block), drive both
+// detector classes, and read the emitted usage events through a real
+// `aliyun_sls` exporter (metadata_only) against a mock SLS endpoint:
+// - the email prompt reaches the upstream UNMASKED (monitor never
+//   rewrites) but the event carries a `would_mask` hit with the email
+//   detector count;
+// - the ID-card prompt returns 200 (monitor never blocks) but the event
+//   carries a `would_block` hit naming the detector;
+// - the matched values themselves never appear in the event (#153).
+
+const CALLER_PLAINTEXT = "sk-monitor-telemetry-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const CREDENTIAL_REF = "mock";
+const SLS_PROJECT = "aisix-e2e-obs";
+const META_LOGSTORE = "monitor-telemetry-events";
+
+const EMAIL = "carol@example.com";
+const CN_ID = "11010519491231002X"; // valid ISO 7064 MOD 11-2 check digit
+const GUARD_NAME = "monitor-telemetry-guard";
+
+describe("guardrail monitor-hit telemetry: would_block/would_mask on usage events", () => {
+  let upstream: OpenAiUpstream | undefined;
+  let sls: MockSls | undefined;
+  let app: SpawnedApp | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    sls = await startMockSls();
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-monitor",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "a plain reply" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+      },
+    });
+
+    app = await spawnApp({
+      extraEnv: {
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: "mock-akid",
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: "mock-secret",
+      },
+    });
+    const admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    await admin.createObservabilityExporter({
+      name: "sls-monitor-telemetry",
+      enabled: true,
+      kind: "aliyun_sls",
+      endpoint: sls.url,
+      project: SLS_PROJECT,
+      logstore: META_LOGSTORE,
+      credential_ref: CREDENTIAL_REF,
+      content_mode: "metadata_only",
+    });
+
+    const pk = await admin.createProviderKey({
+      display_name: "monitor-telemetry-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "monitor-telemetry-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["monitor-telemetry-model"],
+    });
+
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: GUARD_NAME,
+      enabled: true,
+      hook_point: "input",
+      enforcement_mode: "monitor",
+      kind: "pii",
+      detectors: [
+        { type: "email", action: "mask" },
+        { type: "china_id_card", action: "block" },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await sls?.close();
+  });
+
+  const chat = async (content: string) => {
+    const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "monitor-telemetry-model",
+        messages: [{ role: "user", content }],
+      }),
+    });
+    return res;
+  };
+
+  test("would_mask and would_block hits land on exported usage events; traffic unaffected", async (ctx) => {
+    if (!etcdReachable || !app || !upstream || !sls) {
+      ctx.skip();
+      return;
+    }
+
+    // Monitor mode is invisible on the wire, so gate propagation on the
+    // telemetry itself: keep sending an email-bearing probe until an
+    // exported event carries a monitor hit.
+    await waitConfigPropagation(async () => {
+      const res = await chat(`probe mail ${EMAIL} ok`);
+      expect(res.status).toBe(200);
+      return decodedTextFor(sls!, META_LOGSTORE).includes("guardrail_monitor_hits");
+    });
+
+    // The prompt reached the upstream UNMASKED — monitor observes, never
+    // rewrites.
+    const lastReq = upstream.receivedRequests.at(-1);
+    expect(lastReq).toBeDefined();
+    expect(lastReq!.body).toContain(EMAIL);
+
+    // The exported event carries the would_mask hit: action, detector
+    // name, and the guardrail row name.
+    let text = decodedTextFor(sls, META_LOGSTORE);
+    expect(text).toContain("would_mask");
+    expect(text).toContain('"email"');
+    expect(text).toContain(GUARD_NAME);
+
+    // A block-action detector in monitor mode: 200 to the caller, upstream
+    // called, would_block hit with the detector name on the event.
+    const upstreamBefore = upstream.receivedRequests.length;
+    const res = await chat(`my id is ${CN_ID} thanks`);
+    expect(res.status).toBe(200);
+    expect(upstream.receivedRequests.length).toBe(upstreamBefore + 1);
+
+    // Poll until the second event is exported.
+    await waitConfigPropagation(async () =>
+      decodedTextFor(sls!, META_LOGSTORE).includes("would_block"),
+    );
+    text = decodedTextFor(sls, META_LOGSTORE);
+    expect(text).toContain("would_block");
+    expect(text).toContain("china_id_card");
+
+    // No-leak (#153): the matched values never appear in the events.
+    expect(text).not.toContain(EMAIL);
+    expect(text).not.toContain(CN_ID);
+  });
+});


### PR DESCRIPTION
## What

`enforcement_mode: monitor` observations now land on the request's usage event instead of only in gateway logs. Each event carries `guardrail_monitor_hits`: one entry per suppressed decision — `would_block` (with the operator-facing reason) or `would_mask` (with per-detector counts) — plus the guardrail row name and hook. Names only, never matched content (#153).

This closes the monitor-mode observability gap from api7/AISIX-Cloud#562: an operator can stage a policy in monitor mode, audit its would-have-fired rate per request in the dashboard, and only then flip it to `block`. Previously monitor hits went to DP tracing logs only, so the "observe first, enforce later" loop had no dashboard-visible signal.

## How

- `aisix_core::models::GuardrailMonitorHit { guardrail_name, hook, action, reason, counts }`, carried on `UsageEvent.guardrail_monitor_hits` (serde-skipped when empty; older CP images ignore the unknown field — additive wire change).
- The `Guardrail` trait gains `check_{input,output}[_non_segment]_observed` variants returning `(verdict, Vec<GuardrailMonitorHit>)`, with defaults that delegate to the plain checks — concrete kinds are untouched. `SegmentsOutcome` gains `monitor_hits`.
- `MonitorGuardrail` produces the hits: a downgraded Block → `would_block`; the suppressed sync redactor (kind=pii) is probed on the hook's scan text for `would_mask` counts; and it now **delegates the segment pass** (`moderates_segments`), so a monitored bedrock/lakera/presidio row is observed through ONE provider call with mask/count fidelity instead of degrading to the blob path.
- `GuardrailChain` folds observed results and keeps hits collected before an enforcing peer's Block short-circuit.
- Every proxy family threads a per-request accumulator into its usage emission (same shape as the #932 `redacted_entity_counts` plumbing): chat (incl. streaming on_complete + ensemble judge), completions, messages (both stream builders), responses (+bridge), embeddings, rerank, images, audio, jobs, mcp, realtime, passthrough. Failed-attempt / pre-guardrail error events intentionally carry no hits (terminal event does), mirroring how redaction counts already behave.

## Tests

- Unit: monitor-mode observed check reports `would_mask` (with counts) and `would_block` (reason, no value leak); enforcing rows produce no hits; a monitor hit survives an enforcing peer's block short-circuit; existing 208-test suite green.
- E2E (`guardrail-monitor-telemetry-e2e`): real binary + etcd + mock upstream + real `aliyun_sls` exporter against a mock SLS endpoint — a monitor-mode pii guardrail lets an email prompt reach the upstream unmasked while the exported usage event carries the `would_mask` hit, a block-action detector returns 200 while the event carries `would_block`, and the matched values never appear in the exported events.
- Touched-path regression: streaming/messages/responses/completions/passthrough guardrail specs + SLS content-capture specs green.

Fixes api7/AISIX-Cloud#562 (link added post-merge for the Development field; the issue is closed manually once the full stage-0-2 scope lands). The CP ingestion + logs filter lands as the paired AISIX-Cloud PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitor-mode guardrail telemetry across supported API surfaces, capturing would-block and would-mask observations without changing request outcomes.
  * Usage events now include guardrail monitor-hit details for better visibility into suppressed enforcement actions.

* **Bug Fixes**
  * Preserved monitor-hit reporting during streaming, ensemble, and segment-based moderation flows.
  * Ensured monitor telemetry is recorded consistently for success, blocked, and fallback response paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->