### PR TITLE
fix(jobs): batch attribution request_id must be a UUID (telemetry flush poisoning)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5139,6 +5139,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 
 # Time / IDs
 chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "1.11", features = ["v4", "serde"] }
+uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
 hostname = "0.4"
 
 # Observability

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -39,8 +39,9 @@
 //! Management calls emit zero-token UsageEvents (parity with
 //! `/passthrough`, #699). When a **batch retrieve** first observes
 //! `status == "completed"`, the gateway downloads the output JSONL once
-//! (per-process dedup + deterministic `request_id = "batch-<id>"` so
-//! cp-api can idempotently upsert), aggregates per-line `usage`, and
+//! (per-process dedup + a deterministic UUIDv5 `request_id` derived
+//! from the batch identity — the telemetry contract requires a UUID),
+//! aggregates per-line `usage`, and
 //! emits real token counts grouped by the provider-billed model —
 //! LiteLLM's `_handle_completed_batch` equivalent
 //! (`litellm/batches/batch_utils.py`).
@@ -1453,10 +1454,27 @@ async fn forward_simple(
 
 // ─────────────────── batch completion attribution ───────────────────
 
+/// Deterministic UUIDv5 request_id for a batch attribution event.
+///
+/// The `/dp/telemetry` contract requires `request_id` to be a UUID
+/// (cp-api rejects the event otherwise — and with it the whole flush),
+/// while attribution needs a *stable* id per (batch, model-slice) so
+/// re-emission after a DP restart + re-retrieve doesn't mint a new
+/// identity. UUIDv5 over the batch identity gives both.
+fn batch_attribution_request_id(raw_batch_id: &str, idx: usize, multi: bool) -> String {
+    let name = if multi {
+        format!("aisix:batch:{raw_batch_id}:{idx}")
+    } else {
+        format!("aisix:batch:{raw_batch_id}")
+    };
+    uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, name.as_bytes()).to_string()
+}
+
 /// First-completed-observation hook: dedup via the process-local billed
 /// set, then attribute usage in a detached task. The deterministic
-/// `request_id = "batch-<raw_id>[-<n>]"` keeps repeated emission (DP
-/// restart + re-retrieve) idempotent on the cp-api side.
+/// UUIDv5 `request_id` (see [`batch_attribution_request_id`]) keeps
+/// repeated emission (DP restart + re-retrieve) stable per
+/// (batch, model-slice) on the cp-api side.
 fn maybe_attribute_batch(
     state: &ProxyState,
     auth: &AuthenticatedKey,
@@ -1615,11 +1633,7 @@ async fn attribute_batch_usage(
     let snap = state.snapshot.load();
     let multi = per_model.len() > 1;
     for (idx, (provider_model, agg)) in per_model.iter().enumerate() {
-        let request_id = if multi {
-            format!("batch-{raw_batch_id}-{idx}")
-        } else {
-            format!("batch-{raw_batch_id}")
-        };
+        let request_id = batch_attribution_request_id(raw_batch_id, idx, multi);
         let mut event = UsageEvent {
             request_id,
             occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
@@ -1742,6 +1756,19 @@ mod tests {
     }
 
     // ---- id codec ----
+
+    #[test]
+    fn batch_attribution_request_id_is_a_stable_uuid() {
+        let single = batch_attribution_request_id("batch_1", 0, false);
+        uuid::Uuid::parse_str(&single).expect("must be a UUID");
+        assert_eq!(single, batch_attribution_request_id("batch_1", 0, false));
+        // Multi-model slices and different batches get distinct ids.
+        let s0 = batch_attribution_request_id("batch_1", 0, true);
+        let s1 = batch_attribution_request_id("batch_1", 1, true);
+        assert_ne!(s0, s1);
+        assert_ne!(single, s0);
+        assert_ne!(single, batch_attribution_request_id("batch_2", 0, false));
+    }
 
     #[test]
     fn routed_id_roundtrip() {
@@ -2055,7 +2082,15 @@ mod tests {
         }
         assert_eq!(mgmt, 1);
         let agg = agg.expect("aggregated batch event must be emitted");
-        assert_eq!(agg.request_id, "batch-batch_1");
+        // The telemetry contract requires a UUID request_id (a non-UUID
+        // event 400s the whole flush on cp-api, dropping co-flushed
+        // events), and the id must stay deterministic for re-emission.
+        uuid::Uuid::parse_str(&agg.request_id)
+            .expect("batch attribution request_id must be a UUID");
+        assert_eq!(
+            agg.request_id,
+            batch_attribution_request_id("batch_1", 0, false)
+        );
         assert_eq!(agg.prompt_tokens, 17);
         assert_eq!(agg.completion_tokens, 8);
         assert_eq!(agg.cached_prompt_tokens, 2);


### PR DESCRIPTION
## Problem

Batch cost-attribution events are emitted with a deterministic `request_id = "batch-<raw_id>[-<n>]"`. The `/dp/telemetry` contract on cp-api requires `request_id` to be a **UUID** (`internal/dpmgr/api/telemetry.go`), so every flush containing a batch attribution event is rejected with 400 — and since the DP drops the whole flush on a non-2xx, the batch's token/cost never reaches the CP **and every unrelated event co-flushed in the same 5s window is silently lost with it**.

Found in the v0.3.0 release QA (fresh install, reproduced twice: the first rejection also dropped 3 co-flushed management events).

## Fix

Derive the attribution `request_id` as a **deterministic UUIDv5** over the batch identity (`aisix:batch:<raw_id>[:<idx>]`, `NAMESPACE_URL`), via a new `batch_attribution_request_id` helper. This keeps the property the old scheme was after — a stable id per (batch, model-slice) so re-emission after a DP restart + re-retrieve doesn't mint a new identity — while satisfying the UUID wire contract.

Pairs with the cp-api side hardening (skip an invalid event instead of failing the whole batch) in api7/AISIX-Cloud#<pending>; either side alone stops the data loss for this case, both together close the class.

## Tests

- `completed_batch_retrieve_attributes_usage_once` now asserts the emitted `request_id` parses as a UUID (fails on the old code) and equals the deterministic derivation.
- New `batch_attribution_request_id_is_a_stable_uuid` unit test: UUID-parseable, stable across calls, distinct per batch and per multi-model slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch usage events now include a stable, deterministic request identifier for improved tracking and reporting.
  * Multi-model batch slices now receive distinct identifiers while remaining consistent across repeated runs.

* **Bug Fixes**
  * Improved consistency in cost attribution records by replacing unstable request IDs with UUID-based values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->