### PR TITLE
feat(obs): structure-preserving truncation for captured prompt/response content

### DIFF
--- a/crates/aisix-obs/src/sink/mod.rs
+++ b/crates/aisix-obs/src/sink/mod.rs
@@ -19,6 +19,7 @@ mod object_store;
 mod pipeline;
 mod record;
 mod sls;
+mod truncate;
 
 pub use capabilities::{
     BatchUnit, ChannelKey, IdempotencyMarker, IdempotencyScheme, OrderingScope, SinkCapabilities,

--- a/crates/aisix-obs/src/sink/record.rs
+++ b/crates/aisix-obs/src/sink/record.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use serde::Serialize;
 
+use super::truncate::truncate_content;
 use crate::usage::UsageEvent;
 
 /// Current canonical event schema version, emitted on every [`SinkRecord`]
@@ -33,30 +34,19 @@ pub struct SinkContent {
 
 impl SinkContent {
     /// Build captured content, truncating `prompt` and `response` to at most
-    /// `max_bytes` each (on a UTF-8 char boundary so the result stays valid).
-    /// `truncated` is set when either field was cut.
+    /// `max_bytes` each. Oversized valid JSON is reduced structurally so it
+    /// stays valid JSON; other text is cut on a UTF-8 char boundary (see
+    /// [`super::truncate::truncate_content`]). `truncated` is set when
+    /// either field was cut.
     pub fn capture(prompt: &str, response: &str, max_bytes: usize) -> Self {
-        let (prompt, p_cut) = truncate_on_char_boundary(prompt, max_bytes);
-        let (response, r_cut) = truncate_on_char_boundary(response, max_bytes);
+        let (prompt, p_cut) = truncate_content(prompt, max_bytes);
+        let (response, r_cut) = truncate_content(response, max_bytes);
         Self {
-            prompt: prompt.to_owned(),
-            response: response.to_owned(),
+            prompt: prompt.into_owned(),
+            response: response.into_owned(),
             truncated: p_cut || r_cut,
         }
     }
-}
-
-/// Truncate `s` to at most `max_bytes`, backing up to the previous UTF-8 char
-/// boundary so the slice stays valid. Returns the slice and whether it was cut.
-fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> (&str, bool) {
-    if s.len() <= max_bytes {
-        return (s, false);
-    }
-    let mut end = max_bytes;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    (&s[..end], true)
 }
 
 /// Raw captured request/response content, handed from a request handler to the
@@ -77,16 +67,17 @@ pub struct CapturedContent {
 }
 
 impl CapturedContent {
-    /// Capture `prompt` and `response`, truncating each to `max_bytes` (on a
-    /// UTF-8 char boundary) to bound the held buffer at the largest cap any
-    /// content-capturing exporter requested. `truncated` is set if either was
-    /// cut here; a per-exporter `SinkContent` ORs in its own (smaller) cap.
+    /// Capture `prompt` and `response`, truncating each to `max_bytes`
+    /// (structure-preserving for JSON, UTF-8-boundary cut otherwise) to
+    /// bound the held buffer at the largest cap any content-capturing
+    /// exporter requested. `truncated` is set if either was cut here; a
+    /// per-exporter `SinkContent` ORs in its own (smaller) cap.
     pub fn new(prompt: &str, response: &str, max_bytes: usize) -> Self {
-        let (prompt, p_cut) = truncate_on_char_boundary(prompt, max_bytes);
-        let (response, r_cut) = truncate_on_char_boundary(response, max_bytes);
+        let (prompt, p_cut) = truncate_content(prompt, max_bytes);
+        let (response, r_cut) = truncate_content(response, max_bytes);
         Self {
-            prompt: prompt.to_owned(),
-            response: response.to_owned(),
+            prompt: prompt.into_owned(),
+            response: response.into_owned(),
             truncated: p_cut || r_cut,
         }
     }

--- a/crates/aisix-obs/src/sink/truncate.rs
+++ b/crates/aisix-obs/src/sink/truncate.rs
@@ -1,0 +1,326 @@
+//! Structure-preserving truncation for captured prompt/response content.
+//!
+//! Captured content is frequently serialized JSON (the chat prompt is the
+//! serialized request; image/embedding responses are serialized JSON too).
+//! A blunt byte cut at `content_max_bytes` breaks the JSON mid-value, so a
+//! log console can no longer render the field hierarchy of a large payload
+//! (AISIX-Cloud#1014). When oversized content parses as JSON it is instead
+//! reduced *structurally*, so the logged field stays valid JSON:
+//!
+//! - long string values keep a prefix plus an inline
+//!   `...[aisix: truncated, N bytes total]` marker inside the string;
+//! - base64 data URIs collapse to a compact placeholder;
+//! - long arrays keep head+tail samples around an
+//!   `{"_aisix_truncated": true, "omitted_items": N}` placeholder element;
+//! - objects keep every key so the shape stays navigable.
+//!
+//! Reduction walks [`LADDER`] until the serialized result fits the cap.
+//! Non-JSON content — and pathological JSON that cannot fit even at the
+//! tightest rung — falls back to the historical UTF-8-safe byte cut, so
+//! the byte cap is always honored. Re-serialization orders object keys
+//! alphabetically (serde_json map ordering); accepted for over-cap
+//! payloads in exchange for keeping the structure intact.
+
+use std::borrow::Cow;
+
+use serde_json::Value;
+
+/// Reduction rungs, tried in order: (per-string byte cap, array head keep,
+/// array tail keep). Ends tight enough that anything structurally
+/// reducible fits well below the smallest real-world cap.
+const LADDER: &[(usize, usize, usize)] = &[
+    (8192, 64, 16),
+    (2048, 24, 8),
+    (512, 10, 4),
+    (128, 5, 2),
+    (32, 2, 1),
+];
+
+/// Truncate `s` to at most `max_bytes`. Oversized valid JSON is reduced
+/// structurally (stays valid JSON); anything else falls back to a
+/// UTF-8-boundary byte cut. Returns the content and whether it was cut.
+pub(crate) fn truncate_content(s: &str, max_bytes: usize) -> (Cow<'_, str>, bool) {
+    if s.len() <= max_bytes {
+        return (Cow::Borrowed(s), false);
+    }
+    if let Ok(root) = serde_json::from_str::<Value>(s) {
+        for &(string_cap, head, tail) in LADDER {
+            let reduced = shrink(&root, string_cap, head, tail);
+            if let Ok(out) = serde_json::to_string(&reduced) {
+                if out.len() <= max_bytes {
+                    return (Cow::Owned(out), true);
+                }
+            }
+        }
+    }
+    let (cut, _) = truncate_on_char_boundary(s, max_bytes);
+    (Cow::Borrowed(cut), true)
+}
+
+/// Truncate `s` to at most `max_bytes`, backing up to the previous UTF-8 char
+/// boundary so the slice stays valid. Returns the slice and whether it was cut.
+pub(crate) fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> (&str, bool) {
+    if s.len() <= max_bytes {
+        return (s, false);
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    (&s[..end], true)
+}
+
+/// Build a reduced copy of `v`: strings capped at `string_cap` bytes,
+/// arrays sampled to `head`+`tail` items around a placeholder element,
+/// object keys and scalar values kept as-is.
+fn shrink(v: &Value, string_cap: usize, head: usize, tail: usize) -> Value {
+    match v {
+        Value::String(s) => Value::String(shrink_string(s, string_cap)),
+        Value::Array(items) => {
+            if items.len() > head + tail + 1 {
+                let mut out = Vec::with_capacity(head + tail + 1);
+                out.extend(
+                    items[..head]
+                        .iter()
+                        .map(|i| shrink(i, string_cap, head, tail)),
+                );
+                out.push(serde_json::json!({
+                    "_aisix_truncated": true,
+                    "omitted_items": items.len() - head - tail,
+                }));
+                out.extend(
+                    items[items.len() - tail..]
+                        .iter()
+                        .map(|i| shrink(i, string_cap, head, tail)),
+                );
+                Value::Array(out)
+            } else {
+                Value::Array(
+                    items
+                        .iter()
+                        .map(|i| shrink(i, string_cap, head, tail))
+                        .collect(),
+                )
+            }
+        }
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(k, val)| (k.clone(), shrink(val, string_cap, head, tail)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// Cap one string value. Base64 data URIs carry no information a log
+/// reader can use, so they collapse to a placeholder (detection is exact
+/// — bare base64 is left alone rather than guessed at); text keeps a
+/// prefix plus an inline marker naming the original size.
+fn shrink_string(s: &str, cap: usize) -> String {
+    if s.len() <= cap {
+        return s.to_owned();
+    }
+    if is_base64_data_uri(s) {
+        return format!("[aisix: base64 data uri omitted, {} bytes]", s.len());
+    }
+    let (prefix, _) = truncate_on_char_boundary(s, cap);
+    format!("{prefix}...[aisix: truncated, {} bytes total]", s.len())
+}
+
+/// True for `data:<mime>;base64,...` payloads (inline images/audio).
+fn is_base64_data_uri(s: &str) -> bool {
+    if !s.starts_with("data:") {
+        return false;
+    }
+    let (head, _) = truncate_on_char_boundary(s, 256);
+    head.contains(";base64,")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn assert_valid_json_within(out: &str, cap: usize) -> Value {
+        assert!(
+            out.len() <= cap,
+            "output must honor the byte cap: {} > {cap}",
+            out.len()
+        );
+        serde_json::from_str(out).expect("truncated JSON content must stay valid JSON")
+    }
+
+    #[test]
+    fn under_cap_content_is_untouched() {
+        let (out, cut) = truncate_content("{\"a\":1}", 128);
+        assert_eq!(out, "{\"a\":1}");
+        assert!(!cut);
+    }
+
+    #[test]
+    fn large_array_is_sampled_head_and_tail_with_placeholder() {
+        let messages: Vec<Value> = (0..200)
+            .map(|i| json!({"role": "user", "content": format!("message number {i} padded {}", "x".repeat(40))}))
+            .collect();
+        let s = serde_json::to_string(&json!({ "messages": messages })).unwrap();
+        assert!(s.len() > 4096);
+
+        let (out, cut) = truncate_content(&s, 4096);
+        assert!(cut);
+        let v = assert_valid_json_within(&out, 4096);
+
+        let arr = v["messages"].as_array().unwrap();
+        // Head kept, tail kept, one placeholder in between.
+        assert!(arr.first().unwrap()["content"]
+            .as_str()
+            .unwrap()
+            .contains("message number 0"));
+        assert!(arr.last().unwrap()["content"]
+            .as_str()
+            .unwrap()
+            .contains("message number 199"));
+        let placeholder = arr
+            .iter()
+            .find(|e| e["_aisix_truncated"] == json!(true))
+            .expect("array sampling must leave an explicit placeholder");
+        let omitted = placeholder["omitted_items"].as_u64().unwrap();
+        assert!(omitted > 0);
+        // kept + omitted accounts for every original element.
+        assert_eq!(arr.len() as u64 - 1 + omitted, 200);
+    }
+
+    #[test]
+    fn long_string_field_keeps_prefix_and_names_original_size() {
+        let s = serde_json::to_string(
+            &json!({ "content": format!("The quick brown fox. {}", "words and more words ".repeat(600)) }),
+        )
+        .unwrap();
+        let orig_content_len = s.len();
+        let (out, cut) = truncate_content(&s, 2048);
+        assert!(cut);
+        let v = assert_valid_json_within(&out, 2048);
+        let content = v["content"].as_str().unwrap();
+        assert!(
+            content.starts_with("The quick brown fox."),
+            "prefix must survive"
+        );
+        assert!(
+            content.contains("[aisix: truncated,"),
+            "inline marker must say the field was cut: {content}"
+        );
+        assert!(content.contains("bytes total]"));
+        assert!(orig_content_len > 2048);
+    }
+
+    #[test]
+    fn nested_object_keeps_keys_and_hierarchy() {
+        let s = serde_json::to_string(&json!({
+            "model": "m1",
+            "options": {
+                "system": "s".repeat(3000),
+                "temperature": 0.5,
+                "nested": { "deep": { "text": "t".repeat(3000), "keep": 42 } }
+            }
+        }))
+        .unwrap();
+        let (out, cut) = truncate_content(&s, 1024);
+        assert!(cut);
+        let v = assert_valid_json_within(&out, 1024);
+        // Every level of the hierarchy is still addressable.
+        assert_eq!(v["model"], "m1");
+        assert_eq!(v["options"]["temperature"], 0.5);
+        assert_eq!(v["options"]["nested"]["deep"]["keep"], 42);
+        assert!(v["options"]["nested"]["deep"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("[aisix: truncated,"));
+    }
+
+    #[test]
+    fn data_uri_collapses_to_placeholder() {
+        let blob = format!("data:image/png;base64,{}", "AAAA".repeat(2000));
+        let s = serde_json::to_string(&json!({ "image_url": { "url": blob } })).unwrap();
+        let (out, cut) = truncate_content(&s, 1024);
+        assert!(cut);
+        let v = assert_valid_json_within(&out, 1024);
+        let url = v["image_url"]["url"].as_str().unwrap();
+        assert!(url.starts_with("[aisix: base64 data uri omitted,"), "{url}");
+    }
+
+    #[test]
+    fn bare_base64_gets_prefix_marker_not_placeholder() {
+        // Bare base64 (no data-URI wrapper) is indistinguishable from a
+        // long opaque token, so it takes the generic prefix+marker path —
+        // detection stays exact rather than heuristic.
+        let blob = "QUJDREVGR0g=".repeat(500);
+        let s = serde_json::to_string(&json!({ "audio": blob })).unwrap();
+        let (out, _) = truncate_content(&s, 1024);
+        let v = assert_valid_json_within(&out, 1024);
+        assert!(v["audio"].as_str().unwrap().contains("[aisix: truncated,"));
+    }
+
+    #[test]
+    fn multibyte_utf8_stays_valid_through_string_truncation() {
+        let s =
+            serde_json::to_string(&json!({ "content": "非常长的中文内容".repeat(800) })).unwrap();
+        let (out, cut) = truncate_content(&s, 2048);
+        assert!(cut);
+        let v = assert_valid_json_within(&out, 2048);
+        // Parsing back proves both valid JSON and valid UTF-8 inside the value.
+        assert!(v["content"]
+            .as_str()
+            .unwrap()
+            .contains("[aisix: truncated,"));
+    }
+
+    #[test]
+    fn non_json_text_keeps_the_byte_cut_behavior() {
+        let text = "plain log line ".repeat(200);
+        let (out, cut) = truncate_content(&text, 100);
+        assert!(cut);
+        assert_eq!(out.len(), 100);
+        assert!(text.starts_with(&*out));
+    }
+
+    #[test]
+    fn barely_over_cap_json_still_comes_back_valid() {
+        // A payload a few bytes over the cap must not come back as broken
+        // JSON — the old behavior would slice mid-token.
+        let s = serde_json::to_string(&json!({
+            "messages": [{ "role": "user", "content": "c".repeat(600) }]
+        }))
+        .unwrap();
+        let cap = s.len() - 3;
+        let (out, cut) = truncate_content(&s, cap);
+        assert!(cut);
+        assert_valid_json_within(&out, cap);
+    }
+
+    #[test]
+    fn impossible_cap_falls_back_to_byte_cut() {
+        // Even the tightest rung can't fit a JSON document into 8 bytes;
+        // the byte cap still wins via the fallback cut.
+        let s = serde_json::to_string(&json!({ "a": "b".repeat(100) })).unwrap();
+        let (out, cut) = truncate_content(&s, 8);
+        assert!(cut);
+        assert_eq!(out.len(), 8);
+    }
+
+    #[test]
+    fn structured_truncation_composes_across_two_caps() {
+        // Handler-side capture runs at the largest exporter cap; each
+        // exporter then re-truncates to its own smaller cap. The second
+        // pass sees the first pass's (valid JSON) output and must keep it
+        // valid JSON.
+        let messages: Vec<Value> = (0..300)
+            .map(|i| json!({"role": "user", "content": format!("msg {i} {}", "y".repeat(100))}))
+            .collect();
+        let s = serde_json::to_string(&json!({ "messages": messages })).unwrap();
+        let (first, _) = truncate_content(&s, 8192);
+        assert_valid_json_within(&first, 8192);
+        let (second, cut) = truncate_content(&first, 2048);
+        assert!(cut);
+        let v = assert_valid_json_within(&second, 2048);
+        assert!(v["messages"].as_array().unwrap().len() >= 3);
+    }
+}

--- a/crates/aisix-obs/src/sink/truncate.rs
+++ b/crates/aisix-obs/src/sink/truncate.rs
@@ -39,12 +39,34 @@ const LADDER: &[(usize, usize, usize)] = &[
 /// Truncate `s` to at most `max_bytes`. Oversized valid JSON is reduced
 /// structurally (stays valid JSON); anything else falls back to a
 /// UTF-8-boundary byte cut. Returns the content and whether it was cut.
+///
+/// Worst-case cost (only when the content exceeds the cap AND a
+/// full-content exporter is enabled): one parse, one stats pass, and up
+/// to |LADDER| build+serialize rounds over the tree. Structurally
+/// irreducible payloads (no long strings, no long arrays) skip every
+/// rung and pay parse + one compact serialize before the byte-cut
+/// fallback.
 pub(crate) fn truncate_content(s: &str, max_bytes: usize) -> (Cow<'_, str>, bool) {
     if s.len() <= max_bytes {
         return (Cow::Borrowed(s), false);
     }
     if let Ok(root) = serde_json::from_str::<Value>(s) {
+        // Whitespace-heavy (pretty-printed) input may already fit once
+        // compacted, with nothing dropped; this is also the baseline the
+        // rung skip below compares against.
+        if let Ok(compact) = serde_json::to_string(&root) {
+            if compact.len() <= max_bytes {
+                return (Cow::Owned(compact), true);
+            }
+        }
+        let (mut max_str, mut max_arr) = (0usize, 0usize);
+        measure(&root, &mut max_str, &mut max_arr);
         for &(string_cap, head, tail) in LADDER {
+            // A rung that caps no string and samples no array reproduces
+            // the compact serialization — already known not to fit.
+            if string_cap >= max_str && head + tail + 1 >= max_arr {
+                continue;
+            }
             let reduced = shrink(&root, string_cap, head, tail);
             if let Ok(out) = serde_json::to_string(&reduced) {
                 if out.len() <= max_bytes {
@@ -55,6 +77,27 @@ pub(crate) fn truncate_content(s: &str, max_bytes: usize) -> (Cow<'_, str>, bool
     }
     let (cut, _) = truncate_on_char_boundary(s, max_bytes);
     (Cow::Borrowed(cut), true)
+}
+
+/// One pass over the tree: the largest string (bytes) and largest array
+/// (element count) anywhere — used to skip ladder rungs that cannot
+/// change anything.
+fn measure(v: &Value, max_str: &mut usize, max_arr: &mut usize) {
+    match v {
+        Value::String(s) => *max_str = (*max_str).max(s.len()),
+        Value::Array(items) => {
+            *max_arr = (*max_arr).max(items.len());
+            for i in items {
+                measure(i, max_str, max_arr);
+            }
+        }
+        Value::Object(map) => {
+            for val in map.values() {
+                measure(val, max_str, max_arr);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Truncate `s` to at most `max_bytes`, backing up to the previous UTF-8 char
@@ -84,9 +127,18 @@ fn shrink(v: &Value, string_cap: usize, head: usize, tail: usize) -> Value {
                         .iter()
                         .map(|i| shrink(i, string_cap, head, tail)),
                 );
+                // A dropped element that is itself a placeholder from an
+                // earlier (larger-cap) truncation pass stands for
+                // `omitted_items` originals, not 1 — fold its count in so
+                // the accounting survives two-stage capture→exporter
+                // truncation.
+                let omitted: u64 = items[head..items.len() - tail]
+                    .iter()
+                    .map(|i| placeholder_omitted(i).unwrap_or(1))
+                    .sum();
                 out.push(serde_json::json!({
                     "_aisix_truncated": true,
-                    "omitted_items": items.len() - head - tail,
+                    "omitted_items": omitted,
                 }));
                 out.extend(
                     items[items.len() - tail..]
@@ -112,6 +164,13 @@ fn shrink(v: &Value, string_cap: usize, head: usize, tail: usize) -> Value {
     }
 }
 
+/// `Some(count)` when `v` is an array-sampling placeholder produced by
+/// [`shrink`]; the count it stands for (1 if the field is malformed).
+fn placeholder_omitted(v: &Value) -> Option<u64> {
+    (v.get("_aisix_truncated") == Some(&Value::Bool(true)))
+        .then(|| v.get("omitted_items").and_then(|n| n.as_u64()).unwrap_or(1))
+}
+
 /// Cap one string value. Base64 data URIs carry no information a log
 /// reader can use, so they collapse to a placeholder (detection is exact
 /// — bare base64 is left alone rather than guessed at); text keeps a
@@ -124,7 +183,13 @@ fn shrink_string(s: &str, cap: usize) -> String {
         return format!("[aisix: base64 data uri omitted, {} bytes]", s.len());
     }
     let (prefix, _) = truncate_on_char_boundary(s, cap);
-    format!("{prefix}...[aisix: truncated, {} bytes total]", s.len())
+    let marked = format!("{prefix}...[aisix: truncated, {} bytes total]", s.len());
+    // A string barely over the cap can come out LONGER with the marker
+    // appended; keeping the original is then strictly better.
+    if marked.len() >= s.len() {
+        return s.to_owned();
+    }
+    marked
 }
 
 /// True for `data:<mime>;base64,...` payloads (inline images/audio).
@@ -311,7 +376,9 @@ mod tests {
         // Handler-side capture runs at the largest exporter cap; each
         // exporter then re-truncates to its own smaller cap. The second
         // pass sees the first pass's (valid JSON) output and must keep it
-        // valid JSON.
+        // valid JSON — AND keep the omitted-items accounting true to the
+        // ORIGINAL element count (a dropped stage-1 placeholder folds its
+        // count into the stage-2 placeholder instead of counting as 1).
         let messages: Vec<Value> = (0..300)
             .map(|i| json!({"role": "user", "content": format!("msg {i} {}", "y".repeat(100))}))
             .collect();
@@ -321,6 +388,21 @@ mod tests {
         let (second, cut) = truncate_content(&first, 2048);
         assert!(cut);
         let v = assert_valid_json_within(&second, 2048);
-        assert!(v["messages"].as_array().unwrap().len() >= 3);
+
+        let arr = v["messages"].as_array().unwrap();
+        assert!(arr.len() >= 3);
+        let (mut kept, mut omitted) = (0u64, 0u64);
+        for item in arr {
+            match placeholder_omitted(item) {
+                Some(n) => omitted += n,
+                None => kept += 1,
+            }
+        }
+        assert_eq!(
+            kept + omitted,
+            300,
+            "kept + omitted must account for every original element \
+             across both truncation stages (got kept={kept}, omitted={omitted})",
+        );
     }
 }

--- a/tests/e2e/src/cases/sls-structured-truncation-e2e.test.ts
+++ b/tests/e2e/src/cases/sls-structured-truncation-e2e.test.ts
@@ -1,0 +1,278 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  lz4DecompressBlock,
+  spawnApp,
+  startMockSls,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  waitForLogstore,
+  type MockSls,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// AISIX-Cloud#1014: when a captured prompt/response exceeds the exporter's
+// `content_max_bytes`, the logged field must stay VALID JSON — structure
+// preserved, long arrays sampled head+tail around an explicit
+// `{"_aisix_truncated": true, "omitted_items": N}` placeholder — instead of
+// the old blunt byte cut that left half an object behind. This drives a
+// real `aisix` binary + etcd + mock upstream, captures through a real
+// `aliyun_sls` exporter (content_mode=full, tiny cap) into a mock SLS
+// endpoint, decodes the delivered protobuf, and JSON-parses the `prompt`
+// field back.
+
+const CALLER_PLAINTEXT = "sk-sls-trunc-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const CREDENTIAL_REF = "mock";
+const MOCK_AK_ID = "LTAI_mock_ak";
+const MOCK_AK_SECRET = "mock_ak_secret";
+const SLS_PROJECT = "aisix-e2e-obs";
+const LOGSTORE = "structured-trunc-events";
+
+const CONTENT_MAX_BYTES = 2048;
+const HEAD_SENTINEL = "head-sentinel-1a2b3c";
+const TAIL_SENTINEL = "tail-sentinel-9x8y7z";
+const MIDDLE_SENTINEL = "middle-sentinel-5f6e7d";
+
+// --- Minimal SLS LogGroup protobuf reader -------------------------------
+// LogGroup { Logs = 1 (message) { Time = 1 (varint), Contents = 2 (message)
+// { Key = 1 (string), Value = 2 (string) } } }; unknown fields skipped.
+
+function readVarint(buf: Buffer, pos: number): [number, number] {
+  let result = 0;
+  let shift = 0;
+  for (;;) {
+    const b = buf[pos]!;
+    pos += 1;
+    result += (b & 0x7f) * 2 ** shift;
+    if ((b & 0x80) === 0) return [result, pos];
+    shift += 7;
+  }
+}
+
+function skipField(buf: Buffer, pos: number, wireType: number): number {
+  if (wireType === 0) return readVarint(buf, pos)[1];
+  if (wireType === 2) {
+    const [len, p] = readVarint(buf, pos);
+    return p + len;
+  }
+  if (wireType === 5) return pos + 4;
+  if (wireType === 1) return pos + 8;
+  throw new Error(`unsupported wire type ${wireType}`);
+}
+
+function parseContentPair(buf: Buffer): [string, string] {
+  let pos = 0;
+  let key = "";
+  let value = "";
+  while (pos < buf.length) {
+    const [tag, p] = readVarint(buf, pos);
+    pos = p;
+    const field = tag >>> 3;
+    const wireType = tag & 7;
+    if (wireType === 2) {
+      const [len, q] = readVarint(buf, pos);
+      const bytes = buf.subarray(q, q + len);
+      pos = q + len;
+      if (field === 1) key = bytes.toString("utf8");
+      else if (field === 2) value = bytes.toString("utf8");
+    } else {
+      pos = skipField(buf, pos, wireType);
+    }
+  }
+  return [key, value];
+}
+
+function parseLog(buf: Buffer): Map<string, string> {
+  const out = new Map<string, string>();
+  let pos = 0;
+  while (pos < buf.length) {
+    const [tag, p] = readVarint(buf, pos);
+    pos = p;
+    const field = tag >>> 3;
+    const wireType = tag & 7;
+    if (field === 2 && wireType === 2) {
+      const [len, q] = readVarint(buf, pos);
+      const [k, v] = parseContentPair(buf.subarray(q, q + len));
+      out.set(k, v);
+      pos = q + len;
+    } else {
+      pos = skipField(buf, pos, wireType);
+    }
+  }
+  return out;
+}
+
+/** Decode every log delivered to `logstore` into flat key→value maps. */
+function logsFor(sls: MockSls, logstore: string): Map<string, string>[] {
+  const logs: Map<string, string>[] = [];
+  for (const r of sls.requests) {
+    if (r.logstore !== logstore || r.rawSize === 0 || r.body.length === 0) continue;
+    const group = lz4DecompressBlock(r.body, r.rawSize);
+    let pos = 0;
+    while (pos < group.length) {
+      const [tag, p] = readVarint(group, pos);
+      pos = p;
+      const field = tag >>> 3;
+      const wireType = tag & 7;
+      if (field === 1 && wireType === 2) {
+        const [len, q] = readVarint(group, pos);
+        logs.push(parseLog(group.subarray(q, q + len)));
+        pos = q + len;
+      } else {
+        pos = skipField(group, pos, wireType);
+      }
+    }
+  }
+  return logs;
+}
+
+// -------------------------------------------------------------------------
+
+describe("sls e2e: oversized captured content is truncated structurally (#1014)", () => {
+  let upstream: OpenAiUpstream | undefined;
+  let sls: MockSls | undefined;
+  let app: SpawnedApp | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    sls = await startMockSls();
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-trunc",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "short reply" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 500, completion_tokens: 3, total_tokens: 503 },
+      },
+    });
+
+    app = await spawnApp({
+      extraEnv: {
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: MOCK_AK_ID,
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: MOCK_AK_SECRET,
+      },
+    });
+    const admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    await admin.createObservabilityExporter({
+      name: "sls-structured-trunc",
+      enabled: true,
+      kind: "aliyun_sls",
+      endpoint: sls.url,
+      project: SLS_PROJECT,
+      logstore: LOGSTORE,
+      credential_ref: CREDENTIAL_REF,
+      content_mode: "full",
+      content_max_bytes: CONTENT_MAX_BYTES,
+    });
+
+    const pk = await admin.createProviderKey({
+      display_name: "sls-trunc-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "sls-trunc-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["sls-trunc-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await sls?.close();
+  });
+
+  test("oversized JSON prompt lands in SLS as valid JSON with array sampling markers", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+
+    // ~40 messages x ~130 bytes ≈ 5 KiB serialized — well over the 2 KiB cap.
+    const filler = "conversational filler text to inflate the message body ";
+    const messages = [
+      { role: "user" as const, content: `${HEAD_SENTINEL} ${filler}` },
+      ...Array.from({ length: 38 }, (_, i) => ({
+        role: "user" as const,
+        content: `${MIDDLE_SENTINEL} number ${i} ${filler}`,
+      })),
+      { role: "user" as const, content: `${TAIL_SENTINEL} ${filler}` },
+    ];
+
+    const send = async () =>
+      fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "sls-trunc-model", messages }),
+      });
+
+    await waitConfigPropagation(async () => {
+      const r = await send();
+      await r.text();
+      return r.status === 200;
+    });
+
+    const res = await send();
+    expect(res.status).toBe(200);
+    await res.text();
+
+    await waitForLogstore(sls, LOGSTORE);
+    // Poll until a content-bearing log (with a prompt) arrives.
+    const deadline = Date.now() + 10_000;
+    let captured: Map<string, string> | undefined;
+    while (Date.now() < deadline && !captured) {
+      captured = logsFor(sls, LOGSTORE).find((l) => l.has("prompt"));
+      if (!captured) await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(captured, "a full-content log with a prompt field").toBeDefined();
+
+    const prompt = captured!.get("prompt")!;
+    expect(Buffer.byteLength(prompt, "utf8")).toBeLessThanOrEqual(CONTENT_MAX_BYTES);
+    expect(captured!.get("content_truncated")).toBe("true");
+
+    // The core #1014 contract: the truncated prompt is still valid JSON.
+    const parsed = JSON.parse(prompt) as {
+      messages: Array<Record<string, unknown>>;
+    };
+    expect(Array.isArray(parsed.messages)).toBe(true);
+
+    // Head and tail survive; the middle is sampled out through an explicit
+    // placeholder that accounts for every omitted element.
+    expect(JSON.stringify(parsed.messages[0])).toContain(HEAD_SENTINEL);
+    expect(
+      JSON.stringify(parsed.messages[parsed.messages.length - 1]),
+    ).toContain(TAIL_SENTINEL);
+    const placeholder = parsed.messages.find(
+      (m) => m._aisix_truncated === true,
+    );
+    expect(placeholder, "array sampling placeholder").toBeDefined();
+    const omitted = placeholder!.omitted_items as number;
+    expect(omitted).toBeGreaterThan(0);
+    expect(parsed.messages.length - 1 + omitted).toBe(messages.length);
+  });
+});


### PR DESCRIPTION
## Problem

When a captured prompt/response exceeds an exporter's `content_max_bytes`, the cut was a plain UTF-8-boundary byte slice. The chat prompt is the *serialized request JSON*, so an over-cap payload landed in SLS as broken JSON — half an object, a dangling string escape — and the console can no longer show field hierarchy, array contents, or where the problem sits.

## Change

Oversized content that parses as JSON is now reduced **structurally**, so the logged field stays valid JSON:

- long string values keep a prefix plus an inline `...[aisix: truncated, N bytes total]` marker inside the value;
- `data:<mime>;base64,` payloads collapse to `[aisix: base64 data uri omitted, N bytes]` (detection is exact; bare base64 is indistinguishable from long opaque tokens and keeps the generic prefix+marker);
- long arrays keep head+tail samples around an explicit `{"_aisix_truncated": true, "omitted_items": N}` placeholder element;
- objects keep every key, so the shape stays navigable.

Reduction walks a fixed cap ladder (per-string cap × array head/tail keeps) until the serialized result fits `content_max_bytes`. **Non-JSON text keeps the existing UTF-8-safe byte cut**, and JSON that cannot fit even at the tightest rung falls back to it too — the byte cap is always honored. The record-level `content_truncated` flag is unchanged.

Only the `prompt`/`response` content fields are affected; metadata fields are untouched. The logic lives in the shared capture layer (`SinkContent::capture` / `CapturedContent::new`), so the same guarantee holds at both capture stages (handler-side largest cap → per-exporter re-truncate; the composition is covered by a test) and for the OTLP/Datadog `gen_ai.*` content attributes, not just SLS.

## Notes

- Runs only when content actually exceeds the cap — the hot path for normal requests is unchanged.
- Re-serialization orders object keys alphabetically (serde_json map ordering); accepted for over-cap payloads in exchange for intact structure.
- Baseline: mainstream gateways/proxies truncate logged payloads with blunt prefix cuts plus a marker (some add head+tail sampling for DB rows); none preserve JSON validity. We go further because our captured field is serialized JSON rendered in a log console — validity is what makes it readable there.

## Tests

- 11 unit tests covering the acceptance scenarios from the issue: large nested object, large array (placeholder accounts for every omitted element), oversized string field, multibyte UTF-8, non-JSON text, barely-over-cap boundary, impossible-cap fallback, data-URI placeholder, two-stage cap composition.
- New e2e `sls-structured-truncation-e2e.test.ts`: real `aisix` + etcd + `aliyun_sls` exporter (`content_mode=full`, 2 KiB cap) against a mock SLS endpoint; decodes the delivered protobuf and `JSON.parse`s the `prompt` field back, asserting head/tail sentinels survive, the placeholder accounts for all omitted messages, and the cap is honored.
- Neighboring content-capture e2es (aliyun-sls-content-capture, otlp-knobs, masked, nontext) pass unchanged.

Fixes api7/AISIX-Cloud#1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)