### PR TITLE
feat(config): file-based resource source (resources.yaml) for standalone mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,8 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
+ "uuid",
+ "yaml-rust2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,10 @@ etcd-client = { version = "0.14", features = ["tls"] }
 # Config
 config = { version = "0.14", default-features = false, features = ["yaml", "toml", "json"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+# Standalone resources-file source (aisix-core::filesource). Same YAML
+# parser the `config` dependency already pulls in, so this adds no new
+# parser to the dependency tree.
+yaml-rust2 = "0.8"
 
 # Time / IDs
 chrono = { version = "0.4", features = ["serde"] }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -21,6 +21,16 @@ etcd:
   #   # Defaults to the hostname portion of endpoints[0].
   #   # domain_name: "etcd.aisix.cloud"
 
+# Standalone file-based resource source — the alternative to etcd for a
+# single-container gateway. When set, every resource (provider keys,
+# models, API keys, guardrails, MCP servers, A2A agents, cache policies,
+# observability exporters, rate-limit policies) is loaded from this one
+# YAML file at boot and re-read on SIGHUP; the `etcd` section above must
+# then be removed (the two sources are mutually exclusive), and the
+# admin listener serves the resource endpoints read-only. Validate a
+# file without booting via `aisix validate --resources <file>`.
+# resources_file: "/etc/aisix/resources.yaml"
+
 proxy:
   addr: "0.0.0.0:3000"
   request_body_limit_bytes: 10485760   # 10 MiB

--- a/crates/aisix-admin/src/auth.rs
+++ b/crates/aisix-admin/src/auth.rs
@@ -29,18 +29,27 @@ where
     type Rejection = AdminError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let token = extract_bearer(parts)?;
         let admin_state = AdminState::from_ref(state);
-        let is_authorized = admin_state.admin_keys.iter().any(|k| k == &token);
-        if !is_authorized {
+        if !is_admin_authorized(&parts.headers, &admin_state.admin_keys) {
             return Err(AdminError::Unauthorized);
         }
         Ok(AdminAuth)
     }
 }
 
-fn extract_bearer(parts: &Parts) -> Result<String, AdminError> {
-    if let Some(auth) = parts.headers.get(axum::http::header::AUTHORIZATION) {
+/// Header-level admin-key check shared by the extractor above and by
+/// router-layer middleware (which runs *before* per-handler extractors
+/// and therefore cannot use `AdminAuth` directly). True iff the request
+/// carries a valid admin key.
+pub(crate) fn is_admin_authorized(headers: &axum::http::HeaderMap, admin_keys: &[String]) -> bool {
+    match extract_bearer(headers) {
+        Ok(token) => admin_keys.iter().any(|k| k == &token),
+        Err(_) => false,
+    }
+}
+
+fn extract_bearer(headers: &axum::http::HeaderMap) -> Result<String, AdminError> {
+    if let Some(auth) = headers.get(axum::http::header::AUTHORIZATION) {
         let s = auth.to_str().map_err(|_| AdminError::Unauthorized)?;
         if let Some(rest) = s.strip_prefix("Bearer ") {
             let rest = rest.trim();
@@ -51,7 +60,7 @@ fn extract_bearer(parts: &Parts) -> Result<String, AdminError> {
         }
         return Err(AdminError::Unauthorized);
     }
-    if let Some(raw) = parts.headers.get("x-api-key") {
+    if let Some(raw) = headers.get("x-api-key") {
         let s = raw.to_str().map_err(|_| AdminError::Unauthorized)?;
         let s = s.trim();
         if s.is_empty() {
@@ -80,20 +89,26 @@ mod tests {
             axum::http::header::AUTHORIZATION,
             HeaderValue::from_static("Bearer admin-secret"),
         );
-        assert_eq!(extract_bearer(&parts_with(h)).unwrap(), "admin-secret");
+        assert_eq!(
+            extract_bearer(&parts_with(h).headers).unwrap(),
+            "admin-secret"
+        );
     }
 
     #[test]
     fn extract_bearer_accepts_x_api_key_fallback() {
         let mut h = HeaderMap::new();
         h.insert("x-api-key", HeaderValue::from_static("admin-secret"));
-        assert_eq!(extract_bearer(&parts_with(h)).unwrap(), "admin-secret");
+        assert_eq!(
+            extract_bearer(&parts_with(h).headers).unwrap(),
+            "admin-secret"
+        );
     }
 
     #[test]
     fn extract_bearer_rejects_missing_and_wrong_scheme() {
         assert!(matches!(
-            extract_bearer(&parts_with(HeaderMap::new())),
+            extract_bearer(&parts_with(HeaderMap::new()).headers),
             Err(AdminError::Unauthorized)
         ));
 
@@ -103,8 +118,27 @@ mod tests {
             HeaderValue::from_static("Basic Zm9v"),
         );
         assert!(matches!(
-            extract_bearer(&parts_with(h)),
+            extract_bearer(&parts_with(h).headers),
             Err(AdminError::Unauthorized)
         ));
+    }
+
+    #[test]
+    fn is_admin_authorized_checks_key_membership() {
+        let keys = vec!["admin-secret".to_string()];
+        let mut h = HeaderMap::new();
+        h.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer admin-secret"),
+        );
+        assert!(is_admin_authorized(&h, &keys));
+
+        let mut wrong = HeaderMap::new();
+        wrong.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer nope"),
+        );
+        assert!(!is_admin_authorized(&wrong, &keys));
+        assert!(!is_admin_authorized(&HeaderMap::new(), &keys));
     }
 }

--- a/crates/aisix-admin/src/error.rs
+++ b/crates/aisix-admin/src/error.rs
@@ -27,6 +27,12 @@ pub enum AdminError {
     NotFound,
     #[error("name {0:?} already in use by another resource")]
     Conflict(String),
+    /// Resource writes are refused because this gateway loads its
+    /// resources from a declarative file. 409, like [`Self::Conflict`]:
+    /// the request is well-formed but conflicts with how the resource
+    /// set is managed.
+    #[error("{0}")]
+    FileManaged(String),
     #[error("schema validation failed at {path}: {message}")]
     Schema { path: String, message: String },
     #[error("store error: {0}")]
@@ -39,7 +45,7 @@ impl AdminError {
             AdminError::Unauthorized => StatusCode::UNAUTHORIZED,
             AdminError::BadRequest(_) | AdminError::Schema { .. } => StatusCode::BAD_REQUEST,
             AdminError::NotFound => StatusCode::NOT_FOUND,
-            AdminError::Conflict(_) => StatusCode::CONFLICT,
+            AdminError::Conflict(_) | AdminError::FileManaged(_) => StatusCode::CONFLICT,
             AdminError::Store(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -56,7 +62,10 @@ impl From<SchemaError> for AdminError {
 
 impl From<StoreError> for AdminError {
     fn from(e: StoreError) -> Self {
-        AdminError::Store(e.to_string())
+        match e {
+            StoreError::ReadOnly(msg) => AdminError::FileManaged(msg),
+            other => AdminError::Store(other.to_string()),
+        }
     }
 }
 

--- a/crates/aisix-admin/src/file_store.rs
+++ b/crates/aisix-admin/src/file_store.rs
@@ -1,0 +1,171 @@
+//! [`FileManagedStore`] — the [`ConfigStore`] the admin listener uses
+//! when the gateway loads its resources from a file
+//! (`resources_file` in config.yaml) instead of etcd.
+//!
+//! Reads are served from the live snapshot (the same one the proxy
+//! reads), so `GET` lists / gets reflect the loaded file — including
+//! SIGHUP reloads — without a second storage backend. Every write
+//! returns [`StoreError::ReadOnly`], which the HTTP layer maps to a
+//! 409 telling the operator to edit the file and reload. A router-level
+//! guard in `build_router` rejects write requests before handler logic
+//! runs; these store errors are the defense-in-depth backstop for any
+//! non-HTTP caller.
+
+use aisix_core::resource::Resource;
+use aisix_core::resource::ResourceEntry;
+use aisix_core::snapshot::{ResourceTable, SnapshotHandle};
+use aisix_core::{
+    A2aAgent, AisixSnapshot, ApiKey, CachePolicy, Guardrail, McpServer, Model,
+    ObservabilityExporter, ProviderKey,
+};
+
+use crate::store::{ConfigStore, StoreError};
+
+/// Read-only [`ConfigStore`] over the file-loaded snapshot.
+pub struct FileManagedStore {
+    snapshot: SnapshotHandle<AisixSnapshot>,
+    resources_path: String,
+}
+
+impl FileManagedStore {
+    pub fn new(snapshot: SnapshotHandle<AisixSnapshot>, resources_path: impl Into<String>) -> Self {
+        Self {
+            snapshot,
+            resources_path: resources_path.into(),
+        }
+    }
+
+    /// The message every write path returns. Includes the file path so
+    /// the operator knows exactly what to edit.
+    pub fn read_only_message(resources_path: &str) -> String {
+        format!(
+            "resources are file-managed: this gateway loads its resources from \
+             {resources_path}; edit that file and send SIGHUP to reload instead of \
+             using the resource write API"
+        )
+    }
+
+    fn read_only(&self) -> StoreError {
+        StoreError::ReadOnly(Self::read_only_message(&self.resources_path))
+    }
+
+    fn get_from<T: Resource + Clone>(
+        &self,
+        table: fn(&AisixSnapshot) -> &ResourceTable<T>,
+        id: &str,
+    ) -> Option<ResourceEntry<T>> {
+        table(&self.snapshot.load())
+            .get_by_id(id)
+            .map(|e| (*e).clone())
+    }
+
+    fn list_from<T: Resource + Clone>(
+        &self,
+        table: fn(&AisixSnapshot) -> &ResourceTable<T>,
+    ) -> Vec<ResourceEntry<T>> {
+        table(&self.snapshot.load())
+            .entries()
+            .into_iter()
+            .map(|e| (*e).clone())
+            .collect()
+    }
+}
+
+macro_rules! impl_file_managed_store {
+    ($( { $ty:ty, $table:ident, $put:ident, $get:ident, $list:ident, $delete:ident } )+) => {
+        #[async_trait::async_trait]
+        impl ConfigStore for FileManagedStore {
+            $(
+                async fn $put(&self, _entry: ResourceEntry<$ty>) -> Result<(), StoreError> {
+                    Err(self.read_only())
+                }
+
+                async fn $get(&self, id: &str) -> Result<Option<ResourceEntry<$ty>>, StoreError> {
+                    Ok(self.get_from(|s| &s.$table, id))
+                }
+
+                async fn $list(&self) -> Result<Vec<ResourceEntry<$ty>>, StoreError> {
+                    Ok(self.list_from(|s| &s.$table))
+                }
+
+                async fn $delete(&self, _id: &str) -> Result<bool, StoreError> {
+                    Err(self.read_only())
+                }
+            )+
+        }
+    };
+}
+
+impl_file_managed_store! {
+    { Model, models, put_model, get_model, list_models, delete_model }
+    { ApiKey, apikeys, put_apikey, get_apikey, list_apikeys, delete_apikey }
+    { ProviderKey, provider_keys, put_provider_key, get_provider_key, list_provider_keys, delete_provider_key }
+    { Guardrail, guardrails, put_guardrail, get_guardrail, list_guardrails, delete_guardrail }
+    { CachePolicy, cache_policies, put_cache_policy, get_cache_policy, list_cache_policies, delete_cache_policy }
+    { ObservabilityExporter, observability_exporters, put_observability_exporter, get_observability_exporter, list_observability_exporters, delete_observability_exporter }
+    { McpServer, mcp_servers, put_mcp_server, get_mcp_server, list_mcp_servers, delete_mcp_server }
+    { A2aAgent, a2a_agents, put_a2a_agent, get_a2a_agent, list_a2a_agents, delete_a2a_agent }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot_with_model() -> SnapshotHandle<AisixSnapshot> {
+        let snap = AisixSnapshot::new();
+        let model: Model = serde_json::from_str(
+            r#"{
+              "display_name": "file-model",
+              "provider": "openai",
+              "model_name": "gpt-4o",
+              "provider_key_id": "11111111-1111-1111-1111-111111111111"
+            }"#,
+        )
+        .unwrap();
+        snap.models.insert(ResourceEntry::new("m-1", model, 1));
+        SnapshotHandle::new(snap)
+    }
+
+    #[tokio::test]
+    async fn reads_serve_the_live_snapshot() {
+        let handle = snapshot_with_model();
+        let store = FileManagedStore::new(handle.clone(), "/etc/aisix/resources.yaml");
+
+        let listed = store.list_models().await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].value.display_name, "file-model");
+
+        let got = store.get_model("m-1").await.unwrap().unwrap();
+        assert_eq!(got.id, "m-1");
+        assert!(store.get_model("missing").await.unwrap().is_none());
+
+        // A snapshot swap (SIGHUP reload) is immediately visible.
+        handle.store(AisixSnapshot::new());
+        assert!(store.list_models().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn writes_and_deletes_are_read_only_errors_naming_the_file() {
+        let store = FileManagedStore::new(snapshot_with_model(), "/etc/aisix/resources.yaml");
+        let entry = store.get_model("m-1").await.unwrap().unwrap();
+
+        let err = store.put_model(entry).await.unwrap_err();
+        match &err {
+            StoreError::ReadOnly(msg) => {
+                assert!(msg.contains("file-managed"), "{msg}");
+                assert!(msg.contains("/etc/aisix/resources.yaml"), "{msg}");
+                assert!(msg.contains("SIGHUP"), "{msg}");
+            }
+            other => panic!("expected ReadOnly, got {other:?}"),
+        }
+        assert!(matches!(
+            store.delete_model("m-1").await.unwrap_err(),
+            StoreError::ReadOnly(_)
+        ));
+        // Spot-check a second kind so the macro expansion is covered.
+        assert!(matches!(
+            store.delete_guardrail("g-1").await.unwrap_err(),
+            StoreError::ReadOnly(_)
+        ));
+    }
+}

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -41,6 +41,7 @@ mod auth;
 mod cache_policies_handlers;
 mod error;
 pub mod etcd_store;
+pub mod file_store;
 mod guardrails_handlers;
 mod health_handler;
 mod mcp_servers_handlers;
@@ -56,6 +57,7 @@ pub mod store;
 pub use auth::AdminAuth;
 pub use error::{AdminError, ErrorBody};
 pub use etcd_store::EtcdConfigStore;
+pub use file_store::FileManagedStore;
 pub use state::AdminState;
 pub use store::{ConfigStore, InMemoryStore, StoreError};
 
@@ -202,9 +204,39 @@ pub fn build_router(state: AdminState) -> Router {
         .route(
             "/playground/chat/completions",
             post(playground_handler::playground_chat_completions),
-        );
+        )
+        // File-managed write guard: one chokepoint covering every
+        // resource write endpoint (POST/PUT/DELETE, including rotate)
+        // so file mode can't drift as routes are added. Reads and the
+        // playground pass through untouched. No-op when the gateway is
+        // etcd-backed (`file_managed_path` unset).
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            file_managed_write_guard,
+        ));
 
     router.with_state(state)
+}
+
+/// Reject mutating `/admin/v1/*` requests with a 409 when resources are
+/// managed by the resources file. GET/HEAD/OPTIONS — the read surface —
+/// and non-resource endpoints (playground, livez, openapi) pass through.
+async fn file_managed_write_guard(
+    axum::extract::State(state): axum::extract::State<AdminState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    use axum::http::Method;
+    use axum::response::IntoResponse;
+
+    let is_read = matches!(*req.method(), Method::GET | Method::HEAD | Method::OPTIONS);
+    if !is_read && req.uri().path().starts_with("/admin/v1/") {
+        if let Some(path) = state.file_managed_path.as_deref() {
+            return AdminError::FileManaged(FileManagedStore::read_only_message(path))
+                .into_response();
+        }
+    }
+    next.run(req).await
 }
 
 /// Build the router for the **dedicated** Prometheus metrics listener —
@@ -1602,6 +1634,116 @@ mod tests {
         let routing = rows.iter().find(|row| row["id"] == "routing-1").unwrap();
         assert_eq!(routing["kind"], "routing");
         assert_eq!(routing["status"], "not_applicable");
+    }
+
+    // ──────────────────── File-managed mode ────────────────────
+
+    /// AdminState wired the way `aisix-server` wires file mode: the
+    /// store reads from the snapshot, and `file_managed_path` arms the
+    /// router-level write guard.
+    fn build_file_managed_state() -> AdminState {
+        let snapshot = AisixSnapshot::new();
+        let model: aisix_core::Model = serde_json::from_value(model_payload("file-model")).unwrap();
+        snapshot
+            .models
+            .insert(aisix_core::ResourceEntry::new("m-file-1", model, 1));
+        let handle = SnapshotHandle::new(snapshot);
+        let store: Arc<dyn ConfigStore> = Arc::new(FileManagedStore::new(
+            handle.clone(),
+            "/etc/aisix/resources.yaml",
+        ));
+        AdminState::new(handle, store, &cfg()).with_file_managed_path("/etc/aisix/resources.yaml")
+    }
+
+    #[tokio::test]
+    async fn file_managed_mode_rejects_every_resource_write_with_409() {
+        let state = build_file_managed_state();
+        let writes: Vec<(&str, String, Option<Value>)> = vec![
+            (
+                "POST",
+                "/admin/v1/models".into(),
+                Some(model_payload("new")),
+            ),
+            (
+                "PUT",
+                "/admin/v1/models/m-file-1".into(),
+                Some(model_payload("file-model")),
+            ),
+            ("DELETE", "/admin/v1/models/m-file-1".into(), None),
+            (
+                "POST",
+                "/admin/v1/api_keys".into(),
+                Some(apikey_payload("sk-x", &["*"])),
+            ),
+            ("POST", "/admin/v1/api_keys/some-id/rotate".into(), None),
+            (
+                "POST",
+                "/admin/v1/guardrails".into(),
+                Some(guardrail_payload("g")),
+            ),
+        ];
+        for (method, uri, body) in writes {
+            let app = build_router(state.clone());
+            let resp = run(app, auth_req(method, &uri, body)).await;
+            assert_eq!(
+                resp.status(),
+                StatusCode::CONFLICT,
+                "{method} {uri} must be refused in file mode",
+            );
+            let v = body_json(resp).await;
+            let msg = v["error_msg"].as_str().unwrap();
+            assert!(msg.contains("file-managed"), "{method} {uri}: {msg}");
+            assert!(
+                msg.contains("/etc/aisix/resources.yaml"),
+                "message must name the file: {msg}",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn file_managed_mode_serves_reads_from_the_snapshot() {
+        let state = build_file_managed_state();
+
+        // List reflects the file-loaded snapshot.
+        let app = build_router(state.clone());
+        let resp = run(app, auth_req("GET", "/admin/v1/models", None)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["value"]["display_name"], "file-model");
+
+        // Get-by-id too.
+        let app = build_router(state.clone());
+        let resp = run(app, auth_req("GET", "/admin/v1/models/m-file-1", None)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Non-resource surfaces stay untouched: health + models/status +
+        // openapi keep responding.
+        let app = build_router(state.clone());
+        let resp = run(app, auth_req("GET", "/admin/v1/health", None)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let app = build_router(state.clone());
+        let resp = run(app, auth_req("GET", "/admin/v1/models/status", None)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri("/admin/openapi.json")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn write_guard_is_inert_when_not_file_managed() {
+        // Same router build path, no file_managed_path → writes work.
+        let app = build_router(build_state());
+        let resp = run(
+            app,
+            auth_req("POST", "/admin/v1/models", Some(model_payload("ok"))),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -221,6 +221,12 @@ pub fn build_router(state: AdminState) -> Router {
 /// Reject mutating `/admin/v1/*` requests with a 409 when resources are
 /// managed by the resources file. GET/HEAD/OPTIONS — the read surface —
 /// and non-resource endpoints (playground, livez, openapi) pass through.
+///
+/// Auth still wins: this layer runs before the per-handler [`AdminAuth`]
+/// extractor, so it only short-circuits for requests carrying a valid
+/// admin key. Unauthenticated writes fall through to the handler and get
+/// its `401` — the 409 body names the resources-file path, which is not
+/// for unauthenticated eyes.
 async fn file_managed_write_guard(
     axum::extract::State(state): axum::extract::State<AdminState>,
     req: axum::extract::Request,
@@ -232,8 +238,10 @@ async fn file_managed_write_guard(
     let is_read = matches!(*req.method(), Method::GET | Method::HEAD | Method::OPTIONS);
     if !is_read && req.uri().path().starts_with("/admin/v1/") {
         if let Some(path) = state.file_managed_path.as_deref() {
-            return AdminError::FileManaged(FileManagedStore::read_only_message(path))
-                .into_response();
+            if auth::is_admin_authorized(req.headers(), &state.admin_keys) {
+                return AdminError::FileManaged(FileManagedStore::read_only_message(path))
+                    .into_response();
+            }
         }
     }
     next.run(req).await
@@ -1732,6 +1740,41 @@ mod tests {
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn file_managed_mode_unauthenticated_writes_still_get_401_without_path_leak() {
+        // Auth ordering: the write guard must not answer an
+        // unauthenticated caller — the 409 body names the resources
+        // file path, which only authenticated admins may see.
+        let app = build_router(build_file_managed_state());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/admin/v1/models")
+            .header("content-type", "application/json")
+            .body(Body::from(model_payload("x").to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let v = body_json(resp).await;
+        assert!(
+            !v["error_msg"]
+                .as_str()
+                .unwrap()
+                .contains("/etc/aisix/resources.yaml"),
+            "401 body must not leak the resources file path: {v}",
+        );
+
+        // Wrong key is equally unauthorized.
+        let app = build_router(build_file_managed_state());
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/admin/v1/models/m-file-1")
+            .header("authorization", "Bearer wrong-key")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/state.rs
+++ b/crates/aisix-admin/src/state.rs
@@ -42,6 +42,11 @@ pub struct AdminState {
     /// goes through the full proxy middleware stack (auth, rate-limit, bridge)
     /// without an additional network hop.
     pub proxy_router: Option<Router>,
+    /// When set, resources are managed by the resources file at this
+    /// path: every mutating `/admin/v1/*` request is rejected with a
+    /// 409 by the router-level guard in `build_router`, while reads
+    /// keep serving from the snapshot.
+    pub file_managed_path: Option<Arc<str>>,
 }
 
 impl AdminState {
@@ -59,7 +64,15 @@ impl AdminState {
             watch_status: None,
             livez_state: Arc::new(LivezState::new()),
             proxy_router: None,
+            file_managed_path: None,
         }
+    }
+
+    /// Mark the resource surface as file-managed. `path` is surfaced in
+    /// the 409 body so operators know which file to edit.
+    pub fn with_file_managed_path(mut self, path: impl Into<Arc<str>>) -> Self {
+        self.file_managed_path = Some(path.into());
+        self
     }
 
     /// Attach the watch supervisor's freshness status. When set, the

--- a/crates/aisix-admin/src/store.rs
+++ b/crates/aisix-admin/src/store.rs
@@ -17,6 +17,10 @@ use std::sync::Arc;
 pub enum StoreError {
     #[error("store backend failure: {0}")]
     Backend(String),
+    /// The store is read-only because resources come from a declarative
+    /// source (the resources file). Maps to a 409 at the HTTP surface.
+    #[error("{0}")]
+    ReadOnly(String),
 }
 
 // `async_trait` macro is what makes `dyn ConfigStore` trait objects

--- a/crates/aisix-core/Cargo.toml
+++ b/crates/aisix-core/Cargo.toml
@@ -29,6 +29,9 @@ sha2.workspace = true
 hex.workspace = true
 # Trusted-proxy CIDR parsing/validation for proxy.real_ip (#492)
 ipnet.workspace = true
+# filesource: resources.yaml parsing + deterministic UUIDv5 resource ids
+yaml-rust2.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -32,7 +32,19 @@ use crate::error::BootstrapError;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// Dynamic-resource source A: etcd. Required unless `resources_file`
+    /// selects the file source below; the two are mutually exclusive.
+    #[serde(default)]
     pub etcd: EtcdConfig,
+    /// Dynamic-resource source B: a standalone resources file
+    /// (`resources.yaml`). When set, the gateway loads every resource
+    /// (provider keys, models, API keys, …) from this file at boot and
+    /// re-reads it on SIGHUP; the `etcd` section must be absent or left
+    /// unconfigured, and the admin listener serves the resource surface
+    /// read-only. Mutually exclusive with configured `etcd.endpoints`
+    /// and with `managed.enabled`.
+    #[serde(default)]
+    pub resources_file: Option<String>,
     pub proxy: ProxyConfig,
     /// Admin surface. Defaulted so managed-mode configs can omit this
     /// block entirely; the default values are NOT bound at runtime —
@@ -284,6 +296,25 @@ impl ManagedConfig {
     }
     const fn default_heartbeat_interval_secs() -> u64 {
         15
+    }
+}
+
+/// Default is the "unconfigured" shape (no endpoints) so a
+/// `resources_file` deployment can omit the `etcd` section entirely.
+/// [`Config::validate`] still rejects empty endpoints whenever the file
+/// source is not selected, so etcd-mode behavior is unchanged.
+impl Default for EtcdConfig {
+    fn default() -> Self {
+        Self {
+            endpoints: Vec::new(),
+            prefix: Self::default_prefix(),
+            env_id: String::new(),
+            user: None,
+            password_env: None,
+            dial_timeout_ms: Self::default_dial_timeout(),
+            request_timeout_ms: Self::default_request_timeout(),
+            tls: None,
+        }
     }
 }
 
@@ -746,9 +777,34 @@ impl Config {
     }
 
     fn validate(&self) -> Result<(), BootstrapError> {
-        if self.etcd.endpoints.is_empty() {
+        if let Some(path) = self.resources_file.as_deref() {
+            // File source selected: exactly one resource source may be
+            // active. A configured etcd endpoint list alongside the file
+            // is ambiguous — fail loudly instead of silently ignoring one.
+            if path.trim().is_empty() {
+                return Err(BootstrapError::Config(
+                    "resources_file must not be empty when set".into(),
+                ));
+            }
+            if !self.etcd.endpoints.is_empty() {
+                return Err(BootstrapError::Config(
+                    "config sets both etcd.endpoints and resources_file — the etcd \
+                     source and the file source are mutually exclusive; remove one"
+                        .into(),
+                ));
+            }
+            if self.managed.is_managed() {
+                return Err(BootstrapError::Config(
+                    "resources_file cannot be combined with managed.enabled = true \
+                     (managed mode reads resources from the control plane)"
+                        .into(),
+                ));
+            }
+        } else if self.etcd.endpoints.is_empty() {
             return Err(BootstrapError::Config(
-                "etcd.endpoints must contain at least one endpoint".into(),
+                "etcd.endpoints must contain at least one endpoint \
+                 (or set resources_file to load resources from a file)"
+                    .into(),
             ));
         }
         // In managed mode the admin listener is not bound, so requiring
@@ -932,6 +988,103 @@ admin:
             format!("{err}").contains("trusted_proxies"),
             "error should name the bad field: {err}"
         );
+    }
+
+    #[test]
+    fn resources_file_makes_etcd_section_optional() {
+        let f = write_yaml(
+            r#"
+resources_file: "/etc/aisix/resources.yaml"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(
+            cfg.resources_file.as_deref(),
+            Some("/etc/aisix/resources.yaml")
+        );
+        assert!(cfg.etcd.endpoints.is_empty());
+        // Untouched etcd defaults still materialize for downstream code.
+        assert_eq!(cfg.etcd.prefix, "/aisix");
+    }
+
+    #[test]
+    fn resources_file_conflicts_with_configured_etcd_endpoints() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+resources_file: "/etc/aisix/resources.yaml"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("mutually exclusive"), "unexpected: {msg}");
+        assert!(msg.contains("resources_file"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn resources_file_conflicts_with_managed_mode() {
+        let f = write_yaml(
+            r#"
+resources_file: "/etc/aisix/resources.yaml"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+managed:
+  enabled: true
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("managed"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn resources_file_rejects_empty_path() {
+        let f = write_yaml(
+            r#"
+resources_file: ""
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(
+            err.to_string().contains("resources_file"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn resources_file_mode_still_requires_admin_keys() {
+        // The admin listener stays bound (read-only resource surface) in
+        // file mode, so the standalone auth invariant holds.
+        let f = write_yaml(
+            r#"
+resources_file: "/etc/aisix/resources.yaml"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: []
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("admin.admin_keys"));
     }
 
     #[test]

--- a/crates/aisix-core/src/filesource/desugar.rs
+++ b/crates/aisix-core/src/filesource/desugar.rs
@@ -1,0 +1,439 @@
+//! File-only sugar → canonical resource documents.
+//!
+//! The resources file accepts a small amount of sugar on top of the
+//! canonical resource shapes (`schemas/resources/*.schema.json`):
+//!
+//! - `models[].provider_key` — a provider-key *name*, resolved to the
+//!   derived `provider_key_id`. Mutually exclusive with an explicit
+//!   `provider_key_id`.
+//! - `api_keys[].display_name` — required file-side identity, stripped
+//!   before validation (the canonical `api_key` document has no name
+//!   field).
+//! - `api_keys[].key_env` — the NAME of an environment variable whose
+//!   value is the plaintext caller key; hashed to `key_hash` (SHA-256,
+//!   lowercase hex — [`crate::models::ApiKey::hash_bearer`]) and then
+//!   dropped. Exactly one of `key_env` / `key_hash` must be present.
+//! - `rate_limit_policies[].scope_ref` — for `scope: api_key` /
+//!   `scope: model`, a *name* resolved to the referenced entry's derived
+//!   id; other scopes pass through verbatim.
+//!
+//! Everything this module emits must be exactly a canonical resource
+//! document: the caller then runs the same JSON-Schema validators and
+//! typed serde models the etcd path uses. Canonical schemas are not
+//! relaxed for the file source.
+
+use serde_json::Value;
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+use super::yaml::EnvLookup;
+
+/// Fixed UUIDv5 namespace for deterministic file-resource ids.
+///
+/// Derived once as `uuid5(NAMESPACE_URL,
+/// "https://github.com/api7/aisix#resources-file")` and pinned here so
+/// the value can never drift; a unit test re-derives it. Every resource
+/// loaded from the file gets `uuid5(FILE_RESOURCE_NAMESPACE,
+/// "<kind>/<identity>")` — stable across reloads and across processes,
+/// so references and rate-limit counters keyed by id survive a SIGHUP.
+pub const FILE_RESOURCE_NAMESPACE: Uuid = Uuid::from_bytes([
+    0x63, 0xe5, 0x0a, 0xb2, 0x67, 0x7a, 0x54, 0xd3, 0x8d, 0x1e, 0xc0, 0xcb, 0x29, 0xce, 0xae, 0x94,
+]);
+
+/// Deterministic id for a file-defined resource: UUIDv5 over
+/// `"<kind>/<identity>"` in [`FILE_RESOURCE_NAMESPACE`].
+pub fn derive_id(kind: &str, identity: &str) -> String {
+    Uuid::new_v5(
+        &FILE_RESOURCE_NAMESPACE,
+        format!("{kind}/{identity}").as_bytes(),
+    )
+    .to_string()
+}
+
+/// How a kind names its entries in the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IdentityField {
+    /// `display_name` (provider_keys, models, api_keys).
+    DisplayName,
+    /// `name` (guardrails, cache_policies, observability_exporters,
+    /// rate_limit_policies).
+    Name,
+    /// `name`, with `display_name` accepted as the alternative spelling
+    /// (mcp_servers, a2a_agents — mirroring their schemas).
+    NameOrDisplayName,
+}
+
+impl IdentityField {
+    /// Human description for "missing identity" errors.
+    pub(crate) fn describe(self) -> &'static str {
+        match self {
+            Self::DisplayName => "display_name",
+            Self::Name => "name",
+            Self::NameOrDisplayName => "name (or display_name)",
+        }
+    }
+
+    /// Extract the identity string from a JSON entry, if present and a
+    /// non-empty string.
+    pub(crate) fn extract(self, doc: &Value) -> Option<String> {
+        let field = |key: &str| {
+            doc.get(key)
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        };
+        match self {
+            Self::DisplayName => field("display_name"),
+            Self::Name => field("name"),
+            Self::NameOrDisplayName => field("name").or_else(|| field("display_name")),
+        }
+    }
+}
+
+/// Per-kind identity → derived-id map, built in the first pass so later
+/// sugar (name references) can resolve against every defined entry.
+pub(crate) type IdentityMaps = BTreeMap<&'static str, BTreeMap<String, String>>;
+
+fn known_names(maps: &IdentityMaps, kind: &str) -> String {
+    let names: Vec<&str> = maps
+        .get(kind)
+        .map(|m| m.keys().map(String::as_str).collect())
+        .unwrap_or_default();
+    if names.is_empty() {
+        format!("no {kind} are defined in this file")
+    } else {
+        format!("defined {kind}: {}", names.join(", "))
+    }
+}
+
+/// `models[].provider_key` (name) → `provider_key_id` (derived id).
+pub(crate) fn desugar_model(doc: &mut Value, maps: &IdentityMaps) -> Result<(), String> {
+    let obj = match doc.as_object_mut() {
+        Some(o) => o,
+        None => return Ok(()), // non-object entries error upstream
+    };
+    let Some(name_value) = obj.get("provider_key") else {
+        return Ok(());
+    };
+    let Some(name) = name_value.as_str() else {
+        return Err("`provider_key` must be a string (a provider key display_name)".into());
+    };
+    if obj.contains_key("provider_key_id") {
+        return Err(
+            "`provider_key` (a name reference) and `provider_key_id` are mutually \
+             exclusive — set exactly one"
+                .into(),
+        );
+    }
+    let resolved = maps
+        .get("provider_keys")
+        .and_then(|m| m.get(name))
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "`provider_key` references unknown provider key {name:?} ({})",
+                known_names(maps, "provider_keys")
+            )
+        })?;
+    obj.remove("provider_key");
+    obj.insert("provider_key_id".into(), Value::String(resolved));
+    Ok(())
+}
+
+/// `api_keys[]`: strip the identity-only `display_name`, resolve
+/// `key_env` XOR `key_hash`. The plaintext read from the environment is
+/// hashed and dropped — it must never surface in errors, logs, or the
+/// emitted document, so every error here names the *variable*, not its
+/// value.
+pub(crate) fn desugar_api_key(doc: &mut Value, env: EnvLookup<'_>) -> Result<(), String> {
+    let obj = match doc.as_object_mut() {
+        Some(o) => o,
+        None => return Ok(()),
+    };
+    // Identity extraction already require display_name to be present;
+    // here it only needs stripping (the canonical api_key document has
+    // no name field and its schema would reject one).
+    obj.remove("display_name");
+
+    let has_key_env = obj.contains_key("key_env");
+    let has_key_hash = obj.contains_key("key_hash");
+    match (has_key_env, has_key_hash) {
+        (true, true) => {
+            return Err("`key_env` and `key_hash` are mutually exclusive — set exactly one".into())
+        }
+        (false, false) => {
+            return Err(
+                "one of `key_env` (environment variable holding the plaintext key) or \
+                 `key_hash` (SHA-256 hex of the plaintext) is required"
+                    .into(),
+            )
+        }
+        (true, false) => {
+            let var = match obj.get("key_env").and_then(Value::as_str) {
+                Some(v) if !v.is_empty() => v.to_string(),
+                _ => {
+                    return Err(
+                        "`key_env` must be a non-empty string (an environment variable name)"
+                            .into(),
+                    )
+                }
+            };
+            let plaintext = match env(&var) {
+                Some(v) if !v.is_empty() => v,
+                _ => {
+                    return Err(format!(
+                        "`key_env` environment variable `{var}` is unset or empty"
+                    ))
+                }
+            };
+            if plaintext.contains("${") {
+                // Double indirection: the variable holds an uninterpolated
+                // `${...}` reference instead of the actual key.
+                return Err(format!(
+                    "`key_env` environment variable `{var}` contains an uninterpolated \
+                     `${{...}}` reference — set it to the plaintext key itself"
+                ));
+            }
+            let hash = crate::models::ApiKey::hash_bearer(&plaintext);
+            obj.remove("key_env");
+            obj.insert("key_hash".into(), Value::String(hash));
+        }
+        (false, true) => {}
+    }
+    Ok(())
+}
+
+/// `rate_limit_policies[].scope_ref`: for `scope: api_key` / `scope:
+/// model`, resolve the name against the file-defined entries and replace
+/// it with the derived id (the proxy matches policies by entry id).
+/// Other scopes (`team`, `member`, `team_member`, or anything the schema
+/// will reject later) pass through verbatim.
+pub(crate) fn desugar_rate_limit_policy(
+    doc: &mut Value,
+    maps: &IdentityMaps,
+) -> Result<(), String> {
+    let obj = match doc.as_object_mut() {
+        Some(o) => o,
+        None => return Ok(()),
+    };
+    let scope_kind = match obj.get("scope").and_then(Value::as_str) {
+        Some("api_key") => "api_keys",
+        Some("model") => "models",
+        _ => return Ok(()),
+    };
+    let Some(name) = obj.get("scope_ref").and_then(Value::as_str) else {
+        // Missing / non-string scope_ref: canonical validation reports it.
+        return Ok(());
+    };
+    let resolved = maps
+        .get(scope_kind)
+        .and_then(|m| m.get(name))
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "`scope_ref` references unknown {} {name:?} ({})",
+                if scope_kind == "api_keys" {
+                    "api key"
+                } else {
+                    "model"
+                },
+                known_names(maps, scope_kind)
+            )
+        })?;
+    obj.insert("scope_ref".into(), Value::String(resolved));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn maps_with(kind: &'static str, names: &[&str]) -> IdentityMaps {
+        let mut maps = IdentityMaps::new();
+        maps.insert(
+            kind,
+            names
+                .iter()
+                .map(|n| (n.to_string(), derive_id(kind, n)))
+                .collect(),
+        );
+        maps
+    }
+
+    #[test]
+    fn namespace_constant_matches_its_documented_derivation() {
+        assert_eq!(
+            FILE_RESOURCE_NAMESPACE,
+            Uuid::new_v5(
+                &Uuid::NAMESPACE_URL,
+                b"https://github.com/api7/aisix#resources-file"
+            ),
+        );
+    }
+
+    #[test]
+    fn derive_id_is_deterministic_and_kind_scoped() {
+        let a1 = derive_id("models", "gpt-4o");
+        let a2 = derive_id("models", "gpt-4o");
+        assert_eq!(a1, a2, "same input must derive the same id");
+        // Pin one concrete value so any namespace / input-shape change
+        // shows up as a test diff, not a silent id migration.
+        assert_eq!(a1, "6efd592d-a73b-573d-8e2c-e9e103692f92");
+        // Kind participates in the input, so identical names in
+        // different kinds never collide.
+        assert_ne!(derive_id("models", "x"), derive_id("api_keys", "x"));
+        // Valid UUID text form.
+        assert!(Uuid::parse_str(&a1).is_ok());
+    }
+
+    #[test]
+    fn model_provider_key_name_resolves_to_derived_id() {
+        let maps = maps_with("provider_keys", &["openai-prod"]);
+        let mut doc = json!({
+            "display_name": "gpt-4o",
+            "provider": "openai",
+            "model_name": "gpt-4o-2024-11-20",
+            "provider_key": "openai-prod"
+        });
+        desugar_model(&mut doc, &maps).unwrap();
+        assert!(doc.get("provider_key").is_none());
+        assert_eq!(
+            doc["provider_key_id"],
+            json!(derive_id("provider_keys", "openai-prod"))
+        );
+    }
+
+    #[test]
+    fn model_provider_key_unknown_name_lists_defined_keys() {
+        let maps = maps_with("provider_keys", &["a-key", "b-key"]);
+        let mut doc = json!({"display_name": "m", "provider_key": "nope"});
+        let err = desugar_model(&mut doc, &maps).unwrap_err();
+        assert!(err.contains("\"nope\""), "unexpected: {err}");
+        assert!(err.contains("a-key"), "unexpected: {err}");
+        assert!(err.contains("b-key"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn model_provider_key_conflicts_with_provider_key_id() {
+        let maps = maps_with("provider_keys", &["openai-prod"]);
+        let mut doc = json!({
+            "display_name": "m",
+            "provider_key": "openai-prod",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111"
+        });
+        let err = desugar_model(&mut doc, &maps).unwrap_err();
+        assert!(err.contains("mutually exclusive"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn api_key_env_hashes_and_strips_sugar_fields() {
+        let env = |name: &str| (name == "CALLER_KEY").then(|| "sk-plain".to_string());
+        let mut doc = json!({
+            "display_name": "ci-bot",
+            "key_env": "CALLER_KEY",
+            "allowed_models": ["*"]
+        });
+        desugar_api_key(&mut doc, &env).unwrap();
+        assert!(
+            doc.get("display_name").is_none(),
+            "identity must be stripped"
+        );
+        assert!(doc.get("key_env").is_none(), "sugar must be stripped");
+        // SHA-256 lowercase hex, identical to ApiKey::hash_bearer.
+        assert_eq!(
+            doc["key_hash"],
+            json!(crate::models::ApiKey::hash_bearer("sk-plain"))
+        );
+        let hash = doc["key_hash"].as_str().unwrap();
+        assert_eq!(hash.len(), 64);
+        assert!(hash
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        // The plaintext itself must not appear anywhere in the document.
+        assert!(!doc.to_string().contains("sk-plain"));
+    }
+
+    #[test]
+    fn api_key_env_xor_key_hash_is_enforced() {
+        let env = |_: &str| Some("sk-x".to_string());
+        let mut both =
+            json!({"display_name": "k", "key_env": "V", "key_hash": "ab", "allowed_models": []});
+        assert!(desugar_api_key(&mut both, &env)
+            .unwrap_err()
+            .contains("mutually exclusive"));
+        let mut neither = json!({"display_name": "k", "allowed_models": []});
+        assert!(desugar_api_key(&mut neither, &env)
+            .unwrap_err()
+            .contains("required"));
+        // key_hash alone passes through untouched.
+        let mut hash_only = json!({"display_name": "k", "key_hash": "cafe", "allowed_models": []});
+        desugar_api_key(&mut hash_only, &env).unwrap();
+        assert_eq!(hash_only["key_hash"], json!("cafe"));
+    }
+
+    #[test]
+    fn api_key_env_missing_empty_or_indirect_value_errors_without_leaking() {
+        let mut doc = json!({"display_name": "k", "key_env": "MISSING", "allowed_models": []});
+        let err = desugar_api_key(&mut doc, &|_| None).unwrap_err();
+        assert!(err.contains("`MISSING`"), "unexpected: {err}");
+        assert!(err.contains("unset or empty"), "unexpected: {err}");
+
+        let mut doc = json!({"display_name": "k", "key_env": "EMPTY", "allowed_models": []});
+        let err = desugar_api_key(&mut doc, &|_| Some(String::new())).unwrap_err();
+        assert!(err.contains("unset or empty"), "unexpected: {err}");
+
+        // The env value looks like an uninterpolated reference — double
+        // indirection is rejected, and the value itself never appears in
+        // the error message.
+        let mut doc = json!({"display_name": "k", "key_env": "REF", "allowed_models": []});
+        let err =
+            desugar_api_key(&mut doc, &|_| Some("${REAL_SECRET_KEY}".to_string())).unwrap_err();
+        assert!(err.contains("uninterpolated"), "unexpected: {err}");
+        assert!(
+            !err.contains("REAL_SECRET_KEY"),
+            "the env value must never surface in errors: {err}"
+        );
+    }
+
+    #[test]
+    fn scope_ref_resolves_per_scope_and_passes_team_scopes_verbatim() {
+        let mut maps = maps_with("models", &["gpt-4o"]);
+        maps.insert(
+            "api_keys",
+            [("ci-bot".to_string(), derive_id("api_keys", "ci-bot"))]
+                .into_iter()
+                .collect(),
+        );
+
+        let mut model_scope = json!({"name": "p", "scope": "model", "scope_ref": "gpt-4o"});
+        desugar_rate_limit_policy(&mut model_scope, &maps).unwrap();
+        assert_eq!(
+            model_scope["scope_ref"],
+            json!(derive_id("models", "gpt-4o"))
+        );
+
+        let mut key_scope = json!({"name": "p", "scope": "api_key", "scope_ref": "ci-bot"});
+        desugar_rate_limit_policy(&mut key_scope, &maps).unwrap();
+        assert_eq!(
+            key_scope["scope_ref"],
+            json!(derive_id("api_keys", "ci-bot"))
+        );
+
+        // team / member / team_member pass through verbatim.
+        for scope in ["team", "member", "team_member"] {
+            let mut doc = json!({"name": "p", "scope": scope, "scope_ref": "team-uuid-9"});
+            desugar_rate_limit_policy(&mut doc, &maps).unwrap();
+            assert_eq!(doc["scope_ref"], json!("team-uuid-9"));
+        }
+    }
+
+    #[test]
+    fn scope_ref_unknown_name_is_an_error_listing_candidates() {
+        let maps = maps_with("models", &["gpt-4o"]);
+        let mut doc = json!({"name": "p", "scope": "model", "scope_ref": "missing-model"});
+        let err = desugar_rate_limit_policy(&mut doc, &maps).unwrap_err();
+        assert!(err.contains("\"missing-model\""), "unexpected: {err}");
+        assert!(err.contains("gpt-4o"), "unexpected: {err}");
+    }
+}

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -17,7 +17,9 @@
 //!
 //! Errors are collected across the whole file — every load problem is
 //! reported together with kind / entry / field context, instead of
-//! failing on the first one.
+//! failing on the first one. (Within a single entry, interpolation /
+//! shape problems report the first offending field; aggregation is
+//! per-entry and across entries.)
 //!
 //! File format v1 (`_format_version: "1"`, mandatory):
 //! - nine top-level collection keys, each a sequence of maps, named by
@@ -456,6 +458,49 @@ pub fn load_from_str(
                 &semantic.on_embedding_failure
             {
                 check_model_ref(scope, "semantic on_embedding_failure target", target);
+            }
+        }
+    }
+
+    // The runtime credential index is keyed by key_hash, so two api_keys
+    // entries with distinct display_names but the same plaintext would
+    // silently last-wins at auth time (the Admin API rejects exactly
+    // this on create). Enforce credential uniqueness like the identity
+    // uniqueness above. The message names entries, never hashes.
+    let mut seen_hashes: BTreeMap<&str, &str> = BTreeMap::new();
+    for (_, scope, key) in &apikeys {
+        if let Some(first) = seen_hashes.insert(key.key_hash.as_str(), scope.as_str()) {
+            errors.push(LoadError {
+                scope: scope.clone(),
+                message: format!(
+                    "duplicate api key credential: this entry's key resolves to the \
+                     same key_hash as {first} — every api key must have a distinct \
+                     plaintext"
+                ),
+            });
+        }
+    }
+
+    // An explicit `provider_key_id` must also resolve: in file mode every
+    // provider-key id is derived from its name, so any other value is
+    // guaranteed dangling and would only surface per-request.
+    let pk_ids: std::collections::BTreeSet<&str> = identity_maps
+        .get("provider_keys")
+        .unwrap_or(&empty)
+        .values()
+        .map(String::as_str)
+        .collect();
+    for (_, scope, model) in &models {
+        if let Some(pk_id) = model.provider_key_id.as_deref() {
+            if !pk_ids.contains(pk_id) {
+                errors.push(LoadError {
+                    scope: scope.clone(),
+                    message: format!(
+                        "provider_key_id {pk_id:?} does not match any provider key \
+                         defined in this file — reference it by name with \
+                         `provider_key` instead"
+                    ),
+                });
             }
         }
     }

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -1,0 +1,514 @@
+//! Standalone file-based resource source (`resources_file` in
+//! config.yaml).
+//!
+//! Loads every dynamic resource — provider keys, models, API keys,
+//! guardrails, MCP servers, A2A agents, cache policies, observability
+//! exporters, rate-limit policies — from one YAML file instead of etcd,
+//! so a single container can run fully declaratively.
+//!
+//! Pipeline (identical for boot, SIGHUP reload, and `aisix validate`):
+//!
+//! ```text
+//! read file → YAML parse → ${VAR} interpolation (string scalars)
+//!   → per-entry JSON documents → file sugar desugared
+//!   → canonical JSON-Schema validation (same validators as the etcd path)
+//!   → typed serde models → cross-reference checks → AisixSnapshot
+//! ```
+//!
+//! Errors are collected across the whole file — every load problem is
+//! reported together with kind / entry / field context, instead of
+//! failing on the first one.
+//!
+//! File format v1 (`_format_version: "1"`, mandatory):
+//! - nine top-level collection keys, each a sequence of maps, named by
+//!   the plural resource kind; unknown top-level keys are load errors.
+//! - after desugaring, every entry must be exactly a canonical resource
+//!   document (`schemas/resources/*.schema.json`) — the file source
+//!   never relaxes the canonical schemas.
+//! - entries carry no `id`: ids are derived deterministically
+//!   (UUIDv5 of `"<kind>/<identity>"`, see
+//!   [`desugar::FILE_RESOURCE_NAMESPACE`]) and identities must be
+//!   unique per kind.
+
+mod desugar;
+mod yaml;
+
+pub use desugar::{derive_id, FILE_RESOURCE_NAMESPACE};
+
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::path::Path;
+use yaml_rust2::{Yaml, YamlLoader};
+
+use crate::models::{
+    validate_a2a_agent, validate_apikey, validate_cache_policy, validate_guardrail,
+    validate_mcp_server, validate_model, validate_observability_exporter, validate_provider_key,
+    validate_rate_limit_policy, A2aAgent, ApiKey, CachePolicy, Guardrail, McpServer, Model,
+    ObservabilityExporter, ProviderKey, RateLimitPolicy, SchemaError,
+};
+use crate::resource::ResourceEntry;
+use crate::AisixSnapshot;
+
+use desugar::{IdentityField, IdentityMaps};
+use yaml::EnvLookup;
+
+/// One load problem, with enough context to fix it: the entry scope
+/// (`models[2] ("gpt-4o")`, or `(file)` for file-level problems) and a
+/// message that names the offending field where applicable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadError {
+    pub scope: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.scope, self.message)
+    }
+}
+
+/// Aggregated load failure: every error found across the whole file.
+#[derive(Debug)]
+pub struct FileSourceErrors {
+    /// The file the errors refer to, as given by the caller.
+    pub file: String,
+    pub errors: Vec<LoadError>,
+}
+
+impl std::fmt::Display for FileSourceErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "resources file {}: {} error(s):",
+            self.file,
+            self.errors.len()
+        )?;
+        for e in &self.errors {
+            writeln!(f, "  - {e}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for FileSourceErrors {}
+
+/// The supported format version. A missing or unrecognized
+/// `_format_version` is a load error, so future format revisions can
+/// change semantics without silently misreading old gateways' files.
+const SUPPORTED_FORMAT_VERSION: &str = "1";
+
+/// Fixed processing order for the nine resource collections.
+const KINDS: [(&str, IdentityField); 9] = [
+    ("provider_keys", IdentityField::DisplayName),
+    ("models", IdentityField::DisplayName),
+    ("api_keys", IdentityField::DisplayName),
+    ("guardrails", IdentityField::Name),
+    ("mcp_servers", IdentityField::NameOrDisplayName),
+    ("a2a_agents", IdentityField::NameOrDisplayName),
+    ("cache_policies", IdentityField::Name),
+    ("observability_exporters", IdentityField::Name),
+    ("rate_limit_policies", IdentityField::Name),
+];
+
+/// Load `path` into a fresh [`AisixSnapshot`], resolving `${VAR}`
+/// interpolation against the current process environment. `revision` is
+/// stamped on every entry (the file source's generation counter: 1 at
+/// boot, incremented per successful reload).
+pub fn load_resources_file(path: &Path, revision: i64) -> Result<AisixSnapshot, FileSourceErrors> {
+    let label = path.display().to_string();
+    let contents = std::fs::read_to_string(path).map_err(|e| FileSourceErrors {
+        file: label.clone(),
+        errors: vec![LoadError {
+            scope: "(file)".into(),
+            message: format!("cannot read file: {e}"),
+        }],
+    })?;
+    load_from_str(&contents, &label, revision, &|name| {
+        std::env::var(name).ok()
+    })
+}
+
+/// The full pipeline over in-memory contents. Separated from
+/// [`load_resources_file`] so tests can inject file contents and a
+/// closed environment map without touching process state.
+pub fn load_from_str(
+    contents: &str,
+    file_label: &str,
+    revision: i64,
+    env: EnvLookup<'_>,
+) -> Result<AisixSnapshot, FileSourceErrors> {
+    let mut errors: Vec<LoadError> = Vec::new();
+    let fail = |errors: Vec<LoadError>| FileSourceErrors {
+        file: file_label.to_string(),
+        errors,
+    };
+    let file_error = |message: String| LoadError {
+        scope: "(file)".into(),
+        message,
+    };
+
+    // ── YAML parse ────────────────────────────────────────────────────
+    let docs = match YamlLoader::load_from_str(contents) {
+        Ok(docs) => docs,
+        Err(e) => return Err(fail(vec![file_error(format!("YAML parse error: {e}"))])),
+    };
+    let root = match docs.len() {
+        0 => return Err(fail(vec![file_error("file is empty".into())])),
+        1 => &docs[0],
+        n => {
+            return Err(fail(vec![file_error(format!(
+                "expected a single YAML document, found {n}"
+            ))]))
+        }
+    };
+    let Yaml::Hash(root_map) = root else {
+        return Err(fail(vec![file_error(
+            "top level must be a mapping with `_format_version` and resource collections".into(),
+        )]));
+    };
+
+    // ── Format-version gate + unknown-top-level-key gate ─────────────
+    match root_map.get(&Yaml::String("_format_version".into())) {
+        Some(Yaml::String(v)) if v == SUPPORTED_FORMAT_VERSION => {}
+        Some(Yaml::String(v)) => errors.push(file_error(format!(
+            "unrecognized _format_version {v:?} (supported: \"{SUPPORTED_FORMAT_VERSION}\")"
+        ))),
+        Some(_) => errors.push(file_error(format!(
+            "_format_version must be the string \"{SUPPORTED_FORMAT_VERSION}\" (quote it)"
+        ))),
+        None => errors.push(file_error(format!(
+            "missing mandatory _format_version (expected \"{SUPPORTED_FORMAT_VERSION}\")"
+        ))),
+    }
+    for key in root_map.keys() {
+        let Yaml::String(key) = key else {
+            errors.push(file_error(format!(
+                "top-level keys must be plain strings, found {key:?}"
+            )));
+            continue;
+        };
+        if key != "_format_version" && !KINDS.iter().any(|(k, _)| k == key) {
+            let known: Vec<&str> = KINDS.iter().map(|(k, _)| *k).collect();
+            errors.push(file_error(format!(
+                "unknown top-level key `{key}` (expected _format_version and resource \
+                 collections: {})",
+                known.join(", ")
+            )));
+        }
+    }
+
+    // ── Pass 1: interpolate + convert + identity / duplicate checks ──
+    struct Prepared {
+        kind: &'static str,
+        scope: String,
+        identity: String,
+        doc: Value,
+    }
+    let mut prepared: Vec<Prepared> = Vec::new();
+    let mut identity_maps = IdentityMaps::new();
+
+    for (kind, identity_field) in KINDS {
+        let mut seen_at: BTreeMap<String, usize> = BTreeMap::new();
+        let entries = match root_map.get(&Yaml::String(kind.into())) {
+            None | Some(Yaml::Null) => continue,
+            Some(Yaml::Array(items)) => items,
+            Some(_) => {
+                errors.push(file_error(format!("`{kind}` must be a sequence of maps")));
+                continue;
+            }
+        };
+        for (i, item) in entries.iter().enumerate() {
+            let index_scope = format!("{kind}[{i}]");
+            if !matches!(item, Yaml::Hash(_)) {
+                errors.push(LoadError {
+                    scope: index_scope,
+                    message: "entry must be a mapping".into(),
+                });
+                continue;
+            }
+            let doc = match yaml::yaml_to_json(item, "", env) {
+                Ok(doc) => doc,
+                Err((path, message)) => {
+                    errors.push(LoadError {
+                        scope: index_scope,
+                        message: format!("field `{path}`: {message}"),
+                    });
+                    continue;
+                }
+            };
+            let Some(identity) = identity_field.extract(&doc) else {
+                errors.push(LoadError {
+                    scope: index_scope,
+                    message: format!(
+                        "{} is required and must be a non-empty string \
+                         (it is the entry's identity)",
+                        identity_field.describe()
+                    ),
+                });
+                continue;
+            };
+            let scope = format!("{kind}[{i}] ({identity:?})");
+            if let Some(first) = seen_at.get(&identity) {
+                errors.push(LoadError {
+                    scope,
+                    message: format!(
+                        "duplicate {kind} entry: {} {identity:?} is already \
+                         defined at {kind}[{first}] — identities must be unique \
+                         within a kind",
+                        identity_field.describe()
+                    ),
+                });
+                continue;
+            }
+            seen_at.insert(identity.clone(), i);
+            identity_maps
+                .entry(kind)
+                .or_default()
+                .insert(identity.clone(), derive_id(kind, &identity));
+            prepared.push(Prepared {
+                kind,
+                scope,
+                identity,
+                doc,
+            });
+        }
+    }
+
+    // ── Pass 2: desugar → canonical validation → typed models ────────
+    fn finish<T: serde::de::DeserializeOwned>(
+        scope: &str,
+        doc: &Value,
+        validate: fn(&Value) -> Result<(), SchemaError>,
+        errors: &mut Vec<LoadError>,
+    ) -> Option<T> {
+        if let Err(e) = validate(doc) {
+            errors.push(LoadError {
+                scope: scope.to_string(),
+                message: e.to_string(),
+            });
+            return None;
+        }
+        match serde_json::from_value::<T>(doc.clone()) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                errors.push(LoadError {
+                    scope: scope.to_string(),
+                    message: format!("cannot decode canonical document: {e}"),
+                });
+                None
+            }
+        }
+    }
+
+    // Typed buckets carry `(derived_id, scope, value)` so cross-reference
+    // errors can point back at the file entry.
+    let mut models: Vec<(String, String, Model)> = Vec::new();
+    let mut apikeys: Vec<(String, String, ApiKey)> = Vec::new();
+    let mut provider_keys: Vec<(String, String, ProviderKey)> = Vec::new();
+    let mut guardrails: Vec<(String, String, Guardrail)> = Vec::new();
+    let mut mcp_servers: Vec<(String, String, McpServer)> = Vec::new();
+    let mut a2a_agents: Vec<(String, String, A2aAgent)> = Vec::new();
+    let mut cache_policies: Vec<(String, String, CachePolicy)> = Vec::new();
+    let mut observability_exporters: Vec<(String, String, ObservabilityExporter)> = Vec::new();
+    let mut rate_limit_policies: Vec<(String, String, RateLimitPolicy)> = Vec::new();
+
+    for mut entry in prepared {
+        let id = derive_id(entry.kind, &entry.identity);
+        let scope = entry.scope;
+
+        // The file accepts no `id` field on any kind: ids are always
+        // derived. Strict schemas would reject it as an unknown field
+        // anyway; the open ones (guardrail, cache_policy,
+        // observability_exporter) would silently carry it, so the check
+        // is made explicit and uniform here.
+        if entry.doc.get("id").is_some() {
+            errors.push(LoadError {
+                scope,
+                message: "the resources file does not accept `id` — ids are derived \
+                          deterministically from the entry's name"
+                    .into(),
+            });
+            continue;
+        }
+
+        let sugar_result = match entry.kind {
+            "models" => desugar::desugar_model(&mut entry.doc, &identity_maps),
+            "api_keys" => desugar::desugar_api_key(&mut entry.doc, env),
+            "rate_limit_policies" => {
+                desugar::desugar_rate_limit_policy(&mut entry.doc, &identity_maps)
+            }
+            _ => Ok(()),
+        };
+        if let Err(message) = sugar_result {
+            errors.push(LoadError { scope, message });
+            continue;
+        }
+
+        match entry.kind {
+            "provider_keys" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_provider_key, &mut errors) {
+                    provider_keys.push((id, scope, t));
+                }
+            }
+            "models" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_model, &mut errors) {
+                    models.push((id, scope, t));
+                }
+            }
+            "api_keys" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_apikey, &mut errors) {
+                    apikeys.push((id, scope, t));
+                }
+            }
+            "guardrails" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_guardrail, &mut errors) {
+                    guardrails.push((id, scope, t));
+                }
+            }
+            "mcp_servers" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_mcp_server, &mut errors) {
+                    mcp_servers.push((id, scope, t));
+                }
+            }
+            "a2a_agents" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_a2a_agent, &mut errors) {
+                    a2a_agents.push((id, scope, t));
+                }
+            }
+            "cache_policies" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_cache_policy, &mut errors) {
+                    cache_policies.push((id, scope, t));
+                }
+            }
+            "observability_exporters" => {
+                if let Some(t) = finish(
+                    &scope,
+                    &entry.doc,
+                    validate_observability_exporter,
+                    &mut errors,
+                ) {
+                    observability_exporters.push((id, scope, t));
+                }
+            }
+            "rate_limit_policies" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_rate_limit_policy, &mut errors)
+                {
+                    rate_limit_policies.push((id, scope, t));
+                }
+            }
+            other => unreachable!("kind {other} is not in KINDS"),
+        }
+    }
+
+    // ── Pass 3: cross-reference checks ────────────────────────────────
+    // Every model-name reference must resolve at load time so a typo can
+    // never become a silent runtime failure. Entries containing `*` are
+    // glob patterns and are exempt from the existence check.
+    let empty = BTreeMap::new();
+    let model_names = identity_maps.get("models").unwrap_or(&empty);
+    let mut check_model_ref = |scope: &str, field: &str, reference: &str| {
+        if reference.contains('*') || model_names.contains_key(reference) {
+            return;
+        }
+        let mut known: Vec<&str> = model_names.keys().map(String::as_str).collect();
+        known.sort_unstable();
+        errors.push(LoadError {
+            scope: scope.to_string(),
+            message: format!(
+                "{field} references unknown model {reference:?} (defined models: {})",
+                if known.is_empty() {
+                    "none".to_string()
+                } else {
+                    known.join(", ")
+                }
+            ),
+        });
+    };
+
+    for (_, scope, key) in &apikeys {
+        for entry in &key.allowed_models {
+            check_model_ref(scope, "allowed_models entry", entry);
+        }
+    }
+    for (_, scope, model) in &models {
+        if let Some(routing) = &model.routing {
+            for target in &routing.targets {
+                check_model_ref(scope, "routing target", &target.model);
+            }
+        }
+        if let Some(ensemble) = &model.ensemble {
+            for member in &ensemble.panel {
+                check_model_ref(scope, "ensemble panel member", &member.model);
+            }
+            check_model_ref(scope, "ensemble judge", &ensemble.judge.model);
+        }
+        if let Some(semantic) = &model.semantic {
+            check_model_ref(scope, "semantic embedding_model", &semantic.embedding_model);
+            check_model_ref(scope, "semantic default", &semantic.default);
+            for route in &semantic.routes {
+                check_model_ref(
+                    scope,
+                    &format!("semantic route {:?} target", route.name),
+                    &route.target,
+                );
+            }
+            if let crate::models::OnEmbeddingFailure::Target { target } =
+                &semantic.on_embedding_failure
+            {
+                check_model_ref(scope, "semantic on_embedding_failure target", target);
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        return Err(fail(errors));
+    }
+
+    // ── Materialize the snapshot ──────────────────────────────────────
+    let snapshot = AisixSnapshot::new();
+    for (id, _, v) in provider_keys {
+        snapshot
+            .provider_keys
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in models {
+        snapshot.models.insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in apikeys {
+        snapshot.apikeys.insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in guardrails {
+        snapshot
+            .guardrails
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in mcp_servers {
+        snapshot
+            .mcp_servers
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in a2a_agents {
+        snapshot
+            .a2a_agents
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in cache_policies {
+        snapshot
+            .cache_policies
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in observability_exporters {
+        snapshot
+            .observability_exporters
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in rate_limit_policies {
+        snapshot
+            .rate_limit_policies
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    Ok(snapshot)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -433,6 +433,89 @@ models:
 }
 
 #[test]
+fn duplicate_key_hash_across_api_keys_is_a_load_error_without_hash_leak() {
+    // The runtime credential index is keyed by key_hash — a duplicate
+    // plaintext would silently last-wins at auth time, so it must fail
+    // the load like the duplicate-identity rule does. One entry uses
+    // key_env, the other key_hash, resolving to the same credential.
+    let plain = "sk-shared-plaintext";
+    let hash = crate::models::ApiKey::hash_bearer(plain);
+    let contents = format!(
+        r#"
+_format_version: "1"
+api_keys:
+  - display_name: first
+    key_env: SHARED_KEY
+    allowed_models: ["*"]
+  - display_name: second
+    key_hash: {hash}
+    allowed_models: ["*"]
+"#
+    );
+    let env = env_of(&[("SHARED_KEY", plain)]);
+    let errs = errors_of(load(&contents, &env));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(errs[0].contains("duplicate api key credential"), "{errs:?}");
+    // The error names both entries…
+    assert!(errs[0].contains("api_keys[0]"), "{errs:?}");
+    assert!(errs[0].contains("api_keys[1]"), "{errs:?}");
+    // …and never echoes the credential in either form.
+    assert!(!errs[0].contains(plain), "plaintext leaked: {errs:?}");
+    assert!(!errs[0].contains(&hash), "hash leaked: {errs:?}");
+}
+
+#[test]
+fn explicit_provider_key_id_must_match_a_file_defined_key() {
+    // In file mode every provider-key id is derived from its name, so a
+    // pasted foreign UUID is guaranteed dangling — reject it at load.
+    let contents = r#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: sk-1
+models:
+  - display_name: m1
+    provider: openai
+    model_name: x
+    provider_key_id: 11111111-1111-1111-1111-111111111111
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(errs[0].contains("provider_key_id"), "{errs:?}");
+    assert!(
+        errs[0].contains("`provider_key`"),
+        "should point at the name sugar: {errs:?}"
+    );
+
+    // The correctly-derived id (what the sugar would produce) passes —
+    // determinism means a generated file can carry explicit ids.
+    let derived = derive_id("provider_keys", "pk");
+    let contents = format!(
+        r#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: sk-1
+models:
+  - display_name: m1
+    provider: openai
+    model_name: x
+    provider_key_id: {derived}
+"#
+    );
+    let snap = load(&contents, &env_of(&[])).expect("derived id must be accepted");
+    assert_eq!(
+        snap.models
+            .get_by_name("m1")
+            .unwrap()
+            .value
+            .provider_key_id
+            .as_deref(),
+        Some(derived.as_str()),
+    );
+}
+
+#[test]
 fn absent_collections_load_as_empty_and_null_sections_are_tolerated() {
     let contents = "_format_version: \"1\"\nmodels:\n";
     let snap = load(contents, &env_of(&[])).unwrap();

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -1,0 +1,505 @@
+//! Pipeline tests for the resources-file source. Everything goes
+//! through [`load_from_str`] with a closed env map — no process-global
+//! environment mutation, no filesystem.
+
+use super::*;
+use std::collections::HashMap;
+
+fn env_of(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+fn load(contents: &str, env: &HashMap<String, String>) -> Result<AisixSnapshot, FileSourceErrors> {
+    load_from_str(contents, "resources.yaml", 1, &|name| {
+        env.get(name).cloned()
+    })
+}
+
+fn errors_of(result: Result<AisixSnapshot, FileSourceErrors>) -> Vec<String> {
+    result
+        .expect_err("expected load errors")
+        .errors
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+const FULL_VALID_FILE: &str = r#"
+_format_version: "1"
+
+provider_keys:
+  - display_name: openai-prod
+    provider: openai
+    api_key: ${OPENAI_API_KEY}
+    api_base: https://${UPSTREAM_HOST}/v1
+
+models:
+  - display_name: gpt-4o
+    provider: openai
+    model_name: gpt-4o-2024-11-20
+    provider_key: openai-prod
+  - display_name: gpt-4o-mini
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: openai-prod
+  - display_name: balanced
+    routing:
+      strategy: round_robin
+      targets:
+        - model: gpt-4o
+        - model: gpt-4o-mini
+
+api_keys:
+  - display_name: ci-bot
+    key_env: E2E_CI_BOT_KEY
+    allowed_models: ["gpt-4o", "balanced"]
+  - display_name: ops
+    key_hash: 91ed2dbc407561556f3e7be98ba0bd2a57986d6a868c482d867d19c6d40d201c
+    allowed_models: ["*"]
+
+guardrails:
+  - name: no-secrets
+    kind: keyword
+    patterns:
+      - kind: literal
+        value: topsecret
+
+mcp_servers:
+  - name: github
+    url: https://mcp.example.com/mcp
+
+a2a_agents:
+  - name: helper
+    url: https://a2a.example.com/agent
+
+cache_policies:
+  - name: default-cache
+    enabled: true
+    ttl_seconds: 600
+
+observability_exporters:
+  - name: otel
+    kind: otlp_http
+    endpoint: https://otel.example.com/v1/traces
+
+rate_limit_policies:
+  - name: cap-gpt4o
+    scope: model
+    scope_ref: gpt-4o
+    window: minute
+    max_requests: 300
+  - name: cap-ci-bot
+    scope: api_key
+    scope_ref: ci-bot
+    window: minute
+    max_requests: 60
+  - name: cap-team
+    scope: team
+    scope_ref: team-uuid-1
+    window: hour
+    max_requests: 1000
+"#;
+
+fn full_env() -> HashMap<String, String> {
+    env_of(&[
+        ("OPENAI_API_KEY", "sk-upstream"),
+        ("UPSTREAM_HOST", "api.openai.com"),
+        ("E2E_CI_BOT_KEY", "sk-ci-plaintext"),
+    ])
+}
+
+#[test]
+fn full_valid_file_loads_every_kind() {
+    let snap = load(FULL_VALID_FILE, &full_env()).expect("full file must load");
+    assert_eq!(snap.provider_keys.len(), 1);
+    assert_eq!(snap.models.len(), 3);
+    assert_eq!(snap.apikeys.len(), 2);
+    assert_eq!(snap.guardrails.len(), 1);
+    assert_eq!(snap.mcp_servers.len(), 1);
+    assert_eq!(snap.a2a_agents.len(), 1);
+    assert_eq!(snap.cache_policies.len(), 1);
+    assert_eq!(snap.observability_exporters.len(), 1);
+    assert_eq!(snap.rate_limit_policies.len(), 3);
+
+    // Interpolation landed in the provider key (full + partial).
+    let pk = snap.provider_keys.get_by_name("openai-prod").unwrap();
+    assert_eq!(pk.value.api_key, "sk-upstream");
+    assert_eq!(
+        pk.value.api_base.as_deref(),
+        Some("https://api.openai.com/v1")
+    );
+
+    // The model's provider_key name sugar resolved to the derived id.
+    let model = snap.models.get_by_name("gpt-4o").unwrap();
+    assert_eq!(
+        model.value.provider_key_id.as_deref(),
+        Some(derive_id("provider_keys", "openai-prod").as_str()),
+    );
+    assert_eq!(model.id, derive_id("models", "gpt-4o"));
+
+    // key_env became the SHA-256 of the plaintext; the api_keys name
+    // index is keyed by key_hash (matching the etcd path).
+    let expected_hash = crate::models::ApiKey::hash_bearer("sk-ci-plaintext");
+    let key = snap
+        .apikeys
+        .get_by_name(&expected_hash)
+        .expect("hashed key");
+    assert_eq!(key.id, derive_id("api_keys", "ci-bot"));
+
+    // scope_ref resolution per scope: model / api_key → derived ids,
+    // team → verbatim.
+    let by_policy_name = |n: &str| {
+        snap.rate_limit_policies
+            .entries()
+            .into_iter()
+            .find(|e| e.value.name == n)
+            .unwrap()
+    };
+    assert_eq!(
+        by_policy_name("cap-gpt4o").value.scope_ref,
+        derive_id("models", "gpt-4o"),
+    );
+    assert_eq!(
+        by_policy_name("cap-ci-bot").value.scope_ref,
+        derive_id("api_keys", "ci-bot"),
+    );
+    assert_eq!(by_policy_name("cap-team").value.scope_ref, "team-uuid-1");
+}
+
+#[test]
+fn ids_are_deterministic_across_two_loads() {
+    let env = full_env();
+    let a = load(FULL_VALID_FILE, &env).unwrap();
+    let b = load(FULL_VALID_FILE, &env).unwrap();
+    for name in ["gpt-4o", "gpt-4o-mini", "balanced"] {
+        assert_eq!(
+            a.models.get_by_name(name).unwrap().id,
+            b.models.get_by_name(name).unwrap().id,
+            "model {name} id must be stable across reloads",
+        );
+    }
+    assert_eq!(
+        a.provider_keys.get_by_name("openai-prod").unwrap().id,
+        b.provider_keys.get_by_name("openai-prod").unwrap().id,
+    );
+}
+
+#[test]
+fn missing_format_version_is_a_load_error() {
+    let errs = errors_of(load("models: []\n", &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("missing mandatory _format_version"),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn unrecognized_format_version_is_a_load_error() {
+    let errs = errors_of(load("_format_version: \"2\"\n", &env_of(&[])));
+    assert!(errs[0].contains("unrecognized _format_version"), "{errs:?}");
+    // An unquoted `1` parses as a YAML integer — the error nudges toward
+    // quoting instead of claiming the version is missing.
+    let errs = errors_of(load("_format_version: 1\n", &env_of(&[])));
+    assert!(errs[0].contains("quote it"), "{errs:?}");
+}
+
+#[test]
+fn unknown_top_level_key_is_a_load_error() {
+    let errs = errors_of(load("_format_version: \"1\"\nmodles: []\n", &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("unknown top-level key `modles`"),
+        "{errs:?}"
+    );
+    assert!(
+        errs[0].contains("provider_keys"),
+        "should list the collections: {errs:?}"
+    );
+}
+
+#[test]
+fn empty_and_multi_document_files_are_load_errors() {
+    let errs = errors_of(load("", &env_of(&[])));
+    assert!(errs[0].contains("file is empty"), "{errs:?}");
+
+    let errs = errors_of(load(
+        "_format_version: \"1\"\n---\n_format_version: \"1\"\n",
+        &env_of(&[]),
+    ));
+    assert!(errs[0].contains("single YAML document"), "{errs:?}");
+}
+
+#[test]
+fn interpolation_error_names_kind_entry_and_field_path() {
+    let contents = r#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: ${MISSING_KEY}
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(errs[0].starts_with("provider_keys[0]"), "{errs:?}");
+    assert!(errs[0].contains("field `api_key`"), "{errs:?}");
+    assert!(errs[0].contains("`MISSING_KEY`"), "{errs:?}");
+}
+
+#[test]
+fn duplicate_identity_within_a_kind_is_a_load_error() {
+    let contents = r#"
+_format_version: "1"
+provider_keys:
+  - display_name: dup
+    api_key: sk-1
+  - display_name: dup
+    api_key: sk-2
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("duplicate provider_keys entry"),
+        "{errs:?}"
+    );
+    assert!(
+        errs[0].contains("provider_keys[0]"),
+        "should name the first definition: {errs:?}"
+    );
+}
+
+#[test]
+fn id_field_is_rejected_on_strict_and_open_kinds() {
+    // `guardrails` is one of the schema-open kinds — without the
+    // explicit sugar-layer check an `id` would be silently carried.
+    let contents = r#"
+_format_version: "1"
+guardrails:
+  - name: g
+    id: 11111111-1111-1111-1111-111111111111
+    kind: keyword
+    patterns:
+      - kind: literal
+        value: x
+models:
+  - display_name: m
+    id: 22222222-2222-2222-2222-222222222222
+    provider: openai
+    model_name: x
+    provider_key_id: pk-1
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 2, "{errs:?}");
+    for e in &errs {
+        assert!(e.contains("does not accept `id`"), "{errs:?}");
+    }
+}
+
+#[test]
+fn canonical_validation_failures_carry_entry_scope() {
+    // Empty display_name violates the model schema (minLength 1)…
+    // after passing identity extraction? No — identity extraction
+    // requires a non-empty string, so this surfaces as the identity
+    // error. Use a schema-level failure instead: a direct model missing
+    // its provider triple.
+    let contents = r#"
+_format_version: "1"
+models:
+  - display_name: incomplete
+    provider: openai
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].starts_with("models[0] (\"incomplete\")"),
+        "{errs:?}"
+    );
+    assert!(errs[0].contains("schema validation failed"), "{errs:?}");
+}
+
+#[test]
+fn all_errors_are_collected_not_first_only() {
+    let contents = r#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: ${MISSING_A}
+models:
+  - display_name: m1
+    provider: openai
+    model_name: x
+    provider_key: no-such-pk
+api_keys:
+  - display_name: k1
+    key_env: MISSING_B
+    allowed_models: ["ghost-model"]
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    // 1 interpolation error + 1 unknown provider_key name + 1 missing
+    // key_env variable. (`ghost-model` is unreachable for k1 because its
+    // entry already failed desugaring — cross-ref only runs on decoded
+    // entries; the load still fails with everything found.)
+    assert_eq!(errs.len(), 3, "{errs:?}");
+    assert!(errs.iter().any(|e| e.contains("MISSING_A")), "{errs:?}");
+    assert!(errs.iter().any(|e| e.contains("no-such-pk")), "{errs:?}");
+    assert!(errs.iter().any(|e| e.contains("MISSING_B")), "{errs:?}");
+}
+
+#[test]
+fn cross_ref_unknown_allowed_model_is_an_error_globs_exempt() {
+    let contents = r#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: sk-1
+models:
+  - display_name: real-model
+    provider: openai
+    model_name: x
+    provider_key: pk
+api_keys:
+  - display_name: globby
+    key_hash: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    allowed_models: ["*", "openai/*", "real-model"]
+  - display_name: typo
+    key_hash: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    allowed_models: ["real-modle"]
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "globs and exact matches must pass: {errs:?}");
+    assert!(errs[0].contains("api_keys[1]"), "{errs:?}");
+    assert!(errs[0].contains("\"real-modle\""), "{errs:?}");
+    assert!(
+        errs[0].contains("real-model"),
+        "should list defined models: {errs:?}"
+    );
+}
+
+#[test]
+fn cross_ref_covers_routing_ensemble_and_semantic_references() {
+    let contents = r#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: sk-1
+models:
+  - display_name: real
+    provider: openai
+    model_name: x
+    provider_key: pk
+  - display_name: router
+    routing:
+      strategy: round_robin
+      targets:
+        - model: real
+        - model: ghost-target
+  - display_name: council
+    ensemble:
+      panel:
+        - model: real
+        - model: ghost-panel
+      judge:
+        model: ghost-judge
+  - display_name: sem
+    semantic:
+      embedding_model: ghost-embed
+      default: ghost-default
+      routes:
+        - name: r1
+          target: ghost-route
+          examples: ["hi"]
+      match:
+        threshold: 0.7
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    let all = errs.join("\n");
+    for ghost in [
+        "ghost-target",
+        "ghost-panel",
+        "ghost-judge",
+        "ghost-embed",
+        "ghost-default",
+        "ghost-route",
+    ] {
+        assert!(
+            all.contains(ghost),
+            "missing cross-ref error for {ghost}:\n{all}"
+        );
+    }
+    // `real` referenced from routing/ensemble passed the check.
+    assert_eq!(errs.len(), 6, "{errs:?}");
+}
+
+#[test]
+fn absent_collections_load_as_empty_and_null_sections_are_tolerated() {
+    let contents = "_format_version: \"1\"\nmodels:\n";
+    let snap = load(contents, &env_of(&[])).unwrap();
+    assert_eq!(snap.total_entries(), 0);
+}
+
+#[test]
+fn collection_must_be_a_sequence() {
+    let errs = errors_of(load(
+        "_format_version: \"1\"\nmodels: {display_name: x}\n",
+        &env_of(&[]),
+    ));
+    assert!(errs[0].contains("`models` must be a sequence"), "{errs:?}");
+}
+
+#[test]
+fn entry_must_be_a_mapping() {
+    let errs = errors_of(load(
+        "_format_version: \"1\"\nmodels:\n  - just-a-string\n",
+        &env_of(&[]),
+    ));
+    assert!(errs[0].contains("models[0]"), "{errs:?}");
+    assert!(errs[0].contains("must be a mapping"), "{errs:?}");
+}
+
+#[test]
+fn mcp_servers_accept_display_name_as_alternative_identity() {
+    let contents = r#"
+_format_version: "1"
+mcp_servers:
+  - display_name: gh-former
+    url: https://x.example/mcp
+"#;
+    let snap = load(contents, &env_of(&[])).unwrap();
+    // The alias lands on `name` through the same serde path as etcd.
+    assert!(snap.mcp_servers.get_by_name("gh-former").is_some());
+    assert_eq!(
+        snap.mcp_servers.get_by_name("gh-former").unwrap().id,
+        derive_id("mcp_servers", "gh-former"),
+    );
+}
+
+#[test]
+fn revision_is_stamped_on_every_entry() {
+    let env = full_env();
+    let snap = load_from_str(FULL_VALID_FILE, "resources.yaml", 7, &|n| {
+        env.get(n).cloned()
+    })
+    .unwrap();
+    assert_eq!(snap.models.get_by_name("gpt-4o").unwrap().revision, 7);
+    assert_eq!(
+        snap.provider_keys
+            .get_by_name("openai-prod")
+            .unwrap()
+            .revision,
+        7
+    );
+}
+
+#[test]
+fn report_formats_file_and_all_errors() {
+    let err = load("models: []\n", &env_of(&[])).unwrap_err();
+    let text = err.to_string();
+    assert!(text.contains("resources file resources.yaml"), "{text}");
+    assert!(text.contains("1 error(s)"), "{text}");
+    assert!(
+        text.contains("  - (file): missing mandatory _format_version"),
+        "{text}"
+    );
+}

--- a/crates/aisix-core/src/filesource/yaml.rs
+++ b/crates/aisix-core/src/filesource/yaml.rs
@@ -1,0 +1,243 @@
+//! YAML tree → JSON document conversion with `${VAR}` interpolation.
+//!
+//! Interpolation runs on string scalars in the *parsed* YAML tree —
+//! after the YAML parse, before the JSON conversion — so an environment
+//! value can never inject YAML structure. Mapping keys are deliberately
+//! not interpolated for the same reason.
+//!
+//! Interpolation grammar (normative for the resources file):
+//! - `${VAR}`  → the value of environment variable `VAR`; partial
+//!   interpolation is supported (`https://${HOST}/v1`). A missing or
+//!   empty variable is an error.
+//! - `$$`      → a literal `$`.
+//! - bare `$VAR` (no braces) is NOT interpolated and passes through.
+
+use serde_json::{Map, Number, Value};
+use yaml_rust2::Yaml;
+
+/// Environment lookup used by interpolation. Production passes
+/// `std::env::var(..).ok()`; tests inject a closed map so they never
+/// mutate process-global env state.
+pub(crate) type EnvLookup<'a> = &'a dyn Fn(&str) -> Option<String>;
+
+/// Interpolate `${VAR}` references in one string scalar.
+pub(crate) fn interpolate_str(input: &str, env: EnvLookup<'_>) -> Result<String, String> {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '$' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // `$$` → literal `$`.
+            Some('$') => {
+                chars.next();
+                out.push('$');
+            }
+            // `${VAR}` → env lookup.
+            Some('{') => {
+                chars.next();
+                let mut name = String::new();
+                let mut closed = false;
+                for c2 in chars.by_ref() {
+                    if c2 == '}' {
+                        closed = true;
+                        break;
+                    }
+                    name.push(c2);
+                }
+                if !closed {
+                    return Err(format!(
+                        "unterminated `${{` in value {input:?} — close it with `}}` \
+                         or escape the dollar sign as `$$`"
+                    ));
+                }
+                if name.is_empty() {
+                    return Err("empty variable name in `${}`".into());
+                }
+                match env(&name) {
+                    Some(v) if !v.is_empty() => out.push_str(&v),
+                    _ => {
+                        return Err(format!("environment variable `{name}` is unset or empty"));
+                    }
+                }
+            }
+            // Bare `$VAR` (or trailing `$`) — not an interpolation form.
+            _ => out.push('$'),
+        }
+    }
+    Ok(out)
+}
+
+/// Convert a parsed YAML node into a `serde_json::Value`, interpolating
+/// `${VAR}` in every string scalar along the way. Errors carry the
+/// field path relative to the entry root (e.g. `routing.targets[0].model`).
+pub(crate) fn yaml_to_json(
+    node: &Yaml,
+    path: &str,
+    env: EnvLookup<'_>,
+) -> Result<Value, (String, String)> {
+    let at = |msg: String| (path.to_string(), msg);
+    match node {
+        Yaml::Null => Ok(Value::Null),
+        Yaml::Boolean(b) => Ok(Value::Bool(*b)),
+        Yaml::Integer(i) => Ok(Value::Number(Number::from(*i))),
+        Yaml::Real(raw) => {
+            let f: f64 = raw
+                .parse()
+                .map_err(|_| at(format!("invalid number {raw:?}")))?;
+            Number::from_f64(f)
+                .map(Value::Number)
+                .ok_or_else(|| at(format!("number {raw:?} is not representable in JSON")))
+        }
+        Yaml::String(s) => interpolate_str(s, env).map(Value::String).map_err(at),
+        Yaml::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for (i, item) in items.iter().enumerate() {
+                let child_path = format!("{path}[{i}]");
+                out.push(yaml_to_json(item, &child_path, env)?);
+            }
+            Ok(Value::Array(out))
+        }
+        Yaml::Hash(map) => {
+            let mut out = Map::with_capacity(map.len());
+            for (k, v) in map {
+                let key = match k {
+                    Yaml::String(s) => s.clone(),
+                    other => {
+                        return Err(at(format!(
+                            "mapping keys must be plain strings, found {other:?}"
+                        )));
+                    }
+                };
+                let child_path = if path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{path}.{key}")
+                };
+                out.insert(key, yaml_to_json(v, &child_path, env)?);
+            }
+            Ok(Value::Object(out))
+        }
+        Yaml::Alias(_) | Yaml::BadValue => {
+            Err(at("unsupported YAML construct at this position".into()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use yaml_rust2::YamlLoader;
+
+    fn env_of(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn lookup(map: &HashMap<String, String>) -> impl Fn(&str) -> Option<String> + '_ {
+        move |name| map.get(name).cloned()
+    }
+
+    #[test]
+    fn interpolates_full_and_partial_values() {
+        let env = env_of(&[("HOST", "up.example"), ("KEY", "sk-1")]);
+        let f = lookup(&env);
+        assert_eq!(interpolate_str("${KEY}", &f).unwrap(), "sk-1");
+        assert_eq!(
+            interpolate_str("https://${HOST}/v1", &f).unwrap(),
+            "https://up.example/v1"
+        );
+        assert_eq!(
+            interpolate_str("${HOST}:${KEY}", &f).unwrap(),
+            "up.example:sk-1"
+        );
+    }
+
+    #[test]
+    fn double_dollar_escapes_a_literal_dollar() {
+        let env = env_of(&[("VAR", "x")]);
+        let f = lookup(&env);
+        assert_eq!(interpolate_str("$${VAR}", &f).unwrap(), "${VAR}");
+        assert_eq!(interpolate_str("a$$b", &f).unwrap(), "a$b");
+        assert_eq!(interpolate_str("$$$$", &f).unwrap(), "$$");
+        // `$$` then a real interpolation.
+        assert_eq!(interpolate_str("$$${VAR}", &f).unwrap(), "$x");
+    }
+
+    #[test]
+    fn bare_dollar_var_is_left_untouched() {
+        let env = env_of(&[("VAR", "x")]);
+        let f = lookup(&env);
+        assert_eq!(interpolate_str("$VAR", &f).unwrap(), "$VAR");
+        assert_eq!(interpolate_str("cost is 5$", &f).unwrap(), "cost is 5$");
+        assert_eq!(interpolate_str("a$ b", &f).unwrap(), "a$ b");
+    }
+
+    #[test]
+    fn missing_or_empty_variable_is_an_error() {
+        let env = env_of(&[("EMPTY", "")]);
+        let f = lookup(&env);
+        let err = interpolate_str("${NOPE}", &f).unwrap_err();
+        assert!(err.contains("`NOPE`"), "unexpected: {err}");
+        assert!(err.contains("unset or empty"), "unexpected: {err}");
+        let err = interpolate_str("${EMPTY}", &f).unwrap_err();
+        assert!(err.contains("`EMPTY`"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn unterminated_and_empty_braces_are_errors() {
+        let env = env_of(&[]);
+        let f = lookup(&env);
+        assert!(interpolate_str("${OPEN", &f)
+            .unwrap_err()
+            .contains("unterminated"));
+        assert!(interpolate_str("${}", &f)
+            .unwrap_err()
+            .contains("empty variable name"));
+    }
+
+    #[test]
+    fn conversion_interpolates_only_string_scalars_and_tracks_paths() {
+        let env = env_of(&[("HOST", "h")]);
+        let f = lookup(&env);
+        let docs = YamlLoader::load_from_str(
+            "api_base: https://${HOST}/v1\nnested:\n  list:\n    - ${MISSING}\n",
+        )
+        .unwrap();
+
+        // Happy path on the string scalar.
+        let ok = yaml_to_json(&docs[0]["api_base"], "api_base", &f).unwrap();
+        assert_eq!(ok, serde_json::json!("https://h/v1"));
+
+        // Error path carries the full field path.
+        let (path, msg) = yaml_to_json(&docs[0], "", &f).unwrap_err();
+        assert_eq!(path, "nested.list[0]");
+        assert!(msg.contains("`MISSING`"));
+    }
+
+    #[test]
+    fn conversion_preserves_scalar_types() {
+        let env = env_of(&[]);
+        let f = lookup(&env);
+        let docs = YamlLoader::load_from_str("i: 3\nf: 1.5\nb: true\nn: null\ns: hi\n").unwrap();
+        let v = yaml_to_json(&docs[0], "", &f).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({"i": 3, "f": 1.5, "b": true, "n": null, "s": "hi"})
+        );
+    }
+
+    #[test]
+    fn conversion_rejects_non_string_mapping_keys() {
+        let env = env_of(&[]);
+        let f = lookup(&env);
+        let docs = YamlLoader::load_from_str("1: x\n").unwrap();
+        let (_, msg) = yaml_to_json(&docs[0], "", &f).unwrap_err();
+        assert!(msg.contains("plain strings"), "unexpected: {msg}");
+    }
+}

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod config;
 pub mod error;
+pub mod filesource;
 pub mod models;
 pub mod resource;
 pub mod snapshot;

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1003,6 +1003,14 @@ pub fn build_index_from_snapshot(
     // (tracked in https://github.com/api7/ai-gateway/issues/417).
     // After removal, a guardrail with zero attachment rows is a silent no-op —
     // operators must explicitly attach it to a scope.
+    //
+    // NOTE: the standalone resources-file source (aisix-core::filesource)
+    // deliberately writes NO attachment rows — its v1 format has no
+    // attachment collection, so file-defined guardrails are env-global
+    // through exactly this fallback. Do not remove this block without
+    // giving the file format a scoping surface (or synthesizing env-scope
+    // attachments in the file loader). The file-resource-source e2e pins
+    // that a file-defined guardrail fires.
     // Same deterministic created_at-ascending order as the chain-build
     // path: these implicit entries all share priority 0 + env scope, so
     // without a pre-sort their relative order — and which Block fires

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -13,7 +13,7 @@
 //! 10. On SIGINT/SIGTERM: cancel supervisor, stop accepting, join
 
 use std::error::Error as StdError;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 mod cert_bundle;
@@ -21,10 +21,13 @@ mod heartbeat;
 mod managed_bundle;
 mod telemetry;
 
-use aisix_admin::{AdminState, ConfigStore, EtcdConfigStore};
+use aisix_admin::{AdminState, ConfigStore, EtcdConfigStore, FileManagedStore};
 use aisix_cache::{Cache, MemoryCache, RedisCache};
 use aisix_core::models::Adapter;
-use aisix_core::{CacheBackend, Config, EtcdConfig, EtcdTlsConfig, RateLimitBackend};
+use aisix_core::snapshot::SnapshotHandle;
+use aisix_core::{
+    AisixSnapshot, CacheBackend, Config, EtcdConfig, EtcdTlsConfig, RateLimitBackend,
+};
 use aisix_etcd::{EtcdConfigProvider, SnapshotCache, Supervisor};
 use aisix_gateway::Hub;
 use aisix_obs::{init_tracing, install_otlp_tracer, Metrics};
@@ -42,11 +45,33 @@ use etcd_client::{Certificate, ConnectOptions, Identity, TlsOptions};
 use tokio::sync::watch;
 
 #[derive(Debug, Parser)]
-#[command(name = "aisix", version = aisix_core::BUILD_VERSION, about = "aisix AI Gateway")]
+#[command(
+    name = "aisix",
+    version = aisix_core::BUILD_VERSION,
+    about = "aisix AI Gateway",
+    subcommand_negates_reqs = true
+)]
 struct Cli {
     /// Path to the bootstrap config file (YAML / TOML / JSON).
-    #[arg(short, long, env = "AISIX_CONFIG")]
-    config: PathBuf,
+    #[arg(short, long, env = "AISIX_CONFIG", required = true)]
+    config: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Option<CliCommand>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum CliCommand {
+    /// Validate a resources file (the `resources_file` source) without
+    /// booting any listener: the identical read → interpolate → desugar
+    /// → validate pipeline runs and the process exits 0 on success or
+    /// non-zero with the full aggregated error report. `${VAR}`
+    /// references resolve against this process's environment.
+    Validate {
+        /// Path to the resources file to validate.
+        #[arg(long)]
+        resources: PathBuf,
+    },
 }
 
 #[tokio::main]
@@ -65,8 +90,18 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
+    // Subcommands run without loading the bootstrap config or booting
+    // any listener.
+    if let Some(CliCommand::Validate { resources }) = cli.command {
+        return run_validate(&resources);
+    }
+
+    let config_path = cli
+        .config
+        .expect("clap enforces --config unless a subcommand is given");
+
     // Steps 1-2: config.
-    let cfg = Config::load_from_path(Some(&cli.config))
+    let cfg = Config::load_from_path(Some(&config_path))
         .map_err(|e| anyhow::anyhow!("config load failed: {e}"))?;
 
     // Step 3: tracing + optional OTLP export.
@@ -75,6 +110,98 @@ async fn main() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("otlp init failed: {e}"))?;
 
     run(cfg).await
+}
+
+/// `aisix validate --resources <file>`: run the identical file-source
+/// pipeline (read → interpolate → desugar → canonical schema validation
+/// → typed decode → cross-reference checks) that boot and SIGHUP reload
+/// use, without booting any listener. Exit 0 on success; on failure the
+/// aggregated error report (every problem, with kind / entry / field
+/// context) goes to stderr and the process exits non-zero.
+fn run_validate(resources: &Path) -> anyhow::Result<()> {
+    match aisix_core::filesource::load_resources_file(resources, 1) {
+        Ok(snapshot) => {
+            println!(
+                "OK: {} loaded {} resource(s)",
+                resources.display(),
+                snapshot.total_entries(),
+            );
+            Ok(())
+        }
+        Err(report) => {
+            eprintln!("{report}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// SIGHUP → re-run the whole file-source pipeline against the same
+/// resources file. Success swaps the snapshot atomically (the same
+/// [`SnapshotHandle::store`] the etcd watch supervisor uses), stamping
+/// entries with the next generation as their revision; failure keeps
+/// serving the previous snapshot and logs the aggregated error report
+/// at WARN. There is deliberately no file watcher — reloads are
+/// explicit.
+async fn file_reload_loop(
+    path: PathBuf,
+    handle: SnapshotHandle<AisixSnapshot>,
+    mut cancel: watch::Receiver<bool>,
+) {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut hup = match signal(SignalKind::hangup()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = %e, "cannot install SIGHUP handler; resources file reload disabled");
+                return;
+            }
+        };
+        // The boot load stamped revision 1; each successful reload
+        // bumps the generation so snapshot consumers observe a change.
+        let mut generation: i64 = 1;
+        loop {
+            tokio::select! {
+                _ = hup.recv() => {
+                    match aisix_core::filesource::load_resources_file(&path, generation + 1) {
+                        Ok(snapshot) => {
+                            generation += 1;
+                            let resources = snapshot.total_entries();
+                            handle.store(snapshot);
+                            tracing::info!(
+                                file = %path.display(),
+                                resources,
+                                generation,
+                                "resources file reloaded",
+                            );
+                        }
+                        Err(report) => {
+                            tracing::warn!(
+                                file = %path.display(),
+                                "resources file reload failed — keeping the previous snapshot:\n{report}",
+                            );
+                        }
+                    }
+                }
+                changed = cancel.changed() => {
+                    if changed.is_err() || *cancel.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // No SIGHUP on this platform: the boot-time load stays in
+        // effect until restart.
+        let _ = (path, handle);
+        loop {
+            if cancel.changed().await.is_err() || *cancel.borrow() {
+                break;
+            }
+        }
+    }
 }
 
 /// Which managed-mode mTLS bootstrap path to take, given whether a
@@ -265,73 +392,100 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         None
     };
 
-    // Steps 4-6: etcd + supervisor.
-    //
-    // Before handing endpoints to tonic, probe each one via the
-    // stdlib resolver. tonic's HTTP connector collapses any DNS
-    // failure into an opaque "dns error" Status (see
-    // hyper-util/src/client/legacy/connect/http.rs) — even after the
-    // cause-chain logging in aisix-etcd, the deepest cause we see is
-    // still whatever getaddrinfo returned. The probe either logs the
-    // resolved addresses (DNS works; the failure is higher in the
-    // tonic / TLS stack) or logs the raw io::Error (DNS actually
-    // fails). Both outcomes narrow triage substantially.
-    probe_etcd_dns(&cfg.etcd.endpoints).await;
-
-    // Same extra trust root reused by the etcd connect options.
-    let connect_options =
-        build_etcd_connect_options_with_extra_ca(&cfg.etcd, extra_ca_pem.as_deref())?;
-    // effective_prefix() is `<prefix>/<env_id>` in v3 managed mode
-    // (env_id populated from the register response above), bare
-    // `<prefix>` in self-hosted dev where env_id is empty.
-    let etcd_prefix = cfg.etcd.effective_prefix();
-    let provider = Arc::new(
-        EtcdConfigProvider::connect(
-            &cfg.etcd.endpoints,
-            etcd_prefix.clone(),
-            connect_options.clone(),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
-    );
-    // Separate client for the admin write path — only needed when the
-    // admin surface is bound. We could share a single underlying
-    // connection via `Client::clone()` but keeping two is cleaner:
-    // writes and the watch stream don't contend on the same mutex.
-    // In managed mode this client is simply skipped.
-    let admin_client = if cfg.managed.is_managed() {
-        None
-    } else {
-        Some(
-            etcd_client::Client::connect(&cfg.etcd.endpoints, connect_options.clone())
-                .await
-                .map_err(|e| anyhow::anyhow!("etcd admin client connect failed: {e}"))?,
-        )
-    };
-    // Snapshot cache: in managed mode persist to disk (default
-    // /var/lib/aisix/config_cache.json) so the DP can serve traffic
-    // from the last-known config across CP outages and restarts.
-    // Disabled outside managed mode and when the operator clears the
-    // path explicitly.
-    let snapshot_cache = if cfg.managed.is_managed() && !cfg.managed.snapshot_cache_path.is_empty()
-    {
-        SnapshotCache::new(&cfg.managed.snapshot_cache_path)
-    } else {
-        SnapshotCache::disabled()
-    };
-    let supervisor = Arc::new(Supervisor::with_cache(
-        provider,
-        etcd_prefix.clone(),
-        snapshot_cache,
-    ));
-    // Seed the snapshot from disk before the etcd cycle starts so the
-    // proxy is ready to serve from cached config the moment the watch
-    // task takes its first iteration.
-    supervisor.restore_from_cache();
-    let snapshot_handle = supervisor.handle();
-
     let (cancel_tx, cancel_rx) = watch::channel(false);
-    let watch_task = tokio::spawn(supervisor.clone().run(cancel_rx.clone()));
+
+    // Steps 4-6: the resource source — either the standalone resources
+    // file (`resources_file` in config) or etcd + watch supervisor.
+    // Config validation already guaranteed exactly one is selected.
+    let file_source_path = cfg.resources_file.clone().map(PathBuf::from);
+    let (snapshot_handle, supervisor, watch_task, admin_client) =
+        if let Some(path) = &file_source_path {
+            // FILE MODE: load once at boot, fail fast with the aggregated
+            // error report on any problem. SIGHUP re-runs the identical
+            // pipeline; a failed reload keeps the last-good snapshot.
+            let snapshot = aisix_core::filesource::load_resources_file(path, 1)
+                .map_err(|report| anyhow::anyhow!("{report}"))?;
+            tracing::info!(
+                file = %path.display(),
+                resources = snapshot.total_entries(),
+                "resources loaded from file",
+            );
+            let handle = SnapshotHandle::new(snapshot);
+            let reload_task = tokio::spawn(file_reload_loop(
+                path.clone(),
+                handle.clone(),
+                cancel_rx.clone(),
+            ));
+            (handle, None, reload_task, None)
+        } else {
+            // ETCD MODE (unchanged behavior).
+            //
+            // Before handing endpoints to tonic, probe each one via the
+            // stdlib resolver. tonic's HTTP connector collapses any DNS
+            // failure into an opaque "dns error" Status (see
+            // hyper-util/src/client/legacy/connect/http.rs) — even after the
+            // cause-chain logging in aisix-etcd, the deepest cause we see is
+            // still whatever getaddrinfo returned. The probe either logs the
+            // resolved addresses (DNS works; the failure is higher in the
+            // tonic / TLS stack) or logs the raw io::Error (DNS actually
+            // fails). Both outcomes narrow triage substantially.
+            probe_etcd_dns(&cfg.etcd.endpoints).await;
+
+            // Same extra trust root reused by the etcd connect options.
+            let connect_options =
+                build_etcd_connect_options_with_extra_ca(&cfg.etcd, extra_ca_pem.as_deref())?;
+            // effective_prefix() is `<prefix>/<env_id>` in v3 managed mode
+            // (env_id populated from the register response above), bare
+            // `<prefix>` in self-hosted dev where env_id is empty.
+            let etcd_prefix = cfg.etcd.effective_prefix();
+            let provider = Arc::new(
+                EtcdConfigProvider::connect(
+                    &cfg.etcd.endpoints,
+                    etcd_prefix.clone(),
+                    connect_options.clone(),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
+            );
+            // Separate client for the admin write path — only needed when the
+            // admin surface is bound. We could share a single underlying
+            // connection via `Client::clone()` but keeping two is cleaner:
+            // writes and the watch stream don't contend on the same mutex.
+            // In managed mode this client is simply skipped.
+            let admin_client = if cfg.managed.is_managed() {
+                None
+            } else {
+                Some((
+                    etcd_client::Client::connect(&cfg.etcd.endpoints, connect_options.clone())
+                        .await
+                        .map_err(|e| anyhow::anyhow!("etcd admin client connect failed: {e}"))?,
+                    etcd_prefix.clone(),
+                ))
+            };
+            // Snapshot cache: in managed mode persist to disk (default
+            // /var/lib/aisix/config_cache.json) so the DP can serve traffic
+            // from the last-known config across CP outages and restarts.
+            // Disabled outside managed mode and when the operator clears the
+            // path explicitly.
+            let snapshot_cache =
+                if cfg.managed.is_managed() && !cfg.managed.snapshot_cache_path.is_empty() {
+                    SnapshotCache::new(&cfg.managed.snapshot_cache_path)
+                } else {
+                    SnapshotCache::disabled()
+                };
+            let supervisor = Arc::new(Supervisor::with_cache(
+                provider,
+                etcd_prefix,
+                snapshot_cache,
+            ));
+            // Seed the snapshot from disk before the etcd cycle starts so the
+            // proxy is ready to serve from cached config the moment the watch
+            // task takes its first iteration.
+            supervisor.restore_from_cache();
+            let handle = supervisor.handle();
+            let watch_task = tokio::spawn(supervisor.clone().run(cancel_rx.clone()));
+            (handle, Some(supervisor), watch_task, admin_client)
+        };
     // Spawn heartbeat worker if we have a config for it. The
     // JoinHandle is awaited after graceful shutdown below so the
     // final in-flight beat drains cleanly.
@@ -482,7 +636,13 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     //     up with a kine write (#519 B.3)
     //   - supported_guardrail_kinds + exporter_health (#519 B.6 / D.2)
     let heartbeat_task = heartbeat_cfg.map(|mut h| {
-        let supervisor_for_heartbeat = Arc::clone(&supervisor);
+        // Heartbeat only exists in managed mode, which config
+        // validation pins to the etcd source — the supervisor is
+        // always present here.
+        let supervisor = supervisor
+            .as_ref()
+            .expect("managed mode implies the etcd resource source (validated at boot)");
+        let supervisor_for_heartbeat = Arc::clone(supervisor);
         h = h.with_rejection_fetcher(Arc::new(move || {
             supervisor_for_heartbeat.recent_rejections()
         }));
@@ -503,10 +663,18 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let background_cancel_rx = cancel_rx.clone();
     // Wire the config-freshness probe so the proxy's /readyz reflects etcd
     // watch staleness (and pre-first-apply startup), not just shutdown (#591).
-    let readyz_watch_status = supervisor.watch_status();
-    proxy_state = proxy_state.with_config_apply_age(Arc::new(move || {
-        readyz_watch_status.snapshot().last_apply_age
-    }));
+    proxy_state = match supervisor.as_ref() {
+        Some(supervisor) => {
+            let readyz_watch_status = supervisor.watch_status();
+            proxy_state.with_config_apply_age(Arc::new(move || {
+                readyz_watch_status.snapshot().last_apply_age
+            }))
+        }
+        // File mode: the snapshot is applied synchronously at boot /
+        // SIGHUP and there is no watch stream to go stale — report the
+        // config as always freshly applied.
+        None => proxy_state.with_config_apply_age(Arc::new(|| Some(std::time::Duration::ZERO))),
+    };
     let proxy_router = aisix_proxy::build_router(proxy_state);
 
     let background_check_task = tokio::spawn(async move {
@@ -539,10 +707,21 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // In managed mode (`cfg.managed.enabled = true`) the DP reads
     // configuration exclusively from etcd; exposing admin writes or
     // the Playground would bypass the aisix.cloud control plane.
-    let admin_serve_handle = if let Some(admin_client) = admin_client {
-        let admin_store: Arc<dyn ConfigStore> =
-            Arc::new(EtcdConfigStore::new(admin_client, etcd_prefix.clone()));
-        let admin_state = AdminState::new(snapshot_handle.clone(), admin_store, &cfg.admin)
+    //
+    // Which store backs the admin surface depends on the resource
+    // source: etcd standalone gets the writable etcd store; file mode
+    // gets a read-only view of the file-loaded snapshot (writes return
+    // 409 pointing at the file).
+    let admin_store: Option<Arc<dyn ConfigStore>> = match (admin_client, &file_source_path) {
+        (Some((client, prefix)), _) => Some(Arc::new(EtcdConfigStore::new(client, prefix))),
+        (None, Some(path)) if !cfg.managed.is_managed() => Some(Arc::new(FileManagedStore::new(
+            snapshot_handle.clone(),
+            path.display().to_string(),
+        ))),
+        _ => None,
+    };
+    let admin_serve_handle = if let Some(admin_store) = admin_store {
+        let mut admin_state = AdminState::new(snapshot_handle.clone(), admin_store, &cfg.admin)
             // Share the health tracker so /admin/v1/health reflects live
             // per-model upstream failure counts.
             .with_health_tracker(health_tracker)
@@ -550,14 +729,21 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // Share runtime status so /admin/v1/models/status exposes
             // direct-model cooldown/background-health state.
             .with_runtime_status_tracker(runtime_status_tracker)
+            // Share the proxy router so the playground endpoint can forward
+            // requests in-process without an extra network hop.
+            .with_proxy_router(proxy_router.clone());
+        if let Some(supervisor) = supervisor.as_ref() {
             // Share the supervisor's freshness state so /admin/v1/health
             // exposes etcd watch staleness — without this, a wedged
             // watch lets the gateway serve stale config indefinitely
             // while reporting healthy. See issue #114.
-            .with_watch_status(supervisor.watch_status())
-            // Share the proxy router so the playground endpoint can forward
-            // requests in-process without an extra network hop.
-            .with_proxy_router(proxy_router.clone());
+            admin_state = admin_state.with_watch_status(supervisor.watch_status());
+        }
+        if let Some(path) = &file_source_path {
+            // Arm the router-level write guard: every mutating
+            // /admin/v1/* request answers 409 naming the file.
+            admin_state = admin_state.with_file_managed_path(path.display().to_string());
+        }
         let admin_router = aisix_admin::build_router(admin_state);
 
         let admin_addr: std::net::SocketAddr = cfg.admin.addr.parse()?;
@@ -1104,7 +1290,46 @@ mod tests {
         let a = Cli::try_parse_from(["aisix", "-c", "/tmp/x.yaml"]).unwrap();
         let b = Cli::try_parse_from(["aisix", "--config", "/tmp/x.yaml"]).unwrap();
         assert_eq!(a.config, b.config);
-        assert_eq!(a.config, PathBuf::from("/tmp/x.yaml"));
+        assert_eq!(a.config, Some(PathBuf::from("/tmp/x.yaml")));
+        assert!(a.command.is_none());
+    }
+
+    #[test]
+    fn cli_validate_subcommand_does_not_require_config() {
+        // `aisix validate --resources f` runs without --config …
+        let cli = Cli::try_parse_from(["aisix", "validate", "--resources", "/tmp/r.yaml"]).unwrap();
+        assert!(cli.config.is_none());
+        match cli.command {
+            Some(CliCommand::Validate { resources }) => {
+                assert_eq!(resources, PathBuf::from("/tmp/r.yaml"));
+            }
+            other => panic!("expected Validate subcommand, got {other:?}"),
+        }
+        // … and --resources itself is mandatory for the subcommand.
+        assert!(Cli::try_parse_from(["aisix", "validate"]).is_err());
+    }
+
+    #[test]
+    fn run_validate_accepts_a_valid_resources_file() {
+        use std::io::Write as _;
+        let mut f = tempfile::Builder::new().suffix(".yaml").tempfile().unwrap();
+        f.write_all(
+            br#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: sk-test
+models:
+  - display_name: m1
+    provider: openai
+    model_name: gpt-4o
+    provider_key: pk
+"#,
+        )
+        .unwrap();
+        // Success path returns Ok; the failure path exits the process,
+        // which is covered end-to-end by the e2e fail-fast case.
+        run_validate(f.path()).unwrap();
     }
 
     #[test]

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -163,7 +163,27 @@ async fn file_reload_loop(
         loop {
             tokio::select! {
                 _ = hup.recv() => {
-                    match aisix_core::filesource::load_resources_file(&path, generation + 1) {
+                    // File IO + the full parse/validate pipeline are
+                    // synchronous — run them off the async workers so a
+                    // large file can't stall in-flight requests.
+                    let load_path = path.clone();
+                    let next_generation = generation + 1;
+                    let loaded = tokio::task::spawn_blocking(move || {
+                        aisix_core::filesource::load_resources_file(&load_path, next_generation)
+                    })
+                    .await;
+                    let loaded = match loaded {
+                        Ok(result) => result,
+                        Err(join_err) => {
+                            tracing::warn!(
+                                file = %path.display(),
+                                error = %join_err,
+                                "resources file reload task failed — keeping the previous snapshot",
+                            );
+                            continue;
+                        }
+                    };
+                    match loaded {
                         Ok(snapshot) => {
                             generation += 1;
                             let resources = snapshot.total_entries();

--- a/tests/e2e/src/cases/file-resource-source-e2e.test.ts
+++ b/tests/e2e/src/cases/file-resource-source-e2e.test.ts
@@ -1,5 +1,9 @@
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import OpenAI, { APIError } from "openai";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
@@ -28,6 +32,8 @@ import {
 // start with `AISIX_` — the binary's config loader treats that prefix as
 // config overrides (same reason the harness strips them).
 
+const execFileP = promisify(execFile);
+
 const CALLER_PLAINTEXT = "sk-file-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
 const CALLER_KEY_ENV = "FILE_E2E_CALLER_KEY";
@@ -53,6 +59,12 @@ api_keys:
   - display_name: file-caller
     key_env: ${CALLER_KEY_ENV}
     allowed_models: ["file-allowed"]
+guardrails:
+  - name: file-no-secrets
+    kind: keyword
+    patterns:
+      - kind: literal
+        value: file-mode-forbidden-phrase
 `;
 }
 
@@ -192,6 +204,31 @@ describe("file resource source: smoke + admin write-guard", () => {
     const unauthedBody = (await unauthed.json()) as { error_msg: string };
     expect(unauthedBody.error_msg).not.toContain(app.resourcesPath!);
   });
+
+  test("file-defined guardrail fires on matching input", async () => {
+    if (!app || !upstream) throw new Error("setup failed");
+    // The file format has no attachment collection, so file-defined
+    // guardrails apply env-globally. Pin that they actually fire — the
+    // runtime executes them through the zero-attachment fallback in the
+    // guardrail index, and this test is the regression trap for that
+    // dependency.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    const hitsBefore = upstream.receivedRequests.length;
+    const blocked = await proxy.chat({
+      model: "file-allowed",
+      messages: [{ role: "user", content: "contains file-mode-forbidden-phrase here" }],
+    });
+    expect(blocked.status).toBe(422);
+    // Blocked before dispatch: the upstream never sees the request.
+    expect(upstream.receivedRequests.length).toBe(hitsBefore);
+
+    // Clean input still passes end-to-end.
+    const clean = await proxy.chat({
+      model: "file-allowed",
+      messages: [{ role: "user", content: "clean input" }],
+    });
+    expect(clean.status).toBe(200);
+  });
 });
 
 describe("file resource source: differential vs etcd mode", () => {
@@ -203,7 +240,15 @@ describe("file resource source: differential vs etcd mode", () => {
   beforeAll(async () => {
     const etcd = new EtcdClient();
     etcdReachable = await etcd.ping();
-    if (!etcdReachable) return;
+    if (!etcdReachable) {
+      // Local runs may skip quietly; on CI the differential pin is the
+      // point of this file — a silent skip would let the equivalence
+      // contract rot invisibly.
+      if (process.env.CI) {
+        throw new Error("differential case requires etcd on CI (AISIX_E2E_ETCD)");
+      }
+      return;
+    }
 
     upstream = await startOpenAiUpstream();
 
@@ -472,4 +517,48 @@ not_a_collection: []
     expect(msg).toContain('unknown provider key "ghost-pk"');
     expect(msg).toContain('unknown model "nope"');
   }, 30_000);
+});
+
+describe("file resource source: validate subcommand", () => {
+  const BIN_PATH =
+    process.env.AISIX_BIN ?? join(process.cwd(), "..", "..", "target", "debug", "aisix");
+
+  test("valid file exits 0; invalid file exits 1 with the aggregated report on stderr", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "aisix-validate-e2e-"));
+    try {
+      const good = join(dir, "good.yaml");
+      await writeFile(
+        good,
+        [
+          '_format_version: "1"',
+          "provider_keys:",
+          "  - display_name: pk",
+          "    api_key: sk-x",
+          "models:",
+          "  - display_name: m1",
+          "    provider: openai",
+          "    model_name: gpt-4o",
+          "    provider_key: pk",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      const ok = await execFileP(BIN_PATH, ["validate", "--resources", good]);
+      expect(ok.stdout).toContain("OK:");
+
+      const bad = join(dir, "bad.yaml");
+      await writeFile(bad, "models: []\n", "utf8");
+      let failure: (Error & { code?: number; stderr?: string }) | undefined;
+      try {
+        await execFileP(BIN_PATH, ["validate", "--resources", bad]);
+      } catch (e) {
+        failure = e as Error & { code?: number; stderr?: string };
+      }
+      if (!failure) throw new Error("expected `aisix validate` to exit non-zero");
+      expect(failure.code).toBe(1);
+      expect(String(failure.stderr)).toContain("missing mandatory _format_version");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/e2e/src/cases/file-resource-source-e2e.test.ts
+++ b/tests/e2e/src/cases/file-resource-source-e2e.test.ts
@@ -1,0 +1,463 @@
+import { createHash } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the standalone file-based resource source (`resources_file`).
+// A single-container gateway loads provider keys / models / caller keys
+// from one resources.yaml — no etcd, no Admin API writes — and must be
+// observably identical to an etcd-backed gateway serving the same
+// logical resources.
+//
+// Reference: OpenAI Chat Completions API spec
+// (https://platform.openai.com/docs/api-reference/chat/create) for the
+// proxy surface the cases drive.
+//
+// NOTE on env names: the caller-key plaintext travels to the gateway via
+// an environment variable (`key_env` sugar). The variable name must NOT
+// start with `AISIX_` — the binary's config loader treats that prefix as
+// config overrides (same reason the harness strips them).
+
+const CALLER_PLAINTEXT = "sk-file-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+const CALLER_KEY_ENV = "FILE_E2E_CALLER_KEY";
+
+function fileModeResources(upstreamBase: string): string {
+  return `
+_format_version: "1"
+provider_keys:
+  - display_name: file-pk
+    provider: openai
+    api_key: sk-mock
+    api_base: ${upstreamBase}/v1
+models:
+  - display_name: file-allowed
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: file-pk
+  - display_name: file-forbidden
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: file-pk
+api_keys:
+  - display_name: file-caller
+    key_env: ${CALLER_KEY_ENV}
+    allowed_models: ["file-allowed"]
+`;
+}
+
+describe("file resource source: smoke + admin write-guard", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp({
+      resourcesFile: fileModeResources(upstream.baseUrl),
+      extraEnv: { [CALLER_KEY_ENV]: CALLER_PLAINTEXT },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("full chain serves a chat completion from the file-defined resources", async () => {
+    if (!app || !upstream) throw new Error("setup failed");
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // File mode is synchronous at boot: no propagation wait needed —
+    // the first request must already serve.
+    const completion = await client.chat.completions.create({
+      model: "file-allowed",
+      messages: [{ role: "user", content: "hello from file mode" }],
+    });
+    expect(completion.choices[0]?.message.role).toBe("assistant");
+    expect(completion.choices[0]?.message.content).toBe("mock reply");
+    expect(upstream.receivedRequests.length).toBeGreaterThan(0);
+
+    // The caller key's allowed_models still gates access: the sibling
+    // model exists in the file but is not granted → 403, upstream
+    // untouched by the blocked call.
+    const hitsBefore = upstream.receivedRequests.length;
+    let caught: unknown;
+    try {
+      await client.chat.completions.create({
+        model: "file-forbidden",
+        messages: [{ role: "user", content: "must be blocked" }],
+      });
+    } catch (e) {
+      caught = e;
+    }
+    if (!(caught instanceof APIError)) {
+      throw new Error(`expected APIError, got: ${String(caught)}`);
+    }
+    expect(caught.status).toBe(403);
+    expect(upstream.receivedRequests.length).toBe(hitsBefore);
+  });
+
+  test("playground forwards through the proxy stack in file mode", async () => {
+    if (!app) throw new Error("setup failed");
+    // The playground endpoint lives on the admin listener but
+    // authenticates with a *proxy* caller key and must not be caught
+    // by the file-managed write guard.
+    const res = await fetch(`${app.adminUrl}/playground/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "file-allowed",
+        messages: [{ role: "user", content: "playground in file mode" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      choices: Array<{ message: { role: string } }>;
+    };
+    expect(body.choices[0]?.message.role).toBe("assistant");
+  });
+
+  test("admin write endpoints answer 409 file-managed; reads serve the file contents", async () => {
+    if (!app) throw new Error("setup failed");
+    const auth = { authorization: `Bearer ${app.adminKey}` };
+
+    // GET list works and reflects the file.
+    const listRes = await fetch(`${app.adminUrl}/admin/v1/models`, { headers: auth });
+    expect(listRes.status).toBe(200);
+    const listed = (await listRes.json()) as Array<{ value: { display_name: string } }>;
+    expect(listed.map((e) => e.value.display_name).sort()).toEqual([
+      "file-allowed",
+      "file-forbidden",
+    ]);
+
+    // POST is refused with a clear 409 naming the file.
+    const postRes = await fetch(`${app.adminUrl}/admin/v1/models`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({
+        display_name: "sneaky",
+        provider: "openai",
+        model_name: "gpt-4o",
+        provider_key_id: "11111111-1111-1111-1111-111111111111",
+      }),
+    });
+    expect(postRes.status).toBe(409);
+    const postBody = (await postRes.json()) as { error_msg: string };
+    expect(postBody.error_msg).toContain("file-managed");
+    expect(postBody.error_msg).toContain(app.resourcesPath!);
+
+    // The refused write did not change the resource set.
+    const relist = await fetch(`${app.adminUrl}/admin/v1/models`, { headers: auth });
+    expect(((await relist.json()) as unknown[]).length).toBe(2);
+
+    // DELETE and rotate are covered by the same guard.
+    const delRes = await fetch(`${app.adminUrl}/admin/v1/models/any-id`, {
+      method: "DELETE",
+      headers: auth,
+    });
+    expect(delRes.status).toBe(409);
+    const rotateRes = await fetch(`${app.adminUrl}/admin/v1/api_keys/any-id/rotate`, {
+      method: "POST",
+      headers: auth,
+    });
+    expect(rotateRes.status).toBe(409);
+  });
+});
+
+describe("file resource source: differential vs etcd mode", () => {
+  let fileApp: SpawnedApp | undefined;
+  let etcdApp: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+
+    // The SAME logical resource set on both gateways: one provider key,
+    // an allowed model, a forbidden model, one caller key.
+    fileApp = await spawnApp({
+      resourcesFile: `
+_format_version: "1"
+provider_keys:
+  - display_name: diff-pk
+    provider: openai
+    api_key: sk-mock
+    api_base: ${upstream.baseUrl}/v1
+models:
+  - display_name: diff-allowed
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: diff-pk
+  - display_name: diff-forbidden
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: diff-pk
+api_keys:
+  - display_name: diff-caller
+    key_hash: ${CALLER_KEY_HASH}
+    allowed_models: ["diff-allowed"]
+`,
+    });
+
+    etcdApp = await spawnApp();
+    const seed = new SeedClient(etcd, etcdApp.etcdPrefix);
+    const pk = await seed.createProviderKey({
+      display_name: "diff-pk",
+      api_key: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "diff-allowed",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createModel({
+      display_name: "diff-forbidden",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["diff-allowed"],
+    });
+  });
+
+  afterAll(async () => {
+    await fileApp?.exit();
+    await etcdApp?.exit();
+    await upstream?.close();
+  });
+
+  test("identical observable behavior: /v1/models, chat 200, allowed_models 403", async (ctx) => {
+    if (!etcdReachable || !fileApp || !etcdApp || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const fileProxy = new ProxyClient(fileApp.proxyUrl, CALLER_PLAINTEXT);
+    const etcdProxy = new ProxyClient(etcdApp.proxyUrl, CALLER_PLAINTEXT);
+
+    // etcd mode propagates asynchronously — gate on the allowed model
+    // serving. File mode is ready at boot by contract.
+    await waitConfigPropagation(async () => {
+      const r = await etcdProxy.chat({
+        model: "diff-allowed",
+        messages: [{ role: "user", content: "ready-probe" }],
+      });
+      return r.status === 200;
+    });
+
+    // 1) /v1/models — same listing (modulo the `created` timestamp).
+    const fileModels = await fileProxy.listModels();
+    const etcdModels = await etcdProxy.listModels();
+    expect(fileModels.status).toBe(200);
+    expect(etcdModels.status).toBe(200);
+    const normalize = (body: unknown) => {
+      const b = body as { object: string; data: Array<Record<string, unknown>> };
+      return {
+        object: b.object,
+        data: b.data
+          .map(({ id, object, owned_by }) => ({ id, object, owned_by }))
+          .sort((a, z) => String(a.id).localeCompare(String(z.id))),
+      };
+    };
+    expect(normalize(fileModels.body)).toEqual(normalize(etcdModels.body));
+
+    // 2) Chat on the allowed model — 200 with the same completion body
+    // from the shared mock upstream.
+    const fileChat = await fileProxy.chat({
+      model: "diff-allowed",
+      messages: [{ role: "user", content: "differential" }],
+    });
+    const etcdChat = await etcdProxy.chat({
+      model: "diff-allowed",
+      messages: [{ role: "user", content: "differential" }],
+    });
+    expect(fileChat.status).toBe(200);
+    expect(etcdChat.status).toBe(200);
+    const content = (r: unknown) =>
+      (r as { choices: Array<{ message: { role: string; content: string } }> }).choices[0]
+        ?.message;
+    expect(content(fileChat.body)).toEqual(content(etcdChat.body));
+
+    // 3) allowed_models enforcement — same 403 error envelope.
+    const fileBlocked = await fileProxy.chat({
+      model: "diff-forbidden",
+      messages: [{ role: "user", content: "blocked" }],
+    });
+    const etcdBlocked = await etcdProxy.chat({
+      model: "diff-forbidden",
+      messages: [{ role: "user", content: "blocked" }],
+    });
+    expect(fileBlocked.status).toBe(403);
+    expect(etcdBlocked.status).toBe(403);
+    const envelope = (r: unknown) => {
+      const e = (r as { error: { type?: string; code?: unknown } }).error;
+      return { type: e.type, code: e.code };
+    };
+    expect(envelope(fileBlocked.body)).toEqual(envelope(etcdBlocked.body));
+  });
+});
+
+describe("file resource source: SIGHUP reload", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+
+  function reloadFile(upstreamBase: string, models: string[]): string {
+    const blocks = models
+      .map(
+        (name) => `  - display_name: ${name}
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: reload-pk`,
+      )
+      .join("\n");
+    return `
+_format_version: "1"
+provider_keys:
+  - display_name: reload-pk
+    provider: openai
+    api_key: sk-mock
+    api_base: ${upstreamBase}/v1
+models:
+${blocks}
+api_keys:
+  - display_name: reload-caller
+    key_hash: ${CALLER_KEY_HASH}
+    allowed_models: ["*"]
+`;
+  }
+
+  beforeAll(async () => {
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp({
+      resourcesFile: reloadFile(upstream.baseUrl, ["reload-a"]),
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("valid edit applies on SIGHUP; invalid edit keeps last-good", async () => {
+    if (!app || !upstream || !app.resourcesPath) throw new Error("setup failed");
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    const modelIds = async () => {
+      const r = await proxy.listModels();
+      expect(r.status).toBe(200);
+      return (r.body as { data: Array<{ id: string }> }).data.map((m) => m.id).sort();
+    };
+
+    expect(await modelIds()).toEqual(["reload-a"]);
+
+    // Valid edit: add reload-b, SIGHUP, and the new model becomes
+    // callable end-to-end.
+    await writeFile(
+      app.resourcesPath,
+      reloadFile(upstream.baseUrl, ["reload-a", "reload-b"]),
+      "utf8",
+    );
+    app.signal("SIGHUP");
+    await waitConfigPropagation(async () => {
+      const r = await proxy.chat({
+        model: "reload-b",
+        messages: [{ role: "user", content: "post-reload" }],
+      });
+      return r.status === 200;
+    });
+    expect(await modelIds()).toEqual(["reload-a", "reload-b"]);
+
+    // Invalid edit: reload-c appears alongside a broken entry. The
+    // whole reload must be rejected — nothing from the bad file applies
+    // (no partial pickup of reload-c), and the last-good snapshot keeps
+    // serving.
+    const broken = `${reloadFile(upstream.baseUrl, ["reload-a", "reload-b", "reload-c"])}
+guardrails:
+  - name: broken-entry
+    kind: no-such-guardrail-kind
+`;
+    const failuresBefore = (app.output().match(/reload failed/g) ?? []).length;
+    await writeFile(app.resourcesPath, broken, "utf8");
+    app.signal("SIGHUP");
+    // Deterministic wait: the gateway logs the aggregated reload
+    // failure; poll the captured output instead of sleeping.
+    await waitConfigPropagation(async () => {
+      return (app!.output().match(/reload failed/g) ?? []).length > failuresBefore;
+    });
+
+    // Old models still serve; the new one from the rejected file is
+    // absent.
+    expect(await modelIds()).toEqual(["reload-a", "reload-b"]);
+    const stillServing = await proxy.chat({
+      model: "reload-a",
+      messages: [{ role: "user", content: "still-alive" }],
+    });
+    expect(stillServing.status).toBe(200);
+    const notPickedUp = await proxy.chat({
+      model: "reload-c",
+      messages: [{ role: "user", content: "must not exist" }],
+    });
+    expect(notPickedUp.status).toBe(404);
+  });
+});
+
+describe("file resource source: fail-fast boot", () => {
+  test("malformed file exits non-zero with the aggregated named errors on stderr", async () => {
+    let caught: unknown;
+    try {
+      await spawnApp({
+        resourcesFile: `
+_format_version: "1"
+models:
+  - display_name: broken
+    provider: openai
+    provider_key: ghost-pk
+api_keys:
+  - display_name: dup
+    key_hash: aa
+    allowed_models: ["nope"]
+  - display_name: dup
+    key_hash: bb
+    allowed_models: []
+not_a_collection: []
+`,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const msg = (caught as Error).message;
+    // Non-zero exit, not a readiness timeout.
+    expect(msg).toContain("exited early with code=1");
+    // The aggregated report names every problem with its context.
+    expect(msg).toMatch(/4 error\(s\)/);
+    expect(msg).toContain("unknown top-level key `not_a_collection`");
+    expect(msg).toContain('duplicate api_keys entry');
+    expect(msg).toContain('unknown provider key "ghost-pk"');
+    expect(msg).toContain('unknown model "nope"');
+  }, 30_000);
+});

--- a/tests/e2e/src/cases/file-resource-source-e2e.test.ts
+++ b/tests/e2e/src/cases/file-resource-source-e2e.test.ts
@@ -179,6 +179,18 @@ describe("file resource source: smoke + admin write-guard", () => {
       headers: auth,
     });
     expect(rotateRes.status).toBe(409);
+
+    // Auth ordering: an UNAUTHENTICATED write still gets 401, and the
+    // 401 body must not leak the resources-file path (that detail is
+    // only for authenticated admins).
+    const unauthed = await fetch(`${app.adminUrl}/admin/v1/models`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ display_name: "nope" }),
+    });
+    expect(unauthed.status).toBe(401);
+    const unauthedBody = (await unauthed.json()) as { error_msg: string };
+    expect(unauthedBody.error_msg).not.toContain(app.resourcesPath!);
   });
 });
 

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -36,6 +36,15 @@ export interface AppOverrides {
    * AccessKey deliberately never travels on the config path.
    */
   extraEnv?: Record<string, string>;
+  /**
+   * FILE MODE: contents of a standalone `resources.yaml`. When set, the
+   * generated config carries `resources_file` (pointing at this content
+   * written into the tmp dir) and NO `etcd` section — the gateway loads
+   * every resource from the file and etcd is never contacted (no ping,
+   * no prefix cleanup). Rewrite the file at `SpawnedApp.resourcesPath`
+   * and send SIGHUP to exercise reloads.
+   */
+  resourcesFile?: string;
 }
 
 export interface SpawnedApp {
@@ -49,6 +58,17 @@ export interface SpawnedApp {
    * there in that case).
    */
   metricsUrl: string;
+  /**
+   * FILE MODE only: absolute path of the resources.yaml the gateway
+   * loads. Rewrite it and `signal("SIGHUP")` to trigger a reload.
+   */
+  resourcesPath?: string;
+  /**
+   * Combined stdout+stderr captured so far. Lets tests wait
+   * deterministically on log lines (e.g. the reload-failed WARN)
+   * instead of sleeping.
+   */
+  output(): string;
   signal(signal: NodeJS.Signals): void;
   exit(): Promise<void>;
 }
@@ -100,8 +120,11 @@ export function isAddrInUseStartupFailure(err: unknown): boolean {
 }
 
 async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
+  const fileMode = overrides.resourcesFile !== undefined;
   const etcd = new EtcdClient();
-  if (!(await etcd.ping())) {
+  // FILE MODE never contacts etcd — skip the availability gate so the
+  // file source stays exercisable even without the shared etcd.
+  if (!fileMode && !(await etcd.ping())) {
     throw new Error(
       `etcd not reachable at ${process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379"} ` +
         "(set AISIX_E2E_ETCD or run `docker run --rm -p 2379:2379 quay.io/coreos/etcd:v3.5.15`)",
@@ -113,13 +136,25 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   const adminKey = overrides.adminKey ?? `admin-${randomUUID()}`;
   const etcdPrefix = `/aisix-e2e-${randomUUID()}`;
 
+  const dir = await mkdtemp(join(tmpdir(), "aisix-e2e-"));
+  let resourcesPath: string | undefined;
+  if (fileMode) {
+    resourcesPath = join(dir, "resources.yaml");
+    await writeFile(resourcesPath, overrides.resourcesFile!, "utf8");
+  }
+
   const cfg = {
-    etcd: {
-      endpoints: [process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379"],
-      prefix: etcdPrefix,
-      dial_timeout_ms: 5000,
-      request_timeout_ms: 5000,
-    },
+    // Exactly one resource source: the standalone file, or etcd.
+    ...(fileMode
+      ? { resources_file: resourcesPath }
+      : {
+          etcd: {
+            endpoints: [process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379"],
+            prefix: etcdPrefix,
+            dial_timeout_ms: 5000,
+            request_timeout_ms: 5000,
+          },
+        }),
     proxy: {
       addr: `127.0.0.1:${proxyPort}`,
       request_body_limit_bytes: 10485760,
@@ -144,7 +179,6 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
     ...(overrides.extra ?? {}),
   };
 
-  const dir = await mkdtemp(join(tmpdir(), "aisix-e2e-"));
   const cfgPath = join(dir, "config.yaml");
   await writeFile(cfgPath, yamlStringify(cfg), "utf8");
 
@@ -183,10 +217,16 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
     stderrBuf += c.toString("utf8");
   });
   let exitErr: string | undefined;
-  child.once("exit", (code, signal) => {
-    if (code !== 0 && code !== null) {
-      exitErr = `aisix exited early with code=${code} signal=${signal}`;
-    }
+  // Reject the readiness wait the moment the binary exits non-zero, so
+  // an intentional boot failure (e.g. a malformed resources file)
+  // surfaces immediately instead of after the full readiness timeout.
+  const exitedEarly = new Promise<never>((_, reject) => {
+    child.once("exit", (code, signal) => {
+      if (code !== 0 && code !== null) {
+        exitErr = `aisix exited early with code=${code} signal=${signal}`;
+        reject(new Error(exitErr));
+      }
+    });
   });
 
   const proxyUrl = `http://127.0.0.1:${proxyPort}`;
@@ -194,20 +234,23 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   const metricsUrl = `http://127.0.0.1:${metricsPort}`;
 
   try {
-    await Promise.all([
-      waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
-      waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey),
-      // Gate on the dedicated metrics listener too, so scrapes in the test
-      // never race the listener coming up. Skipped when prometheus is
-      // disabled — nothing binds the metrics port then.
-      ...(prometheusEnabled
-        ? [
-            waitForReady(
-              `${metricsUrl}${overrides.prometheusPath ?? "/metrics"}`,
-              READY_TIMEOUT_MS,
-            ),
-          ]
-        : []),
+    await Promise.race([
+      Promise.all([
+        waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
+        waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey),
+        // Gate on the dedicated metrics listener too, so scrapes in the test
+        // never race the listener coming up. Skipped when prometheus is
+        // disabled — nothing binds the metrics port then.
+        ...(prometheusEnabled
+          ? [
+              waitForReady(
+                `${metricsUrl}${overrides.prometheusPath ?? "/metrics"}`,
+                READY_TIMEOUT_MS,
+              ),
+            ]
+          : []),
+      ]),
+      exitedEarly,
     ]);
   } catch (err) {
     const detail = exitErr ?? "still running";
@@ -219,7 +262,7 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
         ? stderrBuf
         : `${stderrBuf.slice(0, 1500)}\n  […]\n${stderrBuf.slice(-1500)}`;
     await terminate(child);
-    await cleanup(etcd, etcdPrefix, dir);
+    await cleanup(fileMode ? undefined : etcd, etcdPrefix, dir);
     throw new Error(
       `${(err as Error).message}\n  binary state: ${detail}\n  stderr:\n${stderr}`,
     );
@@ -231,12 +274,16 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
     adminKey,
     etcdPrefix,
     metricsUrl,
+    resourcesPath,
+    output() {
+      return stderrBuf;
+    },
     signal(signal: NodeJS.Signals) {
       if (child.exitCode === null) child.kill(signal);
     },
     async exit() {
       await terminate(child);
-      await cleanup(etcd, etcdPrefix, dir);
+      await cleanup(fileMode ? undefined : etcd, etcdPrefix, dir);
     },
   };
 }
@@ -281,10 +328,15 @@ async function terminate(child: ChildProcess): Promise<void> {
   }
 }
 
-async function cleanup(etcd: EtcdClient, prefix: string, dir: string): Promise<void> {
-  // Best-effort — never throw from cleanup.
+async function cleanup(
+  etcd: EtcdClient | undefined,
+  prefix: string,
+  dir: string,
+): Promise<void> {
+  // Best-effort — never throw from cleanup. `etcd` is undefined in file
+  // mode, where no prefix was ever written.
   await Promise.allSettled([
-    etcd.deletePrefix(prefix),
+    ...(etcd ? [etcd.deletePrefix(prefix)] : []),
     rm(dir, { recursive: true, force: true }),
   ]);
 }


### PR DESCRIPTION
## What

A standalone **file-based resource source**: a single-container gateway can now load every dynamic resource — provider keys, models, API keys, guardrails, MCP servers, A2A agents, cache policies, observability exporters, rate-limit policies — from **one `resources.yaml`**, instead of running etcd and writing resources through the Admin API. This adds a second, fully declarative way to run standalone; the etcd source is completely unchanged.

```yaml
_format_version: "1"          # mandatory; unknown top-level keys are load errors

provider_keys:
  - display_name: openai-prod
    provider: openai
    api_key: ${OPENAI_API_KEY}          # ${VAR} env interpolation in any string value

models:
  - display_name: gpt-4o
    provider: openai
    model_name: gpt-4o-2024-11-20
    provider_key: openai-prod           # file sugar: name ref → provider_key_id

api_keys:
  - display_name: ci-bot                # file sugar: identity only — stripped from the document
    key_env: CI_BOT_KEY                 # file sugar: env var NAME → SHA-256 → key_hash
    allowed_models: ["gpt-4o"]

rate_limit_policies:
  - name: cap-gpt4o
    scope: model
    scope_ref: gpt-4o                   # file sugar: name → derived id for api_key/model scopes
    window: minute
    max_requests: 300
```

Enable it in `config.yaml`:

```yaml
resources_file: /etc/aisix/resources.yaml   # replaces the etcd section
```

The file format (v1) was pinned after a review of mainstream declarative gateway-config conventions; the format is versioned (`_format_version`) so later revisions can evolve it explicitly.

## Format rules (all enforced at load)

- **Canonical documents underneath.** File sugar desugars *before* validation; after desugaring every entry must be exactly a canonical resource document (`schemas/resources/*.schema.json`) and flows through the **same** JSON-Schema validators and typed serde models as the etcd path. Canonical schemas are untouched by this PR (`dump-schema` / `dump-openapi` byte-identical).
- **`${VAR}` interpolation** in any string value: partial values work (`https://${HOST}/v1`), `$$` escapes a literal `$`, bare `$VAR` is not interpolated, and a missing/empty variable is a load error naming file, kind, entry, and field path. Interpolation runs on parsed string scalars, so environment values can never inject YAML structure.
- **File sugar** (the only three conveniences):
  - `models[].provider_key` — provider-key *name* → derived `provider_key_id`; mutually exclusive with an explicit `provider_key_id`; unknown names error and list what is defined.
  - `api_keys[].display_name` — required file-side identity, stripped before validation (the canonical `api_key` document has no name field). `key_env` XOR `key_hash`; `key_env` names an environment variable whose value is hashed (SHA-256 lowercase hex, identical to `ApiKey::hash_bearer`) and dropped — the plaintext never reaches logs, error messages, or the store. A variable whose value itself looks like `${...}` (double indirection) is rejected.
  - `rate_limit_policies[].scope_ref` — for `scope: api_key` / `scope: model`, a *name* resolved to the referenced entry's derived id; `team` / `member` / `team_member` pass through verbatim.
- **Deterministic ids, no `id` field.** Every entry's identity is its `display_name` (provider_keys, models, api_keys) or `name` (the other six; `mcp_servers`/`a2a_agents` also accept `display_name` per their schemas). The derived id is UUIDv5 of `"<kind>/<identity>"` under a fixed namespace (`FILE_RESOURCE_NAMESPACE = 63e50ab2-677a-54d3-8d1e-c0cb29ceae94`, itself `uuid5(NAMESPACE_URL, "https://github.com/api7/aisix#resources-file")`, pinned by test) — stable across reloads and processes. An `id` field in the file is rejected on every kind, including the schema-open ones.
- **Duplicate identity within a kind is a load error**, naming both entries. Duplicate *credentials* are too: two api_keys entries resolving to the same `key_hash` would silently last-wins in the runtime credential index, so the load rejects them (the same invariant the Admin API enforces on create) — the error names the entries, never the hash or plaintext.
- **Cross-references resolve at load time** so a typo can never become a silent runtime failure: every non-glob `api_keys[].allowed_models` entry, `routing.targets[].model`, ensemble panel/judge ref, and semantic `embedding_model`/`default`/route-target/failure-target must match a defined model name (entries containing `*` are glob patterns and exempt). `scope_ref` resolution follows the same rule for `api_key`/`model` scopes. An *explicit* `models[].provider_key_id` must equal the derived id of a file-defined provider key (ids are deterministic, so generated files can carry them; any other value is guaranteed dangling and is rejected with a pointer to the `provider_key` name sugar).

## Mode wiring

- `resources_file` is a new **optional** top-level config field. When set, the `etcd` section must be absent or unconfigured; setting both is a boot error, as is combining it with `managed.enabled` (managed mode is control-plane-driven by definition). Without `resources_file`, behavior is exactly today's etcd mode.
- In file mode the admin listener stays up: **reads** (GET lists/gets, `/admin/v1/models/status`, `/admin/v1/health`, OpenAPI, `/readyz`) serve from the live snapshot, and the **Playground** works. Every resource **write** (POST/PUT/DELETE, including key rotation) answers **409** with a message naming the file, enforced at one router-level chokepoint (plus read-only store errors as defense in depth). **Auth ordering:** the guard only short-circuits for requests carrying a valid admin key — unauthenticated or wrong-key writes get the same `401` as etcd mode, and the 409 body (which names the operator's file path) is only ever shown to authenticated admins.
- **Guardrails in file mode are env-global.** The v1 format has no attachment collection, so a file-defined guardrail applies to every request in the gateway (the zero-attachment behavior of the guardrail index; a source comment there now pins the dependency, and an e2e case pins that a file-defined guardrail actually fires).

## Fail-fast boot & SIGHUP reload

- **Boot:** any load problem fails the boot with a non-zero exit and an **aggregated** report — every error across the whole file, each with kind/entry/field context — not first-error-only.
- **SIGHUP:** re-runs the identical pipeline; success swaps the snapshot atomically (the same swap machinery the etcd watch path uses, with a bumped generation as the entries' revision); failure logs the aggregated report at WARN and keeps serving the last-good snapshot. Nothing from a rejected file is partially applied.
- **`aisix validate --resources <file>`** runs the same pipeline without booting listeners: exit 0 on success, non-zero with the same aggregated report otherwise. `${VAR}` references resolve against the validating process's environment.

## Deliberately absent

- **No file watcher** — reloads are explicit (SIGHUP), so a half-written file save can't race the loader.
- **No `id` fields in the file** — ids are always derived; hand-managed ids would break the determinism that keeps references and rate-limit counters stable across reloads.
- **Duplicates are errors, not last-wins** — the file is the whole truth; silent overwrite hides mistakes.
- **No load-time existence check for `allowed_tools` / `allowed_agents` entries.** These are permission *masks* (glob patterns matched at request time), not references: an entry granting a tool or agent that is not (yet) defined is a no-op grant, exactly as in etcd mode where an ACL may legitimately predate the resource it names. The load-time reference checks deliberately cover the dispatch-critical refs (models, provider keys, scope_ref), where a dangle means a broken request path rather than an unused grant.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test --workspace` (with live etcd + redis integration env): **2274 passed, 0 failed**.
- 53 new unit tests: 39 filesource pipeline (format gate, unknown keys, interpolation incl. `$$` / bare-`$` / missing-var, sugar resolution, key_env hashing + XOR + no-leak, duplicate identity + duplicate credential, `id` rejection, cross-refs with glob exemption, explicit provider_key_id resolution, scope_ref per scope, UUID determinism), 5 config wiring, 2 file store, 4 admin file-mode routing (409 coverage incl. rotate, snapshot-backed reads, unauthenticated-write 401 without path disclosure, guard inert in etcd mode), 1 auth helper, 3 server CLI/validate.
- New e2e (`tests/e2e/src/cases/file-resource-source-e2e.test.ts`, 8 cases): file-mode smoke (full chain via `key_env` caller + mock upstream; allowed_models 403 with upstream untouched), Playground in file mode, admin write-guard (authenticated 409 + snapshot reads + unauthenticated 401 with no path leak), file-defined guardrail fires (422, upstream untouched), **differential file-mode vs etcd-mode** (same logical resources → identical `/v1/models` listing, chat 200 body, 403 envelope), SIGHUP reload (valid edit applies; invalid edit keeps last-good with nothing partially applied), fail-fast boot (non-zero exit + aggregated named errors on stderr), `aisix validate` exit codes + stderr report.
- Full existing e2e suite green three times (etcd mode untouched): runs 1–2 on the initial push (139 files / 295 tests each, exit 0) and run 3 after the review fixes (139 files / 297 tests, exit 0).
- `cargo run -p aisix-core --bin dump-schema` and `cargo run -p aisix-admin --bin dump-openapi`: no diff — the canonical schemas are intentionally untouched.

## Review trail

An independent audit (no HIGH findings) and the automated review both ran against the first push; every MEDIUM is addressed in code on this branch: auth-ordering on the write guard (unauthenticated writes now 401 without path disclosure), duplicate-credential rejection, explicit provider_key_id resolution, the guardrail zero-attachment dependency pinned in a source comment + e2e, `validate` failure-path e2e, reload pipeline moved to a blocking task, and a CI-loud skip for the differential case. The one deliberate non-change (ACL masks, above) is justified in “Deliberately absent”.
