### PR TITLE
fix(obs): emit deployment cooldown metrics on state transitions

### DIFF
--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -458,25 +458,30 @@ impl ModelRuntimeStatusTracker {
         let entered_cooldown = entry.cooldown_until.is_none_or(|u| u <= now);
         entry.cooldown_until = Some(until);
         entry.status_reason = Some(reason);
-        drop(entry);
+        // Hold the DashMap entry guard across the emit so concurrent
+        // cooldown/recovery on the same model can't publish the gauge out of
+        // order (which would leave it stale until the next transition). The
+        // emit only reads `snapshot` and writes `metrics` — it never re-locks
+        // `entries` — so holding the guard here is deadlock-free.
         if entered_cooldown {
             self.emit_deployment_state(model_id, DeploymentState::Down, true);
         }
     }
 
     pub fn mark_healthy(&self, model_id: &str) {
-        let mut recovered = false;
         if let Some(mut entry) = self.entries.get_mut(model_id) {
-            recovered =
+            let recovered =
                 entry.unhealthy || entry.cooldown_until.is_some_and(|u| u > SystemTime::now());
             entry.unhealthy = false;
             entry.cooldown_until = None;
             entry.status_reason = None;
-        }
-        // Only flip the gauge back to Healthy on an actual recovery, so
-        // already-healthy targets don't churn the metric on every success.
-        if recovered {
-            self.emit_deployment_state(model_id, DeploymentState::Healthy, false);
+            // Only flip the gauge back to Healthy on an actual recovery, so
+            // already-healthy targets don't churn the metric on every success.
+            // Emitted under the guard (see mark_cooldown) to serialize
+            // same-model transitions.
+            if recovered {
+                self.emit_deployment_state(model_id, DeploymentState::Healthy, false);
+            }
         }
     }
 

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -19,6 +19,9 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+use aisix_core::snapshot::SnapshotHandle;
+use aisix_core::AisixSnapshot;
+use aisix_obs::{DeploymentLabels, DeploymentState, Metrics};
 use axum::http::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -351,6 +354,19 @@ const LATENCY_EWMA_ALPHA: f64 = 0.3;
 #[derive(Default, Debug)]
 pub struct ModelRuntimeStatusTracker {
     entries: DashMap<String, RuntimeEntry>,
+    /// Optional metrics sink. Wired only by the production
+    /// [`crate::state::ProxyState::with_components`] bootstrap so cooldown
+    /// transitions surface on the Prometheus scrape
+    /// (`aisix_deployment_state` / `aisix_deployment_cooled_down_total`);
+    /// `None` in tests and the lightweight constructors, where the tracker
+    /// stays a pure state machine.
+    metrics: Option<Arc<Metrics>>,
+    /// Optional snapshot handle, used purely to resolve a cooled target's
+    /// id into rich deployment labels (provider / upstream_model /
+    /// provider_key_id) at emit time — a rare, O(1) `get_by_id` lookup
+    /// only on a cooldown transition. `None` falls back to model-id-only
+    /// labels.
+    snapshot: Option<SnapshotHandle<AisixSnapshot>>,
 }
 
 /// RAII guard that decrements a target's in-flight counter when dropped.
@@ -414,29 +430,99 @@ impl ModelRuntimeStatusTracker {
         Self::default()
     }
 
