### PR TITLE
feat(obs): record the request body on failed chat/messages/responses requests

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -200,6 +200,9 @@ pub async fn chat_completions(
                 &client,
                 &applied_guardrails,
                 &success.routing,
+                // The winner's success event carries the content.
+                /* content_for_last */
+                None,
             );
             // The streaming path wires the WINNER's telemetry into the SSE
             // stream's on_complete callback (it has to wait for the
@@ -418,6 +421,36 @@ pub async fn chat_completions(
             // (guardrail) sets `guardrail_blocked` for the Blocked tab.
             let guardrail_blocked = matches!(err, ProxyError::ContentFiltered(_));
             let model_id_str = resolved_model_id.as_deref().unwrap_or("");
+            // AISIX-Cloud#1013: failed requests carry the (post-mask)
+            // request body so a 4xx/5xx can be triaged from the log alone.
+            // Same opt-in gate and cap as the success path; 401/403 stay
+            // body-less — the body adds nothing to an authorization
+            // failure and callers probing keys shouldn't get their
+            // payloads archived.
+            let mut failure_content = if status == 401 || status == 403 {
+                None
+            } else {
+                content_capture_cap(
+                    snap.observability_exporters
+                        .entries()
+                        .iter()
+                        .map(|e| &e.value),
+                )
+                .map(|cap| {
+                    CapturedContent::new(
+                        &serde_json::to_string(&req).unwrap_or_default(),
+                        "",
+                        cap as usize,
+                    )
+                })
+            };
+            // When every target failed there is no terminal event below —
+            // the content rides the last failed attempt instead.
+            let content_for_last = if charge.is_none() && !routing.attempts.is_empty() {
+                failure_content.take()
+            } else {
+                None
+            };
             // Per #655: emit one zero-token event for each FAILED attempt.
             // `applied_guardrails` (resolved by `dispatch`) is recorded on
             // every attempt so an input-blocked / failed request still
@@ -430,6 +463,7 @@ pub async fn chat_completions(
                 &client,
                 &applied_guardrails,
                 &routing,
+                content_for_last,
             );
             // Terminal event:
             //  - output-blocked (charge present): the WINNING attempt was
@@ -489,7 +523,7 @@ pub async fn chat_completions(
                         /* cost_usd */ 0.0,
                         guardrail_blocked,
                         &client,
-                        /* content */ None,
+                        failure_content.take(),
                     );
                 }
                 None if routing.attempts.is_empty() => {
@@ -520,11 +554,12 @@ pub async fn chat_completions(
                         /* cost_usd */ 0.0,
                         guardrail_blocked,
                         &client,
-                        /* content */ None,
+                        failure_content.take(),
                     );
                 }
                 None => {
-                    // All attempts failed; each was emitted above.
+                    // All attempts failed; each was emitted above (the last
+                    // one carrying the captured request body).
                 }
             }
             err.into_response()
