### PR TITLE
fix(obs): derive aisix_deployment_state from the target's serving state

### DIFF
--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -238,9 +238,29 @@ struct RuntimeEntry {
     /// is released (and for the streaming path, after the handler returns).
     /// Drives the `least_busy` routing strategy.
     in_flight: Arc<AtomicUsize>,
+    /// Last value published to the `aisix_deployment_state` gauge for this
+    /// target, so [`ModelRuntimeStatusTracker::sync_deployment_state`] can
+    /// skip a write when nothing changed. `None` = never published.
+    emitted_state: Option<DeploymentState>,
 }
 
 impl RuntimeEntry {
+    /// Serving state as the router sees it: a target that is cooling down,
+    /// or that its background check has marked unhealthy, is out of
+    /// rotation ([`ModelRuntimeStatusTracker::should_skip_for_routing`]).
+    ///
+    /// The gauge is derived from this — never from "did we just observe a
+    /// transition". A cooldown lapses on its own with nothing calling back
+    /// into the tracker, so an edge-triggered gauge misses the recovery and
+    /// pins the target at Down forever.
+    fn deployment_state(&self, now: SystemTime) -> DeploymentState {
+        if self.unhealthy || self.cooldown_until.is_some_and(|until| until > now) {
+            DeploymentState::Down
+        } else {
+            DeploymentState::Healthy
+        }
+    }
+
     fn snapshot(&self, now: SystemTime, stale_after: Option<Duration>) -> RuntimeStatusSnapshot {
         let cooldown_until = self.cooldown_until.filter(|until| *until > now);
         let unhealthy = self.unhealthy && !self.is_stale(now, stale_after);
@@ -464,33 +484,63 @@ impl ModelRuntimeStatusTracker {
         // emit only reads `snapshot` and writes `metrics` — it never re-locks
         // `entries` — so holding the guard here is deadlock-free.
         if entered_cooldown {
-            self.emit_deployment_state(model_id, DeploymentState::Down, true);
+            self.record_cooldown(model_id);
         }
+        self.sync_deployment_state(model_id, &mut entry, now);
     }
 
     pub fn mark_healthy(&self, model_id: &str) {
         if let Some(mut entry) = self.entries.get_mut(model_id) {
-            let recovered =
-                entry.unhealthy || entry.cooldown_until.is_some_and(|u| u > SystemTime::now());
             entry.unhealthy = false;
             entry.cooldown_until = None;
             entry.status_reason = None;
-            // Only flip the gauge back to Healthy on an actual recovery, so
-            // already-healthy targets don't churn the metric on every success.
-            // Emitted under the guard (see mark_cooldown) to serialize
-            // same-model transitions.
-            if recovered {
-                self.emit_deployment_state(model_id, DeploymentState::Healthy, false);
-            }
+            self.sync_deployment_state(model_id, &mut entry, SystemTime::now());
         }
     }
 
-    /// Emit the deployment gauge (and, on a fresh cooldown, the cooldown
-    /// counter) for `model_id`. No-op unless a metrics sink is wired.
-    /// Rich labels (provider / upstream_model / provider_key_id) are
-    /// resolved from the snapshot by id; a missing snapshot or unknown id
-    /// falls back to a model-id-only label set.
-    fn emit_deployment_state(&self, model_id: &str, state: DeploymentState, count_cooldown: bool) {
+    /// Publish `aisix_deployment_state` for `model_id` when the entry's
+    /// serving state differs from what the gauge currently shows. Called
+    /// after every mutation of `unhealthy` / `cooldown_until` — including
+    /// the ones that merely *observe* a lapsed cooldown — so the gauge can
+    /// never disagree with [`RuntimeEntry::deployment_state`]. The dedupe
+    /// keeps already-healthy targets from writing the gauge on every
+    /// successful request.
+    ///
+    /// Emitted while the caller still holds the DashMap entry guard, so
+    /// concurrent cooldown/recovery on the same model can't publish out of
+    /// order (see `mark_cooldown`).
+    fn sync_deployment_state(&self, model_id: &str, entry: &mut RuntimeEntry, now: SystemTime) {
+        let state = entry.deployment_state(now);
+        if entry.emitted_state == Some(state) {
+            return;
+        }
+        entry.emitted_state = Some(state);
+        self.emit_deployment_state(model_id, state);
+    }
+
+    /// Bump `aisix_deployment_cooled_down_total` for `model_id`.
+    fn record_cooldown(&self, model_id: &str) {
+        self.with_deployment_labels(model_id, |metrics, labels| {
+            metrics.record_deployment_cooldown(labels);
+        });
+    }
+
+    /// Set the `aisix_deployment_state` gauge for `model_id`.
+    fn emit_deployment_state(&self, model_id: &str, state: DeploymentState) {
+        self.with_deployment_labels(model_id, |metrics, labels| {
+            metrics.set_deployment_state(labels, state);
+        });
+    }
+
+    /// Resolve `model_id`'s deployment labels and hand them to `f`. No-op
+    /// unless a metrics sink is wired. Rich labels (provider /
+    /// upstream_model / provider_key_id) come from the snapshot by id; a
+    /// missing snapshot or unknown id falls back to a model-id-only set.
+    fn with_deployment_labels(
+        &self,
+        model_id: &str,
+        f: impl FnOnce(&Metrics, DeploymentLabels<'_>),
+    ) {
         let Some(metrics) = self.metrics.as_ref() else {
             return;
         };
@@ -518,16 +568,15 @@ impl ModelRuntimeStatusTracker {
                     "unknown".to_string(),
                 )
             });
-        let labels = DeploymentLabels {
-            provider: &provider,
-            model: &model,
-            upstream_model: &upstream_model,
-            provider_key_id: &provider_key_id,
-        };
-        if count_cooldown {
-            metrics.record_deployment_cooldown(labels);
-        }
-        metrics.set_deployment_state(labels, state);
+        f(
+            metrics,
+            DeploymentLabels {
+                provider: &provider,
+                model: &model,
+                upstream_model: &upstream_model,
+                provider_key_id: &provider_key_id,
+            },
+        );
     }
 
     pub fn clear_unhealthy(&self, model_id: &str) {
@@ -536,13 +585,15 @@ impl ModelRuntimeStatusTracker {
             if entry.status_reason.as_deref() == Some("background_check_failed") {
                 entry.status_reason = None;
             }
+            self.sync_deployment_state(model_id, &mut entry, SystemTime::now());
         }
     }
 
     pub fn mark_unhealthy(&self, model_id: &str, status: Option<u16>, reason: impl Into<String>) {
         let now = SystemTime::now();
         let reason = reason.into();
-        self.entries
+        let mut entry = self
+            .entries
             .entry(model_id.to_string())
             .and_modify(|entry| {
                 entry.unhealthy = true;
@@ -557,6 +608,7 @@ impl ModelRuntimeStatusTracker {
                 status_reason: Some(reason),
                 ..RuntimeEntry::default()
             });
+        self.sync_deployment_state(model_id, &mut entry, now);
     }
 
     pub fn record_ignored_check(&self, model_id: &str, status: u16, reason: impl Into<String>) {
@@ -858,16 +910,100 @@ mod tests {
 
         // Recovery flips the gauge back to Healthy(0).
         tracker.mark_healthy("m-cool");
-        let scrape = metrics.render();
-        let state = scrape
+        assert_eq!(
+            deployment_state_gauge(&metrics),
+            Some(0.0),
+            "state gauge is Healthy(0) after recovery"
+        );
+    }
+
+    /// A cooldown that lapses on its own is the *ordinary* recovery: the
+    /// router filters cooled targets out of rotation, so nothing calls back
+    /// into the tracker while the TTL runs down, and the first success
+    /// arrives only after it has already expired. The old edge-triggered
+    /// gauge could not see a transition at that point and left the target
+    /// pinned at Down(2) forever.
+    #[test]
+    fn gauge_returns_to_healthy_after_a_cooldown_expires_naturally() {
+        let metrics = Arc::new(Metrics::new(false));
+        let tracker = ModelRuntimeStatusTracker::with_observability(
+            metrics.clone(),
+            SnapshotHandle::new(AisixSnapshot::new()),
+        );
+
+        tracker.mark_cooldown(
+            "m-expiry",
+            Duration::from_millis(5),
+            "upstream_server_error",
+        );
+        assert_eq!(deployment_state_gauge(&metrics), Some(2.0), "cooled → Down");
+
+        thread::sleep(Duration::from_millis(15));
+        assert_eq!(
+            tracker.status("m-expiry").status,
+            RuntimeStatus::Healthy,
+            "the cooldown has lapsed, so the target is back in rotation"
+        );
+
+        tracker.mark_healthy("m-expiry");
+        assert_eq!(
+            deployment_state_gauge(&metrics),
+            Some(0.0),
+            "gauge follows the target back into rotation"
+        );
+    }
+
+    /// A background check failure takes the target out of rotation exactly
+    /// like a cooldown does (`should_skip_for_routing` → Unhealthy), so the
+    /// gauge has to say Down — and come back on the next passing check.
+    #[test]
+    fn gauge_tracks_background_check_failures_and_recovery() {
+        let metrics = Arc::new(Metrics::new(false));
+        let tracker = ModelRuntimeStatusTracker::with_observability(
+            metrics.clone(),
+            SnapshotHandle::new(AisixSnapshot::new()),
+        );
+
+        tracker.mark_unhealthy("m-bg", Some(503), "background_check_failed");
+        assert_eq!(deployment_state_gauge(&metrics), Some(2.0));
+
+        tracker.clear_unhealthy("m-bg");
+        assert_eq!(deployment_state_gauge(&metrics), Some(0.0));
+    }
+
+    /// The gauge is level-triggered but not chatty: a target that is already
+    /// healthy must not re-publish on every successful request, and the
+    /// cooldown counter must not move when nothing entered cooldown.
+    #[test]
+    fn repeated_success_neither_churns_the_gauge_nor_the_cooldown_counter() {
+        let metrics = Arc::new(Metrics::new(false));
+        let tracker = ModelRuntimeStatusTracker::with_observability(
+            metrics.clone(),
+            SnapshotHandle::new(AisixSnapshot::new()),
+        );
+
+        // begin_in_flight is what creates the entry on the request path.
+        drop(tracker.begin_in_flight("m-ok"));
+        tracker.mark_healthy("m-ok");
+        tracker.mark_healthy("m-ok");
+        tracker.mark_healthy("m-ok");
+
+        assert_eq!(deployment_state_gauge(&metrics), Some(0.0));
+        assert!(
+            !metrics
+                .render()
+                .contains("aisix_deployment_cooled_down_total"),
+            "a never-cooled target must not emit the cooldown counter"
+        );
+    }
+
+    /// Value of the single `aisix_deployment_state` series in the scrape.
+    fn deployment_state_gauge(metrics: &Metrics) -> Option<f64> {
+        metrics
+            .render()
             .lines()
             .find(|l| l.starts_with("aisix_deployment_state{"))
-            .expect("deployment state gauge line");
-        let value: f64 = state.rsplit(' ').next().unwrap().parse().unwrap();
-        assert_eq!(
-            value, 0.0,
-            "state gauge is Healthy(0) after recovery: {state}"
-        );
+            .and_then(|l| l.rsplit(' ').next()?.parse().ok())
     }
 
     #[test]

--- a/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
@@ -864,3 +864,203 @@ describe("cooldown observability — a cooldown transition emits aisix_deploymen
     expect(Number(stateLine!.trim().split(/\s+/).pop())).toBe(2);
   });
 });
+
+/** Value of the `aisix_deployment_state` series carrying `model="<model>"`. */
+async function scrapeDeploymentState(
+  metricsUrl: string,
+  model: string,
+): Promise<number | undefined> {
+  const text = await (await fetch(`${metricsUrl}/metrics`)).text();
+  const line = text
+    .split("\n")
+    .find(
+      (l) =>
+        l.startsWith("aisix_deployment_state{") &&
+        l.includes(`model="${model}"`),
+    );
+  return line ? Number(line.trim().split(/\s+/).pop()) : undefined;
+}
+
+describe("cooldown observability — the state gauge follows a target back into rotation", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let etcdReachable = false;
+  let flakyUpstream: OpenAiUpstream | undefined;
+  let stableUpstream: OpenAiUpstream | undefined;
+  let flakyModelID = "";
+
+  const RECOVERED_REPLY = "recovered after cooldown";
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    // First request 500s (trips the cooldown); every later request
+    // succeeds, so the target is genuinely healthy again once the TTL
+    // lapses. `scriptedResponses` runs before the static opts.
+    flakyUpstream = await startOpenAiUpstream({
+      scriptedResponses: [
+        {
+          status: 500,
+          errorBody: { error: { message: "boom", type: "server_error" } },
+        },
+      ],
+      nonStreamBody: {
+        id: "cmpl-recovered",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: RECOVERED_REPLY },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    stableUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-recover-stable",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "recover stable fallback" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+
+    app = await spawnApp();
+    admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const flakyPk = await admin.createProviderKey({
+      display_name: "cd-recover-flaky-pk",
+      secret: "sk-mock",
+      api_base: `${flakyUpstream.baseUrl}/v1`,
+    });
+    const stablePk = await admin.createProviderKey({
+      display_name: "cd-recover-stable-pk",
+      secret: "sk-mock",
+      api_base: `${stableUpstream.baseUrl}/v1`,
+    });
+
+    flakyModelID = (
+      await admin.createModel({
+        display_name: "cd-recover-flaky-model",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: flakyPk.id,
+        // A 1s TTL keeps the test honest: it must observe the cooldown
+        // lapsing on its own, which is what the router does in production.
+        cooldown: { default_seconds: 1 },
+      })
+    ).id;
+    await admin.createModel({
+      display_name: "cd-recover-stable-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stablePk.id,
+    });
+    await admin.createModel({
+      display_name: "cd-recover-router",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "cd-recover-flaky-model" },
+          { model: "cd-recover-stable-model" },
+        ],
+        max_fallbacks: 1,
+      },
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [
+        "cd-recover-router",
+        "cd-recover-flaky-model",
+        "cd-recover-stable-model",
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await flakyUpstream?.close();
+    await stableUpstream?.close();
+  });
+
+  // The router filters cooled targets out of rotation, so nothing touches
+  // the tracker while the TTL runs down — the cooldown simply lapses. An
+  // edge-triggered gauge has no transition to observe when the next success
+  // finally arrives and pins the target at Down(2) for the rest of the
+  // process's life. The gauge must instead follow the target's actual
+  // serving state.
+  test("after the cooldown lapses on its own, the next success drives the gauge back to Healthy(0)", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !flakyUpstream || !stableUpstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "cd-recover-stable-model",
+          messages: [{ role: "user", content: "ready-recover-stable" }],
+        });
+        return probe.choices[0]?.message.content === "recover stable fallback";
+      } catch {
+        return false;
+      }
+    });
+
+    // Trip the cooldown on the flaky target (router falls over → caller 200).
+    const tripped = await client.chat.completions.create({
+      model: "cd-recover-router",
+      messages: [{ role: "user", content: "trip the cooldown" }],
+    });
+    expect(tripped.choices[0]?.message.content).toBe("recover stable fallback");
+
+    expect(
+      (await admin.listModelStatuses()).find((r) => r.id === flakyModelID)
+        ?.status,
+    ).toBe("cooldown");
+    expect(
+      await scrapeDeploymentState(app.metricsUrl, "cd-recover-flaky-model"),
+    ).toBe(2);
+
+    // Let the 1s TTL lapse. Nothing calls back into the tracker here — that
+    // is the whole point.
+    await expect
+      .poll(
+        async () =>
+          (await admin!.listModelStatuses()).find((r) => r.id === flakyModelID)
+            ?.status,
+        { timeout: 10_000, interval: 200 },
+      )
+      .toBe("healthy");
+
+    // The target is back in rotation and serving. The gauge must agree.
+    const recovered = await client.chat.completions.create({
+      model: "cd-recover-router",
+      messages: [{ role: "user", content: "after the cooldown lapsed" }],
+    });
+    expect(recovered.choices[0]?.message.content).toBe(RECOVERED_REPLY);
+
+    expect(
+      await scrapeDeploymentState(app.metricsUrl, "cd-recover-flaky-model"),
+      "the recovered target must not stay pinned at Down(2)",
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
`aisix_deployment_state` is edge-triggered today: `mark_cooldown` publishes `Down`, and `mark_healthy` publishes `Healthy` only when it can still *see* a recovery — `unhealthy` is set, or the cooldown has not expired yet.

The router filters cooled targets out of rotation, so in the ordinary case nothing calls back into the tracker while the TTL runs down; the cooldown just lapses. By the time the next success arrives both conditions read false, no `Healthy` is published, and the target stays pinned at `Down(2)` for the rest of the process's life. The in-window recovery that *does* publish `Healthy` is only reachable through a direct-alias call or `when_all_unavailable: try_anyway`.

The same class of miss covers the background health check: `mark_unhealthy` takes a target out of rotation exactly like a cooldown does (`should_skip_for_routing` → `Unhealthy`), but published nothing at all — the gauge kept reporting `Healthy` for a target the router was already skipping.

## Fix

Make the gauge level-triggered. `RuntimeEntry::deployment_state()` derives the value from the entry — cooling down **or** background-unhealthy ⇒ `Down`, otherwise `Healthy` — and every mutation of those fields ends in `sync_deployment_state()`, which publishes only when the value actually changed.

Consequences:

| path | before | after |
|---|---|---|
| cooldown lapses, next success | stays `2` | `2` → `0` |
| background check fails | stays `0` | `0` → `2` |
| background check passes again | stays `0` | `2` → `0` |
| repeated success on a healthy target | no write | no write (dedupe) |
| fresh cooldown | `cooled_down_total`++ | unchanged |

`aisix_deployment_cooled_down_total` keeps counting fresh transitions only.

This matches LiteLLM, which sets `litellm_deployment_state` to `0` on every successful request and to `2` on a cooldown event instead of gating on an observed transition.

## Behavior change

`aisix_deployment_state` now reports `2` while a target is failing its background health check. Alerts on `aisix_deployment_state > 0` will start firing for that case — which is the point: the target is out of rotation.

`PartialFailure(1)` remains unused, as before.

## Tests

- `health.rs` unit tests: natural cooldown expiry → gauge returns to `0`; background-check failure → `2`, recovery → `0`; repeated success neither churns the gauge nor the cooldown counter.
- DP e2e (`cooldown-contract-e2e.test.ts`): a 1s cooldown is tripped through a failover router, left to lapse on its own, and the next success must drive the scraped gauge back to `0`.

All four fail on the previous edge-triggered code and pass here.

Docs: the metric reference in `api7/docs` is updated in a paired PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)