### PR TITLE
docs(openapi): polish Admin API schema descriptions

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3391,7 +3391,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
           },
           "kind": {
             "$ref": "#/components/schemas/ModelKind",
-            "description": "Whether the row describes a direct upstream model or a routing model."
+            "description": "Whether the entry describes a direct upstream model or a routing model."
           },
           "status": {
             "$ref": "#/components/schemas/RuntimeStatus",
@@ -3535,7 +3535,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly."
+            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted, set to `null`, or set to an empty list, the key has no MCP tool access — access is granted explicitly."
           },
           "allowed_agents": {
             "type": [
@@ -3903,7 +3903,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly.",
+            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted, set to `null`, or set to an empty list, the key has no MCP tool access — access is granted explicitly.",
             "example": [
               "github__create_issue"
             ]
@@ -4704,8 +4704,8 @@ mod tests {
             .as_str()
             .unwrap();
         assert!(
-            request_allowed_tools.contains("omitted or set to `null`"),
-            "self-hosted API key request schema must document null tool-access behavior"
+            request_allowed_tools.contains("omitted, set to `null`, or set to an empty list"),
+            "self-hosted API key request schema must document no-access tool-list behavior"
         );
         assert!(
             request_allowed_tools.contains("<server>__*"),
@@ -4735,8 +4735,8 @@ mod tests {
             .as_str()
             .unwrap();
         assert!(
-            public_allowed_tools.contains("omitted or set to `null`"),
-            "API key response schema must document null tool-access behavior"
+            public_allowed_tools.contains("omitted, set to `null`, or set to an empty list"),
+            "API key response schema must document no-access tool-list behavior"
         );
         assert!(
             public_allowed_tools.contains("<server>__*"),

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -52,9 +52,9 @@ pub struct ApiKey {
     /// (the form the gateway exposes). Entries are matched as single-`*`
     /// globs, mirroring `allowed_models`: `"*"` grants every tool and
     /// `"<server>__*"` grants every tool on one server (e.g. `"github__*"`);
-    /// an entry without a `*` matches one tool exactly. When omitted or set
-    /// to `null`, the key has no MCP tool access — access is granted
-    /// explicitly.
+    /// an entry without a `*` matches one tool exactly. When omitted, set to
+    /// `null`, or set to an empty list, the key has no MCP tool access —
+    /// access is granted explicitly.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
 

--- a/crates/aisix-core/src/models/ensemble.rs
+++ b/crates/aisix-core/src/models/ensemble.rs
@@ -27,8 +27,8 @@ pub struct PanelMember {
     /// Sampling seed for this panel member.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seed: Option<u64>,
-    /// Reserved for the future voting/quorum strategy. Ignored by the v1
-    /// synthesis path.
+    /// Reserved for a future voting/quorum strategy. AISIX currently ignores
+    /// this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub weight: Option<u32>,
 }

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -333,10 +333,9 @@ fn default_aliyun_risk_level_threshold() -> String {
     "high".to_owned()
 }
 
-/// One built-in detector selection for `kind: "pii"`. The `type` names a
-/// detector compiled into the DP (`aisix-guardrails::pii::BUILTIN_DETECTORS`);
-/// `action` optionally overrides the guardrail-level `default_action` for
-/// this detector only.
+/// One built-in detector selection for `kind: "pii"`. The `type` names the
+/// detector to enable; `action` optionally overrides the guardrail-level
+/// `default_action` for this detector only.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PiiDetectorConfig {
@@ -359,8 +358,8 @@ pub struct PiiCustomPattern {
     /// telemetry counts, and block reasons. Never the matched value.
     #[schemars(length(min = 1, max = 64))]
     pub name: String,
-    /// Regular expression the DP compiles at chain build. Invalid patterns
-    /// are logged and the row is skipped (same contract as keyword rules).
+    /// Regular expression AISIX compiles when building the guardrail chain.
+    /// Invalid patterns are logged and skipped.
     #[schemars(length(min = 1))]
     pub regex: String,
     /// Per-pattern action override: `mask` or `block`. Falls back to the
@@ -381,8 +380,8 @@ pub struct PiiCustomPattern {
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PiiConfig {
-    /// Built-in detectors to enable. Unknown detector ids are rejected at
-    /// build time (row skipped + warn), so a typo can't silently disarm
+    /// Built-in detectors to enable. Unknown detector ids are rejected when
+    /// AISIX builds the guardrail chain, so a typo cannot silently disable
     /// the policy.
     #[serde(default)]
     pub detectors: Vec<PiiDetectorConfig>,
@@ -518,8 +517,8 @@ pub struct OpenaiModerationConfig {
     /// before projection. Plaintext is held in memory only and is not logged.
     #[schemars(length(min = 1))]
     pub api_key: String,
-    /// Endpoint override (an Azure OpenAI deployment or a mock). The data
-    /// plane appends `/moderations`. Defaults to `https://api.openai.com/v1`.
+    /// Endpoint override, such as an Azure OpenAI deployment. AISIX appends
+    /// `/moderations`. Defaults to `https://api.openai.com/v1`.
     #[serde(default)]
     #[schemars(length(min = 1))]
     pub endpoint: Option<String>,
@@ -530,9 +529,8 @@ pub struct OpenaiModerationConfig {
     pub model: String,
     /// Per-category score thresholds, e.g. `{"violence": 0.5}`. When set,
     /// only the listed categories are enforced and a category blocks when
-    /// its score reaches the threshold. When empty (the default), the API's
-    /// own `flagged` boolean decides — the LiteLLM `openai_moderation`
-    /// baseline behavior.
+    /// its score reaches the threshold. When empty (the default), the
+    /// provider's `flagged` decision determines whether to block.
     #[serde(default)]
     pub category_thresholds: std::collections::BTreeMap<String, f64>,
     /// HTTP call timeout in milliseconds. `fail_open` and `output_fail_open`
@@ -790,23 +788,21 @@ pub struct Guardrail {
     #[serde(flatten)]
     pub config: GuardrailKind,
 
-    // --- P0c additive fields (outer-struct level; no deny_unknown_fields) ---
-    //
-    // cp-api's marshalGuardrailKV will start emitting these once the P0c
-    // CP PR lands. Until then, old kine rows omit them and the defaults apply.
-    /// How the data plane behaves when this guardrail fires. `monitor` is stored for compatibility but not yet enforced.
+    /// How AISIX handles matching content. `block` enforces the guardrail.
+    /// `monitor` records what would have happened without blocking or
+    /// redacting the caller-visible response.
     #[serde(default = "default_enforcement_mode")]
     pub enforcement_mode: String,
 
     /// Whether guardrail evaluation errors are fatal. When `true`, a remote
-    /// guardrail that can't reach its upstream blocks the request instead of
-    /// failing open — it overrides `fail_open` on the failure path (the DP
-    /// wraps the row in a MandatoryGuardrail that turns a `Bypass` into a
-    /// `Block`). Default `false` keeps the `fail_open` behaviour.
+    /// guardrail that cannot reach its upstream blocks the request instead of
+    /// failing open, overriding `fail_open` on the failure path. The default
+    /// `false` keeps the `fail_open` behavior.
     #[serde(default)]
     pub mandatory: bool,
 
-    /// Attachment direction hint: `input`, `output`, or `both`. Stored for compatibility. Current hook selection still follows `hook_point`.
+    /// Attachment direction hint: `input`, `output`, or `both`. Guardrail
+    /// execution still follows `hook_point`.
     #[serde(default = "default_direction")]
     pub direction: String,
 
@@ -854,9 +850,9 @@ impl Resource for Guardrail {
 
 /// Which dimension of the request a guardrail attachment is scoped to.
 ///
-/// `Env` applies to every request in the environment (the pre-P0c behaviour).
-/// The narrower scopes let operators attach a guardrail to just the models,
-/// API keys, or teams that need it.
+/// `Env` applies to every request in the environment. The narrower scopes let
+/// operators attach a guardrail to only the models, API keys, or teams that
+/// need it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum GuardrailScopeType {
@@ -866,14 +862,10 @@ pub enum GuardrailScopeType {
     Team,
 }
 
-/// One attachment row — written by cp-api to `/aisix/<env>/guardrail_attachments/<uuid>`.
-///
-/// The DP loads these alongside the guardrail definitions and builds a
-/// `GuardrailIndex` that resolves the applicable chain per request via
-/// `scope_type` + `scope_id` matching.
-///
-/// `deny_unknown_fields` is intentionally NOT set: cp-api includes `env_id`
-/// in the payload (for its own idempotency checks) which the DP doesn't need.
+/// Guardrail attachment that scopes one guardrail to an environment, model,
+/// caller API key, or team. AISIX loads attachments with the guardrail
+/// definitions and uses `scope_type` plus `scope_id` to decide which
+/// guardrails apply to each request.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct GuardrailAttachment {
     /// UUID of the guardrail definition this attachment points to.
@@ -892,8 +884,7 @@ pub struct GuardrailAttachment {
     /// and duplicates are dropped.
     pub priority: i32,
 
-    /// When `false`, `GuardrailIndex::resolve` skips this attachment
-    /// entirely (same as the row not existing).
+    /// When `false`, AISIX ignores this attachment.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -359,7 +359,7 @@ pub struct PiiCustomPattern {
     #[schemars(length(min = 1, max = 64))]
     pub name: String,
     /// Regular expression AISIX compiles when building the guardrail chain.
-    /// Invalid patterns are logged and skipped.
+    /// An invalid pattern makes AISIX log and skip the guardrail.
     #[schemars(length(min = 1))]
     pub regex: String,
     /// Per-pattern action override: `mask` or `block`. Falls back to the

--- a/crates/aisix-core/src/models/semantic.rs
+++ b/crates/aisix-core/src/models/semantic.rs
@@ -63,15 +63,14 @@ pub struct SemanticRoute {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(min = 1))]
     pub description: Option<String>,
-    /// Example utterances that define this route. The DP embeds each at
-    /// apply time and caches the vector; a request is matched against
-    /// these. At least one is required (description does not participate
-    /// in matching).
+    /// Example utterances that define this route. AISIX embeds each example
+    /// when applying the configuration and caches the vector. A request is
+    /// matched against these examples. At least one example is required.
     #[schemars(length(min = 1), inner(length(min = 1)))]
     pub examples: Vec<String>,
     /// Per-route similarity threshold. A request matches this route only
     /// when its aggregated score is `>=` this value. When omitted, the
-    /// router-level [`SemanticMatch::threshold`] applies.
+    /// router-level threshold applies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 0.0, max = 1.0))]
     pub threshold: Option<f32>,
@@ -107,13 +106,10 @@ pub enum EmbeddingFailureMode {
     Fail,
 }
 
-/// What the router does when the embedding call errors or times out.
-///
-/// Wire shape mirrors the proposal: the bare string `"default"` / `"fail"`,
-/// or an object `{ "target": "<direct alias>" }` to fall back to a specific
-/// safe model. Replicates the spirit of
-/// [`WhenAllUnavailablePolicy`](super::WhenAllUnavailablePolicy) with the added
-/// explicit-target option.
+/// What the router does when the embedding call errors or times out. Use
+/// `"default"` to route to the router's default model, `"fail"` to reject the
+/// request with `503`, or `{ "target": "<direct alias>" }` to route to a
+/// specific fallback model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum OnEmbeddingFailure {

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -91,7 +91,7 @@
       "type": "array"
     },
     "allowed_tools": {
-      "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted or set to `null`, the key has no MCP tool access — access is granted explicitly.",
+      "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted, set to `null`, or set to an empty list, the key has no MCP tool access — access is granted explicitly.",
       "items": {
         "type": "string"
       },

--- a/schemas/resources/ensemble.schema.json
+++ b/schemas/resources/ensemble.schema.json
@@ -98,7 +98,7 @@
           "minimum": 0.0
         },
         "weight": {
-          "description": "Reserved for the future voting/quorum strategy. Ignored by the v1 synthesis path.",
+          "description": "Reserved for a future voting/quorum strategy. AISIX currently ignores this field.",
           "type": [
             "integer",
             "null"

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -164,7 +164,7 @@
           "type": "string"
         },
         "regex": {
-          "description": "Regular expression AISIX compiles when building the guardrail chain. Invalid patterns are logged and skipped.",
+          "description": "Regular expression AISIX compiles when building the guardrail chain. An invalid pattern makes AISIX log and skip the guardrail.",
           "minLength": 1,
           "type": "string"
         }

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -164,7 +164,7 @@
           "type": "string"
         },
         "regex": {
-          "description": "Regular expression the DP compiles at chain build. Invalid patterns are logged and the row is skipped (same contract as keyword rules).",
+          "description": "Regular expression AISIX compiles when building the guardrail chain. Invalid patterns are logged and skipped.",
           "minLength": 1,
           "type": "string"
         }
@@ -177,7 +177,7 @@
     },
     "PiiDetectorConfig": {
       "additionalProperties": false,
-      "description": "One built-in detector selection for `kind: \"pii\"`. The `type` names a detector compiled into the DP (`aisix-guardrails::pii::BUILTIN_DETECTORS`); `action` optionally overrides the guardrail-level `default_action` for this detector only.",
+      "description": "One built-in detector selection for `kind: \"pii\"`. The `type` names the detector to enable; `action` optionally overrides the guardrail-level `default_action` for this detector only.",
       "properties": {
         "action": {
           "description": "Per-detector action override: `mask` or `block`. Falls back to the guardrail's `default_action` when omitted.",
@@ -605,7 +605,7 @@
         },
         "detectors": {
           "default": [],
-          "description": "Built-in detectors to enable. Unknown detector ids are rejected at build time (row skipped + warn), so a typo can't silently disarm the policy.",
+          "description": "Built-in detectors to enable. Unknown detector ids are rejected when AISIX builds the guardrail chain, so a typo cannot silently disable the policy.",
           "items": {
             "$ref": "#/definitions/PiiDetectorConfig"
           },
@@ -706,12 +706,12 @@
             "type": "number"
           },
           "default": {},
-          "description": "Per-category score thresholds, e.g. `{\"violence\": 0.5}`. When set, only the listed categories are enforced and a category blocks when its score reaches the threshold. When empty (the default), the API's own `flagged` boolean decides — the LiteLLM `openai_moderation` baseline behavior.",
+          "description": "Per-category score thresholds, e.g. `{\"violence\": 0.5}`. When set, only the listed categories are enforced and a category blocks when its score reaches the threshold. When empty (the default), the provider's `flagged` decision determines whether to block.",
           "type": "object"
         },
         "endpoint": {
           "default": null,
-          "description": "Endpoint override (an Azure OpenAI deployment or a mock). The data plane appends `/moderations`. Defaults to `https://api.openai.com/v1`.",
+          "description": "Endpoint override, such as an Azure OpenAI deployment. AISIX appends `/moderations`. Defaults to `https://api.openai.com/v1`.",
           "minLength": 1,
           "type": "string"
         },
@@ -839,7 +839,7 @@
     },
     "direction": {
       "default": "both",
-      "description": "Attachment direction hint: `input`, `output`, or `both`. Stored for compatibility. Current hook selection still follows `hook_point`.",
+      "description": "Attachment direction hint: `input`, `output`, or `both`. Guardrail execution still follows `hook_point`.",
       "type": "string"
     },
     "enabled": {
@@ -849,7 +849,7 @@
     },
     "enforcement_mode": {
       "default": "block",
-      "description": "How the data plane behaves when this guardrail fires. `monitor` is stored for compatibility but not yet enforced.",
+      "description": "How AISIX handles matching content. `block` enforces the guardrail. `monitor` records what would have happened without blocking or redacting the caller-visible response.",
       "type": "string"
     },
     "fail_open": {
@@ -868,7 +868,7 @@
     },
     "mandatory": {
       "default": false,
-      "description": "Whether guardrail evaluation errors are fatal. When `true`, a remote guardrail that can't reach its upstream blocks the request instead of failing open — it overrides `fail_open` on the failure path (the DP wraps the row in a MandatoryGuardrail that turns a `Bypass` into a `Block`). Default `false` keeps the `fail_open` behaviour.",
+      "description": "Whether guardrail evaluation errors are fatal. When `true`, a remote guardrail that cannot reach its upstream blocks the request instead of failing open, overriding `fail_open` on the failure path. The default `false` keeps the `fail_open` behavior.",
       "type": "boolean"
     },
     "name": {

--- a/schemas/resources/guardrail_attachment.schema.json
+++ b/schemas/resources/guardrail_attachment.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "GuardrailScopeType": {
-      "description": "Which dimension of the request a guardrail attachment is scoped to.\n\n`Env` applies to every request in the environment (the pre-P0c behaviour). The narrower scopes let operators attach a guardrail to just the models, API keys, or teams that need it.",
+      "description": "Which dimension of the request a guardrail attachment is scoped to.\n\n`Env` applies to every request in the environment. The narrower scopes let operators attach a guardrail to only the models, API keys, or teams that need it.",
       "enum": [
         "env",
         "model",
@@ -12,11 +12,11 @@
       "type": "string"
     }
   },
-  "description": "One attachment row — written by cp-api to `/aisix/<env>/guardrail_attachments/<uuid>`.\n\nThe DP loads these alongside the guardrail definitions and builds a `GuardrailIndex` that resolves the applicable chain per request via `scope_type` + `scope_id` matching.\n\n`deny_unknown_fields` is intentionally NOT set: cp-api includes `env_id` in the payload (for its own idempotency checks) which the DP doesn't need.",
+  "description": "Guardrail attachment that scopes one guardrail to an environment, model, caller API key, or team. AISIX loads attachments with the guardrail definitions and uses `scope_type` plus `scope_id` to decide which guardrails apply to each request.",
   "properties": {
     "enabled": {
       "default": true,
-      "description": "When `false`, `GuardrailIndex::resolve` skips this attachment entirely (same as the row not existing).",
+      "description": "When `false`, AISIX ignores this attachment.",
       "type": "boolean"
     },
     "guardrail_id": {

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -274,7 +274,7 @@
           "type": "object"
         }
       ],
-      "description": "What the router does when the embedding call errors or times out.\n\nWire shape mirrors the proposal: the bare string `\"default\"` / `\"fail\"`, or an object `{ \"target\": \"<direct alias>\" }` to fall back to a specific safe model. Replicates the spirit of [`WhenAllUnavailablePolicy`](super::WhenAllUnavailablePolicy) with the added explicit-target option."
+      "description": "What the router does when the embedding call errors or times out. Use `\"default\"` to route to the router's default model, `\"fail\"` to reject the request with `503`, or `{ \"target\": \"<direct alias>\" }` to route to a specific fallback model."
     },
     "PanelMember": {
       "additionalProperties": false,
@@ -298,7 +298,7 @@
           "type": "number"
         },
         "weight": {
-          "description": "Reserved for the future voting/quorum strategy. Ignored by the v1 synthesis path.",
+          "description": "Reserved for a future voting/quorum strategy. AISIX currently ignores this field.",
           "format": "uint32",
           "minimum": 0.0,
           "type": "integer"
@@ -584,7 +584,7 @@
           "type": "string"
         },
         "examples": {
-          "description": "Example utterances that define this route. The DP embeds each at apply time and caches the vector; a request is matched against these. At least one is required (description does not participate in matching).",
+          "description": "Example utterances that define this route. AISIX embeds each example when applying the configuration and caches the vector. A request is matched against these examples. At least one example is required.",
           "items": {
             "minLength": 1,
             "type": "string"
@@ -603,7 +603,7 @@
           "type": "string"
         },
         "threshold": {
-          "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level [`SemanticMatch::threshold`] applies.",
+          "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level threshold applies.",
           "format": "float",
           "maximum": 1.0,
           "minimum": 0.0,

--- a/schemas/resources/semantic.schema.json
+++ b/schemas/resources/semantic.schema.json
@@ -100,7 +100,7 @@
       ]
     },
     "OnEmbeddingFailure": {
-      "description": "What the router does when the embedding call errors or times out.\n\nWire shape mirrors the proposal: the bare string `\"default\"` / `\"fail\"`, or an object `{ \"target\": \"<direct alias>\" }` to fall back to a specific safe model. Replicates the spirit of [`WhenAllUnavailablePolicy`](super::WhenAllUnavailablePolicy) with the added explicit-target option.",
+      "description": "What the router does when the embedding call errors or times out. Use `\"default\"` to route to the router's default model, `\"fail\"` to reject the request with `503`, or `{ \"target\": \"<direct alias>\" }` to route to a specific fallback model.",
       "anyOf": [
         {
           "description": "`\"default\"` or `\"fail\"`.",
@@ -179,7 +179,7 @@
           "minLength": 1
         },
         "examples": {
-          "description": "Example utterances that define this route. The DP embeds each at apply time and caches the vector; a request is matched against these. At least one is required (description does not participate in matching).",
+          "description": "Example utterances that define this route. AISIX embeds each example when applying the configuration and caches the vector. A request is matched against these examples. At least one example is required.",
           "type": "array",
           "items": {
             "type": "string",
@@ -198,7 +198,7 @@
           "minLength": 1
         },
         "threshold": {
-          "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level [`SemanticMatch::threshold`] applies.",
+          "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level threshold applies.",
           "type": [
             "number",
             "null"


### PR DESCRIPTION
## Summary
- clarify that omitted, null, or empty allowed_tools all grant no MCP tool access
- update stale guardrail enforcement_mode wording now that monitor mode records matches without blocking or redacting
- remove implementation-oriented wording from public schema descriptions for guardrails, semantic routing, ensemble weight, and model status entries
- regenerate affected resource schema files

## Validation
- cargo fmt
- cargo run -p aisix-core --bin dump-schema
- cargo run -p aisix-admin --bin dump-openapi
- cargo test -p aisix-admin openapi
- cargo test -p aisix-core --test resource_schema_characterization
- cargo test -p aisix-core --test model_schema_characterization
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API key, guardrail, semantic routing, and ensemble schema descriptions for more accurate user-facing guidance.
  * Updated wording around MCP tool access to explicitly note that omitted, `null`, or empty lists grant no tool access.
  * Refined guardrail and semantic route descriptions to better explain current behavior, defaults, and supported fallback options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->