### PR TITLE
docs: clarify A2A OAuth2 auth runtime support

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1756,6 +1756,12 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/A2aAgent"
+              },
+              "example": {
+                "display_name": "invoice-processor",
+                "url": "https://agents.example.com/invoice",
+                "protocol_version": "0.3",
+                "auth_type": "none"
               }
             }
           },

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -26,7 +26,7 @@ use std::sync::OnceLock;
 
 use axum::http::header;
 use axum::response::{Html, IntoResponse, Response};
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 /// Paths + OpenAPI-specific wrapper schemas (`ModelEntry`,
 /// `ApiKeyEntry`, `ModelStatusView`, `AdminError`, etc.). Resource
@@ -4084,10 +4084,20 @@ pub(crate) fn merged_openapi() -> &'static str {
         add_variant_titles(&mut doc);
         add_missing_property_descriptions(&mut doc);
         add_schema_defaults(&mut doc);
+        add_schema_examples(&mut doc);
         wrap_ref_siblings_for_redoc(&mut doc);
 
         serde_json::to_string(&doc).expect("merged OpenAPI must serialise")
     })
+}
+
+fn add_schema_examples(doc: &mut Value) {
+    doc["components"]["schemas"]["A2aAgent"]["example"] = json!({
+        "display_name": "invoice-processor",
+        "url": "https://agents.example.com/invoice",
+        "protocol_version": "0.3",
+        "auth_type": "none"
+    });
 }
 
 /// ReDoc uses `title` for `oneOf` tab labels. Schemars does not title generated

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1790,7 +1790,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "400": {
-            "description": "Schema validation failed, the JSON body is malformed, `display_name` contains a `/` (it is the agent's URL path segment), or the credentials required by `auth_type` are missing (`secret` for `bearer`/`api_key`; `client_id`, `token_url`, and `secret` for `oauth2`)",
+            "description": "Invalid request body, `display_name` contains `/`, or the selected `auth_type` is missing required credentials.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1948,7 +1948,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "400": {
-            "description": "Schema validation failed, the JSON body is malformed, `display_name` contains a `/` (it is the agent's URL path segment), or the credentials required by `auth_type` are missing (`secret` for `bearer`/`api_key`; `client_id`, `token_url`, and `secret` for `oauth2`)",
+            "description": "Invalid request body, `display_name` contains `/`, or the selected `auth_type` is missing required credentials.",
             "content": {
               "application/json": {
                 "schema": {

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1774,6 +1774,17 @@ const OPENAPI_JSON_BASE: &str = r##"{
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/A2aAgentEntry"
+                },
+                "example": {
+                  "id": "1d95ac57-7f27-46a4-b5a3-55d3c3ad0a12",
+                  "value": {
+                    "display_name": "invoice-processor",
+                    "url": "https://agents.example.com/invoice",
+                    "protocol_version": "0.3",
+                    "auth_type": "none",
+                    "enabled": true
+                  },
+                  "revision": 1
                 }
               }
             }
@@ -3634,7 +3645,18 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "example": 1845
           }
         },
-        "description": "Stored Admin API resource entry."
+        "description": "Stored Admin API resource entry.",
+        "example": {
+          "id": "1d95ac57-7f27-46a4-b5a3-55d3c3ad0a12",
+          "value": {
+            "display_name": "invoice-processor",
+            "url": "https://agents.example.com/invoice",
+            "protocol_version": "0.3",
+            "auth_type": "none",
+            "enabled": true
+          },
+          "revision": 1
+        }
       },
       "A2aAgentEntry": {
         "type": "object",

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3645,18 +3645,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "example": 1845
           }
         },
-        "description": "Stored Admin API resource entry.",
-        "example": {
-          "id": "1d95ac57-7f27-46a4-b5a3-55d3c3ad0a12",
-          "value": {
-            "display_name": "invoice-processor",
-            "url": "https://agents.example.com/invoice",
-            "protocol_version": "0.3",
-            "auth_type": "none",
-            "enabled": true
-          },
-          "revision": 1
-        }
+        "description": "Stored Admin API resource entry."
       },
       "A2aAgentEntry": {
         "type": "object",
@@ -3681,7 +3670,18 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "example": 1845
           }
         },
