### PR TITLE
feat(obs): bucketed TTFT + e2e latency histograms for SLO quantiles

### DIFF
--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -28,7 +28,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 pub use access_log::AccessLog;
 pub use metrics::{
     client_type_from_user_agent, BudgetGauges, BudgetLabels, DeploymentLabels, DeploymentState,
-    LlmUsage, Metrics, RequestLabels, RequestOutcome, UsageLabels,
+    LatencyLabels, LlmUsage, Metrics, RequestLabels, RequestOutcome, UsageLabels,
 };
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::{content_capture_cap, OtlpHttpFanOut, OtlpSink};

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -108,6 +108,9 @@ pub const M_OTLP_FANOUT_FAILURES_TOTAL: &str = "aisix_otlp_fanout_failures_total
 /// non-streaming requests and failures, at stream completion for
 /// committed streams (full stream duration, matching the usage event's
 /// `latency_ms` — NOT the time-to-first-byte the summary series record).
+/// A stream the client cancels mid-flight still observes once, with the
+/// committed status (2xx) and the duration up to the abort — the same
+/// client-perceived semantics as the usage event.
 pub const M_REQUEST_E2E_LATENCY_SECONDS: &str = "aisix_request_e2e_latency_seconds";
 /// Time-to-first-token for streaming requests, same label set as
 /// [`M_REQUEST_E2E_LATENCY_SECONDS`] (with `streaming="true"` always).

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -20,7 +20,9 @@
 //! `metrics-exporter-prometheus`'s text renderer; no global recorder is
 //! installed, so tests can spin up isolated instances per case.
 
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle, PrometheusRecorder};
+use metrics_exporter_prometheus::{
+    Matcher, PrometheusBuilder, PrometheusHandle, PrometheusRecorder,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -93,6 +95,31 @@ pub const M_GUARDRAIL_BYPASSES_TOTAL: &str = "aisix_guardrail_bypasses_total";
 pub const M_USAGE_EVENT_EMITS_TOTAL: &str = "aisix_usage_events_emitted_total";
 pub const M_OTLP_FANOUT_DROPS_TOTAL: &str = "aisix_otlp_fanout_drops_total";
 pub const M_OTLP_FANOUT_FAILURES_TOTAL: &str = "aisix_otlp_fanout_failures_total";
+/// AISIX-Cloud#1011: SLO-grade latency distributions as REAL bucketed
+/// histograms (`_bucket{le=…}`), aggregatable across DP instances with
+/// `histogram_quantile()`. Every other `histogram!` series in this file
+/// renders as a summary (no buckets configured) whose quantiles cannot
+/// be re-aggregated — these two get explicit buckets in [`Metrics::new`]
+/// and a DEDICATED low-cardinality label set ([`LatencyLabels`]) so the
+/// per-key/per-user dimensions never multiply the bucket count.
+///
+/// `aisix_request_e2e_latency_seconds` observes the client-perceived
+/// end-to-end latency once per request: at handler return for
+/// non-streaming requests and failures, at stream completion for
+/// committed streams (full stream duration, matching the usage event's
+/// `latency_ms` — NOT the time-to-first-byte the summary series record).
+pub const M_REQUEST_E2E_LATENCY_SECONDS: &str = "aisix_request_e2e_latency_seconds";
+/// Time-to-first-token for streaming requests, same label set as
+/// [`M_REQUEST_E2E_LATENCY_SECONDS`] (with `streaming="true"` always).
+pub const M_REQUEST_TTFT_SECONDS: &str = "aisix_request_ttft_seconds";
+
+/// Bucket edges for the two SLO histograms, spanning LLM latency ranges:
+/// sub-100ms cache hits / TTFT through multi-minute long generations.
+/// 14 edges → 15 `_bucket` series per label combination; keep
+/// [`LatencyLabels`] lean before adding edges.
+pub const LATENCY_HISTOGRAM_BUCKETS: &[f64] = &[
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+];
 
 /// Holds an isolated `PrometheusRecorder` plus its render handle.
 /// `metrics::*` macros talk to whatever recorder is in scope; we use
@@ -107,6 +134,10 @@ struct MetricsInner {
     recorder: PrometheusRecorder,
     handle: PrometheusHandle,
     proxy_in_flight: Mutex<HashMap<(String, String), i64>>,
+    /// Constant `env_id` label for the SLO latency histograms — one DP
+    /// process serves exactly one environment. `"unknown"` when the DP
+    /// runs standalone (no control plane).
+    env_id: String,
 }
 
 impl std::fmt::Debug for Metrics {
@@ -120,13 +151,40 @@ impl Metrics {
     /// use but currently has no effect — every Metrics instance runs
     /// with a local recorder so parallel tests don't collide.
     pub fn new(_install_global: bool) -> Self {
-        let recorder = PrometheusBuilder::new().build_recorder();
+        Self::new_with_env_id("unknown")
+    }
+
+    /// Like [`Metrics::new`], stamping `env_id` onto the SLO latency
+    /// histograms. Empty ids (standalone DP) collapse to `"unknown"`,
+    /// matching the missing-dimension convention used elsewhere.
+    pub fn new_with_env_id(env_id: &str) -> Self {
+        // Buckets ONLY for the two SLO histograms: with `metrics-exporter-
+        // prometheus`, a distribution without configured buckets renders as
+        // a summary — which is what every legacy `histogram!` series here
+        // intentionally stays as.
+        let recorder = PrometheusBuilder::new()
+            .set_buckets_for_metric(
+                Matcher::Full(M_REQUEST_E2E_LATENCY_SECONDS.to_string()),
+                LATENCY_HISTOGRAM_BUCKETS,
+            )
+            .expect("static bucket list is non-empty")
+            .set_buckets_for_metric(
+                Matcher::Full(M_REQUEST_TTFT_SECONDS.to_string()),
+                LATENCY_HISTOGRAM_BUCKETS,
+            )
+            .expect("static bucket list is non-empty")
+            .build_recorder();
         let handle = recorder.handle();
         Self {
             inner: Arc::new(MetricsInner {
                 recorder,
                 handle,
                 proxy_in_flight: Mutex::new(HashMap::new()),
+                env_id: if env_id.is_empty() {
+                    "unknown".to_string()
+                } else {
+                    env_id.to_string()
+                },
             }),
         }
     }
@@ -543,6 +601,72 @@ impl Metrics {
             metrics::counter!(M_OTLP_FANOUT_FAILURES_TOTAL, "exporter" => exporter.to_string())
                 .increment(1);
         });
+    }
+
+    /// Observe one request's client-perceived end-to-end latency on
+    /// [`M_REQUEST_E2E_LATENCY_SECONDS`]. Call exactly once per request:
+    /// at handler return for non-streaming requests and failures, at
+    /// stream completion for committed streams.
+    pub fn record_request_e2e_latency(&self, labels: LatencyLabels<'_>, elapsed: Duration) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::histogram!(
+                M_REQUEST_E2E_LATENCY_SECONDS,
+                "env_id" => self.inner.env_id.clone(),
+                "endpoint" => labels.endpoint.to_string(),
+                "model" => non_empty_or_unknown(labels.model),
+                "provider" => non_empty_or_unknown(labels.provider),
+                "status_class" => status_bucket(labels.status),
+                "streaming" => bool_str(labels.streaming),
+            )
+            .record(elapsed.as_secs_f64());
+        });
+    }
+
+    /// Observe a streaming request's time-to-first-token on
+    /// [`M_REQUEST_TTFT_SECONDS`]. Zero durations are skipped (TTFT was
+    /// never measured — e.g. the stream died before the first token).
+    pub fn record_request_ttft(&self, labels: LatencyLabels<'_>, ttft: Duration) {
+        if ttft.is_zero() {
+            return;
+        }
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::histogram!(
+                M_REQUEST_TTFT_SECONDS,
+                "env_id" => self.inner.env_id.clone(),
+                "endpoint" => labels.endpoint.to_string(),
+                "model" => non_empty_or_unknown(labels.model),
+                "provider" => non_empty_or_unknown(labels.provider),
+                "status_class" => status_bucket(labels.status),
+                "streaming" => bool_str(labels.streaming),
+            )
+            .record(ttft.as_secs_f64());
+        });
+    }
+}
+
+/// Labels for the SLO latency histograms (AISIX-Cloud#1011). Deliberately
+/// low-cardinality: bounded endpoint set, configured model/provider names,
+/// bucketed status — never per-key / per-user dimensions, which would
+/// multiply every bucket edge.
+#[derive(Clone, Copy)]
+pub struct LatencyLabels<'a> {
+    /// Route template, e.g. `/v1/chat/completions`. Bounded set.
+    pub endpoint: &'a str,
+    /// Gateway-level model name (the dashboard alias the caller requested).
+    pub model: &'a str,
+    /// Provider kind (`openai`, `anthropic`, …); `unknown` pre-resolution.
+    pub provider: &'a str,
+    /// Raw HTTP status; bucketed to `2xx`/`4xx`/… at record time.
+    pub status: u16,
+    pub streaming: bool,
+}
+
+/// Missing dimensions default to `"unknown"`, never an empty label value.
+fn non_empty_or_unknown(v: &str) -> String {
+    if v.is_empty() {
+        "unknown".to_string()
+    } else {
+        v.to_string()
     }
 }
 
