### PR TITLE
fix(responses): monitor-mode output guardrails must not hold back or fail streaming closed

### DIFF
--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -2037,6 +2037,14 @@ impl SseTextCapture {
     fn into_text(self) -> String {
         self.terminal.unwrap_or(self.deltas)
     }
+
+    /// [`Self::into_text`] without consuming — the end-of-stream scan reads
+    /// the text while the completion guard stays armed (a client disconnect
+    /// mid-scan must still fire the guard's Drop emit with the captured
+    /// text), so it clones instead of taking.
+    fn text(&self) -> String {
+        self.terminal.clone().unwrap_or_else(|| self.deltas.clone())
+    }
 }
 
 /// Drop guard that fires `on_complete` exactly once with the usage parsed from
@@ -2161,9 +2169,11 @@ where
 {
     // The scan reads the same assembled output text the capture produces, so
     // an attached scan forces the accumulator on even when no exporter wants
-    // content — capped at the scan bound in that case. `CapturedContent::new`
-    // re-truncates to the exporter cap, so a larger scan cap never leaks
-    // extra bytes into the export.
+    // content. The cap bounds delta accumulation; a terminal event's full
+    // output text is instead bounded by MAX_SSE_FRAME_BUF_BYTES (an oversized
+    // frame never parses) and re-truncated by both consumers —
+    // `CapturedContent::new` at the exporter cap and `EosOutputScan::observe`
+    // at the scan bound — so neither sees beyond its own limit.
     let capture_cap = match (content_cap, eos_scan.is_some()) {
         (Some(cap), true) => {
             Some((cap as usize).max(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES))
@@ -2208,15 +2218,27 @@ where
             yield item;
         }
         // Clean end-of-stream: run the monitor observation (needs async, so
-        // it can't live in the Drop guard) and complete explicitly. A client
-        // disconnect never reaches here — the guard's Drop fires instead.
+        // it can't live in the Drop guard), then complete explicitly. The
+        // scan awaits a remote guardrail provider, and SDK clients routinely
+        // close the connection right after the terminal frame — dropping
+        // this generator at that await. The guard therefore MUST stay armed
+        // across the scan: its Drop then still emits the usage event (with
+        // the captured text, without hits — same as any disconnect). Taking
+        // the slot before the await would silently lose the event for a
+        // fully-delivered stream.
+        let hits = match eos_scan {
+            Some(scan) => {
+                let text = guard.parts().1.map(|c| c.text()).unwrap_or_default();
+                scan.observe(&text).await
+            }
+            None => Vec::new(),
+        };
         if let Some((f, usage, capture)) = guard.slot.take() {
-            let text = capture.map(SseTextCapture::into_text).unwrap_or_default();
-            let hits = match eos_scan {
-                Some(scan) => scan.observe(&text).await,
-                None => Vec::new(),
-            };
-            f(usage.unwrap_or_default(), text, hits);
+            f(
+                usage.unwrap_or_default(),
+                capture.map(SseTextCapture::into_text).unwrap_or_default(),
+                hits,
+            );
         }
     }
 }
@@ -3495,6 +3517,110 @@ mod tests {
             "the end-of-stream scan must record the would-block observation, got {:?}",
             event.guardrail_monitor_hits,
         );
