### PR TITLE
feat(observability): /status/config load-observability endpoint and config metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "aisix-core",
  "async-trait",
  "base64 0.22.1",
+ "chrono",
  "etcd-client",
  "futures",
  "serde",

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -62,10 +62,20 @@ pub use state::AdminState;
 pub use store::{ConfigStore, InMemoryStore, StoreError};
 
 use aisix_core::config::PrometheusConfig;
+use aisix_core::ConfigStatus;
 use aisix_obs::Metrics;
 use axum::routing::{get, post};
 use axum::{http::StatusCode, response::Response, Router};
 use std::sync::Arc;
+
+/// Shared state for the dedicated metrics/status listener: the Prometheus
+/// [`Metrics`] handle plus the load-observability [`ConfigStatus`]. Both are
+/// cheap to clone.
+#[derive(Clone)]
+pub struct MetricsState {
+    pub metrics: Arc<Metrics>,
+    pub config_status: ConfigStatus,
+}
 
 pub fn admin_openapi_json() -> &'static str {
     openapi::merged_openapi()
@@ -247,40 +257,91 @@ async fn file_managed_write_guard(
     next.run(req).await
 }
 
-/// Build the router for the **dedicated** Prometheus metrics listener —
-/// only the scrape endpoint at `prometheus.path`, backed by the shared
-/// [`Metrics`] handle. No admin state, no auth-protected routes, no
-/// playground.
+/// Build the router for the **dedicated** metrics/status listener — the
+/// Prometheus scrape endpoint at `prometheus.path`, plus the load-
+/// observability endpoints `GET /status/config` and `GET /status/ready`,
+/// backed by the shared [`Metrics`] and [`ConfigStatus`] handles. No admin
+/// state, no auth-protected routes, no playground.
 ///
 /// `aisix-server` binds this on `observability.metrics.prometheus.addr`
