### PR TITLE
refactor(models): converge provider_key/mcp/a2a field names to the canonical resource model

### DIFF
--- a/crates/aisix-admin/src/a2a_agents_handlers.rs
+++ b/crates/aisix-admin/src/a2a_agents_handlers.rs
@@ -1,11 +1,11 @@
 //! CRUD handlers for `/admin/v1/a2a_agents`.
 //!
 //! Same shape as the McpServers handlers: validate against the JSON schema,
-//! reject duplicate display_names (409), generate a uuid v4 on POST, bump
-//! revision on PUT. The display_name is the path segment under which the agent
-//! is exposed (`/a2a/<display_name>`), so it must be a single URL path segment
-//! (no `/`). The per-auth_type credential coupling is enforced here too, since
-//! the flat schema stays permissive on it.
+//! reject duplicate names (409), generate a uuid v4 on POST, bump revision on
+//! PUT. The name is the path segment under which the agent is exposed
+//! (`/a2a/<name>`), so it must be a single URL path segment (no `/`). The
+//! per-auth_type credential coupling is enforced here too, since the flat
+//! schema stays permissive on it.
 
 use aisix_core::models::validate_a2a_agent;
 use aisix_core::resource::ResourceEntry;
@@ -49,7 +49,7 @@ pub async fn create_a2a_agent(
 ) -> Result<Json<ResourceEntry<A2aAgent>>, AdminError> {
     let agent = decode(&raw)?;
     let all = state.store.list_a2a_agents().await?;
-    assert_unique_display_name(&all, &agent.display_name, None)?;
+    assert_unique_name(&all, &agent.name, None)?;
 
     let id = Uuid::new_v4().to_string();
     let entry = ResourceEntry::new(&id, agent, STARTING_REVISION);
@@ -71,7 +71,7 @@ pub async fn update_a2a_agent(
     let agent = decode(&raw)?;
 
     let all = state.store.list_a2a_agents().await?;
-    assert_unique_display_name(&all, &agent.display_name, Some(&id))?;
+    assert_unique_name(&all, &agent.name, Some(&id))?;
 
     let entry = ResourceEntry::new(&id, agent, existing.revision + 1);
     state.store.put_a2a_agent(entry.clone()).await?;
@@ -94,11 +94,11 @@ fn decode(raw: &Value) -> Result<A2aAgent, AdminError> {
     validate_a2a_agent(raw)?;
     let agent: A2aAgent = serde_json::from_value(raw.clone())
         .map_err(|e| AdminError::BadRequest(format!("malformed A2aAgent payload: {e}")))?;
-    // The display_name is the path segment in `/a2a/<display_name>`, so it must
-    // be a single URL path segment.
-    if agent.display_name.contains('/') {
+    // The name is the path segment in `/a2a/<name>`, so it must be a single
+    // URL path segment.
+    if agent.name.contains('/') {
         return Err(AdminError::BadRequest(
-            "display_name must not contain `/` — it is the agent's URL path segment".to_string(),
+            "name must not contain `/` — it is the agent's URL path segment".to_string(),
         ));
     }
     // Per-auth_type credential coupling. The JSON schema stays flat and
@@ -122,14 +122,14 @@ fn decode(raw: &Value) -> Result<A2aAgent, AdminError> {
     Ok(agent)
 }
 
-fn assert_unique_display_name(
+fn assert_unique_name(
     existing: &[ResourceEntry<A2aAgent>],
-    display_name: &str,
+    name: &str,
     self_id: Option<&str>,
 ) -> Result<(), AdminError> {
     for e in existing {
-        if e.value.display_name == display_name && self_id.is_none_or(|sid| sid != e.id) {
-            return Err(AdminError::Conflict(display_name.to_string()));
+        if e.value.name == name && self_id.is_none_or(|sid| sid != e.id) {
+            return Err(AdminError::Conflict(name.to_string()));
         }
     }
     Ok(())
@@ -141,9 +141,9 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn decode_rejects_slash_in_display_name() {
+    fn decode_rejects_slash_in_name() {
         let err = decode(&json!({"display_name": "a/b", "url": "https://x/a2a"}))
-            .expect_err("`/` in display_name must be rejected");
+            .expect_err("`/` in the agent name must be rejected");
         assert!(matches!(err, AdminError::BadRequest(_)));
     }
 
@@ -183,7 +183,7 @@ mod tests {
             "secret": "tok"
         }))
         .expect("valid agent should decode");
-        assert_eq!(agent.display_name, "invoice-processor");
+        assert_eq!(agent.name, "invoice-processor");
         assert_eq!(agent.secret.as_deref(), Some("tok"));
     }
 }

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -12,8 +12,9 @@
 //! Admin-key protected routes:
 //! - `GET|POST            /admin/v1/models`
 //! - `GET|PUT|DELETE      /admin/v1/models/:id`
-//! - `GET|POST            /admin/v1/apikeys`
-//! - `GET|PUT|DELETE      /admin/v1/apikeys/:id`
+//! - `GET|POST            /admin/v1/api_keys` (also served at the former
+//!   `/admin/v1/apikeys` spelling, same handlers)
+//! - `GET|PUT|DELETE      /admin/v1/api_keys/:id`
 //! - `GET|POST            /admin/v1/provider_keys`
 //! - `GET|PUT|DELETE      /admin/v1/provider_keys/:id`
 //! - `GET|POST            /admin/v1/guardrails`
@@ -95,6 +96,23 @@ pub fn build_router(state: AdminState) -> Router {
         .route(
             "/admin/v1/models/status",
             get(models_status_handler::get_models_status),
+        )
+        // Caller API keys are served at the canonical `api_keys` path —
+        // the resource's configuration key — and at the former `apikeys`
+        // spelling. Same handlers; existing callers keep working.
+        .route(
+            "/admin/v1/api_keys",
+            get(apikeys_handlers::list_apikeys).post(apikeys_handlers::create_apikey),
+        )
+        .route(
+            "/admin/v1/api_keys/:id",
+            get(apikeys_handlers::get_apikey)
+                .put(apikeys_handlers::update_apikey)
+                .delete(apikeys_handlers::delete_apikey),
+        )
+        .route(
+            "/admin/v1/api_keys/:id/rotate",
+            post(apikeys_handlers::rotate_apikey),
         )
         .route(
             "/admin/v1/apikeys",
@@ -855,6 +873,66 @@ mod tests {
         let resp = run(
             app,
             auth_req("POST", "/admin/v1/apikeys/nonexistent/rotate", None),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // Caller API keys are served at both the canonical `/admin/v1/api_keys`
+    // path and the former `/admin/v1/apikeys` spelling — same handlers,
+    // same store. Pin that a resource written through one path is fully
+    // addressable through the other.
+    #[tokio::test]
+    async fn api_keys_canonical_and_former_paths_share_the_same_resources() {
+        let state = build_state();
+
+        // Create through the canonical path.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req(
+                "POST",
+                "/admin/v1/api_keys",
+                Some(apikey_payload("sk-canonical", &["my-model"])),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let created = body_json(resp).await;
+        let id = created["id"].as_str().unwrap().to_string();
+
+        // Read it back through the former spelling.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("GET", &format!("/admin/v1/apikeys/{id}"), None),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Rotate through the canonical spelling.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("POST", &format!("/admin/v1/api_keys/{id}/rotate"), None),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let rotated = body_json(resp).await;
+        assert_eq!(rotated["entry"]["revision"], 2);
+
+        // Delete through the former spelling; the canonical GET 404s.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("DELETE", &format!("/admin/v1/apikeys/{id}"), None),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let app = build_router(state);
+        let resp = run(
+            app,
+            auth_req("GET", &format!("/admin/v1/api_keys/{id}"), None),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/crates/aisix-admin/src/mcp_servers_handlers.rs
+++ b/crates/aisix-admin/src/mcp_servers_handlers.rs
@@ -1,9 +1,9 @@
 //! CRUD handlers for `/admin/v1/mcp_servers`.
 //!
 //! Same shape as the ProviderKeys handlers: validate against the JSON schema,
-//! reject duplicate display_names (409), generate a uuid v4 on POST, bump
-//! revision on PUT. Additionally rejects a display_name containing the reserved
-//! tool-namespace separator `__`, since the name prefixes the server's tools.
+//! reject duplicate names (409), generate a uuid v4 on POST, bump revision on
+//! PUT. Additionally rejects a name containing the reserved tool-namespace
+//! separator `__`, since the name prefixes the server's tools.
 
 use aisix_core::models::validate_mcp_server;
 use aisix_core::resource::ResourceEntry;
@@ -20,8 +20,7 @@ use crate::state::AdminState;
 const STARTING_REVISION: i64 = 1;
 
 /// Reserved separator between a server's name and a tool name in the gateway's
-/// aggregated namespace (`<display_name>__<tool>`). A server name must not
-/// contain it.
+/// aggregated namespace (`<name>__<tool>`). A server name must not contain it.
 const TOOL_NAMESPACE_SEPARATOR: &str = "__";
 
 pub async fn list_mcp_servers(
@@ -52,7 +51,7 @@ pub async fn create_mcp_server(
 ) -> Result<Json<ResourceEntry<McpServer>>, AdminError> {
     let mcp_server = decode(&raw)?;
     let all = state.store.list_mcp_servers().await?;
-    assert_unique_display_name(&all, &mcp_server.display_name, None)?;
+    assert_unique_name(&all, &mcp_server.name, None)?;
 
     let id = Uuid::new_v4().to_string();
     let entry = ResourceEntry::new(&id, mcp_server, STARTING_REVISION);
@@ -74,7 +73,7 @@ pub async fn update_mcp_server(
     let mcp_server = decode(&raw)?;
 
     let all = state.store.list_mcp_servers().await?;
-    assert_unique_display_name(&all, &mcp_server.display_name, Some(&id))?;
+    assert_unique_name(&all, &mcp_server.name, Some(&id))?;
 
     let entry = ResourceEntry::new(&id, mcp_server, existing.revision + 1);
     state.store.put_mcp_server(entry.clone()).await?;
@@ -97,9 +96,9 @@ fn decode(raw: &Value) -> Result<McpServer, AdminError> {
     validate_mcp_server(raw)?;
     let server: McpServer = serde_json::from_value(raw.clone())
         .map_err(|e| AdminError::BadRequest(format!("malformed McpServer payload: {e}")))?;
-    if server.display_name.contains(TOOL_NAMESPACE_SEPARATOR) {
+    if server.name.contains(TOOL_NAMESPACE_SEPARATOR) {
         return Err(AdminError::BadRequest(format!(
-            "display_name must not contain the reserved separator `{TOOL_NAMESPACE_SEPARATOR}`"
+            "name must not contain the reserved separator `{TOOL_NAMESPACE_SEPARATOR}`"
         )));
     }
     // Per-auth_type credential coupling. The JSON schema stays flat and
@@ -134,14 +133,14 @@ fn decode(raw: &Value) -> Result<McpServer, AdminError> {
     Ok(server)
 }
 
-fn assert_unique_display_name(
+fn assert_unique_name(
     existing: &[ResourceEntry<McpServer>],
-    display_name: &str,
+    name: &str,
     self_id: Option<&str>,
 ) -> Result<(), AdminError> {
     for e in existing {
-        if e.value.display_name == display_name && self_id.is_none_or(|sid| sid != e.id) {
-            return Err(AdminError::Conflict(display_name.to_string()));
+        if e.value.name == name && self_id.is_none_or(|sid| sid != e.id) {
+            return Err(AdminError::Conflict(name.to_string()));
         }
     }
     Ok(())
@@ -153,9 +152,9 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn decode_rejects_separator_in_display_name() {
+    fn decode_rejects_separator_in_name() {
         let err = decode(&json!({"display_name": "a__b", "url": "https://x/mcp"}))
-            .expect_err("`__` in display_name must be rejected");
+            .expect_err("`__` in the server name must be rejected");
         assert!(matches!(err, AdminError::BadRequest(_)));
     }
 
@@ -239,7 +238,7 @@ mod tests {
             "secret": "tok"
         }))
         .expect("valid server should decode");
-        assert_eq!(server.display_name, "github");
+        assert_eq!(server.name, "github");
         assert_eq!(server.secret.as_deref(), Some("tok"));
     }
 }

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -574,7 +574,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
         ]
       }
     },
-    "/admin/v1/apikeys": {
+    "/admin/v1/api_keys": {
       "get": {
         "summary": "List Caller API Keys",
         "responses": {
@@ -713,7 +713,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
         ]
       }
     },
-    "/admin/v1/apikeys/{id}": {
+    "/admin/v1/api_keys/{id}": {
       "parameters": [
         {
           "name": "id",
@@ -930,7 +930,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
         "description": "Delete a caller API key by ID."
       }
     },
-    "/admin/v1/apikeys/{id}/rotate": {
+    "/admin/v1/api_keys/{id}/rotate": {
       "parameters": [
         {
           "name": "id",
@@ -1417,7 +1417,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "400": {
-            "description": "Schema validation failed, the JSON body is malformed, `display_name` contains the reserved `__` separator, or the credentials required by `auth_type` are missing (`secret` for `bearer`/`api_key`; `client_id`, `token_url`, and `secret` for `oauth2`)",
+            "description": "Schema validation failed, the JSON body is malformed, `name` contains the reserved `__` separator, or the credentials required by `auth_type` are missing (`secret` for `bearer`/`api_key`; `client_id`, `token_url`, and `secret` for `oauth2`)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1442,7 +1442,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "409": {
-            "description": "Duplicate display_name",
+            "description": "Duplicate name",
             "content": {
               "application/json": {
                 "schema": {
@@ -1485,7 +1485,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
         "tags": [
           "MCP Servers"
         ],
-        "description": "Create an upstream MCP server resource. The gateway validates the payload, rejects duplicate `display_name` values, and returns the stored resource entry."
+        "description": "Create an upstream MCP server resource. The gateway validates the payload, rejects duplicate `name` values, and returns the stored resource entry."
       }
     },
     "/admin/v1/mcp_servers/{id}": {
@@ -1575,7 +1575,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "400": {
-            "description": "Schema validation failed, the JSON body is malformed, `display_name` contains the reserved `__` separator, or the credentials required by `auth_type` are missing (`secret` for `bearer`/`api_key`; `client_id`, `token_url`, and `secret` for `oauth2`)",
+            "description": "Schema validation failed, the JSON body is malformed, `name` contains the reserved `__` separator, or the credentials required by `auth_type` are missing (`secret` for `bearer`/`api_key`; `client_id`, `token_url`, and `secret` for `oauth2`)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1610,7 +1610,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "409": {
-            "description": "Duplicate display_name",
+            "description": "Duplicate name",
             "content": {
               "application/json": {
                 "schema": {
@@ -1653,7 +1653,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
         "tags": [
           "MCP Servers"
         ],
-        "description": "Update an upstream MCP server resource by ID. The gateway validates the payload, rejects duplicate `display_name` values, preserves the resource ID, and increments the revision."
+        "description": "Update an upstream MCP server resource by ID. The gateway validates the payload, rejects duplicate `name` values, preserves the resource ID, and increments the revision."
       },
       "delete": {
         "summary": "Delete MCP Server by ID",
@@ -1758,7 +1758,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
                 "$ref": "#/components/schemas/A2aAgent"
               },
               "example": {
-                "display_name": "invoice-processor",
+                "name": "invoice-processor",
                 "url": "https://agents.example.com/invoice",
                 "protocol_version": "0.3",
                 "auth_type": "none"
@@ -1778,7 +1778,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
                 "example": {
                   "id": "1d95ac57-7f27-46a4-b5a3-55d3c3ad0a12",
                   "value": {
-                    "display_name": "invoice-processor",
+                    "name": "invoice-processor",
                     "url": "https://agents.example.com/invoice",
                     "protocol_version": "0.3",
                     "auth_type": "none",
@@ -1790,7 +1790,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "400": {
-            "description": "Invalid request body, `display_name` contains `/`, or the selected `auth_type` is missing required credentials.",
+            "description": "Invalid request body, `name` contains `/`, or the selected `auth_type` is missing required credentials.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1815,7 +1815,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "409": {
-            "description": "Duplicate display_name",
+            "description": "Duplicate name",
             "content": {
               "application/json": {
                 "schema": {
@@ -1858,7 +1858,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
         "tags": [
           "A2A Agents"
         ],
-        "description": "Create an upstream A2A agent resource. The gateway validates the payload, rejects duplicate `display_name` values, and returns the stored resource entry."
+        "description": "Create an upstream A2A agent resource. The gateway validates the payload, rejects duplicate `name` values, and returns the stored resource entry."
       }
     },
     "/admin/v1/a2a_agents/{id}": {
@@ -1948,7 +1948,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             }
           },
           "400": {
-            "description": "Invalid request body, `display_name` contains `/`, or the selected `auth_type` is missing required credentials.",
+            "description": "Invalid request body, `name` contains `/`, or the selected `auth_type` is missing required credentials.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2016,7 +2016,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
         "tags": [
           "A2A Agents"
         ],
-        "description": "Update an upstream A2A agent resource by ID. The gateway validates the payload, rejects duplicate `display_name` values, preserves the resource ID, and increments the revision."
+        "description": "Update an upstream A2A agent resource by ID. The gateway validates the payload, rejects duplicate `name` values, preserves the resource ID, and increments the revision."
       },
       "delete": {
         "summary": "Delete A2A Agent by ID",
@@ -3684,7 +3684,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
         "example": {
           "id": "1d95ac57-7f27-46a4-b5a3-55d3c3ad0a12",
           "value": {
-            "display_name": "invoice-processor",
+            "name": "invoice-processor",
             "url": "https://agents.example.com/invoice",
             "protocol_version": "0.3",
             "auth_type": "none",
@@ -4112,15 +4112,66 @@ pub(crate) fn merged_openapi() -> &'static str {
         add_missing_property_descriptions(&mut doc);
         add_schema_defaults(&mut doc);
         add_schema_examples(&mut doc);
+        document_former_apikeys_paths(&mut doc);
         wrap_ref_siblings_for_redoc(&mut doc);
 
         serde_json::to_string(&doc).expect("merged OpenAPI must serialise")
     })
 }
 
+/// The caller API key operations are served at both the canonical
+/// `/admin/v1/api_keys` paths and the former `/admin/v1/apikeys` spelling
+/// (same handlers — see `build_router`). The base document describes the
+/// canonical paths; mirror each one onto the former path so the published
+/// reference matches the router exactly, without a second hand-maintained
+/// copy that could drift.
+fn document_former_apikeys_paths(doc: &mut Value) {
+    const PATH_PAIRS: &[(&str, &str)] = &[
+        ("/admin/v1/api_keys", "/admin/v1/apikeys"),
+        ("/admin/v1/api_keys/{id}", "/admin/v1/apikeys/{id}"),
+        (
+            "/admin/v1/api_keys/{id}/rotate",
+            "/admin/v1/apikeys/{id}/rotate",
+        ),
+    ];
+    for (canonical, former) in PATH_PAIRS {
+        let mut item = doc["paths"][*canonical].clone();
+        assert!(
+            item.is_object(),
+            "canonical path {canonical} must be documented"
+        );
+        if let Some(ops) = item.as_object_mut() {
+            for (method, op) in ops.iter_mut() {
+                if !matches!(method.as_str(), "get" | "post" | "put" | "delete") {
+                    continue;
+                }
+                let Some(op) = op.as_object_mut() else {
+                    continue;
+                };
+                if let Some(Value::String(summary)) = op.get_mut("summary") {
+                    summary.push_str(" (alternate path)");
+                }
+                let note = format!(
+                    "Alternate spelling of `{canonical}`. \
+                     Requests and responses are identical on both paths."
+                );
+                match op.get_mut("description") {
+                    Some(Value::String(description)) => {
+                        *description = format!("{note} {description}");
+                    }
+                    _ => {
+                        op.insert("description".to_string(), Value::String(note));
+                    }
+                }
+            }
+        }
+        doc["paths"][*former] = item;
+    }
+}
+
 fn add_schema_examples(doc: &mut Value) {
     doc["components"]["schemas"]["A2aAgent"]["example"] = json!({
-        "display_name": "invoice-processor",
+        "name": "invoice-processor",
         "url": "https://agents.example.com/invoice",
         "protocol_version": "0.3",
         "auth_type": "none"
@@ -4128,7 +4179,7 @@ fn add_schema_examples(doc: &mut Value) {
     doc["components"]["schemas"]["A2aAgentEntry"]["example"] = json!({
         "id": "1d95ac57-7f27-46a4-b5a3-55d3c3ad0a12",
         "value": {
-            "display_name": "invoice-processor",
+            "name": "invoice-processor",
             "url": "https://agents.example.com/invoice",
             "protocol_version": "0.3",
             "auth_type": "none",
@@ -4566,6 +4617,9 @@ mod tests {
             "/admin/v1/models",
             "/admin/v1/models/{id}",
             "/admin/v1/models/status",
+            "/admin/v1/api_keys",
+            "/admin/v1/api_keys/{id}",
+            "/admin/v1/api_keys/{id}/rotate",
             "/admin/v1/apikeys",
             "/admin/v1/apikeys/{id}",
             "/admin/v1/apikeys/{id}/rotate",
@@ -4652,6 +4706,9 @@ mod tests {
             "/admin/v1/models",
             "/admin/v1/models/{id}",
             "/admin/v1/models/status",
+            "/admin/v1/api_keys",
+            "/admin/v1/api_keys/{id}",
+            "/admin/v1/api_keys/{id}/rotate",
             "/admin/v1/apikeys",
             "/admin/v1/apikeys/{id}",
             "/admin/v1/apikeys/{id}/rotate",
@@ -4682,6 +4739,8 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(merged_openapi()).expect("merged_openapi must parse");
         for (path, method) in [
+            ("/admin/v1/api_keys", "post"),
+            ("/admin/v1/api_keys/{id}", "put"),
             ("/admin/v1/apikeys", "post"),
             ("/admin/v1/apikeys/{id}", "put"),
         ] {

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -212,7 +212,7 @@ async fn mcp_servers_round_trip_through_real_etcd() {
         state,
         "/admin/v1/mcp_servers",
         json!({
-            "display_name": "github-it",
+            "name": "github-it",
             "url": "https://api.example.com/mcp",
             "auth_type": "bearer",
             "secret": "tok-it"

--- a/crates/aisix-core/src/models/a2a_agent.rs
+++ b/crates/aisix-core/src/models/a2a_agent.rs
@@ -2,8 +2,8 @@
 //!
 //! Registers an upstream agent that speaks the A2A protocol (HTTP + JSON-RPC
 //! 2.0) so the gateway can front it: callers reach it through the gateway's own
-//! `/a2a/<display_name>` endpoint, its agent card is served (with URLs rewritten
-//! to the gateway) at `/a2a/<display_name>/.well-known/agent.json`, and
+//! `/a2a/<name>` endpoint, its agent card is served (with URLs rewritten
+//! to the gateway) at `/a2a/<name>/.well-known/agent.json`, and
 //! `message/send` / `message/stream` are routed through the same auth / ACL /
 //! guardrail / quota pipeline as LLM and MCP traffic. The upstream credential is
 //! held by the gateway and is never exposed to the calling client.
@@ -13,7 +13,7 @@
 //! Engine) and gateway-composed virtual agents are later additions and are not
 //! part of this entity yet.
 //!
-//! etcd path: `{prefix}/a2a_agents/{uuid}`. Secondary index on `display_name`.
+//! etcd path: `{prefix}/a2a_agents/{uuid}`. Secondary index on `name`.
 
 use serde::{Deserialize, Serialize};
 
@@ -23,10 +23,15 @@ use crate::resource::Resource;
 #[serde(deny_unknown_fields)]
 pub struct A2aAgent {
     /// Operator-facing label, unique within the gateway. It is the path segment
-    /// under which the agent is exposed to callers as `/a2a/<display_name>`, so
-    /// it must be a single non-empty URL path segment.
+    /// under which the agent is exposed to callers as `/a2a/<name>`, so it must
+    /// be a single non-empty URL path segment.
+    // `display_name` is the field's former name; stored documents and
+    // callers that still use it keep deserializing (schema-side acceptance
+    // lives in `schema::a2a_agent_root_schema`). Re-serialization always
+    // emits `name`.
+    #[serde(alias = "display_name")]
     #[schemars(length(min = 1))]
-    pub display_name: String,
+    pub name: String,
 
     /// The upstream agent's base URL, such as `https://agents.example.com/a2a`.
     /// AISIX reaches this URL over HTTP with the A2A JSON-RPC 2.0 protocol and
@@ -117,7 +122,7 @@ impl Resource for A2aAgent {
     }
 
     fn name(&self) -> &str {
-        &self.display_name
+        &self.name
     }
 
     fn kind() -> &'static str {
@@ -135,7 +140,7 @@ mod tests {
             r#"{"display_name":"invoice-processor","url":"https://agents.example.com/a2a"}"#,
         )
         .unwrap();
-        assert_eq!(a.display_name, "invoice-processor");
+        assert_eq!(a.name, "invoice-processor");
         assert_eq!(a.url, "https://agents.example.com/a2a");
         // Defaults.
         assert_eq!(a.protocol_version, A2aProtocolVersion::V1_0);
@@ -214,6 +219,42 @@ mod tests {
         assert!(r.is_err());
     }
 
+    // ---- `display_name` → `name` rename ----
+
+    #[test]
+    fn accepts_canonical_name_spelling() {
+        let a: A2aAgent =
+            serde_json::from_str(r#"{"name":"invoice","url":"https://x/a2a"}"#).unwrap();
+        assert_eq!(a.name, "invoice");
+    }
+
+    #[test]
+    fn serialises_label_under_name_only() {
+        // Emission contract: re-serialization uses the canonical `name`,
+        // never the former `display_name` spelling (the fixtures above
+        // keep exercising the deserialize-side alias).
+        let a: A2aAgent =
+            serde_json::from_str(r#"{"display_name":"invoice","url":"https://x/a2a"}"#).unwrap();
+        let json = serde_json::to_string(&a).unwrap();
+        assert!(json.contains(r#""name":"invoice""#), "got: {json}");
+        assert!(!json.contains("display_name"), "got: {json}");
+    }
+
+    #[test]
+    fn rejects_document_carrying_both_spellings() {
+        // serde maps the alias onto the same field, so a document that
+        // carries both spellings is a duplicate-field error — the
+        // ambiguity is rejected instead of one value silently winning.
+        let r: Result<A2aAgent, _> = serde_json::from_str(
+            r#"{"name":"invoice","display_name":"invoice-old","url":"https://x/a2a"}"#,
+        );
+        let err = r.expect_err("both spellings in one document must be rejected");
+        assert!(
+            err.to_string().contains("duplicate field"),
+            "expected a duplicate-field error, got: {err}"
+        );
+    }
+
     #[test]
     fn rejects_unknown_protocol_version_and_auth_type() {
         assert!(serde_json::from_str::<A2aAgent>(
@@ -227,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn resource_trait_routes_through_display_name() {
+    fn resource_trait_routes_through_name() {
         let mut a: A2aAgent =
             serde_json::from_str(r#"{"display_name":"invoice","url":"https://x/a2a"}"#).unwrap();
         a.runtime_id = "uuid-a2a-1".into();
@@ -239,7 +280,7 @@ mod tests {
     #[test]
     fn round_trip_omits_default_optionals() {
         let original = A2aAgent {
-            display_name: "invoice".into(),
+            name: "invoice".into(),
             url: "https://x/a2a".into(),
             protocol_version: A2aProtocolVersion::V1_0,
             auth_type: A2aAuthType::None,

--- a/crates/aisix-core/src/models/mcp_server.rs
+++ b/crates/aisix-core/src/models/mcp_server.rs
@@ -2,11 +2,11 @@
 //!
 //! Registers an upstream Model Context Protocol (MCP) server so the gateway can
 //! front it: its tools are aggregated into the gateway's own MCP endpoint under
-//! the namespace `<display_name>__<tool>`, and tool calls are routed back to it.
+//! the namespace `<name>__<tool>`, and tool calls are routed back to it.
 //! The upstream credential is held by the gateway and is never exposed to the
 //! calling client.
 //!
-//! etcd path: `{prefix}/mcp_servers/{uuid}`. Secondary index on `display_name`.
+//! etcd path: `{prefix}/mcp_servers/{uuid}`. Secondary index on `name`.
 
 use serde::{Deserialize, Serialize};
 
@@ -17,10 +17,14 @@ use crate::resource::Resource;
 pub struct McpServer {
     /// Operator-facing label, unique within the gateway. It is used as the
     /// namespace prefix for this server's tools, which are exposed to clients as
-    /// `<display_name>__<tool>`, so it must not contain the reserved separator
-    /// `__`.
+    /// `<name>__<tool>`, so it must not contain the reserved separator `__`.
+    // `display_name` is the field's former name; stored documents and
+    // callers that still use it keep deserializing (schema-side acceptance
+    // lives in `schema::mcp_server_root_schema`). Re-serialization always
+    // emits `name`.
+    #[serde(alias = "display_name")]
     #[schemars(length(min = 1))]
-    pub display_name: String,
+    pub name: String,
 
     /// The upstream server's MCP endpoint URL, reached over the Streamable HTTP
     /// transport, such as `https://api.example.com/mcp`.
@@ -134,7 +138,7 @@ impl Resource for McpServer {
     }
 
     fn name(&self) -> &str {
-        &self.display_name
+        &self.name
     }
 
     fn kind() -> &'static str {
@@ -152,7 +156,7 @@ mod tests {
             r#"{"display_name":"github","url":"https://api.example.com/mcp"}"#,
         )
         .unwrap();
-        assert_eq!(s.display_name, "github");
+        assert_eq!(s.name, "github");
         assert_eq!(s.url, "https://api.example.com/mcp");
         // Defaults.
         assert_eq!(s.transport, McpTransport::StreamableHttp);
@@ -225,6 +229,42 @@ mod tests {
         assert!(r.is_err());
     }
 
+    // ---- `display_name` → `name` rename ----
+
+    #[test]
+    fn accepts_canonical_name_spelling() {
+        let s: McpServer =
+            serde_json::from_str(r#"{"name":"github","url":"https://x/mcp"}"#).unwrap();
+        assert_eq!(s.name, "github");
+    }
+
+    #[test]
+    fn serialises_label_under_name_only() {
+        // Emission contract: re-serialization uses the canonical `name`,
+        // never the former `display_name` spelling (the fixtures above
+        // keep exercising the deserialize-side alias).
+        let s: McpServer =
+            serde_json::from_str(r#"{"display_name":"github","url":"https://x/mcp"}"#).unwrap();
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains(r#""name":"github""#), "got: {json}");
+        assert!(!json.contains("display_name"), "got: {json}");
+    }
+
+    #[test]
+    fn rejects_document_carrying_both_spellings() {
+        // serde maps the alias onto the same field, so a document that
+        // carries both spellings is a duplicate-field error — the
+        // ambiguity is rejected instead of one value silently winning.
+        let r: Result<McpServer, _> = serde_json::from_str(
+            r#"{"name":"github","display_name":"github-old","url":"https://x/mcp"}"#,
+        );
+        let err = r.expect_err("both spellings in one document must be rejected");
+        assert!(
+            err.to_string().contains("duplicate field"),
+            "expected a duplicate-field error, got: {err}"
+        );
+    }
+
     #[test]
     fn rejects_unknown_transport_and_auth_type() {
         assert!(serde_json::from_str::<McpServer>(
@@ -238,7 +278,7 @@ mod tests {
     }
 
     #[test]
-    fn resource_trait_routes_through_display_name() {
+    fn resource_trait_routes_through_name() {
         let mut s: McpServer =
             serde_json::from_str(r#"{"display_name":"github","url":"https://x/mcp"}"#).unwrap();
         s.runtime_id = "uuid-mcp-1".into();
@@ -250,7 +290,7 @@ mod tests {
     #[test]
     fn round_trip_omits_default_optionals() {
         let original = McpServer {
-            display_name: "github".into(),
+            name: "github".into(),
             url: "https://x/mcp".into(),
             transport: McpTransport::StreamableHttp,
             auth_type: McpAuthType::None,

--- a/crates/aisix-core/src/models/provider_key.rs
+++ b/crates/aisix-core/src/models/provider_key.rs
@@ -2,7 +2,7 @@
 //!
 //! A ProviderKey lets operators store an upstream provider's API key
 //! (OpenAI, Anthropic, Gemini, DeepSeek, …) once and have many Models
-//! reference it by id (`provider_key_id`). Rotating the secret then
+//! reference it by id (`provider_key_id`). Rotating the key then
 //! becomes a single PUT against the ProviderKey rather than rewriting
 //! every Model that uses it.
 //!
@@ -38,8 +38,13 @@ pub struct ProviderKey {
     /// Upstream provider's API key. The data plane receives plaintext so it
     /// can authenticate to the upstream provider. Protect the configuration
     /// store and transport accordingly.
+    // `secret` is the field's former name; stored documents and callers
+    // that still use it keep deserializing (schema-side acceptance lives
+    // in `schema::provider_key_root_schema`). Re-serialization always
+    // emits `api_key`.
+    #[serde(alias = "secret")]
     #[schemars(length(min = 1))]
-    pub secret: String,
+    pub api_key: String,
 
     /// Override base URL for the upstream provider. Required for custom or OpenAI-compatible providers that should not use a built-in vendor endpoint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -283,7 +288,7 @@ mod tests {
             serde_json::from_str(r#"{"display_name":"openai-prod","secret":"sk-prod-xxxx"}"#)
                 .unwrap();
         assert_eq!(p.display_name, "openai-prod");
-        assert_eq!(p.secret, "sk-prod-xxxx");
+        assert_eq!(p.api_key, "sk-prod-xxxx");
         assert!(p.api_base.is_none());
     }
 
@@ -301,6 +306,53 @@ mod tests {
         let r: Result<ProviderKey, _> =
             serde_json::from_str(r#"{"display_name":"x","secret":"k","extra":1}"#);
         assert!(r.is_err());
+    }
+
+    // ---- `secret` → `api_key` rename ----
+
+    #[test]
+    fn accepts_canonical_api_key_spelling() {
+        let p: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"openai-prod","api_key":"sk-prod-xxxx"}"#)
+                .unwrap();
+        assert_eq!(p.api_key, "sk-prod-xxxx");
+    }
+
+    #[test]
+    fn legacy_secret_spelling_still_deserialises() {
+        // Stored documents written before the rename spell the field
+        // `secret`; the serde alias must keep loading them. (Most other
+        // fixtures in this module double as coverage for this, but pin
+        // it explicitly so the intent survives fixture migrations.)
+        let p: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"openai-prod","secret":"sk-legacy"}"#).unwrap();
+        assert_eq!(p.api_key, "sk-legacy");
+    }
+
+    #[test]
+    fn serialises_credential_under_api_key_only() {
+        // Emission contract: re-serialization (admin GET responses,
+        // admin-written documents) uses the canonical name, never the
+        // former spelling.
+        let p: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"x","secret":"sk-x"}"#).unwrap();
+        let s = serde_json::to_string(&p).unwrap();
+        assert!(s.contains(r#""api_key":"sk-x""#), "got: {s}");
+        assert!(!s.contains(r#""secret""#), "got: {s}");
+    }
+
+    #[test]
+    fn rejects_document_carrying_both_spellings() {
+        // serde maps the alias onto the same field, so a document that
+        // carries both spellings is a duplicate-field error — the
+        // ambiguity is rejected instead of one value silently winning.
+        let r: Result<ProviderKey, _> =
+            serde_json::from_str(r#"{"display_name":"x","api_key":"sk-new","secret":"sk-old"}"#);
+        let err = r.expect_err("both spellings in one document must be rejected");
+        assert!(
+            err.to_string().contains("duplicate field"),
+            "expected a duplicate-field error, got: {err}"
+        );
     }
 
     #[test]
@@ -415,7 +467,7 @@ mod tests {
         // struct.
         let original = ProviderKey {
             display_name: "openai-prod".into(),
-            secret: "sk-x".into(),
+            api_key: "sk-x".into(),
             api_base: None,
             provider: String::new(),
             adapter: None,

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -87,7 +87,13 @@ pub fn validate(validator: &Validator, value: &Value) -> Result<(), SchemaError>
     if let Some(err) = errors.next() {
         return Err(SchemaError {
             path: err.instance_path.to_string(),
-            message: err.to_string(),
+            // Mask instance values in the message. Validation errors flow
+            // into logs, the rejection buffer surfaced upstream, and admin
+            // 400 bodies — and resource documents carry credentials. The
+            // renamed-field `anyOf` (see `accept_renamed_field`) sits at
+            // the document root, so its unmasked message would echo the
+            // whole stored document, credentials included.
+            message: err.masked().to_string(),
         });
     }
     Ok(())
@@ -2705,6 +2711,25 @@ mod tests {
         validate_a2a_agent(&json!({"name": "invoice", "url": "https://x/a2a"})).unwrap();
         validate_a2a_agent(&json!({"display_name": "invoice", "url": "https://x/a2a"})).unwrap();
         assert!(validate_a2a_agent(&json!({"url": "https://x/a2a"})).is_err());
+    }
+
+    #[test]
+    fn schema_error_for_missing_name_does_not_echo_the_document() {
+        // The renamed-field `anyOf` sits at the document root, and an
+        // unmasked anyOf failure message interpolates the entire failing
+        // instance — which for these resources can carry a live upstream
+        // credential. `validate` masks instance values, so a name-less
+        // document's error must not echo its `secret`.
+        let err = validate_mcp_server(&json!({
+            "url": "https://x/mcp",
+            "auth_type": "bearer",
+            "secret": "tok-sensitive"
+        }))
+        .expect_err("name-less document must fail");
+        assert!(
+            !err.to_string().contains("tok-sensitive"),
+            "validation error must not echo credential values; got: {err}"
+        );
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -185,8 +185,73 @@ pub fn apikey_root_schema() -> Value {
 /// `Option` representation (`true`): `TelemetryTags` carries fields cp-api
 /// sends as explicit `null` (`branded_provider`/`pk_label`/`byo_label`), and
 /// keeping all optionals nullable matches the resource's wire contract.
+/// The credential is accepted under both its canonical name `api_key` and
+/// its former name `secret` (see [`accept_renamed_field`]).
 pub fn provider_key_root_schema() -> Value {
-    struct_root_schema::<crate::models::ProviderKey>(true)
+    let mut schema = struct_root_schema::<crate::models::ProviderKey>(true);
+    accept_renamed_field(
+        &mut schema,
+        "api_key",
+        "secret",
+        "Accepted as an alternative spelling of `api_key`. \
+         Provide the credential under exactly one of the two names.",
+    );
+    schema
+}
+
+/// Mirror a struct field's `#[serde(alias = "…")]` in the generated schema.
+///
+/// `schemars` does not emit serde aliases, so a naively generated schema
+/// would list only the canonical name and — with `additionalProperties:
+/// false` — reject every stored document that still uses the former one at
+/// the snapshot loader's schema gate. This transform makes the generated
+/// schema accept both spellings:
+///
+/// - the former name is declared as a property with the same shape as the
+///   canonical one (so `minLength` and type constraints keep applying);
+/// - the canonical name is removed from `required` and requiredness becomes
+///   a top-level `anyOf` of the two single-field `required` forms — at
+///   least one spelling must be present;
+/// - `additionalProperties: false` stays intact, so unknown fields are
+///   still rejected.
+///
+/// A document carrying **both** spellings passes this schema and is then
+/// rejected by serde's duplicate-field check at deserialize (both names map
+/// to the same field), so the ambiguity never loads.
+fn accept_renamed_field(schema: &mut Value, canonical: &str, former: &str, note: &str) {
+    let obj = schema
+        .as_object_mut()
+        .expect("resource root schema is a JSON object");
+    assert!(
+        !obj.contains_key("anyOf"),
+        "top-level anyOf already in use; compose the rename acceptance with allOf instead"
+    );
+
+    let properties = obj
+        .get_mut("properties")
+        .and_then(Value::as_object_mut)
+        .expect("resource root schema has properties");
+    let mut former_schema = properties
+        .get(canonical)
+        .unwrap_or_else(|| panic!("schema property `{canonical}` exists"))
+        .clone();
+    if let Some(former_obj) = former_schema.as_object_mut() {
+        former_obj.insert("description".to_string(), Value::String(note.to_string()));
+    }
+    properties.insert(former.to_string(), former_schema);
+
+    if let Some(Value::Array(required)) = obj.get_mut("required") {
+        required.retain(|v| v.as_str() != Some(canonical));
+    }
+    // The branch titles label the two spellings in rendered references
+    // (reference UIs use `title` for `anyOf` tab labels).
+    obj.insert(
+        "anyOf".to_string(),
+        json!([
+            { "title": canonical, "required": [canonical] },
+            { "title": former, "required": [former] },
+        ]),
+    );
 }
 
 /// Canonical JSON Schema for the `mcp_server` resource, derived from the
@@ -198,9 +263,18 @@ pub fn provider_key_root_schema() -> Value {
 /// [`McpTransport`](crate::models::McpTransport) /
 /// [`McpAuthType`](crate::models::McpAuthType) enums. The per-`auth_type`
 /// credential coupling is intentionally not encoded here (see the note on the
-/// struct); the schema stays permissive and write paths enforce it.
+/// struct); the schema stays permissive and write paths enforce it. The label
+/// is accepted under both its canonical name `name` and its former name
+/// `display_name` (see [`accept_renamed_field`]).
 pub fn mcp_server_root_schema() -> Value {
     let mut schema = struct_root_schema::<crate::models::McpServer>(true);
+    accept_renamed_field(
+        &mut schema,
+        "name",
+        "display_name",
+        "Accepted as an alternative spelling of `name`. \
+         Provide the label under exactly one of the two names.",
+    );
     if let Some(Value::Object(defs)) = schema.get_mut("definitions") {
         title_single_value_enum_variants(
             defs,
@@ -221,8 +295,19 @@ pub fn mcp_server_root_schema() -> Value {
     schema
 }
 
+/// Canonical JSON Schema for the `a2a_agent` resource, derived from the
+/// [`A2aAgent`](crate::models::A2aAgent) struct. The label is accepted under
+/// both its canonical name `name` and its former name `display_name` (see
+/// [`accept_renamed_field`]).
 pub fn a2a_agent_root_schema() -> Value {
     let mut schema = struct_root_schema::<crate::models::A2aAgent>(true);
+    accept_renamed_field(
+        &mut schema,
+        "name",
+        "display_name",
+        "Accepted as an alternative spelling of `name`. \
+         Provide the label under exactly one of the two names.",
+    );
     if let Some(Value::Object(defs)) = schema.get_mut("definitions") {
         title_single_value_enum_variants(
             defs,
@@ -2569,6 +2654,74 @@ mod tests {
             }
         });
         assert!(validate_provider_key(&v).is_err());
+    }
+
+    // ---- renamed-field dual acceptance ----
+    //
+    // provider_key `secret`→`api_key` and mcp_server / a2a_agent
+    // `display_name`→`name`: the generated schema must accept both
+    // spellings (stored documents and current control-plane writes still
+    // carry the former names), require at least one, and keep rejecting
+    // unknown fields. A document carrying both spellings passes the
+    // schema and is rejected by serde's duplicate-field check — that
+    // split is pinned by the loader tests in `aisix-etcd`.
+
+    #[test]
+    fn provider_key_accepts_both_credential_spellings() {
+        validate_provider_key(&json!({"display_name": "x", "api_key": "sk-x"})).unwrap();
+        validate_provider_key(&json!({"display_name": "x", "secret": "sk-x"})).unwrap();
+    }
+
+    #[test]
+    fn provider_key_requires_at_least_one_credential_spelling() {
+        assert!(validate_provider_key(&json!({"display_name": "x"})).is_err());
+    }
+
+    #[test]
+    fn provider_key_former_spelling_keeps_field_constraints() {
+        // The former property clones the canonical one, so `minLength: 1`
+        // keeps applying under either name.
+        assert!(validate_provider_key(&json!({"display_name": "x", "api_key": ""})).is_err());
+        assert!(validate_provider_key(&json!({"display_name": "x", "secret": ""})).is_err());
+    }
+
+    #[test]
+    fn provider_key_schema_passes_document_with_both_spellings() {
+        // Schema-layer half of the both-spellings corner: `anyOf` admits
+        // the document; the serde layer rejects it as a duplicate field.
+        validate_provider_key(&json!({"display_name": "x", "api_key": "a", "secret": "b"}))
+            .unwrap();
+    }
+
+    #[test]
+    fn mcp_server_accepts_both_label_spellings() {
+        validate_mcp_server(&json!({"name": "github", "url": "https://x/mcp"})).unwrap();
+        validate_mcp_server(&json!({"display_name": "github", "url": "https://x/mcp"})).unwrap();
+        assert!(validate_mcp_server(&json!({"url": "https://x/mcp"})).is_err());
+    }
+
+    #[test]
+    fn a2a_agent_accepts_both_label_spellings() {
+        validate_a2a_agent(&json!({"name": "invoice", "url": "https://x/a2a"})).unwrap();
+        validate_a2a_agent(&json!({"display_name": "invoice", "url": "https://x/a2a"})).unwrap();
+        assert!(validate_a2a_agent(&json!({"url": "https://x/a2a"})).is_err());
+    }
+
+    #[test]
+    fn renamed_field_acceptance_keeps_unknown_fields_rejected() {
+        // The dual-name transform must not loosen `additionalProperties`.
+        assert!(
+            validate_provider_key(&json!({"display_name": "x", "api_key": "k", "rogue": 1}))
+                .is_err()
+        );
+        assert!(validate_mcp_server(
+            &json!({"name": "github", "url": "https://x/mcp", "rogue": 1})
+        )
+        .is_err());
+        assert!(validate_a2a_agent(
+            &json!({"name": "invoice", "url": "https://x/a2a", "rogue": 1})
+        )
+        .is_err());
     }
 
     // ---- mcp_server schema tests (#666 timeout_ms guard) ----

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -273,13 +273,22 @@ fn rate_limit_policy_corpus() {
 
 #[test]
 fn provider_key_corpus() {
+    // Corpus fixtures deliberately keep the credential's former `secret`
+    // spelling — they double as acceptance proof for stored documents
+    // written before the field's rename to `api_key`. The canonical
+    // spelling is pinned by the dedicated cases below.
     check(
         validate_provider_key,
         &[
             (
-                "minimal",
+                "minimal (former `secret` spelling)",
                 true,
                 json!({"display_name": "openai-prod", "secret": "sk-x"}),
+            ),
+            (
+                "minimal (canonical `api_key` spelling)",
+                true,
+                json!({"display_name": "openai-prod", "api_key": "sk-x"}),
             ),
             (
                 "with api_base + provider",
@@ -287,7 +296,16 @@ fn provider_key_corpus() {
                 json!({"display_name": "p", "secret": "sk-x", "api_base": "https://api.openai.com/v1", "provider": "deepseek"}),
             ),
             ("missing display_name", false, json!({"secret": "sk-x"})),
-            ("missing secret", false, json!({"display_name": "x"})),
+            (
+                "credential absent under both spellings",
+                false,
+                json!({"display_name": "x"}),
+            ),
+            (
+                "both credential spellings (schema layer admits; serde rejects the duplicate)",
+                true,
+                json!({"display_name": "x", "api_key": "a", "secret": "b"}),
+            ),
             (
                 "unknown top-level field",
                 false,
@@ -297,6 +315,11 @@ fn provider_key_corpus() {
                 "empty display_name",
                 false,
                 json!({"display_name": "", "secret": "k"}),
+            ),
+            (
+                "empty api_key",
+                false,
+                json!({"display_name": "x", "api_key": ""}),
             ),
             (
                 "empty secret",

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -549,6 +549,100 @@ mod tests {
         assert_eq!(stats.schema_rejected, 1);
     }
 
+    // ---- renamed-field dual acceptance ----
+    //
+    // provider_key `secret`→`api_key` and mcp_server / a2a_agent
+    // `display_name`→`name`: documents written under the former names
+    // (existing etcd data, current control-plane writes) and documents
+    // written under the canonical names must BOTH pass this loader's
+    // schema gate and serde parse. A regression here silently drops
+    // resources from the snapshot in managed mode.
+
+    #[test]
+    fn provider_key_accepts_both_credential_spellings() {
+        let entries = vec![
+            raw(
+                "/aisix/provider_keys/pk-former",
+                br#"{"display_name":"pk-former","secret":"sk-x"}"#,
+                1,
+            ),
+            raw(
+                "/aisix/provider_keys/pk-canonical",
+                br#"{"display_name":"pk-canonical","api_key":"sk-x"}"#,
+                2,
+            ),
+        ];
+        let (snap, stats) = build_snapshot("/aisix", &entries);
+        assert_eq!(stats.accepted, 2, "rejections: {:?}", stats.rejections);
+        assert_eq!(snap.provider_keys.len(), 2);
+        // Both spellings land on the same typed field.
+        for id in ["pk-former", "pk-canonical"] {
+            let entry = snap.provider_keys.get_by_id(id).unwrap();
+            assert_eq!(entry.value.api_key, "sk-x");
+        }
+    }
+
+    #[test]
+    fn provider_key_with_both_spellings_is_rejected_as_parse_failure() {
+        // The schema's `anyOf` admits a document carrying both spellings;
+        // serde then rejects it as a duplicate field (both names map to
+        // the same field), so the ambiguous row is skipped — not loaded
+        // with one value silently winning — and the batch continues.
+        let entries = vec![
+            raw(
+                "/aisix/provider_keys/pk-ambiguous",
+                br#"{"display_name":"pk-a","api_key":"sk-new","secret":"sk-old"}"#,
+                1,
+            ),
+            raw(
+                "/aisix/provider_keys/pk-good",
+                br#"{"display_name":"pk-good","api_key":"sk-x"}"#,
+                2,
+            ),
+        ];
+        let (snap, stats) = build_snapshot("/aisix", &entries);
+        assert_eq!(stats.schema_rejected, 0);
+        assert_eq!(stats.parse_rejected, 1);
+        assert_eq!(stats.accepted, 1);
+        assert_eq!(stats.rejections.len(), 1);
+        assert_eq!(stats.rejections[0].kind, RejectionKind::ParseFailed);
+        assert!(snap.provider_keys.get_by_id("pk-good").is_some());
+        assert!(snap.provider_keys.get_by_id("pk-ambiguous").is_none());
+    }
+
+    #[test]
+    fn mcp_server_and_a2a_agent_accept_both_label_spellings() {
+        let entries = vec![
+            raw(
+                "/aisix/mcp_servers/mcp-former",
+                br#"{"display_name":"gh-former","url":"https://x/mcp"}"#,
+                1,
+            ),
+            raw(
+                "/aisix/mcp_servers/mcp-canonical",
+                br#"{"name":"gh-canonical","url":"https://x/mcp"}"#,
+                2,
+            ),
+            raw(
+                "/aisix/a2a_agents/a2a-former",
+                br#"{"display_name":"agent-former","url":"https://x/a2a"}"#,
+                3,
+            ),
+            raw(
+                "/aisix/a2a_agents/a2a-canonical",
+                br#"{"name":"agent-canonical","url":"https://x/a2a"}"#,
+                4,
+            ),
+        ];
+        let (snap, stats) = build_snapshot("/aisix", &entries);
+        assert_eq!(stats.accepted, 4, "rejections: {:?}", stats.rejections);
+        // The name index is fed by the renamed field for both spellings.
+        assert!(snap.mcp_servers.get_by_name("gh-former").is_some());
+        assert!(snap.mcp_servers.get_by_name("gh-canonical").is_some());
+        assert!(snap.a2a_agents.get_by_name("agent-former").is_some());
+        assert!(snap.a2a_agents.get_by_name("agent-canonical").is_some());
+    }
+
     #[test]
     fn one_bad_entry_does_not_abort_the_batch() {
         let entries = vec![

--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -581,7 +581,7 @@ mod tests {
         // #367 follow-up: auth-material problems (empty/invalid secret,
         // unparseable credential JSON) are a 401 authentication_error,
         // not a 400 — they're a distinct class from request/routing shape.
-        let e = BridgeError::InvalidUpstreamCredentials("provider_key.secret is empty".into());
+        let e = BridgeError::InvalidUpstreamCredentials("provider_key.api_key is empty".into());
         assert_eq!(e.http_status(), 401);
         assert_eq!(e.error_type(), "authentication_error");
     }

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -146,7 +146,7 @@ impl McpGateway {
     /// Build a gateway whose upstreams are the **enabled** `mcp_servers` in the
     /// snapshot, each reached through an [`EphemeralBridge`] (connect per
     /// request). Disabled servers are skipped. Registration order follows the
-    /// snapshot's iteration order; duplicate display_names are deduped (first
+    /// snapshot's iteration order; duplicate names are deduped (first
     /// wins) by [`McpGateway::new`], though the Admin API already enforces
     /// uniqueness.
     pub fn from_snapshot(snapshot: &AisixSnapshot) -> Self {
@@ -158,7 +158,7 @@ impl McpGateway {
             .map(|entry| {
                 let upstream = upstream_from_mcp_server(&entry.value);
                 let bridge: Arc<dyn McpBridge> = Arc::new(EphemeralBridge::new(upstream));
-                (entry.value.display_name.clone(), bridge)
+                (entry.value.name.clone(), bridge)
             });
         McpGateway::new(upstreams)
     }

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -146,10 +146,10 @@ fn resolve_base(ctx: &BridgeContext) -> Result<String, BridgeError> {
 }
 
 fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
-    let k = &ctx.provider_key.secret;
+    let k = &ctx.provider_key.api_key;
     if k.is_empty() {
         return Err(BridgeError::InvalidUpstreamCredentials(
-            "provider_key.secret is empty".into(),
+            "provider_key.api_key is empty".into(),
         ));
     }
     // Reject a secret that can't be a valid `x-api-key` header value
@@ -158,7 +158,7 @@ fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
     // later with an opaque builder error (#367).
     if header::HeaderValue::from_str(k).is_err() {
         return Err(BridgeError::InvalidUpstreamCredentials(
-            "provider_key.secret contains invalid header characters".into(),
+            "provider_key.api_key contains invalid header characters".into(),
         ));
     }
     Ok(k.as_str())
@@ -545,7 +545,7 @@ mod tests {
     async fn missing_api_key_is_a_credentials_error() {
         let mut pk: ProviderKey =
             serde_json::from_str(r#"{"display_name":"empty","secret":"placeholder"}"#).unwrap();
-        pk.secret.clear();
+        pk.api_key.clear();
 
         let bridge = AnthropicBridge::new();
         let ctx = BridgeContext::new("req-1", sample_model(), Arc::new(pk));

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -52,7 +52,7 @@ pub struct AzureOpenAiBridge {
     /// traffic in metrics.
     name: &'static str,
     /// In-process AAD token cache + minter. Used only when the
-    /// inbound `ProviderKey.secret` parses to the AAD branch; the
+    /// inbound `ProviderKey.api_key` parses to the AAD branch; the
     /// api-key branch bypasses this entirely. `Arc` so the bridge
     /// remains cheaply clonable for callers that share it across
     /// Hub registrations.
@@ -128,7 +128,7 @@ impl AzureOpenAiBridge {
     /// surface as `Err` here so `chat()` / `chat_stream()` short-
     /// circuit BEFORE attempting the upstream Azure OpenAI call.
     async fn resolve_auth(&self, ctx: &BridgeContext) -> Result<AzureAuth, BridgeError> {
-        match AzureSecret::parse(&ctx.provider_key.secret)? {
+        match AzureSecret::parse(&ctx.provider_key.api_key)? {
             AzureSecret::ApiKey(key) => Ok(AzureAuth {
                 api_key: Some(key),
                 bearer_token: None,
@@ -288,7 +288,7 @@ impl AzureUpstreamRef {
                 // api-key / AAD path for auth, never URL-embedded.
                 return Err(BridgeError::InvalidUpstreamConfig(format!(
                     "azure api_base {base:?} must not embed userinfo (@); use the \
-                     api-key / AAD credentials in `provider_key.secret` instead"
+                     api-key / AAD credentials in `provider_key.api_key` instead"
                 )));
             }
             if base.contains('?') {
@@ -383,7 +383,7 @@ pub(crate) enum AzureSecret {
 }
 
 impl AzureSecret {
-    /// Parse the inbound `ProviderKey.secret` into either the api-key
+    /// Parse the inbound `ProviderKey.api_key` into either the api-key
     /// or AAD branch.
     ///
     /// **Audit-aware:** error messages MUST NOT echo raw secret
@@ -395,14 +395,14 @@ impl AzureSecret {
         let trimmed = secret.trim();
         if trimmed.is_empty() {
             return Err(BridgeError::InvalidUpstreamCredentials(
-                "provider_key.secret is empty".into(),
+                "provider_key.api_key is empty".into(),
             ));
         }
         if trimmed.starts_with('{') {
             let creds: crate::aad_token_mint::AadCredentials = serde_json::from_str(trimmed)
                 .map_err(|_e| {
                     BridgeError::InvalidUpstreamCredentials(
-                        "azure provider_key.secret looks JSON-shaped but failed to parse \
+                        "azure provider_key.api_key looks JSON-shaped but failed to parse \
                          as AAD client_credentials \
                          {tenant_id, client_id, client_secret}"
                             .into(),
@@ -1360,7 +1360,7 @@ mod tests {
     #[tokio::test]
     async fn chat_with_empty_secret_errors_before_dispatch() {
         let bridge = AzureOpenAiBridge::new();
-        // Build a PK whose secret is empty.
+        // Build a PK whose api_key is empty.
         let pk: Arc<ProviderKey> = Arc::new(
             serde_json::from_str(
                 r#"{"display_name": "azure-prod", "secret": "", "api_base": "https://acme-west.openai.azure.com"}"#,
@@ -1373,7 +1373,7 @@ mod tests {
         assert_eq!(err.http_status(), 401);
         match err {
             BridgeError::InvalidUpstreamCredentials(msg) => {
-                assert!(msg.contains("secret is empty"), "got {msg}");
+                assert!(msg.contains("api_key is empty"), "got {msg}");
             }
             other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }

--- a/crates/aisix-provider-azure-openai/src/lib.rs
+++ b/crates/aisix-provider-azure-openai/src/lib.rs
@@ -5,7 +5,7 @@
 //! ## Status (issue #302 Phase F)
 //!
 //! - [x] D6.1 — `api-key` header auth (resource-key scheme;
-//!   `provider_key.secret` is a verbatim string)
+//!   `provider_key.api_key` is a verbatim string)
 //! - [x] D6.2 — Azure URL pattern:
 //!   `https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<version>`
 //! - [x] D6.3 — Deployment-keyed dispatch from `Model.model_name`
@@ -18,7 +18,7 @@
 //!   (no `deny_unknown_fields`), so the extension passes through
 //!   without breaking decoding.
 //! - [x] D6.6 — AAD (Entra ID) Bearer auth as a second auth scheme.
-//!   `provider_key.secret` autodetects between the resource-key path
+//!   `provider_key.api_key` autodetects between the resource-key path
 //!   (verbatim string) and the AAD client_credentials path (JSON
 //!   `{tenant_id, client_id, client_secret}`) by checking the leading
 //!   character. The AAD path mints + caches tokens in-process via the

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -9,7 +9,7 @@
 //! publishers + streaming surface clear `not yet implemented` errors
 //! referencing D7.x follow-ups — see crate-level docs.
 //!
-//! Credentials: `ProviderKey.secret` is a JSON-encoded
+//! Credentials: `ProviderKey.api_key` is a JSON-encoded
 //! `{access_key_id, secret_access_key, session_token?, region}`
 //! struct. The bridge parses it per request (cheap — strings only)
 //! and constructs a per-call SDK client. `ProviderKey.api_base` (if
@@ -279,7 +279,7 @@ fn strip_region_prefix(model_id: &str) -> &str {
     }
 }
 
-/// Schema for `ProviderKey.secret` on a Bedrock provider key.
+/// Schema for `ProviderKey.api_key` on a Bedrock provider key.
 ///
 /// Convention: AWS credentials are JSON-encoded into the `secret`
 /// field. The cp-api side delivers them already-decrypted (mTLS-only
@@ -310,7 +310,7 @@ impl BedrockSecret {
     fn parse(secret: &str) -> Result<Self, BridgeError> {
         if secret.trim().is_empty() {
             return Err(BridgeError::InvalidUpstreamCredentials(
-                "bedrock provider_key.secret is empty — \
+                "bedrock provider_key.api_key is empty — \
                  expected JSON {access_key_id, secret_access_key, region, session_token?}"
                     .into(),
             ));
@@ -322,7 +322,7 @@ impl BedrockSecret {
             // in the JSON). Generic shape hint is enough for the
             // operator who controls the registration.
             BridgeError::InvalidUpstreamCredentials(
-                "bedrock provider_key.secret must be valid JSON: \
+                "bedrock provider_key.api_key must be valid JSON: \
                  {access_key_id, secret_access_key, region, session_token?}"
                     .into(),
             )
@@ -339,7 +339,7 @@ fn build_client(
 ) -> Result<BedrockClient, BridgeError> {
     if creds.region.trim().is_empty() {
         return Err(BridgeError::InvalidUpstreamConfig(
-            "bedrock provider_key.secret.region is empty — \
+            "bedrock provider_key.api_key.region is empty — \
              AWS Bedrock dispatch is region-keyed and requires e.g. \"us-west-2\""
                 .into(),
         ));
@@ -840,7 +840,7 @@ impl BedrockBridge {
         // Parse credentials per-request to keep the bridge stateless —
         // credential rotation lands as soon as the PK snapshot
         // refreshes, no client cache invalidation needed.
-        let creds = BedrockSecret::parse(&ctx.provider_key.secret)?;
+        let creds = BedrockSecret::parse(&ctx.provider_key.api_key)?;
         let endpoint_url = {
             #[cfg(test)]
             {
@@ -1925,8 +1925,8 @@ mod tests {
         match err {
             BridgeError::InvalidUpstreamCredentials(msg) => {
                 assert!(
-                    msg.contains("secret is empty"),
-                    "must mention empty secret; got {msg}"
+                    msg.contains("api_key is empty"),
+                    "must mention the empty api_key; got {msg}"
                 );
                 assert!(
                     msg.contains("access_key_id"),
@@ -2074,7 +2074,7 @@ mod tests {
         assert_eq!(err.http_status(), 401);
         match err {
             BridgeError::InvalidUpstreamCredentials(msg) => {
-                assert!(msg.contains("secret is empty"));
+                assert!(msg.contains("api_key is empty"));
             }
             other => panic!("expected InvalidUpstreamCredentials error, got {other:?}"),
         }

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -199,10 +199,10 @@ fn normalize_canonical_openai(base: &str) -> String {
 }
 
 fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
-    let k = &ctx.provider_key.secret;
+    let k = &ctx.provider_key.api_key;
     if k.is_empty() {
         return Err(BridgeError::InvalidUpstreamCredentials(
-            "provider_key.secret is empty".into(),
+            "provider_key.api_key is empty".into(),
         ));
     }
     // Reject a secret that can't be a valid Authorization header value
@@ -211,7 +211,7 @@ fn api_key(ctx: &BridgeContext) -> Result<&str, BridgeError> {
     // build_request_headers, so validating here covers them all (#367).
     if HeaderValue::from_str(k).is_err() {
         return Err(BridgeError::InvalidUpstreamCredentials(
-            "provider_key.secret contains invalid header characters".into(),
+            "provider_key.api_key contains invalid header characters".into(),
         ));
     }
     Ok(k.as_str())
@@ -1113,7 +1113,7 @@ mod tests {
         // upstream with a bare bearer (#367 follow-up).
         let mut pk: ProviderKey =
             serde_json::from_str(r#"{"display_name":"empty","secret":"placeholder"}"#).unwrap();
-        pk.secret.clear();
+        pk.api_key.clear();
 
         let bridge = OpenAiBridge::new();
         let ctx = BridgeContext::new("req-1", sample_model(), Arc::new(pk));

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -13,7 +13,7 @@
 //! an OpenAI-compatible body (model in BOTH the URL and the body). All
 //! five Vertex publisher rails are now wired.
 //!
-//! Credentials: `ProviderKey.secret` is a JSON-encoded
+//! Credentials: `ProviderKey.api_key` is a JSON-encoded
 //! `{access_token, project, region}` struct. The `access_token` is
 //! a pre-minted GCP OAuth2 bearer (operator-managed refresh; D5.1
 //! follow-up adds in-process JWT-signing).
@@ -325,7 +325,7 @@ impl VertexPublisher {
     }
 }
 
-/// `ProviderKey.secret` schema for a Vertex provider key.
+/// `ProviderKey.api_key` schema for a Vertex provider key.
 ///
 /// Convention: GCP credentials are JSON-encoded into the `secret`
 /// field. The operator chooses ONE of two credential modes:
@@ -373,7 +373,7 @@ impl VertexSecret {
     fn parse(secret: &str) -> Result<Self, BridgeError> {
         if secret.trim().is_empty() {
             return Err(BridgeError::InvalidUpstreamCredentials(
-                "vertex provider_key.secret is empty — \
+                "vertex provider_key.api_key is empty — \
                  expected JSON with project, region, and either access_token \
                  or service_account_json"
                     .into(),
@@ -381,7 +381,7 @@ impl VertexSecret {
         }
         let parsed: VertexSecret = serde_json::from_str(secret).map_err(|_e| {
             BridgeError::InvalidUpstreamCredentials(
-                "vertex provider_key.secret must be valid JSON: \
+                "vertex provider_key.api_key must be valid JSON: \
                  {project, region, and either access_token or service_account_json}"
                     .into(),
             )
@@ -392,7 +392,7 @@ impl VertexSecret {
         // generic "neither set".
         if parsed.access_token.as_deref().is_some_and(str::is_empty) {
             return Err(BridgeError::InvalidUpstreamCredentials(
-                "vertex provider_key.secret.access_token is empty".into(),
+                "vertex provider_key.api_key.access_token is empty".into(),
             ));
         }
         let has_token = parsed
@@ -402,14 +402,14 @@ impl VertexSecret {
         let has_sa = parsed.service_account_json.is_some();
         if has_token && has_sa {
             return Err(BridgeError::InvalidUpstreamCredentials(
-                "vertex provider_key.secret must set exactly one of access_token \
+                "vertex provider_key.api_key must set exactly one of access_token \
                  or service_account_json (both were provided)"
                     .into(),
             ));
         }
         if !has_token && !has_sa {
             return Err(BridgeError::InvalidUpstreamCredentials(
-                "vertex provider_key.secret must set either access_token or \
+                "vertex provider_key.api_key must set either access_token or \
                  service_account_json (neither was provided)"
                     .into(),
             ));
@@ -658,7 +658,7 @@ impl Bridge for VertexBridge {
         ctx: &BridgeContext,
     ) -> Result<EmbeddingResponse, BridgeError> {
         let upstream_id = upstream_model(ctx)?;
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
@@ -772,7 +772,7 @@ impl VertexBridge {
         ctx: &BridgeContext,
         upstream_id: &str,
     ) -> Result<ChatResponse, BridgeError> {
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         // Validate all URL-path tokens to keep operator-supplied
         // strings from injecting path segments / query params.
         validate_url_token("project", &creds.project)?;
@@ -871,7 +871,7 @@ impl VertexBridge {
         ctx: &BridgeContext,
         upstream_id: &str,
     ) -> Result<ChatResponse, BridgeError> {
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
@@ -959,7 +959,7 @@ impl VertexBridge {
         ctx: &BridgeContext,
         upstream_id: &str,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
@@ -1088,7 +1088,7 @@ impl VertexBridge {
         ctx: &BridgeContext,
         upstream_id: &str,
     ) -> Result<ChatResponse, BridgeError> {
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         // Only project + region are URL-path tokens; the model id rides
         // in the body and may legitimately contain `/` (e.g.
         // `meta/llama-3.3-70b-instruct-maas`), so it is NOT validated as
@@ -1148,7 +1148,7 @@ impl VertexBridge {
         ctx: &BridgeContext,
         upstream_id: &str,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
 
@@ -1270,7 +1270,7 @@ impl VertexBridge {
         upstream_id: &str,
         publisher: VertexPublisher,
     ) -> Result<ChatResponse, BridgeError> {
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
         // The model id is a URL path segment here (Mistral / AI21 ids are
@@ -1343,7 +1343,7 @@ impl VertexBridge {
         upstream_id: &str,
         publisher: VertexPublisher,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
@@ -1457,7 +1457,7 @@ impl VertexBridge {
         ctx: &BridgeContext,
         upstream_id: &str,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let creds = VertexSecret::parse(&ctx.provider_key.secret)?;
+        let creds = VertexSecret::parse(&ctx.provider_key.api_key)?;
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
@@ -1686,7 +1686,7 @@ fn build_request_headers(
 ) -> Result<HeaderMap, BridgeError> {
     if access_token.is_empty() {
         return Err(BridgeError::Config(
-            "vertex provider_key.secret.access_token is empty".into(),
+            "vertex provider_key.api_key.access_token is empty".into(),
         ));
     }
     let mut headers = HeaderMap::new();
@@ -2330,7 +2330,7 @@ mod tests {
         let err = VertexSecret::parse("").unwrap_err();
         match err {
             BridgeError::InvalidUpstreamCredentials(msg) => {
-                assert!(msg.contains("secret is empty"));
+                assert!(msg.contains("api_key is empty"));
             }
             other => panic!("expected InvalidUpstreamCredentials, got {other:?}"),
         }

--- a/crates/aisix-provider-vertex/src/lib.rs
+++ b/crates/aisix-provider-vertex/src/lib.rs
@@ -7,7 +7,7 @@
 //! - [x] D5.1 — In-process GCP OAuth2 token mint. The bridge now
 //!   accepts EITHER a pre-minted `access_token` (operator manages
 //!   refresh, backward-compatible) OR a full `service_account_json`
-//!   in `ProviderKey.secret`. When the SA path is taken, the bridge
+//!   in `ProviderKey.api_key`. When the SA path is taken, the bridge
 //!   signs a JWT with the SA's RSA private key, posts to the SA's
 //!   `token_uri` to mint an OAuth2 access token, and caches it
 //!   in-process keyed by SA `client_email` with TTL refresh ~60s

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -552,7 +552,7 @@ async fn multipart_dispatch(
     let provider = crate::dispatch::require_provider(model)?;
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
-    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
+    let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?;
 
     let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
     // build_v1_url owns the /v1 prefix; callers pass the suffix
@@ -923,7 +923,7 @@ async fn speech_dispatch(
     let provider = crate::dispatch::require_provider(model)?;
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
-    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
+    let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?;
 
     let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
     let provider_label = provider.to_ascii_lowercase();

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -259,7 +259,7 @@ async fn count_tokens_to_target(
 ) -> Result<Response, ProxyError> {
     let mut body = body.clone();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
-    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?;
+    let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?;
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
     // Rewrite the `model` field to the upstream value, exactly as the

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -246,20 +246,20 @@ pub(crate) fn build_v1_url(base: &str, path: &str) -> String {
     }
 }
 
-/// The upstream API key — `provider_key.secret`. Empty string is
+/// The upstream API key — `provider_key.api_key`. Empty string is
 /// treated as a config error (ProviderKey rows shouldn't be empty,
 /// but a hand-edited kine row could surface one).
-pub(crate) fn require_secret<'a>(
+pub(crate) fn require_api_key<'a>(
     provider_key: &'a ProviderKey,
     model: &Model,
 ) -> Result<&'a str, ProxyError> {
-    if provider_key.secret.is_empty() {
+    if provider_key.api_key.is_empty() {
         return Err(ProxyError::InvalidRequest(format!(
-            "model {:?} provider_key has empty secret",
+            "model {:?} provider_key has empty api_key",
             model.display_name
         )));
     }
-    Ok(provider_key.secret.as_str())
+    Ok(provider_key.api_key.as_str())
 }
 
 #[cfg(test)]

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -239,7 +239,7 @@ pub(crate) fn resolve_target(
             model.display_name, pk_entry.value.provider
         ))
     })?;
-    let secret = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
+    let secret = crate::dispatch::require_api_key(&pk_entry.value, model)?.to_string();
 
     Ok(JobTarget {
         model_entry,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -915,7 +915,7 @@ async fn anthropic_passthrough_dispatch(
     input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let mut body = body.clone();
-    let api_key = crate::dispatch::require_secret(pk_value, model)?;
+    let api_key = crate::dispatch::require_api_key(pk_value, model)?;
 
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -285,7 +285,7 @@ async fn dispatch(
     crate::dispatch::check_ip_access(model, source_ip)?;
 
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
-    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
+    let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?.to_string();
 
     // #911 [6]: resolve the guardrail chain for the model whose credentials
     // this passthrough borrows, so the raw tunnel is subject to the same

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -150,7 +150,7 @@ async fn prepare(
     crate::dispatch::check_ip_access(model, &client.source_ip)?;
 
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
-    let secret = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
+    let secret = crate::dispatch::require_api_key(&pk_entry.value, model)?.to_string();
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
     let upstream_request = match pk_entry.value.adapter {

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -321,7 +321,7 @@ async fn dispatch(
     }
 
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
-    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
+    let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?.to_string();
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
     // Rewrite model field.

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -843,7 +843,7 @@ async fn responses_to_target(
     // Resolved PK id for per-PK telemetry attribution on the emitted
     // UsageEvent (AISIX-Cloud#867).
     let provider_key_id = pk_entry.id.clone();
-    let api_key = crate::dispatch::require_secret(&pk_entry.value, model)?.to_string();
+    let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?.to_string();
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();
 
     // Rewrite model field to upstream name.

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -1,6 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "name"
+      ],
+      "title": "name"
+    },
+    {
+      "required": [
+        "display_name"
+      ],
+      "title": "display_name"
+    }
+  ],
   "definitions": {
     "A2aAuthType": {
       "description": "How the gateway authenticates to an upstream A2A agent.",
@@ -64,7 +78,7 @@
       "description": "How the gateway authenticates to the upstream agent. The credential is held by the gateway and is never forwarded from or exposed to the calling client."
     },
     "display_name": {
-      "description": "Operator-facing label, unique within the gateway. It is the path segment under which the agent is exposed to callers as `/a2a/<display_name>`, so it must be a single non-empty URL path segment.",
+      "description": "Accepted as an alternative spelling of `name`. Provide the label under exactly one of the two names.",
       "minLength": 1,
       "type": "string"
     },
@@ -72,6 +86,11 @@
       "default": true,
       "description": "Whether this agent is active. When `false`, it is not served and cannot be reached.",
       "type": "boolean"
+    },
+    "name": {
+      "description": "Operator-facing label, unique within the gateway. It is the path segment under which the agent is exposed to callers as `/a2a/<name>`, so it must be a single non-empty URL path segment.",
+      "minLength": 1,
+      "type": "string"
     },
     "protocol_version": {
       "allOf": [
@@ -105,7 +124,6 @@
     }
   },
   "required": [
-    "display_name",
     "url"
   ],
   "title": "A2aAgent",

--- a/schemas/resources/mcp_server.schema.json
+++ b/schemas/resources/mcp_server.schema.json
@@ -1,6 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "name"
+      ],
+      "title": "name"
+    },
+    {
+      "required": [
+        "display_name"
+      ],
+      "title": "display_name"
+    }
+  ],
   "definitions": {
     "McpAuthType": {
       "description": "How the gateway authenticates to an upstream MCP server.",
@@ -71,7 +85,7 @@
       ]
     },
     "display_name": {
-      "description": "Operator-facing label, unique within the gateway. It is used as the namespace prefix for this server's tools, which are exposed to clients as `<display_name>__<tool>`, so it must not contain the reserved separator `__`.",
+      "description": "Accepted as an alternative spelling of `name`. Provide the label under exactly one of the two names.",
       "minLength": 1,
       "type": "string"
     },
@@ -79,6 +93,11 @@
       "default": true,
       "description": "Whether this server is active. When `false`, its tools are not listed and cannot be called.",
       "type": "boolean"
+    },
+    "name": {
+      "description": "Operator-facing label, unique within the gateway. It is used as the namespace prefix for this server's tools, which are exposed to clients as `<name>__<tool>`, so it must not contain the reserved separator `__`.",
+      "minLength": 1,
+      "type": "string"
     },
     "scopes": {
       "description": "OAuth scopes to request. Joined with spaces into the `scope` parameter of the token request. Only used when `auth_type` is `oauth2`.",
@@ -129,7 +148,6 @@
     }
   },
   "required": [
-    "display_name",
     "url"
   ],
   "title": "McpServer",

--- a/schemas/resources/provider_key.schema.json
+++ b/schemas/resources/provider_key.schema.json
@@ -1,6 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "api_key"
+      ],
+      "title": "api_key"
+    },
+    {
+      "required": [
+        "secret"
+      ],
+      "title": "secret"
+    }
+  ],
   "definitions": {
     "Adapter": {
       "description": "Upstream API protocol family used for provider dispatch.",
@@ -208,6 +222,11 @@
         "null"
       ]
     },
+    "api_key": {
+      "description": "Upstream provider's API key. The data plane receives plaintext so it can authenticate to the upstream provider. Protect the configuration store and transport accordingly.",
+      "minLength": 1,
+      "type": "string"
+    },
     "display_name": {
       "description": "Operator-facing label, unique within the gateway. Surfaces in the Admin API list view and in dashboard UIs that wrap this resource.",
       "minLength": 1,
@@ -241,7 +260,7 @@
       "description": "Per-key response-shape overrides applied by provider bridges that support response transformation."
     },
     "secret": {
-      "description": "Upstream provider's API key. The data plane receives plaintext so it can authenticate to the upstream provider. Protect the configuration store and transport accordingly.",
+      "description": "Accepted as an alternative spelling of `api_key`. Provide the credential under exactly one of the two names.",
       "minLength": 1,
       "type": "string"
     },
@@ -271,8 +290,7 @@
     }
   },
   "required": [
-    "display_name",
-    "secret"
+    "display_name"
   ],
   "title": "ProviderKey",
   "type": "object"

--- a/tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts
@@ -282,10 +282,13 @@ describe("api key lifecycle e2e: expired/disabled keys fail closed, rotate swaps
     const plaintext = "sk-lifecycle-rotate";
     const { id } = await seedKey(plaintext, {}, is200);
 
+    // Rotate through the canonical `api_keys` route; the disabled-key
+    // rotation below keeps the former `apikeys` spelling so both stay
+    // exercised end-to-end.
     const rotated = await admin.json<{
       entry: { id: string };
       plaintext: string;
-    }>("POST", `/admin/v1/apikeys/${id}/rotate`);
+    }>("POST", `/admin/v1/api_keys/${id}/rotate`);
     expect(rotated.entry.id).toBe(id);
     expect(rotated.plaintext).not.toBe(plaintext);
 

--- a/tests/e2e/src/cases/auth-baseline-e2e.test.ts
+++ b/tests/e2e/src/cases/auth-baseline-e2e.test.ts
@@ -59,7 +59,9 @@ describe("auth baseline e2e: missing/malformed/unknown bearer all fail closed", 
     // must NOT degrade to "any-key-works".
     const pk = await seed.createProviderKey({
       display_name: "auth-baseline-pk",
-      secret: "sk-mock",
+      // Canonical credential spelling; most other cases still seed the
+      // former `secret` spelling, keeping both accepted long-term.
+      api_key: "sk-mock",
       api_base: `${upstream.baseUrl}/v1`,
     });
     await seed.createModel({

--- a/tests/e2e/src/cases/canary-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/canary-routing-e2e.test.ts
@@ -64,7 +64,7 @@ describe("sticky (A/B / canary) weighted routing e2e", () => {
     if (!seed) throw new Error("seed client not initialized");
     const providerKey = await seed.createProviderKey({
       display_name: `${displayName}-pk`,
-      secret: "sk-mock",
+      api_key: "sk-mock",
       api_base: `${upstream.baseUrl}/v1`,
     });
     await seed.createModel({

--- a/tests/e2e/src/cases/seed-vs-admin-characterization-e2e.test.ts
+++ b/tests/e2e/src/cases/seed-vs-admin-characterization-e2e.test.ts
@@ -53,8 +53,8 @@ describe("seed-vs-admin characterization: direct etcd writes ≡ Admin API write
   let etcdClient: EtcdClient | undefined;
   let etcdReachable = false;
 
-  let adminPk: Entry, seedPk: Entry;
-  let adminModel: Entry, seedModel: Entry;
+  let adminPk: Entry, seedPk: Entry, seedPkCanonical: Entry;
+  let adminModel: Entry, seedModel: Entry, seedModelCanonical: Entry;
   let adminKey: Entry, seedKey: Entry;
   let adminExporter: Entry, seedExporter: Entry;
 
@@ -82,6 +82,14 @@ describe("seed-vs-admin characterization: direct etcd writes ≡ Admin API write
       secret: "sk-mock",
       api_base: `${upstream.baseUrl}/v1`,
     });
+    // The same logical provider_key seeded under the credential's
+    // canonical `api_key` spelling — the field-spelling differential
+    // below pins that both spellings load and serve identically.
+    seedPkCanonical = await seed.createProviderKey({
+      display_name: "char-seed-pk-canonical",
+      api_key: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
 
     adminModel = await admin.createModel({
       display_name: "char-admin-model",
@@ -95,6 +103,12 @@ describe("seed-vs-admin characterization: direct etcd writes ≡ Admin API write
       model_name: "gpt-4o-mini",
       provider_key_id: seedPk.id,
     });
+    seedModelCanonical = await seed.createModel({
+      display_name: "char-seed-model-canonical",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: seedPkCanonical.id,
+    });
 
     // Carry optional fields too so the projection comparison below has
     // non-empty residue after the varied fields are stripped.
@@ -106,7 +120,7 @@ describe("seed-vs-admin characterization: direct etcd writes ≡ Admin API write
     });
     seedKey = await seed.createApiKey({
       key_hash: sha256(SEED_CALLER),
-      allowed_models: ["char-seed-model"],
+      allowed_models: ["char-seed-model", "char-seed-model-canonical"],
       rate_limit: { rpm: 1000 },
       expires_at: "2030-01-01T00:00:00Z",
     });
@@ -263,6 +277,72 @@ describe("seed-vs-admin characterization: direct etcd writes ≡ Admin API write
       normalize(find(exporters, seedExporter.id, "seed exporter").value, ["name"]),
     ).toEqual(
       normalize(find(exporters, adminExporter.id, "admin exporter").value, ["name"]),
+    );
+  });
+
+  // Field-spelling differential for the provider_key credential rename
+  // (`secret` → `api_key`): the same logical provider_key seeded once
+  // under each spelling must load and serve identically, and the Admin
+  // API must emit the canonical `api_key` name for both — whichever
+  // front door wrote the document and whichever spelling it used.
+  test("provider_key credential loads under either spelling; admin GET emits api_key for both", async (ctx) => {
+    if (!etcdReachable || !admin || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const seedClient = new OpenAI({
+      apiKey: SEED_CALLER,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Serve-behavior differential: a 200 through each model proves the
+    // provider_key behind it — one stored with `secret`, one with
+    // `api_key` — loaded, resolved, and authenticated upstream. Doubles
+    // as this test's own propagation gate for the canonical-spelling
+    // resources (the earlier gate only probed the legacy-spelling pair).
+    await waitConfigPropagation(async () => {
+      try {
+        const [legacy, canonical] = await Promise.all(
+          ["char-seed-model", "char-seed-model-canonical"].map((model) =>
+            seedClient.chat.completions.create({
+              model,
+              messages: [{ role: "user", content: "spelling-probe" }],
+            }),
+          ),
+        );
+        return (
+          legacy.choices[0]?.message.role === "assistant" &&
+          canonical.choices[0]?.message.role === "assistant"
+        );
+      } catch {
+        return false;
+      }
+    });
+
+    // Emission differential: admin GET deserializes the stored document
+    // and re-serializes — the credential must come back as `api_key`
+    // (never `secret`) for all three write paths: admin+`secret`,
+    // seed+`secret`, seed+`api_key`.
+    const pks = await admin.json<Entry[]>("GET", "/admin/v1/provider_keys");
+    for (const [label, id] of [
+      ["admin-created (secret spelling)", adminPk.id],
+      ["seeded (secret spelling)", seedPk.id],
+      ["seeded (api_key spelling)", seedPkCanonical.id],
+    ] as const) {
+      const entry = pks.find((e) => e.id === id);
+      if (!entry) throw new Error(`${label} provider_key (${id}) missing from admin GET`);
+      expect(entry.value.api_key, `${label}: api_key`).toBe("sk-mock");
+      expect(entry.value.secret, `${label}: former spelling must not be emitted`).toBeUndefined();
+    }
+
+    // Document differential: modulo the identity field, the two seeded
+    // documents read back identical — the spelling leaves no residue.
+    const bySeed = pks.find((e) => e.id === seedPk.id)!;
+    const byCanonical = pks.find((e) => e.id === seedPkCanonical.id)!;
+    expect(normalize(byCanonical.value, ["display_name"])).toEqual(
+      normalize(bySeed.value, ["display_name"]),
     );
   });
 


### PR DESCRIPTION
## Motivation

CLAUDE.md, "The Resource Model Is Canonical in cp-admin.yaml": when this repo and the control plane disagree about a resource field's name, the control plane's spec wins and this repo converges to it, with `#[serde(alias = "…")]` so stored documents and existing callers keep loading, and regenerated `schemas/resources/` afterwards. Three fields and one route spelling had drifted; this PR converges them:

| Resource | Former name | Canonical name |
|---|---|---|
| `provider_keys` | `secret` | `api_key` |
| `mcp_servers` | `display_name` | `name` |
| `a2a_agents` | `display_name` | `name` |
| Admin route | `/admin/v1/apikeys*` | `/admin/v1/api_keys*` (former spelling still served, same handlers) |

House precedent for `!` renames with explicit compatibility notes: #657, #755.

## Dual-layer acceptance (the load-bearing part)

The etcd snapshot loader validates every document against the generated JSON Schema **before** serde (`crates/aisix-etcd/src/loader.rs`), and a schema-rejected row is silently skipped. Stored etcd data and current control-plane writes still carry the former names, so acceptance must hold at both layers:

- **serde**: the renamed fields carry `#[serde(alias = "secret")]` / `#[serde(alias = "display_name")]`. Alias names are known fields to serde, so this composes with `deny_unknown_fields`.
- **JSON Schema**: `schemars` does not emit serde aliases — a naively regenerated schema would list only the new name and, with `additionalProperties: false`, reject every old-name document at the loader's schema gate. A new `accept_renamed_field` transform in `crates/aisix-core/src/models/schema.rs` (applied inside the same `*_root_schema()` producers that feed both the runtime validators and `dump-schema`, so published schema == enforced schema by construction) declares the former name as a property with the canonical property's shape (`minLength` etc. keep applying) and rewrites requiredness as `anyOf: [{required:["api_key"]}, {required:["secret"]}]`, keeping `additionalProperties: false`.

`schemas/resources/{provider_key,mcp_server,a2a_agent}.schema.json` are regenerated via `cargo run -p aisix-core --bin dump-schema`; the admin OpenAPI (which embeds these files) is regenerated/verified via `cargo run -p aisix-admin --bin dump-openapi`. Both are idempotent, matching the CI drift checks.

## Both-spellings corner

A document carrying **both** the canonical and the former spelling passes the schema (`anyOf` admits it) and is then rejected by serde's duplicate-field error — both names map to the same field — so the ambiguous document never loads with one value silently winning. In the loader this surfaces as a `ParseFailed` rejection (row skipped, batch continues, rejection reported on the health surface); on the Admin API write path it is a 400. Pinned by unit tests in each model, schema tests, and loader tests.

## Emission is the visible change

Re-serialization now emits only the canonical names:

- Admin API GET responses return `api_key` / `name`.
- Admin-API-written documents are stored with the canonical names.

Requests and stored documents are accepted under **both** spellings, and `/admin/v1/apikeys*` keeps working unchanged.

**For standalone operators:** nothing to migrate. Existing etcd data keeps loading as-is; scripts that POST/PUT the former field names or call `/admin/v1/apikeys*` keep working. Only tooling that *reads* `secret` / `display_name` out of Admin API responses for these three resources needs to read `api_key` / `name` instead.

**Mixed-version fleets sharing one etcd:** a gateway replica on an older version schema-rejects canonical-spelling documents (its schema requires the former names and closes `additionalProperties`) and silently drops them from its snapshot. In multi-replica deployments sharing one configuration store, upgrade every replica to this version **before** writing resources through the Admin API for these kinds (this version's admin writes store the canonical spellings) — and before any writer flips its emission to the canonical names.

**For the control plane:** its writes carry the former names today and keep validating and loading through the alias + schema `anyOf`; it can move its own emission to the canonical names independently once the data planes it writes for are on this version — nothing else in this PR forces timing on that.

## Admin API surface

- Router serves the canonical `/admin/v1/api_keys`, `/admin/v1/api_keys/{id}`, `/admin/v1/api_keys/{id}/rotate` alongside the former spelling (same handlers).
- The OpenAPI base document describes the canonical paths; a `document_former_apikeys_paths` step mirrors each onto the former path (summary suffixed "(alternate path)", description prefixed with the equivalence note) so the published reference matches the router exactly without a second hand-maintained copy.
- mcp/a2a handler unique-name checks and error strings follow the renamed field (`name must not contain …`).

## Tests

- Unit: canonical-spelling acceptance, former-spelling acceptance, canonical-only emission, and the both-spellings duplicate-field rejection pinned per model; schema-layer dual-acceptance tests including that unknown fields stay rejected; loader tests for both spellings of all three resources plus the both-spellings `ParseFailed` path.
- Admin: routed-path test proving a key created via `/admin/v1/api_keys` is readable/rotatable/deletable via `/admin/v1/apikeys` and vice versa; OpenAPI tests assert the exact path set including both spellings.
- e2e: existing fixtures deliberately keep the former spellings (they double as acceptance proof). New differential case in `seed-vs-admin-characterization-e2e.test.ts` seeds the same logical provider_key once per spelling and asserts identical serve behavior and that admin GET emits `api_key` (never `secret`) for admin-written and both seeded documents. A small number of fixtures migrate to the canonical spellings (`auth-baseline`, `canary-routing`, one `apikey-lifecycle` rotation via the canonical route, one mcp integration fixture) so both spellings stay exercised long-term.

## Audit follow-up

The independent post-push audit flagged that the renamed-field `anyOf` sits at the document root, and the JSON-Schema library's `anyOf` failure message interpolates the entire failing instance — so a document missing both name spellings but carrying a live upstream credential would have that credential echoed into loader warnings, the rejection detail surfaced on the health/heartbeat path, and Admin API 400 bodies. Fixed by masking instance values in `validate()` (`err.masked()`), which also stops the pre-existing property-level value echoes; messages keep their structure and JSON pointer. Pinned by `schema_error_for_missing_name_does_not_echo_the_document`.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — green.
- etcd-gated integration suites (`aisix-admin` etcd_integration, `aisix-etcd` watch_integration) — green against a real etcd.
- Full e2e suite (`tests/e2e`, real etcd + redis) — green twice.
- `dump-schema` and `dump-openapi` idempotent (CI mirror).