+    /// Production constructor: wires the metrics sink and snapshot handle
+    /// so cooldown transitions emit `aisix_deployment_state` /
+    /// `aisix_deployment_cooled_down_total`. Used by
+    /// [`crate::state::ProxyState::with_components`]; the plain [`new`]
+    /// (and `Default`) stay metrics-free for tests.
+    pub fn with_observability(
+        metrics: Arc<Metrics>,
+        snapshot: SnapshotHandle<AisixSnapshot>,
+    ) -> Self {
+        Self {
+            entries: DashMap::new(),
+            metrics: Some(metrics),
+            snapshot: Some(snapshot),
+        }
+    }
+
     pub fn mark_cooldown(&self, model_id: &str, ttl: Duration, reason: impl Into<String>) {
         let now = SystemTime::now();
         let until = now + ttl;
         let reason = reason.into();
-        self.entries
-            .entry(model_id.to_string())
-            .and_modify(|entry| {
-                entry.cooldown_until = Some(until);
-                entry.status_reason = Some(reason.clone());
-            })
-            .or_insert_with(|| RuntimeEntry {
-                cooldown_until: Some(until),
-                status_reason: Some(reason),
-                ..RuntimeEntry::default()
-            });
+        let mut entry = self.entries.entry(model_id.to_string()).or_default();
+        // A fresh cooldown = the target was not already cooling (never
+        // cooled, or a previous cooldown has since expired). Only that
+        // transition is counted, so a burst of failures re-marking an
+        // already-cooled target doesn't inflate the counter.
+        let entered_cooldown = entry.cooldown_until.is_none_or(|u| u <= now);
+        entry.cooldown_until = Some(until);
+        entry.status_reason = Some(reason);
+        drop(entry);
+        if entered_cooldown {
+            self.emit_deployment_state(model_id, DeploymentState::Down, true);
+        }
     }
 
     pub fn mark_healthy(&self, model_id: &str) {
+        let mut recovered = false;
         if let Some(mut entry) = self.entries.get_mut(model_id) {
+            recovered =
+                entry.unhealthy || entry.cooldown_until.is_some_and(|u| u > SystemTime::now());
             entry.unhealthy = false;
             entry.cooldown_until = None;
             entry.status_reason = None;
         }
+        // Only flip the gauge back to Healthy on an actual recovery, so
+        // already-healthy targets don't churn the metric on every success.
+        if recovered {
+            self.emit_deployment_state(model_id, DeploymentState::Healthy, false);
+        }
+    }
+
+    /// Emit the deployment gauge (and, on a fresh cooldown, the cooldown
+    /// counter) for `model_id`. No-op unless a metrics sink is wired.
+    /// Rich labels (provider / upstream_model / provider_key_id) are
+    /// resolved from the snapshot by id; a missing snapshot or unknown id
+    /// falls back to a model-id-only label set.
+    fn emit_deployment_state(&self, model_id: &str, state: DeploymentState, count_cooldown: bool) {
+        let Some(metrics) = self.metrics.as_ref() else {
+            return;
+        };
+        let (provider, model, upstream_model, provider_key_id) = self
+            .snapshot
+            .as_ref()
+            .and_then(|handle| {
+                let snap = handle.load();
+                let entry = snap.models.get_by_id(model_id)?;
+                let m = &entry.value;
+                Some((
+                    m.provider.clone().unwrap_or_else(|| "unknown".to_string()),
+                    m.display_name.clone(),
+                    m.upstream_model().unwrap_or("unknown").to_string(),
+                    m.provider_key_id
+                        .clone()
+                        .unwrap_or_else(|| "unknown".to_string()),
+                ))
+            })
+            .unwrap_or_else(|| {
+                (
+                    "unknown".to_string(),
+                    model_id.to_string(),
+                    "unknown".to_string(),
+                    "unknown".to_string(),
+                )
+            });
+        let labels = DeploymentLabels {
+            provider: &provider,
+            model: &model,
+            upstream_model: &upstream_model,
+            provider_key_id: &provider_key_id,
+        };
+        if count_cooldown {
+            metrics.record_deployment_cooldown(labels);
+        }
+        metrics.set_deployment_state(labels, state);
     }
 
     pub fn clear_unhealthy(&self, model_id: &str) {
@@ -713,6 +799,70 @@ mod tests {
         assert_eq!(unhealthy.last_check_status, Some(500));
         t.mark_healthy("m-1");
         assert_eq!(t.status("m-1").status, RuntimeStatus::Healthy);
+    }
+
+    #[test]
+    fn cooldown_transition_emits_deployment_metrics_once() {
+        use aisix_core::{Model, ResourceEntry};
+
+        // A snapshot with one direct model lets the tracker resolve rich
+        // labels (provider / upstream_model / provider_key_id) for the
+        // cooled target id instead of falling back to model-id-only.
+        let model: Model = serde_json::from_value(serde_json::json!({
+            "display_name": "cooldown-metrics-model",
+            "provider": "openai",
+            "model_name": "gpt-4o-mini",
+            "provider_key_id": "pk-cooldown",
+        }))
+        .unwrap();
+        let snapshot = AisixSnapshot::new();
+        snapshot
+            .models
+            .insert(ResourceEntry::new("m-cool", model, 1));
+
+        let metrics = Arc::new(Metrics::new(false));
+        let tracker = ModelRuntimeStatusTracker::with_observability(
+            metrics.clone(),
+            SnapshotHandle::new(snapshot),
+        );
+
+        // First mark = a fresh transition (counter++, gauge → Down). The
+        // second mark re-cools an already-cooled target and must NOT
+        // double-count.
+        tracker.mark_cooldown("m-cool", Duration::from_secs(30), "upstream_server_error");
+        tracker.mark_cooldown("m-cool", Duration::from_secs(30), "upstream_server_error");
+
+        let scrape = metrics.render();
+        assert!(
+            scrape.contains("aisix_deployment_cooled_down_total"),
+            "cooldown counter missing from scrape:\n{scrape}"
+        );
+        // Labels came from the snapshot, not the model-id-only fallback.
+        assert!(
+            scrape.contains("provider=\"openai\"")
+                && scrape.contains("upstream_model=\"gpt-4o-mini\"")
+                && scrape.contains("provider_key_id=\"pk-cooldown\""),
+            "expected resolved deployment labels in scrape:\n{scrape}"
+        );
+        let cooled = scrape
+            .lines()
+            .find(|l| l.starts_with("aisix_deployment_cooled_down_total{"))
+            .expect("cooldown counter line");
+        let count: f64 = cooled.rsplit(' ').next().unwrap().parse().unwrap();
+        assert_eq!(count, 1.0, "cooldown counted once per transition: {cooled}");
+
+        // Recovery flips the gauge back to Healthy(0).
+        tracker.mark_healthy("m-cool");
+        let scrape = metrics.render();
+        let state = scrape
+            .lines()
+            .find(|l| l.starts_with("aisix_deployment_state{"))
+            .expect("deployment state gauge line");
+        let value: f64 = state.rsplit(' ').next().unwrap().parse().unwrap();
+        assert_eq!(
+            value, 0.0,
+            "state gauge is Healthy(0) after recovery: {state}"
+        );
     }
 
     #[test]

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -218,6 +218,14 @@ impl ProxyState {
         cfg: &ProxyConfig,
     ) -> Self {
         let guardrail_index = LiveGuardrailIndex::new(snapshot.clone(), None);
+        // The bootstrap constructor is the one place the tracker gets a
+        // metrics sink + snapshot handle, so cooldown transitions emit
+        // `aisix_deployment_*`. Clone both before they are moved into the
+        // struct below.
+        let runtime_status = Arc::new(ModelRuntimeStatusTracker::with_observability(
+            metrics.clone(),
+            snapshot.clone(),
+        ));
         Self {
             snapshot,
             hub,
@@ -231,7 +239,7 @@ impl ProxyState {
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
             config_apply_age: None,
-            runtime_status: Arc::new(ModelRuntimeStatusTracker::new()),
+            runtime_status,
             usage_sink: UsageSink::disabled(),
             otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,

--- a/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
@@ -711,3 +711,156 @@ describe("filter contract (H3 escape hatch) — try_anyway sends to known-bad", 
     expect(downUpstream.receivedRequests.length - baseline).toBe(1);
   });
 });
+
+describe("cooldown observability — a cooldown transition emits aisix_deployment_* metrics", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  let failUpstream: OpenAiUpstream | undefined;
+  let stableUpstream: OpenAiUpstream | undefined;
+  let failModelID = "";
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // 500 is a default cooldown trigger status → the failing target
+    // cools down; the router then falls over to the stable target.
+    failUpstream = await startOpenAiUpstream({
+      status: 500,
+      errorBody: { error: { message: "boom", type: "server_error" } },
+    });
+    stableUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-metrics-stable",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "metrics stable fallback" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const failPk = await admin.createProviderKey({
+      display_name: "cd-metrics-fail-pk",
+      secret: "sk-mock",
+      api_base: `${failUpstream.baseUrl}/v1`,
+    });
+    const stablePk = await admin.createProviderKey({
+      display_name: "cd-metrics-stable-pk",
+      secret: "sk-mock",
+      api_base: `${stableUpstream.baseUrl}/v1`,
+    });
+
+    failModelID = (
+      await admin.createModel({
+        display_name: "cd-metrics-500-model",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: failPk.id,
+      })
+    ).id;
+    await admin.createModel({
+      display_name: "cd-metrics-stable-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stablePk.id,
+    });
+    await admin.createModel({
+      display_name: "cd-metrics-router",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "cd-metrics-500-model" },
+          { model: "cd-metrics-stable-model" },
+        ],
+        max_fallbacks: 1,
+      },
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["cd-metrics-router", "cd-metrics-stable-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await failUpstream?.close();
+    await stableUpstream?.close();
+  });
+
+  test("the deployment cooldown counter and state gauge appear on the scrape with the cooled target's labels", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !failUpstream || !stableUpstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "cd-metrics-stable-model",
+          messages: [{ role: "user", content: "ready-metrics-stable" }],
+        });
+        return probe.choices[0]?.message.content === "metrics stable fallback";
+      } catch {
+        return false;
+      }
+    });
+
+    // Trip the 500 target: it cools down (and the router fails over to
+    // the stable target, so the caller still gets a 200).
+    const res = await client.chat.completions.create({
+      model: "cd-metrics-router",
+      messages: [{ role: "user", content: "trip cooldown for metrics" }],
+    });
+    expect(res.choices[0]?.message.content).toBe("metrics stable fallback");
+
+    // Confirm the cooldown actually landed before scraping.
+    const statuses = await admin.listModelStatuses();
+    expect(statuses.find((r) => r.id === failModelID)?.status).toBe("cooldown");
+
+    const scrape = await fetch(`${app.metricsUrl}/metrics`);
+    expect(scrape.status).toBe(200);
+    const text = await scrape.text();
+
+    // The cooldown counter is emitted for the cooled target, labelled by
+    // its resolved deployment identity (not model-id-only "unknown").
+    const cooledLine = text
+      .split("\n")
+      .find(
+        (l) =>
+          l.startsWith("aisix_deployment_cooled_down_total{") &&
+          l.includes('model="cd-metrics-500-model"'),
+      );
+    expect(cooledLine, `cooldown counter missing:\n${text}`).toBeTruthy();
+    expect(cooledLine).toContain('provider="openai"');
+    expect(cooledLine).toContain('upstream_model="gpt-4o-mini"');
+    expect(Number(cooledLine!.trim().split(/\s+/).pop())).toBeGreaterThanOrEqual(1);
+
+    // The state gauge reflects the cooled target as out-of-rotation (Down=2).
+    const stateLine = text
+      .split("\n")
+      .find(
+        (l) =>
+          l.startsWith("aisix_deployment_state{") &&
+          l.includes('model="cd-metrics-500-model"'),
+      );
+    expect(stateLine, `deployment state gauge missing:\n${text}`).toBeTruthy();
+    expect(Number(stateLine!.trim().split(/\s+/).pop())).toBe(2);
+  });
+});


