### PR TITLE
refactor(a2a)!: converge a2a_agent auth_type to the control-plane enum (drop oauth2)

### DIFF
--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -100,10 +100,6 @@ async fn read_capped(resp: reqwest::Response) -> Result<Vec<u8>, A2aError> {
 /// How the gateway authenticates to an upstream A2A agent. The credential is
 /// held here on the gateway side and is never exposed to the calling client —
 /// the client presents only its AISIX key.
-///
-/// The `oauth2` upstream auth type is accepted on the [`A2aAgent`] resource for
-/// forward compatibility but is not yet implemented in this runtime;
-/// [`upstream_from_a2a_agent`] rejects it with [`A2aError::Unsupported`].
 #[derive(Clone)]
 pub enum A2aAuth {
     /// No upstream auth — the agent is reachable as-is.
@@ -154,30 +150,22 @@ impl std::fmt::Debug for A2aUpstream {
 }
 
 /// Build an [`A2aUpstream`] from a registered [`A2aAgent`] resource.
-///
-/// Returns [`A2aError::Unsupported`] for the `oauth2` auth type, which this
-/// runtime does not implement yet.
-pub fn upstream_from_a2a_agent(agent: &A2aAgent) -> Result<A2aUpstream, A2aError> {
+pub fn upstream_from_a2a_agent(agent: &A2aAgent) -> A2aUpstream {
     let secret = agent.secret.clone().unwrap_or_default();
     let auth = match agent.auth_type {
         A2aAuthType::None => A2aAuth::None,
         A2aAuthType::Bearer => A2aAuth::Bearer(secret),
         A2aAuthType::ApiKey => A2aAuth::ApiKey(secret),
-        A2aAuthType::OAuth2 => {
-            return Err(A2aError::Unsupported(
-                "oauth2 upstream auth is not yet implemented".to_string(),
-            ))
-        }
     };
     let timeout = agent
         .timeout_ms
         .map(Duration::from_millis)
         .unwrap_or(DEFAULT_UPSTREAM_TIMEOUT);
-    Ok(A2aUpstream {
+    A2aUpstream {
         url: agent.url.clone(),
         auth,
         timeout,
-    })
+    }
 }
 
 /// An upstream agent's card, as fetched from its well-known URI.
@@ -306,24 +294,15 @@ mod tests {
     fn upstream_maps_none_bearer_api_key() {
         let mut none = agent("none");
         none.secret = None;
+        assert!(matches!(upstream_from_a2a_agent(&none).auth, A2aAuth::None));
         assert!(matches!(
-            upstream_from_a2a_agent(&none).unwrap().auth,
-            A2aAuth::None
-        ));
-        assert!(matches!(
-            upstream_from_a2a_agent(&agent("bearer")).unwrap().auth,
+            upstream_from_a2a_agent(&agent("bearer")).auth,
             A2aAuth::Bearer(_)
         ));
         assert!(matches!(
-            upstream_from_a2a_agent(&agent("api_key")).unwrap().auth,
+            upstream_from_a2a_agent(&agent("api_key")).auth,
             A2aAuth::ApiKey(_)
         ));
-    }
-
-    #[test]
-    fn upstream_rejects_oauth2_as_unsupported() {
-        let err = upstream_from_a2a_agent(&agent("oauth2")).unwrap_err();
-        assert!(matches!(err, A2aError::Unsupported(_)));
     }
 
     #[test]
@@ -331,11 +310,11 @@ mod tests {
         let mut a = agent("none");
         a.timeout_ms = Some(1234);
         assert_eq!(
-            upstream_from_a2a_agent(&a).unwrap().timeout,
+            upstream_from_a2a_agent(&a).timeout,
             Duration::from_millis(1234)
         );
         assert_eq!(
-            upstream_from_a2a_agent(&agent("none")).unwrap().timeout,
+            upstream_from_a2a_agent(&agent("none")).timeout,
             DEFAULT_UPSTREAM_TIMEOUT
         );
     }

--- a/crates/aisix-a2a/src/error.rs
+++ b/crates/aisix-a2a/src/error.rs
@@ -19,9 +19,4 @@ pub enum A2aError {
     /// status on the JSON-RPC call, or a malformed response body.
     #[error("upstream A2A request failed: {0}")]
     Request(String),
-
-    /// The configured upstream authentication method is not yet supported by
-    /// this data-plane runtime.
-    #[error("unsupported A2A upstream auth: {0}")]
-    Unsupported(String),
 }

--- a/crates/aisix-admin/src/a2a_agents_handlers.rs
+++ b/crates/aisix-admin/src/a2a_agents_handlers.rs
@@ -117,17 +117,6 @@ fn decode(raw: &Value) -> Result<A2aAgent, AdminError> {
                 "secret is required and must be non-empty when auth_type is `api_key`".to_string(),
             ));
         }
-        A2aAuthType::OAuth2 => {
-            let has_client_id = !agent.client_id.as_deref().unwrap_or_default().is_empty();
-            let has_token_url = !agent.token_url.as_deref().unwrap_or_default().is_empty();
-            if !has_secret || !has_client_id || !has_token_url {
-                return Err(AdminError::BadRequest(
-                    "client_id, token_url, and secret (the OAuth client secret) are required \
-                     and must be non-empty when auth_type is `oauth2`"
-                        .to_string(),
-                ));
-            }
-        }
         A2aAuthType::Bearer | A2aAuthType::ApiKey => {}
     }
     Ok(agent)
@@ -170,23 +159,18 @@ mod tests {
     }
 
     #[test]
-    fn decode_rejects_incomplete_oauth2() {
-        for missing in ["client_id", "token_url", "secret"] {
-            let mut v = json!({
-                "display_name": "agent",
-                "url": "https://x/a2a",
-                "auth_type": "oauth2",
-                "client_id": "cid",
-                "token_url": "https://auth.example.com/oauth/token",
-                "secret": "cs"
-            });
-            v.as_object_mut().unwrap().remove(missing);
-            let err = decode(&v).unwrap_err();
-            assert!(
-                matches!(err, AdminError::BadRequest(_)),
-                "oauth2 without `{missing}` must be a BadRequest"
-            );
-        }
+    fn decode_rejects_oauth2_auth_type_as_schema_error() {
+        // `oauth2` is not part of the a2a_agent resource model — `auth_type`
+        // allows only `none` / `bearer` / `api_key` — so a payload carrying it
+        // fails schema validation with a 400 before reaching the store.
+        let err = decode(&json!({
+            "display_name": "agent",
+            "url": "https://x/a2a",
+            "auth_type": "oauth2",
+            "secret": "cs"
+        }))
+        .expect_err("oauth2 auth_type must be rejected by schema validation");
+        assert_eq!(err.status(), axum::http::StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/a2a_agent.rs
+++ b/crates/aisix-core/src/models/a2a_agent.rs
@@ -48,35 +48,17 @@ pub struct A2aAgent {
 
     /// Credential AISIX uses to authenticate to the upstream agent. For
     /// `bearer`, AISIX sends it as `Authorization: Bearer <secret>`; for
-    /// `api_key`, AISIX sends it as `x-api-key: <secret>`. For `oauth2`, it is
-    /// stored as the client secret for forward compatibility, but the runtime
-    /// does not yet mint upstream A2A access tokens. Leave unset for `none`.
+    /// `api_key`, AISIX sends it as `x-api-key: <secret>`. Leave unset for
+    /// `none`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secret: Option<String>,
 
-    // Cross-field coupling (`oauth2` requires `client_id` + `secret` +
-    // `token_url`; `bearer`/`api_key` require `secret`) is deliberately NOT
-    // expressed in this flat schema — that would force restructuring the
-    // resource into a oneOf. The control plane enforces the coupling strictly
-    // at write time, this gateway's own Admin API re-checks it on write, and
-    // the runtime degrades gracefully when a snapshot-loaded agent is
-    // misconfigured.
-    /// OAuth client identifier stored for future OAuth 2.0 client credentials
-    /// support. Required when `auth_type` is `oauth2`; ignored otherwise.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub client_id: Option<String>,
-
-    /// OAuth token endpoint URL stored for future OAuth 2.0 client credentials
-    /// support, such as `https://auth.example.com/oauth/token`. Required when
-    /// `auth_type` is `oauth2`; ignored otherwise.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub token_url: Option<String>,
-
-    /// OAuth scopes stored for future OAuth 2.0 client credentials support.
-    /// Only used when `auth_type` is `oauth2`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub scopes: Option<Vec<String>>,
-
+    // Cross-field coupling (`bearer`/`api_key` require `secret`) is
+    // deliberately NOT expressed in this flat schema — that would force
+    // restructuring the resource into a oneOf. The control plane enforces the
+    // coupling strictly at write time, this gateway's own Admin API re-checks
+    // it on write, and the runtime degrades gracefully when a snapshot-loaded
+    // agent is misconfigured.
     /// Maximum time, in milliseconds, to wait for a single upstream operation,
     /// including fetching the agent card or invoking the agent. When omitted,
     /// AISIX applies a built-in default.
@@ -127,11 +109,6 @@ pub enum A2aAuthType {
     /// API key authentication. The key is supplied in `secret` and sent as an
     /// `x-api-key: <secret>` header on every upstream request.
     ApiKey,
-    /// OAuth 2.0 client credentials grant. Accepted on the resource for forward
-    /// compatibility, but the runtime does not yet mint tokens for upstream A2A
-    /// agents.
-    #[serde(rename = "oauth2")]
-    OAuth2,
 }
 
 impl Resource for A2aAgent {
@@ -164,9 +141,6 @@ mod tests {
         assert_eq!(a.protocol_version, A2aProtocolVersion::V1_0);
         assert_eq!(a.auth_type, A2aAuthType::None);
         assert!(a.secret.is_none());
-        assert!(a.client_id.is_none());
-        assert!(a.token_url.is_none());
-        assert!(a.scopes.is_none());
         assert!(a.timeout_ms.is_none());
         assert!(a.enabled);
     }
@@ -185,19 +159,26 @@ mod tests {
     }
 
     #[test]
-    fn deserialises_with_oauth2_auth() {
-        let a: A2aAgent = serde_json::from_str(
-            r#"{"display_name":"a","url":"https://x/a2a","auth_type":"oauth2","secret":"cs-1","client_id":"cid","token_url":"https://auth/x/token","scopes":["read","write"]}"#,
+    fn rejects_oauth2_auth_type_and_oauth_fields() {
+        // `auth_type` accepts only `none` / `bearer` / `api_key` — the same
+        // closed set as the control plane's a2a_agent resource.
+        assert!(serde_json::from_str::<A2aAgent>(
+            r#"{"display_name":"a","url":"https://x/a2a","auth_type":"oauth2","secret":"cs-1"}"#,
         )
-        .unwrap();
-        assert_eq!(a.auth_type, A2aAuthType::OAuth2);
-        assert_eq!(a.secret.as_deref(), Some("cs-1"));
-        assert_eq!(a.client_id.as_deref(), Some("cid"));
-        assert_eq!(a.token_url.as_deref(), Some("https://auth/x/token"));
-        assert_eq!(
-            a.scopes.as_deref(),
-            Some(&["read".to_string(), "write".to_string()][..])
-        );
+        .is_err());
+        // The OAuth-specific fields were removed with the `oauth2` arm, so a
+        // document carrying one is rejected as an unknown field.
+        for field in [
+            r#""client_id":"cid""#,
+            r#""token_url":"https://auth/x/token""#,
+            r#""scopes":["read","write"]"#,
+        ] {
+            let doc = format!(r#"{{"display_name":"a","url":"https://x/a2a",{field}}}"#);
+            assert!(
+                serde_json::from_str::<A2aAgent>(&doc).is_err(),
+                "field must be rejected as unknown: {doc}"
+            );
+        }
     }
 
     #[test]
@@ -210,14 +191,18 @@ mod tests {
     }
 
     #[test]
-    fn oauth2_round_trips_and_omits_unset_optionals() {
+    fn api_key_round_trips_and_omits_unset_optionals() {
         let original: A2aAgent = serde_json::from_str(
-            r#"{"display_name":"a","url":"https://x/a2a","auth_type":"oauth2","secret":"cs","client_id":"cid","token_url":"https://auth/token"}"#,
+            r#"{"display_name":"a","url":"https://x/a2a","auth_type":"api_key","secret":"k-1"}"#,
         )
         .unwrap();
         let s = serde_json::to_string(&original).unwrap();
-        assert!(s.contains(r#""auth_type":"oauth2""#), "got: {s}");
-        assert!(!s.contains("scopes"), "unset scopes must be omitted: {s}");
+        // The tag serialises as `api_key` (not a PascalCased `ApiKey`).
+        assert!(s.contains(r#""auth_type":"api_key""#), "got: {s}");
+        assert!(
+            !s.contains("timeout_ms"),
+            "unset timeout_ms must be omitted: {s}"
+        );
         let back: A2aAgent = serde_json::from_str(&s).unwrap();
         assert_eq!(original, back);
     }
@@ -259,9 +244,6 @@ mod tests {
             protocol_version: A2aProtocolVersion::V1_0,
             auth_type: A2aAuthType::None,
             secret: None,
-            client_id: None,
-            token_url: None,
-            scopes: None,
             timeout_ms: None,
             enabled: true,
             runtime_id: String::new(),

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -231,7 +231,6 @@ pub fn a2a_agent_root_schema() -> Value {
                 ("none", "No authentication"),
                 ("bearer", "Bearer token"),
                 ("api_key", "API key"),
-                ("oauth2", "OAuth 2.0 client credentials"),
             ],
         );
         title_single_value_enum_variants(

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -121,23 +121,7 @@ async fn dispatch(
             .into_response();
     }
 
-    let upstream = match upstream_from_a2a_agent(&entry.value) {
-        Ok(upstream) => upstream,
-        // Currently only oauth2 upstream auth, which the runtime does not
-        // implement yet — surface it as "not implemented".
-        Err(err) => {
-            emit_a2a_usage(
-                state,
-                &auth,
-                request_id,
-                agent,
-                "",
-                StatusCode::NOT_IMPLEMENTED.as_u16(),
-                Duration::ZERO,
-            );
-            return (StatusCode::NOT_IMPLEMENTED, err.to_string()).into_response();
-        }
-    };
+    let upstream = upstream_from_a2a_agent(&entry.value);
 
     let (_parts, body) = request.into_parts();
     let bytes = match to_bytes(body, state.request_body_limit_bytes).await {
@@ -231,10 +215,7 @@ pub async fn a2a_agent_card(
         )
             .into_response();
     }
-    let upstream = match upstream_from_a2a_agent(&entry.value) {
-        Ok(upstream) => upstream,
-        Err(err) => return (StatusCode::NOT_IMPLEMENTED, err.to_string()).into_response(),
-    };
+    let upstream = upstream_from_a2a_agent(&entry.value);
 
     let bridge = HttpBridge::new(upstream);
     let mut card = match bridge.fetch_agent_card().await {
@@ -267,12 +248,11 @@ fn gateway_base(headers: &HeaderMap) -> Option<String> {
     Some(format!("{scheme}://{host}"))
 }
 
-/// Map a bridge error to the client-visible HTTP status: an upstream that could
-/// not be reached is a bad gateway; a not-yet-supported config is not
-/// implemented; anything else from the call is a bad gateway too.
+/// Map a bridge error to the client-visible HTTP status: whether the upstream
+/// could not be reached or the call itself failed, the gateway surfaces it as
+/// a bad gateway.
 fn a2a_error_status(err: &A2aError) -> StatusCode {
     match err {
-        A2aError::Unsupported(_) => StatusCode::NOT_IMPLEMENTED,
         A2aError::Connect(_) | A2aError::Request(_) => StatusCode::BAD_GATEWAY,
     }
 }
@@ -329,11 +309,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn error_status_maps_unsupported_to_501_and_transport_to_502() {
-        assert_eq!(
-            a2a_error_status(&A2aError::Unsupported("oauth2".into())),
-            StatusCode::NOT_IMPLEMENTED
-        );
+    fn error_status_maps_transport_errors_to_502() {
         assert_eq!(
             a2a_error_status(&A2aError::Connect("dns".into())),
             StatusCode::BAD_GATEWAY

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -28,14 +28,6 @@
           ],
           "title": "API key",
           "type": "string"
-        },
-        {
-          "description": "OAuth 2.0 client credentials grant. Accepted on the resource for forward compatibility, but the runtime does not yet mint tokens for upstream A2A agents.",
-          "enum": [
-            "oauth2"
-          ],
-          "title": "OAuth 2.0 client credentials",
-          "type": "string"
         }
       ]
     },
@@ -71,13 +63,6 @@
       "default": "none",
       "description": "How the gateway authenticates to the upstream agent. The credential is held by the gateway and is never forwarded from or exposed to the calling client."
     },
-    "client_id": {
-      "description": "OAuth client identifier stored for future OAuth 2.0 client credentials support. Required when `auth_type` is `oauth2`; ignored otherwise.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "display_name": {
       "description": "Operator-facing label, unique within the gateway. It is the path segment under which the agent is exposed to callers as `/a2a/<display_name>`, so it must be a single non-empty URL path segment.",
       "minLength": 1,
@@ -97,18 +82,8 @@
       "default": "1.0",
       "description": "The A2A wire-format version AISIX uses for this agent. AISIX pins the version explicitly so the served agent card and accepted requests stay consistent."
     },
-    "scopes": {
-      "description": "OAuth scopes stored for future OAuth 2.0 client credentials support. Only used when `auth_type` is `oauth2`.",
-      "items": {
-        "type": "string"
-      },
-      "type": [
-        "array",
-        "null"
-      ]
-    },
     "secret": {
-      "description": "Credential AISIX uses to authenticate to the upstream agent. For `bearer`, AISIX sends it as `Authorization: Bearer <secret>`; for `api_key`, AISIX sends it as `x-api-key: <secret>`. For `oauth2`, it is stored as the client secret for forward compatibility, but the runtime does not yet mint upstream A2A access tokens. Leave unset for `none`.",
+      "description": "Credential AISIX uses to authenticate to the upstream agent. For `bearer`, AISIX sends it as `Authorization: Bearer <secret>`; for `api_key`, AISIX sends it as `x-api-key: <secret>`. Leave unset for `none`.",
       "type": [
         "string",
         "null"
@@ -120,13 +95,6 @@
       "minimum": 1.0,
       "type": [
         "integer",
-        "null"
-      ]
-    },
-    "token_url": {
-      "description": "OAuth token endpoint URL stored for future OAuth 2.0 client credentials support, such as `https://auth.example.com/oauth/token`. Required when `auth_type` is `oauth2`; ignored otherwise.",
-      "type": [
-        "string",
         "null"
       ]
     },


### PR DESCRIPTION
## What

Converge the `a2a_agent` resource's `auth_type` to the control-plane resource model, per the repo rule **"The Resource Model Is Canonical in cp-admin.yaml"** (CLAUDE.md): the control-plane spec allows only `none` / `bearer` / `api_key` for A2A agents and defines no OAuth fields on this resource.

The `oauth2` arm here was schema-only forward compatibility: the runtime never implemented it, so an agent configured with `auth_type: oauth2` always answered `501 Not Implemented` at request time, and the control plane never accepted such a document in the first place. After this change, schema == spec == runtime reality.

(The `mcp_server` resource's `oauth2` auth is a different story — it is part of the control-plane spec **and** fully implemented in the runtime. It is deliberately untouched.)

## Changes

- `crates/aisix-core/src/models/a2a_agent.rs` — remove the `A2aAuthType::OAuth2` variant and the oauth2-exclusive `client_id` / `token_url` / `scopes` fields (none of which exist on the control-plane a2a_agent resource, and none of which were read by the `bearer` / `api_key` paths); update the `secret` doc comment accordingly.
- `crates/aisix-core/src/models/schema.rs` — drop the `oauth2` title entry from the generated `A2aAuthType` schema.
- `crates/aisix-a2a/src/bridge.rs` — `upstream_from_a2a_agent` is now infallible (every representable `auth_type` maps to a working upstream auth); remove the forward-compat doc note.
- `crates/aisix-a2a/src/error.rs` — remove the now-unconstructable `A2aError::Unsupported` variant.
- `crates/aisix-proxy/src/a2a.rs` — delete the unreachable `501` branches in the `/a2a/:agent` dispatch and agent-card handlers and the `Unsupported → 501` status mapping.
- `crates/aisix-admin/src/a2a_agents_handlers.rs` — delete the oauth2 credential-coupling check; an `oauth2` payload now fails schema validation up front.
- `schemas/resources/a2a_agent.schema.json` — regenerated (`cargo run -p aisix-core --bin dump-schema`).

Test coverage was converted, not deleted:

- model: `oauth2` acceptance test → rejection test (`auth_type: "oauth2"` and each former OAuth field now fail deserialization), plus an `api_key` round-trip test replacing the oauth2 round-trip.
- Admin API: "incomplete oauth2 → 400" → "`oauth2` auth_type → 400 schema rejection".
- proxy: status-map test keeps the `Connect`/`Request` → `502` assertions.

No case under `tests/e2e/` references the `/a2a` surface, so there was no oauth2 e2e pin to convert.

## Compatibility note (breaking)

Stored `a2a_agent` documents carrying `auth_type: oauth2` — only creatable through the standalone Admin API, and always `501` at request time — no longer validate: the snapshot loader skips them with a warning and surfaces them as rejected entries, and the Admin API rejects such payloads with `400` (previously accepted-then-`501`). Documents using `none` / `bearer` / `api_key` are unaffected; no field they use changed.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p aisix-core -p aisix-a2a -p aisix-admin -p aisix-proxy` — 1126 passed, 0 failed, 2 ignored (pre-existing)
- `cargo run -p aisix-core --bin dump-schema` — only `schemas/resources/a2a_agent.schema.json` changed (drift gate will agree)
- `cargo run -p aisix-admin --bin dump-openapi` — succeeds; in the dumped spec the `A2aAgent` / `A2aAgentEntry` / `A2aAuthType` components carry no `oauth2` / `client_id` / `token_url` / `scopes` remnant, while `McpServer` still documents its (implemented) `oauth2`
- `cargo build --bin aisix` — succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed OAuth 2.0 authentication support from A2A agent configuration.
  * OAuth 2.0 configurations and related fields are now rejected during validation.
  * Supported authentication methods are now limited to None, Bearer, and API key.

* **Bug Fixes**
  * Simplified A2A connection handling and removed incorrect “Not Implemented” responses for unsupported authentication configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Standalone operators, two additional notes:** a previously stored `auth_type: oauth2` agent document is skipped by the loader after this change (WARN log `schema validation failed; skipping` plus the `schema_rejected` counter); find such documents via that log line and delete or fix them — `DELETE /admin/v1/a2a_agents/{id}` works without decoding the document. Calls to such an agent's `/a2a/<name>` path change from `501` to `404`, because the resource is absent from the snapshot.
