### PR TITLE
docs: expose allowed_agents in API key OpenAPI schemas

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3545,7 +3545,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted or set to `null`, the key has no A2A agent access — access is granted explicitly."
+            "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted, set to `null`, or set to an empty list, the key has no A2A agent access — access is granted explicitly."
           },
           "expires_at": {
             "type": [
@@ -3916,7 +3916,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted or set to `null`, the key has no A2A agent access — access is granted explicitly.",
+            "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted, set to `null`, or set to an empty list, the key has no A2A agent access — access is granted explicitly.",
             "example": [
               "invoice-processor"
             ]
@@ -4719,8 +4719,8 @@ mod tests {
             .as_str()
             .unwrap();
         assert!(
-            request_allowed_agents.contains("omitted or set to `null`"),
-            "self-hosted API key request schema must document null agent-access behavior"
+            request_allowed_agents.contains("omitted, set to `null`, or set to an empty list"),
+            "self-hosted API key request schema must document no-access agent-list behavior"
         );
         assert!(
             request_allowed_agents.contains("grants every agent"),
@@ -4750,8 +4750,8 @@ mod tests {
             .as_str()
             .unwrap();
         assert!(
-            public_allowed_agents.contains("omitted or set to `null`"),
-            "API key response schema must document null agent-access behavior"
+            public_allowed_agents.contains("omitted, set to `null`, or set to an empty list"),
+            "API key response schema must document no-access agent-list behavior"
         );
         assert!(
             public_allowed_agents.contains("grants every agent"),

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3537,6 +3537,16 @@ const OPENAPI_JSON_BASE: &str = r##"{
             },
             "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly."
           },
+          "allowed_agents": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted or set to `null`, the key has no A2A agent access — access is granted explicitly."
+          },
           "expires_at": {
             "type": [
               "string",
@@ -3898,6 +3908,19 @@ const OPENAPI_JSON_BASE: &str = r##"{
               "github__create_issue"
             ]
           },
+          "allowed_agents": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted or set to `null`, the key has no A2A agent access — access is granted explicitly.",
+            "example": [
+              "invoice-processor"
+            ]
+          },
           "expires_at": {
             "type": [
               "string",
@@ -3947,6 +3970,10 @@ const OPENAPI_JSON_BASE: &str = r##"{
     {
       "name": "MCP Servers",
       "description": "Upstream MCP servers exposed through the gateway MCP endpoint."
+    },
+    {
+      "name": "A2A Agents",
+      "description": "Upstream A2A agents exposed through the gateway Agent Gateway endpoint."
     },
     {
       "name": "Guardrails",
@@ -4684,6 +4711,21 @@ mod tests {
             request_allowed_tools.contains("<server>__*"),
             "self-hosted API key request schema must document the per-server wildcard"
         );
+        assert!(
+            request["properties"].get("allowed_agents").is_some(),
+            "self-hosted API key requests must document A2A agent access"
+        );
+        let request_allowed_agents = request["properties"]["allowed_agents"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            request_allowed_agents.contains("omitted or set to `null`"),
+            "self-hosted API key request schema must document null agent-access behavior"
+        );
+        assert!(
+            request_allowed_agents.contains("grants every agent"),
+            "self-hosted API key request schema must document wildcard agent access"
+        );
         let public = &parsed["components"]["schemas"]["PublicApiKey"];
         assert!(
             public["properties"].get("allowed_tools").is_some(),
@@ -4699,6 +4741,21 @@ mod tests {
         assert!(
             public_allowed_tools.contains("<server>__*"),
             "API key response schema must document the per-server wildcard"
+        );
+        assert!(
+            public["properties"].get("allowed_agents").is_some(),
+            "API key responses must document A2A agent access"
+        );
+        let public_allowed_agents = public["properties"]["allowed_agents"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            public_allowed_agents.contains("omitted or set to `null`"),
+            "API key response schema must document null agent-access behavior"
+        );
+        assert!(
+            public_allowed_agents.contains("grants every agent"),
+            "API key response schema must document wildcard agent access"
         );
         assert!(request["properties"].get("team_id").is_none());
         assert!(request["properties"].get("user_id").is_none());

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -61,8 +61,8 @@ pub struct ApiKey {
     /// A2A agents this key may reach, named by their registered names. Entries
     /// are matched as single-`*` globs, mirroring `allowed_tools`: `"*"` grants
     /// every agent and an entry without a `*` matches one agent exactly. When
-    /// omitted or set to `null`, the key has no A2A agent access — access is
-    /// granted explicitly.
+    /// omitted, set to `null`, or set to an empty list, the key has no A2A
+    /// agent access — access is granted explicitly.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_agents: Option<Vec<String>>,
 

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -74,7 +74,7 @@
   },
   "properties": {
     "allowed_agents": {
-      "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs, mirroring `allowed_tools`: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted or set to `null`, the key has no A2A agent access — access is granted explicitly.",
+      "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs, mirroring `allowed_tools`: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted, set to `null`, or set to an empty list, the key has no A2A agent access — access is granted explicitly.",
       "items": {
         "type": "string"
       },


### PR DESCRIPTION
## Summary
- add allowed_agents to the API key create/update OpenAPI schema
- add allowed_agents to the public API key response schema
- register the A2A Agents tag in the generated Admin API reference
- extend the OpenAPI unit coverage for A2A agent access on caller API keys

## Validation
- cargo test -p aisix-admin openapi_uses_self_hosted_apikey_request_schema
- cargo fmt --check
- git diff --check

This supports api7/docs#1790, where the Agent Gateway guides use allowed_agents in caller API key examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for allowing A2A agents on caller API keys.
  * Key details now include an optional agent-access list with wildcard matching and clear “omitted or null means no access” behavior.
  * Added a new OpenAPI tag for A2A Agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->