+    }
+
+    /// AISIX-Cloud#1010 audit H1: the end-of-stream observation awaits a
+    /// remote guardrail provider, and SDK clients close the connection right
+    /// after the terminal frame — the generator is dropped at that await.
+    /// The completion guard must stay armed across the scan so the Drop
+    /// still emits the usage event: a fully-delivered 200 stream must never
+    /// lose its billing/logs record to a disconnect during the observation.
+    #[tokio::test]
+    async fn monitor_scan_disconnect_still_emits_usage_event() {
+        use aisix_obs::UsageSink;
+        use futures::StreamExt;
+        let upstream = MockServer::start().await;
+        let sse = "event: response.output_text.delta\n\
+                   data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello there\"}\n\n\
+                   event: response.completed\n\
+                   data: {\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello there\"}]}],\"usage\":{\"input_tokens\":5,\"output_tokens\":3}}}\n\n\
+                   data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        // Remote moderation backend that never answers within the test —
+        // parks the end-of-stream scan so the disconnect lands mid-await.
+        let acs = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/contentsafety/text:analyze"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_secs(30))
+                    .set_body_json(serde_json::json!({
+                        "categoriesAnalysis": [],
+                        "blocklistsMatch": []
+                    })),
+            )
+            .mount(&acs)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let textmod_json = format!(
+            r#"{{"name":"textmod-mon","enabled":true,"kind":"azure_content_safety_text_moderation","hook_point":"output","enforcement_mode":"monitor","endpoint":"{}","api_key":"k"}}"#,
+            acs.uri()
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&textmod_json).unwrap();
+        snap.guardrails
+            .insert(ResourceEntry::new("g-textmod-mon", g, 1));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Read frames until the terminal [DONE] is on the wire, then poll
+        // once more so the generator advances past the loop and parks on the
+        // remote-scan await — and drop the body there, like an SDK client
+        // closing after the terminal frame.
+        let mut body_stream = resp.into_body().into_data_stream();
+        let mut wire = Vec::new();
+        while !String::from_utf8_lossy(&wire).contains("[DONE]") {
+            let chunk =
+                tokio::time::timeout(std::time::Duration::from_millis(2000), body_stream.next())
+                    .await
+                    .expect("stream must deliver the terminal frame promptly")
+                    .expect("stream ended before [DONE]")
+                    .expect("stream errored");
+            wire.extend_from_slice(chunk.as_ref());
+        }
+        let parked =
+            tokio::time::timeout(std::time::Duration::from_millis(300), body_stream.next()).await;
+        assert!(
+            parked.is_err(),
+            "generator should be parked on the remote scan await",
+        );
+        drop(body_stream);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(1000), rx.recv())
+            .await
+            .expect("disconnect during the EOS scan must still emit the usage event")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.status_code, 200);
+        assert!(!event.guardrail_blocked);
+        assert_eq!(event.prompt_tokens, 5);
+        assert_eq!(event.completion_tokens, 3);
     }
 
     /// AISIX-Cloud#1010, cross-provider bridge path: a monitor-mode output

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -585,7 +585,7 @@ async fn dispatch(
                     &target.model,
                     &target.id,
                     request_id,
-                    resolved_chain.as_ref(),
+                    resolved_chain.clone(),
                     started,
                     &model_name,
                     &auth.entry.id,
@@ -808,7 +808,9 @@ async fn responses_to_target(
     model: &aisix_core::Model,
     model_id: &str,
     request_id: &str,
-    chain: &aisix_guardrails::GuardrailChain,
+    // Arc so the live-forward streaming path can carry the chain into its
+    // end-of-stream observation (AISIX-Cloud#1010).
+    chain: Arc<aisix_guardrails::GuardrailChain>,
     // #808: end-of-stream UsageEvent context for the verbatim streaming
     // path's Drop guard. Unused by the non-streaming / buffered paths,
     // which emit from the handler.
@@ -826,6 +828,8 @@ async fn responses_to_target(
     // `input_redactions`.
     input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
+    let chain_arc = chain;
+    let chain = chain_arc.as_ref();
     // Largest content cap any enabled content-capturing exporter wants, or
     // `None` when none do (AISIX-Cloud#947). The captured prompt is the
     // client-facing request body (post-#932-redaction), taken BEFORE the
@@ -971,15 +975,21 @@ async fn responses_to_target(
     if is_stream {
         let headers = upstream_resp.headers().clone();
 
-        // #719: when an output-hook guardrail is attached, the streaming
-        // response can't be forwarded token-by-token — a blocked phrase
-        // would already be on the wire before it scans clean, the same
-        // surface-switch bypass via `stream:true`. Mirror the chat
-        // surface's secure default (BufferFull): hold the whole SSE
+        // #719: when an output-hook guardrail with a hold-back streaming
+        // policy (Window/BufferFull — any block-capable output chain) is
+        // attached, the streaming response can't be forwarded token-by-token
+        // — a blocked phrase would already be on the wire before it scans
+        // clean, the same surface-switch bypass via `stream:true`. Mirror the
+        // chat surface's secure default (BufferFull): hold the whole SSE
         // response, scan the assistant output text, then release the bytes
-        // verbatim or block with 422. Requests with no output-hook
-        // guardrail keep the zero-copy verbatim passthrough below.
-        if aisix_guardrails::Guardrail::runs_on_output(chain) {
+        // verbatim or block with 422. A monitor-only chain resolves to
+        // EndOfStreamCheck — it can never block, so it must never hold the
+        // stream back nor fail closed on the buffer cap (AISIX-Cloud#1010);
+        // it takes the live-forward path below, which scans at end-of-stream
+        // for observation. Requests with no output-hook guardrail keep the
+        // zero-copy verbatim passthrough.
+        let output_policy = aisix_guardrails::Guardrail::stream_output_policy(chain);
+        if aisix_guardrails::Guardrail::runs_on_output(chain) && output_policy.holds_back() {
             // Hold the whole SSE response back to scan it, but cap the
             // buffer so a huge (or malicious) upstream response can't OOM the
             // gateway. Mirror the chat surface's secure BufferFull default
@@ -987,7 +997,7 @@ async fn responses_to_target(
             // response exceeds the cap — an output-hook guardrail must never
             // release content it couldn't fully buffer to scan. The cap is
             // taken from the chain's resolved streaming policy.
-            let max_buffer_bytes = match aisix_guardrails::Guardrail::stream_output_policy(chain) {
+            let max_buffer_bytes = match output_policy {
                 aisix_guardrails::StreamOutputPolicy::BufferFull {
                     max_buffer_bytes, ..
                 } => max_buffer_bytes,
@@ -1220,8 +1230,19 @@ async fn responses_to_target(
         let stream_hold = reservation.take().map(|r| r.into_stream_hold());
         let limiter_c = std::sync::Arc::clone(&state.limiter);
         let captured_prompt_c = captured_prompt.clone();
-        let parsed_stream =
-            build_responses_passthrough_stream(body_stream, content_cap, move |usage, out_text| {
+        // AISIX-Cloud#1010: a monitor-only output chain (EndOfStreamCheck —
+        // the only way an output-hook chain reaches this live-forward branch)
+        // still gets its end-of-stream scan, so would-block / would-mask
+        // observations reach telemetry. `None` without an output hook.
+        let eos_scan = aisix_guardrails::Guardrail::runs_on_output(chain).then(|| EosOutputScan {
+            chain: Arc::clone(&chain_arc),
+            upstream_model: upstream_model.clone(),
+        });
+        let parsed_stream = build_responses_passthrough_stream(
+            body_stream,
+            content_cap,
+            eos_scan,
+            move |usage, out_text, output_hits| {
                 // Streams that reach here are committed 200s — the
                 // `!status.is_success()` guard above returned early on errors.
                 //
@@ -1261,6 +1282,13 @@ async fn responses_to_target(
                     },
                     started.elapsed(),
                 );
+                // Live-forward path: no output masking possible (a masking
+                // guardrail holds back → buffered branch; a monitor-mode one
+                // suppresses its masks), so only the input-side counts apply.
+                // The end-of-stream scan's monitor observations ride along
+                // with the input-side hits (AISIX-Cloud#1010).
+                let mut monitor_hits = input_monitor_hits.clone();
+                monitor_hits.extend(output_hits);
                 emit_usage_event(
                     &state_c,
                     &request_id_c,
@@ -1274,14 +1302,12 @@ async fn responses_to_target(
                     &client_c,
                     attempt,
                     /* guardrail_blocked */ false,
-                    // Live-forward path: no output masking possible (an
-                    // output-masking guardrail forces the buffered branch),
-                    // so only the input-side counts apply.
                     input_redactions.clone(),
-                    input_monitor_hits.clone(),
+                    monitor_hits,
                     captured_content.as_ref(),
                 );
-            });
+            },
+        );
         let mut response =
             axum::response::Response::new(axum::body::Body::from_stream(Box::pin(parsed_stream)));
         apply_passthrough_headers(&mut response, &headers, request_id);
@@ -1560,20 +1586,25 @@ async fn responses_cross_provider_to_target(
             requested_model,
             created_at,
         );
-        // Only an output-hook guardrail needs the streamed response text. When
-        // attached, the bridge buffers the SSE and scans before releasing it
-        // (#719 secure default); cap the buffer the same way the verbatim path
-        // does so a huge response can't OOM the gateway.
+        // Only an output-hook guardrail needs the streamed response text.
+        // When attached with a hold-back policy (Window/BufferFull — any
+        // block-capable chain), the bridge buffers the SSE and scans before
+        // releasing it (#719 secure default); cap the buffer the same way the
+        // verbatim path does so a huge response can't OOM the gateway. A
+        // monitor-only chain resolves to EndOfStreamCheck — it can never
+        // block, so the bridge forwards live and scans at end-of-stream for
+        // observation only (AISIX-Cloud#1010).
         let output_guardrail = (!chain.is_empty()
             && aisix_guardrails::Guardrail::runs_on_output(chain.as_ref()))
         .then(|| chain.clone());
-        let max_buffer_bytes =
-            match aisix_guardrails::Guardrail::stream_output_policy(chain.as_ref()) {
-                aisix_guardrails::StreamOutputPolicy::BufferFull {
-                    max_buffer_bytes, ..
-                } => max_buffer_bytes,
-                _ => aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES,
-            };
+        let output_policy = aisix_guardrails::Guardrail::stream_output_policy(chain.as_ref());
+        let hold_back = output_policy.holds_back();
+        let max_buffer_bytes = match output_policy {
+            aisix_guardrails::StreamOutputPolicy::BufferFull {
+                max_buffer_bytes, ..
+            } => max_buffer_bytes,
+            _ => aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES,
+        };
 
         let state_c = state.clone();
         let request_id_c = request_id.to_string();
@@ -1597,6 +1628,7 @@ async fn responses_cross_provider_to_target(
             encoder,
             started,
             output_guardrail,
+            hold_back,
             max_buffer_bytes,
             requested_model.to_string(),
             content_cap,
@@ -2014,12 +2046,17 @@ impl SseTextCapture {
 /// `None` means no terminal usage was seen (e.g. an abort before completion);
 /// the emit then records a zero-token 200 so the request still appears in the
 /// dashboard Logs. The second callback argument is the captured output text
-/// (AISIX-Cloud#947) — empty when no exporter wants content.
-struct ResponsesUsageGuard<F: FnOnce(ResponseUsage, String)> {
+/// (AISIX-Cloud#947) — empty when no exporter wants content. The third is the
+/// end-of-stream scan's monitor observations (AISIX-Cloud#1010) — the Drop
+/// (disconnect) path passes none: the response never completed, so there is
+/// nothing final to observe, matching the chat surface's disconnect behavior.
+struct ResponsesUsageGuard<F: FnOnce(ResponseUsage, String, Vec<aisix_core::GuardrailMonitorHit>)> {
     slot: Option<(F, Option<ResponseUsage>, Option<SseTextCapture>)>,
 }
 
-impl<F: FnOnce(ResponseUsage, String)> ResponsesUsageGuard<F> {
+impl<F: FnOnce(ResponseUsage, String, Vec<aisix_core::GuardrailMonitorHit>)>
+    ResponsesUsageGuard<F>
+{
     fn parts(&mut self) -> (&mut Option<ResponseUsage>, Option<&mut SseTextCapture>) {
         let slot = self
             .slot
@@ -2029,37 +2066,118 @@ impl<F: FnOnce(ResponseUsage, String)> ResponsesUsageGuard<F> {
     }
 }
 
-impl<F: FnOnce(ResponseUsage, String)> Drop for ResponsesUsageGuard<F> {
+impl<F: FnOnce(ResponseUsage, String, Vec<aisix_core::GuardrailMonitorHit>)> Drop
+    for ResponsesUsageGuard<F>
+{
     fn drop(&mut self) {
         if let Some((f, usage, capture)) = self.slot.take() {
             f(
                 usage.unwrap_or_default(),
                 capture.map(SseTextCapture::into_text).unwrap_or_default(),
+                Vec::new(),
             );
         }
+    }
+}
+
+/// End-of-stream output observation for the live-forward verbatim path
+/// (AISIX-Cloud#1010). Reachable only when the output-hook chain's resolved
+/// streaming policy is `EndOfStreamCheck` — today that is exactly the
+/// monitor-only chains, which can never block. Runs the same two-phase scan
+/// as the buffered branch (blob check + segment pass) so would-block /
+/// would-mask hits reach telemetry; the bytes are already on the wire, so a
+/// `Block` verdict (unreachable for monitor members) is logged, not enforced.
+struct EosOutputScan {
+    chain: Arc<aisix_guardrails::GuardrailChain>,
+    upstream_model: String,
+}
+
+impl EosOutputScan {
+    async fn observe(self, text: &str) -> Vec<aisix_core::GuardrailMonitorHit> {
+        // Bound the provider calls the same way the buffered branch's byte
+        // cap does — scan at most the cap's worth of text.
+        let mut end = text
+            .len()
+            .min(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES);
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        let scan_text = &text[..end];
+        if scan_text.is_empty() {
+            return Vec::new();
+        }
+        let synth = synth_chat_response(&self.upstream_model, scan_text.to_string());
+        let (verdict, mut hits) = aisix_guardrails::Guardrail::check_output_non_segment_observed(
+            self.chain.as_ref(),
+            &synth,
+        )
+        .await;
+        // Segment pass (bedrock/lakera/presidio members): offer the flattened
+        // text as one segment so monitor-mode segment moderators record their
+        // observations too. Masks are suppressed in monitor mode, and nothing
+        // could be rewritten anyway — the counts are discarded.
+        let mut seg_counts = crate::redact::RedactionCounts::new();
+        let verdict = crate::redact::moderate_body(
+            self.chain.as_ref(),
+            crate::redact::Direction::Output,
+            verdict,
+            &mut seg_counts,
+            &mut hits,
+            |g| {
+                let _ = g.redact_output_text(scan_text);
+                crate::redact::RedactionCounts::new()
+            },
+        )
+        .await;
+        if let aisix_guardrails::GuardrailVerdict::Block { reason, .. } = verdict {
+            tracing::warn!(
+                guardrail_hook = "output",
+                model = %self.upstream_model,
+                reason = %reason,
+                "output guardrail returned a block after live forward; \
+                 response already sent (EndOfStreamCheck policy)",
+            );
+        }
+        hits
     }
 }
 
 /// Wrap a Responses-API upstream byte stream so the terminal event's usage is
 /// parsed in-flight and `on_complete` fires once at end-of-stream (or
 /// client-disconnect) with the accumulated counts (#808) plus the captured
-/// output text (AISIX-Cloud#947, empty when `content_cap` is `None`). Bytes
-/// forward verbatim — the client sees the exact upstream SSE wire shape.
+/// output text (AISIX-Cloud#947, empty when `content_cap` is `None`) and the
+/// end-of-stream scan's monitor hits (AISIX-Cloud#1010, empty without
+/// `eos_scan`). Bytes forward verbatim — the client sees the exact upstream
+/// SSE wire shape.
 fn build_responses_passthrough_stream<S, F>(
     upstream: S,
     content_cap: Option<u32>,
+    eos_scan: Option<EosOutputScan>,
     on_complete: F,
 ) -> impl futures::Stream<Item = reqwest::Result<bytes::Bytes>>
 where
     S: futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send + 'static,
-    F: FnOnce(ResponseUsage, String) + Send + 'static,
+    F: FnOnce(ResponseUsage, String, Vec<aisix_core::GuardrailMonitorHit>) + Send + 'static,
 {
+    // The scan reads the same assembled output text the capture produces, so
+    // an attached scan forces the accumulator on even when no exporter wants
+    // content — capped at the scan bound in that case. `CapturedContent::new`
+    // re-truncates to the exporter cap, so a larger scan cap never leaks
+    // extra bytes into the export.
+    let capture_cap = match (content_cap, eos_scan.is_some()) {
+        (Some(cap), true) => {
+            Some((cap as usize).max(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES))
+        }
+        (Some(cap), false) => Some(cap as usize),
+        (None, true) => Some(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES),
+        (None, false) => None,
+    };
     async_stream::stream! {
         let mut guard = ResponsesUsageGuard {
             slot: Some((
                 on_complete,
                 None,
-                content_cap.map(|cap| SseTextCapture::new(cap as usize)),
+                capture_cap.map(SseTextCapture::new),
             )),
         };
         futures::pin_mut!(upstream);
@@ -2089,7 +2207,17 @@ where
             // Forward the original item verbatim (Ok bytes OR a mid-stream Err).
             yield item;
         }
-        // guard drops here → on_complete fires.
+        // Clean end-of-stream: run the monitor observation (needs async, so
+        // it can't live in the Drop guard) and complete explicitly. A client
+        // disconnect never reaches here — the guard's Drop fires instead.
+        if let Some((f, usage, capture)) = guard.slot.take() {
+            let text = capture.map(SseTextCapture::into_text).unwrap_or_default();
+            let hits = match eos_scan {
+                Some(scan) => scan.observe(&text).await,
+                None => Vec::new(),
+            };
+            f(usage.unwrap_or_default(), text, hits);
+        }
     }
 }
 
@@ -3238,6 +3366,197 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(v["error"]["type"], "content_filter");
+    }
+
+    /// `keyword_output_guardrail` with `enforcement_mode: monitor` — the
+    /// chain resolves to `EndOfStreamCheck` (never holds back, never blocks).
+    fn keyword_output_guardrail_monitor(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
+        let json = format!(
+            r#"{{"name":"test-out-mon","enabled":true,"hook_point":"output","fail_open":false,"enforcement_mode":"monitor","kind":"keyword","patterns":[{{"kind":"literal","value":"{literal}"}}]}}"#
+        );
+        let g: aisix_core::Guardrail = serde_json::from_str(&json).unwrap();
+        ResourceEntry::new("g-out-mon-1", g, 1)
+    }
+
+    /// AISIX-Cloud#1010: a MONITOR-mode output guardrail must never make a
+    /// streaming /v1/responses request fail closed. Same oversized stream as
+    /// the fail-closed test above, but the chain resolves to EndOfStreamCheck
+    /// — the bytes forward live and the client gets the full 200 SSE, not a
+    /// 422. Pre-fix, any output-hook guardrail (monitor included) forced the
+    /// hold-back branch and a >256 KiB response was rejected with
+    /// `content_filter` — a monitor rule "blocking", which it must never do.
+    #[tokio::test]
+    async fn monitor_output_guardrail_oversized_stream_released() {
+        let upstream = MockServer::start().await;
+        let big = "x".repeat(300_000);
+        let sse =
+            format!("data: {{\"type\":\"response.output_text.delta\",\"delta\":\"{big}\"}}\n\ndata: [DONE]\n\n");
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails
+            .insert(keyword_output_guardrail_monitor("BLOCKME"));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a monitor-only chain must never fail a stream closed on the buffer cap",
+        );
+        let bytes = to_bytes(resp.into_body(), 4 * 1024 * 1024).await.unwrap();
+        let body = String::from_utf8_lossy(&bytes);
+        assert!(
+            body.len() >= 300_000 && body.contains("[DONE]"),
+            "the full SSE must be released, got {} bytes",
+            body.len(),
+        );
+    }
+
+    /// AISIX-Cloud#1010 companion: on the live-forward monitor path the
+    /// end-of-stream scan still runs — a violating stream is delivered
+    /// verbatim (200, content included) and the emitted usage event carries
+    /// the `would_block` observation instead of `guardrail_blocked`.
+    #[tokio::test]
+    async fn monitor_output_guardrail_streams_live_and_records_would_block() {
+        use aisix_obs::UsageSink;
+        let upstream = MockServer::start().await;
+        let sse = "event: response.output_text.delta\n\
+                   data: {\"type\":\"response.output_text.delta\",\"delta\":\"sure: BLOCKME\"}\n\n\
+                   event: response.completed\n\
+                   data: {\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"sure: BLOCKME\"}]}],\"usage\":{\"input_tokens\":5,\"output_tokens\":3}}}\n\n\
+                   data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails
+            .insert(keyword_output_guardrail_monitor("BLOCKME"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"gpt-4o-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert!(
+            String::from_utf8_lossy(&bytes).contains("BLOCKME"),
+            "monitor mode must deliver the stream verbatim",
+        );
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(1000), rx.recv())
+            .await
+            .expect("usage event must be emitted")
+            .expect("usage_sink sender dropped");
+        assert!(!event.guardrail_blocked);
+        assert_eq!(event.status_code, 200);
+        assert!(
+            event
+                .guardrail_monitor_hits
+                .iter()
+                .any(|h| h.hook == "output" && h.action == "would_block"),
+            "the end-of-stream scan must record the would-block observation, got {:?}",
+            event.guardrail_monitor_hits,
+        );
+    }
+
+    /// AISIX-Cloud#1010, cross-provider bridge path: a monitor-mode output
+    /// guardrail must not hold back or fail the bridged stream on the buffer
+    /// cap either. An oversized bridged response is released in full with no
+    /// `content_filter` error frame, and the usage event stays an unblocked
+    /// 200.
+    #[tokio::test]
+    async fn monitor_output_guardrail_oversized_cross_provider_stream_released() {
+        use aisix_obs::UsageSink;
+        let upstream = MockServer::start().await;
+        let big = serde_json::to_string(&"y".repeat(300_000)).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(anthropic_text_sse(&big)),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_anthropic_at(&upstream.uri());
+        snap.models.insert(anthropic_model("claude-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails
+            .insert(keyword_output_guardrail_monitor("BLOCKME"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let resp = app
+            .oneshot(make_req(
+                serde_json::json!({"model":"claude-resp","input":"hi","stream":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 8 * 1024 * 1024).await.unwrap();
+        let body = String::from_utf8_lossy(&bytes);
+        assert!(
+            body.contains(&"y".repeat(1000)),
+            "the bridged stream must be released, not withheld",
+        );
+        assert!(
+            !body.contains("content_filter"),
+            "no fail-closed error frame on a monitor-only chain",
+        );
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(1000), rx.recv())
+            .await
+            .expect("usage event must be emitted")
+            .expect("usage_sink sender dropped");
+        assert!(!event.guardrail_blocked);
+        assert_eq!(event.status_code, 200);
     }
 
     /// #546: output tool-call arguments must be scanned. A blocked literal in

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1088,6 +1088,24 @@ pub fn build_responses_bridge_stream(
         // chat surface's EndOfStreamCheck behavior.
         let (text, tool_calls) = encoder.assembled_assistant_message();
         if !text.is_empty() || !tool_calls.is_empty() {
+            // Live mode releases oversized streams (that's the point of
+            // AISIX-Cloud#1010), so the assembled text is unbounded here —
+            // cap the scan input like the verbatim path's EosOutputScan
+            // does, keeping the observation provider calls bounded. Held
+            // (buffering) text is already capped by the hold-back budget.
+            let text = if buffering {
+                text
+            } else {
+                let mut text = text;
+                let mut end = text
+                    .len()
+                    .min(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES);
+                while end > 0 && !text.is_char_boundary(end) {
+                    end -= 1;
+                }
+                text.truncate(end);
+                text
+            };
             // Live mode has no held frames for the segment pass to walk —
             // offer the flattened text as one segment so monitor-mode
             // segment moderators still record their observations.
@@ -1144,7 +1162,11 @@ pub fn build_responses_bridge_stream(
             )
             .await;
             guard.comp().monitor_hits.extend(seg_hits);
-            if !seg_counts.is_empty() {
+            // `buffering` gate: only the hold-back walk can actually rewrite
+            // wire bytes — the live walk is read-only, so a masked outcome
+            // there (unreachable today) must not clobber the capture with a
+            // rebuild from the empty `joined`.
+            if buffering && !seg_counts.is_empty() {
                 // Bedrock masked the held bytes — rebuild the content-
                 // capture accumulator from the masked text channels,
                 // keeping the original soft cap (#932 × AISIX-Cloud#947).

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -939,20 +939,26 @@ impl<F: FnOnce(ResponsesStreamCompletion)> Drop for CompleteOnDrop<F> {
 /// callback fires from a Drop guard (so it runs on normal end and on client
 /// disconnect).
 ///
-/// When `output_guardrail` is `Some`, the encoded SSE is **held back** and
-/// released only after the assembled assistant output passes the scan —
-/// mirroring the verbatim `/v1/responses` path's secure BufferFull default
-/// (#719), so a configured output block can't be bypassed by streaming a
-/// non-OpenAI model. The scan reads the fully-reassembled text + tool calls
-/// (not raw deltas), and the buffer is capped — an output guardrail must
-/// never release content it couldn't fully buffer to scan, so an overflow
-/// fails closed. With no output guardrail the bytes forward live.
+/// When `output_guardrail` is `Some` and `hold_back` is true (the chain's
+/// resolved streaming policy holds back — any block-capable output chain),
+/// the encoded SSE is **held back** and released only after the assembled
+/// assistant output passes the scan — mirroring the verbatim `/v1/responses`
+/// path's secure BufferFull default (#719), so a configured output block
+/// can't be bypassed by streaming a non-OpenAI model. The scan reads the
+/// fully-reassembled text + tool calls (not raw deltas), and the buffer is
+/// capped — an output guardrail must never release content it couldn't fully
+/// buffer to scan, so an overflow fails closed. When `hold_back` is false
+/// (EndOfStreamCheck — a monitor-only chain, which can never block), the
+/// bytes forward live and the same end-of-stream scan runs for observation
+/// only (AISIX-Cloud#1010). With no output guardrail the bytes forward live
+/// unscanned.
 #[allow(clippy::too_many_arguments)]
 pub fn build_responses_bridge_stream(
     upstream: ChatChunkStream,
     encoder: ResponsesSseEncoder,
     started: Instant,
     output_guardrail: Option<Arc<aisix_guardrails::GuardrailChain>>,
+    hold_back: bool,
     max_buffer_bytes: usize,
     model_label: String,
     // Largest content cap any content-capturing exporter wants
@@ -967,7 +973,7 @@ pub fn build_responses_bridge_stream(
         let mut guard = CompleteOnDrop { slot: Some((on_complete, ResponsesStreamCompletion::default())) };
         let mut upstream = upstream;
         let mut first_chunk_seen = false;
-        let buffering = output_guardrail.is_some();
+        let buffering = output_guardrail.is_some() && hold_back;
         // Held SSE events when an output guardrail is attached; empty (and
         // unused) on the live-forward path.
         let mut held: Vec<bytes::Bytes> = Vec::new();
@@ -1053,11 +1059,12 @@ pub fn build_responses_bridge_stream(
             }
         }
 
-        // Live-forward path: nothing held, nothing to scan.
+        // No output-hook guardrail: nothing to scan.
         let Some(chain) = output_guardrail.as_ref() else { return; };
 
-        // Buffer overflow: an output guardrail must not release content it
-        // couldn't fully buffer to scan — fail closed (#719).
+        // Buffer overflow (hold-back mode only): an output guardrail must
+        // not release content it couldn't fully buffer to scan — fail
+        // closed (#719).
         if overflowed {
             tracing::warn!(
                 guardrail_hook = "output",
@@ -1072,9 +1079,19 @@ pub fn build_responses_bridge_stream(
 
         // End-of-stream output guardrail (#719): scan the fully-reassembled
         // assistant output (canonical tool calls, so a literal split across
-        // argument deltas can't slip through), then release or block.
+        // argument deltas can't slip through), then release or block. On the
+        // live-forward path (EndOfStreamCheck — monitor-only chain,
+        // AISIX-Cloud#1010) the same scan runs for observation: the bytes are
+        // already on the wire, so a Block (unreachable for monitor members;
+        // `mandatory` unavailability is the one composition that can still
+        // produce it) is signalled with a trailing error frame, mirroring the
+        // chat surface's EndOfStreamCheck behavior.
         let (text, tool_calls) = encoder.assembled_assistant_message();
         if !text.is_empty() || !tool_calls.is_empty() {
+            // Live mode has no held frames for the segment pass to walk —
+            // offer the flattened text as one segment so monitor-mode
+            // segment moderators still record their observations.
+            let live_seg_text = (!buffering).then(|| text.clone());
             let mut message = aisix_gateway::ChatMessage::assistant(text);
             if !tool_calls.is_empty() {
                 message.extra.insert("tool_calls".to_string(), Value::Array(tool_calls));
@@ -1109,13 +1126,20 @@ pub fn build_responses_bridge_stream(
                 verdict,
                 &mut seg_counts,
                 &mut seg_hits,
-                |g| match crate::redact::redact_responses_sse(g, &joined) {
-                    Some((rewritten, counts)) => {
-                        joined = rewritten;
-                        seg_rewrote = true;
-                        counts
+                |g| match live_seg_text.as_deref() {
+                    // Live-forward: observation only — nothing to rewrite.
+                    Some(t) => {
+                        let _ = g.redact_output_text(t);
+                        crate::redact::RedactionCounts::new()
                     }
-                    None => crate::redact::RedactionCounts::new(),
+                    None => match crate::redact::redact_responses_sse(g, &joined) {
+                        Some((rewritten, counts)) => {
+                            joined = rewritten;
+                            seg_rewrote = true;
+                            counts
+                        }
+                        None => crate::redact::RedactionCounts::new(),
+                    },
                 },
             )
             .await;

--- a/tests/e2e/src/cases/responses-streaming-monitor-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/responses-streaming-monitor-guardrail-e2e.test.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E regression for AISIX-Cloud#1010: a MONITOR-mode output guardrail must
+// never make a streaming /v1/responses request fail closed on the hold-back
+// buffer cap.
+//
+// Pre-fix, ANY output-hook guardrail — enforcement_mode ignored — forced the
+// streaming /v1/responses path into the whole-response hold-back branch with
+// a 256 KiB cap, and an oversized stream was rejected 422 `content_filter`.
+// A monitor rule ("observe, never block") therefore intermittently blocked
+// exactly the long generations Codex produces: the customer-visible shape
+// was 422 + 0 tokens + tens of seconds of latency on /v1/responses, while
+// short responses passed — "monitor mode is flaky".
+//
+// The test is self-gating against config-propagation races:
+//   1. block mode: the oversized stream 422s (proves the rule is loaded AND
+//      pins the block-mode fail-closed secure default, which must not
+//      change);
+//   2. flip the SAME rule to monitor: the same oversized stream returns 200
+//      with the full SSE released live — the block→monitor transition can
+//      only mean monitor semantics took effect.
+
+const CALLER_PLAINTEXT = "sk-issue-1010-monitor-stream";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const FORBIDDEN_WORD = "BLOCKME";
+
+// > 256 KiB (262 144 bytes) of SSE once the mock wraps each event in
+// `data: ...\n\n`: 220 deltas × ~1.3 KB ≈ 295 KB. One delta carries the
+// forbidden literal so the monitor scan has a real violation to observe.
+const DELTA_TEXT = "z".repeat(1250);
+const STREAM_EVENTS = [
+  JSON.stringify({ type: "response.created", response: { id: "resp_1010" } }),
+  JSON.stringify({
+    type: "response.output_text.delta",
+    delta: `sure thing ${FORBIDDEN_WORD}: `,
+  }),
+  ...Array.from({ length: 220 }, () =>
+    JSON.stringify({ type: "response.output_text.delta", delta: DELTA_TEXT }),
+  ),
+  JSON.stringify({
+    type: "response.completed",
+    response: {
+      id: "resp_1010",
+      status: "completed",
+      usage: { input_tokens: 7, output_tokens: 9 },
+    },
+  }),
+  "[DONE]",
+];
+
+function guardrailBody(enforcementMode: "block" | "monitor") {
+  return {
+    name: "gr-1010-output",
+    enabled: true,
+    hook_point: "output",
+    enforcement_mode: enforcementMode,
+    kind: "keyword",
+    patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
+  };
+}
+
+describe("responses streaming with monitor-mode output guardrail (AISIX-Cloud#1010)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  let guardrailId: string | undefined;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({ streamEvents: STREAM_EVENTS });
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "gr-1010-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "gr-1010-model",
+      provider: "openai",
+      model_name: "gpt-5-codex",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["gr-1010-model"],
+    });
+    // Start in BLOCK mode so phase 1 proves the rule is loaded + enforcing
+    // before the flip.
+    const g = await seed.createGuardrail(guardrailBody("block"));
+    guardrailId = g.id as string;
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  async function streamOnce(): Promise<{ status: number; body: string }> {
+    const r = await fetch(`${app!.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gr-1010-model",
+        input: "write a very long program",
+        stream: true,
+      }),
+    });
+    return { status: r.status, body: await r.text() };
+  }
+
+  test("block mode fails the oversized stream closed; monitor mode releases it live", async (ctx) => {
+    if (!etcdReachable || !app || !upstream || !seed || !guardrailId) {
+      ctx.skip();
+      return;
+    }
+
+    // 1. Block mode: the >256 KiB stream must fail closed (422
+    //    content_filter) — the rule is loaded and the secure default holds.
+    await waitConfigPropagation(async () => {
+      const { status } = await streamOnce();
+      return status === 422;
+    });
+    const blocked = await streamOnce();
+    expect(blocked.status).toBe(422);
+    expect(blocked.body).toContain("content_filter");
+    expect(blocked.body).not.toContain(DELTA_TEXT);
+
+    // 2. Flip the SAME rule to monitor (full-resource PUT).
+    await seed.update("guardrails", guardrailId, guardrailBody("monitor"));
+
+    // 3. Monitor mode: the same oversized stream is released in full — 200,
+    //    live SSE, no content_filter rejection. Pre-#1010-fix this stayed
+    //    422 forever.
+    await waitConfigPropagation(async () => {
+      const { status } = await streamOnce();
+      return status === 200;
+    });
+    const released = await streamOnce();
+    expect(released.status).toBe(200);
+    expect(released.body.length).toBeGreaterThan(262_144);
+    expect(released.body).toContain(FORBIDDEN_WORD);
+    expect(released.body).toContain("[DONE]");
+    expect(released.body).not.toContain('"content_filter"');
+  }, 120_000);
+});


### PR DESCRIPTION
## Problem

AISIX-Cloud#1010: a customer running 0.3.1 with an **aliyun output guardrail in monitor mode** saw intermittent `422` rejections on Codex traffic — dashboard rows showing `content_filter`, 0 tokens, $0.0000, and 16–26 s latency. Monitor mode is documented to observe and never block.

Root cause: the streaming `/v1/responses` path (both the verbatim OpenAI forward and the cross-provider bridge) entered the **whole-response hold-back branch whenever any output-hook guardrail was attached**, ignoring the chain's resolved `stream_output_policy`:

- a monitor-only chain resolves to `EndOfStreamCheck` (can never block), yet its stream was fully buffered — the client saw nothing until the generation finished;
- past the buffer cap (`DEFAULT_STREAM_OUTPUT_BUFFER_BYTES` = 256 KiB, hit by exactly the long SSE streams Codex produces), the request was rejected `422 content_filter` **before any verdict ran** — MonitorGuardrail never got the chance to downgrade.

`chat.rs` and `messages.rs` already gate hold-back on the policy (`holds_back()` / BufferFull-only); `/v1/responses` was the one deviating surface (family audit: completions/audio/passthrough/realtime have no streaming output-buffer path).

## Fix

- Hold-back (and its fail-closed overflow) now engages only when the resolved policy actually holds back (`Window`/`BufferFull` — any block-capable chain). **Block-mode behavior is unchanged**, including the fail-closed cap.
- An `EndOfStreamCheck` chain (monitor-only) forwards the SSE live and runs the same two-phase scan (blob check + segment pass) at end-of-stream, so `would_block`/`would_mask` monitor hits still reach telemetry. The scan runs **while the completion guard stays armed**: SDK clients close the connection right after the terminal frame, and a disconnect mid-scan must fall back to the guard's Drop emit rather than lose the usage event for a fully-delivered stream. Scan input is bounded to the same 256 KiB on both paths so observation provider calls stay bounded.
- A `Block` verdict on the live path (only reachable via the documented `mandatory`-unavailability composition) is logged and, on the bridge path, signalled with a trailing error frame — mirroring chat's `EndOfStreamCheck` behavior.

## Behavior change

Monitor-mode-only output chains on streaming `/v1/responses`: clients now receive tokens live (no whole-response buffering latency) and oversized responses are no longer rejected. Blocking chains: no change.

## LiteLLM baseline

LiteLLM never withholds or fails a stream for logging-only / `on_flagged: monitor` guardrails, and has no scan-buffer size cap at all — live-forward + observe-at-end matches the baseline. Keeping the fail-closed cap for *blocking* chains is our stricter, OOM-bounding divergence (pre-existing, unchanged).

## Tests

- Unit (`responses.rs`): oversized (300 KB) stream + monitor guardrail released with 200 on **both** paths (verbatim + cross-provider bridge) — both fail before the fix (mutation-verified); live-path `would_block` observation recorded on the usage event; disconnect-during-scan still emits the usage event (parks the scan on a delayed moderation backend, drops the body — mutation-verified against the take-before-await shape); existing block-mode oversized fail-closed tests still pass unchanged.
- E2E (`tests/e2e`): self-gating block→monitor flip on a >256 KiB `/v1/responses` stream — block mode 422s (pins the secure default), monitor mode releases the full SSE live.

Fixes api7/AISIX-Cloud#1010