-/// whenever prometheus is enabled. This is the only metrics surface —
-/// the same in standalone and managed mode; the admin listener never
-/// serves `/metrics`.
-pub fn metrics_router(metrics: Arc<Metrics>, prometheus: &PrometheusConfig) -> Router {
+/// whenever prometheus is enabled. This is the only metrics/status surface —
+/// the same in standalone and managed mode; the admin listener never serves
+/// `/metrics` or `/status/config`.
+pub fn metrics_router(
+    metrics: Arc<Metrics>,
+    config_status: ConfigStatus,
+    prometheus: &PrometheusConfig,
+) -> Router {
+    let state = MetricsState {
+        metrics,
+        config_status,
+    };
     Router::new()
         .route(
             &normalized_prometheus_path(&prometheus.path),
             get(metrics_handler),
         )
-        .with_state(metrics)
+        .route("/status/config", get(status_config_handler))
+        .route("/status/ready", get(status_ready_handler))
+        .with_state(state)
 }
 
-/// Prometheus scrape handler. The recorder handle is a required
-/// argument, so there is no 503 branch. Unauthenticated by design —
-/// restrict access at the network layer. Emits
-/// `text/plain; version=0.0.4`.
+/// Prometheus scrape handler. Reflects the live config load-observability
+/// state into the recorder (so the `aisix_config_*` series are current) then
+/// renders. Unauthenticated by design — restrict access at the network layer.
+/// Emits `text/plain; version=0.0.4`.
 async fn metrics_handler(
-    axum::extract::State(metrics): axum::extract::State<Arc<Metrics>>,
+    axum::extract::State(state): axum::extract::State<MetricsState>,
 ) -> Response {
     use axum::http::header::CONTENT_TYPE;
     use axum::response::IntoResponse;
 
+    state
+        .metrics
+        .sync_config_status(&state.config_status.metrics());
     (
         StatusCode::OK,
         [(CONTENT_TYPE, "text/plain; version=0.0.4")],
-        metrics.render(),
+        state.metrics.render(),
     )
         .into_response()
+}
+
+/// `GET /status/config` — the load-observability contract. Answers "did my
+/// config take effect, and if not why?" from the live [`ConfigStatus`].
+/// Unauthenticated like the scrape; restrict at the network layer.
+async fn status_config_handler(
+    axum::extract::State(state): axum::extract::State<MetricsState>,
+) -> Response {
+    use axum::response::IntoResponse;
+    (StatusCode::OK, axum::Json(state.config_status.view())).into_response()
+}
+
+/// `GET /status/ready` — 503 with "no configuration available" until the
+/// first valid configuration is applied, 200 afterward. A liveness-agnostic
+/// readiness gate for the config source only; the admin listener's `/readyz`
+/// keeps its shutdown/staleness semantics.
+async fn status_ready_handler(
+    axum::extract::State(state): axum::extract::State<MetricsState>,
+) -> Response {
+    use axum::http::header::CONTENT_TYPE;
+    use axum::response::IntoResponse;
+
+    if state.config_status.is_ready() {
+        (
+            StatusCode::OK,
+            [(CONTENT_TYPE, "text/plain; charset=utf-8")],
+            "ok",
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(CONTENT_TYPE, "text/plain; charset=utf-8")],
+            "no configuration available",
+        )
+            .into_response()
+    }
 }
 
 fn normalized_prometheus_path(path: &str) -> String {
@@ -448,6 +509,7 @@ mod tests {
 
         let app = metrics_router(
             metrics,
+            aisix_core::ConfigStatus::new(aisix_core::SourceKind::Etcd),
             &PrometheusConfig {
                 enabled: true,
                 path: "/metrics".into(),
@@ -498,6 +560,7 @@ mod tests {
 
         let app = metrics_router(
             Arc::new(Metrics::new(false)),
+            aisix_core::ConfigStatus::new(aisix_core::SourceKind::Etcd),
             &PrometheusConfig {
                 enabled: true,
                 path: "internal/prom".into(),
@@ -526,6 +589,160 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn status_ready_is_503_before_config_and_200_after() {
+        use aisix_core::config_status::{
+            AppliedSnapshot, ConfigStatus, LoadObservation, SourceKind,
+        };
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        let app = metrics_router(
+            Arc::new(Metrics::new(false)),
+            cs.clone(),
+            &PrometheusConfig {
+                enabled: true,
+                path: "/metrics".into(),
+                addr: "0.0.0.0:9090".into(),
+            },
+        );
+
+        // Before any config: 503 "no configuration available".
+        let resp = run(
+            app.clone(),
+            Request::builder()
+                .uri("/status/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(
+            std::str::from_utf8(&bytes).unwrap(),
+            "no configuration available"
+        );
+
+        // After a valid apply: 200.
+        cs.record_load(LoadObservation {
+            source_hash: "h".into(),
+            observed_revision: Some(1),
+            applied: Some(AppliedSnapshot {
+                config_hash: "h".into(),
+                revision: Some(1),
+                resource_counts: Default::default(),
+            }),
+            rejected: vec![],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let resp = run(
+            app,
+            Request::builder()
+                .uri("/status/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn status_config_serves_the_derived_view() {
+        use aisix_core::config_status::{
+            AppliedSnapshot, ConfigStatus, LoadObservation, SourceKind,
+        };
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "src".into(),
+            observed_revision: Some(9),
+            applied: Some(AppliedSnapshot {
+                config_hash: "app".into(),
+                revision: Some(9),
+                resource_counts: [("models".to_string(), 1)].into_iter().collect(),
+            }),
+            rejected: vec![aisix_core::IncomingRejection {
+                identity: "/aisix/models/bad".into(),
+                resource_kind: "models".into(),
+                resource_id: "bad".into(),
+                last_error_kind: "schema_failed".into(),
+                last_error: "schema validation failed at `/display_name`".into(),
+                seen_at: chrono::Utc::now(),
+            }],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let app = metrics_router(
+            Arc::new(Metrics::new(false)),
+            cs,
+            &PrometheusConfig {
+                enabled: true,
+                path: "/metrics".into(),
+                addr: "0.0.0.0:9090".into(),
+            },
+        );
+        let resp = run(
+            app,
+            Request::builder()
+                .uri("/status/config")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["state"], "degraded");
+        assert_eq!(v["source"]["type"], "etcd");
+        assert_eq!(v["source"]["observed_revision"], 9);
+        assert_eq!(v["applied"]["applied_revision"], 9);
+        assert_eq!(v["applied"]["resource_counts"]["models"], 1);
+        assert_eq!(v["rejected"][0]["resource_kind"], "models");
+        assert_eq!(v["rejected"][0]["last_error_kind"], "schema_failed");
+    }
+
+    #[tokio::test]
+    async fn metrics_scrape_reflects_config_status_series() {
+        use aisix_core::config_status::{
+            AppliedSnapshot, ConfigStatus, LoadObservation, SourceKind,
+        };
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "src".into(),
+            observed_revision: Some(5),
+            applied: Some(AppliedSnapshot {
+                config_hash: "deadbeef".into(),
+                revision: Some(5),
+                resource_counts: [("models".to_string(), 2)].into_iter().collect(),
+            }),
+            rejected: vec![],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let app = metrics_router(
+            Arc::new(Metrics::new(false)),
+            cs,
+            &PrometheusConfig {
+                enabled: true,
+                path: "/metrics".into(),
+                addr: "0.0.0.0:9090".into(),
+            },
+        );
+        let resp = run(
+            app,
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(text.contains("aisix_config_last_reload_successful 1"));
+        assert!(text.contains("aisix_config_observed_revision 5"));
+        assert!(text.contains("aisix_config_applied_revision 5"));
+        assert!(text.contains("aisix_config_hash_info{hash=\"deadbeef\"} 1"));
+        assert!(text.contains("aisix_config_source_connected 1"));
     }
 
     #[tokio::test]

--- a/crates/aisix-core/src/config_status.rs
+++ b/crates/aisix-core/src/config_status.rs
@@ -1,0 +1,1044 @@
+//! Load-observability state for the data plane's configuration source.
+//!
+//! Answers one operator question — *did my configuration take effect, and
+//! if not, why?* — for both load paths the gateway supports:
+//!
+//! - the **etcd** watch source (managed mode), and
+//! - the standalone **file** source (`resources_file`).
+//!
+//! [`ConfigStatus`] is a cheap-to-clone shared handle the load paths update
+//! as they observe and apply snapshots. It is read by the non-admin
+//! metrics/status listener to serve `GET /status/config`, `GET /status/ready`,
+//! and the `aisix_config_*` Prometheus series.
+//!
+//! Nothing here does new *tracking* — the etcd supervisor and the file source
+//! already collect rejected entries and revisions. This module gives that
+//! internal state one canonical, source-agnostic shape and derives the
+//! reported [`ConfigState`] from it.
+//!
+//! ## Reported state
+//!
+//! [`ConfigState`] is server-derived from the last observed and applied
+//! snapshots (see [`ConfigStatusInner::derive_state`]).
+//!
+//! ## Hash definition
+//!
+//! `source_hash` and `config_hash` are deterministic and reproducible by a
+//! caller that knows what it wrote:
+//!
+//! - **etcd**: `sha256` over the entries, each rendered as
+//!   `key '\0' canonical_json_value '\n'`, concatenated in ascending key
+//!   order. `canonical_json_value` recursively sorts object keys and drops
+//!   insignificant whitespace ([`canonical_json`]); a value that is not JSON
+//!   is hashed as its raw bytes. `source_hash` covers every entry in the last
+//!   observed full snapshot; `config_hash` covers only the accepted subset
+//!   (the entries actually served). When a full snapshot is applied with no
+//!   rejections the two are equal. A resource rejected on a *live watch event*
+//!   is surfaced via `rejected[]` and does not enter `source_hash` until the
+//!   next full resync (the watch delta never carries the bad bytes into the
+//!   served entry map) — so `source_hash == config_hash` can hold while the
+//!   state is `degraded`; `rejected[]` is the authoritative partial-rejection
+//!   signal, not a hash diff.
+//! - **file**: `sha256` over the raw file bytes. On a clean load the applied
+//!   `config_hash` equals `source_hash` (the whole file is applied); on a
+//!   rejected reload the applied hash stays at the last-good file's hash.
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+/// Which source the data plane reads configuration from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    Etcd,
+    File,
+}
+
+impl SourceKind {
+    fn is_etcd(self) -> bool {
+        matches!(self, SourceKind::Etcd)
+    }
+}
+
+/// Server-derived configuration state reported by `GET /status/config`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigState {
+    /// Applied config matches the latest observed snapshot and nothing was
+    /// rejected.
+    Synced,
+    /// Applied config is serving, but the latest snapshot carried entries the
+    /// gateway rejected.
+    Degraded,
+    /// The latest observed snapshot was wholly rejected; the gateway is
+    /// serving the last-good snapshot (or nothing usable from the latest).
+    OutOfSync,
+    /// A valid configuration was applied but it holds zero resources.
+    Empty,
+    /// No valid configuration has ever been applied this boot.
+    NeverLoaded,
+}
+
+/// Coarse reason bucket for `aisix_config_reload_failures_total{reason}`.
+///
+/// Deliberately low-cardinality — the per-resource detail lives in
+/// `rejected[]`, this is the aggregate "why did a reload not fully succeed".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReloadReason {
+    /// The source could not be fetched (etcd unreachable, file unreadable).
+    Fetch,
+    /// The source was fetched but could not be parsed (non-JSON value, bad
+    /// YAML).
+    Parse,
+    /// The source parsed but a resource failed schema / shape / reference
+    /// validation.
+    Validate,
+}
+
+impl ReloadReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReloadReason::Fetch => "fetch",
+            ReloadReason::Parse => "parse",
+            ReloadReason::Validate => "validate",
+        }
+    }
+
+    /// Map a rejected entry's `last_error_kind` (the loader's `RejectionKind`
+    /// rendered snake_case, or a file classification) to a coarse reason.
+    ///
+    /// `non_json` is the only source-format ("parse") kind; every other
+    /// resource-level rejection is a shape/identity ("validate") failure.
+    pub fn from_error_kind(last_error_kind: &str) -> Self {
+        match last_error_kind {
+            "non_json" => ReloadReason::Parse,
+            _ => ReloadReason::Validate,
+        }
+    }
+}
+
+/// A resource the gateway rejected, as reported on the wire. Field names
+/// match the control plane's `rejected_resources` surface so an operator sees
+/// the same vocabulary on both planes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RejectedResource {
+    /// Plural resource kind (`models`, `provider_keys`, …); empty when the
+    /// source identifier could not be parsed into `kind`/`id`.
+    pub resource_kind: String,
+    /// Resource id; empty when unparseable.
+    pub resource_id: String,
+    /// Snake-case failure kind: `bad_key | non_json | schema_failed |
+    /// parse_failed | unknown_kind` for etcd; a file classification otherwise.
+    pub last_error_kind: String,
+    /// Human-readable error message. Schema-validation messages are
+    /// credential-masked at the schema layer (instance values redacted before
+    /// they reach this buffer); parse / decode / key messages are positional
+    /// and carry no instance values.
+    pub last_error: String,
+    /// RFC3339 UTC timestamp the rejection was first observed this boot.
+    pub first_seen_at: String,
+    /// RFC3339 UTC timestamp the rejection was most recently observed.
+    pub last_seen_at: String,
+}
+
+/// One rejected entry handed to [`ConfigStatus`] by a load path. `identity`
+/// (the etcd key or file scope) is the stable merge key used to preserve
+/// `first_seen_at` across reloads; it is never serialized.
+#[derive(Debug, Clone)]
+pub struct IncomingRejection {
+    pub identity: String,
+    pub resource_kind: String,
+    pub resource_id: String,
+    pub last_error_kind: String,
+    pub last_error: String,
+    pub seen_at: DateTime<Utc>,
+}
+
+/// The result of a snapshot the gateway actually applied (served).
+#[derive(Debug, Clone)]
+pub struct AppliedSnapshot {
+    /// Hash of the accepted (served) entry set.
+    pub config_hash: String,
+    /// etcd revision the applied snapshot reflects; `None` in file mode.
+    pub revision: Option<i64>,
+    /// Per-kind counts of served resources.
+    pub resource_counts: BTreeMap<String, usize>,
+}
+
+/// A completed load observation handed to [`ConfigStatus::record_load`].
+#[derive(Debug, Clone)]
+pub struct LoadObservation {
+    /// Hash of the full raw snapshot observed from the source.
+    pub source_hash: String,
+    /// etcd revision the observed snapshot reflects; `None` in file mode.
+    pub observed_revision: Option<i64>,
+    /// The applied snapshot, when this load produced/kept a served snapshot.
+    /// `None` only when a reload was wholly rejected and the last-good
+    /// snapshot is retained (file reload failure) — the caller then sets
+    /// [`Self::wholly_rejected`].
+    pub applied: Option<AppliedSnapshot>,
+    /// Rejected entries observed in this snapshot.
+    pub rejected: Vec<IncomingRejection>,
+    /// Whether this load counts as a config reload for
+    /// `aisix_config_reloads_total` (full (re)syncs and file loads do;
+    /// incremental etcd events do not).
+    pub is_reload: bool,
+    /// True when the latest observed snapshot was rejected as a whole and the
+    /// gateway kept serving a previous snapshot (file reload failure).
+    pub wholly_rejected: bool,
+}
+
+/// Cheap-to-clone shared handle to the config load state.
+#[derive(Debug, Clone)]
+pub struct ConfigStatus {
+    inner: Arc<Mutex<ConfigStatusInner>>,
+}
+
+#[derive(Debug)]
+struct RetainedRejection {
+    resource_kind: String,
+    resource_id: String,
+    last_error_kind: String,
+    last_error: String,
+    first_seen_at: DateTime<Utc>,
+    last_seen_at: DateTime<Utc>,
+}
+
+#[derive(Debug)]
+struct ConfigStatusInner {
+    source_kind: SourceKind,
+
+    // Observed (latest raw snapshot seen from the source).
+    connected: bool,
+    observed_revision: Option<i64>,
+    source_hash: Option<String>,
+    observed_at: Option<DateTime<Utc>>,
+
+    // Applied (last snapshot actually served).
+    ever_applied: bool,
+    config_hash: Option<String>,
+    applied_revision: Option<i64>,
+    applied_at: Option<DateTime<Utc>>,
+    apply_seq: u64,
+    resource_counts: BTreeMap<String, usize>,
+
+    // Latest observed snapshot rejected as a whole (last-good retained).
+    latest_wholly_rejected: bool,
+
+    // Reload signals.
+    last_reload_successful: bool,
+    last_reload_at: Option<DateTime<Utc>>,
+    last_reload_success_at: Option<DateTime<Utc>>,
+
+    // Sticky failure (until next boot).
+    last_failure: Option<StickyFailure>,
+
+    // Retained rejections, keyed by source identity to keep first_seen stable.
+    rejected: BTreeMap<String, RetainedRejection>,
+
+    // Metric counters.
+    reloads_total: u64,
+    reload_failures: BTreeMap<&'static str, u64>,
+}
+
+#[derive(Debug, Clone)]
+struct StickyFailure {
+    at: DateTime<Utc>,
+    last_error_kind: String,
+    last_error: String,
+}
+
+impl ConfigStatus {
+    /// Construct a status handle for a source. Starts in `never_loaded`.
+    pub fn new(source_kind: SourceKind) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ConfigStatusInner {
+                source_kind,
+                connected: false,
+                observed_revision: None,
+                source_hash: None,
+                observed_at: None,
+                ever_applied: false,
+                config_hash: None,
+                applied_revision: None,
+                applied_at: None,
+                apply_seq: 0,
+                resource_counts: BTreeMap::new(),
+                latest_wholly_rejected: false,
+                last_reload_successful: false,
+                last_reload_at: None,
+                last_reload_success_at: None,
+                last_failure: None,
+                rejected: BTreeMap::new(),
+                reloads_total: 0,
+                reload_failures: BTreeMap::new(),
+            })),
+        }
+    }
+
+    /// Record a completed load observation. Idempotent enough to be called
+    /// on every apply: `apply_seq` and `applied_at` only advance when the
+    /// applied `config_hash` changes.
+    pub fn record_load(&self, obs: LoadObservation) {
+        let now = Utc::now();
+        let mut inner = self.inner.lock().unwrap();
+
+        inner.connected = true;
+        inner.observed_at = Some(now);
+        inner.source_hash = Some(obs.source_hash);
+        inner.observed_revision = obs.observed_revision;
+        inner.latest_wholly_rejected = obs.wholly_rejected;
+
+        if let Some(applied) = obs.applied {
+            let changed = inner.config_hash.as_deref() != Some(applied.config_hash.as_str());
+            if changed || !inner.ever_applied {
+                inner.apply_seq += 1;
+                inner.applied_at = Some(now);
+            }
+            inner.ever_applied = true;
+            inner.config_hash = Some(applied.config_hash);
+            inner.applied_revision = applied.revision;
+            inner.resource_counts = applied.resource_counts;
+        }
+
+        // Merge rejections, preserving first_seen for identities still present.
+        let mut merged: BTreeMap<String, RetainedRejection> = BTreeMap::new();
+        for r in obs.rejected {
+            let first_seen_at = inner
+                .rejected
+                .get(&r.identity)
+                .map(|prev| prev.first_seen_at)
+                .unwrap_or(r.seen_at);
+            merged.insert(
+                r.identity,
+                RetainedRejection {
+                    resource_kind: r.resource_kind,
+                    resource_id: r.resource_id,
+                    last_error_kind: r.last_error_kind,
+                    last_error: r.last_error,
+                    first_seen_at,
+                    last_seen_at: r.seen_at,
+                },
+            );
+        }
+        inner.rejected = merged;
+
+        let clean = inner.rejected.is_empty();
+        inner.last_reload_successful = clean;
+        inner.last_reload_at = Some(now);
+        if clean {
+            inner.last_reload_success_at = Some(now);
+        } else if let Some((kind, err)) = inner
+            .rejected
+            .values()
+            .next()
+            .map(|r| (r.last_error_kind.clone(), r.last_error.clone()))
+        {
+            inner.last_failure = Some(StickyFailure {
+                at: now,
+                last_error_kind: kind,
+                last_error: err,
+            });
+        }
+
+        if obs.is_reload {
+            inner.reloads_total += 1;
+            // One increment per reason category present in this reload.
+            let mut reasons: BTreeMap<&'static str, ()> = BTreeMap::new();
+            for r in inner.rejected.values() {
+                reasons.insert(
+                    ReloadReason::from_error_kind(&r.last_error_kind).as_str(),
+                    (),
+                );
+            }
+            for reason in reasons.keys() {
+                *inner.reload_failures.entry(reason).or_insert(0) += 1;
+            }
+        }
+    }
+
+    /// Record that the source became unreachable (etcd connect / load failed).
+    /// Counts a fetch-reason reload failure and marks the source disconnected;
+    /// leaves the last-good applied state intact.
+    pub fn record_fetch_failure(&self) {
+        let now = Utc::now();
+        let mut inner = self.inner.lock().unwrap();
+        inner.connected = false;
+        inner.last_reload_successful = false;
+        inner.last_reload_at = Some(now);
+        inner.reloads_total += 1;
+        *inner
+            .reload_failures
+            .entry(ReloadReason::Fetch.as_str())
+            .or_insert(0) += 1;
+        inner.last_failure = Some(StickyFailure {
+            at: now,
+            last_error_kind: "fetch".to_string(),
+            last_error: "configuration source unreachable".to_string(),
+        });
+    }
+
+    /// Whether a valid configuration has ever been applied. Gates
+    /// `GET /status/ready`.
+    pub fn is_ready(&self) -> bool {
+        self.inner.lock().unwrap().ever_applied
+    }
+
+    /// Point-in-time JSON view for `GET /status/config`.
+    pub fn view(&self) -> ConfigStatusView {
+        self.inner.lock().unwrap().view()
+    }
+
+    /// Point-in-time numeric view for the `aisix_config_*` Prometheus series.
+    pub fn metrics(&self) -> ConfigMetricsView {
+        self.inner.lock().unwrap().metrics()
+    }
+}
+
+impl ConfigStatusInner {
+    fn applied_total(&self) -> usize {
+        self.resource_counts.values().sum()
+    }
+
+    fn derive_state(&self) -> ConfigState {
+        if !self.ever_applied {
+            return ConfigState::NeverLoaded;
+        }
+        if self.latest_wholly_rejected {
+            return ConfigState::OutOfSync;
+        }
+        let total = self.applied_total();
+        if !self.rejected.is_empty() {
+            // A whole-snapshot rejection that stored an empty snapshot still
+            // reads as out-of-sync; a partial rejection is degraded.
+            if total == 0 {
+                ConfigState::OutOfSync
+            } else {
+                ConfigState::Degraded
+            }
+        } else if total == 0 {
+            ConfigState::Empty
+        } else {
+            ConfigState::Synced
+        }
+    }
+
+    fn view(&self) -> ConfigStatusView {
+        let etcd = self.source_kind.is_etcd();
+        let source = SourceView {
+            source_type: self.source_kind,
+            connected: etcd.then_some(self.connected),
+            observed_revision: if etcd { self.observed_revision } else { None },
+            source_hash: self.source_hash.clone(),
+            observed_at: self.observed_at.map(rfc3339),
+        };
+        let applied = if self.ever_applied {
+            Some(AppliedView {
+                applied_revision: if etcd { self.applied_revision } else { None },
+                config_hash: self.config_hash.clone().unwrap_or_default(),
+                apply_seq: self.apply_seq,
+                applied_at: self.applied_at.map(rfc3339).unwrap_or_default(),
+                resource_counts: self.resource_counts.clone(),
+            })
+        } else {
+            None
+        };
+        let last_reload = self.last_reload_at.map(|at| LastReloadView {
+            successful: self.last_reload_successful,
+            at: rfc3339(at),
+        });
+        let last_failure = self.last_failure.as_ref().map(|f| FailureView {
+            at: rfc3339(f.at),
+            last_error_kind: f.last_error_kind.clone(),
+            last_error: f.last_error.clone(),
+        });
+        let mut rejected: Vec<RejectedResource> = self
+            .rejected
+            .values()
+            .map(|r| RejectedResource {
+                resource_kind: r.resource_kind.clone(),
+                resource_id: r.resource_id.clone(),
+                last_error_kind: r.last_error_kind.clone(),
+                last_error: r.last_error.clone(),
+                first_seen_at: rfc3339(r.first_seen_at),
+                last_seen_at: rfc3339(r.last_seen_at),
+            })
+            .collect();
+        rejected.sort_by(|a, b| {
+            (&a.resource_kind, &a.resource_id).cmp(&(&b.resource_kind, &b.resource_id))
+        });
+        ConfigStatusView {
+            state: self.derive_state(),
+            source,
+            applied,
+            last_reload,
+            last_failure,
+            rejected,
+        }
+    }
+
+    fn metrics(&self) -> ConfigMetricsView {
+        let etcd = self.source_kind.is_etcd();
+        let mut rejected_by_kind: BTreeMap<String, usize> = BTreeMap::new();
+        for r in self.rejected.values() {
+            *rejected_by_kind.entry(r.resource_kind.clone()).or_insert(0) += 1;
+        }
+        ConfigMetricsView {
+            source_kind: self.source_kind,
+            last_reload_successful: self.last_reload_successful,
+            last_reload_success_ts: self.last_reload_success_at.map(|t| t.timestamp()),
+            reloads_total: self.reloads_total,
+            reload_failures: self.reload_failures.iter().map(|(k, v)| (*k, *v)).collect(),
+            rejected_by_kind,
+            observed_revision: if etcd { self.observed_revision } else { None },
+            applied_revision: if etcd { self.applied_revision } else { None },
+            config_hash: self.config_hash.clone(),
+            connected: etcd.then_some(self.connected),
+        }
+    }
+}
+
+/// `GET /status/config` response body.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfigStatusView {
+    pub state: ConfigState,
+    pub source: SourceView,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub applied: Option<AppliedView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_reload: Option<LastReloadView>,
+    /// `null` when no failure has occurred this boot.
+    pub last_failure: Option<FailureView>,
+    pub rejected: Vec<RejectedResource>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceView {
+    #[serde(rename = "type")]
+    pub source_type: SourceKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connected: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_revision: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AppliedView {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub applied_revision: Option<i64>,
+    pub config_hash: String,
+    pub apply_seq: u64,
+    pub applied_at: String,
+    pub resource_counts: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LastReloadView {
+    pub successful: bool,
+    pub at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FailureView {
+    pub at: String,
+    pub last_error_kind: String,
+    pub last_error: String,
+}
+
+/// Numeric view consumed by the metrics exporter.
+#[derive(Debug, Clone)]
+pub struct ConfigMetricsView {
+    pub source_kind: SourceKind,
+    pub last_reload_successful: bool,
+    pub last_reload_success_ts: Option<i64>,
+    pub reloads_total: u64,
+    pub reload_failures: BTreeMap<&'static str, u64>,
+    pub rejected_by_kind: BTreeMap<String, usize>,
+    pub observed_revision: Option<i64>,
+    pub applied_revision: Option<i64>,
+    pub config_hash: Option<String>,
+    pub connected: Option<bool>,
+}
+
+fn rfc3339(t: DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+/// Hash an etcd entry set: `sha256` over `key '\0' canonical_value '\n'` for
+/// each entry, in ascending key order. See the module docs for the exact
+/// definition. `entries` is `(key, raw_value_bytes)`.
+pub fn hash_entries<'a, I>(entries: I) -> String
+where
+    I: IntoIterator<Item = (&'a str, &'a [u8])>,
+{
+    let mut sorted: Vec<(&str, &[u8])> = entries.into_iter().collect();
+    sorted.sort_by(|a, b| a.0.cmp(b.0));
+    let mut hasher = Sha256::new();
+    for (key, value) in sorted {
+        hasher.update(key.as_bytes());
+        hasher.update([0u8]);
+        match serde_json::from_slice::<serde_json::Value>(value) {
+            Ok(v) => hasher.update(canonical_json(&v).as_bytes()),
+            // Not JSON (rejected as non_json): hash the raw bytes so the
+            // observed hash still changes deterministically with the input.
+            Err(_) => hasher.update(value),
+        }
+        hasher.update([b'\n']);
+    }
+    hex(hasher.finalize().as_slice())
+}
+
+/// Hash raw file bytes: `sha256` hex.
+pub fn hash_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex(hasher.finalize().as_slice())
+}
+
+/// Serialize a JSON value with object keys sorted recursively and no
+/// insignificant whitespace, so two structurally-equal documents hash the
+/// same regardless of key order or spacing.
+fn canonical_json(value: &serde_json::Value) -> String {
+    let mut out = String::new();
+    write_canonical(value, &mut out);
+    out
+}
+
+fn write_canonical(value: &serde_json::Value, out: &mut String) {
+    use serde_json::Value;
+    match value {
+        Value::Object(map) => {
+            out.push('{');
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                // A JSON string key is itself canonical via serde_json.
+                out.push_str(&serde_json::to_string(k).unwrap_or_default());
+                out.push(':');
+                write_canonical(&map[*k], out);
+            }
+            out.push('}');
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_canonical(item, out);
+            }
+            out.push(']');
+        }
+        // Scalars round-trip deterministically through serde_json.
+        other => out.push_str(&serde_json::to_string(other).unwrap_or_default()),
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        s.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn incoming(
+        identity: &str,
+        kind: &str,
+        id: &str,
+        error_kind: &str,
+        error: &str,
+    ) -> IncomingRejection {
+        IncomingRejection {
+            identity: identity.to_string(),
+            resource_kind: kind.to_string(),
+            resource_id: id.to_string(),
+            last_error_kind: error_kind.to_string(),
+            last_error: error.to_string(),
+            seen_at: Utc::now(),
+        }
+    }
+
+    fn applied(hash: &str, counts: &[(&str, usize)]) -> AppliedSnapshot {
+        AppliedSnapshot {
+            config_hash: hash.to_string(),
+            revision: Some(7),
+            resource_counts: counts.iter().map(|(k, v)| (k.to_string(), *v)).collect(),
+        }
+    }
+
+    #[test]
+    fn never_loaded_before_any_load() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        assert_eq!(cs.view().state, ConfigState::NeverLoaded);
+        assert!(!cs.is_ready());
+    }
+
+    #[test]
+    fn synced_when_clean_load_with_resources() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "h".into(),
+            observed_revision: Some(7),
+            applied: Some(applied("h", &[("models", 2)])),
+            rejected: vec![],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let v = cs.view();
+        assert_eq!(v.state, ConfigState::Synced);
+        assert!(cs.is_ready());
+        let applied = v.applied.unwrap();
+        assert_eq!(applied.applied_revision, Some(7));
+        assert_eq!(applied.resource_counts.get("models"), Some(&2));
+        assert_eq!(applied.apply_seq, 1);
+        assert!(v.last_failure.is_none());
+    }
+
+    #[test]
+    fn empty_when_clean_load_with_zero_resources() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "h".into(),
+            observed_revision: Some(3),
+            applied: Some(applied("h", &[])),
+            rejected: vec![],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        assert_eq!(cs.view().state, ConfigState::Empty);
+        assert!(cs.is_ready());
+    }
+
+    #[test]
+    fn degraded_when_partial_rejection() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "src".into(),
+            observed_revision: Some(9),
+            applied: Some(applied("applied", &[("models", 1)])),
+            rejected: vec![incoming(
+                "/aisix/models/bad",
+                "models",
+                "bad",
+                "schema_failed",
+                "schema validation failed at `/display_name`",
+            )],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let v = cs.view();
+        assert_eq!(v.state, ConfigState::Degraded);
+        assert_eq!(v.rejected.len(), 1);
+        assert_eq!(v.rejected[0].resource_kind, "models");
+        assert_eq!(v.rejected[0].last_error_kind, "schema_failed");
+        assert!(v.last_failure.is_some());
+    }
+
+    #[test]
+    fn out_of_sync_when_whole_snapshot_rejected_and_last_good_retained() {
+        let cs = ConfigStatus::new(SourceKind::File);
+        // First a clean load establishes last-good.
+        cs.record_load(LoadObservation {
+            source_hash: "good".into(),
+            observed_revision: None,
+            applied: Some(applied("good", &[("models", 1)])),
+            rejected: vec![],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        // A reload that fails wholesale keeps last-good but flags wholly-rejected.
+        cs.record_load(LoadObservation {
+            source_hash: "bad".into(),
+            observed_revision: None,
+            applied: None,
+            rejected: vec![incoming(
+                "models[0] (\"x\")",
+                "models",
+                "x",
+                "schema_failed",
+                "boom",
+            )],
+            is_reload: true,
+            wholly_rejected: true,
+        });
+        assert_eq!(cs.view().state, ConfigState::OutOfSync);
+    }
+
+    #[test]
+    fn out_of_sync_when_etcd_resync_wholly_rejected_to_empty() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "src".into(),
+            observed_revision: Some(4),
+            applied: Some(applied("empty", &[])), // zero accepted
+            rejected: vec![incoming(
+                "/aisix/models/bad",
+                "models",
+                "bad",
+                "non_json",
+                "not json",
+            )],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        assert_eq!(cs.view().state, ConfigState::OutOfSync);
+    }
+
+    #[test]
+    fn apply_seq_advances_only_on_config_change() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        let obs = |hash: &str| LoadObservation {
+            source_hash: hash.into(),
+            observed_revision: Some(1),
+            applied: Some(applied(hash, &[("models", 1)])),
+            rejected: vec![],
+            is_reload: false,
+            wholly_rejected: false,
+        };
+        cs.record_load(obs("a"));
+        assert_eq!(cs.view().applied.unwrap().apply_seq, 1);
+        cs.record_load(obs("a")); // unchanged
+        assert_eq!(cs.view().applied.unwrap().apply_seq, 1);
+        cs.record_load(obs("b")); // changed
+        assert_eq!(cs.view().applied.unwrap().apply_seq, 2);
+    }
+
+    #[test]
+    fn last_failure_is_sticky_across_a_later_clean_reload() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "s1".into(),
+            observed_revision: Some(1),
+            applied: Some(applied("a1", &[("models", 1)])),
+            rejected: vec![incoming(
+                "/aisix/models/bad",
+                "models",
+                "bad",
+                "schema_failed",
+                "boom",
+            )],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        assert!(cs.view().last_failure.is_some());
+        // Clean reload: last_reload flips to successful but last_failure stays.
+        cs.record_load(LoadObservation {
+            source_hash: "s2".into(),
+            observed_revision: Some(2),
+            applied: Some(applied("a2", &[("models", 1)])),
+            rejected: vec![],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let v = cs.view();
+        assert_eq!(v.state, ConfigState::Synced);
+        assert!(v.last_reload.unwrap().successful);
+        assert!(v.last_failure.is_some(), "last_failure must be sticky");
+        assert!(v.rejected.is_empty());
+    }
+
+    #[test]
+    fn first_seen_is_preserved_across_reloads() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        let mut r = incoming(
+            "/aisix/models/bad",
+            "models",
+            "bad",
+            "schema_failed",
+            "boom",
+        );
+        r.seen_at = "2026-07-14T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        cs.record_load(LoadObservation {
+            source_hash: "s".into(),
+            observed_revision: Some(1),
+            applied: Some(applied("a", &[])),
+            rejected: vec![r],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let first = cs.view().rejected[0].first_seen_at.clone();
+
+        let mut r2 = incoming(
+            "/aisix/models/bad",
+            "models",
+            "bad",
+            "schema_failed",
+            "boom again",
+        );
+        r2.seen_at = "2026-07-14T01:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        cs.record_load(LoadObservation {
+            source_hash: "s".into(),
+            observed_revision: Some(2),
+            applied: Some(applied("a", &[])),
+            rejected: vec![r2],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let v = cs.view();
+        assert_eq!(
+            v.rejected[0].first_seen_at, first,
+            "first_seen must be stable"
+        );
+        assert_eq!(v.rejected[0].last_seen_at, "2026-07-14T01:00:00Z");
+    }
+
+    #[test]
+    fn file_mode_omits_etcd_only_fields() {
+        let cs = ConfigStatus::new(SourceKind::File);
+        cs.record_load(LoadObservation {
+            source_hash: "f".into(),
+            observed_revision: None,
+            applied: Some(AppliedSnapshot {
+                config_hash: "f".into(),
+                revision: None,
+                resource_counts: [("models".to_string(), 1)].into_iter().collect(),
+            }),
+            rejected: vec![],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let json = serde_json::to_value(cs.view()).unwrap();
+        assert_eq!(json["source"]["type"], "file");
+        assert!(json["source"].get("connected").is_none());
+        assert!(json["source"].get("observed_revision").is_none());
+        assert!(json["applied"].get("applied_revision").is_none());
+    }
+
+    #[test]
+    fn etcd_mode_includes_connected_and_revisions() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "e".into(),
+            observed_revision: Some(11),
+            applied: Some(applied("e", &[("models", 1)])),
+            rejected: vec![],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let json = serde_json::to_value(cs.view()).unwrap();
+        assert_eq!(json["source"]["type"], "etcd");
+        assert_eq!(json["source"]["connected"], true);
+        assert_eq!(json["source"]["observed_revision"], 11);
+        assert_eq!(json["applied"]["applied_revision"], 7);
+    }
+
+    #[test]
+    fn reload_failure_counters_bucket_by_reason() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            source_hash: "s".into(),
+            observed_revision: Some(1),
+            applied: Some(applied("a", &[("models", 1)])),
+            rejected: vec![
+                incoming("/aisix/models/a", "models", "a", "non_json", "x"),
+                incoming(
+                    "/aisix/provider_keys/b",
+                    "provider_keys",
+                    "b",
+                    "schema_failed",
+                    "y",
+                ),
+            ],
+            is_reload: true,
+            wholly_rejected: false,
+        });
+        let m = cs.metrics();
+        assert_eq!(m.reloads_total, 1);
+        assert_eq!(m.reload_failures.get("parse"), Some(&1)); // non_json
+        assert_eq!(m.reload_failures.get("validate"), Some(&1)); // schema_failed
+        assert_eq!(m.rejected_by_kind.get("models"), Some(&1));
+        assert_eq!(m.rejected_by_kind.get("provider_keys"), Some(&1));
+    }
+
+    #[test]
+    fn fetch_failure_marks_disconnected_and_counts_fetch_reason() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_fetch_failure();
+        let m = cs.metrics();
+        assert_eq!(m.connected, Some(false));
+        assert_eq!(m.reload_failures.get("fetch"), Some(&1));
+        // Still never_loaded — a fetch failure never applied anything.
+        assert_eq!(cs.view().state, ConfigState::NeverLoaded);
+    }
+
+    #[test]
+    fn hash_is_order_independent_over_keys_and_whitespace() {
+        let a = hash_entries([
+            ("/aisix/models/m1", br#"{"b":1,"a":2}"#.as_slice()),
+            ("/aisix/models/m2", br#"{"x":  "y"}"#.as_slice()),
+        ]);
+        // Same entries, different insertion order + key order + whitespace.
+        let b = hash_entries([
+            ("/aisix/models/m2", br#"{"x":"y"}"#.as_slice()),
+            ("/aisix/models/m1", br#"{ "a":2, "b":1 }"#.as_slice()),
+        ]);
+        assert_eq!(a, b, "hash must be canonical over key order and whitespace");
+    }
+
+    #[test]
+    fn hash_changes_when_a_value_changes() {
+        let a = hash_entries([("/aisix/models/m1", br#"{"a":1}"#.as_slice())]);
+        let b = hash_entries([("/aisix/models/m1", br#"{"a":2}"#.as_slice())]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn accepted_subset_hash_equals_source_hash_when_nothing_rejected() {
+        let entries: [(&str, &[u8]); 2] = [
+            ("/aisix/models/m1", br#"{"a":1}"#),
+            ("/aisix/models/m2", br#"{"b":2}"#),
+        ];
+        let source = hash_entries(entries.iter().map(|(k, v)| (*k, *v)));
+        let accepted = hash_entries(entries.iter().map(|(k, v)| (*k, *v)));
+        assert_eq!(source, accepted);
+    }
+
+    #[test]
+    fn non_json_value_still_hashes_deterministically() {
+        let a = hash_entries([("/aisix/models/m1", b"not-json".as_slice())]);
+        let b = hash_entries([("/aisix/models/m1", b"not-json".as_slice())]);
+        assert_eq!(a, b);
+        let c = hash_entries([("/aisix/models/m1", b"other".as_slice())]);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn reload_reason_maps_error_kinds() {
+        assert_eq!(
+            ReloadReason::from_error_kind("non_json"),
+            ReloadReason::Parse
+        );
+        assert_eq!(
+            ReloadReason::from_error_kind("schema_failed"),
+            ReloadReason::Validate
+        );
+        assert_eq!(
+            ReloadReason::from_error_kind("parse_failed"),
+            ReloadReason::Validate
+        );
+        assert_eq!(
+            ReloadReason::from_error_kind("bad_key"),
+            ReloadReason::Validate
+        );
+        assert_eq!(
+            ReloadReason::from_error_kind("unknown_kind"),
+            ReloadReason::Validate
+        );
+    }
+}

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -33,9 +33,11 @@
 //!   unique per kind.
 
 mod desugar;
+mod status;
 mod yaml;
 
 pub use desugar::{derive_id, FILE_RESOURCE_NAMESPACE};
+pub use status::load_resources_file_tracked;
 
 use serde_json::Value;
 use std::collections::BTreeMap;

--- a/crates/aisix-core/src/filesource/status.rs
+++ b/crates/aisix-core/src/filesource/status.rs
@@ -1,0 +1,240 @@
+//! Load-observability bridge for the file source.
+//!
+//! Turns a file load outcome ([`FileSourceErrors`] or a snapshot) into a
+//! [`LoadObservation`] and records it on a [`ConfigStatus`], so the standalone
+//! file mode reports the same `/status/config` shape as the etcd path. The
+//! file source is all-or-nothing: a clean load applies the whole file, a
+//! failing reload keeps the last-good snapshot (flagged `wholly_rejected`).
+
+use std::path::Path;
+
+use chrono::Utc;
+
+use crate::config_status::{
+    hash_bytes, AppliedSnapshot, ConfigStatus, IncomingRejection, LoadObservation,
+};
+use crate::AisixSnapshot;
+
+use super::{load_from_str, FileSourceErrors, LoadError};
+
+/// Load `path` and record the outcome on `config_status`, returning the same
+/// `Result` as [`super::load_resources_file`]. `is_reload` counts the load
+/// toward `aisix_config_reloads_total` (boot and SIGHUP reloads both do).
+///
+/// A file that cannot be read is a fetch failure (source unreachable); a file
+/// that loads with errors is a wholesale rejection (last-good retained).
+pub fn load_resources_file_tracked(
+    path: &Path,
+    revision: i64,
+    is_reload: bool,
+    config_status: &ConfigStatus,
+) -> Result<AisixSnapshot, FileSourceErrors> {
+    let label = path.display().to_string();
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            // Cannot even read the file: a fetch failure, not a per-resource
+            // rejection. Leave the last-good applied snapshot intact.
+            config_status.record_fetch_failure();
+            return Err(FileSourceErrors {
+                file: label,
+                errors: vec![LoadError {
+                    scope: "(file)".into(),
+                    message: format!("cannot read file: {e}"),
+                }],
+            });
+        }
+    };
+
+    let source_hash = hash_bytes(contents.as_bytes());
+    let result = load_from_str(&contents, &label, revision, &|name| {
+        std::env::var(name).ok()
+    });
+
+    match &result {
+        Ok(snapshot) => {
+            config_status.record_load(LoadObservation {
+                source_hash: source_hash.clone(),
+                observed_revision: None,
+                applied: Some(AppliedSnapshot {
+                    // All-or-nothing: the applied set is the whole file, so the
+                    // applied hash equals the source hash on a clean load.
+                    config_hash: source_hash,
+                    revision: None,
+                    resource_counts: resource_counts(snapshot),
+                }),
+                rejected: vec![],
+                is_reload,
+                wholly_rejected: false,
+            });
+        }
+        Err(errors) => {
+            let now = Utc::now();
+            let rejected = errors
+                .errors
+                .iter()
+                .map(|e| map_load_error(e, now))
+                .collect();
+            config_status.record_load(LoadObservation {
+                source_hash,
+                observed_revision: None,
+                // No snapshot applied — the previous one keeps serving.
+                applied: None,
+                rejected,
+                is_reload,
+                // The whole file was rejected; last-good retained.
+                wholly_rejected: true,
+            });
+        }
+    }
+
+    result
+}
+
+/// Per-kind counts of the loaded snapshot, keyed by the plural resource kind.
+fn resource_counts(snap: &AisixSnapshot) -> std::collections::BTreeMap<String, usize> {
+    let mut counts = std::collections::BTreeMap::new();
+    for (kind, n) in [
+        ("models", snap.models.len()),
+        ("api_keys", snap.apikeys.len()),
+        ("provider_keys", snap.provider_keys.len()),
+        ("guardrails", snap.guardrails.len()),
+        ("guardrail_attachments", snap.guardrail_attachments.len()),
+        ("cache_policies", snap.cache_policies.len()),
+        (
+            "observability_exporters",
+            snap.observability_exporters.len(),
+        ),
+        ("rate_limit_policies", snap.rate_limit_policies.len()),
+        ("mcp_servers", snap.mcp_servers.len()),
+        ("a2a_agents", snap.a2a_agents.len()),
+    ] {
+        if n > 0 {
+            counts.insert(kind.to_string(), n);
+        }
+    }
+    counts
+}
+
+/// Map a file [`LoadError`] to the source-agnostic rejection wire shape.
+///
+/// The file source carries no per-entry `RejectionKind`, so the kind is
+/// classified from the message: a YAML parse failure is `non_json` (a source-
+/// format problem), a canonical-decode failure is `parse_failed`, and every
+/// other validation / reference / structure error is `schema_failed`. The
+/// scope (`models[2] ("gpt-4o")`) yields `resource_kind` / `resource_id`;
+/// a file-level scope (`(file)`) leaves both empty, mirroring the etcd path.
+fn map_load_error(e: &LoadError, seen_at: chrono::DateTime<Utc>) -> IncomingRejection {
+    let (resource_kind, resource_id) = parse_scope(&e.scope);
+    IncomingRejection {
+        identity: e.scope.clone(),
+        resource_kind,
+        resource_id,
+        last_error_kind: classify(&e.message).to_string(),
+        last_error: e.message.clone(),
+        seen_at,
+    }
+}
+
+fn classify(message: &str) -> &'static str {
+    if message.contains("YAML parse error") {
+        "non_json"
+    } else if message.starts_with("cannot decode canonical document") {
+        "parse_failed"
+    } else {
+        "schema_failed"
+    }
+}
+
+/// Split a file scope into `(kind, id)`. `models[2] ("gpt-4o")` → `("models",
+/// "gpt-4o")`; `models[2]` → `("models", "")`; `(file)` → `("", "")`.
+fn parse_scope(scope: &str) -> (String, String) {
+    if scope.starts_with('(') {
+        return (String::new(), String::new());
+    }
+    let kind = scope
+        .split(['[', ' '])
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let id = scope
+        .split_once('"')
+        .and_then(|(_, rest)| rest.split_once('"'))
+        .map(|(id, _)| id.to_string())
+        .unwrap_or_default();
+    (kind, id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config_status::{ConfigState, SourceKind};
+
+    #[test]
+    fn parse_scope_extracts_kind_and_id() {
+        assert_eq!(
+            parse_scope("models[2] (\"gpt-4o\")"),
+            ("models".to_string(), "gpt-4o".to_string())
+        );
+        assert_eq!(
+            parse_scope("provider_keys[0]"),
+            ("provider_keys".to_string(), String::new())
+        );
+        assert_eq!(parse_scope("(file)"), (String::new(), String::new()));
+    }
+
+    #[test]
+    fn classify_maps_message_to_error_kind() {
+        assert_eq!(classify("YAML parse error: ..."), "non_json");
+        assert_eq!(
+            classify("cannot decode canonical document: missing field"),
+            "parse_failed"
+        );
+        assert_eq!(
+            classify("schema validation failed at `/name`"),
+            "schema_failed"
+        );
+    }
+
+    #[test]
+    fn tracked_load_of_valid_file_reports_synced_without_revisions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("resources.yaml");
+        std::fs::write(
+            &path,
+            "_format_version: \"1\"\nprovider_keys:\n  - display_name: pk\n    api_key: sk-x\n",
+        )
+        .unwrap();
+        let cs = ConfigStatus::new(SourceKind::File);
+        let result = load_resources_file_tracked(&path, 1, true, &cs);
+        assert!(result.is_ok(), "load failed: {:?}", result.err());
+        let view = cs.view();
+        assert_eq!(view.state, ConfigState::Synced);
+        // File mode omits revision fields.
+        let json = serde_json::to_value(&view).unwrap();
+        assert!(json["source"].get("observed_revision").is_none());
+        assert!(json["applied"].get("applied_revision").is_none());
+        assert_eq!(json["applied"]["resource_counts"]["provider_keys"], 1);
+    }
+
+    #[test]
+    fn tracked_reload_failure_keeps_last_good_and_reports_out_of_sync() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("resources.yaml");
+        std::fs::write(
+            &path,
+            "_format_version: \"1\"\nprovider_keys:\n  - display_name: pk\n    api_key: sk-x\n",
+        )
+        .unwrap();
+        let cs = ConfigStatus::new(SourceKind::File);
+        load_resources_file_tracked(&path, 1, true, &cs).unwrap();
+
+        // A broken reload: unknown top-level key.
+        std::fs::write(&path, "_format_version: \"1\"\nnot_a_collection: []\n").unwrap();
+        let result = load_resources_file_tracked(&path, 2, true, &cs);
+        assert!(result.is_err());
+        assert_eq!(cs.view().state, ConfigState::OutOfSync);
+        assert!(!cs.view().rejected.is_empty());
+    }
+}

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -17,6 +17,7 @@
 #![deny(rust_2018_idioms)]
 
 pub mod config;
+pub mod config_status;
 pub mod error;
 pub mod filesource;
 pub mod models;
@@ -29,6 +30,10 @@ pub use config::{
     AdminConfig, CacheBackend, CacheConfig, Config, EtcdConfig, EtcdTlsConfig, ManagedConfig,
     ObservabilityConfig, ProxyConfig, RateLimitBackend, RateLimitConfig, RealIpConfig,
     RedisConnConfig, RedisMode, TlsConfig,
+};
+pub use config_status::{
+    hash_bytes, hash_entries, AppliedSnapshot, ConfigMetricsView, ConfigState, ConfigStatus,
+    ConfigStatusView, IncomingRejection, LoadObservation, RejectedResource, SourceKind,
 };
 pub use error::{
     AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,

--- a/crates/aisix-etcd/Cargo.toml
+++ b/crates/aisix-etcd/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 base64.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -15,10 +15,14 @@
 //! snapshot into a new one, mutate, and `store` it. That keeps the
 //! read path reading a fully-formed `Arc<Snapshot>` the whole time.
 
+use aisix_core::config_status::{
+    hash_entries, AppliedSnapshot, ConfigStatus, IncomingRejection, LoadObservation, SourceKind,
+};
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::AisixSnapshot;
+use chrono::{DateTime, Utc};
 use futures::StreamExt;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -146,6 +150,12 @@ pub struct Supervisor<P: ConfigProvider> {
     /// admin handler.
     status: WatchStatus,
 
+    /// Load-observability signal exposed on the metrics/status listener
+    /// (`/status/config`, `/status/ready`, `aisix_config_*` series).
+    /// Recomputed from `state` / `rejections` / the published snapshot after
+    /// every apply so operators can answer "did my config take effect".
+    config_status: ConfigStatus,
+
     /// Most recent loader rejections, capped at
     /// [`MAX_RETAINED_REJECTIONS`]. Read by the heartbeat path so the
     /// CP can surface "your DP rejected these resources" in the
@@ -187,6 +197,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             revision: Mutex::new(0),
             cache,
             status: WatchStatus::new(),
+            config_status: ConfigStatus::new(SourceKind::Etcd),
             rejections: Mutex::new(Vec::new()),
             pending_writes: Mutex::new(Vec::new()),
         }
@@ -197,6 +208,84 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// "snapshot age" metrics. See [`WatchStatus`].
     pub fn watch_status(&self) -> WatchStatus {
         self.status.clone()
+    }
+
+    /// Cheap clonable handle to the load-observability state. Read by the
+    /// metrics/status listener to serve `/status/config`, `/status/ready`,
+    /// and the `aisix_config_*` series.
+    pub fn config_status(&self) -> ConfigStatus {
+        self.config_status.clone()
+    }
+
+    /// Recompute the load-observability view from the supervisor's
+    /// authoritative in-memory state (the raw entry map, the retained
+    /// rejection buffer, the published snapshot, and the revision floor) and
+    /// publish it to [`Self::config_status`]. Idempotent: safe to call after
+    /// every apply. `is_reload` counts a config reload for
+    /// `aisix_config_reloads_total` — set only on full (re)syncs, not on
+    /// incremental watch events.
+    fn sync_config_status(&self, is_reload: bool) {
+        let source_hash;
+        let config_hash;
+        let rejected: Vec<IncomingRejection>;
+        {
+            let state = self.state.lock().unwrap();
+            let rejections = self.rejections.lock().unwrap();
+            // `state` is the raw entry map the DP holds. A full resync inserts
+            // every entry (including rejected ones), so on that path source_hash
+            // covers the whole observed snapshot. A live watch Put that is
+            // rejected never enters `state`, so it is reported only via
+            // `rejected[]` and folds into source_hash at the next resync — see
+            // the `config_status` module docs.
+            source_hash =
+                hash_entries(state.values().map(|e| (e.key.as_str(), e.value.as_slice())));
+            let rejected_keys: HashSet<&str> = rejections.iter().map(|r| r.key.as_str()).collect();
+            config_hash = hash_entries(
+                state
+                    .values()
+                    .filter(|e| !rejected_keys.contains(e.key.as_str()))
+                    .map(|e| (e.key.as_str(), e.value.as_slice())),
+            );
+            rejected = rejections.iter().map(|r| self.map_rejection(r)).collect();
+        }
+        let revision = *self.revision.lock().unwrap();
+        let resource_counts = resource_counts(&self.handle.load());
+
+        self.config_status.record_load(LoadObservation {
+            source_hash,
+            observed_revision: Some(revision),
+            applied: Some(AppliedSnapshot {
+                config_hash,
+                revision: Some(revision),
+                resource_counts,
+            }),
+            rejected,
+            is_reload,
+            // etcd always publishes the accepted subset (even an empty one);
+            // it never retains a previous snapshot wholesale, so a wholly-
+            // rejected resync is captured by the empty accepted set instead.
+            wholly_rejected: false,
+        });
+    }
+
+    /// Map a loader [`RejectedEntry`] to the source-agnostic wire shape. The
+    /// key is split into `<kind>/<id>` via [`key::parse`]; an unparseable key
+    /// (the `bad_key` path) reports empty kind/id, mirroring the control
+    /// plane's rejected-resources surface.
+    fn map_rejection(&self, r: &RejectedEntry) -> IncomingRejection {
+        let (kind, id) = match key::parse(&self.prefix, &r.key) {
+            Ok(parsed) => (parsed.kind.to_string(), parsed.id.to_string()),
+            Err(_) => (String::new(), String::new()),
+        };
+        IncomingRejection {
+            identity: r.key.clone(),
+            resource_kind: kind,
+            resource_id: id,
+            last_error_kind: r.kind.as_str().to_string(),
+            last_error: r.error.clone(),
+            seen_at: DateTime::from_timestamp(r.timestamp_unix_secs as i64, 0)
+                .unwrap_or_else(Utc::now),
+        }
     }
 
     /// Snapshot of the most recent loader rejections (capped). Used by
@@ -273,6 +362,9 @@ impl<P: ConfigProvider> Supervisor<P> {
         // may have compacted past it; load_all + watch from latest is
         // always safer.
         *self.revision.lock().unwrap() = revision;
+        // Reflect the cached revision on the status view (apply_resync above
+        // synced with the entry-max revision).
+        self.sync_config_status(false);
         tracing::info!(
             accepted = stats.accepted,
             revision,
@@ -313,11 +405,17 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// `WatchStatus.last_apply_at` so `/admin/v1/health` reflects the
     /// successful round-trip with etcd even on an empty config.
     fn set_revision_floor(&self, revision: i64) {
-        let mut rev = self.revision.lock().unwrap();
-        if revision > *rev {
-            *rev = revision;
+        {
+            let mut rev = self.revision.lock().unwrap();
+            if revision > *rev {
+                *rev = revision;
+            }
         }
         self.status.record_apply(revision);
+        // Reflect the finalised revision on the status view (the preceding
+        // apply_resync synced with the entry-max revision; this corrects it to
+        // the load/watch header revision). Not itself a reload event.
+        self.sync_config_status(false);
     }
 
     /// Apply a single Put event on top of the current snapshot.
@@ -333,6 +431,9 @@ impl<P: ConfigProvider> Supervisor<P> {
             for r in stats.rejections.drain(..) {
                 self.push_rejection(r);
             }
+            // A rejected watch event still changes the reported state
+            // (rejected[] gains this entry; last_reload flips unsuccessful).
+            self.sync_config_status(false);
             return false;
         }
 
@@ -402,6 +503,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         // /admin/v1/health reads this — record the apply so `last_apply_age`
         // resets on every event we successfully process.
         self.status.record_apply(entry.revision);
+        self.sync_config_status(false);
         self.flush_cache();
         true
     }
@@ -446,6 +548,8 @@ impl<P: ConfigProvider> Supervisor<P> {
             if removed_rejection {
                 let cur_rev = *self.revision.lock().unwrap();
                 self.status.record_apply(cur_rev);
+                // Clearing a rejected key changes the reported state.
+                self.sync_config_status(false);
             }
             return removed_rejection;
         }
@@ -501,6 +605,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         // resets even if the revision number doesn't move.
         let cur_rev = *self.revision.lock().unwrap();
         self.status.record_apply(cur_rev);
+        self.sync_config_status(false);
         self.flush_cache();
         true
     }
@@ -537,6 +642,9 @@ impl<P: ConfigProvider> Supervisor<P> {
         // per-key rejection list is no longer accurate — replace it
         // wholesale with what this build produced (issue #115).
         self.set_rejections(stats.rejections.clone());
+        // A full resync is a config reload — publish the observability view
+        // (source/config hashes, counts, rejected list) and count it.
+        self.sync_config_status(true);
         self.flush_cache();
         stats
     }
@@ -591,6 +699,10 @@ impl<P: ConfigProvider> Supervisor<P> {
                 }
                 Err(SupervisorError::Cancelled) => return,
                 Err(SupervisorError::Provider(err)) => {
+                    // Surface the source outage on /status/config: connected
+                    // flips false and a fetch-reason reload failure is counted.
+                    // The last-good applied snapshot keeps serving.
+                    self.config_status.record_fetch_failure();
                     let delay = backoff.next_delay();
                     tracing::warn!(
                         error = %err,
@@ -729,6 +841,33 @@ fn clone_snapshot(src: &AisixSnapshot) -> AisixSnapshot {
         out.a2a_agents.insert(clone_entry(&e));
     }
     out
+}
+
+/// Per-kind counts of the served snapshot, keyed by the plural etcd resource
+/// kind (matching the `<prefix>/<kind>/<id>` key segment). Only non-empty
+/// kinds are included, so an empty snapshot yields an empty map.
+fn resource_counts(snap: &AisixSnapshot) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for (kind, n) in [
+        ("models", snap.models.len()),
+        ("api_keys", snap.apikeys.len()),
+        ("provider_keys", snap.provider_keys.len()),
+        ("guardrails", snap.guardrails.len()),
+        ("guardrail_attachments", snap.guardrail_attachments.len()),
+        ("cache_policies", snap.cache_policies.len()),
+        (
+            "observability_exporters",
+            snap.observability_exporters.len(),
+        ),
+        ("rate_limit_policies", snap.rate_limit_policies.len()),
+        ("mcp_servers", snap.mcp_servers.len()),
+        ("a2a_agents", snap.a2a_agents.len()),
+    ] {
+        if n > 0 {
+            counts.insert(kind.to_string(), n);
+        }
+    }
+    counts
 }
 
 fn clone_entry<T: Clone>(src: &Arc<aisix_core::ResourceEntry<T>>) -> aisix_core::ResourceEntry<T> {

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -116,6 +116,21 @@ pub const M_REQUEST_E2E_LATENCY_SECONDS: &str = "aisix_request_e2e_latency_secon
 /// [`M_REQUEST_E2E_LATENCY_SECONDS`] (with `streaming="true"` always).
 pub const M_REQUEST_TTFT_SECONDS: &str = "aisix_request_ttft_seconds";
 
+// ── Config load-observability series (load-observability contract) ─────────
+// Reflected from [`aisix_core::ConfigMetricsView`] at scrape time via
+// [`Metrics::sync_config_status`]. Standard Prometheus config-reload naming so
+// the series read the same as the control plane exposes.
+pub const M_CONFIG_LAST_RELOAD_SUCCESSFUL: &str = "aisix_config_last_reload_successful";
+pub const M_CONFIG_LAST_RELOAD_SUCCESS_TIMESTAMP: &str =
+    "aisix_config_last_reload_success_timestamp_seconds";
+pub const M_CONFIG_RELOADS_TOTAL: &str = "aisix_config_reloads_total";
+pub const M_CONFIG_RELOAD_FAILURES_TOTAL: &str = "aisix_config_reload_failures_total";
+pub const M_CONFIG_REJECTED_RESOURCES: &str = "aisix_config_rejected_resources";
+pub const M_CONFIG_OBSERVED_REVISION: &str = "aisix_config_observed_revision";
+pub const M_CONFIG_APPLIED_REVISION: &str = "aisix_config_applied_revision";
+pub const M_CONFIG_HASH_INFO: &str = "aisix_config_hash_info";
+pub const M_CONFIG_SOURCE_CONNECTED: &str = "aisix_config_source_connected";
+
 /// Bucket edges for the two SLO histograms, spanning LLM latency ranges:
 /// sub-100ms cache hits / TTFT through multi-minute long generations.
 /// 14 edges → 15 `_bucket` series per label combination; keep
@@ -141,6 +156,17 @@ struct MetricsInner {
     /// process serves exactly one environment. `"unknown"` when the DP
     /// runs standalone (no control plane).
     env_id: String,
+    /// Last labels emitted for the config load-observability gauges, so
+    /// [`Metrics::sync_config_status`] can zero out stale label series (the
+    /// applied hash changed, or a kind's rejections cleared) instead of
+    /// leaving a second, contradictory sample in the exposition.
+    config_labels: Mutex<ConfigLabelState>,
+}
+
+#[derive(Default)]
+struct ConfigLabelState {
+    last_hash: Option<String>,
+    last_rejected_kinds: std::collections::HashSet<String>,
 }
 
 impl std::fmt::Debug for Metrics {
@@ -188,6 +214,7 @@ impl Metrics {
                 } else {
                     env_id.to_string()
                 },
+                config_labels: Mutex::new(ConfigLabelState::default()),
             }),
         }
     }
@@ -195,6 +222,83 @@ impl Metrics {
     /// Render the current metric values in Prometheus text exposition format.
     pub fn render(&self) -> String {
         self.inner.handle.render()
+    }
+
+    /// Reflect the config load-observability state into the recorder. Called
+    /// at scrape time by the metrics/status listener so `aisix_config_*`
+    /// series always mirror the live [`aisix_core::ConfigStatus`]. Idempotent
+    /// and cheap; safe to call on every scrape.
+    ///
+    /// Etcd-only series (`observed_revision`, `applied_revision`,
+    /// `source_connected`) are emitted only in etcd mode. Label churn on the
+    /// info/rejected gauges (`hash_info`, `rejected_resources`) zeroes the
+    /// prior label set so the exposition never carries two live samples.
+    pub fn sync_config_status(&self, view: &aisix_core::ConfigMetricsView) {
+        use aisix_core::SourceKind;
+        let etcd = matches!(view.source_kind, SourceKind::Etcd);
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::gauge!(M_CONFIG_LAST_RELOAD_SUCCESSFUL).set(if view.last_reload_successful {
+                1.0
+            } else {
+                0.0
+            });
+            if let Some(ts) = view.last_reload_success_ts {
+                metrics::gauge!(M_CONFIG_LAST_RELOAD_SUCCESS_TIMESTAMP).set(ts as f64);
+            }
+            // Counters are tracked authoritatively in ConfigStatus; mirror the
+            // absolute value so the counter stays monotonic across scrapes.
+            metrics::counter!(M_CONFIG_RELOADS_TOTAL).absolute(view.reloads_total);
+            for (reason, count) in &view.reload_failures {
+                metrics::counter!(M_CONFIG_RELOAD_FAILURES_TOTAL, "reason" => *reason)
+                    .absolute(*count);
+            }
+
+            if etcd {
+                metrics::gauge!(M_CONFIG_SOURCE_CONNECTED).set(if view.connected == Some(true) {
+                    1.0
+                } else {
+                    0.0
+                });
+                if let Some(rev) = view.observed_revision {
+                    metrics::gauge!(M_CONFIG_OBSERVED_REVISION).set(rev as f64);
+                }
+                if let Some(rev) = view.applied_revision {
+                    metrics::gauge!(M_CONFIG_APPLIED_REVISION).set(rev as f64);
+                }
+            }
+
+            let mut labels = self.inner.config_labels.lock().expect("config label state");
+
+            // Info-style hash gauge: exactly one live `hash_info{hash=…} 1`;
+            // the previously-current hash is zeroed on change so a scraper can
+            // filter `== 1`. The `hash` label churns as the applied config
+            // changes, and a zeroed series is retained by the recorder — but
+            // the churn is bounded by the number of DISTINCT config states
+            // (operator/CP edits, a low-frequency event — never per-request),
+            // not by traffic. The series name is part of the frozen cross-plane
+            // metric contract the control plane also exposes, so it stays.
+            if labels.last_hash.as_deref() != view.config_hash.as_deref() {
+                if let Some(prev) = labels.last_hash.take() {
+                    metrics::gauge!(M_CONFIG_HASH_INFO, "hash" => prev).set(0.0);
+                }
+            }
+            if let Some(hash) = &view.config_hash {
+                metrics::gauge!(M_CONFIG_HASH_INFO, "hash" => hash.clone()).set(1.0);
+                labels.last_hash = Some(hash.clone());
+            }
+
+            // Rejected-resource gauge per kind: set current, zero cleared kinds.
+            for kind in &labels.last_rejected_kinds {
+                if !view.rejected_by_kind.contains_key(kind) {
+                    metrics::gauge!(M_CONFIG_REJECTED_RESOURCES, "kind" => kind.clone()).set(0.0);
+                }
+            }
+            for (kind, count) in &view.rejected_by_kind {
+                metrics::gauge!(M_CONFIG_REJECTED_RESOURCES, "kind" => kind.clone())
+                    .set(*count as f64);
+            }
+            labels.last_rejected_kinds = view.rejected_by_kind.keys().cloned().collect();
+        });
     }
 
     /// Record the outcome of one proxy request.
@@ -1417,6 +1521,85 @@ mod tests {
             "legacy duration series must stay a summary (quantiles), got:\n{out}"
         );
         assert!(out.contains("aisix_request_duration_seconds"));
+    }
+
+    fn config_metrics_view(source_kind: aisix_core::SourceKind) -> aisix_core::ConfigMetricsView {
+        aisix_core::ConfigMetricsView {
+            source_kind,
+            last_reload_successful: true,
+            last_reload_success_ts: Some(1_760_000_000),
+            reloads_total: 3,
+            reload_failures: std::collections::BTreeMap::new(),
+            rejected_by_kind: std::collections::BTreeMap::new(),
+            observed_revision: Some(42),
+            applied_revision: Some(42),
+            config_hash: Some("abc123".into()),
+            connected: Some(true),
+        }
+    }
+
+    #[test]
+    fn config_status_sync_renders_all_series_in_etcd_mode() {
+        let m = Metrics::new(false);
+        let mut view = config_metrics_view(aisix_core::SourceKind::Etcd);
+        view.last_reload_successful = false;
+        view.reload_failures.insert("validate", 2);
+        view.rejected_by_kind.insert("models".to_string(), 1);
+        m.sync_config_status(&view);
+        let out = m.render();
+
+        assert!(out.contains(&format!("{M_CONFIG_LAST_RELOAD_SUCCESSFUL} 0")));
+        assert!(out.contains(M_CONFIG_LAST_RELOAD_SUCCESS_TIMESTAMP));
+        assert!(out.contains(&format!("{M_CONFIG_RELOADS_TOTAL} 3")));
+        assert!(out.contains(&format!(
+            "{M_CONFIG_RELOAD_FAILURES_TOTAL}{{reason=\"validate\"}} 2"
+        )));
+        assert!(out.contains(&format!(
+            "{M_CONFIG_REJECTED_RESOURCES}{{kind=\"models\"}} 1"
+        )));
+        assert!(out.contains(&format!("{M_CONFIG_OBSERVED_REVISION} 42")));
+        assert!(out.contains(&format!("{M_CONFIG_APPLIED_REVISION} 42")));
+        assert!(out.contains(&format!("{M_CONFIG_HASH_INFO}{{hash=\"abc123\"}} 1")));
+        assert!(out.contains(&format!("{M_CONFIG_SOURCE_CONNECTED} 1")));
+    }
+
+    #[test]
+    fn config_status_sync_omits_etcd_only_series_in_file_mode() {
+        let m = Metrics::new(false);
+        let view = config_metrics_view(aisix_core::SourceKind::File);
+        m.sync_config_status(&view);
+        let out = m.render();
+        // Source-agnostic series still present.
+        assert!(out.contains(M_CONFIG_LAST_RELOAD_SUCCESSFUL));
+        assert!(out.contains(M_CONFIG_RELOADS_TOTAL));
+        // Etcd-only series absent in file mode.
+        assert!(!out.contains(M_CONFIG_OBSERVED_REVISION));
+        assert!(!out.contains(M_CONFIG_APPLIED_REVISION));
+        assert!(!out.contains(M_CONFIG_SOURCE_CONNECTED));
+    }
+
+    #[test]
+    fn config_status_sync_zeroes_stale_hash_and_rejected_labels() {
+        let m = Metrics::new(false);
+        let mut first = config_metrics_view(aisix_core::SourceKind::Etcd);
+        first.config_hash = Some("hash-A".into());
+        first.rejected_by_kind.insert("models".to_string(), 2);
+        m.sync_config_status(&first);
+
+        // The applied config changes and the models rejection clears.
+        let mut second = config_metrics_view(aisix_core::SourceKind::Etcd);
+        second.config_hash = Some("hash-B".into());
+        // rejected_by_kind empty now.
+        m.sync_config_status(&second);
+
+        let out = m.render();
+        // Exactly one live hash sample: old zeroed, new is 1.
+        assert!(out.contains(&format!("{M_CONFIG_HASH_INFO}{{hash=\"hash-A\"}} 0")));
+        assert!(out.contains(&format!("{M_CONFIG_HASH_INFO}{{hash=\"hash-B\"}} 1")));
+        // The cleared kind is zeroed, not left at its stale count.
+        assert!(out.contains(&format!(
+            "{M_CONFIG_REJECTED_RESOURCES}{{kind=\"models\"}} 0"
+        )));
     }
 
     /// Issue #408 audit MEDIUM-2: pin every boundary of

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -26,7 +26,8 @@ use aisix_cache::{Cache, MemoryCache, RedisCache};
 use aisix_core::models::Adapter;
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{
-    AisixSnapshot, CacheBackend, Config, EtcdConfig, EtcdTlsConfig, RateLimitBackend,
+    AisixSnapshot, CacheBackend, Config, ConfigStatus, EtcdConfig, EtcdTlsConfig, RateLimitBackend,
+    SourceKind,
 };
 use aisix_etcd::{EtcdConfigProvider, SnapshotCache, Supervisor};
 use aisix_gateway::Hub;
@@ -145,6 +146,7 @@ fn run_validate(resources: &Path) -> anyhow::Result<()> {
 async fn file_reload_loop(
     path: PathBuf,
     handle: SnapshotHandle<AisixSnapshot>,
+    config_status: ConfigStatus,
     mut cancel: watch::Receiver<bool>,
 ) {
     #[cfg(unix)]
@@ -168,8 +170,14 @@ async fn file_reload_loop(
                     // large file can't stall in-flight requests.
                     let load_path = path.clone();
                     let next_generation = generation + 1;
+                    let reload_status = config_status.clone();
                     let loaded = tokio::task::spawn_blocking(move || {
-                        aisix_core::filesource::load_resources_file(&load_path, next_generation)
+                        aisix_core::filesource::load_resources_file_tracked(
+                            &load_path,
+                            next_generation,
+                            true,
+                            &reload_status,
+                        )
                     })
                     .await;
                     let loaded = match loaded {
@@ -418,13 +426,15 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // file (`resources_file` in config) or etcd + watch supervisor.
     // Config validation already guaranteed exactly one is selected.
     let file_source_path = cfg.resources_file.clone().map(PathBuf::from);
-    let (snapshot_handle, supervisor, watch_task, admin_client) =
+    let (snapshot_handle, supervisor, watch_task, admin_client, config_status) =
         if let Some(path) = &file_source_path {
             // FILE MODE: load once at boot, fail fast with the aggregated
             // error report on any problem. SIGHUP re-runs the identical
             // pipeline; a failed reload keeps the last-good snapshot.
-            let snapshot = aisix_core::filesource::load_resources_file(path, 1)
-                .map_err(|report| anyhow::anyhow!("{report}"))?;
+            let config_status = ConfigStatus::new(SourceKind::File);
+            let snapshot =
+                aisix_core::filesource::load_resources_file_tracked(path, 1, true, &config_status)
+                    .map_err(|report| anyhow::anyhow!("{report}"))?;
             tracing::info!(
                 file = %path.display(),
                 resources = snapshot.total_entries(),
@@ -434,9 +444,10 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             let reload_task = tokio::spawn(file_reload_loop(
                 path.clone(),
                 handle.clone(),
+                config_status.clone(),
                 cancel_rx.clone(),
             ));
-            (handle, None, reload_task, None)
+            (handle, None, reload_task, None, config_status)
         } else {
             // ETCD MODE (unchanged behavior).
             //
@@ -502,9 +513,16 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // proxy is ready to serve from cached config the moment the watch
             // task takes its first iteration.
             supervisor.restore_from_cache();
+            let config_status = supervisor.config_status();
             let handle = supervisor.handle();
             let watch_task = tokio::spawn(supervisor.clone().run(cancel_rx.clone()));
-            (handle, Some(supervisor), watch_task, admin_client)
+            (
+                handle,
+                Some(supervisor),
+                watch_task,
+                admin_client,
+                config_status,
+            )
         };
     // Spawn heartbeat worker if we have a config for it. The
     // JoinHandle is awaited after graceful shutdown below so the
@@ -802,7 +820,8 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // probe.
             std::net::TcpListener::bind(metrics_addr)
                 .map_err(|e| anyhow::anyhow!("metrics listener bind {metrics_addr} failed: {e}"))?;
-            let metrics_router = aisix_admin::metrics_router(metrics.clone(), prom);
+            let metrics_router =
+                aisix_admin::metrics_router(metrics.clone(), config_status.clone(), prom);
             Some(tokio::spawn(serve_http(
                 metrics_addr,
                 metrics_router,

--- a/tests/e2e/src/cases/status-config-e2e.test.ts
+++ b/tests/e2e/src/cases/status-config-e2e.test.ts
@@ -1,0 +1,425 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { stringify as yamlStringify } from "yaml";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  pickFreePorts,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const BIN_PATH =
+  process.env.AISIX_BIN ?? join(process.cwd(), "..", "..", "target", "debug", "aisix");
+
+// E2E for the load-observability contract: `GET /status/config`,
+// `GET /status/ready`, and the `aisix_config_*` Prometheus series on the
+// dedicated metrics/status listener. Exercises both load paths (etcd watch
+// and standalone file) against the real binary — the endpoints report the
+// gateway's own internal load state, so these are source-blind black-box
+// checks of the observable contract.
+
+const CALLER_PLAINTEXT = "sk-status-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+interface StatusConfig {
+  state: string;
+  source: {
+    type: string;
+    connected?: boolean;
+    observed_revision?: number;
+    source_hash?: string;
+    observed_at?: string;
+  };
+  applied?: {
+    applied_revision?: number;
+    config_hash: string;
+    apply_seq: number;
+    applied_at: string;
+    resource_counts: Record<string, number>;
+  };
+  last_reload?: { successful: boolean; at: string };
+  last_failure: { at: string; last_error_kind: string; last_error: string } | null;
+  rejected: Array<{
+    resource_kind: string;
+    resource_id: string;
+    last_error_kind: string;
+    last_error: string;
+    first_seen_at: string;
+    last_seen_at: string;
+  }>;
+}
+
+async function getStatusConfig(app: SpawnedApp): Promise<StatusConfig> {
+  const res = await fetch(`${app.metricsUrl}/status/config`);
+  expect(res.status).toBe(200);
+  return (await res.json()) as StatusConfig;
+}
+
+async function scrape(app: SpawnedApp): Promise<string> {
+  const res = await fetch(`${app.metricsUrl}/metrics`);
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+/** Value of a single-sample (no-label) gauge line from a scrape. */
+function gaugeValue(scrapeText: string, metric: string): number | undefined {
+  for (const line of scrapeText.split("\n")) {
+    if (line.startsWith(`${metric} `)) {
+      const v = Number(line.slice(metric.length + 1).trim());
+      if (!Number.isNaN(v)) return v;
+    }
+  }
+  return undefined;
+}
+
+describe("status/config: etcd watch source", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "status-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "status-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["status-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("clean config reports synced with revisions and resource counts", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    let cfg: StatusConfig | undefined;
+    await waitConfigPropagation(async () => {
+      cfg = await getStatusConfig(app!);
+      return cfg.state === "synced";
+    });
+
+    expect(cfg!.source.type).toBe("etcd");
+    expect(cfg!.source.connected).toBe(true);
+    // observed >= applied revision, both present in etcd mode.
+    expect(typeof cfg!.source.observed_revision).toBe("number");
+    expect(typeof cfg!.applied?.applied_revision).toBe("number");
+    expect(cfg!.source.observed_revision!).toBeGreaterThanOrEqual(
+      cfg!.applied!.applied_revision!,
+    );
+    expect(cfg!.source.source_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(cfg!.applied!.config_hash).toMatch(/^[0-9a-f]{64}$/);
+    // Clean load: applied hash equals the observed source hash.
+    expect(cfg!.applied!.config_hash).toBe(cfg!.source.source_hash);
+    expect(cfg!.applied!.resource_counts.models).toBe(1);
+    expect(cfg!.applied!.resource_counts.provider_keys).toBe(1);
+    expect(cfg!.applied!.resource_counts.api_keys).toBe(1);
+    expect(cfg!.last_reload?.successful).toBe(true);
+    expect(cfg!.last_failure).toBeNull();
+    expect(cfg!.rejected).toHaveLength(0);
+  });
+
+  test("metrics listener exposes aisix_config_* series", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    await waitConfigPropagation(async () => (await getStatusConfig(app!)).state === "synced");
+
+    const text = await scrape(app);
+    expect(gaugeValue(text, "aisix_config_last_reload_successful")).toBe(1);
+    expect(gaugeValue(text, "aisix_config_source_connected")).toBe(1);
+    expect(text).toContain("aisix_config_last_reload_success_timestamp_seconds");
+    expect(text).toContain("aisix_config_reloads_total");
+    expect(text).toMatch(/aisix_config_observed_revision \d+/);
+    expect(text).toMatch(/aisix_config_applied_revision \d+/);
+    expect(text).toMatch(/aisix_config_hash_info\{hash="[0-9a-f]{64}"\} 1/);
+  });
+
+  test("a bad doc alongside good ones degrades without dropping the good config", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const etcd = new EtcdClient();
+    // A schema-invalid model written straight to etcd (empty display_name
+    // violates minLength) — the CP would reject it, but the DP loader must
+    // skip it and keep serving the rest.
+    const badId = randomUUID();
+    await etcd.put(
+      `${app.etcdPrefix}/models/${badId}`,
+      JSON.stringify({
+        display_name: "",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: "pk-nonexistent",
+      }),
+    );
+
+    let cfg: StatusConfig | undefined;
+    await waitConfigPropagation(async () => {
+      cfg = await getStatusConfig(app!);
+      return cfg.state === "degraded" && cfg.rejected.length > 0;
+    });
+
+    // The good model is still applied (serving), not dropped.
+    expect(cfg!.applied!.resource_counts.models).toBe(1);
+    const rej = cfg!.rejected.find((r) => r.resource_id === badId);
+    expect(rej, JSON.stringify(cfg!.rejected)).toBeDefined();
+    expect(rej!.resource_kind).toBe("models");
+    expect(rej!.last_error_kind).toBe("schema_failed");
+    expect(rej!.first_seen_at).toMatch(/Z$/);
+
+    // The bad doc surfaces on the metrics listener too.
+    const text = await scrape(app);
+    expect(text).toMatch(/aisix_config_rejected_resources\{kind="models"\} 1/);
+    expect(gaugeValue(text, "aisix_config_last_reload_successful")).toBe(0);
+
+    // End-to-end: a real chat on the still-good model returns 200.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    const chat = await proxy.chat({
+      model: "status-model",
+      messages: [{ role: "user", content: "still serving despite the bad doc" }],
+    });
+    expect(chat.status, JSON.stringify(chat.body)).toBe(200);
+
+    // Cleanup the bad doc so it doesn't bleed into sibling tests.
+    await etcd.delete(`${app.etcdPrefix}/models/${badId}`);
+  });
+
+  test("a rejected provider_key never leaks its secret into status or metrics", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const SECRET = "sk-LEAKED-SECRET-abcdef0123456789";
+    const leakId = randomUUID();
+    const etcd = new EtcdClient();
+    // The credential itself is the schema-failing instance: `api_key` must be
+    // a string, so an array fails validation and the UNMASKED error message
+    // would echo the secret. This asserts the masking actually redacts it —
+    // not that the secret merely happens to sit in a valid sibling field.
+    await etcd.put(
+      `${app.etcdPrefix}/provider_keys/${leakId}`,
+      JSON.stringify({ display_name: "leak-pk", api_key: [SECRET] }),
+    );
+
+    await waitConfigPropagation(async () => {
+      const cfg = await getStatusConfig(app!);
+      return cfg.rejected.some((r) => r.resource_id === leakId);
+    });
+
+    // The secret must be absent from the whole /status/config body …
+    const raw = await fetch(`${app.metricsUrl}/status/config`).then((r) => r.text());
+    expect(raw).not.toContain(SECRET);
+    // … and from the metrics scrape.
+    const text = await scrape(app);
+    expect(text).not.toContain(SECRET);
+
+    await etcd.delete(`${app.etcdPrefix}/provider_keys/${leakId}`);
+  });
+});
+
+describe("status/config: standalone file source", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp({
+      resourcesFile: `
+_format_version: "1"
+provider_keys:
+  - display_name: file-status-pk
+    provider: openai
+    api_key: sk-mock
+    api_base: ${upstream.baseUrl}/v1
+models:
+  - display_name: file-status-model
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: file-status-pk
+api_keys:
+  - display_name: file-status-caller
+    key_hash: ${CALLER_KEY_HASH}
+    allowed_models: ["file-status-model"]
+`,
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("file mode boots synced with no revision fields", async () => {
+    if (!app) throw new Error("setup failed");
+    // File mode is synchronous at boot — no propagation wait needed.
+    const cfg = await getStatusConfig(app);
+    expect(cfg.state).toBe("synced");
+    expect(cfg.source.type).toBe("file");
+    // Revision + connected fields are etcd-only and must be absent in file mode.
+    expect(cfg.source.connected).toBeUndefined();
+    expect(cfg.source.observed_revision).toBeUndefined();
+    expect(cfg.applied?.applied_revision).toBeUndefined();
+    expect(cfg.source.source_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(cfg.applied!.resource_counts.models).toBe(1);
+    expect(cfg.applied!.resource_counts.provider_keys).toBe(1);
+    expect(cfg.rejected).toHaveLength(0);
+
+    // The scrape omits the etcd-only revision/connected series in file mode.
+    const text = await scrape(app);
+    expect(gaugeValue(text, "aisix_config_last_reload_successful")).toBe(1);
+    expect(text).not.toContain("aisix_config_observed_revision");
+    expect(text).not.toContain("aisix_config_source_connected");
+  });
+
+  test("status/ready is 200 once the file config is applied", async () => {
+    if (!app) throw new Error("setup failed");
+    const res = await fetch(`${app.metricsUrl}/status/ready`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+});
+
+// A DP pointed at an unreachable etcd never applies a config, so it stays in
+// `never_loaded` — but that also makes `/admin/v1/health` (an etcd-backed
+// store read) fail, which the standard harness gate waits on. So this case
+// spawns the binary directly and gates only on the metrics/status listener,
+// which binds independently of the config source.
+interface MinimalApp {
+  metricsUrl: string;
+  stop(): Promise<void>;
+}
+
+async function spawnPointedAtDeadEtcd(): Promise<MinimalApp> {
+  const [proxyPort, adminPort, metricsPort, deadPort] = await pickFreePorts(4);
+  const dir = await mkdtemp(join(tmpdir(), "aisix-status-nl-"));
+  const cfg = {
+    // etcd-client's connect is lazy (no eager dial without auth), so the
+    // gateway boots and binds its listeners even though nothing answers here;
+    // the watch supervisor's first load never succeeds → never_loaded.
+    etcd: {
+      endpoints: [`http://127.0.0.1:${deadPort}`],
+      prefix: "/aisix-never-loaded",
+      dial_timeout_ms: 2000,
+      request_timeout_ms: 2000,
+    },
+    proxy: { addr: `127.0.0.1:${proxyPort}`, request_body_limit_bytes: 10485760 },
+    admin: { addr: `127.0.0.1:${adminPort}`, admin_keys: [`admin-${randomUUID()}`] },
+    observability: {
+      service_name: "aisix-status-nl",
+      log_level: "warn",
+      access_log: false,
+      metrics: {
+        prometheus: { enabled: true, path: "/metrics", addr: `127.0.0.1:${metricsPort}` },
+        otlp: { enabled: false, endpoint: "http://127.0.0.1:4317" },
+      },
+      tracing: { otlp: { enabled: false, endpoint: "http://127.0.0.1:4317", sample_ratio: 1 } },
+    },
+    cache: { backend: "memory" },
+  };
+  const cfgPath = join(dir, "config.yaml");
+  await writeFile(cfgPath, yamlStringify(cfg), "utf8");
+
+  // Strip AISIX_* so the harness's own env can't override the config.
+  const childEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && !k.startsWith("AISIX_")) childEnv[k] = v;
+  }
+  childEnv.RUST_LOG = "warn";
+
+  const child: ChildProcess = spawn(BIN_PATH, ["--config", cfgPath], {
+    stdio: ["ignore", "ignore", "ignore"],
+    env: childEnv,
+  });
+  const metricsUrl = `http://127.0.0.1:${metricsPort}`;
+
+  // Gate only on the metrics/status listener answering (any status — a 503
+  // from /status/ready still means the listener is up).
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    if (child.exitCode !== null) throw new Error(`aisix exited early code=${child.exitCode}`);
+    try {
+      const res = await fetch(`${metricsUrl}/status/ready`);
+      await res.text();
+      break;
+    } catch {
+      if (Date.now() > deadline) throw new Error("metrics listener never came up");
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+
+  return {
+    metricsUrl,
+    async stop() {
+      if (child.exitCode === null) child.kill("SIGTERM");
+      await Promise.race([
+        new Promise<void>((r) => child.once("exit", () => r())),
+        new Promise<void>((r) => setTimeout(r, 3000)),
+      ]);
+      if (child.exitCode === null) child.kill("SIGKILL");
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("status/ready: never_loaded before any config", () => {
+  let app: MinimalApp | undefined;
+
+  beforeAll(async () => {
+    app = await spawnPointedAtDeadEtcd();
+  });
+
+  afterAll(async () => {
+    await app?.stop();
+  });
+
+  test("status/ready is 503 and status/config reports never_loaded", async () => {
+    if (!app) throw new Error("setup failed");
+
+    const ready = await fetch(`${app.metricsUrl}/status/ready`);
+    expect(ready.status).toBe(503);
+    expect(await ready.text()).toBe("no configuration available");
+
+    const res = await fetch(`${app.metricsUrl}/status/config`);
+    expect(res.status).toBe(200);
+    const cfg = (await res.json()) as StatusConfig;
+    expect(cfg.state).toBe("never_loaded");
+    expect(cfg.applied).toBeUndefined();
+    // The etcd source shows disconnected while it keeps retrying.
+    expect(cfg.source.type).toBe("etcd");
+    expect(cfg.source.connected).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a load-observability surface to the data plane so an operator (or the
control plane, or an automation) can answer one question directly against the
gateway: **did my configuration take effect, and if not, why?** It works for
both config load paths the DP supports — the etcd watch source and the
standalone `resources_file` source.

Three things ship, all on the DP's existing non-admin metrics/status listener:

- `GET /status/config` — a JSON snapshot of the load state.
- `GET /status/ready` — a config-loaded readiness gate.
- `aisix_config_*` Prometheus series on the scrape endpoint.

Nothing here adds new *tracking*. The etcd supervisor already collects rejected
entries and the applied revision; the file source already produces aggregated
load errors on boot/SIGHUP. This change gives that internal state one canonical,
source-agnostic shape and exposes it on a local endpoint.

## `GET /status/config`

```json
{
  "state": "synced",
  "source": {
    "type": "etcd",
    "connected": true,
    "observed_revision": 4213,
    "source_hash": "9f2c…(sha256 hex)",
    "observed_at": "2026-07-14T12:34:56Z"
  },
  "applied": {
    "applied_revision": 4213,
    "config_hash": "9f2c…",
    "apply_seq": 7,
    "applied_at": "2026-07-14T12:34:56Z",
    "resource_counts": { "models": 3, "provider_keys": 2, "api_keys": 5 }
  },
  "last_reload": { "successful": true, "at": "2026-07-14T12:34:56Z" },
  "last_failure": null,
  "rejected": []
}
```

`state` is **server-derived**:

| state | meaning |
|-------|---------|
| `synced` | applied config matches the latest observed snapshot; nothing rejected (`applied_hash == source_hash`, `rejected` empty) |
| `degraded` | applied and serving, but the latest snapshot carried entries the DP rejected |
| `out_of_sync` | the latest observed snapshot was rejected as a whole; the DP is serving the last-good snapshot (or nothing usable from the latest) |
| `empty` | a valid configuration was applied but it holds zero resources |
| `never_loaded` | no valid configuration has ever been applied this boot |

A `degraded` response with a populated `rejected[]` is the money case — most
config applied, these specific rows did not, and here is why.

### `rejected[]` — field-aligned with the control plane

Each entry is `{ resource_kind, resource_id, last_error_kind, last_error,
first_seen_at, last_seen_at }`. These are **the same field names the control
plane's `rejected_resources` surface already uses**, so an operator sees one
vocabulary on both planes. `last_error_kind` is a snake-case classification:
`bad_key | non_json | schema_failed | parse_failed | unknown_kind`. The etcd key
`<prefix>/<kind>/<id>` is split into `resource_kind` / `resource_id`; an
unparseable key reports both empty, mirroring the CP. `first_seen_at` stays
stable across reloads while `last_seen_at` advances.

### etcd-only vs file-mode

Revision identity only exists for etcd, so:

- **etcd**: `source.connected`, `source.observed_revision`, and
  `applied.applied_revision` are present. Semantics: `observed_revision ≥
  applied_revision`. The store head (`store_revision`) is the CP/etcd's, not the
  DP's, so it is deliberately omitted here.
- **file**: all revision + `connected` fields are omitted. Identity is
  `config_hash` + `apply_seq`. The file source is all-or-nothing: a clean load
  applies the whole file (`synced`/`empty`); a failing reload keeps the last-good
  snapshot (`out_of_sync`).

## `GET /status/ready`

`503` with body `no configuration available` until the first valid configuration
is applied, `200 ok` afterward. This is a config-source readiness gate only; the
admin listener's existing `/livez` and `/readyz` keep their liveness /
shutdown / staleness semantics untouched.

## Metrics

On the scrape endpoint (reflected from the live state at scrape time):

```
aisix_config_last_reload_successful                 gauge 0/1
aisix_config_last_reload_success_timestamp_seconds  gauge
aisix_config_reloads_total                          counter
aisix_config_reload_failures_total{reason}          counter   # reason = fetch|parse|validate
aisix_config_rejected_resources{kind}               gauge
aisix_config_observed_revision                      gauge     # etcd mode only
aisix_config_applied_revision                       gauge     # etcd mode only
aisix_config_hash_info{hash}                         gauge 1   # info-style
aisix_config_source_connected                       gauge 0/1 # etcd mode only
```

`reason` buckets the per-resource `last_error_kind` coarsely: `non_json` →
`parse`; source unreachable → `fetch`; everything else → `validate`. The
info-style `hash_info` keeps exactly one live sample (the prior hash label is
zeroed when the applied config changes), and `rejected_resources{kind}` zeroes a
kind's sample when its rejections clear.

## Hash definition (reproducible)

Both hashes are `sha256`, deterministic, and reproducible by whoever wrote the
config:

- **etcd**: over the entries, each rendered as `key '\0' canonical_json_value
  '\n'`, concatenated in ascending key order. `canonical_json_value` sorts object
  keys recursively and drops insignificant whitespace; a value that is not JSON
  is hashed as its raw bytes. `source_hash` covers every entry in the last
  observed full snapshot; `config_hash` covers only the accepted (served)
  subset — so a full snapshot applied with no rejections has the two equal.
  Note: a resource rejected on a *live watch event* is surfaced via `rejected[]`
  but does not fold into `source_hash` until the next full resync (the watch
  delta never carries the bad bytes into the served map), so
  `source_hash == config_hash` can hold while the state is `degraded` — treat
  `rejected[]` (not a hash diff) as the authoritative partial-rejection signal.
- **file**: over the raw file bytes. On a clean load `config_hash == source_hash`
  (the whole file is applied).

## Security — no credential leakage

Schema-validation messages are credential-masked at the schema layer (instance
values are redacted before they reach the rejection buffer), so a resource whose
credential field fails validation cannot echo the credential. Parse / decode /
key messages are positional and value-free (a serde error names the offending
field, not its value). The masking e2e makes the credential *itself* the
schema-failing instance (an `api_key` array — its unmasked message would carry
the secret) and asserts the secret is absent from both `/status/config` and
`/metrics`, so a masking regression would fail the test.

## Tests

- **Rust unit** — state-machine derivation for each of the five states,
  `RejectionKind`/scope → snake-case mapping, key → kind/id parsing incl.
  unparseable, hash determinism (order + whitespace independent), reload-reason
  bucketing, sticky `last_failure`, `apply_seq` advancing only on change, metrics
  reflection incl. etcd-only omission and label-churn zeroing, and the endpoint
  handlers (`/status/ready` 503→200, `/status/config` shape, scrape reflection).
- **e2e (`tests/e2e/src/cases/status-config-e2e.test.ts`)** — etcd mode: clean
  config → `synced` with revisions + counts; a bad doc alongside good ones →
  `degraded`, `rejected[]` carries it with the right kind, the good model still
  serves a real chat 200, and the scrape reflects it; masking: a rejected
  provider_key's secret never appears. File mode: boot → `synced`, no revision
  fields, `/status/ready` 200. `never_loaded`: a DP pointed at an unreachable
  etcd reports `never_loaded` and `/status/ready` 503.

`cargo fmt`/`clippy -D warnings` clean; `dump-schema`/`dump-openapi` idempotent
(neither is touched).

## Independent audit triage

An independent review found **no HIGH** issues (state machine, lock discipline,
incremental-watch path, and breaking-change surface all sound) and four MEDIUMs,
all resolved:

- **M1 (fixed)** — the masking e2e proved nothing as written: the secret sat in
  a valid sibling field and never reached any error message. The seed now makes
  the credential the schema-failing instance (`api_key: [secret]`), so masking is
  actually exercised — a regression would leak the secret and fail.
- **M2 (fixed)** — the `last_error` doc claimed blanket "credential-masked".
  Narrowed to the truth: schema messages are masked; parse/decode/key messages
  are positional and value-free. Confirmed no resource schema carries an
  untyped/permissive credential field (`observability_exporter` headers are a
  typed `map<string,string>` under `deny_unknown_fields`).
- **M3 (justified)** — `aisix_config_hash_info{hash}` churns its label as the
  applied config changes and the recorder retains zeroed series. Kept as-is: the
  series name is part of the frozen cross-plane metric contract, and the churn is
  bounded by distinct config states (operator/CP edits — low frequency, never
  per-request), with exactly one live `== 1` sample. Documented at the call site.
- **M4 (fixed)** — corrected the `source_hash` claim (see the hash-definition
  note above): a live-watch reject is reported via `rejected[]` and does not fold
  into `source_hash` until the next resync.

LOW items are non-blocking (e.g. status endpoints share the metrics listener's
enable toggle — `/readyz` on the admin listener remains the k8s gate; file-mode
masking is unit-covered via the shared masked `validate()` path).
