### PR TITLE
feat(version): stamp the release version into the binary at build time

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -108,6 +108,19 @@ jobs:
         # metadata-action's `type=sha,format=short` puts in the tag.
         run: echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
+      # Release version stamped into the binary so the shipped image
+      # self-reports the tagged version (Server header, --version,
+      # heartbeat dp_version) with no manual Cargo.toml bump. Empty on
+      # non-tag builds → binary falls back to the crate version.
+      - name: Compute release version from tag
+        id: relver
+        run: |
+          v=""
+          case "$GITHUB_REF" in
+            refs/tags/v*) v="${GITHUB_REF_NAME#v}" ;;
+          esac
+          echo "value=$v" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         id: build
         uses: docker/build-push-action@v7
@@ -121,9 +134,24 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_SHA=${{ steps.shortsha.outputs.value }}
+            BUILD_VERSION=${{ steps.relver.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false   # keep manifest format compatible with older clients
+
+      # Fail the release if the published image does not self-report the
+      # tagged version — the guard that keeps `Server: AISIX/<ver>` /
+      # `aisix --version` / dashboard dp_version from ever regressing to
+      # a stale crate version again (QA v0.3.0 finding: 0.3.0 image
+      # reported 0.1.0).
+      - name: Verify self-reported version matches the release tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -eux
+          VER="${GITHUB_REF_NAME#v}"
+          IMG="${REGISTRY}/${IMAGE_NAME}@${{ steps.build.outputs.digest }}"
+          docker run --rm --entrypoint /usr/local/bin/aisix "$IMG" --version | tee /tmp/aisix-version
+          grep -qx "aisix ${VER}" /tmp/aisix-version
 
       # The image contract customers rely on for hostNetwork/:80
       # deployments: the default non-root user (uid 10001) must be able

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-a2a"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "async-trait",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-admin"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-etcd",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-cache"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-etcd"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "async-trait",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-gateway"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "async-trait",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-guardrails"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-mcp"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-obs"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aliyun-log-sdk-protobuf",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-provider-anthropic"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-provider-azure-openai"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-provider-bedrock"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-provider-openai"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-provider-vertex"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-proxy"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-a2a",
  "aisix-cache",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-ratelimit"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-redis",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-redis"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-core",
  "redis",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "aisix-server"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aisix-admin",
  "aisix-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.93"
 license = "Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,20 @@ RUN apt-get update \
 WORKDIR /src
 
 # Short git sha stamped into the binary (heartbeat `version` =
-# `<crate-version>+sha-<BUILD_SHA>`) so a running DP can be matched to
+# `<version>+sha-<BUILD_SHA>`) so a running DP can be matched to
 # its image tag. CI passes the same short sha that tags the image;
 # plain `docker build` (no arg) produces a binary that reports the bare
 # crate version.
 ARG BUILD_SHA=
 ENV AISIX_BUILD_SHA=$BUILD_SHA
+
+# Release version stamped into the binary. CI derives this from the
+# release tag (v0.4.0 → 0.4.0), so `aisix --version`, the `Server`
+# response header, and the heartbeat dp_version always self-report the
+# tagged version — no manual Cargo.toml bump at release time. Empty
+# (non-release / local build) falls back to the workspace crate version.
+ARG BUILD_VERSION=
+ENV AISIX_BUILD_VERSION=$BUILD_VERSION
 
 # BuildKit cache mounts carry `~/.cargo/registry` + `target/` across
 # builds, so changes to source files still reuse compiled dependencies.

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod error;
 pub mod models;
 pub mod resource;
 pub mod snapshot;
+pub mod version;
 pub mod wildcard;
 
 pub use config::{
@@ -44,3 +45,4 @@ pub use models::{
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};
+pub use version::BUILD_VERSION;

--- a/crates/aisix-core/src/version.rs
+++ b/crates/aisix-core/src/version.rs
@@ -1,0 +1,33 @@
+//! Build-time version identity.
+//!
+//! Release builds are stamped by CI: the `docker-image` workflow derives
+//! `AISIX_BUILD_VERSION` from the release tag (`v0.4.0` → `0.4.0`) and
+//! passes it as a Docker build-arg, so a released binary always
+//! self-reports the version it was tagged with — the `Server` response
+//! header, `aisix --version`, and the heartbeat `dp_version` all come
+//! from here, and no manual `Cargo.toml` bump is required at release
+//! time. Local builds (no stamp) fall back to the workspace crate
+//! version. (QA v0.3.0 finding: the 0.3.0 image self-reported 0.1.0
+//! because the crate version was the only source and was never bumped.)
+
+/// Version the binary reports about itself.
+pub const BUILD_VERSION: &str = match option_env!("AISIX_BUILD_VERSION") {
+    Some(v) => v,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
+#[cfg(test)]
+mod tests {
+    use super::BUILD_VERSION;
+
+    #[test]
+    fn build_version_is_nonempty_semverish() {
+        assert!(!BUILD_VERSION.is_empty());
+        // Both sources (stamp or crate version) must look like a
+        // dotted version, not a placeholder.
+        assert!(
+            BUILD_VERSION.chars().next().unwrap().is_ascii_digit(),
+            "BUILD_VERSION must start with a digit, got {BUILD_VERSION:?}"
+        );
+    }
+}

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -81,9 +81,13 @@ use tower_http::set_header::SetResponseHeaderLayer;
 
 /// Product token emitted in the `Server` response header. Format follows
 /// RFC 9110 §10.2.4 (`product/version`) and matches the convention used
-/// by adjacent gateways (APISIX, nginx, kong). Version is the workspace
-/// crate version, baked in at compile time.
-const SERVER_HEADER_VALUE: &str = concat!("AISIX/", env!("CARGO_PKG_VERSION"));
+/// by adjacent gateways (APISIX, nginx, kong). Version is
+/// [`aisix_core::BUILD_VERSION`]: CI-stamped from the release tag, crate
+/// version for local builds.
+static SERVER_HEADER_VALUE: std::sync::LazyLock<HeaderValue> = std::sync::LazyLock::new(|| {
+    HeaderValue::from_str(&format!("AISIX/{}", aisix_core::BUILD_VERSION))
+        .expect("build version must be a valid ASCII header value")
+});
 
 /// Build the proxy router. Mounts `/livez` plus the
 /// OpenAI-compatible proxy surface.
@@ -180,7 +184,7 @@ pub fn build_router(state: ProxyState) -> Router {
         // identity.
         .layer(SetResponseHeaderLayer::overriding(
             header::SERVER,
-            HeaderValue::from_static(SERVER_HEADER_VALUE),
+            SERVER_HEADER_VALUE.clone(),
         ))
         .with_state(state)
 }

--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -38,15 +38,16 @@ use serde::Serialize;
 use tokio::sync::watch;
 
 /// Build identity reported to cp-api (heartbeat `version` field + HTTP
-/// User-Agent). CI stamps `AISIX_BUILD_SHA` — the same short git sha
-/// that tags the container image — at compile time, so the wire carries
-/// `0.1.0+sha-103d3ec` and an operator can match a DP node directly to
-/// its `ghcr.io/...:sha-103d3ec` image. Local builds (no stamp) report
-/// the bare crate version. cp-api persists this into
+/// User-Agent). The base version is [`aisix_core::BUILD_VERSION`] —
+/// release builds are stamped from the git tag, local builds fall back
+/// to the crate version. CI additionally stamps `AISIX_BUILD_SHA` — the
+/// same short git sha that tags the container image — so the wire
+/// carries `0.4.0+sha-103d3ec` and an operator can match a DP node
+/// directly to its image. cp-api persists this into
 /// `dpmgr_nodes.dp_version`, replacing the `"pending"` placeholder it
 /// wrote at install-command time.
 pub static BUILD_VERSION: LazyLock<String> = LazyLock::new(|| {
-    format_build_version(env!("CARGO_PKG_VERSION"), option_env!("AISIX_BUILD_SHA"))
+    format_build_version(aisix_core::BUILD_VERSION, option_env!("AISIX_BUILD_SHA"))
 });
 
 fn format_build_version(pkg_version: &str, build_sha: Option<&str>) -> String {

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -42,7 +42,7 @@ use etcd_client::{Certificate, ConnectOptions, Identity, TlsOptions};
 use tokio::sync::watch;
 
 #[derive(Debug, Parser)]
-#[command(name = "aisix", version, about = "aisix AI Gateway")]
+#[command(name = "aisix", version = aisix_core::BUILD_VERSION, about = "aisix AI Gateway")]
 struct Cli {
     /// Path to the bootstrap config file (YAML / TOML / JSON).
     #[arg(short, long, env = "AISIX_CONFIG")]


### PR DESCRIPTION
## Problem

The workspace crate version (`Cargo.toml`, `0.1.0`) was the only source for the DP's self-reported version — the `Server: AISIX/<ver>` response header, `aisix --version`, and the heartbeat `dp_version` (persisted into `dpmgr_nodes.dp_version` and shown on the dashboard data-planes page). It was never bumped at release time, so the shipped **0.3.0 image self-reported `0.1.0`** (found in the v0.3.0 release QA; the image is otherwise correct — cosign confirms it was built from the v0.3.0 tag).

## Fix — build-time stamping so it can't drift again

- New `aisix_core::BUILD_VERSION`: `option_env!("AISIX_BUILD_VERSION")` with a fallback to `CARGO_PKG_VERSION`. All three self-report sites now read it (`Server` header, clap `--version`, heartbeat `BUILD_VERSION` base).
- The `docker-image` workflow derives the version from the release tag (`v0.4.0` → `0.4.0`) and passes it as the `AISIX_BUILD_VERSION` Docker build-arg. So a **released** binary always self-reports the tagged version — no manual `Cargo.toml` edit is part of the release procedure. Non-tag / local builds leave the arg empty and fall back to the crate version.
- A release-only workflow step runs the published image's `--version` against the tag and **fails the build on mismatch**, so a future release can't silently regress to a stale version again.
- Workspace `version` bumped `0.1.0` → `0.3.0` as the honest baseline for local builds.

## Behavior change

Released images now report their real version everywhere; local `cargo build` reports `0.3.0` (was `0.1.0`). The heartbeat still appends `+sha-<short>` when `AISIX_BUILD_SHA` is set. No wire/schema change. No LiteLLM equivalent (internal build identity).

## Tests

- `aisix_core::version` unit test: `BUILD_VERSION` is non-empty and version-shaped.
- Verified locally: default build → `aisix 0.3.0`; `AISIX_BUILD_VERSION=9.9.9` build → `aisix 9.9.9`. `cargo fmt`/`clippy -D warnings`/`cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)