### PR DESCRIPTION
## Problem

`aisix_deployment_state` (gauge) and `aisix_deployment_cooled_down_total` (counter) are defined in `aisix-obs` but have no callers, so managed mode has **no observable surface for target cooldown** — even though the behavior works (a cooled target is skipped in routing and recovers on TTL). Surfaced by QA on 0.3.0.

## Fix

Emit both metrics from the single point every dispatch path already funnels through — `ModelRuntimeStatusTracker::mark_cooldown` / `mark_healthy` — instead of threading labels through the ~22 individual `mark_cooldown` call sites (chat/messages/responses/rerank/count_tokens/audio/passthrough).

The tracker gains an optional metrics sink + snapshot handle, wired **only** by the production `ProxyState::with_components` bootstrap (`None` in tests and the lightweight constructors, which stay pure state machines):

- **`mark_cooldown`** increments the counter and sets the gauge to `Down(2)` **only on a fresh healthy→cooldown transition** — a burst of failures re-marking an already-cooled target does not inflate the counter.
- **`mark_healthy`** sets the gauge back to `Healthy(0)` on an actual recovery (not on every success of an already-healthy target).
- Labels (`provider` / `model` / `upstream_model` / `provider_key_id`) are resolved from the snapshot by target id via O(1) `get_by_id`, only on a transition (rare). A missing/unknown id falls back to a model-id-only label set.

## Behavior change

New series appear on the Prometheus scrape in managed mode:

```
aisix_deployment_cooled_down_total{provider="openai",model="…",upstream_model="…",provider_key_id="…"}
aisix_deployment_state{…}   # 0 = healthy, 2 = cooled down (out of rotation)
```

No change to routing, cooldown decisions, or the client-visible path.

## Tests

- **Unit** (`health.rs`): asserts the counter fires exactly once per transition (not per re-mark), that labels resolve from the snapshot (not the `unknown` fallback), and that the gauge returns to `Healthy(0)` on recovery.
- **E2E** (`cooldown-contract-e2e.test.ts`): drives a real `500 → cooldown` against the shipped binary + etcd and asserts both series appear on the scrape with the cooled target's resolved labels and the gauge at `Down(2)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment health and cooldown Prometheus metrics with richer, snapshot-derived labels for clearer observability in dashboards.
  * Cooldown state now tracks and reports deployment-level metrics, not just per-target status.

* **Bug Fixes**
  * Updated cooldown and recovery transitions so metrics emit only on real state changes, reducing duplicate metric churn.
  * Label resolution now falls back safely when snapshot details aren’t available.

* **Tests**
  * Added end-to-end coverage validating cooldown metrics, label values, and correct deployment state reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->