### PR TITLE
feat(admin): deprecate the Admin API write path in favor of declarative configuration

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -29,6 +29,13 @@
 //! [`ConfigStore`] trait; production wires an etcd-backed impl in a
 //! follow-up PR, tests use [`InMemoryStore`].
 //!
+//! The write endpoints above (POST/PUT/DELETE, including rotate) are
+//! deprecated in favor of the declarative configuration paths — a
+//! `resources_file` source (`resources.yaml`) or direct etcd writes.
+//! They remain functional; every mutating response carries the RFC 9745
+//! `Deprecation` header and a `rel="deprecation"` `Link` (stamped by
+//! [`deprecated_write_headers`] so new write routes can't omit them).
+//!
 //! Errors follow the simple admin envelope: `{"error_msg": "..."}`,
 //! distinct from the proxy's OpenAI-style envelope.
 
@@ -80,6 +87,22 @@ pub struct MetricsState {
 pub fn admin_openapi_json() -> &'static str {
     openapi::merged_openapi()
 }
+
+/// RFC 9745 `Deprecation` value for the Admin API write path: a
+/// structured-field date (RFC 9651 Section 3.3.7), as the RFC requires —
+/// the boolean form from earlier drafts is not valid. The timestamp is
+/// the release date of the file-based resource source (`resources_file`),
+/// the point at which declarative configuration became the recommended
+/// way to manage standalone resources; a past date means the write path
+/// "was deprecated at that date". It stays functional — this header is
+/// the in-band signal, not a removal.
+const ADMIN_WRITE_DEPRECATION: &str = "@1783929480";
+
+/// RFC 8288 `Link` with the `deprecation` relation type registered by
+/// RFC 9745 — human-readable documentation covering the declarative
+/// configuration paths that replace Admin API writes.
+const ADMIN_WRITE_DEPRECATION_LINK: &str =
+    "<https://docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart>; rel=\"deprecation\"";
 
 pub fn build_router(state: AdminState) -> Router {
     // Eagerly build the merged OpenAPI doc so any panic in schema
@@ -223,9 +246,60 @@ pub fn build_router(state: AdminState) -> Router {
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             file_managed_write_guard,
-        ));
+        ))
+        // Deprecation signal for the Admin API write path. Added after
+        // (= outside of) the file-managed guard so the guard's 409 file-
+        // managed responses carry the headers too.
+        .layer(axum::middleware::from_fn(deprecated_write_headers));
 
     router.with_state(state)
+}
+
+/// True for a mutating request against the `/admin/v1/*` resource
+/// surface — POST/PUT/DELETE, rotate included. GET/HEAD/OPTIONS are the
+/// read surface, and non-resource endpoints (playground, livez/readyz,
+/// openapi) never count. One predicate shared by the file-managed write
+/// guard and the deprecation-header layer so the two views of "a write"
+/// can't drift apart.
+fn is_admin_resource_write(method: &axum::http::Method, path: &str) -> bool {
+    use axum::http::Method;
+
+    !matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
+        && path.starts_with("/admin/v1/")
+}
+
+/// Stamp the deprecation signal onto every mutating `/admin/v1/*`
+/// response, whatever its status: one chokepoint above the whole
+/// resource router, so newly added write routes can't ship without it.
+/// Applies in both etcd mode and file mode (the file-managed 409
+/// carries it too). The read surface and non-resource endpoints pass
+/// through untouched.
+///
+/// Emits, per RFC 9745:
+/// - `Deprecation: @<sf-date>` ([`ADMIN_WRITE_DEPRECATION`])
+/// - `Link: <docs>; rel="deprecation"` ([`ADMIN_WRITE_DEPRECATION_LINK`])
+async fn deprecated_write_headers(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    use axum::http::{header, HeaderName, HeaderValue};
+
+    let is_write = is_admin_resource_write(req.method(), req.uri().path());
+    let mut resp = next.run(req).await;
+    if is_write {
+        let headers = resp.headers_mut();
+        headers.insert(
+            HeaderName::from_static("deprecation"),
+            HeaderValue::from_static(ADMIN_WRITE_DEPRECATION),
+        );
+        // `Link` is list-valued (RFC 8288) — append rather than insert
+        // so a handler-provided link relation is never clobbered.
+        headers.append(
+            header::LINK,
+            HeaderValue::from_static(ADMIN_WRITE_DEPRECATION_LINK),
+        );
+    }
+    resp
 }
 
 /// Reject mutating `/admin/v1/*` requests with a 409 when resources are
