### PR TITLE
docs: add CONTRIBUTING + RELEASING; draft release on tag push

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,39 @@
+name: release-draft
+
+# Create a draft GitHub Release with auto-generated notes whenever a
+# release tag (vX.Y.Z) is pushed — the skeleton a maintainer polishes into
+# curated notes before publishing (see RELEASING.md). Draft releases do
+# not notify watchers, so nothing goes out until a human publishes.
+#
+# No-op if a release for the tag already exists (e.g. created manually).
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-draft-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Create draft release with generated notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          if gh release view "$TAG" -R "$REPO" >/dev/null 2>&1; then
+            echo "release for $TAG already exists — nothing to do"
+            exit 0
+          fi
+          gh release create "$TAG" -R "$REPO" \
+            --draft \
+            --generate-notes \
+            --title "$TAG"

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -33,7 +33,9 @@ jobs:
             echo "release for $TAG already exists — nothing to do"
             exit 0
           fi
-          gh release create "$TAG" -R "$REPO" \
+          # Pre-release tags (v0.4.0-rc.1) get the prerelease flag.
+          case "$TAG" in *-*) PRE=--prerelease ;; *) PRE= ;; esac
+          gh release create "$TAG" -R "$REPO" $PRE \
             --draft \
             --generate-notes \
             --title "$TAG"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,12 @@ cargo run -p aisix-server --bin aisix -- --config config.yaml
 ```
 
 CI enforces `fmt`, `clippy -D warnings`, unit tests with a coverage gate, the
-E2E suite, and two generated-artifact checks: resource JSON schemas
-(`schemas/`) and the Admin API OpenAPI document must be regenerated when the
-resource structs change — CI fails on drift, and the failing job's log shows
-the regeneration command.
+E2E suite, and two generated-artifact checks: the resource JSON Schemas in
+`schemas/` must be regenerated (`cargo run -p aisix-core --bin dump-schema`)
+and committed when the resource structs change — CI fails on drift — and the
+Admin API OpenAPI document (generated at build time, not committed) must
+still build and pass its structural checks
+(`cargo run -p aisix-admin --bin dump-openapi`).
 
 ## Making changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to AISIX
+
+Thanks for your interest in AISIX! Contributions of every kind are welcome —
+bug reports, feature requests, docs fixes, and code.
+
+## Where to start
+
+- **Bug reports & feature requests** — open a
+  [GitHub issue](https://github.com/api7/aisix/issues). For bugs, include the
+  gateway version (`aisix --version`), your config shape (redact secrets), and
+  a minimal reproduction.
+- **Questions & ideas** — ask on
+  [Discord](https://discord.gg/dUmRZ7Rvf); rough ideas are welcome there
+  before they harden into an issue.
+- **Roadmap** — see [ROADMAP.md](ROADMAP.md) for where the project is headed.
+
+## Development setup
+
+Prerequisites: the Rust toolchain pinned in `rust-toolchain.toml` (rustup picks
+it up automatically), plus Docker (for etcd).
+
+```bash
+cargo check --workspace
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+
+# Run locally (needs a reachable etcd + a config.yaml — see the docs quickstart)
+cargo run -p aisix-server --bin aisix -- --config config.yaml
+```
+
+CI enforces `fmt`, `clippy -D warnings`, unit tests with a coverage gate, the
+E2E suite, and two generated-artifact checks: resource JSON schemas
+(`schemas/`) and the Admin API OpenAPI document must be regenerated when the
+resource structs change — CI fails on drift, and the failing job's log shows
+the regeneration command.
+
+## Making changes
+
+1. Fork and create a topic branch from `main`.
+2. Keep PRs small and focused — one logical change per PR.
+3. Add or update tests for what you change. E2E tests live in `tests/` and
+   assert observable gateway behavior (wire-level requests and responses), not
+   implementation details.
+4. Make sure the checks above pass locally before pushing.
+
+### Commit and PR style
+
+Commit subjects follow Conventional Commits, matching the existing history:
+
+```
+<type>(<scope>): <imperative summary>
+```
+
+with types like `feat`, `fix`, `docs`, `test`, `refactor`, `ci`, `chore`, and
+scopes like `routing`, `guardrails`, `mcp`, `obs`. Mark breaking changes with a
+`!` after the scope (e.g. `refactor(routing)!: ...`). PRs are squash-merged, so
+the PR title should follow the same convention — it becomes the commit subject
+on `main`.
+
+## License
+
+AISIX is licensed under [Apache 2.0](LICENSE). By contributing, you agree that
+your contributions are licensed under the same terms.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ cargo run -p aisix-server --bin aisix -- --config config.yaml
 
 - **Discord** — [discord.gg/dUmRZ7Rvf](https://discord.gg/dUmRZ7Rvf)
 - **Issues & discussions** — [github.com/api7/aisix/issues](https://github.com/api7/aisix/issues)
+- **Contributing** — [CONTRIBUTING.md](CONTRIBUTING.md)
 - **Website** — [api7.ai/ai-gateway](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme)
 
 If AISIX is useful to you, a ⭐ helps other engineers find it.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,7 +17,8 @@ Pushing the tag triggers two workflows:
   `ghcr.io/api7/aisix:X.Y.Z` (plus `:X.Y`, `:X`, `:latest`, `:sha-<short>`),
   mirrors the release tag to `docker.io/api7/aisix` for private/offline
   deployments, signs the images with cosign, and stamps the version into the
-  binary so a running gateway self-reports `X.Y.Z+sha-<short>`.
+  binary so a running gateway self-reports `X.Y.Z` (`--version`, `Server`
+  header) and `X.Y.Z+sha-<short>` in its managed-mode heartbeat.
 - **`release-draft.yml`** creates a **draft** GitHub Release for the tag with
   auto-generated notes as a starting skeleton.
 
@@ -42,7 +43,7 @@ Edit the draft before publishing. House style (see the
   docker pull ghcr.io/api7/aisix:X.Y.Z
   ```
 