-        "description": "Stored Admin API resource entry."
+        "description": "Stored Admin API resource entry.",
+        "example": {
+          "id": "1d95ac57-7f27-46a4-b5a3-55d3c3ad0a12",
+          "value": {
+            "display_name": "invoice-processor",
+            "url": "https://agents.example.com/invoice",
+            "protocol_version": "0.3",
+            "auth_type": "none",
+            "enabled": true
+          },
+          "revision": 1
+        }
       },
       "GuardrailEntry": {
         "type": "object",
@@ -4098,6 +4098,20 @@ fn add_schema_examples(doc: &mut Value) {
         "protocol_version": "0.3",
         "auth_type": "none"
     });
+    doc["components"]["schemas"]["A2aAgentEntry"]["example"] = json!({
+        "id": "1d95ac57-7f27-46a4-b5a3-55d3c3ad0a12",
+        "value": {
+            "display_name": "invoice-processor",
+            "url": "https://agents.example.com/invoice",
+            "protocol_version": "0.3",
+            "auth_type": "none",
+            "enabled": true
+        },
+        "revision": 1
+    });
+    if let Some(obj) = doc["components"]["schemas"]["McpServerEntry"].as_object_mut() {
+        obj.remove("example");
+    }
 }
 
 /// ReDoc uses `title` for `oneOf` tab labels. Schemars does not title generated

--- a/crates/aisix-core/src/models/a2a_agent.rs
+++ b/crates/aisix-core/src/models/a2a_agent.rs
@@ -129,11 +129,9 @@ pub enum A2aAuthType {
     /// API key authentication. The key is supplied in `secret` and sent as an
     /// `x-api-key: <secret>` header on every upstream request.
     ApiKey,
-    /// OAuth 2.0 client credentials grant. The gateway exchanges `client_id`,
-    /// the client secret in `secret`, and the optional `scopes` at `token_url`
-    /// for an access token, and sends it as `Authorization: Bearer
-    /// <access_token>` on every upstream request. Access tokens are cached
-    /// until shortly before their reported expiry.
+    /// OAuth 2.0 client credentials grant. Accepted on the resource for forward
+    /// compatibility, but the runtime does not yet mint tokens for upstream A2A
+    /// agents.
     #[serde(rename = "oauth2")]
     OAuth2,
 }