@@ -1168,6 +1292,128 @@ mod tests {
             rendered.contains(" 0"),
             "expected gauge to return to zero:\n{rendered}"
         );
+    }
+
+    /// AISIX-Cloud#1011: the two SLO series must render as REAL bucketed
+    /// histograms (`_bucket{le=…}` + `_sum`/`_count`) — the property that
+    /// makes `histogram_quantile()` and cross-instance aggregation work.
+    /// Every other `histogram!` series stays a summary (no buckets), so a
+    /// bucket-config regression is invisible without this pin.
+    #[test]
+    fn slo_latency_series_render_as_bucketed_histograms() {
+        let m = Metrics::new_with_env_id("env-42");
+        let labels = LatencyLabels {
+            endpoint: "/v1/chat/completions",
+            model: "gpt-4o",
+            provider: "openai",
+            status: 200,
+            streaming: false,
+        };
+        m.record_request_e2e_latency(labels, Duration::from_millis(1500));
+        m.record_request_ttft(
+            LatencyLabels {
+                streaming: true,
+                ..labels
+            },
+            Duration::from_millis(80),
+        );
+        let out = m.render();
+
+        // Real histogram exposition: le-bucketed series + sum/count.
+        assert!(
+            out.contains("aisix_request_e2e_latency_seconds_bucket"),
+            "e2e series must expose _bucket lines:\n{out}"
+        );
+        assert!(out.contains("aisix_request_e2e_latency_seconds_sum"));
+        assert!(out.contains("aisix_request_e2e_latency_seconds_count"));
+        assert!(out.contains("aisix_request_ttft_seconds_bucket"));
+        assert!(
+            out.contains("le=\"2.5\""),
+            "configured bucket edges present"
+        );
+
+        // The label contract: constant env_id, bucketed status, bounded
+        // dims — and none of the per-key/per-user dimensions.
+        assert!(out.contains("env_id=\"env-42\""));
+        assert!(out.contains("status_class=\"2xx\""));
+        assert!(out.contains("streaming=\"false\""));
+        assert!(out.contains("streaming=\"true\""));
+        for high_card in ["api_key_id", "user_id", "team_id", "provider_key_id"] {
+            for line in out.lines().filter(|l| l.contains("aisix_request_")) {
+                assert!(
+                    !line.contains(high_card),
+                    "SLO histogram must not carry {high_card}: {line}"
+                );
+            }
+        }
+    }
+
+    /// A 1.5s observation lands in the 2.5 bucket but not the 1.0 bucket —
+    /// pins that the configured edges actually apply (a default-bucket
+    /// fallback would place them differently or render a summary).
+    #[test]
+    fn slo_latency_observation_lands_in_the_right_bucket() {
+        let m = Metrics::new_with_env_id("");
+        m.record_request_e2e_latency(
+            LatencyLabels {
+                endpoint: "/v1/messages",
+                model: "m",
+                provider: "anthropic",
+                status: 502,
+                streaming: false,
+            },
+            Duration::from_millis(1500),
+        );
+        let out = m.render();
+        let bucket_val = |le: &str| -> u64 {
+            out.lines()
+                .find(|l| {
+                    l.starts_with("aisix_request_e2e_latency_seconds_bucket")
+                        && l.contains(&format!("le=\"{le}\""))
+                })
+                .and_then(|l| l.rsplit(' ').next())
+                .and_then(|v| v.parse().ok())
+                .unwrap_or_else(|| panic!("no bucket le={le} in:\n{out}"))
+        };
+        assert_eq!(bucket_val("1"), 0, "1.5s must not land in le=1");
+        assert_eq!(bucket_val("2.5"), 1, "1.5s must land in le=2.5");
+        // Empty env_id collapses to the missing-dimension convention.
+        assert!(out.contains("env_id=\"unknown\""));
+        assert!(out.contains("status_class=\"5xx\""));
+    }
+
+    /// Zero TTFT (never measured) is skipped, and the legacy duration
+    /// series keep their summary exposition — no `_bucket` lines appear
+    /// for them even after the SLO buckets are configured.
+    #[test]
+    fn slo_ttft_skips_zero_and_legacy_series_stay_summaries() {
+        let m = Metrics::new_with_env_id("e");
+        let labels = LatencyLabels {
+            endpoint: "/v1/chat/completions",
+            model: "m",
+            provider: "openai",
+            status: 200,
+            streaming: true,
+        };
+        m.record_request_ttft(labels, Duration::ZERO);
+        assert!(
+            !m.render().contains("aisix_request_ttft_seconds"),
+            "zero TTFT must not be observed"
+        );
+
+        m.record_request(
+            "openai",
+            "m",
+            200,
+            RequestOutcome::Success,
+            Duration::from_millis(100),
+        );
+        let out = m.render();
+        assert!(
+            !out.contains("aisix_request_duration_seconds_bucket"),
+            "legacy duration series must stay a summary (quantiles), got:\n{out}"
+        );
+        assert!(out.contains("aisix_request_duration_seconds"));
     }
 
     /// Issue #408 audit MEDIUM-2: pin every boundary of

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2639,6 +2639,31 @@ async fn dispatch_ensemble(
                     &client_for_telem,
                     /* content */ None,
                 );