@@ -242,11 +316,9 @@ async fn file_managed_write_guard(
     req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> Response {
-    use axum::http::Method;
     use axum::response::IntoResponse;
 
-    let is_read = matches!(*req.method(), Method::GET | Method::HEAD | Method::OPTIONS);
-    if !is_read && req.uri().path().starts_with("/admin/v1/") {
+    if is_admin_resource_write(req.method(), req.uri().path()) {
         if let Some(path) = state.file_managed_path.as_deref() {
             if auth::is_admin_authorized(req.headers(), &state.admin_keys) {
                 return AdminError::FileManaged(FileManagedStore::read_only_message(path))
@@ -2004,6 +2076,128 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ──────────────────── Write-path deprecation signal ────────────────────
+
+    fn assert_deprecation_headers(resp: &axum::http::Response<Body>, context: &str) {
+        let deprecation = resp
+            .headers()
+            .get("deprecation")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_else(|| panic!("{context}: missing Deprecation header"));
+        // RFC 9745: the value is a structured-field Date (`@<unix>`),
+        // pinned to the release that shipped the file-based source.
+        assert_eq!(deprecation, ADMIN_WRITE_DEPRECATION, "{context}");
+        assert!(deprecation.starts_with('@'), "{context}: not an sf-date");
+
+        let link = resp
+            .headers()
+            .get(axum::http::header::LINK)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_else(|| panic!("{context}: missing Link header"));
+        assert!(
+            link.contains("rel=\"deprecation\""),
+            "{context}: Link lacks the deprecation relation: {link}"
+        );
+        assert!(
+            link.contains("https://docs.api7.ai/"),
+            "{context}: Link must point at the published docs: {link}"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_write_responses_carry_rfc9745_deprecation_headers() {
+        // Representative create: 200 with both headers.
+        let state = build_state();
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("POST", "/admin/v1/models", Some(model_payload("dep"))),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_deprecation_headers(&resp, "POST /admin/v1/models");
+
+        // The signal covers the whole write path, not just the happy
+        // path: rotate (POST), a DELETE, and even a failed write (404)
+        // all carry it — the deprecation is a property of the endpoint,
+        // not of the outcome.
+        let app = build_router(state.clone());
+        let resp = run(
+            app,
+            auth_req("POST", "/admin/v1/api_keys/missing/rotate", None),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_deprecation_headers(&resp, "POST /admin/v1/api_keys/{id}/rotate");
+
+        // Former `apikeys` spelling is the same deprecated write path.
+        let app = build_router(state);
+        let resp = run(app, auth_req("DELETE", "/admin/v1/apikeys/missing", None)).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_deprecation_headers(&resp, "DELETE /admin/v1/apikeys/{id}");
+    }
+
+    #[tokio::test]
+    async fn file_managed_409_carries_the_deprecation_headers_too() {
+        let app = build_router(build_file_managed_state());
+        let resp = run(
+            app,
+            auth_req("POST", "/admin/v1/models", Some(model_payload("new"))),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        assert_deprecation_headers(&resp, "file-managed POST /admin/v1/models");
+    }
+
+    #[tokio::test]
+    async fn read_and_non_resource_responses_carry_no_deprecation_header() {
+        let state = build_state();
+
+        // Reads across the resource + status surface.
+        for uri in [
+            "/admin/v1/models",
+            "/admin/v1/models/status",
+            "/admin/v1/health",
+        ] {
+            let app = build_router(state.clone());
+            let resp = run(app, auth_req("GET", uri, None)).await;
+            assert_eq!(resp.status(), StatusCode::OK, "GET {uri}");
+            assert!(
+                resp.headers().get("deprecation").is_none(),
+                "GET {uri} must NOT carry a Deprecation header"
+            );
+        }
+
+        // Unauthenticated public surface.
+        let app = build_router(state.clone());
+        let req = Request::builder()
+            .uri("/admin/openapi.json")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.headers().get("deprecation").is_none());
+
+        // The playground is a POST on the admin listener but NOT part of
+        // the deprecated resource write path (501 here: no proxy router
+        // is wired in this test state).
+        let app = build_router(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/playground/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({"model": "m", "messages": []}).to_string(),
+            ))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+        assert!(
+            resp.headers().get("deprecation").is_none(),
+            "playground must NOT carry a Deprecation header"
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -38,7 +38,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
   "info": {
     "title": "AISIX Admin API",
     "version": "dev",
-    "description": "The AISIX Admin API is the self-hosted management interface for configuring the gateway at runtime. Use it when you operate AISIX directly and need to create or update models, caller API keys, provider credentials, guardrails, cache policies, and observability exporters.\n\nManaged deployments do not expose this listener. Configure managed gateways through the AISIX managed control plane."
+    "description": "The AISIX Admin API is the self-hosted management interface for configuring the gateway at runtime. Use it when you operate AISIX directly and need to create or update models, caller API keys, provider credentials, guardrails, cache policies, and observability exporters.\n\nThe write endpoints (POST, PUT, DELETE) are deprecated in favor of declarative configuration: load resources from a `resources_file` (`resources.yaml`) or write them to etcd directly. Write endpoints remain functional, and every mutating response carries a `Deprecation` header (RFC 9745) plus a `Link` header with `rel=\"deprecation\"` pointing at the migration documentation. Read endpoints are not deprecated.\n\nManaged deployments do not expose this listener. Configure managed gateways through the AISIX managed control plane."
   },
   "paths": {
     "/livez": {
@@ -4123,6 +4123,7 @@ pub(crate) fn merged_openapi() -> &'static str {
         add_schema_defaults(&mut doc);
         add_schema_examples(&mut doc);
         document_former_apikeys_paths(&mut doc);
+        mark_admin_write_operations_deprecated(&mut doc);
         wrap_ref_siblings_for_redoc(&mut doc);
 
         serde_json::to_string(&doc).expect("merged OpenAPI must serialise")
@@ -4176,6 +4177,49 @@ fn document_former_apikeys_paths(doc: &mut Value) {
             }
         }
         doc["paths"][*former] = item;
+    }
+}
+
+/// Mark every mutating `/admin/v1/*` operation (POST/PUT/DELETE,
+/// rotate included) as `deprecated: true` and point its description at
+/// the declarative configuration paths. One programmatic pass instead
+/// of thirty hand-edited operations, mirroring the router-level header
+/// chokepoint: a newly documented write route picks the marking up
+/// automatically. Runs after [`document_former_apikeys_paths`] so the
+/// former `apikeys` spelling is covered too. Read operations and
+/// non-resource endpoints (playground, health, OpenAPI) are untouched.
+fn mark_admin_write_operations_deprecated(doc: &mut Value) {
+    const NOTE: &str = "**Deprecated write path**: configure resources declaratively \
+         instead, either through a `resources_file` (`resources.yaml`) or by writing \
+         to etcd directly. This endpoint remains functional; mutating responses carry \
+         a `Deprecation` header (RFC 9745) and a `Link` header with `rel=\"deprecation\"` \
+         pointing at the migration documentation.";
+
+    let Some(paths) = doc["paths"].as_object_mut() else {
+        return;
+    };
+    for (path, item) in paths.iter_mut() {
+        if !path.starts_with("/admin/v1/") {
+            continue;
+        }
+        let Some(ops) = item.as_object_mut() else {
+            continue;
+        };
+        for method in ["post", "put", "delete"] {
+            let Some(op) = ops.get_mut(method).and_then(Value::as_object_mut) else {
+                continue;
+            };
+            op.insert("deprecated".to_string(), Value::Bool(true));
+            match op.get_mut("description") {
+                Some(Value::String(description)) => {
+                    description.push_str("\n\n");
+                    description.push_str(NOTE);
+                }
+                _ => {
+                    op.insert("description".to_string(), Value::String(NOTE.to_string()));
+                }
+            }
+        }
     }
 }
 
@@ -4741,6 +4785,52 @@ mod tests {
         assert_eq!(
             actual, expected,
             "OpenAPI paths must match the admin router exactly; metrics live on the dedicated metrics listener"
+        );
+    }
+
+    #[tokio::test]
+    async fn openapi_marks_every_admin_write_operation_deprecated() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(merged_openapi()).expect("merged_openapi must parse");
+        let paths = parsed["paths"]
+            .as_object()
+            .expect("paths must be an object");
+
+        let mut write_ops = 0;
+        for (path, item) in paths {
+            let item = item.as_object().expect("path item must be an object");
+            for (method, op) in item {
+                if method == "parameters" {
+                    continue;
+                }
+                let is_admin_write = path.starts_with("/admin/v1/")
+                    && matches!(method.as_str(), "post" | "put" | "delete");
+                if is_admin_write {
+                    write_ops += 1;
+                    assert_eq!(
+                        op["deprecated"], true,
+                        "{method} {path} is a resource write and must be marked deprecated"
+                    );
+                    let description = op["description"].as_str().unwrap_or_default();
+                    assert!(
+                        description.contains("resources_file"),
+                        "{method} {path} must point at the declarative configuration paths"
+                    );
+                } else {
+                    assert!(
+                        op.get("deprecated").is_none(),
+                        "{method} {path} is a read or non-resource operation and must NOT be marked deprecated"
+                    );
+                }
+            }
+        }
+        // 8 resource collections × (create + update + delete) + the
+        // api_keys rotate, plus the four write operations mirrored onto
+        // the former `apikeys` spelling. Update deliberately when the
+        // resource surface changes — like the exact path-set test above.
+        assert_eq!(
+            write_ops, 29,
+            "unexpected number of deprecated write operations"
         );
     }
 

--- a/tests/e2e/src/cases/openai-sdk-compat.test.ts
+++ b/tests/e2e/src/cases/openai-sdk-compat.test.ts
@@ -209,4 +209,45 @@ describe("openai SDK compat: drive gateway through real client", () => {
     expect(testCalls).toHaveLength(1);
     expect(testCalls[0]?.method).toBe("POST");
   });
+
+  // The deprecation signal is part of the admin-write contract this
+  // suite deliberately exercises: every mutating Admin API response
+  // must carry the `Deprecation` header — a structured-field date per
+  // RFC 9745 (https://www.rfc-editor.org/rfc/rfc9745), so `@<unix>`,
+  // not the draft-era boolean — plus a `Link` with rel="deprecation"
+  // pointing at the declarative-configuration docs. Reads carry
+  // neither: the read surface is not deprecated.
+  test("admin writes carry the RFC 9745 deprecation signal; reads do not", async (ctx) => {
+    if (!etcdReachable || !app || !nonStreamUpstream) {
+      ctx.skip();
+      return;
+    }
+
+    const auth = {
+      authorization: `Bearer ${app.adminKey}`,
+      "content-type": "application/json",
+    };
+    const write = await fetch(`${app.adminUrl}/admin/v1/provider_keys`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        display_name: "sdk-compat-deprecation-probe-pk",
+        provider: "openai",
+        adapter: "openai",
+        secret: "sk-mock",
+        api_base: `${nonStreamUpstream.baseUrl}/v1`,
+      }),
+    });
+    expect(write.status).toBe(200);
+    expect(write.headers.get("deprecation")).toMatch(/^@\d+$/);
+    const link = write.headers.get("link") ?? "";
+    expect(link).toContain('rel="deprecation"');
+    expect(link).toMatch(/<https:\/\/[^>]+>/);
+
+    const read = await fetch(`${app.adminUrl}/admin/v1/provider_keys`, {
+      headers: { authorization: `Bearer ${app.adminKey}` },
+    });
+    expect(read.status).toBe(200);
+    expect(read.headers.get("deprecation")).toBeNull();
+  });
 });

--- a/tests/e2e/src/cases/smoke.test.ts
+++ b/tests/e2e/src/cases/smoke.test.ts
@@ -1,40 +1,64 @@
 import { createHash } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
-  AdminClient,
-  EtcdClient,
   ProxyClient,
   spawnApp,
   startOpenAiUpstream,
-  waitConfigPropagation,
   type OpenAiUpstream,
   type SpawnedApp,
 } from "../harness/index.js";
 
-// v3 self-hosted CP wire (§9A.7B.4): the snapshot stores SHA-256 of
-// the plaintext bearer, never the plaintext itself. The DP hashes
-// incoming `Bearer <plaintext>` and looks the key up by hash.
+// Smoke: the recommended standalone configuration path. The gateway
+// boots from a declarative resources.yaml (`resources_file`) — no etcd,
+// no Admin API writes — and the file-defined resources serve a chat
+// round-trip end-to-end. File mode is synchronous at boot, so there is
+// no propagation wait anywhere in this suite: the first request must
+// already serve.
+//
+// The Admin API write path stays deliberately covered during its
+// deprecation window by the seed-vs-admin characterization case and
+// the cases marked "Deliberately seeds via the Admin API".
+//
+// v3 self-hosted CP wire (§9A.7B.4): the resources file stores SHA-256
+// of the plaintext bearer, never the plaintext itself. The gateway
+// hashes incoming `Bearer <plaintext>` and looks the key up by hash.
 // Keep this helper inline so the test independently re-derives the
 // hash the same way `aisix_core::ApiKey::hash_bearer` does on the
-// Rust side — divergence between the two is the bug we want to
-// catch.
+// Rust side — divergence between the two is the bug we want to catch.
 const CALLER_PLAINTEXT = "sk-smoke-caller";
 const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
 
-describe("smoke: admin write → proxy read", () => {
+function smokeResources(upstreamBase: string): string {
+  return `
+_format_version: "1"
+provider_keys:
+  - display_name: smoke-openai
+    provider: openai
+    api_key: sk-mock
+    # The OpenAI bridge appends \`/chat/completions\`, so the api_base
+    # already needs the \`/v1\` segment to land on \`/v1/chat/completions\`.
+    api_base: ${upstreamBase}/v1
+models:
+  - display_name: smoke-gpt
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: smoke-openai
+api_keys:
+  - display_name: smoke-caller
+    key_hash: ${CALLER_KEY_HASH}
+    allowed_models: ["smoke-gpt"]
+`;
+}
+
+describe("smoke: file-based resources → proxy read", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
-  let admin: AdminClient | undefined;
-  let etcdReachable = false;
 
   beforeAll(async () => {
-    etcdReachable = await new EtcdClient().ping();
-    if (!etcdReachable) return;
     upstream = await startOpenAiUpstream();
-    app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    app = await spawnApp({ resourcesFile: smokeResources(upstream.baseUrl) });
   });
 
   afterAll(async () => {
@@ -42,43 +66,10 @@ describe("smoke: admin write → proxy read", () => {
     await upstream?.close();
   });
 
-  test("a Model + ApiKey written via Admin API are visible to /v1/models", async (ctx) => {
-    if (!etcdReachable || !app || !admin || !upstream) {
-      ctx.skip();
-      return;
-    }
-
-    // Phase B Model shape: ProviderKey carries the upstream secret +
-    // optional api_base override; Model references it by id.
-    const pk = await admin.createProviderKey({
-      display_name: "smoke-openai",
-      secret: "sk-mock",
-      // The OpenAI bridge appends `/chat/completions`, so the api_base
-      // already needs the `/v1` segment to land on `/v1/chat/completions`.
-      api_base: `${upstream.baseUrl}/v1`,
-    });
-    await admin.createModel({
-      display_name: "smoke-gpt",
-      provider: "openai",
-      model_name: "gpt-4o-mini",
-      provider_key_id: pk.id,
-    });
-    await admin.createApiKey({
-      key_hash: CALLER_KEY_HASH,
-      allowed_models: ["smoke-gpt"],
-    });
+  test("a Model + ApiKey defined in resources.yaml are visible to /v1/models", async () => {
+    if (!app || !upstream) throw new Error("setup failed");
 
     const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    // Poll /v1/models until the freshly-written model is visible — the
-    // supervisor's watch pipeline normally catches up within ~50ms but
-    // CI runners occasionally lag behind a fixed sleep.
-    await waitConfigPropagation(async () => {
-      const res = await proxy.listModels();
-      if (res.status !== 200) return false;
-      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
-      return data.some((m) => m.id === "smoke-gpt");
-    });
-
     const { status, body } = await proxy.listModels();
     expect(status).toBe(200);
     expect(body).toMatchObject({
@@ -87,30 +78,10 @@ describe("smoke: admin write → proxy read", () => {
     });
   });
 
-  test("a chat completion forwards to the mock upstream", async (ctx) => {
-    if (!etcdReachable || !app || !upstream) {
-      ctx.skip();
-      return;
-    }
+  test("a chat completion forwards to the mock upstream", async () => {
+    if (!app || !upstream) throw new Error("setup failed");
 
     const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    // The Model + ProviderKey writes from the previous test propagate
-    // independently. /v1/models confirms the Model row but not the
-    // referenced ProviderKey — poll the chat path itself until the
-    // dispatcher stops returning `unknown provider_key_id`, the only
-    // signal that captures the snapshot's complete state.
-    await waitConfigPropagation(async () => {
-      const probe = await proxy.chat({
-        model: "smoke-gpt",
-        messages: [{ role: "user", content: "ping" }],
-      });
-      if (probe.status === 200) return true;
-      const msg = JSON.stringify(probe.body);
-      return !msg.includes("unknown provider_key_id");
-    });
-
-    // Baseline-isolate the readiness probe so the assertion below
-    // measures only the test call's effect on the upstream.
     const baseline = upstream.receivedRequests.length;
     const { status, body } = await proxy.chat({
       model: "smoke-gpt",


### PR DESCRIPTION
## What

Admin API **write** endpoints (POST/PUT/DELETE across every resource collection, `rotate` included, on both the canonical `api_keys` and the former `apikeys` spelling) now signal in-band that they are deprecated in favor of the declarative configuration paths — a `resources_file` source (`resources.yaml`) or direct etcd writes. The endpoints remain fully functional: no request/response body, status code, or behavior changes — only the two response headers and the OpenAPI marking below.

Three surfaces:

1. **Runtime headers** — every mutating `/admin/v1/*` response carries, per RFC 9745:
   - `Deprecation: @1783929480`
   - `Link: <https://docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart>; rel="deprecation"`
2. **OpenAPI** — every write operation is marked `deprecated: true` with a description line pointing at the declarative paths; `info.description` explains the write-path deprecation once. Read operations are untouched.
3. **e2e smoke** — the smoke test now boots the gateway the recommended way (file mode) instead of admin-write→proxy-read.

## Header form: why `Deprecation: @1783929480` and not `true`

RFC 9745 (the published IETF standard for this header) requires the value to be an RFC 9651 structured-field **Date** — `@<unix-timestamp>`. The bare boolean `true` from earlier drafts is not valid in the final RFC. We deliberately promise no removal timeline, and the RFC supports exactly that: a **past** date means "the resource in context *was deprecated* at that date" and implies nothing about removal (that would be sunset signaling, a separate mechanism this PR intentionally does not emit). `1783929480` is the merge timestamp of `9b8b407`, the change that shipped the file-based resource source — the factual point at which declarative configuration became the recommended standalone path.

The `Link` header uses the `deprecation` relation type registered by RFC 9745 §3, pointing at the published quickstart that documents the declarative configuration flow (the same docs URL family the README already references).

## Chokepoint design

One router-level layer, `deprecated_write_headers` in `crates/aisix-admin/src/lib.rs`, stamps both headers. It shares a single `is_admin_resource_write` predicate with the existing file-managed write guard, so the two views of "a write" cannot drift. Properties:

- Covers every current **and future** mutating `/admin/v1/*` route — a newly added write route cannot ship without the signal.
- Wraps the file-managed guard, so file mode's 409 file-managed responses carry the headers too.
- Status-independent: 200s, validation 4xxs, and the 409 all signal — the deprecation is a property of the endpoint, not of the outcome.
- The read surface (GET/HEAD/OPTIONS, `/admin/v1/models/status`, `/admin/v1/health`, `/admin/openapi.json`) and non-resource endpoints (`/playground/*`, `/livez`, `/readyz`) are untouched. `Link` is appended, never inserted, so a handler-provided link relation can't be clobbered.

The OpenAPI marking mirrors the same idea: one programmatic pass (`mark_admin_write_operations_deprecated`) over the merged document instead of 29 hand-edited operations, running after the former-`apikeys` alias mirroring so those operations are covered too.

## Smoke conversion

`tests/e2e/src/cases/smoke.test.ts` now boots from a declarative `resources.yaml` (the harness's file mode) and asserts the same observable contract as before: the file-defined model is visible on `/v1/models`, and a chat completion round-trips to the mock upstream exactly once at `/v1/chat/completions`. File mode is synchronous at boot, so the etcd-propagation polling scaffolding is gone, and the smoke no longer requires etcd at all.

Deliberate Admin-API-write coverage remains where it is marked: the seed-vs-admin characterization case and the two cases commented "Deliberately seeds via the Admin API" (`openai-sdk-compat`, `datadog-exporter`). `openai-sdk-compat` additionally pins the deprecation signal itself now: an admin write must answer with an RFC-9745-shaped `Deprecation` value (`@<unix>`) and a `rel="deprecation"` link, and an admin read must answer with neither.

## Tests

- **Unit (`aisix-admin`)**: a representative create, a rotate, a former-spelling delete, and the file-managed 409 all carry both headers with the exact pinned values; GET reads, `/admin/openapi.json`, and the playground POST carry none; every OpenAPI write operation is `deprecated: true` with the declarative-paths description, and no read/non-resource operation is marked.
- **e2e**: converted smoke (file mode) + the sdk-compat deprecation-signal case; full suite run locally.
- `cargo run -p aisix-admin --bin dump-openapi` verified idempotent (two consecutive runs byte-identical); no checked-in artifacts change (resource schemas are untouched).
- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` clean.
