### PR TITLE
docs(admin): clarify self-hosted and managed API scope

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -38,7 +38,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
   "info": {
     "title": "AISIX Admin API",
     "version": "dev",
-    "description": "The AISIX Admin API is the standalone management interface for configuring the gateway at runtime. Use it when you operate AISIX directly and need to create or update models, caller API keys, provider credentials, guardrails, cache policies, and observability exporters.\n\nManaged deployments do not expose this listener. Configure managed gateways through the AISIX managed control plane."
+    "description": "The AISIX Admin API is the self-hosted management interface for configuring the gateway at runtime. Use it when you operate AISIX directly and need to create or update models, caller API keys, provider credentials, guardrails, cache policies, and observability exporters.\n\nManaged deployments do not expose this listener. Configure managed gateways through the AISIX managed control plane."
   },
   "paths": {
     "/livez": {
@@ -3947,7 +3947,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
           }
         },
         "additionalProperties": false,
-        "description": "Standalone Admin API request body for creating or updating a caller API key. Ownership fields supplied by the managed control plane are not accepted by this API."
+        "description": "Self-hosted Admin API request body for creating or updating a caller API key. Ownership fields supplied by the managed control plane are not accepted by this API."
       }
     }
   },

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -38,7 +38,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
   "info": {
     "title": "AISIX Admin API",
     "version": "dev",
-    "description": "The AISIX Admin API is the self-hosted management interface for configuring the gateway at runtime. Use it when you operate AISIX directly and need to create or update models, caller API keys, provider credentials, guardrails, cache policies, and observability exporters.\n\nAISIX Cloud does not expose this listener. Managed configuration is handled by the Cloud control plane."
+    "description": "The AISIX Admin API is the standalone management interface for configuring the gateway at runtime. Use it when you operate AISIX directly and need to create or update models, caller API keys, provider credentials, guardrails, cache policies, and observability exporters.\n\nManaged deployments do not expose this listener. Configure managed gateways through the AISIX managed control plane."
   },
   "paths": {
     "/livez": {
@@ -3947,7 +3947,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
           }
         },
         "additionalProperties": false,
-        "description": "Self-hosted Admin API request body for creating or updating a caller API key. Cloud-projected ownership fields are not accepted by this API."
+        "description": "Standalone Admin API request body for creating or updating a caller API key. Ownership fields supplied by the managed control plane are not accepted by this API."
       }
     }
   },


### PR DESCRIPTION
## Summary

Clarify the deployment boundary in the generated AISIX Admin API reference while retaining the established **self-hosted** gateway terminology.

## Why

The current description says only AISIX Cloud does not expose the self-hosted Admin API listener. The same boundary applies to AISIX Cloud On-Premises because both managed products configure gateways through the AISIX managed control plane.

The AI Gateway docs use **self-hosted gateway** for direct operation through the local Admin API and etcd. **AISIX Cloud On-Premises** is the documentation label for the customer-hosted AISIX Cloud control-plane stack. Keeping those terms distinct avoids presenting shared managed behavior as Cloud-only without introducing a competing `standalone` label.

## Changes

- Retain the AISIX Admin API description as the self-hosted runtime management interface.
- Explain that managed deployments configure gateways through the AISIX managed control plane.
- Describe caller-key ownership fields as managed-control-plane data instead of Cloud-projected data.

This changes public OpenAPI descriptions only. It does not change API behavior or schemas.

Related terminology investigation: https://github.com/api7/docs/issues/1803
Related Cloud Admin API contract PR: https://github.com/api7/AISIX-Cloud/pull/1016
Related docs PR: https://github.com/api7/docs/pull/1822

## Validation

- `git diff --check`
- `cargo run -p aisix-admin --bin dump-openapi`
- `cargo test -p aisix-admin openapi --lib` (20 passed)
