### PR TITLE
docs(admin): document the 409 response on a2a agent update

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -5353,6 +5353,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openapi_documents_admin_duplicate_name_conflicts() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(merged_openapi()).expect("merged_openapi must parse");
+
+        for (path, method) in [
+            ("/admin/v1/models", "post"),
+            ("/admin/v1/models/{id}", "put"),
+            ("/admin/v1/apikeys", "post"),
+            ("/admin/v1/apikeys/{id}", "put"),
+            ("/admin/v1/provider_keys", "post"),
+            ("/admin/v1/provider_keys/{id}", "put"),
+            ("/admin/v1/mcp_servers", "post"),
+            ("/admin/v1/mcp_servers/{id}", "put"),
+            ("/admin/v1/a2a_agents", "post"),
+            ("/admin/v1/a2a_agents/{id}", "put"),
+            ("/admin/v1/guardrails", "post"),
+            ("/admin/v1/guardrails/{id}", "put"),
+            ("/admin/v1/cache_policies", "post"),
+            ("/admin/v1/cache_policies/{id}", "put"),
+            ("/admin/v1/observability_exporters", "post"),
+            ("/admin/v1/observability_exporters/{id}", "put"),
+        ] {
+            let response = &parsed["paths"][path][method]["responses"]["409"];
+            assert_eq!(
+                response["content"]["application/json"]["schema"]["$ref"],
+                "#/components/schemas/AdminError",
+                "{method} {path} should document duplicate-name conflicts as 409/AdminError"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn openapi_documents_admin_auth_and_error_envelope() {
         let parsed: serde_json::Value =
             serde_json::from_str(merged_openapi()).expect("merged_openapi must parse");

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1982,6 +1982,16 @@ const OPENAPI_JSON_BASE: &str = r##"{
               }
             }
           },
+          "409": {
+            "description": "Duplicate name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminError"
+                }
+              }
+            }
+          },
           "413": {
             "description": "JSON request body exceeds the admin body-size limit",
             "content": {


### PR DESCRIPTION
## What

Adds the missing `409` response to the `PUT /admin/v1/a2a_agents/{id}` operation in the hand-written admin OpenAPI assembly (`crates/aisix-admin/src/openapi.rs`), mirroring the wording already used by `PUT /admin/v1/mcp_servers/{id}` ("Duplicate name", `AdminError` schema).

## Why

The handler can actually return it: `update_a2a_agent` runs the unique-name check on update too (`assert_unique_name(&all, &agent.name, Some(&id))` in `crates/aisix-admin/src/a2a_agents_handlers.rs`), returning `AdminError::Conflict` → 409 when the replacement payload reuses another agent's `name`. The operation's own prose description already says "rejects duplicate `name` values" — only the response table was missing the code. Every other resource's update operation (models, api_keys, provider_keys, mcp_servers, guardrails, cache_policies, observability_exporters) already documents its 409; a2a_agents was the one gap.

Spec-only change; no runtime behavior touched.

## Audit follow-up

An independent audit of the first commit found one MEDIUM: nothing tested 409 documentation, so the omission this PR fixes was unguarded (the suite passed with or without the fix). Addressed in the second commit with `openapi_documents_admin_duplicate_name_conflicts`, a 409/`AdminError` parity test over all 8 resources' POST + PUT operations, mirroring the existing 413 body-limit parity test.

## Test plan

- [x] `cargo run -p aisix-admin --bin dump-openapi > /tmp/admin-api.openapi.json` — a2a PUT now lists `200/400/401/404/409/413/415/500`; its 409 object is byte-identical to the mcp_server PUT's
- [x] `cargo test -p aisix-admin openapi` — 20 passed, 0 failed (including the new parity test)