@@ -3229,6 +3264,7 @@ struct UsageExtras {
 /// (direct-model success / pre-dispatch error). Each event shares the
 /// request's `request_id` (the trace key) and carries this attempt's
 /// status / error / latency.
+#[allow(clippy::too_many_arguments)]
 fn emit_failed_attempts(
     state: &ProxyState,
     request_id: &str,
@@ -3237,8 +3273,25 @@ fn emit_failed_attempts(
     client: &ClientContext,
     applied_guardrails: &[AppliedGuardrail],
     routing: &RoutingTelemetry,
+    // AISIX-Cloud#1013: when every target failed there is no terminal
+    // event, so the captured request body rides the LAST failed attempt —
+    // the one whose status the caller saw. Other attempts (and the
+    // success-path caller) stay content-less to avoid duplicating a large
+    // prompt across N events.
+    mut content_for_last: Option<CapturedContent>,
 ) {
-    for rec in routing.attempts.iter().filter(|a| !a.success) {
+    let last_failed = routing.attempts.iter().rposition(|a| !a.success);
+    for (i, rec) in routing
+        .attempts
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| !a.success)
+    {
+        let content = if Some(i) == last_failed {
+            content_for_last.take()
+        } else {
+            None
+        };
         emit_usage_event(
             state,
             request_id,
@@ -3264,7 +3317,7 @@ fn emit_failed_attempts(
             /* cost_usd */ 0.0,
             /* guardrail_blocked */ false,
             client,
-            /* content */ None,
+            content,
         );
     }
 }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -424,7 +424,9 @@ pub async fn chat_completions(
             // AISIX-Cloud#1013: failed requests carry the (post-mask)
             // request body so a 4xx/5xx can be triaged from the log alone.
             // Same opt-in gate and cap as the success path; 401/403 stay
-            // body-less — the body adds nothing to an authorization
+            // body-less (a 401 here is upstream-auth passthrough — caller
+            // 401s are rejected by the auth extractor before any event
+            // exists) — the body adds nothing to an authorization
             // failure and callers probing keys shouldn't get their
             // payloads archived.
             let mut failure_content = if status == 401 || status == 403 {
@@ -934,6 +936,17 @@ async fn dispatch(
             // carries only the firing guardrail's name (#519 B.4b) so
             // callers can't enumerate the blocklist by inspecting
             // error responses.
+            // AISIX-Cloud#1013: the blocked request's body is captured
+            // into full-content exporters, so run the mask-action rewrite
+            // BEFORE returning — otherwise the capture would export the
+            // pre-mask text the success path would have masked. (Remote
+            // segment masks — moderate_body's Bedrock pass — are still
+            // skipped: the request is dead, don't burn a provider call;
+            // those entities were never locally detected.)
+            crate::redact::merge_counts(
+                redactions_out,
+                crate::redact::redact_chat_format(resolved_chain.as_ref(), req),
+            );
             tracing::warn!(
                 guardrail_hook = "input",
                 model = %req.model,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -307,7 +307,9 @@ pub async fn messages(
             // AISIX-Cloud#1013: failed requests carry the (post-mask)
             // request body so a 4xx/5xx can be triaged from the log alone.
             // Same opt-in gate and cap as the success path; 401/403 stay
-            // body-less (the body adds nothing to an authorization failure).
+            // body-less (a 401 here is upstream-auth passthrough — caller
+            // 401s are rejected by the auth extractor before any event
+            // exists) (the body adds nothing to an authorization failure).
             let mut failure_content = if status == 401 || status == 403 {
                 None
             } else {
@@ -544,6 +546,12 @@ async fn dispatch(
                 guardrail_name,
             } = verdict
             {
+                // AISIX-Cloud#1013: mask before returning so the failure
+                // content capture exports post-mask text (see chat.rs).
+                crate::redact::merge_counts(
+                    redactions_out,
+                    crate::redact::redact_anthropic_request(resolved_chain.as_ref(), body),
+                );
                 tracing::warn!(
                     guardrail_hook = "input",
                     model = %model_name,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -220,6 +220,9 @@ pub async fn messages(
                 &client,
                 &applied_guardrails,
                 &routing,
+                // The winner's success event carries the content.
+                /* content_for_last */
+                None,
             );
             if !usage_handled_by_stream {
                 // Winning-attempt classification (#655). Direct models have
@@ -301,6 +304,34 @@ pub async fn messages(
             };
             state.metrics.record_proxy_request(fail_labels, elapsed);
             state.metrics.record_llm_request(fail_labels, elapsed);
+            // AISIX-Cloud#1013: failed requests carry the (post-mask)
+            // request body so a 4xx/5xx can be triaged from the log alone.
+            // Same opt-in gate and cap as the success path; 401/403 stay
+            // body-less (the body adds nothing to an authorization failure).
+            let mut failure_content = if status == 401 || status == 403 {
+                None
+            } else {
+                content_capture_cap(
+                    snap.observability_exporters
+                        .entries()
+                        .iter()
+                        .map(|e| &e.value),
+                )
+                .map(|cap| {
+                    CapturedContent::new(
+                        &serde_json::to_string(&body).unwrap_or_default(),
+                        "",
+                        cap as usize,
+                    )
+                })
+            };
+            // When every target failed there is no terminal event below —
+            // the content rides the last failed attempt instead.
+            let content_for_last = if !routing.attempts.is_empty() {
+                failure_content.take()
+            } else {
+                None
+            };
             // Per #655: emit one zero-token UsageEvent per FAILED attempt so
             // the dashboard's Logs tab surfaces each failed upstream try.
             emit_failed_attempts_anthropic(
@@ -316,6 +347,7 @@ pub async fn messages(
                 &client,
                 &applied_guardrails,
                 &routing,
+                content_for_last,
             );
             // Pre-dispatch failure (model-not-found, auth, budget, guardrail
             // block before any upstream attempt) records no attempts — emit a
@@ -347,7 +379,7 @@ pub async fn messages(
                     // Input masking may have fired before the failure.
                     redaction_counts.clone(),
                     monitor_hits.clone(),
-                    /* content */ None,
+                    failure_content.take(),
                 );
             }
             // /v1/messages must return Anthropic-shape error envelope
@@ -377,8 +409,24 @@ fn emit_failed_attempts_anthropic(
     client: &ClientContext,
     applied_guardrails: &[AppliedGuardrail],
     routing: &RoutingTelemetry,
+    // AISIX-Cloud#1013: when every target failed there is no terminal
+    // event, so the captured request body rides the LAST failed attempt —
+    // the one whose status the caller saw. Other attempts (and the
+    // success-path caller) stay content-less.
+    mut content_for_last: Option<CapturedContent>,
 ) {
-    for rec in routing.attempts.iter().filter(|a| !a.success) {
+    let last_failed = routing.attempts.iter().rposition(|a| !a.success);
+    for (i, rec) in routing
+        .attempts
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| !a.success)
+    {
+        let content = if Some(i) == last_failed {
+            content_for_last.take()
+        } else {
+            None
+        };
         emit_anthropic_usage_event(
             state,
             request_id,
@@ -403,7 +451,7 @@ fn emit_failed_attempts_anthropic(
             // terminal (winner / pre-dispatch) event does.
             crate::redact::RedactionCounts::new(),
             Vec::new(),
-            /* content */ None,
+            content,
         );
     }
 }

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -270,7 +270,9 @@ pub async fn responses(
             // AISIX-Cloud#1013: failed requests carry the (post-mask)
             // request body so a 4xx/5xx can be triaged from the log alone.
             // Same opt-in gate and cap as the success path; 401/403 stay
-            // body-less (the body adds nothing to an authorization failure).
+            // body-less (a 401 here is upstream-auth passthrough — caller
+            // 401s are rejected by the auth extractor before any event
+            // exists) (the body adds nothing to an authorization failure).
             let mut failure_content = if status == 401 || status == 403 {
                 None
             } else {
@@ -428,6 +430,12 @@ async fn dispatch(
             // wire envelope names only the guardrail that fired (#519 B.4b)
             // so callers can't enumerate the blocklist by probing error
             // responses.
+            // AISIX-Cloud#1013: mask before returning so the failure
+            // content capture exports post-mask text (see chat.rs).
+            crate::redact::merge_counts(
+                redactions_out,
+                crate::redact::redact_responses_request(resolved_chain.as_ref(), body),
+            );
             tracing::warn!(
                 guardrail_hook = "input",
                 model = %model_name,
@@ -1319,9 +1327,14 @@ async fn responses_to_target(
                     output_redactions: crate::redact::RedactionCounts::new(),
                     // Hits observed by the blocking check still count.
                     output_monitor_hits,
-                    // Blocked responses never reached the client — no content
-                    // capture, matching the chat surface.
-                    captured_content: None,
+                    // AISIX-Cloud#1013: the billed-then-blocked event carries
+                    // the (post-mask) prompt; the blocked output itself stays
+                    // out of the log — blocking it and then archiving it would
+                    // defeat the block.
+                    captured_content: match (&captured_prompt, content_cap) {
+                        (Some(p), Some(cap)) => Some(CapturedContent::new(p, "", cap as usize)),
+                        _ => None,
+                    },
                 });
             }
         }
@@ -1707,9 +1720,14 @@ async fn responses_cross_provider_to_target(
                 output_redactions: crate::redact::RedactionCounts::new(),
                 // Hits observed by the blocking check still count.
                 output_monitor_hits,
-                // Blocked responses never reached the client — no content
-                // capture, matching the chat surface.
-                captured_content: None,
+                // AISIX-Cloud#1013: the billed-then-blocked event carries
+                // the (post-mask) prompt; the blocked output itself stays
+                // out of the log — blocking it and then archiving it would
+                // defeat the block.
+                captured_content: match (&captured_prompt, content_cap) {
+                    (Some(p), Some(cap)) => Some(CapturedContent::new(p, "", cap as usize)),
+                    _ => None,
+                },
             });
         }
     }

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -199,6 +199,9 @@ pub async fn responses(
                 &api_key_id,
                 &client,
                 &success.routing,
+                // The winner's success event carries the content.
+                /* content_for_last */
+                None,
             );
             // Issue #404: emit UsageEvent so cp-api's budget ledger
             // and customer-facing /logs analytics see /v1/responses
@@ -264,6 +267,34 @@ pub async fn responses(
                 RequestOutcome::from_status(status),
                 elapsed,
             );
+            // AISIX-Cloud#1013: failed requests carry the (post-mask)
+            // request body so a 4xx/5xx can be triaged from the log alone.
+            // Same opt-in gate and cap as the success path; 401/403 stay
+            // body-less (the body adds nothing to an authorization failure).
+            let mut failure_content = if status == 401 || status == 403 {
+                None
+            } else {
+                content_capture_cap(
+                    snap.observability_exporters
+                        .entries()
+                        .iter()
+                        .map(|e| &e.value),
+                )
+                .map(|cap| {
+                    CapturedContent::new(
+                        &serde_json::to_string(&body).unwrap_or_default(),
+                        "",
+                        cap as usize,
+                    )
+                })
+            };
+            // When every target failed there is no terminal event below —
+            // the content rides the last failed attempt instead.
+            let content_for_last = if !routing.attempts.is_empty() {
+                failure_content.take()
+            } else {
+                None
+            };
             // Per #655: emit one zero-token UsageEvent per FAILED attempt so
             // the dashboard's Logs tab surfaces each failed upstream try.
             emit_failed_attempts(
@@ -273,6 +304,7 @@ pub async fn responses(
                 &api_key_id,
                 &client,
                 &routing,
+                content_for_last,
             );
             // Pre-dispatch failure (model-not-found, auth, budget) records no
             // attempts — emit a single terminal event carrying the failure
@@ -298,6 +330,7 @@ pub async fn responses(
                     // Input masking may have fired before the failure.
                     redaction_counts.clone(),
                     monitor_hits.clone(),
+                    failure_content.take(),
                 );
             }
             err.into_response()
@@ -2234,6 +2267,9 @@ fn emit_zero_token_event(
     // Monitor-mode guardrail observations (AISIX-Cloud#562) that fired
     // before the failure.
     guardrail_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
+    // AISIX-Cloud#1013: captured (post-mask) request body for failed
+    // requests. Forwarded only to `fan_out`, never to the CP sink.
+    content: Option<CapturedContent>,
 ) {
     let snap = state.snapshot.load();
     let tags = provider_telemetry_tags(&snap, provider_key_id);
@@ -2264,15 +2300,14 @@ fn emit_zero_token_event(
     };
     state.usage_sink.try_emit("responses", event.clone());
     let exporters = snap.observability_exporters.entries();
-    state.otlp_fan_out.fan_out(
-        &event,
-        /* content */ None,
-        exporters.iter().map(|e| &e.value),
-    );
+    state
+        .otlp_fan_out
+        .fan_out(&event, content.as_ref(), exporters.iter().map(|e| &e.value));
 }
 
 /// Emit one zero-token `UsageEvent` per FAILED attempt of a `/v1/responses`
 /// request (#655). The winner / terminal event is emitted separately.
+#[allow(clippy::too_many_arguments)]
 fn emit_failed_attempts(
     state: &ProxyState,
     request_id: &str,
@@ -2280,8 +2315,24 @@ fn emit_failed_attempts(
     api_key_id: &str,
     client: &ClientContext,
     routing: &RoutingTelemetry,
+    // AISIX-Cloud#1013: when every target failed there is no terminal
+    // event, so the captured request body rides the LAST failed attempt —
+    // the one whose status the caller saw. Other attempts (and the
+    // success-path caller) stay content-less.
+    mut content_for_last: Option<CapturedContent>,
 ) {
-    for rec in routing.attempts.iter().filter(|a| !a.success) {
+    let last_failed = routing.attempts.iter().rposition(|a| !a.success);
+    for (i, rec) in routing
+        .attempts
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| !a.success)
+    {
+        let content = if Some(i) == last_failed {
+            content_for_last.take()
+        } else {
+            None
+        };
         emit_zero_token_event(
             state,
             request_id,
@@ -2299,6 +2350,7 @@ fn emit_failed_attempts(
             // terminal event does.
             crate::redact::RedactionCounts::new(),
             Vec::new(),
+            content,
         );
     }
 }

--- a/tests/e2e/src/cases/sls-failure-content-e2e.test.ts
+++ b/tests/e2e/src/cases/sls-failure-content-e2e.test.ts
@@ -1,0 +1,438 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  lz4DecompressBlock,
+  spawnApp,
+  startMockSls,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type MockSls,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// AISIX-Cloud#1013: non-200 requests must also record the (post-mask)
+// request body in full-content SLS logs — previously content was attached
+// only on the 200 success path, so a 4xx/5xx row showed status + error
+// class but never WHAT was sent, making triage guesswork. This drives a
+// real `aisix` binary + etcd against a hard-failing mock upstream and a
+// keyword guardrail, and reads the delivered SLS protobuf back:
+//
+//   1. upstream failure (chat)        → record carries `prompt`
+//   2. guardrail input block 422      → record carries `prompt`
+//   3. 403 model-forbidden            → record exists WITHOUT `prompt`
+//      (auth-class failures stay body-less by design)
+//   4. /v1/messages upstream failure  → record carries `prompt`
+//   5. /v1/responses upstream failure → record carries `prompt`
+//
+// A metadata_only exporter runs alongside and must never see any prompt.
+
+const CALLER_PLAINTEXT = "sk-failure-content-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const CREDENTIAL_REF = "mock";
+const MOCK_AK_ID = "LTAI_mock_ak";
+const MOCK_AK_SECRET = "mock_ak_secret";
+const SLS_PROJECT = "aisix-e2e-obs";
+const FULL_LOGSTORE = "failure-content-full";
+const META_LOGSTORE = "failure-content-meta";
+
+const FORBIDDEN_WORD = "failurecontentforbidden";
+const UPSTREAM_FAIL_SENTINEL = "upstream-fail-prompt-7c1d2e";
+const GUARDRAIL_SENTINEL = `${FORBIDDEN_WORD} plus context 4b9f0a`;
+const FORBIDDEN_MODEL_SENTINEL = "forbidden-model-prompt-9e3a1b";
+const MESSAGES_SENTINEL = "messages-fail-prompt-5d8c4f";
+const RESPONSES_SENTINEL = "responses-fail-prompt-2a6e9d";
+
+// --- Minimal SLS LogGroup protobuf reader (see sink/sls.rs encoder) -----
+// LogGroup { Logs = 1 (message) { Time = 1 (varint), Contents = 2 (message)
+// { Key = 1 (string), Value = 2 (string) } } }; unknown fields skipped.
+
+function readVarint(buf: Buffer, pos: number): [number, number] {
+  let result = 0;
+  let shift = 0;
+  for (;;) {
+    const b = buf[pos]!;
+    pos += 1;
+    result += (b & 0x7f) * 2 ** shift;
+    if ((b & 0x80) === 0) return [result, pos];
+    shift += 7;
+  }
+}
+
+function skipField(buf: Buffer, pos: number, wireType: number): number {
+  if (wireType === 0) return readVarint(buf, pos)[1];
+  if (wireType === 2) {
+    const [len, p] = readVarint(buf, pos);
+    return p + len;
+  }
+  if (wireType === 5) return pos + 4;
+  if (wireType === 1) return pos + 8;
+  throw new Error(`unsupported wire type ${wireType}`);
+}
+
+function parseContentPair(buf: Buffer): [string, string] {
+  let pos = 0;
+  let key = "";
+  let value = "";
+  while (pos < buf.length) {
+    const [tag, p] = readVarint(buf, pos);
+    pos = p;
+    const field = tag >>> 3;
+    const wireType = tag & 7;
+    if (wireType === 2) {
+      const [len, q] = readVarint(buf, pos);
+      const bytes = buf.subarray(q, q + len);
+      pos = q + len;
+      if (field === 1) key = bytes.toString("utf8");
+      else if (field === 2) value = bytes.toString("utf8");
+    } else {
+      pos = skipField(buf, pos, wireType);
+    }
+  }
+  return [key, value];
+}
+
+function parseLog(buf: Buffer): Map<string, string> {
+  const out = new Map<string, string>();
+  let pos = 0;
+  while (pos < buf.length) {
+    const [tag, p] = readVarint(buf, pos);
+    pos = p;
+    const field = tag >>> 3;
+    const wireType = tag & 7;
+    if (field === 2 && wireType === 2) {
+      const [len, q] = readVarint(buf, pos);
+      const [k, v] = parseContentPair(buf.subarray(q, q + len));
+      out.set(k, v);
+      pos = q + len;
+    } else {
+      pos = skipField(buf, pos, wireType);
+    }
+  }
+  return out;
+}
+
+/** Decode every log delivered to `logstore` into flat key→value maps. */
+function logsFor(sls: MockSls, logstore: string): Map<string, string>[] {
+  const logs: Map<string, string>[] = [];
+  for (const r of sls.requests) {
+    if (r.logstore !== logstore || r.rawSize === 0 || r.body.length === 0) continue;
+    const group = lz4DecompressBlock(r.body, r.rawSize);
+    let pos = 0;
+    while (pos < group.length) {
+      const [tag, p] = readVarint(group, pos);
+      pos = p;
+      const field = tag >>> 3;
+      const wireType = tag & 7;
+      if (field === 1 && wireType === 2) {
+        const [len, q] = readVarint(group, pos);
+        logs.push(parseLog(group.subarray(q, q + len)));
+        pos = q + len;
+      } else {
+        pos = skipField(group, pos, wireType);
+      }
+    }
+  }
+  return logs;
+}
+
+/** Poll until a FULL_LOGSTORE log matching `pred` arrives (or time out). */
+async function waitForLog(
+  sls: MockSls,
+  pred: (l: Map<string, string>) => boolean,
+  what: string,
+  timeoutMs = 10_000,
+): Promise<Map<string, string>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hit = logsFor(sls, FULL_LOGSTORE).find(pred);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`no SLS log matching: ${what}`);
+}
+
+// -------------------------------------------------------------------------
+
+describe("sls e2e: failed requests record the request body (#1013)", () => {
+  let okUpstream: OpenAiUpstream | undefined;
+  let failUpstream: OpenAiUpstream | undefined;
+  let sls: MockSls | undefined;
+  let app: SpawnedApp | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    sls = await startMockSls();
+    // Healthy upstream — used only to gate config propagation.
+    okUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-ok",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "fine" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      },
+    });
+    // Hard-failing upstream: every call returns 500.
+    failUpstream = await startOpenAiUpstream({
+      status: 500,
+      errorBody: { error: { message: "mock upstream exploded", type: "server_error" } },
+    });
+
+    app = await spawnApp({
+      extraEnv: {
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: MOCK_AK_ID,
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: MOCK_AK_SECRET,
+      },
+    });
+    const admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    await admin.createObservabilityExporter({
+      name: "sls-failure-full",
+      enabled: true,
+      kind: "aliyun_sls",
+      endpoint: sls.url,
+      project: SLS_PROJECT,
+      logstore: FULL_LOGSTORE,
+      credential_ref: CREDENTIAL_REF,
+      content_mode: "full",
+    });
+    await admin.createObservabilityExporter({
+      name: "sls-failure-meta",
+      enabled: true,
+      kind: "aliyun_sls",
+      endpoint: sls.url,
+      project: SLS_PROJECT,
+      logstore: META_LOGSTORE,
+      credential_ref: CREDENTIAL_REF,
+      content_mode: "metadata_only",
+    });
+
+    const okPk = await admin.createProviderKey({
+      display_name: "failure-content-ok-pk",
+      secret: "sk-mock",
+      api_base: `${okUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "failure-content-ok",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: okPk.id,
+    });
+    const failPk = await admin.createProviderKey({
+      display_name: "failure-content-fail-pk",
+      secret: "sk-mock",
+      api_base: `${failUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "failure-content-fail",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: failPk.id,
+    });
+    // A model the caller is NOT allowed to use (403 case).
+    await admin.createModel({
+      display_name: "failure-content-offlimits",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: okPk.id,
+    });
+
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["failure-content-ok", "failure-content-fail"],
+    });
+
+    // Input-side keyword guardrail (block mode) for the 422 case.
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: "failure-content-guard",
+      enabled: true,
+      hook_point: "input",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
+    });
+
+    // Gate: benign chat succeeds AND the guardrail is live (risky 422).
+    await waitConfigPropagation(async () => {
+      const ok = await chat("failure-content-ok", "a plain benign question");
+      if (ok.status !== 200) return false;
+      const blocked = await chat("failure-content-ok", `probe ${FORBIDDEN_WORD}`);
+      return blocked.status === 422;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await okUpstream?.close();
+    await failUpstream?.close();
+    await sls?.close();
+  });
+
+  async function chat(model: string, content: string): Promise<Response> {
+    const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ model, messages: [{ role: "user", content }] }),
+    });
+    await res.text();
+    return res;
+  }
+
+  test("upstream failure: the failed chat request's record carries the prompt", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    const res = await chat("failure-content-fail", UPSTREAM_FAIL_SENTINEL);
+    expect(res.status).toBeGreaterThanOrEqual(500);
+
+    const log = await waitForLog(
+      sls,
+      (l) => (l.get("prompt") ?? "").includes(UPSTREAM_FAIL_SENTINEL),
+      "failed-upstream chat record with prompt",
+    );
+    // It is the FAILED request's record: non-2xx status, no response text.
+    expect(Number(log.get("status_code"))).toBeGreaterThanOrEqual(400);
+    expect(log.get("response") ?? "").toBe("");
+    // The prompt is the request body — valid JSON with the messages array.
+    const prompt = JSON.parse(log.get("prompt")!) as {
+      messages: Array<{ content: string }>;
+    };
+    expect(prompt.messages[0]!.content).toContain(UPSTREAM_FAIL_SENTINEL);
+  });
+
+  test("guardrail input block (422): the record carries the prompt", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    const res = await chat("failure-content-ok", GUARDRAIL_SENTINEL);
+    expect(res.status).toBe(422);
+
+    const log = await waitForLog(
+      sls,
+      (l) => (l.get("prompt") ?? "").includes(GUARDRAIL_SENTINEL),
+      "guardrail-blocked record with prompt",
+    );
+    expect(log.get("status_code")).toBe("422");
+    expect(log.get("guardrail_blocked")).toBe("true");
+  });
+
+  test("403 model-forbidden: the record exists but stays body-less", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    const res = await chat("failure-content-offlimits", FORBIDDEN_MODEL_SENTINEL);
+    expect(res.status).toBe(403);
+
+    // The 403 event lands in SLS…
+    const log = await waitForLog(
+      sls,
+      (l) =>
+        l.get("status_code") === "403" &&
+        (l.get("requested_model") ?? "") === "failure-content-offlimits",
+      "403 record",
+    );
+    // …but carries no prompt, and the sentinel never reaches the logstore.
+    expect(log.get("prompt")).toBeUndefined();
+    for (const l of logsFor(sls, FULL_LOGSTORE)) {
+      expect(l.get("prompt") ?? "").not.toContain(FORBIDDEN_MODEL_SENTINEL);
+    }
+  });
+
+  test("/v1/messages upstream failure: the record carries the prompt", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    const res = await fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "x-api-key": CALLER_PLAINTEXT,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "failure-content-fail",
+        max_tokens: 32,
+        messages: [{ role: "user", content: MESSAGES_SENTINEL }],
+      }),
+    });
+    await res.text();
+    expect(res.status).toBeGreaterThanOrEqual(400);
+
+    const log = await waitForLog(
+      sls,
+      (l) => (l.get("prompt") ?? "").includes(MESSAGES_SENTINEL),
+      "failed /v1/messages record with prompt",
+    );
+    expect(Number(log.get("status_code"))).toBeGreaterThanOrEqual(400);
+  });
+
+  test("/v1/responses upstream failure: the record carries the prompt", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    const res = await fetch(`${app!.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "failure-content-fail",
+        input: RESPONSES_SENTINEL,
+      }),
+    });
+    await res.text();
+    expect(res.status).toBeGreaterThanOrEqual(400);
+
+    const log = await waitForLog(
+      sls,
+      (l) => (l.get("prompt") ?? "").includes(RESPONSES_SENTINEL),
+      "failed /v1/responses record with prompt",
+    );
+    expect(Number(log.get("status_code"))).toBeGreaterThanOrEqual(400);
+  });
+
+  test("metadata_only exporter never receives any failed-request prompt", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    // Runs last: every sentinel above has already been sent and captured
+    // into the FULL logstore. None may appear in the metadata logstore.
+    const metaText = logsFor(sls, META_LOGSTORE)
+      .flatMap((l) => [...l.values()])
+      .join(" ");
+    for (const sentinel of [
+      UPSTREAM_FAIL_SENTINEL,
+      GUARDRAIL_SENTINEL,
+      MESSAGES_SENTINEL,
+      RESPONSES_SENTINEL,
+    ]) {
+      expect(metaText).not.toContain(sentinel);
+    }
+    for (const l of logsFor(sls, META_LOGSTORE)) {
+      expect(l.get("prompt")).toBeUndefined();
+    }
+  });
+});

--- a/tests/e2e/src/cases/sls-failure-content-e2e.test.ts
+++ b/tests/e2e/src/cases/sls-failure-content-e2e.test.ts
@@ -45,6 +45,11 @@ const GUARDRAIL_SENTINEL = `${FORBIDDEN_WORD} plus context 4b9f0a`;
 const FORBIDDEN_MODEL_SENTINEL = "forbidden-model-prompt-9e3a1b";
 const MESSAGES_SENTINEL = "messages-fail-prompt-5d8c4f";
 const RESPONSES_SENTINEL = "responses-fail-prompt-2a6e9d";
+const GROUP_SENTINEL = "group-all-failed-prompt-8f2b6c";
+const RECOVER_SENTINEL = "group-recovered-prompt-3c7d1a";
+const EMAIL = "dana@example.com";
+const CN_ID = "11010519491231002X"; // valid ISO 7064 MOD 11-2 check digit
+const MASKED_BLOCK_SENTINEL = "masked-block-prompt-6a4e8b";
 
 // --- Minimal SLS LogGroup protobuf reader (see sink/sls.rs encoder) -----
 // LogGroup { Logs = 1 (message) { Time = 1 (varint), Contents = 2 (message)
@@ -242,6 +247,9 @@ describe("sls e2e: failed requests record the request body (#1013)", () => {
       provider: "openai",
       model_name: "gpt-4o-mini",
       provider_key_id: failPk.id,
+      // Keep the failing target in rotation across tests — a cooldown
+      // would silently shrink the routing groups below to one target.
+      cooldown: { enabled: false },
     });
     // A model the caller is NOT allowed to use (403 case).
     await admin.createModel({
@@ -250,10 +258,46 @@ describe("sls e2e: failed requests record the request body (#1013)", () => {
       model_name: "gpt-4o-mini",
       provider_key_id: okPk.id,
     });
+    // Second hard-failing target so a routing group can fail on BOTH
+    // targets (content must ride the LAST attempt only).
+    await admin.createModel({
+      display_name: "failure-content-fail-b",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: failPk.id,
+      cooldown: { enabled: false },
+    });
+    await admin.createModel({
+      display_name: "failure-content-group",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "failure-content-fail" },
+          { model: "failure-content-fail-b" },
+        ],
+      },
+    });
+    // Fail-then-recover group: the failed attempt must stay content-less
+    // while the winner's success event carries the prompt.
+    await admin.createModel({
+      display_name: "failure-content-recover",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "failure-content-fail" },
+          { model: "failure-content-ok" },
+        ],
+      },
+    });
 
     await admin.createApiKey({
       key_hash: CALLER_KEY_HASH,
-      allowed_models: ["failure-content-ok", "failure-content-fail"],
+      allowed_models: [
+        "failure-content-ok",
+        "failure-content-fail",
+        "failure-content-group",
+        "failure-content-recover",
+      ],
     });
 
     // Input-side keyword guardrail (block mode) for the 422 case.
@@ -264,13 +308,33 @@ describe("sls e2e: failed requests record the request body (#1013)", () => {
       kind: "keyword",
       patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
     });
+    // PII guardrail: email masks, china_id_card blocks. A blocked request
+    // carrying BOTH must capture the post-mask body (the email placeholder,
+    // never the raw address).
+    await admin.json("POST", "/admin/v1/guardrails", {
+      name: "failure-content-pii",
+      enabled: true,
+      hook_point: "input",
+      kind: "pii",
+      detectors: [
+        { type: "email", action: "mask" },
+        { type: "china_id_card", action: "block" },
+      ],
+    });
 
-    // Gate: benign chat succeeds AND the guardrail is live (risky 422).
+    // Gate: benign chat succeeds, both guardrails are live (each blocks),
+    // and the routing groups resolved.
     await waitConfigPropagation(async () => {
       const ok = await chat("failure-content-ok", "a plain benign question");
       if (ok.status !== 200) return false;
       const blocked = await chat("failure-content-ok", `probe ${FORBIDDEN_WORD}`);
-      return blocked.status === 422;
+      if (blocked.status !== 422) return false;
+      const pii = await chat("failure-content-ok", `probe id ${CN_ID}`);
+      if (pii.status !== 422) return false;
+      const grp = await chat("failure-content-group", "group probe");
+      if (grp.status === 404) return false;
+      const rec = await chat("failure-content-recover", "recover probe");
+      return rec.status === 200;
     });
   });
 
@@ -413,6 +477,102 @@ describe("sls e2e: failed requests record the request body (#1013)", () => {
     expect(Number(log.get("status_code"))).toBeGreaterThanOrEqual(400);
   });
 
+  test("blocked request carrying maskable PII captures the POST-mask body", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    // The china_id_card detector blocks; the email detector masks. The
+    // captured prompt must show what the success path would have sent —
+    // the masked email — never the raw address.
+    const res = await chat(
+      "failure-content-ok",
+      `${MASKED_BLOCK_SENTINEL} write to ${EMAIL} about id ${CN_ID}`,
+    );
+    expect(res.status).toBe(422);
+
+    const log = await waitForLog(
+      sls,
+      (l) => (l.get("prompt") ?? "").includes(MASKED_BLOCK_SENTINEL),
+      "pii-blocked record with prompt",
+    );
+    expect(log.get("guardrail_blocked")).toBe("true");
+    const prompt = log.get("prompt")!;
+    expect(prompt).toContain("[EMAIL_REDACTED]");
+    expect(prompt).not.toContain(EMAIL);
+    // And the raw address never reaches the logstore in any record.
+    for (const l of logsFor(sls, FULL_LOGSTORE)) {
+      for (const v of l.values()) {
+        expect(v).not.toContain(EMAIL);
+      }
+    }
+  });
+
+  test("all targets failed: exactly one record carries the prompt, on the last attempt", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    const res = await chat("failure-content-group", GROUP_SENTINEL);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+
+    const withPrompt = await waitForLog(
+      sls,
+      (l) => (l.get("prompt") ?? "").includes(GROUP_SENTINEL),
+      "all-targets-failed record with prompt",
+    );
+    const requestId = withPrompt.get("request_id")!;
+    expect(requestId).toBeTruthy();
+
+    // Both attempts produced a record…
+    const requestLogs = logsFor(sls, FULL_LOGSTORE).filter(
+      (l) => l.get("request_id") === requestId,
+    );
+    expect(requestLogs.length).toBeGreaterThanOrEqual(2);
+    // …but exactly ONE carries the prompt, and it is the LAST attempt
+    // (the failure the caller actually saw), not the first.
+    const promptBearers = requestLogs.filter((l) =>
+      (l.get("prompt") ?? "").includes(GROUP_SENTINEL),
+    );
+    expect(promptBearers.length).toBe(1);
+    const maxAttempt = Math.max(
+      ...requestLogs.map((l) => Number(l.get("attempt_index") ?? "0")),
+    );
+    expect(Number(promptBearers[0]!.get("attempt_index"))).toBe(maxAttempt);
+    expect(maxAttempt).toBeGreaterThanOrEqual(1);
+  });
+
+  test("fallback recovers: failed attempt stays content-less, the success record carries the prompt", async (ctx) => {
+    if (!etcdReachable || !app || !sls) {
+      ctx.skip();
+      return;
+    }
+    const res = await chat("failure-content-recover", RECOVER_SENTINEL);
+    expect(res.status).toBe(200);
+
+    const successLog = await waitForLog(
+      sls,
+      (l) =>
+        (l.get("prompt") ?? "").includes(RECOVER_SENTINEL) &&
+        l.get("status_code") === "200",
+      "recovered request's success record with prompt",
+    );
+    const requestId = successLog.get("request_id")!;
+    // The failed first attempt is recorded — without the prompt.
+    const deadline = Date.now() + 10_000;
+    let failedAttempt: Map<string, string> | undefined;
+    while (Date.now() < deadline && !failedAttempt) {
+      failedAttempt = logsFor(sls, FULL_LOGSTORE).find(
+        (l) =>
+          l.get("request_id") === requestId &&
+          Number(l.get("status_code") ?? "0") >= 400,
+      );
+      if (!failedAttempt) await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(failedAttempt, "failed attempt record").toBeDefined();
+    expect(failedAttempt!.get("prompt")).toBeUndefined();
+  });
+
   test("metadata_only exporter never receives any failed-request prompt", async (ctx) => {
     if (!etcdReachable || !app || !sls) {
       ctx.skip();
@@ -420,6 +580,17 @@ describe("sls e2e: failed requests record the request body (#1013)", () => {
     }
     // Runs last: every sentinel above has already been sent and captured
     // into the FULL logstore. None may appear in the metadata logstore.
+    // Vacuous-pass guard: the meta pipeline must have delivered the failed
+    // requests before we assert what its records lack.
+    const failedMeta = () =>
+      logsFor(sls!, META_LOGSTORE).filter(
+        (l) => Number(l.get("status_code") ?? "0") >= 400,
+      );
+    const deadline = Date.now() + 10_000;
+    while (failedMeta().length < 4 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(failedMeta().length).toBeGreaterThanOrEqual(4);
     const metaText = logsFor(sls, META_LOGSTORE)
       .flatMap((l) => [...l.values()])
       .join(" ");


### PR DESCRIPTION
## Problem

Content capture was structurally success-only: `DispatchFailure` carried no content field and every failure-path emit passed `None`. A 4xx/5xx row in SLS showed status, error class and attempt metadata — but never **what was sent**, so triaging "is this a caller problem or a gateway/upstream problem" required reproducing the call (AISIX-Cloud#1013).

## Change

Failed requests on the three routing endpoints (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`) now capture the **(post-mask) request body** into the `prompt` content field, under exactly the same rules as the success path — only when a `content_mode: full` exporter is enabled, capped at `content_max_bytes`, body-only (headers/credentials are never part of captured content):

- **pre-dispatch terminal events** (guardrail input block, validation, budget, model-not-found) carry the prompt;
- **all-targets-failed**: there is no terminal event, so the prompt rides the **last failed attempt** — the one whose status the caller saw; earlier attempts stay content-less so a large prompt is never duplicated ×N;
- **billed-then-blocked** (output guardrail, chat): the terminal event carries the prompt; the blocked model output intentionally stays out of the log — blocking it and then archiving it would defeat the block;
- **401/403 stay body-less** — a body adds nothing to an authorization failure, and callers probing keys shouldn't get their payloads archived (per the issue's own caution for auth failures).