+                // SLO histograms (AISIX-Cloud#1011): the handler's
+                // record_success is stream-gated, so the ensemble stream
+                // records its e2e/TTFT here like the plain streaming path.
+                state_for_telem.metrics.record_request_e2e_latency(
+                    LatencyLabels {
+                        endpoint: "/v1/chat/completions",
+                        model: &client_model_for_telem,
+                        // Matches the legacy series: no single provider
+                        // governs an ensemble response.
+                        provider: "ensemble",
+                        status: 200,
+                        streaming: true,
+                    },
+                    started.elapsed(),
+                );
+                state_for_telem.metrics.record_request_ttft(
+                    LatencyLabels {
+                        endpoint: "/v1/chat/completions",
+                        model: &client_model_for_telem,
+                        provider: "ensemble",
+                        status: 200,
+                        streaming: true,
+                    },
+                    Duration::from_millis(u64::from(comp.ttft_ms)),
+                );
                 // Release the concurrency permit(s) now the stream is done
                 // (or was cancelled) — on_complete fires on both paths (#450).
                 drop(stream_concurrency_hold);

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -21,8 +21,8 @@ use aisix_core::AppliedGuardrail;
 use aisix_gateway::{BridgeContext, BridgeError, ChatFormat};
 use aisix_guardrails::GuardrailVerdict;
 use aisix_obs::{
-    content_capture_cap, AccessLog, CapturedContent, LlmUsage, Metrics, RequestLabels,
-    RequestOutcome, UsageEvent, UsageLabels,
+    content_capture_cap, AccessLog, CapturedContent, LatencyLabels, LlmUsage, Metrics,
+    RequestLabels, RequestOutcome, UsageEvent, UsageLabels,
 };
 use axum::extract::State;
 use axum::http::HeaderValue;
@@ -397,6 +397,16 @@ pub async fn chat_completions(
             };
             state.metrics.record_proxy_request(fail_labels, elapsed);
             state.metrics.record_llm_request(fail_labels, elapsed);