-  `**Full changelog**: https://github.com/api7/aisix/compare/vX.Y.(Z-1)...vX.Y.Z`
+  `**Full changelog**: https://github.com/api7/aisix/compare/<previous release tag>...vX.Y.Z`
 
 ## 3. Publish
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,57 @@
+# Releasing
+
+How an AISIX data-plane release is cut. Order matters: downstream packaging
+(AISIX Cloud and the self-hosted bundle) pins the exact data-plane image
+version, so the data plane is always tagged and published **first**.
+
+## 1. Tag
+
+```bash
+git tag vX.Y.Z <commit>
+git push origin vX.Y.Z
+```
+
+Pushing the tag triggers two workflows:
+
+- **`docker-image.yml`** builds and publishes
+  `ghcr.io/api7/aisix:X.Y.Z` (plus `:X.Y`, `:X`, `:latest`, `:sha-<short>`),
+  mirrors the release tag to `docker.io/api7/aisix` for private/offline
+  deployments, signs the images with cosign, and stamps the version into the
+  binary so a running gateway self-reports `X.Y.Z+sha-<short>`.
+- **`release-draft.yml`** creates a **draft** GitHub Release for the tag with
+  auto-generated notes as a starting skeleton.
+
+## 2. Polish the release notes
+
+Edit the draft before publishing. House style (see the
+[published releases](https://github.com/api7/aisix/releases) for examples):
+
+- Lead with a short narrative line when the release has one (e.g. "AISIX
+  becomes a gateway for AI agents"), then 3–6 **highlights** in plain
+  language. Group the remainder under themed sections (routing, guardrails,
+  API surface, security, observability).
+- **Breaking changes get their own ⚠️ section**, with the old → new config
+  spelling and what to update.
+- Reference only public artifacts: this repo's PR numbers are fine; never
+  cite internal issue trackers.
+- Describe each feature by its own function — no comparisons against other
+  products.
+- End with the install snippet and a full-changelog compare link:
+
+  ```bash
+  docker pull ghcr.io/api7/aisix:X.Y.Z
+  ```
+
+  `**Full changelog**: https://github.com/api7/aisix/compare/vX.Y.(Z-1)...vX.Y.Z`
+
+## 3. Publish
+
+Publish the draft and mark it **Latest**. Give it a descriptive title when the
+release has a headline feature (e.g. `v0.2.0 — Semantic routing`), or just the
+version for patch releases.
+
+## 4. Downstream
+
+Only after the images are published, downstream release flows (AISIX Cloud /
+the self-hosted package) may tag the same `vX.Y.Z` — their packaging pulls
+`docker.io/api7/aisix:X.Y.Z` and fails if it does not exist yet.


### PR DESCRIPTION
## What

Two of the launch-prep items: a contributor entry point, and "tag → release notes" fixed into the release process.

- **CONTRIBUTING.md** — dev setup, the CI gates (fmt / clippy / unit + coverage / e2e / schema + OpenAPI drift), conventional-commit + squash-merge PR style, and the Apache-2.0 inbound=outbound terms. Linked from the README Community section.
- **RELEASING.md** — writes down the release order (data plane is tagged and published **first**; downstream packaging pins the exact image version) and the release-notes house style used by the existing v0.1.0–v0.3.1 releases: highlights first, breaking changes in their own section, public references only, no external-product comparisons, install snippet + compare link.
- **`.github/workflows/release-draft.yml`** — on a `vX.Y.Z` tag push, creates a **draft** GitHub Release with auto-generated notes as the skeleton a maintainer polishes before publishing. Drafts don't notify watchers; the workflow is a no-op when a release for the tag already exists.

## Test plan

- [x] `gh release view` guard verified against existing tags (v0.1.0–v0.3.1 already have releases → workflow no-ops)
- [ ] Next real release tag: confirm the draft appears with generated notes

Docs + CI-workflow only — no runtime surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated draft releases are now created from version tags, helping ensure release notes are prepared consistently.

* **Documentation**
  * Added and expanded contributor, release, and project onboarding guidance.
  * The README now links directly to the contribution guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->