Masking note: PII mask guardrails rewrite the request in place before dispatch, so captured failure bodies are post-mask whenever the failure occurred at or after the guardrail stage; failures *before* that stage (e.g. malformed-parameter 400s) log the body as received — same semantics as the success path, where capture is also post-mask.

## Deliberately out of scope

`completions`/`embeddings`/`rerank`/`images`/`audio` emit **no usage events at all** on failure today (success-only emitters) — there is no record to attach content to. That's a separate, pre-existing gap: filed as #748. `count_tokens` emits no usage events by design (free endpoint).

## Tests

New e2e `sls-failure-content-e2e.test.ts` (real `aisix` + etcd + mock SLS, decodes the delivered protobuf):
1. upstream failure (chat) → record carries the prompt, no response text
2. guardrail input block 422 → record carries the prompt, `guardrail_blocked=true`
3. 403 model-forbidden → record exists **without** a prompt (and the sentinel never reaches the logstore)
4. /v1/messages upstream failure → prompt present
5. /v1/responses upstream failure → prompt present
6. a `metadata_only` exporter running alongside never receives any failed-request prompt

Verified fail-before/pass-after: on unpatched main, tests 1/2/4/5 fail with "no SLS log matching … with prompt"; with this change all six pass. Neighboring content-capture and guardrail e2es pass unchanged.

Baseline: mainstream LLM proxies log the request messages on failures as well (failure logging payloads carry the input alongside structured error info), with redaction — not omission — as the sensitive-data control. This change brings failure logs to parity while keeping capture opt-in and capped.

Fixes api7/AISIX-Cloud#1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)