+            state.metrics.record_request_e2e_latency(
+                LatencyLabels {
+                    endpoint: "/v1/chat/completions",
+                    model: metric_model,
+                    provider: "unknown",
+                    status,
+                    streaming: req.is_streaming(),
+                },
+                elapsed,
+            );
             emit_access_log(
                 method,
                 path,
@@ -1464,6 +1474,26 @@ async fn dispatch(
                     u64::from(comp.prompt_tokens),
                     u64::from(comp.completion_tokens),
                     comp.total_tokens,
+                );
+                metrics_for_stream.record_request_e2e_latency(
+                    LatencyLabels {
+                        endpoint: "/v1/chat/completions",
+                        model: &model_for_metrics,
+                        provider: &provider_for_metrics,
+                        status: 200,
+                        streaming: true,
+                    },
+                    started.elapsed(),
+                );
+                metrics_for_stream.record_request_ttft(
+                    LatencyLabels {
+                        endpoint: "/v1/chat/completions",
+                        model: &model_for_metrics,
+                        provider: &provider_for_metrics,
+                        status: 200,
+                        streaming: true,
+                    },
+                    Duration::from_millis(u64::from(comp.ttft_ms)),
                 );
                 metrics_for_stream.record_time_to_first_token(
                     UsageLabels {
@@ -2949,6 +2979,21 @@ fn record_success(
     };
     metrics.record_proxy_request(request_labels, elapsed);
     metrics.record_llm_request(request_labels, elapsed);
+    // SLO e2e histogram (AISIX-Cloud#1011): non-streaming only here —
+    // `elapsed` for a stream is time-to-response-start; the stream's
+    // on_complete records the full duration instead.
+    if !stream {
+        metrics.record_request_e2e_latency(
+            LatencyLabels {
+                endpoint: "/v1/chat/completions",
+                model,
+                provider,
+                status,
+                streaming: false,
+            },
+            elapsed,
+        );
+    }
     if let Some(total) = s.total_tokens {
         metrics.record_tokens(provider, model, total);
     }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -37,8 +37,8 @@
 
 use aisix_core::AppliedGuardrail;
 use aisix_obs::{
-    content_capture_cap, AccessLog, CapturedContent, LlmUsage, RequestLabels, RequestOutcome,
-    UsageEvent, UsageLabels,
+    content_capture_cap, AccessLog, CapturedContent, LatencyLabels, LlmUsage, RequestLabels,
+    RequestOutcome, UsageEvent, UsageLabels,
 };
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
@@ -204,6 +204,20 @@ pub async fn messages(
             };
             state.metrics.record_proxy_request(labels, elapsed);
             state.metrics.record_llm_request(labels, elapsed);
+            // SLO e2e histogram (AISIX-Cloud#1011): non-streaming only —
+            // a stream records its full duration at completion instead.
+            if !stream_requested {
+                state.metrics.record_request_e2e_latency(
+                    LatencyLabels {
+                        endpoint: "/v1/messages",
+                        model: &model_name,
+                        provider: &provider_label,
+                        status,
+                        streaming: false,
+                    },
+                    elapsed,
+                );
+            }
             // Per #655: one zero-token UsageEvent per failed attempt that
             // preceded the winner (non-streaming failover). No-op for a
             // first-try success and for the single-attempt streaming path.
@@ -301,6 +315,16 @@ pub async fn messages(
             };
             state.metrics.record_proxy_request(fail_labels, elapsed);
             state.metrics.record_llm_request(fail_labels, elapsed);
+            state.metrics.record_request_e2e_latency(
+                LatencyLabels {
+                    endpoint: "/v1/messages",
+                    model: metric_model,
+                    provider: "unknown",
+                    status,
+                    streaming: stream_requested,
+                },
+                elapsed,
+            );
             // Per #655: emit one zero-token UsageEvent per FAILED attempt so
             // the dashboard's Logs tab surfaces each failed upstream try.
             emit_failed_attempts_anthropic(
@@ -1130,6 +1154,16 @@ async fn anthropic_passthrough_dispatch(
                     finish_reason: usage.finish_reason,
                     ttft_ms: usage.ttft_ms,
                 };
+                state_c.metrics.record_request_e2e_latency(
+                    LatencyLabels {
+                        endpoint: "/v1/messages",
+                        model: &model_name_c,
+                        provider: &provider_c,
+                        status: 200,
+                        streaming: true,
+                    },
+                    started.elapsed(),
+                );
                 emit_anthropic_usage_event(
                     &state_c,
                     &request_id_c,
@@ -1640,6 +1674,16 @@ async fn cross_provider_dispatch(
                     finish_reason: comp.finish_reason,
                     ttft_ms: comp.ttft_ms,
                 };
+                state_for_telem.metrics.record_request_e2e_latency(
+                    LatencyLabels {
+                        endpoint: "/v1/messages",
+                        model: &model_for_telem,
+                        provider: &provider_for_telem,
+                        status: 200,
+                        streaming: true,
+                    },
+                    started_for_telem.elapsed(),
+                );
                 emit_anthropic_usage_event(
                     &state_for_telem,
                     &request_id_for_telem,
@@ -2354,6 +2398,16 @@ fn emit_anthropic_usage_event(
         total_tokens_all,
     );
     if metrics.ttft_ms > 0 {
+        state.metrics.record_request_ttft(
+            LatencyLabels {
+                endpoint: "/v1/messages",
+                model,
+                provider,
+                status: status_code,
+                streaming: true,
+            },
+            Duration::from_millis(u64::from(metrics.ttft_ms)),
+        );
         state.metrics.record_time_to_first_token(
             UsageLabels {
                 endpoint: "/v1/messages",

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -216,6 +216,22 @@ pub async fn responses(
             // `response.completed` event. `usage_handled_by_stream` guards
             // against a double-emit; `usage` is `None` on that path.
             if !success.usage_handled_by_stream {
+                // SLO e2e histogram (AISIX-Cloud#1011): recorded even when
+                // the upstream response carried no parseable usage block —
+                // latency observation must not depend on token accounting.
+                state.metrics.record_request_e2e_latency(
+                    LatencyLabels {
+                        endpoint: "/v1/responses",
+                        model: &model_name,
+                        provider: &success.provider,
+                        status,
+                        streaming: body
+                            .get("stream")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false),
+                    },
+                    elapsed,
+                );
                 if let Some(usage) = success.usage {
                     // Winning-attempt classification (#655). Direct models
                     // have no recorded attempt → AttemptInfo defaults.
@@ -233,7 +249,6 @@ pub async fn responses(
                         &success.provider_key_id,
                         status,
                         elapsed,
-                        /* streaming */ false,
                         &usage,
                         &client,
                         attempt,
@@ -1148,6 +1163,7 @@ async fn responses_to_target(
         let requested_model_c = requested_model.to_string();
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
+        let provider_c = provider_label.clone();
         let client_c = client_ctx.clone();
         // #688: carry the reservation into the end-of-stream guard — keys drive
         // post-stream TPM/TPD accounting, the hold keeps the concurrency slot(s)
@@ -1187,6 +1203,17 @@ async fn responses_to_target(
                     }
                     _ => None,
                 };
+                // SLO e2e histogram: full stream duration (verbatim path).
+                state_c.metrics.record_request_e2e_latency(
+                    LatencyLabels {
+                        endpoint: "/v1/responses",
+                        model: &requested_model_c,
+                        provider: &provider_c,
+                        status: 200,
+                        streaming: true,
+                    },
+                    started.elapsed(),
+                );
                 emit_usage_event(
                     &state_c,
                     &request_id_c,
@@ -1196,7 +1223,6 @@ async fn responses_to_target(
                     &provider_key_id_c,
                     200,
                     started.elapsed(),
-                    /* streaming */ true,
                     &usage,
                     &client_c,
                     attempt,
@@ -1503,6 +1529,7 @@ async fn responses_cross_provider_to_target(
         let requested_model_c = requested_model.to_string();
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
+        let provider_c = provider_label.clone();
         let client_c = client_ctx.clone();
         let attempt_c = attempt.clone();
         // #688: carry the reservation into the end-of-stream guard — keys drive
@@ -1562,6 +1589,18 @@ async fn responses_cross_provider_to_target(
                     ),
                     _ => None,
                 };
+                // SLO e2e histogram: full stream duration (bridge path).
+                // Blocked streams keep this guard's 422 status.
+                state_c.metrics.record_request_e2e_latency(
+                    LatencyLabels {
+                        endpoint: "/v1/responses",
+                        model: &requested_model_c,
+                        provider: &provider_c,
+                        status,
+                        streaming: true,
+                    },
+                    started.elapsed(),
+                );
                 emit_usage_event(
                     &state_c,
                     &request_id_c,
@@ -1571,7 +1610,6 @@ async fn responses_cross_provider_to_target(
                     &provider_key_id_c,
                     status,
                     started.elapsed(),
-                    /* streaming */ true,
                     &usage,
                     &client_c,
                     attempt_c,
@@ -2175,10 +2213,6 @@ fn emit_usage_event(
     provider_key_id: &str,
     status_code: u16,
     elapsed: Duration,
-    // SLO e2e histogram dimension (AISIX-Cloud#1011): callers pass true
-    // from the two stream-completion sites (where `elapsed` is the full
-    // stream duration), false from the non-streaming terminal emit.
-    streaming: bool,
     usage: &ResponseUsage,
     client: &ClientContext,
     attempt: AttemptInfo,
@@ -2195,18 +2229,6 @@ fn emit_usage_event(
 ) {
     let snap = state.snapshot.load();
     let tags = provider_telemetry_tags(&snap, provider_key_id);
-    // This function runs exactly once per successful request (attempts go
-    // through emit_zero_token_event), so it is the e2e observation point.
-    state.metrics.record_request_e2e_latency(
-        LatencyLabels {
-            endpoint: "/v1/responses",
-            model: requested_model,
-            provider: tags.kind.map(|k| k.as_str()).unwrap_or("unknown"),
-            status: status_code,
-            streaming,
-        },
-        elapsed,
-    );
     let event = UsageEvent {
         request_id: request_id.to_string(),
         occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -13,7 +13,9 @@
 //! 400 with an explanatory message.
 
 use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse, FinishReason, UsageStats};
-use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, RequestOutcome, UsageEvent};
+use aisix_obs::{
+    content_capture_cap, AccessLog, CapturedContent, LatencyLabels, RequestOutcome, UsageEvent,
+};
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
 use axum::response::{IntoResponse, Response};
@@ -231,6 +233,7 @@ pub async fn responses(
                         &success.provider_key_id,
                         status,
                         elapsed,
+                        /* streaming */ false,
                         &usage,
                         &client,
                         attempt,
@@ -262,6 +265,19 @@ pub async fn responses(
                 metric_model,
                 status,
                 RequestOutcome::from_status(status),
+                elapsed,
+            );
+            state.metrics.record_request_e2e_latency(
+                LatencyLabels {
+                    endpoint: "/v1/responses",
+                    model: metric_model,
+                    provider: "unknown",
+                    status,
+                    streaming: body
+                        .get("stream")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
+                },
                 elapsed,
             );
             // Per #655: emit one zero-token UsageEvent per FAILED attempt so
@@ -1180,6 +1196,7 @@ async fn responses_to_target(
                     &provider_key_id_c,
                     200,
                     started.elapsed(),
+                    /* streaming */ true,
                     &usage,
                     &client_c,
                     attempt,
@@ -1554,6 +1571,7 @@ async fn responses_cross_provider_to_target(
                     &provider_key_id_c,
                     status,
                     started.elapsed(),
+                    /* streaming */ true,
                     &usage,
                     &client_c,
                     attempt_c,
@@ -2157,6 +2175,10 @@ fn emit_usage_event(
     provider_key_id: &str,
     status_code: u16,
     elapsed: Duration,
+    // SLO e2e histogram dimension (AISIX-Cloud#1011): callers pass true
+    // from the two stream-completion sites (where `elapsed` is the full
+    // stream duration), false from the non-streaming terminal emit.
+    streaming: bool,
     usage: &ResponseUsage,
     client: &ClientContext,
     attempt: AttemptInfo,
@@ -2173,6 +2195,18 @@ fn emit_usage_event(
 ) {
     let snap = state.snapshot.load();
     let tags = provider_telemetry_tags(&snap, provider_key_id);
+    // This function runs exactly once per successful request (attempts go
+    // through emit_zero_token_event), so it is the e2e observation point.
+    state.metrics.record_request_e2e_latency(
+        LatencyLabels {
+            endpoint: "/v1/responses",
+            model: requested_model,
+            provider: tags.kind.map(|k| k.as_str()).unwrap_or("unknown"),
+            status: status_code,
+            streaming,
+        },
+        elapsed,
+    );
     let event = UsageEvent {
         request_id: request_id.to_string(),
         occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -406,7 +406,10 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         }
         RateLimitBackend::Memory => Limiter::new(),
     });
-    let metrics = Arc::new(Metrics::new(true));
+    // env_id is resolved by now (managed provisioning / sidecar restore
+    // above); it becomes the constant `env_id` label on the SLO latency
+    // histograms. Standalone DPs leave it empty → "unknown".
+    let metrics = Arc::new(Metrics::new_with_env_id(&cfg.etcd.env_id));
     // Cache backends (#519 B.8). The memory cache is always built
     // (in-process, cheap); the redis cache is built iff `cache.redis`
     // is configured. Which instance serves a request is selected by

--- a/tests/e2e/src/cases/latency-histograms-e2e.test.ts
+++ b/tests/e2e/src/cases/latency-histograms-e2e.test.ts
@@ -1,0 +1,242 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// AISIX-Cloud#1011: TTFT and end-to-end request latency must be exposed
+// as REAL Prometheus histograms — `_bucket{le=…}` series that
+// `histogram_quantile()` can aggregate across DP instances — with a
+// dedicated low-cardinality label set (env_id / endpoint / model /
+// provider / status_class / streaming). The pre-existing duration series
+// render as summaries (client-side quantiles), which cannot be
+// re-aggregated; they stay untouched.
+//
+// Drives a real `aisix` + etcd + mock upstream through non-streaming,
+// streaming, and failing requests on /v1/chat/completions and
+// /v1/messages, then scrapes the dedicated metrics listener.
+
+const CALLER_PLAINTEXT = "sk-latency-histo-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const E2E_SERIES = "aisix_request_e2e_latency_seconds";
+const TTFT_SERIES = "aisix_request_ttft_seconds";
+
+describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let streamUpstream: OpenAiUpstream | undefined;
+  let failUpstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-histo",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "quick reply" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+      },
+    });
+    // The mock serves SSE whenever streamEvents is set, so streaming
+    // traffic gets its own upstream + model.
+    streamUpstream = await startOpenAiUpstream({
+      streamEvents: [
+        '{"id":"strm-histo","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+        '{"id":"strm-histo","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"streamed text"},"finish_reason":null}]}',
+        '{"id":"strm-histo","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+        "[DONE]",
+      ],
+      eventDelayMs: 20,
+    });
+    failUpstream = await startOpenAiUpstream({
+      status: 500,
+      errorBody: { error: { message: "mock outage", type: "server_error" } },
+    });
+
+    app = await spawnApp();
+    const admin = new AdminClient(app.adminUrl, app.adminKey);
+
+    const pk = await admin.createProviderKey({
+      display_name: "histo-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "histo-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    const streamPk = await admin.createProviderKey({
+      display_name: "histo-stream-pk",
+      secret: "sk-mock",
+      api_base: `${streamUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "histo-stream-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: streamPk.id,
+    });
+    const failPk = await admin.createProviderKey({
+      display_name: "histo-fail-pk",
+      secret: "sk-mock",
+      api_base: `${failUpstream.baseUrl}/v1`,
+    });
+    await admin.createModel({
+      display_name: "histo-fail-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: failPk.id,
+    });
+    await admin.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["histo-model", "histo-stream-model", "histo-fail-model"],
+    });
+
+    await waitConfigPropagation(async () => {
+      const r = await chat("histo-model", false);
+      return r.status === 200;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await streamUpstream?.close();
+    await failUpstream?.close();
+  });
+
+  async function chat(model: string, stream: boolean): Promise<Response> {
+    const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "hello" }],
+        ...(stream ? { stream: true } : {}),
+      }),
+    });
+    await res.text();
+    return res;
+  }
+
+  async function scrape(): Promise<string> {
+    const res = await fetch(`${app!.metricsUrl}/metrics`);
+    expect(res.status).toBe(200);
+    return res.text();
+  }
+
+  /** Lines of `series` matching every given label pair. */
+  function bucketLines(body: string, series: string, labels: Record<string, string>): string[] {
+    return body.split("\n").filter(
+      (l) =>
+        l.startsWith(`${series}_bucket{`) &&
+        Object.entries(labels).every(([k, v]) => l.includes(`${k}="${v}"`)),
+    );
+  }
+
+  test("non-streaming, streaming and failed requests land in le-bucketed series", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    expect((await chat("histo-model", false)).status).toBe(200);
+    expect((await chat("histo-stream-model", true)).status).toBe(200);
+    expect((await chat("histo-fail-model", false)).status).toBeGreaterThanOrEqual(500);
+
+    // Streaming observation happens at stream completion; poll the scrape.
+    let body = "";
+    const deadline = Date.now() + 10_000;
+    for (;;) {
+      body = await scrape();
+      const haveAll =
+        bucketLines(body, E2E_SERIES, { streaming: "false", status_class: "2xx" }).length > 0 &&
+        bucketLines(body, E2E_SERIES, { streaming: "true", status_class: "2xx" }).length > 0 &&
+        bucketLines(body, E2E_SERIES, { status_class: "5xx" }).length > 0 &&
+        bucketLines(body, TTFT_SERIES, { streaming: "true" }).length > 0;
+      if (haveAll || Date.now() > deadline) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    // Real histogram exposition for all three request shapes + TTFT.
+    const nonStream = bucketLines(body, E2E_SERIES, {
+      streaming: "false",
+      status_class: "2xx",
+      model: "histo-model",
+      endpoint: "/v1/chat/completions",
+      provider: "openai",
+    });
+    expect(nonStream.length, `non-streaming buckets in:\n${body}`).toBeGreaterThan(0);
+    expect(nonStream.some((l) => l.includes('le="+Inf"'))).toBe(true);
+
+    const streamed = bucketLines(body, E2E_SERIES, {
+      streaming: "true",
+      status_class: "2xx",
+      model: "histo-stream-model",
+    });
+    expect(streamed.length, "streaming e2e buckets").toBeGreaterThan(0);
+
+    const failed = bucketLines(body, E2E_SERIES, {
+      status_class: "5xx",
+      model: "histo-fail-model",
+    });
+    expect(failed.length, "failed-request buckets").toBeGreaterThan(0);
+
+    const ttft = bucketLines(body, TTFT_SERIES, {
+      streaming: "true",
+      model: "histo-stream-model",
+    });
+    expect(ttft.length, "TTFT buckets").toBeGreaterThan(0);
+
+    // histogram_quantile() needs _sum/_count too.
+    expect(body).toContain(`${E2E_SERIES}_sum`);
+    expect(body).toContain(`${E2E_SERIES}_count`);
+    expect(body).toContain(`${TTFT_SERIES}_sum`);
+
+    // env_id label present on every series line (standalone DP → unknown).
+    for (const l of [...nonStream, ...streamed, ...failed, ...ttft]) {
+      expect(l).toContain('env_id="');
+    }
+  });
+
+  test("the SLO series carry no per-key/per-user labels; legacy series stay summaries", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const body = await scrape();
+    for (const line of body.split("\n")) {
+      if (!line.startsWith(E2E_SERIES) && !line.startsWith(TTFT_SERIES)) continue;
+      for (const highCard of ["api_key_id", "user_id", "team_id", "provider_key_id", "user_name"]) {
+        expect(line, `no ${highCard} on SLO series`).not.toContain(`${highCard}="`);
+      }
+    }
+    // The pre-existing duration series keep their summary exposition —
+    // adding buckets to them would multiply their high-cardinality labels.
+    expect(body).not.toContain("aisix_llm_request_duration_seconds_bucket");
+    expect(body).not.toContain("aisix_proxy_request_duration_seconds_bucket");
+    expect(body).toContain("aisix_llm_request_duration_seconds");
+  });
+});

--- a/tests/e2e/src/cases/latency-histograms-e2e.test.ts
+++ b/tests/e2e/src/cases/latency-histograms-e2e.test.ts
@@ -19,8 +19,10 @@ import {
 // re-aggregated; they stay untouched.
 //
 // Drives a real `aisix` + etcd + mock upstream through non-streaming,
-// streaming, and failing requests on /v1/chat/completions and
-// /v1/messages, then scrapes the dedicated metrics listener.
+// streaming, and failing chat requests plus a /v1/messages request, then
+// scrapes the dedicated metrics listener. Exactly-once accounting is
+// pinned via _count (a double-observation or dropped-observation
+// regression shifts the count off 1).
 
 const CALLER_PLAINTEXT = "sk-latency-histo-caller";
 const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
@@ -157,6 +159,19 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
     );
   }
 
+  /** Sum of `series`_count across label combinations matching `labels`. */
+  function countOf(body: string, series: string, labels: Record<string, string>): number {
+    return body
+      .split("\n")
+      .filter(
+        (l) =>
+          l.startsWith(`${series}_count{`) &&
+          Object.entries(labels).every(([k, v]) => l.includes(`${k}="${v}"`)),
+      )
+      .map((l) => parseInt(l.split("}").at(-1)!.trim(), 10))
+      .reduce((a, b) => a + b, 0);
+  }
+
   test("non-streaming, streaming and failed requests land in le-bucketed series", async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();
@@ -165,6 +180,22 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
     expect((await chat("histo-model", false)).status).toBe(200);
     expect((await chat("histo-stream-model", true)).status).toBe(200);
     expect((await chat("histo-fail-model", false)).status).toBeGreaterThanOrEqual(500);
+    // One /v1/messages request so the anthropic-protocol wiring is covered.
+    const msg = await fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "x-api-key": CALLER_PLAINTEXT,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "histo-model",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    await msg.text();
+    expect(msg.status).toBe(200);
 
     // Streaming observation happens at stream completion; poll the scrape.
     let body = "";
@@ -209,6 +240,20 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
       model: "histo-stream-model",
     });
     expect(ttft.length, "TTFT buckets").toBeGreaterThan(0);
+
+    const messagesSeries = bucketLines(body, E2E_SERIES, {
+      endpoint: "/v1/messages",
+      model: "histo-model",
+    });
+    expect(messagesSeries.length, "/v1/messages buckets").toBeGreaterThan(0);
+
+    // Exactly-once accounting: this suite sent exactly ONE streaming chat
+    // to histo-stream-model — a double observation (e.g. handler-return
+    // AND stream-completion both recording) or a dropped one shifts this
+    // off 1. Same for its single TTFT.
+    expect(countOf(body, E2E_SERIES, { model: "histo-stream-model" })).toBe(1);
+    expect(countOf(body, TTFT_SERIES, { model: "histo-stream-model" })).toBe(1);
+    expect(countOf(body, E2E_SERIES, { model: "histo-fail-model" })).toBe(1);
 
     // histogram_quantile() needs _sum/_count too.
     expect(body).toContain(`${E2E_SERIES}_sum`);


### PR DESCRIPTION
## Problem

Every `histogram!` series in the DP is recorded with **no configured buckets**, so `metrics-exporter-prometheus` renders them all as **summaries** (client-side quantiles + `_sum`/`_count`). Summary quantiles cannot be fed to `histogram_quantile()`, cannot be aggregated across DP instances, and cannot be re-sliced by label — a global (or per-model/per-provider) p90 is not computable from the current scrape. On top of that, the existing latency series carry an 11-label set including per-key/per-user dimensions, so simply bucketing them would explode series count. (AISIX-Cloud#1011)

## Change

Two new SLO series with explicit buckets and a dedicated low-cardinality label set — `env_id`, `endpoint`, `model`, `provider`, `status_class` (bucketed `2xx`/`4xx`/…), `streaming`:

| series | semantics |
|---|---|
| `aisix_request_e2e_latency_seconds` | client-perceived end-to-end latency, observed **once per request**: at handler return for non-streaming requests and failures; at **stream completion** for committed streams (full stream duration — note the legacy summaries record only time-to-response-start for streams) |
| `aisix_request_ttft_seconds` | time-to-first-token, streaming requests only |

Buckets `0.01 … 300`s (14 edges — LLM-appropriate: cache hits/TTFT through multi-minute generations), configured via `set_buckets_for_metric(Matcher::Full…)` for exactly these two names, so **every existing series keeps its current summary exposition** (verified by tests). `env_id` is stamped as a constant label from the managed-provisioning config (`unknown` for standalone DPs); `model` uses the bounded metric-model label on failure paths (#911 cardinality guard).

Wired across the three routing endpoints — `/v1/chat/completions`, `/v1/messages` (both streaming variants), `/v1/responses` (verbatim + bridge streaming via the terminal-emit chokepoint) — success and failure arms.

Example query:
```promql
histogram_quantile(0.90, sum by (le, model) (rate(aisix_request_e2e_latency_seconds_bucket{status_class="2xx"}[5m])))
```

## Deliberately out of scope

- `completions`/`embeddings`/`rerank`/`images`/`audio`: non-routing endpoints; their failure paths don't even emit usage events today (#748) — will be wired together with that cleanup so coverage lands consistently rather than success-only.
- `/v1/messages/count_tokens`: routing-family endpoint but emits no usage events (free counting endpoint) — no latency SLO value.
- `/v1/responses` TTFT: neither streaming variant measures TTFT into a metric today (pre-existing; the bridge path stamps it on usage events only). Left as-is to avoid single-variant coverage that reads as endpoint-wide.
- Converting the legacy summaries to histograms: breaking for existing scrape consumers and multiplies an 11-label set by 15 buckets.

## Tests

- Unit: the two series render `_bucket{le=…}`/`_sum`/`_count` (a bucket-config regression is invisible otherwise); a 1.5s observation lands in `le=2.5` and not `le=1`; zero TTFT skipped; high-cardinality labels asserted absent; legacy series asserted to STAY summaries.
- e2e (real `aisix` + etcd + mock upstreams): non-streaming, streaming and failed requests each land in le-bucketed series with the right `streaming`/`status_class`; TTFT appears for the stream; `env_id` on every line; no per-key labels; legacy series still summary-shaped.
- `metrics-dimensions-890` + `metric-cardinality-passthrough` e2e regressions pass.

Baseline: mainstream gateways expose request latency and TTFT as bucketed Prometheus histograms with a shared bucket ladder; summaries are not used for latency. This change matches that pattern.

Fixes api7/AISIX-Cloud#1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)