--- a/crates/aisix-core/src/models/a2a_agent.rs
+++ b/crates/aisix-core/src/models/a2a_agent.rs
@@ -28,15 +28,15 @@ pub struct A2aAgent {
     #[schemars(length(min = 1))]
     pub display_name: String,
 
-    /// The upstream agent's base URL, reached over HTTP with the A2A protocol
-    /// (JSON-RPC 2.0), such as `https://agents.example.com/a2a`. The agent card
-    /// is discovered relative to this URL.
+    /// The upstream agent's base URL, such as `https://agents.example.com/a2a`.
+    /// AISIX reaches this URL over HTTP with the A2A JSON-RPC 2.0 protocol and
+    /// discovers the agent card relative to it.
     #[schemars(length(min = 1))]
     pub url: String,
 
-    /// The A2A wire-format version the gateway pins for this agent. Pinned
-    /// explicitly rather than inferred from client signals, so the served agent
-    /// card and the accepted requests stay consistent.
+    /// The A2A wire-format version AISIX uses for this agent. AISIX pins the
+    /// version explicitly so the served agent card and accepted requests stay
+    /// consistent.
     #[serde(default)]
     pub protocol_version: A2aProtocolVersion,
 
@@ -46,11 +46,10 @@ pub struct A2aAgent {
     #[serde(default)]
     pub auth_type: A2aAuthType,
 
-    /// Authentication credential for the upstream agent. Its meaning follows
-    /// `auth_type`: the bearer token when `auth_type` is `bearer` (sent as
-    /// `Authorization: Bearer <secret>`), the API key when `auth_type` is
-    /// `api_key` (sent as `x-api-key: <secret>`), or the OAuth client secret
-    /// when `auth_type` is `oauth2`. Leave unset when `auth_type` is `none`.
+    /// Credential AISIX uses to authenticate to the upstream agent. For
+    /// `bearer`, AISIX sends it as `Authorization: Bearer <secret>`; for
+    /// `api_key`, AISIX sends it as `x-api-key: <secret>`; for `oauth2`, it is
+    /// the client secret. Leave unset for `none`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secret: Option<String>,
 
@@ -79,9 +78,9 @@ pub struct A2aAgent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
 
-    /// Maximum time, in milliseconds, to wait for a single upstream operation
-    /// (fetching the agent card or invoking the agent). Must be at least `1`
-    /// when set. When omitted, the gateway applies a built-in default.
+    /// Maximum time, in milliseconds, to wait for a single upstream operation,
+    /// including fetching the agent card or invoking the agent. Must be at
+    /// least `1` when set. When omitted, AISIX applies a built-in default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 1))]
     pub timeout_ms: Option<u64>,
@@ -105,11 +104,11 @@ fn default_enabled() -> bool {
     Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
 )]
 pub enum A2aProtocolVersion {
-    /// A2A 1.0 wire format (protobuf-JSON envelopes, PascalCase methods).
+    /// A2A 1.0 wire format with protobuf-JSON envelopes and PascalCase methods.
     #[default]
     #[serde(rename = "1.0")]
     V1_0,
-    /// A2A 0.3 wire format (`kind`-discriminated JSON-RPC objects).
+    /// A2A 0.3 wire format with `kind`-discriminated JSON-RPC objects.
     #[serde(rename = "0.3")]
     V0_3,
 }

--- a/crates/aisix-core/src/models/a2a_agent.rs
+++ b/crates/aisix-core/src/models/a2a_agent.rs
@@ -79,8 +79,8 @@ pub struct A2aAgent {
     pub scopes: Option<Vec<String>>,
 
     /// Maximum time, in milliseconds, to wait for a single upstream operation,
-    /// including fetching the agent card or invoking the agent. Must be at
-    /// least `1` when set. When omitted, AISIX applies a built-in default.
+    /// including fetching the agent card or invoking the agent. When omitted,
+    /// AISIX applies a built-in default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 1))]
     pub timeout_ms: Option<u64>,

--- a/crates/aisix-core/src/models/a2a_agent.rs
+++ b/crates/aisix-core/src/models/a2a_agent.rs
@@ -48,8 +48,9 @@ pub struct A2aAgent {
 
     /// Credential AISIX uses to authenticate to the upstream agent. For
     /// `bearer`, AISIX sends it as `Authorization: Bearer <secret>`; for
-    /// `api_key`, AISIX sends it as `x-api-key: <secret>`; for `oauth2`, it is
-    /// the client secret. Leave unset for `none`.
+    /// `api_key`, AISIX sends it as `x-api-key: <secret>`. For `oauth2`, it is
+    /// stored as the client secret for forward compatibility, but the runtime
+    /// does not yet mint upstream A2A access tokens. Leave unset for `none`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secret: Option<String>,
 
@@ -59,22 +60,20 @@ pub struct A2aAgent {
     // resource into a oneOf. The control plane enforces the coupling strictly
     // at write time, this gateway's own Admin API re-checks it on write, and
     // the runtime degrades gracefully when a snapshot-loaded agent is
-    // mis-configured: its credential exchange fails and the agent becomes
-    // unavailable, logged like any other upstream failure.
-    /// OAuth client identifier used for the OAuth 2.0 client credentials grant.
-    /// Required when `auth_type` is `oauth2`; ignored otherwise.
+    // misconfigured.
+    /// OAuth client identifier stored for future OAuth 2.0 client credentials
+    /// support. Required when `auth_type` is `oauth2`; ignored otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_id: Option<String>,
 
-    /// OAuth token endpoint URL where the gateway exchanges the client
-    /// credentials for an access token, such as
-    /// `https://auth.example.com/oauth/token`. Required when `auth_type` is
-    /// `oauth2`; ignored otherwise.
+    /// OAuth token endpoint URL stored for future OAuth 2.0 client credentials
+    /// support, such as `https://auth.example.com/oauth/token`. Required when
+    /// `auth_type` is `oauth2`; ignored otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_url: Option<String>,
 
-    /// OAuth scopes to request. Joined with spaces into the `scope` parameter of
-    /// the token request. Only used when `auth_type` is `oauth2`.
+    /// OAuth scopes stored for future OAuth 2.0 client credentials support.
+    /// Only used when `auth_type` is `oauth2`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
 

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -61,12 +61,6 @@
       ]
     }
   },
-  "example": {
-    "display_name": "invoice-processor",
-    "url": "https://agents.example.com/invoice",
-    "protocol_version": "0.3",
-    "auth_type": "none"
-  },
   "properties": {
     "auth_type": {
       "allOf": [

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -121,7 +121,7 @@
       ]
     },
     "timeout_ms": {
-      "description": "Maximum time, in milliseconds, to wait for a single upstream operation, including fetching the agent card or invoking the agent. Must be at least `1` when set. When omitted, AISIX applies a built-in default.",
+      "description": "Maximum time, in milliseconds, to wait for a single upstream operation, including fetching the agent card or invoking the agent. When omitted, AISIX applies a built-in default.",
       "format": "uint64",
       "minimum": 1.0,
       "type": [

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -30,7 +30,7 @@
           "type": "string"
         },
         {
-          "description": "OAuth 2.0 client credentials grant. The gateway exchanges `client_id`, the client secret in `secret`, and the optional `scopes` at `token_url` for an access token, and sends it as `Authorization: Bearer <access_token>` on every upstream request. Access tokens are cached until shortly before their reported expiry.",
+          "description": "OAuth 2.0 client credentials grant. Accepted on the resource for forward compatibility, but the runtime does not yet mint tokens for upstream A2A agents.",
           "enum": [
             "oauth2"
           ],

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -72,7 +72,7 @@
       "description": "How the gateway authenticates to the upstream agent. The credential is held by the gateway and is never forwarded from or exposed to the calling client."
     },
     "client_id": {
-      "description": "OAuth client identifier used for the OAuth 2.0 client credentials grant. Required when `auth_type` is `oauth2`; ignored otherwise.",
+      "description": "OAuth client identifier stored for future OAuth 2.0 client credentials support. Required when `auth_type` is `oauth2`; ignored otherwise.",
       "type": [
         "string",
         "null"
@@ -98,7 +98,7 @@
       "description": "The A2A wire-format version AISIX uses for this agent. AISIX pins the version explicitly so the served agent card and accepted requests stay consistent."
     },
     "scopes": {
-      "description": "OAuth scopes to request. Joined with spaces into the `scope` parameter of the token request. Only used when `auth_type` is `oauth2`.",
+      "description": "OAuth scopes stored for future OAuth 2.0 client credentials support. Only used when `auth_type` is `oauth2`.",
       "items": {
         "type": "string"
       },
@@ -108,7 +108,7 @@
       ]
     },
     "secret": {
-      "description": "Credential AISIX uses to authenticate to the upstream agent. For `bearer`, AISIX sends it as `Authorization: Bearer <secret>`; for `api_key`, AISIX sends it as `x-api-key: <secret>`; for `oauth2`, it is the client secret. Leave unset for `none`.",
+      "description": "Credential AISIX uses to authenticate to the upstream agent. For `bearer`, AISIX sends it as `Authorization: Bearer <secret>`; for `api_key`, AISIX sends it as `x-api-key: <secret>`. For `oauth2`, it is stored as the client secret for forward compatibility, but the runtime does not yet mint upstream A2A access tokens. Leave unset for `none`.",
       "type": [
         "string",
         "null"
@@ -124,7 +124,7 @@
       ]
     },
     "token_url": {
-      "description": "OAuth token endpoint URL where the gateway exchanges the client credentials for an access token, such as `https://auth.example.com/oauth/token`. Required when `auth_type` is `oauth2`; ignored otherwise.",
+      "description": "OAuth token endpoint URL stored for future OAuth 2.0 client credentials support, such as `https://auth.example.com/oauth/token`. Required when `auth_type` is `oauth2`; ignored otherwise.",
       "type": [
         "string",
         "null"

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -61,6 +61,12 @@
       ]
     }
   },
+  "example": {
+    "display_name": "invoice-processor",
+    "url": "https://agents.example.com/invoice",
+    "protocol_version": "0.3",
+    "auth_type": "none"
+  },
   "properties": {
     "auth_type": {
       "allOf": [

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -43,7 +43,7 @@
       "description": "The A2A wire-format version pinned for an upstream agent.",
       "oneOf": [
         {
-          "description": "A2A 1.0 wire format (protobuf-JSON envelopes, PascalCase methods).",
+          "description": "A2A 1.0 wire format with protobuf-JSON envelopes and PascalCase methods.",
           "enum": [
             "1.0"
           ],
@@ -51,7 +51,7 @@
           "type": "string"
         },
         {
-          "description": "A2A 0.3 wire format (`kind`-discriminated JSON-RPC objects).",
+          "description": "A2A 0.3 wire format with `kind`-discriminated JSON-RPC objects.",
           "enum": [
             "0.3"
           ],
@@ -95,7 +95,7 @@
         }
       ],
       "default": "1.0",
-      "description": "The A2A wire-format version the gateway pins for this agent. Pinned explicitly rather than inferred from client signals, so the served agent card and the accepted requests stay consistent."
+      "description": "The A2A wire-format version AISIX uses for this agent. AISIX pins the version explicitly so the served agent card and accepted requests stay consistent."
     },
     "scopes": {
       "description": "OAuth scopes to request. Joined with spaces into the `scope` parameter of the token request. Only used when `auth_type` is `oauth2`.",
@@ -108,14 +108,14 @@
       ]
     },
     "secret": {
-      "description": "Authentication credential for the upstream agent. Its meaning follows `auth_type`: the bearer token when `auth_type` is `bearer` (sent as `Authorization: Bearer <secret>`), the API key when `auth_type` is `api_key` (sent as `x-api-key: <secret>`), or the OAuth client secret when `auth_type` is `oauth2`. Leave unset when `auth_type` is `none`.",
+      "description": "Credential AISIX uses to authenticate to the upstream agent. For `bearer`, AISIX sends it as `Authorization: Bearer <secret>`; for `api_key`, AISIX sends it as `x-api-key: <secret>`; for `oauth2`, it is the client secret. Leave unset for `none`.",
       "type": [
         "string",
         "null"
       ]
     },
     "timeout_ms": {
-      "description": "Maximum time, in milliseconds, to wait for a single upstream operation (fetching the agent card or invoking the agent). Must be at least `1` when set. When omitted, the gateway applies a built-in default.",
+      "description": "Maximum time, in milliseconds, to wait for a single upstream operation, including fetching the agent card or invoking the agent. Must be at least `1` when set. When omitted, AISIX applies a built-in default.",
       "format": "uint64",
       "minimum": 1.0,
       "type": [
@@ -131,7 +131,7 @@
       ]
     },
     "url": {
-      "description": "The upstream agent's base URL, reached over HTTP with the A2A protocol (JSON-RPC 2.0), such as `https://agents.example.com/a2a`. The agent card is discovered relative to this URL.",
+      "description": "The upstream agent's base URL, such as `https://agents.example.com/a2a`. AISIX reaches this URL over HTTP with the A2A JSON-RPC 2.0 protocol and discovers the agent card relative to it.",
       "minLength": 1,
       "type": "string"
     }


### PR DESCRIPTION
## Summary

Clarifies the A2A agent `oauth2` auth type descriptions in the core model docs and generated resource schema.

## Why

The A2A agent resource accepts `auth_type: "oauth2"` for forward compatibility, but the current runtime returns `501` instead of minting upstream OAuth tokens. The previous descriptions implied token exchange and caching already worked, which could make the generated Admin API reference overstate runtime support.

## Validation

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified OAuth 2.0 authentication behavior for forward compatibility, including that upstream A2A access token minting is not yet available at runtime.
  * Updated the public A2A agent schema wording to match the revised authentication/protocol descriptions.
  * Enhanced the admin OpenAPI specification with concrete request/response examples and improved endpoint error text for invalid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->