### PR TITLE
feat(observability): serve per-model runtime health on the status listener

### DIFF
--- a/crates/aisix-admin/Cargo.toml
+++ b/crates/aisix-admin/Cargo.toml
@@ -28,7 +28,7 @@ etcd-client.workspace = true
 aisix-obs = { path = "../aisix-obs" }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 testcontainers.workspace = true
 aisix-gateway = { path = "../aisix-gateway" }
 aisix-provider-openai = { path = "../aisix-provider-openai" }

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -440,14 +440,35 @@ async fn status_ready_handler(
 /// while both exist. Unauthenticated like `/status/config` — it exposes
 /// model names and health states, the same sensitivity class; restrict
 /// access at the network layer.
+///
+/// Store failures answer a fixed `{"error_msg": "failed to list models"}`
+/// 500: this listener is unauthenticated, so backend detail (etcd
+/// endpoints, connection errors) stays in the server log instead of the
+/// response body. The admin-key-gated endpoint keeps its detailed
+/// envelope.
 async fn status_models_handler(
     axum::extract::State(state): axum::extract::State<MetricsState>,
-) -> Result<axum::Json<Vec<models_status_handler::ModelStatusView>>, AdminError> {
-    let all_models = state.models_status.store.list_models().await?;
-    Ok(axum::Json(models_status_handler::render_models_status(
+) -> Response {
+    use axum::response::IntoResponse;
+
+    let all_models = match state.models_status.store.list_models().await {
+        Ok(models) => models,
+        Err(e) => {
+            tracing::error!(error = %e, "GET /status/models: listing models failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(ErrorBody {
+                    error_msg: "failed to list models".into(),
+                }),
+            )
+                .into_response();
+        }
+    };
+    axum::Json(models_status_handler::render_models_status(
         all_models,
         state.models_status.runtime_status_tracker.as_deref(),
-    )))
+    ))
+    .into_response()
 }
 
 fn normalized_prometheus_path(path: &str) -> String {
@@ -969,6 +990,86 @@ mod tests {
             .unwrap();
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn status_models_store_failure_never_leaks_backend_detail() {
+        use aisix_core::resource::ResourceEntry;
+        use aisix_core::{
+            A2aAgent, ApiKey, CachePolicy, Guardrail, McpServer, Model, ObservabilityExporter,
+            ProviderKey,
+        };
+
+        // A store whose every call fails with backend detail an anonymous
+        // caller must never see (mimics an etcd outage: the client error
+        // names endpoints/addresses).
+        const LEAKY: &str = "connect to http://10.0.0.7:2379 refused";
+        struct FailingStore;
+
+        macro_rules! impl_failing_store {
+            ($( { $ty:ty, $put:ident, $get:ident, $list:ident, $delete:ident } )+) => {
+                #[async_trait::async_trait]
+                impl ConfigStore for FailingStore {
+                    $(
+                        async fn $put(&self, _entry: ResourceEntry<$ty>) -> Result<(), StoreError> {
+                            Err(StoreError::Backend(LEAKY.into()))
+                        }
+                        async fn $get(
+                            &self,
+                            _id: &str,
+                        ) -> Result<Option<ResourceEntry<$ty>>, StoreError> {
+                            Err(StoreError::Backend(LEAKY.into()))
+                        }
+                        async fn $list(&self) -> Result<Vec<ResourceEntry<$ty>>, StoreError> {
+                            Err(StoreError::Backend(LEAKY.into()))
+                        }
+                        async fn $delete(&self, _id: &str) -> Result<bool, StoreError> {
+                            Err(StoreError::Backend(LEAKY.into()))
+                        }
+                    )+
+                }
+            };
+        }
+        impl_failing_store! {
+            { Model, put_model, get_model, list_models, delete_model }
+            { ApiKey, put_apikey, get_apikey, list_apikeys, delete_apikey }
+            { ProviderKey, put_provider_key, get_provider_key, list_provider_keys, delete_provider_key }
+            { Guardrail, put_guardrail, get_guardrail, list_guardrails, delete_guardrail }
+            { CachePolicy, put_cache_policy, get_cache_policy, list_cache_policies, delete_cache_policy }
+            { ObservabilityExporter, put_observability_exporter, get_observability_exporter, list_observability_exporters, delete_observability_exporter }
+            { McpServer, put_mcp_server, get_mcp_server, list_mcp_servers, delete_mcp_server }
+            { A2aAgent, put_a2a_agent, get_a2a_agent, list_a2a_agents, delete_a2a_agent }
+        }
+
+        let app = metrics_router(
+            Arc::new(Metrics::new(false)),
+            aisix_core::ConfigStatus::new(aisix_core::SourceKind::Etcd),
+            &PrometheusConfig {
+                enabled: true,
+                path: "/metrics".into(),
+                addr: "0.0.0.0:9090".into(),
+            },
+            ModelsStatusState {
+                store: Arc::new(FailingStore),
+                runtime_status_tracker: None,
+            },
+        );
+        let resp = run(
+            app,
+            Request::builder()
+                .uri("/status/models")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            !body.contains("10.0.0.7") && !body.contains("connect"),
+            "unauthenticated status listener must not leak store backend detail: {body}",
+        );
+        assert_eq!(body, r#"{"error_msg":"failed to list models"}"#);
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -71,17 +71,29 @@ pub use store::{ConfigStore, InMemoryStore, StoreError};
 use aisix_core::config::PrometheusConfig;
 use aisix_core::ConfigStatus;
 use aisix_obs::Metrics;
+use aisix_proxy::ModelRuntimeStatusTracker;
 use axum::routing::{get, post};
 use axum::{http::StatusCode, response::Response, Router};
 use std::sync::Arc;
 
 /// Shared state for the dedicated metrics/status listener: the Prometheus
-/// [`Metrics`] handle plus the load-observability [`ConfigStatus`]. Both are
-/// cheap to clone.
+/// [`Metrics`] handle, the load-observability [`ConfigStatus`], and the
+/// [`ModelsStatusState`] behind `GET /status/models`. All cheap to clone.
 #[derive(Clone)]
 pub struct MetricsState {
     pub metrics: Arc<Metrics>,
     pub config_status: ConfigStatus,
+    pub models_status: ModelsStatusState,
+}
+
+/// Sources behind `GET /status/models` on the metrics/status listener:
+/// the same resource store the admin surface reads plus the proxy's
+/// shared runtime status tracker, so the status-listener view renders
+/// from exactly the sources `GET /admin/v1/models/status` renders from.
+#[derive(Clone)]
+pub struct ModelsStatusState {
+    pub store: Arc<dyn ConfigStore>,
+    pub runtime_status_tracker: Option<Arc<ModelRuntimeStatusTracker>>,
 }
 
 pub fn admin_openapi_json() -> &'static str {
@@ -330,10 +342,11 @@ async fn file_managed_write_guard(
 }
 
 /// Build the router for the **dedicated** metrics/status listener — the
-/// Prometheus scrape endpoint at `prometheus.path`, plus the load-
-/// observability endpoints `GET /status/config` and `GET /status/ready`,
-/// backed by the shared [`Metrics`] and [`ConfigStatus`] handles. No admin
-/// state, no auth-protected routes, no playground.
+/// Prometheus scrape endpoint at `prometheus.path`, plus the operational
+/// read endpoints `GET /status/config`, `GET /status/ready`, and
+/// `GET /status/models`, backed by the shared [`Metrics`],
+/// [`ConfigStatus`], and [`ModelsStatusState`] handles. No admin state,
+/// no auth-protected routes, no playground.
 ///
 /// `aisix-server` binds this on `observability.metrics.prometheus.addr`
 /// whenever prometheus is enabled. This is the only metrics/status surface —
@@ -343,10 +356,12 @@ pub fn metrics_router(
     metrics: Arc<Metrics>,
     config_status: ConfigStatus,
     prometheus: &PrometheusConfig,
+    models_status: ModelsStatusState,
 ) -> Router {
     let state = MetricsState {
         metrics,
         config_status,
+        models_status,
     };
     Router::new()
         .route(
@@ -355,6 +370,7 @@ pub fn metrics_router(
         )
         .route("/status/config", get(status_config_handler))
         .route("/status/ready", get(status_ready_handler))
+        .route("/status/models", get(status_models_handler))
         .with_state(state)
 }
 
@@ -416,6 +432,24 @@ async fn status_ready_handler(
     }
 }
 
+/// `GET /status/models` — the per-model runtime health view (cooldown /
+/// background-check state) as an operational read on the status listener.
+/// Renders through [`models_status_handler::render_models_status`], the
+/// same render (and the same store + tracker handles) behind
+/// `GET /admin/v1/models/status`, so the two responses are identical
+/// while both exist. Unauthenticated like `/status/config` — it exposes
+/// model names and health states, the same sensitivity class; restrict
+/// access at the network layer.
+async fn status_models_handler(
+    axum::extract::State(state): axum::extract::State<MetricsState>,
+) -> Result<axum::Json<Vec<models_status_handler::ModelStatusView>>, AdminError> {
+    let all_models = state.models_status.store.list_models().await?;
+    Ok(axum::Json(models_status_handler::render_models_status(
+        all_models,
+        state.models_status.runtime_status_tracker.as_deref(),
+    )))
+}
+
 fn normalized_prometheus_path(path: &str) -> String {
     let path = path.trim();
     if path.is_empty() {
@@ -473,6 +507,15 @@ mod tests {
         let handle = SnapshotHandle::new(AisixSnapshot::new());
         let store = InMemoryStore::new() as Arc<dyn ConfigStore>;
         AdminState::new(handle, store, &cfg())
+    }
+
+    /// `ModelsStatusState` over an empty in-memory store, for metrics
+    /// listener tests that don't exercise `/status/models`.
+    fn empty_models_status() -> ModelsStatusState {
+        ModelsStatusState {
+            store: InMemoryStore::new() as Arc<dyn ConfigStore>,
+            runtime_status_tracker: None,
+        }
     }
 
     fn model_payload(name: &str) -> Value {
@@ -587,6 +630,7 @@ mod tests {
                 path: "/metrics".into(),
                 addr: "0.0.0.0:9090".into(),
             },
+            empty_models_status(),
         );
 
         // The dedicated listener serves the prometheus scrape.
@@ -638,6 +682,7 @@ mod tests {
                 path: "internal/prom".into(),
                 addr: "0.0.0.0:9090".into(),
             },
+            empty_models_status(),
         );
 
         // Path is normalized to a leading slash and served there.
@@ -677,6 +722,7 @@ mod tests {
                 path: "/metrics".into(),
                 addr: "0.0.0.0:9090".into(),
             },
+            empty_models_status(),
         );
 
         // Before any config: 503 "no configuration available".
@@ -752,6 +798,7 @@ mod tests {
                 path: "/metrics".into(),
                 addr: "0.0.0.0:9090".into(),
             },
+            empty_models_status(),
         );
         let resp = run(
             app,
@@ -798,6 +845,7 @@ mod tests {
                 path: "/metrics".into(),
                 addr: "0.0.0.0:9090".into(),
             },
+            empty_models_status(),
         );
         let resp = run(
             app,
@@ -815,6 +863,112 @@ mod tests {
         assert!(text.contains("aisix_config_applied_revision 5"));
         assert!(text.contains("aisix_config_hash_info{hash=\"deadbeef\"} 1"));
         assert!(text.contains("aisix_config_source_connected 1"));
+    }
+
+    #[tokio::test]
+    async fn status_models_serves_the_admin_view_byte_for_byte() {
+        use aisix_core::resource::ResourceEntry;
+        use aisix_core::Model;
+        use aisix_proxy::ModelRuntimeStatusTracker;
+        use std::time::Duration;
+
+        let store = InMemoryStore::new() as Arc<dyn ConfigStore>;
+        let direct: Model = serde_json::from_value(model_payload("gpt4")).unwrap();
+        store
+            .put_model(ResourceEntry {
+                id: "direct-1".into(),
+                value: direct,
+                revision: 1,
+            })
+            .await
+            .unwrap();
+        let routing: Model = serde_json::from_value(json!({
+            "display_name": "router",
+            "routing": {
+                "targets": [{"model": "gpt4"}]
+            }
+        }))
+        .unwrap();
+        store
+            .put_model(ResourceEntry {
+                id: "routing-1".into(),
+                value: routing,
+                revision: 1,
+            })
+            .await
+            .unwrap();
+
+        let tracker = Arc::new(ModelRuntimeStatusTracker::new());
+        tracker.mark_cooldown("direct-1", Duration::from_secs(60), "upstream_rate_limited");
+
+        // Admin listener view (auth-protected).
+        let admin_app = build_router(
+            AdminState::new(
+                SnapshotHandle::new(AisixSnapshot::new()),
+                Arc::clone(&store),
+                &cfg(),
+            )
+            .with_runtime_status_tracker(Arc::clone(&tracker)),
+        );
+        let resp = run(admin_app, auth_req("GET", "/admin/v1/models/status", None)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let admin_bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+
+        // Status listener view — no auth header — over the SAME store +
+        // tracker handles, exactly how `aisix-server` wires standalone mode.
+        let metrics_app = metrics_router(
+            Arc::new(Metrics::new(false)),
+            aisix_core::ConfigStatus::new(aisix_core::SourceKind::Etcd),
+            &PrometheusConfig {
+                enabled: true,
+                path: "/metrics".into(),
+                addr: "0.0.0.0:9090".into(),
+            },
+            ModelsStatusState {
+                store,
+                runtime_status_tracker: Some(tracker),
+            },
+        );
+        let resp = run(
+            metrics_app,
+            Request::builder()
+                .uri("/status/models")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let status_bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+
+        assert_eq!(
+            admin_bytes, status_bytes,
+            "GET /status/models must serve the exact bytes of GET /admin/v1/models/status",
+        );
+
+        // Sanity on the shared body: cooldown state and the virtual row
+        // actually render.
+        let rows: Value = serde_json::from_slice(&status_bytes).unwrap();
+        let rows = rows.as_array().unwrap();
+        assert_eq!(rows.len(), 2);
+        let direct = rows.iter().find(|row| row["id"] == "direct-1").unwrap();
+        assert_eq!(direct["status"], "cooldown");
+        assert_eq!(direct["status_reason"], "upstream_rate_limited");
+        assert!(!direct["cooldown_until"].is_null());
+        let routing = rows.iter().find(|row| row["id"] == "routing-1").unwrap();
+        assert_eq!(routing["status"], "not_applicable");
+    }
+
+    #[tokio::test]
+    async fn admin_router_does_not_serve_status_models() {
+        // The operational read lives on the metrics/status listener; the
+        // admin listener keeps only its own `/admin/v1/models/status`.
+        let app = build_router(build_state());
+        let req = Request::builder()
+            .uri("/status/models")
+            .body(Body::empty())
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -432,36 +432,63 @@ async fn status_ready_handler(
     }
 }
 
+/// Upper bound on the store read behind `GET /status/models`: the
+/// listener is unauthenticated and polled by probes and dashboards, so a
+/// stalled configuration store must not park those requests (or hold the
+/// shared store client) indefinitely — past this, the request answers
+/// the same fixed 500 a store error does.
+const STATUS_MODELS_STORE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// The fixed store-failure answer for `GET /status/models`: this
+/// listener is unauthenticated, so backend detail (etcd endpoints,
+/// connection errors) stays in the server log instead of the response
+/// body. The admin-key-gated endpoint keeps its detailed envelope.
+fn status_models_store_failure() -> Response {
+    use axum::response::IntoResponse;
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        axum::Json(ErrorBody {
+            error_msg: "failed to list models".into(),
+        }),
+    )
+        .into_response()
+}
+
 /// `GET /status/models` — the per-model runtime health view (cooldown /
 /// background-check state) as an operational read on the status listener.
 /// Renders through [`models_status_handler::render_models_status`], the
 /// same render (and the same store + tracker handles) behind
 /// `GET /admin/v1/models/status`, so the two responses are identical
 /// while both exist. Unauthenticated like `/status/config` — it exposes
-/// model names and health states, the same sensitivity class; restrict
+/// the model catalog (ids and display names) and health states; restrict
 /// access at the network layer.
 ///
-/// Store failures answer a fixed `{"error_msg": "failed to list models"}`
-/// 500: this listener is unauthenticated, so backend detail (etcd
-/// endpoints, connection errors) stays in the server log instead of the
-/// response body. The admin-key-gated endpoint keeps its detailed
-/// envelope.
+/// Store failures answer the fixed 500 from
+/// [`status_models_store_failure`], and the store read is bounded by
+/// [`STATUS_MODELS_STORE_TIMEOUT`] so a hung store degrades into that
+/// same answer instead of parking anonymous pollers.
 async fn status_models_handler(
     axum::extract::State(state): axum::extract::State<MetricsState>,
 ) -> Response {
     use axum::response::IntoResponse;
 
-    let all_models = match state.models_status.store.list_models().await {
-        Ok(models) => models,
-        Err(e) => {
+    let listed = tokio::time::timeout(
+        STATUS_MODELS_STORE_TIMEOUT,
+        state.models_status.store.list_models(),
+    )
+    .await;
+    let all_models = match listed {
+        Ok(Ok(models)) => models,
+        Ok(Err(e)) => {
             tracing::error!(error = %e, "GET /status/models: listing models failed");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                axum::Json(ErrorBody {
-                    error_msg: "failed to list models".into(),
-                }),
-            )
-                .into_response();
+            return status_models_store_failure();
+        }
+        Err(_) => {
+            tracing::error!(
+                timeout = ?STATUS_MODELS_STORE_TIMEOUT,
+                "GET /status/models: listing models timed out"
+            );
+            return status_models_store_failure();
         }
     };
     axum::Json(models_status_handler::render_models_status(
@@ -1069,6 +1096,82 @@ mod tests {
             !body.contains("10.0.0.7") && !body.contains("connect"),
             "unauthenticated status listener must not leak store backend detail: {body}",
         );
+        assert_eq!(body, r#"{"error_msg":"failed to list models"}"#);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn status_models_answers_the_fixed_500_when_the_store_hangs() {
+        use aisix_core::resource::ResourceEntry;
+        use aisix_core::{
+            A2aAgent, ApiKey, CachePolicy, Guardrail, McpServer, Model, ObservabilityExporter,
+            ProviderKey,
+        };
+
+        // A store whose every call never resolves (mimics a blackholed
+        // etcd: the connection hangs instead of failing). The paused
+        // clock auto-advances past STATUS_MODELS_STORE_TIMEOUT, so the
+        // test asserts the timeout arm without real waiting.
+        struct HangingStore;
+
+        macro_rules! impl_hanging_store {
+            ($( { $ty:ty, $put:ident, $get:ident, $list:ident, $delete:ident } )+) => {
+                #[async_trait::async_trait]
+                impl ConfigStore for HangingStore {
+                    $(
+                        async fn $put(&self, _entry: ResourceEntry<$ty>) -> Result<(), StoreError> {
+                            std::future::pending().await
+                        }
+                        async fn $get(
+                            &self,
+                            _id: &str,
+                        ) -> Result<Option<ResourceEntry<$ty>>, StoreError> {
+                            std::future::pending().await
+                        }
+                        async fn $list(&self) -> Result<Vec<ResourceEntry<$ty>>, StoreError> {
+                            std::future::pending().await
+                        }
+                        async fn $delete(&self, _id: &str) -> Result<bool, StoreError> {
+                            std::future::pending().await
+                        }
+                    )+
+                }
+            };
+        }
+        impl_hanging_store! {
+            { Model, put_model, get_model, list_models, delete_model }
+            { ApiKey, put_apikey, get_apikey, list_apikeys, delete_apikey }
+            { ProviderKey, put_provider_key, get_provider_key, list_provider_keys, delete_provider_key }
+            { Guardrail, put_guardrail, get_guardrail, list_guardrails, delete_guardrail }
+            { CachePolicy, put_cache_policy, get_cache_policy, list_cache_policies, delete_cache_policy }
+            { ObservabilityExporter, put_observability_exporter, get_observability_exporter, list_observability_exporters, delete_observability_exporter }
+            { McpServer, put_mcp_server, get_mcp_server, list_mcp_servers, delete_mcp_server }
+            { A2aAgent, put_a2a_agent, get_a2a_agent, list_a2a_agents, delete_a2a_agent }
+        }
+
+        let app = metrics_router(
+            Arc::new(Metrics::new(false)),
+            aisix_core::ConfigStatus::new(aisix_core::SourceKind::Etcd),
+            &PrometheusConfig {
+                enabled: true,
+                path: "/metrics".into(),
+                addr: "0.0.0.0:9090".into(),
+            },
+            ModelsStatusState {
+                store: Arc::new(HangingStore),
+                runtime_status_tracker: None,
+            },
+        );
+        let resp = run(
+            app,
+            Request::builder()
+                .uri("/status/models")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
         assert_eq!(body, r#"{"error_msg":"failed to list models"}"#);
     }
 

--- a/crates/aisix-admin/src/models_status_handler.rs
+++ b/crates/aisix-admin/src/models_status_handler.rs
@@ -1,11 +1,15 @@
-//! `GET /admin/v1/models/status` — runtime per-model status.
+//! Runtime per-model status: the render shared by
+//! `GET /admin/v1/models/status` (admin listener) and
+//! `GET /status/models` (metrics/status listener).
 
 use axum::extract::State;
 use axum::Json;
 use serde::Serialize;
 use std::time::Duration;
 
-use aisix_proxy::{RuntimeStatus, RuntimeStatusSnapshot};
+use aisix_core::resource::ResourceEntry;
+use aisix_core::Model;
+use aisix_proxy::{ModelRuntimeStatusTracker, RuntimeStatus, RuntimeStatusSnapshot};
 
 use crate::auth::AdminAuth;
 use crate::error::AdminError;
@@ -34,9 +38,21 @@ pub async fn get_models_status(
     State(state): State<AdminState>,
 ) -> Result<Json<Vec<ModelStatusView>>, AdminError> {
     let all_models = state.store.list_models().await?;
-    let tracker = state.runtime_status_tracker.as_ref();
+    Ok(Json(render_models_status(
+        all_models,
+        state.runtime_status_tracker.as_deref(),
+    )))
+}
 
-    let models = all_models
+/// Render the per-model runtime status view from a resource listing plus
+/// the proxy's runtime tracker. The single render behind both serving
+/// endpoints — admin listener and metrics/status listener — so the two
+/// responses cannot drift while both exist.
+pub(crate) fn render_models_status(
+    all_models: Vec<ResourceEntry<Model>>,
+    tracker: Option<&ModelRuntimeStatusTracker>,
+) -> Vec<ModelStatusView> {
+    all_models
         .into_iter()
         .map(|entry| {
             // Virtual routers (routing / ensemble / semantic) have no
@@ -80,7 +96,5 @@ pub async fn get_models_status(
                 }
             }
         })
-        .collect();
-
-    Ok(Json(models))
+        .collect()
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -805,6 +805,23 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         ))),
         _ => None,
     };
+    // Per-model runtime health as an operational read on the metrics/status
+    // listener (`GET /status/models`). Standalone mode shares the admin
+    // surface's store handle, so the status-listener view and
+    // `GET /admin/v1/models/status` read the very same source; managed mode
+    // has no admin store and serves the applied snapshot through the same
+    // read-only view file mode uses (the path only appears in write
+    // rejections, which the read-only status listener never issues).
+    let status_models_state = aisix_admin::ModelsStatusState {
+        store: match &admin_store {
+            Some(store) => Arc::clone(store),
+            None => Arc::new(FileManagedStore::new(
+                snapshot_handle.clone(),
+                "the control plane",
+            )),
+        },
+        runtime_status_tracker: Some(runtime_status_tracker.clone()),
+    };
     let admin_serve_handle = if let Some(admin_store) = admin_store {
         let mut admin_state = AdminState::new(snapshot_handle.clone(), admin_store, &cfg.admin)
             // Share the health tracker so /admin/v1/health reflects live
@@ -867,8 +884,12 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // probe.
             std::net::TcpListener::bind(metrics_addr)
                 .map_err(|e| anyhow::anyhow!("metrics listener bind {metrics_addr} failed: {e}"))?;
-            let metrics_router =
-                aisix_admin::metrics_router(metrics.clone(), config_status.clone(), prom);
+            let metrics_router = aisix_admin::metrics_router(
+                metrics.clone(),
+                config_status.clone(),
+                prom,
+                status_models_state,
+            );
             Some(tokio::spawn(serve_http(
                 metrics_addr,
                 metrics_router,

--- a/tests/e2e/src/cases/background-health-e2e.test.ts
+++ b/tests/e2e/src/cases/background-health-e2e.test.ts
@@ -60,7 +60,7 @@ describe("background health e2e", () => {
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const unhealthyPk = await seed.createProviderKey({

--- a/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
@@ -75,7 +75,7 @@ describe("cooldown contract (H1) — 401 cools down despite being non-retryable"
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const failPk = await seed.createProviderKey({
@@ -226,7 +226,7 @@ describe("cooldown contract (M1) — 429 cools down even when retry_on_429=false
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const rateLimitedPk = await seed.createProviderKey({
@@ -379,7 +379,7 @@ describe("cooldown contract (H2) — Retry-After header from upstream drives TTL
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const upstreamPk = await seed.createProviderKey({
@@ -517,7 +517,7 @@ describe("filter contract (H3) — all candidates unhealthy returns 503", () => 
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const aPk = await seed.createProviderKey({
@@ -647,7 +647,7 @@ describe("filter contract (H3 escape hatch) — try_anyway sends to known-bad", 
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const pk = await seed.createProviderKey({
@@ -766,7 +766,7 @@ describe("cooldown observability — a cooldown transition emits aisix_deploymen
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const failPk = await seed.createProviderKey({
@@ -959,7 +959,7 @@ describe("cooldown observability — the state gauge follows a target back into 
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const flakyPk = await seed.createProviderKey({

--- a/tests/e2e/src/cases/retry-on-429-vs-background-ignore-e2e.test.ts
+++ b/tests/e2e/src/cases/retry-on-429-vs-background-ignore-e2e.test.ts
@@ -64,7 +64,7 @@ describe("retry_on_429 vs background ignore e2e", () => {
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const primaryPk = await seed.createProviderKey({

--- a/tests/e2e/src/cases/runtime-mixed-filtering-e2e.test.ts
+++ b/tests/e2e/src/cases/runtime-mixed-filtering-e2e.test.ts
@@ -77,7 +77,7 @@ describe("runtime mixed filtering e2e", () => {
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const unhealthyPk = await seed.createProviderKey({

--- a/tests/e2e/src/cases/runtime-status-e2e.test.ts
+++ b/tests/e2e/src/cases/runtime-status-e2e.test.ts
@@ -75,7 +75,7 @@ describe("runtime status e2e", () => {
     });
 
     app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const flakyPk = await seed.createProviderKey({

--- a/tests/e2e/src/cases/status-models-e2e.test.ts
+++ b/tests/e2e/src/cases/status-models-e2e.test.ts
@@ -1,0 +1,246 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for `GET /status/models` on the dedicated metrics/status listener:
+// the per-model runtime health view (cooldown / background-check state) as
+// an operational read that does not depend on the admin listener. While
+// both endpoints exist, the status-listener response must be exactly the
+// admin listener's `GET /admin/v1/models/status` response — same JSON,
+// same ordering — which these cases pin against the live gateway in both
+// resource-source modes (etcd watch and standalone file).
+
+const CALLER_PLAINTEXT = "sk-status-models-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+async function fetchStatusModels(
+  app: SpawnedApp,
+): Promise<{ raw: string; rows: Array<Record<string, unknown>>; contentType: string | null }> {
+  const res = await fetch(`${app.metricsUrl}/status/models`);
+  expect(res.status).toBe(200);
+  const raw = await res.text();
+  return {
+    raw,
+    rows: JSON.parse(raw) as Array<Record<string, unknown>>,
+    contentType: res.headers.get("content-type"),
+  };
+}
+
+async function fetchAdminModelStatuses(
+  app: SpawnedApp,
+): Promise<{ raw: string; rows: Array<Record<string, unknown>>; contentType: string | null }> {
+  const res = await fetch(`${app.adminUrl}/admin/v1/models/status`, {
+    headers: { authorization: `Bearer ${app.adminKey}` },
+  });
+  expect(res.status).toBe(200);
+  const raw = await res.text();
+  return {
+    raw,
+    rows: JSON.parse(raw) as Array<Record<string, unknown>>,
+    contentType: res.headers.get("content-type"),
+  };
+}
+
+describe("status/models: etcd mode — equivalence with the admin endpoint", () => {
+  let app: SpawnedApp | undefined;
+  let authFailUpstream: OpenAiUpstream | undefined;
+  let stableUpstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+  let authFailModelID = "";
+  let stableModelID = "";
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    authFailUpstream = await startOpenAiUpstream({
+      status: 401,
+      errorBody: {
+        error: { message: "Incorrect API key provided", type: "invalid_request_error" },
+      },
+    });
+    stableUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-status-models-stable",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "status-models stable" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const failPk = await seed.createProviderKey({
+      display_name: "status-models-401-pk",
+      secret: "sk-mock",
+      api_base: `${authFailUpstream.baseUrl}/v1`,
+    });
+    const stablePk = await seed.createProviderKey({
+      display_name: "status-models-stable-pk",
+      secret: "sk-mock",
+      api_base: `${stableUpstream.baseUrl}/v1`,
+    });
+    authFailModelID = (
+      await seed.createModel({
+        display_name: "status-models-401",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: failPk.id,
+      })
+    ).id;
+    stableModelID = (
+      await seed.createModel({
+        display_name: "status-models-stable",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: stablePk.id,
+      })
+    ).id;
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["status-models-401", "status-models-stable"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await authFailUpstream?.close();
+    await stableUpstream?.close();
+  });
+
+  test("serves the same JSON as the admin endpoint, with one model in cooldown", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // Readiness: both models visible on the status listener AND the
+    // stable model actually dispatchable end-to-end.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const { rows } = await fetchStatusModels(app!);
+      if (rows.length < 2) return false;
+      const probe = await proxy.chat({
+        model: "status-models-stable",
+        messages: [{ role: "user", content: "ready-status-models" }],
+      });
+      return probe.status === 200;
+    });
+
+    // Trip the auth-failing model once: the 401 surfaces to the caller
+    // and puts the direct model into cooldown.
+    const tripped = await proxy.chat({
+      model: "status-models-401",
+      messages: [{ role: "user", content: "trip cooldown" }],
+    });
+    expect(tripped.status).toBe(401);
+    await waitConfigPropagation(async () => {
+      const { rows } = await fetchStatusModels(app!);
+      return rows.some((row) => row.id === authFailModelID && row.status === "cooldown");
+    });
+
+    // The status-listener body is the admin body: same JSON, same order,
+    // same content type. Raw-text equality is the strongest form; the
+    // parsed deep-equal repeats it with a readable diff on failure.
+    const admin = await fetchAdminModelStatuses(app);
+    const status = await fetchStatusModels(app);
+    expect(status.rows).toEqual(admin.rows);
+    expect(status.raw).toBe(admin.raw);
+    expect(status.contentType).toBe(admin.contentType);
+
+    // And the shared body carries the expected runtime state.
+    const cooled = status.rows.find((row) => row.id === authFailModelID)!;
+    expect(cooled.kind).toBe("direct");
+    expect(cooled.status).toBe("cooldown");
+    expect(cooled.status_reason).toBe("upstream_auth_failure");
+    expect(cooled.cooldown_until).toBeTruthy();
+    const stable = status.rows.find((row) => row.id === stableModelID)!;
+    expect(stable.status).toBe("healthy");
+  });
+
+  test("status listener needs no key while the admin route still requires one", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // Unauthenticated operational read — same trust domain as
+    // /status/config on the same listener.
+    const status = await fetch(`${app.metricsUrl}/status/models`);
+    expect(status.status).toBe(200);
+    await status.text();
+
+    // The admin listener's endpoint keeps its admin-key auth.
+    const admin = await fetch(`${app.adminUrl}/admin/v1/models/status`);
+    expect(admin.status).toBe(401);
+    await admin.text();
+  });
+});
+
+describe("status/models: standalone file source", () => {
+  let app: SpawnedApp | undefined;
+
+  beforeAll(async () => {
+    app = await spawnApp({
+      resourcesFile: `
+_format_version: "1"
+provider_keys:
+  - display_name: file-status-models-pk
+    provider: openai
+    api_key: sk-mock
+    api_base: http://127.0.0.1:9/v1
+models:
+  - display_name: file-status-models-direct
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: file-status-models-pk
+`,
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+  });
+
+  test("file mode serves the runtime health view on the status listener", async () => {
+    if (!app) throw new Error("setup failed");
+
+    // File mode is synchronous at boot — no propagation wait needed.
+    const { rows } = await fetchStatusModels(app);
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.display_name).toBe("file-status-models-direct");
+    expect(typeof row.id).toBe("string");
+    expect(row.id).toBeTruthy();
+    expect(row.kind).toBe("direct");
+    expect(row.status).toBe("healthy");
+  });
+
+  test("file mode status listener matches the admin endpoint too", async () => {
+    if (!app) throw new Error("setup failed");
+
+    const admin = await fetchAdminModelStatuses(app);
+    const status = await fetchStatusModels(app);
+    expect(status.rows).toEqual(admin.rows);
+    expect(status.raw).toBe(admin.raw);
+  });
+});

--- a/tests/e2e/src/harness/admin.ts
+++ b/tests/e2e/src/harness/admin.ts
@@ -8,6 +8,12 @@ export class AdminClient {
   constructor(
     private readonly baseUrl: string,
     private readonly adminKey: string,
+    /**
+     * Base URL of the dedicated metrics/status listener
+     * (`app.metricsUrl`). Required by `listModelStatuses`, which reads
+     * the per-model runtime health view from `GET /status/models` there.
+     */
+    private readonly metricsBaseUrl?: string,
   ) {}
 
   async createModel(
@@ -58,7 +64,25 @@ export class AdminClient {
   }
 
   async listModelStatuses(): Promise<Array<Record<string, unknown>>> {
-    return this.json<Array<Record<string, unknown>>>("GET", "/admin/v1/models/status");
+    // Per-model runtime health is an operational read served by the
+    // metrics/status listener (`GET /status/models`, unauthenticated —
+    // same trust domain as `/status/config`). Same JSON as the admin
+    // listener's `GET /admin/v1/models/status`; consumers keep their
+    // assertions while exercising the status-listener endpoint.
+    if (!this.metricsBaseUrl) {
+      throw new Error(
+        "listModelStatuses reads GET /status/models on the metrics/status listener — " +
+          "construct AdminClient with the metricsBaseUrl argument (app.metricsUrl)",
+      );
+    }
+    const res = await harnessRequest(`${this.metricsBaseUrl}/status/models`, {
+      method: "GET",
+    });
+    const text = await res.body.text();
+    if (res.statusCode >= 300) {
+      throw new Error(`GET /status/models → ${res.statusCode}: ${text.slice(0, 512)}`);
+    }
+    return JSON.parse(text) as Array<Record<string, unknown>>;
   }
 
   async json<T = Record<string, unknown>>(


### PR DESCRIPTION
## What

`GET /status/models` on the dedicated metrics/status listener: the per-model runtime health view (cooldown / background-check state) as an operational read, next to `/status/config` and `/status/ready`. The response is exactly what `GET /admin/v1/models/status` serves; the admin endpoint is unchanged.

## Why

Operational reads now have a home on the operational listener. The runtime health view is proxy-runtime state — which targets are cooling down and why — the kind of state probes, dashboards, and scrape-side tooling poll on day 2. Serving it only on the admin listener couples those reads to the management surface and its admin-key auth (and managed mode does not bind an admin listener at all). The metrics/status listener is already the unauthenticated, network-restricted operational surface (#774), identical in every mode, which mirrors the ecosystem-wide split between a management API and a dedicated status/health port.

Sensitivity class matches the listener: the view exposes the model catalog (ids and display names) and health states — the same class as `/status/config`'s `resource_counts` and `rejected[]` resource ids already served there. No auth, like the scrape — restrict at the network layer.

## Design: one render, one source

- `render_models_status(...)` is extracted in `models_status_handler.rs` and is the single render behind **both** endpoints, so the two responses cannot drift while both exist.
- The status listener reads through the **same** `Arc<dyn ConfigStore>` handle the admin surface uses (etcd store in etcd mode, snapshot read-view in file mode) plus the same shared `ModelRuntimeStatusTracker` — same data, same ordering, same serialization. A unit test pins the two bodies **byte-for-byte**.
- Managed mode (no admin store) serves the applied snapshot through the same read-only store view file mode uses, keeping the metrics/status listener surface identical across modes.
- Store failures answer a fixed `{"error_msg": "failed to list models"}` 500 on this unauthenticated surface — backend detail (etcd endpoints, connection errors) stays in the server log, while the admin-key-gated endpoint keeps its detailed envelope. Success bodies stay byte-identical.
- The store read is bounded by a 5-second timeout that degrades into the same fixed 500: a hung store (blackholed etcd) cannot park anonymous pollers or hold the shared store client while they pile up.
- No OpenAPI change: the generated Admin API spec documents the admin listener only; status-listener endpoints follow the `/status/config` precedent. Docs-site follow-up will list `/status/models` alongside the other status endpoints.

## e2e harness repoint

`AdminClient.listModelStatuses()` now reads `GET /status/models` on the metrics/status listener (new optional `metricsBaseUrl` constructor argument; method signature and return shape unchanged). The existing runtime-status consumers — background-health, cooldown-contract, retry-on-429-vs-background-ignore, runtime-mixed-filtering, runtime-status — exercise the new endpoint end-to-end with their assertions untouched.

## Tests

- Unit: `status_models_serves_the_admin_view_byte_for_byte` (same store + tracker handles → byte-identical bodies, covering a cooldown row and a virtual `not_applicable` row); `status_models_store_failure_never_leaks_backend_detail` (failing store → fixed 500 body, no backend detail); `status_models_answers_the_fixed_500_when_the_store_hangs` (paused-clock test with a never-resolving store → the timeout arm answers the same fixed body); `admin_router_does_not_serve_status_models`; the existing metrics-listener tests updated for the new router argument.
- e2e (`status-models-e2e.test.ts`, new):
  - etcd mode: one model tripped into cooldown by a real 401 upstream, then `GET /status/models` vs `GET /admin/v1/models/status` asserted deep-equal **and** raw-text-equal (same order, same bytes), plus the expected cooldown contract (`status=cooldown`, `status_reason=upstream_auth_failure`, `cooldown_until` set).
  - Auth split: the status listener serves without a key while the admin route still requires one.
  - File mode: the view serves on the status listener and matches the admin endpoint.
- Managed mode is wired but not e2e-covered (the e2e harness has no control plane); its serving path — the read-only snapshot store view feeding the shared render on the status listener — is the same one the file-mode e2e cases exercise, just with a different snapshot feeder.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` green; full e2e suite green twice locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated `GET /status/models` endpoint on the metrics/status listener.
  * Exposes per-model runtime health and status information, matching the admin model-status view.
  * Supports model status reporting in both managed and standalone deployments.

* **Bug Fixes**
  * Model listing failures and timeouts now return a consistent, non-sensitive error response.
  * Improved status-client handling for metrics endpoint requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->