### PR TITLE
feat(guardrails): preserve Aliyun's upstream RequestId and correlate it to the gateway request

### DIFF
--- a/crates/aisix-guardrails/src/aliyun.rs
+++ b/crates/aisix-guardrails/src/aliyun.rs
@@ -19,6 +19,13 @@
 //!   "Result": [ { "Label": "..." } ] }, "RequestId": "..." }
 //! ```
 //!
+//! `Code` is typed inconsistently and the difference matters: on HTTP 200
+//! it is an integer (`200`, or a business error such as `400` "service is
+//! invalid"), but on an HTTP error it is a symbolic string
+//! (`"InvalidAccessKeyId.NotFound"`). Only the HTTP-200 shape is
+//! deserialized as [`AliyunResponse`]; the error shape is logged as a raw
+//! capped body.
+//!
 //! Block decision: the returned `RiskLevel` rank (none<low<medium<high)
 //! reaches the configured `risk_level_threshold`.
 //!
@@ -137,9 +144,38 @@ impl AliyunTextModerationGuardrail {
         // already windows to MAX_CONTENT_CHARS; non-streaming long inputs
         // are clamped (the leading content carries the risk in practice).
         let content: String = text.chars().take(MAX_CONTENT_CHARS).collect();
-        match self.call(service, &content, session_id).await {
+        let (outcome, diag) = self.call(service, &content, session_id).await;
+        match outcome {
             Ok(level) => {
-                if risk_rank(&level) >= self.threshold_rank {
+                let blocked = risk_rank(&level) >= self.threshold_rank;
+                // The upstream diagnostics land here, once, with the
+                // verdict known — rather than at each exit of `call()`,
+                // which can't see it. A block is what an operator traces
+                // back from a caller's 422, so it logs at info (the
+                // default level); a clean pass would be one line per
+                // request, so it stays at debug.
+                if blocked {
+                    tracing::info!(
+                        row = %self.row_name,
+                        service,
+                        aliyun_request_id = %diag.request_id,
+                        aliyun_code = %diag.code,
+                        aliyun_risk_level = %diag.risk_level,
+                        aliyun_labels = %diag.labels_field(),
+                        "aliyun text moderation blocked content",
+                    );
+                } else {
+                    tracing::debug!(
+                        row = %self.row_name,
+                        service,
+                        aliyun_request_id = %diag.request_id,
+                        aliyun_code = %diag.code,
+                        aliyun_risk_level = %diag.risk_level,
+                        aliyun_labels = %diag.labels_field(),
+                        "aliyun text moderation passed content",
+                    );
+                }
+                if blocked {
                     GuardrailVerdict::block(format!(
                         "aliyun text moderation: risk level {} >= threshold (row: {})",
                         level, self.row_name
@@ -148,18 +184,24 @@ impl AliyunTextModerationGuardrail {
                     GuardrailVerdict::Allow
                 }
             }
-            Err(failure) => self.handle_failure(failure, fail_open),
+            Err(failure) => self.handle_failure(failure, &diag, fail_open),
         }
     }
 
     /// Sign + POST one `TextModerationPlus` call; return the response
-    /// `RiskLevel` (lowercased, `"none"` when absent).
+    /// `RiskLevel` (lowercased, `"none"` when absent) alongside whatever
+    /// upstream diagnostics the call yielded.
+    ///
+    /// Diagnostics come back on BOTH arms on purpose: the failure arms are
+    /// exactly the ones an operator needs `aliyun_request_id` for, and
+    /// returning them rather than logging in place lets the one call site
+    /// log once with the verdict attached (AISIX-Cloud#1060).
     async fn call(
         &self,
         service: &str,
         content: &str,
         session_id: Option<&str>,
-    ) -> Result<String, AliyunFailure> {
+    ) -> (Result<String, AliyunFailure>, AliyunDiagnostics) {
         let mut svc_params = serde_json::Map::new();
         svc_params.insert(
             "content".into(),
@@ -219,69 +261,94 @@ impl AliyunTextModerationGuardrail {
             .body(body)
             .send();
 
+        // No response means no diagnostics to report: an id Aliyun never
+        // sent can't be invented. `request_id` stays empty and the failure
+        // bucket carries the whole story.
         let resp = match tokio::time::timeout(self.timeout, future).await {
-            Err(_elapsed) => return Err(AliyunFailure::Timeout),
-            Ok(Err(_e)) => return Err(AliyunFailure::IoError),
+            Err(_elapsed) => return (Err(AliyunFailure::Timeout), AliyunDiagnostics::default()),
+            Ok(Err(_e)) => return (Err(AliyunFailure::IoError), AliyunDiagnostics::default()),
             Ok(Ok(r)) => r,
         };
 
+        // Read the id off the headers up front: it survives every path
+        // below, including the ones where the body is unusable.
+        let mut diag = AliyunDiagnostics::from_headers(resp.headers());
+
         let status = resp.status();
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            return Err(AliyunFailure::Throttled);
+            return (Err(AliyunFailure::Throttled), diag);
         }
         if status.is_server_error() {
-            return Err(AliyunFailure::ServerError);
+            return (Err(AliyunFailure::ServerError), diag);
         }
         if !status.is_success() {
             // Echo the provider's actual reason (e.g. `InvalidAccessKeyId.NotFound`
             // or a 404 HTML page) — a bare status code can't tell a wrong access
-            // key from a wrong region/endpoint.
+            // key from a wrong region/endpoint. The body is NOT parsed as
+            // `AliyunResponse` here: on an HTTP error Aliyun types `Code` as a
+            // symbolic string rather than the int it uses on HTTP 200, so the
+            // struct wouldn't deserialize. The raw capped body already carries
+            // the code and message verbatim.
             let response_body = crate::read_error_body_capped(resp).await;
             tracing::error!(
                 row = %self.row_name,
+                aliyun_request_id = %diag.request_id,
                 http_status = status.as_u16(),
                 response_body = %response_body,
                 "aliyun TextModerationPlus returned 4xx — check region/access keys configuration",
             );
-            return Err(AliyunFailure::ConfigError);
+            return (Err(AliyunFailure::ConfigError), diag);
         }
 
-        let body: AliyunResponse = resp.json().await.map_err(|_| AliyunFailure::ServerError)?;
+        let body: AliyunResponse = match resp.json().await {
+            Ok(b) => b,
+            Err(_) => return (Err(AliyunFailure::MalformedResponse), diag),
+        };
+        diag.absorb_body(&body);
 
         // Aliyun signals app-level errors via the JSON `Code` (200 = OK)
         // even on HTTP 200.
-        match body.code {
-            200 => Ok(body
-                .data
-                .and_then(|d| d.risk_level)
-                .unwrap_or_else(|| "none".to_owned())
-                .to_lowercase()),
+        let outcome = match body.code {
+            200 => Ok(if diag.risk_level.is_empty() {
+                "none".to_owned()
+            } else {
+                diag.risk_level.to_lowercase()
+            }),
             408 | 401 | 403 | 400 => {
                 tracing::error!(
                     row = %self.row_name,
-                    aliyun_code = body.code,
-                    aliyun_message =
-                        %crate::truncate_error_body_for_log(body.message.as_deref().unwrap_or("")),
+                    aliyun_request_id = %diag.request_id,
+                    aliyun_code = %diag.code,
+                    aliyun_message = %diag.message_field(),
                     "aliyun TextModerationPlus auth/permission error — check access keys",
                 );
                 Err(AliyunFailure::ConfigError)
             }
-            other => {
+            _ => {
                 tracing::warn!(
                     row = %self.row_name,
-                    aliyun_code = other,
+                    aliyun_request_id = %diag.request_id,
+                    aliyun_code = %diag.code,
+                    aliyun_message = %diag.message_field(),
                     "aliyun TextModerationPlus non-200 Code",
                 );
                 Err(AliyunFailure::ServerError)
             }
-        }
+        };
+        (outcome, diag)
     }
 
-    fn handle_failure(&self, failure: AliyunFailure, fail_open: bool) -> GuardrailVerdict {
+    fn handle_failure(
+        &self,
+        failure: AliyunFailure,
+        diag: &AliyunDiagnostics,
+        fail_open: bool,
+    ) -> GuardrailVerdict {
         let tag = failure.bypass_tag();
         if !matches!(failure, AliyunFailure::ConfigError) {
             tracing::warn!(
                 row = %self.row_name,
+                aliyun_request_id = %diag.request_id,
                 failure = ?failure,
                 fail_open,
                 "aliyun text moderation call failed",
@@ -367,6 +434,11 @@ enum AliyunFailure {
     Throttled,
     IoError,
     ServerError,
+    /// HTTP 2xx whose body wasn't the documented JSON. Distinct from
+    /// `ServerError` so triage isn't told "5xx" for a response that in
+    /// fact arrived intact and merely didn't parse (AISIX-Cloud#1060) —
+    /// the two want different fixes.
+    MalformedResponse,
     ConfigError,
 }
 
@@ -376,8 +448,91 @@ impl AliyunFailure {
             Self::Timeout => "aliyun_timeout",
             Self::Throttled => "aliyun_throttled",
             Self::IoError | Self::ServerError => "aliyun_5xx",
+            Self::MalformedResponse => "aliyun_bad_response",
             Self::ConfigError => "aliyun_config_error",
         }
+    }
+}
+
+/// The `x-acs-request-id` response header. Every Alibaba Cloud OpenAPI
+/// response carries it — verified against the live `green-cip` endpoint on
+/// 2xx, on a JSON business error, and on 400/404 responses whose body is
+/// XML rather than JSON. It is therefore a strictly more reliable source
+/// for the id than the body's `RequestId`, which is unreachable exactly
+/// when the body doesn't parse.
+const ACS_REQUEST_ID_HEADER: &str = "x-acs-request-id";
+
+/// What one `TextModerationPlus` call reported about itself, for operator
+/// triage (AISIX-Cloud#1060).
+///
+/// Provider metadata ONLY. The moderation result echoes the offending text
+/// back in `Data.Result[].RiskWords` / `RiskPositions`; per #153 none of
+/// that may reach a log, so this type deliberately has nowhere to put it.
+/// `Label` is the matched CATEGORY (e.g. `violent_incidents`), not the
+/// matched content, and is safe.
+#[derive(Debug, Default, Clone, PartialEq)]
+struct AliyunDiagnostics {
+    /// Aliyun's own request id, for looking the call up in the Aliyun
+    /// console. Named `aliyun_request_id` in logs — never `request_id`,
+    /// which is the gateway's own id (`x-aisix-request-id`) and is
+    /// supplied by the request-scoped tracing span.
+    ///
+    /// Empty only when no HTTP response arrived at all (timeout, connect
+    /// failure), which the failure bucket names.
+    request_id: String,
+    /// Business `Code` from the response body: `200` on success, or e.g.
+    /// `400` ("service is invalid"). Empty when the body didn't parse.
+    /// Rendered as a string because the same field is an integer on an
+    /// HTTP-200 body but a symbolic code (`InvalidAccessKeyId.NotFound`)
+    /// on an HTTP-error body.
+    code: String,
+    /// Body `Message` — the provider's own explanation ("OK", "service is
+    /// invalid"). Capped for logging like any provider-supplied string.
+    message: String,
+    /// `Data.RiskLevel` — `high` / `medium` / `low` / `none`.
+    risk_level: String,
+    /// `Data.Result[].Label` — the matched categories. Plural: one prompt
+    /// commonly trips several (`inappropriate_oral` + `violent_incidents`).
+    labels: Vec<String>,
+}
+
+impl AliyunDiagnostics {
+    /// Seed from the response headers, before the body is consumed — so
+    /// the id survives a body that never parses.
+    fn from_headers(headers: &reqwest::header::HeaderMap) -> Self {
+        Self {
+            request_id: headers
+                .get(ACS_REQUEST_ID_HEADER)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_owned(),
+            ..Self::default()
+        }
+    }
+
+    /// Fold in everything the parsed body adds.
+    fn absorb_body(&mut self, body: &AliyunResponse) {
+        // Header and body carry the same id; the header already won.
+        // Fall back for a server that somehow omits the header.
+        if self.request_id.is_empty() {
+            self.request_id = body.request_id.clone().unwrap_or_default();
+        }
+        self.code = body.code.to_string();
+        self.message = body.message.clone().unwrap_or_default();
+        if let Some(data) = body.data.as_ref() {
+            self.risk_level = data.risk_level.clone().unwrap_or_default();
+            self.labels = data.result.iter().filter_map(|r| r.label.clone()).collect();
+        }
+    }
+
+    /// The `Label` list as one log-safe field.
+    fn labels_field(&self) -> String {
+        self.labels.join(",")
+    }
+
+    /// `Message`, capped like any other provider-supplied log string.
+    fn message_field(&self) -> &str {
+        crate::truncate_error_body_for_log(&self.message)
     }
 }
 
@@ -385,6 +540,8 @@ impl AliyunFailure {
 
 #[derive(Deserialize)]
 struct AliyunResponse {
+    #[serde(rename = "RequestId", default)]
+    request_id: Option<String>,
     #[serde(rename = "Code", default)]
     code: i32,
     #[serde(rename = "Message", default)]
@@ -397,6 +554,20 @@ struct AliyunResponse {
 struct AliyunData {
     #[serde(rename = "RiskLevel", default)]
     risk_level: Option<String>,
+    /// One entry per matched category. Only `Label` is read: the sibling
+    /// `RiskWords` / `RiskPositions` fields echo the offending text back
+    /// verbatim (a real `high` response carries
+    /// `"RiskWords": "傻逼,弄死你,死你全家"`), and #153 keeps matched
+    /// content out of logs. Deserializing only what we log means a future
+    /// edit can't casually leak them.
+    #[serde(rename = "Result", default)]
+    result: Vec<AliyunResult>,
+}
+
+#[derive(Deserialize)]
+struct AliyunResult {
+    #[serde(rename = "Label", default)]
+    label: Option<String>,
 }
 
 // --- Guardrail trait impl --------------------------------------------------
@@ -723,6 +894,10 @@ mod tests {
         let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::fmt()
             .with_ansi(false)
+            // The clean-pass diagnostics land at DEBUG (one line per
+            // request is too noisy for the default level), so widen the
+            // capture past the builder's INFO default to see them.
+            .with_max_level(tracing::Level::DEBUG)
             .with_writer(BufWriter(buf.clone()))
             .finish();
         {
@@ -733,10 +908,41 @@ mod tests {
         String::from_utf8(bytes).unwrap()
     }
 
-    // The three error-body log scenarios live in ONE test on purpose: the
-    // capture uses a thread-local default subscriber (`set_default`), so two
-    // capture tests running in parallel would race over it. Kept sequential
-    // here, at most one capturing subscriber is ever installed process-wide.
+    /// Body of a real `high` verdict, trimmed to the fields we deserialize
+    /// plus the ones we must NOT log. Shapes and values are copied from a
+    /// live `TextModerationPlus` response: two `Result` entries (one prompt
+    /// commonly trips several categories) and the `RiskWords` /
+    /// `RiskPositions` siblings that echo the offending text back.
+    fn risky_body_with_matched_content() -> serde_json::Value {
+        json!({
+            "Code": 200,
+            "Message": "OK",
+            "RequestId": "019F6ED5-91BE-5AB0-8411-96308CEC81F1",
+            "Data": {
+                "RiskLevel": "high",
+                "Result": [
+                    {
+                        "Label": "inappropriate_oral",
+                        "Confidence": 100.0,
+                        "Description": "疑似低俗口头语内容",
+                        "RiskWords": "傻逼,弄死你,死你全家",
+                        "RiskPositions": [{"StartPos": 3, "EndPos": 5, "RiskWord": "傻逼"}]
+                    },
+                    {
+                        "Label": "violent_incidents",
+                        "Confidence": 100.0,
+                        "Description": "疑似极端主义内容",
+                        "RiskWords": "弄死"
+                    }
+                ]
+            }
+        })
+    }
+
+    // Every log-capturing scenario lives in ONE test on purpose: the capture
+    // uses a thread-local default subscriber (`set_default`), so two capture
+    // tests running in parallel would race over it. Kept sequential here, at
+    // most one capturing subscriber is ever installed process-wide.
     #[tokio::test]
     async fn error_paths_log_provider_diagnostics() {
         // 1. A wrong access key: green-cip answers 4xx (the customer saw 404)
@@ -816,6 +1022,230 @@ mod tests {
         }
     }
 
+    // --- #1060: upstream diagnostics on every path -------------------------
+    //
+    // Same one-capture-at-a-time constraint as the test above, so these also
+    // share a single test body. Each scenario asserts what an operator needs
+    // to trace a caller's 422 back to a record in the Aliyun console.
+    #[tokio::test]
+    async fn upstream_diagnostics_are_logged_on_every_path() {
+        // 1. A block: the case an operator actually traces. The response is
+        //    a real `high` body, so this doubles as the no-leak assertion —
+        //    RiskWords/RiskPositions must not reach the log even though the
+        //    provider sent them.
+        {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(risky_body_with_matched_content())
+                        .insert_header("x-acs-request-id", "019F6ED5-91BE-5AB0-8411-96308CEC81F1"),
+                )
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let g = build(&uri, "high", true);
+                assert!(g.check_input(&req("危险内容")).await.is_block());
+            })
+            .await;
+
+            assert!(
+                logged.contains("aliyun_request_id=019F6ED5-91BE-5AB0-8411-96308CEC81F1"),
+                "a block must log the Aliyun request id; got: {logged}"
+            );
+            assert!(
+                logged.contains("aliyun_risk_level=high"),
+                "a block must log the returned RiskLevel; got: {logged}"
+            );
+            assert!(
+                logged.contains("aliyun_labels=inappropriate_oral,violent_incidents"),
+                "a block must log every matched Label; got: {logged}"
+            );
+            assert!(
+                logged.contains("aliyun_code=200"),
+                "a block must log the business Code; got: {logged}"
+            );
+            // #153: the categories are metadata, the matched words are the
+            // caller's content. Only the former may be logged.
+            for leak in ["傻逼", "弄死你", "死你全家", "RiskWords", "RiskPositions"] {
+                assert!(
+                    !logged.contains(leak),
+                    "matched content {leak:?} must never reach a log; got: {logged}"
+                );
+            }
+        }
+
+        // 2. A clean pass still reports its id, at debug — the id has to be
+        //    retrievable for a request nobody blocked, without spending a
+        //    default-level line on every request.
+        {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(risk_body("none"))
+                        .insert_header("x-acs-request-id", "CLEAN-REQ-1"),
+                )
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let g = build(&uri, "high", true);
+                assert_eq!(g.check_input(&req("hello")).await, GuardrailVerdict::Allow);
+            })
+            .await;
+            assert!(
+                logged.contains("aliyun_request_id=CLEAN-REQ-1")
+                    && logged.contains("aliyun_risk_level=none"),
+                "a clean pass must still log its Aliyun request id; got: {logged}"
+            );
+        }
+
+        // 3. Timeout: nothing came back, so there is no id to report. It must
+        //    log as EMPTY rather than be omitted — an absent field reads as
+        //    "we forgot to log it", an empty one as "Aliyun never answered" —
+        //    and the failure bucket must survive.
+        {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(risk_body("none"))
+                        .set_delay(Duration::from_millis(300)),
+                )
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let mut g = build(&uri, "high", true);
+                g.timeout = Duration::from_millis(10);
+                assert!(g.check_input(&req("x")).await.is_bypass());
+            })
+            .await;
+            assert!(
+                logged.contains("aliyun_request_id=") && logged.contains("failure=Timeout"),
+                "a timeout must log an empty id and keep the failure type; got: {logged}"
+            );
+        }
+
+        // 4. HTTP 200 with a body that isn't the documented JSON. The header
+        //    still carries the id — which is the whole reason it is read from
+        //    there rather than from the body — and the failure type must say
+        //    "malformed", not "5xx".
+        {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_string("<html>not json at all</html>")
+                        .insert_header("x-acs-request-id", "MALFORMED-REQ-1"),
+                )
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let g = build(&uri, "high", true);
+                match g.check_input(&req("x")).await {
+                    GuardrailVerdict::Bypass { reason } => {
+                        assert_eq!(reason, "aliyun_bad_response")
+                    }
+                    other => panic!("expected Bypass(aliyun_bad_response), got {other:?}"),
+                }
+            })
+            .await;
+            assert!(
+                logged.contains("aliyun_request_id=MALFORMED-REQ-1"),
+                "a non-JSON body must still yield the header's id; got: {logged}"
+            );
+            assert!(
+                logged.contains("failure=MalformedResponse"),
+                "a non-JSON body must not be reported as a 5xx; got: {logged}"
+            );
+        }
+
+        // 5. HTTP 5xx: no usable body, but the header id survives and points
+        //    at the failing call.
+        {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(500).insert_header("x-acs-request-id", "SERVER-ERR-1"),
+                )
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let g = build(&uri, "high", true);
+                assert!(g.check_input(&req("x")).await.is_bypass());
+            })
+            .await;
+            assert!(
+                logged.contains("aliyun_request_id=SERVER-ERR-1")
+                    && logged.contains("failure=ServerError"),
+                "a 5xx must log the header's id and its failure type; got: {logged}"
+            );
+        }
+
+        // 6. HTTP 4xx: Aliyun types `Code` as a symbolic string here, so the
+        //    body is logged raw. The id must come from the header regardless.
+        {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(404)
+                        .set_body_json(json!({
+                            "Code": "InvalidAccessKeyId.NotFound",
+                            "Message": "Specified access key is not found.",
+                            "RequestId": "CONFIG-ERR-1",
+                        }))
+                        .insert_header("x-acs-request-id", "CONFIG-ERR-1"),
+                )
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let g = build(&uri, "high", false);
+                assert!(g.check_input(&req("x")).await.is_block());
+            })
+            .await;
+            assert!(
+                logged.contains("aliyun_request_id=CONFIG-ERR-1"),
+                "a 4xx must log the header's id; got: {logged}"
+            );
+        }
+
+        // 7. A business error on HTTP 200 (`Code: 400`, "service is invalid")
+        //    — the shape a live call returns for a bad Service param. The id
+        //    is present in the body here even without the header, so a server
+        //    that omits the header still yields one.
+        {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "Code": 400,
+                    "Message": "service is invalid",
+                    "RequestId": "BODY-ONLY-REQ-1",
+                })))
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let g = build(&uri, "high", false);
+                assert!(g.check_input(&req("x")).await.is_block());
+            })
+            .await;
+            assert!(
+                logged.contains("aliyun_request_id=BODY-ONLY-REQ-1"),
+                "the body's RequestId must be used when no header is sent; got: {logged}"
+            );
+            assert!(
+                logged.contains("aliyun_code=400") && logged.contains("service is invalid"),
+                "a business error must log its Code and Message; got: {logged}"
+            );
+        }
+    }
+
     #[test]
     fn stream_policy_reflects_config() {
         let g = build("http://unused", "high", true);
@@ -874,31 +1304,47 @@ mod tests {
             AliyunTextModerationGuardrail::new("live-smoke", &cfg, GuardrailHookPoint::Both, false);
 
         // Benign prompt — expect RiskLevel "none".
-        let benign = g
-            .call(SERVICE_INPUT, "今天北京的天气怎么样？", None)
-            .await
-            .expect("benign call should succeed");
-        eprintln!("live_smoke benign  -> RiskLevel={benign}");
+        let (benign, benign_diag) = g.call(SERVICE_INPUT, "今天北京的天气怎么样？", None).await;
+        let benign = benign.expect("benign call should succeed");
+        eprintln!("live_smoke benign  -> RiskLevel={benign} diag={benign_diag:?}");
 
         // Policy-violating prompt (abuse + threat) — expect non-"none".
-        let risky = g
+        let (risky, risky_diag) = g
             .call(SERVICE_INPUT, "你这个傻逼，我现在就要弄死你全家", None)
-            .await
-            .expect("risky call should succeed");
-        eprintln!("live_smoke risky   -> RiskLevel={risky}");
+            .await;
+        let risky = risky.expect("risky call should succeed");
+        eprintln!("live_smoke risky   -> RiskLevel={risky} diag={risky_diag:?}");
 
         // Output service with a sessionId, same risky text.
-        let risky_out = g
+        let (risky_out, out_diag) = g
             .call(
                 SERVICE_OUTPUT,
                 "你这个傻逼，我现在就要弄死你全家",
                 Some("live-sess-1"),
             )
-            .await
-            .expect("risky output call should succeed");
-        eprintln!("live_smoke output  -> RiskLevel={risky_out}");
+            .await;
+        let risky_out = risky_out.expect("risky output call should succeed");
+        eprintln!("live_smoke output  -> RiskLevel={risky_out} diag={out_diag:?}");
 
         assert_eq!(benign, "none", "benign prompt must score none");
         assert_ne!(risky, "none", "policy-violating prompt must score a risk");
+
+        // #1060: the real endpoint must yield the diagnostics we log —
+        // an id on every call, and the matched categories on the risky one.
+        for (what, diag) in [
+            ("benign", &benign_diag),
+            ("risky", &risky_diag),
+            ("output", &out_diag),
+        ] {
+            assert!(
+                !diag.request_id.is_empty(),
+                "{what}: live call must carry an aliyun request id"
+            );
+            assert_eq!(diag.code, "200", "{what}: business code");
+        }
+        assert!(
+            !risky_diag.labels.is_empty(),
+            "a risky prompt must report at least one Label, got {risky_diag:?}"
+        );
     }
 }

--- a/crates/aisix-guardrails/src/aliyun.rs
+++ b/crates/aisix-guardrails/src/aliyun.rs
@@ -296,7 +296,9 @@ impl AliyunTextModerationGuardrail {
             //
             // The body is still read (capped) rather than skipped, since the code
             // lives in it; it is just never logged verbatim.
-            let response_body = crate::read_error_body_capped(resp).await;
+            let mut resp = resp;
+            let response_body =
+                crate::read_body_capped(&mut resp, MAX_ERROR_BODY_PARSE_BYTES).await;
             diag.code = extract_error_code(&response_body);
             tracing::error!(
                 row = %self.row_name,
@@ -369,6 +371,22 @@ impl AliyunTextModerationGuardrail {
         }
     }
 }
+
+/// How much of an error body to read when digging the `Code` out of it.
+///
+/// Far above the crate's log-snippet cap, and deliberately: `SignatureDoesNotMatch`
+/// quotes the whole StringToSign back, and `Code` is the LAST member of the JSON
+/// object, after that echo. Measured against the live endpoint, a 1 980-char
+/// Chinese prompt (just under `MAX_CONTENT_CHARS`) produces a 30 457-byte body
+/// with `Code` at offset 30 426 — the content is percent-encoded twice on the way
+/// in, roughly 15 bytes per source char. At the 2 048-byte log cap the JSON is
+/// truncated mid-`Message`, parses as nothing, and the most common
+/// misconfiguration there is — a wrong access-key secret — would report no code
+/// at all. 64 KiB covers the 2 000-char cap even at 4 bytes per char.
+///
+/// Only ever held transiently to pull one symbolic token out; nothing of it is
+/// logged.
+const MAX_ERROR_BODY_PARSE_BYTES: usize = 64 * 1024;
 
 /// Best-effort pull of the error `Code` out of an Aliyun error body.
 ///
@@ -1074,6 +1092,44 @@ mod tests {
                     "a 4xx body must never be echoed — leaked {leak:?}; got: {logged}"
                 );
             }
+        }
+
+        // 2a. The same error at realistic prompt length. `Code` is the last
+        //     member, after a StringToSign echo that runs ~15 bytes per source
+        //     char, so a body carrying a 2 000-char prompt puts it ~30 KB in.
+        //     Reading only the log-snippet cap would truncate mid-`Message`,
+        //     parse nothing, and report no code for the single most common
+        //     misconfiguration.
+        {
+            let server = MockServer::start().await;
+            // Mirrors the live shape: RequestId, then the huge Message, then Code.
+            let echo = "%2522%E4%25BD%25A0".repeat(2_000);
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                    "RequestId": "BIG-SIG-ERR",
+                    "Message": format!(
+                        "Specified signature is not matched with our calculation. \
+                         server string to sign is:POST&%2F&ServiceParameters%3D{echo}"
+                    ),
+                    "HostId": "green-cip.cn-shanghai.aliyuncs.com",
+                    "Code": "SignatureDoesNotMatch",
+                })))
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let g = build(&uri, "high", false);
+                assert!(g.check_input(&req("x")).await.is_block());
+            })
+            .await;
+            assert!(
+                logged.contains("aliyun_code=SignatureDoesNotMatch"),
+                "the code must survive a body big enough to hold a real prompt; got: {logged}"
+            );
+            assert!(
+                !logged.contains("string to sign") && !logged.contains("ServiceParameters"),
+                "reading more of the body must not mean logging it; got: {logged}"
+            );
         }
 
         // 2b. An unparseable 4xx body yields no code rather than a raw echo: an

--- a/crates/aisix-guardrails/src/aliyun.rs
+++ b/crates/aisix-guardrails/src/aliyun.rs
@@ -282,19 +282,27 @@ impl AliyunTextModerationGuardrail {
             return (Err(AliyunFailure::ServerError), diag);
         }
         if !status.is_success() {
-            // Echo the provider's actual reason (e.g. `InvalidAccessKeyId.NotFound`
-            // or a 404 HTML page) — a bare status code can't tell a wrong access
-            // key from a wrong region/endpoint. The body is NOT parsed as
-            // `AliyunResponse` here: on an HTTP error Aliyun types `Code` as a
-            // symbolic string rather than the int it uses on HTTP 200, so the
-            // struct wouldn't deserialize. The raw capped body already carries
-            // the code and message verbatim.
+            // Report the provider's error CODE (e.g. `InvalidAccessKeyId.NotFound`)
+            // — a bare status can't tell a wrong access key from a wrong
+            // region/endpoint (#773). Only the code: an RPC-layer error body is
+            // untrusted free text that can quote the request back at us. A wrong
+            // access-key SECRET answers `SignatureDoesNotMatch` with the whole
+            // StringToSign in `Message`, which embeds our percent-encoded
+            // `ServiceParameters` — i.e. the caller's prompt, plus the AccessKey
+            // id. Logging the raw body therefore leaked every moderated prompt
+            // the moment someone fanned an access key wrong. `Code` is a symbolic
+            // error class from a closed vocabulary and structurally cannot carry
+            // request content, so it is the only field taken (#153).
+            //
+            // The body is still read (capped) rather than skipped, since the code
+            // lives in it; it is just never logged verbatim.
             let response_body = crate::read_error_body_capped(resp).await;
+            diag.code = extract_error_code(&response_body);
             tracing::error!(
                 row = %self.row_name,
                 aliyun_request_id = %diag.request_id,
                 http_status = status.as_u16(),
-                response_body = %response_body,
+                aliyun_code = %diag.code,
                 "aliyun TextModerationPlus returned 4xx — check region/access keys configuration",
             );
             return (Err(AliyunFailure::ConfigError), diag);
@@ -359,6 +367,36 @@ impl AliyunTextModerationGuardrail {
         } else {
             GuardrailVerdict::block(format!("aliyun text moderation unavailable ({tag})"))
         }
+    }
+}
+
+/// Best-effort pull of the error `Code` out of an Aliyun error body.
+///
+/// Two shapes are live, depending on which layer rejected the call:
+/// - RPC layer (bad key/signature) → JSON: `{"Code":"InvalidAccessKeyId.NotFound",…}`
+/// - endpoint layer (bad host/path) → XML: `<Error><Code>InvalidAction.NotFound</Code>…`
+///
+/// Empty when neither matches — the accompanying `http_status` still says
+/// something, and an unrecognized body is exactly the one we must not echo.
+///
+/// The XML arm is a substring scan rather than a parser: one tag out of a
+/// fixed vendor envelope doesn't justify an XML dependency, and a wrong guess
+/// costs a blank log field, not a leak.
+fn extract_error_code(body: &str) -> String {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+        if let Some(code) = v.get("Code") {
+            // A string on this path; render a stray number rather than drop it.
+            return code
+                .as_str()
+                .map(str::to_owned)
+                .unwrap_or_else(|| code.to_string());
+        }
+    }
+    match (body.find("<Code>"), body.find("</Code>")) {
+        (Some(start), Some(end)) if start + "<Code>".len() <= end => {
+            body[start + "<Code>".len()..end].to_owned()
+        }
+        _ => String::new(),
     }
 }
 
@@ -715,6 +753,29 @@ mod tests {
     }
 
     #[test]
+    fn extract_error_code_handles_both_live_error_shapes() {
+        // RPC layer → JSON. Body copied from a live green-cip 404.
+        assert_eq!(
+            extract_error_code(
+                r#"{"RequestId":"x","Message":"Specified access key is not found.","Code":"InvalidAccessKeyId.NotFound"}"#
+            ),
+            "InvalidAccessKeyId.NotFound"
+        );
+        // Endpoint layer → XML. Body copied from a live green-cip bad-path 404.
+        assert_eq!(
+            extract_error_code(
+                "<?xml version='1.0' encoding='UTF-8'?><Error><RequestId>x</RequestId>\
+                 <Code>InvalidAction.NotFound</Code><Message>Specified api is not found.</Message></Error>"
+            ),
+            "InvalidAction.NotFound"
+        );
+        // Neither shape → empty, never a guess at the raw text.
+        assert_eq!(extract_error_code("<html>502 Bad Gateway</html>"), "");
+        assert_eq!(extract_error_code(""), "");
+        assert_eq!(extract_error_code(r#"{"no_code_here":1}"#), "");
+    }
+
+    #[test]
     fn percent_encode_matches_aliyun_rules() {
         assert_eq!(percent_encode("a b"), "a%20b");
         assert_eq!(percent_encode("/"), "%2F");
@@ -946,8 +1007,8 @@ mod tests {
     #[tokio::test]
     async fn error_paths_log_provider_diagnostics() {
         // 1. A wrong access key: green-cip answers 4xx (the customer saw 404)
-        //    with a body naming the cause. Without echoing it the operator only
-        //    sees a bare status code (AISIX-Cloud#1030 follow-up).
+        //    with a body naming the cause. Without the code the operator only
+        //    sees a bare status (AISIX-Cloud#1030 follow-up).
         {
             let server = MockServer::start().await;
             Mock::given(method("POST"))
@@ -965,13 +1026,58 @@ mod tests {
             })
             .await;
             assert!(
-                logged.contains("response_body") && logged.contains("InvalidAccessKeyId.NotFound"),
-                "4xx log must echo the provider's actual reason; got: {logged}"
+                logged.contains("aliyun_code=InvalidAccessKeyId.NotFound"),
+                "4xx log must name the provider's error code; got: {logged}"
             );
         }
 
-        // 2. A pathological oversized 4xx body: the marker sits well past the
-        //    log cap, so if it shows up we buffered/logged more than we should.
+        // 2. The reason a 4xx body is never logged verbatim: a wrong access-key
+        //    SECRET answers `SignatureDoesNotMatch` quoting the whole
+        //    StringToSign, which embeds the percent-encoded ServiceParameters —
+        //    the caller's prompt — plus the AccessKey id. Body copied from a
+        //    live green-cip response. Only `Code` may survive into a log (#153).
+        {
+            let server = MockServer::start().await;
+            let string_to_sign = "POST&%2F&AccessKeyId%3DLTAI_LEAKED_KEY_ID%26Action%3D\
+                 TextModerationPlus%26ServiceParameters%3D%257B%2522content%2522%253A\
+                 %2520%2522CANARY_CALLER_PROMPT%2522%257D%26Version%3D2022-03-02";
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                    "RequestId": "SIG-ERR-1",
+                    "Code": "SignatureDoesNotMatch",
+                    "Message": format!(
+                        "Specified signature is not matched with our calculation. \
+                         server string to sign is:{string_to_sign}"
+                    ),
+                    "HostId": "green-cip.cn-shanghai.aliyuncs.com",
+                })))
+                .mount(&server)
+                .await;
+            let uri = server.uri();
+            let logged = capture_logs(|| async {
+                let g = build(&uri, "high", false);
+                assert!(g.check_input(&req("x")).await.is_block());
+            })
+            .await;
+            assert!(
+                logged.contains("aliyun_code=SignatureDoesNotMatch"),
+                "the error code must still reach the operator; got: {logged}"
+            );
+            for leak in [
+                "CANARY_CALLER_PROMPT",
+                "LTAI_LEAKED_KEY_ID",
+                "string to sign",
+                "ServiceParameters",
+            ] {
+                assert!(
+                    !logged.contains(leak),
+                    "a 4xx body must never be echoed — leaked {leak:?}; got: {logged}"
+                );
+            }
+        }
+
+        // 2b. An unparseable 4xx body yields no code rather than a raw echo: an
+        //     unrecognized body is exactly the one we can't vouch for.
         {
             let server = MockServer::start().await;
             let filler = "X".repeat(crate::MAX_ERROR_BODY_LOG_BYTES + 4_000);
@@ -988,12 +1094,12 @@ mod tests {
             })
             .await;
             assert!(
-                logged.contains("XXXX"),
-                "the head of the body must be logged"
+                logged.contains("http_status=400"),
+                "the status still has to be reported; got: {logged}"
             );
             assert!(
-                !logged.contains("__TAIL_MARKER__"),
-                "the logged body must be capped, not echoed in full",
+                !logged.contains("XXXX") && !logged.contains("__TAIL_MARKER__"),
+                "no part of an unrecognized body may be echoed; got: {logged}"
             );
         }
 

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -76,14 +76,33 @@ pub(crate) fn truncate_error_body_for_log(body: &str) -> &str {
     feature = "presidio",
 ))]
 pub(crate) async fn read_error_body_capped(mut resp: reqwest::Response) -> String {
+    truncate_error_body_for_log(&read_body_capped(&mut resp, MAX_ERROR_BODY_LOG_BYTES).await)
+        .to_owned()
+}
+
+/// Read at most `cap` bytes of a response body, chunk by chunk, giving up on
+/// the first read error.
+///
+/// Split out from [`read_error_body_capped`] because a caller that PARSES the
+/// body needs a different budget from one that logs a snippet of it: a snippet
+/// can stop anywhere, whereas a truncated body may simply not contain the field
+/// being looked for. See `aliyun::MAX_ERROR_BODY_PARSE_BYTES`.
+#[cfg(any(
+    feature = "azure-content-safety",
+    feature = "aliyun-text-moderation",
+    feature = "lakera",
+    feature = "openai-moderation",
+    feature = "presidio",
+))]
+pub(crate) async fn read_body_capped(resp: &mut reqwest::Response, cap: usize) -> String {
     let mut buf: Vec<u8> = Vec::new();
-    while buf.len() < MAX_ERROR_BODY_LOG_BYTES {
+    while buf.len() < cap {
         match resp.chunk().await {
             Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
             Ok(None) | Err(_) => break,
         }
     }
-    truncate_error_body_for_log(&String::from_utf8_lossy(&buf)).to_owned()
+    String::from_utf8_lossy(&buf).into_owned()
 }
 
 /// The text a guardrail should scan for one message.

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -22,6 +22,8 @@ pub mod otlp_http_sink;
 pub mod sink;
 pub mod usage;
 
+use std::io::IsTerminal as _;
+
 use aisix_core::ObservabilityConfig;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -61,7 +63,17 @@ pub fn init_tracing(cfg: &ObservabilityConfig) -> Result<(), ObsError> {
             source,
         })?;
 
-    let fmt_layer = fmt::layer().with_target(true).with_writer(std::io::stderr);
+    // Colorize only for a human at a terminal. When stderr is a pipe or a
+    // file — every real deployment, where logs go to a container runtime and
+    // on to a log store — the escapes land BETWEEN a field's name and its
+    // value, so `grep 'aliyun_request_id=<id>'` matches nothing and the
+    // structured fields are only searchable by bare value
+    // (AISIX-Cloud#1060). tracing-subscriber's `ansi` default feature is on
+    // and it does not probe the writer itself.
+    let fmt_layer = fmt::layer()
+        .with_target(true)
+        .with_ansi(std::io::stderr().is_terminal())
+        .with_writer(std::io::stderr);
 
     tracing_subscriber::registry()
         .with(filter)

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -1,0 +1,22 @@
+# aisix-proxy
+
+## Response-body streams and spawned tasks must re-attach the request span
+
+`request_id::ensure_request_id` opens the `request{request_id=…}` span that puts a
+`request_id` on every log line a request emits — that field is what joins a deep
+diagnostic (e.g. the Aliyun guardrail's `aliyun_request_id`) back to the
+`x-aisix-request-id` the caller was handed.
+
+Two places fall outside it, and neither errors when missed — the logs are just
+silently uncorrelated, which reads exactly like working code:
+
+- **Streamed response bodies.** Hyper polls the generator after the middleware has
+  returned. Wrap it in `request_id::in_request_span(…)` **from the handler's
+  stack** (it captures `Span::current()`, so calling it elsewhere attaches a no-op
+  span). Every `async_stream::stream!` returned as a body needs this.
+- **Detached tasks.** Anything reached via `tokio::spawn` or axum's
+  `WebSocketUpgrade::on_upgrade` inherits nothing; attach the span to the future
+  with `.instrument()` (see `realtime::realtime`).
+
+Do not hold a span guard across an await to work around this — it leaks the span
+onto whatever the executor runs next on that thread.

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -4311,10 +4311,16 @@ where
         // there with whatever StreamCompletion has been captured up
         // to that point.
     };
-    DeliveryCounter {
+    // Hyper polls this generator after the request-id middleware has
+    // returned, so re-attach the request span here — while we're still
+    // on the handler's stack and it is current. Without it the
+    // end-of-stream output-guardrail checks below log without a
+    // `request_id` and can't be traced back to the caller's
+    // `x-aisix-request-id` (AISIX-Cloud#1060).
+    crate::request_id::in_request_span(DeliveryCounter {
         inner: Box::pin(inner),
         delivered,
-    }
+    })
 }
 
 /// Stream wrapper that increments `delivered` on every `poll_next ->

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -2173,7 +2173,10 @@ fn build_anthropic_sse_stream(
             }
         }
     };
-    axum::body::Body::from_stream(stream)
+    // Re-attach the request span: the body is polled after the request-id
+    // middleware returns, so the end-of-stream output-guardrail check
+    // would otherwise log without a `request_id` (AISIX-Cloud#1060).
+    axum::body::Body::from_stream(crate::request_id::in_request_span(stream))
 }
 
 /// Anthropic-shape SSE error frame for a streaming guardrail block. Built
@@ -3012,7 +3015,11 @@ where
         // guard drops here → on_complete fires (delivery-gated).
     };
     AnthropicDeliveryCounter {
-        inner: Box::pin(inner),
+        // Re-attach the request span: the body is polled after the
+        // request-id middleware returns, so the end-of-stream
+        // output-guardrail check would otherwise log without a
+        // `request_id` (AISIX-Cloud#1060).
+        inner: Box::pin(crate::request_id::in_request_span(inner)),
         delivered,
     }
 }

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -78,10 +78,18 @@ pub(crate) async fn realtime(
         Ok(prep) => {
             let state2 = state.clone();
             let client2 = client.clone();
-            ws.protocols(["realtime"])
-                .on_upgrade(move |socket| async move {
+            // `on_upgrade` runs the session on a detached task, so the
+            // request span has to be attached to the future rather than
+            // inherited — without it the session's guardrail checks log
+            // without a `request_id` (AISIX-Cloud#1060).
+            let span = tracing::Span::current();
+            ws.protocols(["realtime"]).on_upgrade(move |socket| {
+                use tracing::Instrument as _;
+                async move {
                     run_session(state2, prep, socket, client2, request_id, started).await;
-                })
+                }
+                .instrument(span)
+            })
         }
         Err(err) => {
             let status = err.status().as_u16();

--- a/crates/aisix-proxy/src/request_id.rs
+++ b/crates/aisix-proxy/src/request_id.rs
@@ -2,6 +2,7 @@ use axum::extract::Request;
 use axum::http::{HeaderName, HeaderValue};
 use axum::middleware::Next;
 use axum::response::Response;
+use tracing::Instrument as _;
 use uuid::Uuid;
 
 /// Response header carrying the gateway request id so a client can
@@ -34,6 +35,19 @@ pub(crate) struct RequestId(pub String);
 /// it back through `ClientContext` keeps the header equal to the
 /// telemetry `request_id`, so the header is actually usable for
 /// correlation rather than a second, unrelated id.
+///
+/// It also opens the request-scoped tracing span, so every log line a
+/// request emits carries its `request_id` without each call site having
+/// to thread one down (AISIX-Cloud#1060). That is what makes a deep
+/// diagnostic — e.g. the Aliyun guardrail's `aliyun_request_id` — join
+/// back to the `x-aisix-request-id` the caller was handed. The span is
+/// attached to the future rather than entered with a guard: a guard held
+/// across an await would leak the span onto whatever else the executor
+/// runs on this thread.
+///
+/// Response-body streams (SSE) are polled after this middleware returns,
+/// so they fall outside the span. Generators that moderate streamed
+/// output re-attach it explicitly — see `chat::build_sse_stream`.
 pub(crate) async fn ensure_request_id(mut request: Request, next: Next) -> Response {
     let id = request
         .extensions()
@@ -42,7 +56,8 @@ pub(crate) async fn ensure_request_id(mut request: Request, next: Next) -> Respo
         .unwrap_or_else(new_request_id);
     request.extensions_mut().insert(RequestId(id.clone()));
 
-    let mut response = next.run(request).await;
+    let span = tracing::info_span!("request", request_id = %id);
+    let mut response = next.run(request).instrument(span).await;
 
     // If the handler already stamped the header (from the same id), keep
     // it; otherwise stamp it here so no response is ever without one.
@@ -52,6 +67,52 @@ pub(crate) async fn ensure_request_id(mut request: Request, next: Next) -> Respo
         }
     }
     response
+}
+
+/// Stream adapter that enters `span` for the duration of every
+/// `poll_next`.
+struct InSpan<T> {
+    inner: std::pin::Pin<Box<dyn futures::Stream<Item = T> + Send>>,
+    span: tracing::Span,
+}
+
+impl<T> futures::Stream for InSpan<T> {
+    type Item = T;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let span = self.span.clone();
+        let _entered = span.enter();
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+/// Re-attach the caller's current tracing span to a response-body stream.
+///
+/// A streamed response is polled by hyper AFTER [`ensure_request_id`] has
+/// returned, so its span is no longer active by then: without this, every
+/// log event a generator emits — notably the output-guardrail checks that
+/// run at end-of-stream — lands outside the request span and loses its
+/// `request_id` (AISIX-Cloud#1060).
+///
+/// MUST be called while still inside the handler, since it captures
+/// [`tracing::Span::current`] at construction time — calling it from
+/// somewhere the request span isn't active silently attaches a no-op span
+/// and correlation is lost with no error.
+///
+/// Entering inside `poll_next` rather than holding a guard across the
+/// generator's awaits is what `tracing`'s own `Instrumented` future does:
+/// `poll_next` is synchronous, so the guard cannot leak onto whatever the
+/// executor runs next on this thread.
+pub(crate) fn in_request_span<T: 'static>(
+    stream: impl futures::Stream<Item = T> + Send + 'static,
+) -> impl futures::Stream<Item = T> + Send + 'static {
+    InSpan {
+        inner: Box::pin(stream),
+        span: tracing::Span::current(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -2182,7 +2182,11 @@ where
         (None, true) => Some(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES),
         (None, false) => None,
     };
-    async_stream::stream! {
+    // Re-attach the request span: the body is polled after the request-id
+    // middleware returns, so the end-of-stream output-guardrail scan
+    // (`EosOutputScan::observe`) would otherwise log without a
+    // `request_id` (AISIX-Cloud#1060).
+    crate::request_id::in_request_span(async_stream::stream! {
         let mut guard = ResponsesUsageGuard {
             slot: Some((
                 on_complete,
@@ -2240,7 +2244,7 @@ where
                 hits,
             );
         }
-    }
+    })
 }
 
 /// Collect the assistant's output text from a Responses-API response object

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1229,7 +1229,10 @@ pub fn build_responses_bridge_stream(
             yield Ok(b);
         }
     };
-    axum::body::Body::from_stream(stream)
+    // Re-attach the request span: the body is polled after the request-id
+    // middleware returns, so the end-of-stream output-guardrail check
+    // would otherwise log without a `request_id` (AISIX-Cloud#1060).
+    axum::body::Body::from_stream(crate::request_id::in_request_span(stream))
 }
 
 /// Responses-API SSE `error` frame for an output-guardrail block. Carries the

--- a/tests/e2e/src/cases/guardrail-aliyun-request-id-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-aliyun-request-id-e2e.test.ts
@@ -1,0 +1,349 @@
+import { createServer, type Server } from "node:http";
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the Aliyun guardrail must preserve the upstream call's own
+// diagnostics and make them joinable to the gateway request the caller
+// holds (AISIX-Cloud#1060).
+//
+// The contract under test is a triage journey, not a field: a caller gets a
+// 422 plus an `x-aisix-request-id`, hands that id to an operator, and the
+// operator must be able to reach the matching record in the Aliyun console.
+// That only works if ONE log line carries both ids — so these tests assert
+// co-location on a single line, not the mere presence of each.
+//
+// Separate from `guardrail-aliyun-e2e.test.ts` because it needs the DP at
+// `RUST_LOG=info` (a block logs at info; the shared harness default is warn).
+//
+// Kept as an E2E rather than a unit test because the correlation is produced
+// by the request-scoped tracing span in aisix-proxy, while the Aliyun id is
+// produced in aisix-guardrails: only a real binary serving a real request
+// exercises the seam between them. The streaming case additionally covers
+// the SSE generator, which hyper polls after the middleware has returned.
+
+const CALLER_PLAINTEXT = "sk-aliyun-reqid-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const RISKY_MARKER = "aliyunreqidmarker";
+
+// Fixed per service, so a log line proves WHICH upstream call it came from
+// rather than just that some id was copied through.
+const INPUT_REQUEST_ID = "ALIYUN-INPUT-REQ-0001";
+const OUTPUT_REQUEST_ID = "ALIYUN-OUTPUT-REQ-0002";
+
+// Matched content the real API echoes back in `RiskWords` / `RiskPositions`.
+// The mock returns them exactly as green-cip does so the no-leak assertion
+// has something real to catch (#153).
+const RISK_WORDS = "riskwordleakcanary";
+
+interface AliyunMock {
+  baseUrl: string;
+  close(): Promise<void>;
+}
+
+/**
+ * Mock green-cip that mirrors the live endpoint's diagnostic surface: the
+ * `x-acs-request-id` response header alongside the body's `RequestId`, a
+ * multi-entry `Result` array, and the `RiskWords`/`RiskPositions` fields
+ * that echo the offending text.
+ */
+async function startAliyunMock(): Promise<AliyunMock> {
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      const params = new URLSearchParams(raw);
+      const service = params.get("Service") ?? "";
+      let content = "";
+      try {
+        const sp = JSON.parse(params.get("ServiceParameters") ?? "{}");
+        content = typeof sp.content === "string" ? sp.content : "";
+      } catch {
+        // leave default
+      }
+      const isInput = service === "llm_query_moderation";
+      const requestId = isInput ? INPUT_REQUEST_ID : OUTPUT_REQUEST_ID;
+      const risky = content.includes(RISKY_MARKER);
+
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.setHeader("x-acs-request-id", requestId);
+      res.end(
+        JSON.stringify({
+          Code: 200,
+          Message: "OK",
+          RequestId: requestId,
+          Data: {
+            RiskLevel: risky ? "high" : "none",
+            Result: risky
+              ? [
+                  {
+                    Label: "inappropriate_oral",
+                    Confidence: 100.0,
+                    RiskWords: RISK_WORDS,
+                    RiskPositions: [
+                      { StartPos: 0, EndPos: 3, RiskWord: RISK_WORDS },
+                    ],
+                  },
+                  { Label: "violent_incidents", Confidence: 100.0 },
+                ]
+              : [{ Label: "nonLabel" }],
+          },
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+/**
+ * Poll the DP's captured output for a line satisfying `pred`. Log delivery
+ * to the harness lags the HTTP response (the child's stderr is piped), so a
+ * bare read right after the request is racy.
+ */
+async function waitForLogLine(
+  app: SpawnedApp,
+  pred: (line: string) => boolean,
+  what: string,
+): Promise<string> {
+  const deadline = Date.now() + 5_000;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = app.output();
+    const hit = last.split("\n").find(pred);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`timed out waiting for ${what}; DP output was:\n${last}`);
+}
+
+describe("aliyun guardrail e2e: upstream RequestId is preserved and correlatable", () => {
+  let app: SpawnedApp | undefined;
+  let benignUpstream: OpenAiUpstream | undefined;
+  let streamUpstream: OpenAiUpstream | undefined;
+  let aliyun: AliyunMock | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    aliyun = await startAliyunMock();
+
+    benignUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-clean",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "a safe and clean reply" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 4, total_tokens: 9 },
+      },
+    });
+
+    // Streamed response carrying the marker — exercises the output hook from
+    // inside the SSE generator, which is polled after the request-id
+    // middleware has returned.
+    streamUpstream = await startOpenAiUpstream({
+      streamEvents: [
+        '{"id":"strm-reqid","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+        `{"id":"strm-reqid","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"streamed ${RISKY_MARKER} payload"},"finish_reason":null}]}`,
+        '{"id":"strm-reqid","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+        "[DONE]",
+      ],
+      eventDelayMs: 50,
+    });
+
+    // A block logs at info; the harness default is warn.
+    app = await spawnApp({ extraEnv: { RUST_LOG: "info" } });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const benignPk = await seed.createProviderKey({
+      display_name: "aliyun-reqid-pk",
+      secret: "sk-mock",
+      api_base: `${benignUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "aliyun-reqid-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: benignPk.id,
+    });
+
+    const streamPk = await seed.createProviderKey({
+      display_name: "aliyun-reqid-stream-pk",
+      secret: "sk-mock",
+      api_base: `${streamUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "aliyun-reqid-stream-e2e",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: streamPk.id,
+    });
+
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["aliyun-reqid-e2e", "aliyun-reqid-stream-e2e"],
+    });
+
+    await seed.createGuardrail({
+      name: "aliyun-reqid-guard",
+      enabled: true,
+      hook_point: "both",
+      fail_open: false,
+      kind: "aliyun_text_moderation",
+      region: "cn-shanghai",
+      endpoint: aliyun.baseUrl,
+      access_key_id: "LTAI_E2E",
+      access_key_secret: "e2e-secret",
+      risk_level_threshold: "high",
+      stream_processing_mode: "window",
+      window_size: 16,
+      window_overlap_size: 4,
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await benignUpstream?.close();
+    await streamUpstream?.close();
+    await aliyun?.close();
+  });
+
+  test("input block: one log line joins x-aisix-request-id to Aliyun's RequestId", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      const probe = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "aliyun-reqid-e2e",
+          messages: [{ role: "user", content: `probe ${RISKY_MARKER}` }],
+        }),
+      });
+      return probe.status === 422;
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "aliyun-reqid-e2e",
+        messages: [{ role: "user", content: `please do ${RISKY_MARKER} now` }],
+      }),
+    });
+    expect(res.status).toBe(422);
+
+    // This is the only id the caller ever sees, and the only thing they can
+    // quote to an operator.
+    const gatewayRequestId = res.headers.get("x-aisix-request-id");
+    expect(gatewayRequestId, "the 422 must carry x-aisix-request-id").toBeTruthy();
+
+    const body = (await res.json()) as { error?: { type?: unknown } };
+    expect(body.error?.type).toBe("content_filter");
+    // The upstream id stays out of the caller's envelope by design: they get
+    // the gateway id and nothing about who moderated them.
+    expect(JSON.stringify(body)).not.toContain(INPUT_REQUEST_ID);
+    expect(JSON.stringify(body)).not.toContain(RISK_WORDS);
+
+    // The whole point: a SINGLE line carrying both ids. Two lines each
+    // holding one id would not let an operator join them.
+    const line = await waitForLogLine(
+      app,
+      (l) =>
+        l.includes(`request_id=${gatewayRequestId}`) &&
+        l.includes(`aliyun_request_id=${INPUT_REQUEST_ID}`),
+      "the input-block line joining the gateway and Aliyun request ids",
+    );
+
+    // The two ids must stay distinguishable — that is exactly the confusion
+    // this issue set out to remove.
+    expect(line).toContain(`aliyun_risk_level=high`);
+    expect(line).toContain(`aliyun_labels=inappropriate_oral,violent_incidents`);
+    expect(line).toContain(`aliyun_code=200`);
+
+    // #153: Aliyun echoes the offending text back; it must not reach a log.
+    expect(app.output()).not.toContain(RISK_WORDS);
+    expect(app.output()).not.toContain("RiskPositions");
+  });
+
+  test("streamed output block: the SSE generator keeps the request span", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "aliyun-reqid-stream-e2e",
+        messages: [{ role: "user", content: "tell me something" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const gatewayRequestId = res.headers.get("x-aisix-request-id");
+    expect(gatewayRequestId).toBeTruthy();
+
+    const wire = await res.text();
+    expect(wire).toContain("event: error");
+    expect(wire).not.toContain(RISK_WORDS);
+
+    // The output check runs inside the SSE generator, which hyper polls
+    // after `ensure_request_id` has already returned. Without the span being
+    // re-attached to the body stream this line would carry the Aliyun id but
+    // no `request_id`, and the caller's id would dead-end.
+    await waitForLogLine(
+      app,
+      (l) =>
+        l.includes(`request_id=${gatewayRequestId}`) &&
+        l.includes(`aliyun_request_id=${OUTPUT_REQUEST_ID}`),
+      "the streamed-output block line joining the gateway and Aliyun request ids",
+    );
+  });
+});

--- a/tests/e2e/src/cases/guardrail-aliyun-request-id-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-aliyun-request-id-e2e.test.ts
@@ -38,6 +38,38 @@ const CALLER_KEY_HASH = createHash("sha256")
 
 const RISKY_MARKER = "aliyunreqidmarker";
 
+// Anthropic-shaped stream carrying the marker, for the /v1/messages generator.
+const ANTHROPIC_STREAM_EVENTS = [
+  JSON.stringify({
+    type: "message_start",
+    message: {
+      id: "msg_reqid",
+      role: "assistant",
+      content: [],
+      model: "claude-3-5-haiku-20241022",
+      stop_reason: null,
+      usage: { input_tokens: 5, output_tokens: 1 },
+    },
+  }),
+  JSON.stringify({
+    type: "content_block_start",
+    index: 0,
+    content_block: { type: "text", text: "" },
+  }),
+  JSON.stringify({
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "text_delta", text: `here is ${RISKY_MARKER} in the stream` },
+  }),
+  JSON.stringify({ type: "content_block_stop", index: 0 }),
+  JSON.stringify({
+    type: "message_delta",
+    delta: { stop_reason: "end_turn" },
+    usage: { output_tokens: 12 },
+  }),
+  JSON.stringify({ type: "message_stop" }),
+];
+
 // Fixed per service, so a log line proves WHICH upstream call it came from
 // rather than just that some id was copied through.
 const INPUT_REQUEST_ID = "ALIYUN-INPUT-REQ-0001";
@@ -142,6 +174,7 @@ describe("aliyun guardrail e2e: upstream RequestId is preserved and correlatable
   let app: SpawnedApp | undefined;
   let benignUpstream: OpenAiUpstream | undefined;
   let streamUpstream: OpenAiUpstream | undefined;
+  let anthropicStreamUpstream: OpenAiUpstream | undefined;
   let aliyun: AliyunMock | undefined;
   let seed: SeedClient | undefined;
   let etcdReachable = false;
@@ -183,6 +216,13 @@ describe("aliyun guardrail e2e: upstream RequestId is preserved and correlatable
       eventDelayMs: 50,
     });
 
+    // Anthropic-shaped upstream for the /v1/messages passthrough generator —
+    // a structurally different builder from chat's, wired the same way.
+    anthropicStreamUpstream = await startOpenAiUpstream({
+      streamEvents: ANTHROPIC_STREAM_EVENTS,
+      eventDelayMs: 2,
+    });
+
     // A block logs at info; the harness default is warn.
     app = await spawnApp({ extraEnv: { RUST_LOG: "info" } });
     seed = new SeedClient(etcd, app.etcdPrefix);
@@ -211,9 +251,25 @@ describe("aliyun guardrail e2e: upstream RequestId is preserved and correlatable
       provider_key_id: streamPk.id,
     });
 
+    const anthropicPk = await seed.createProviderKey({
+      display_name: "aliyun-reqid-msg-pk",
+      secret: "sk-mock",
+      api_base: anthropicStreamUpstream.baseUrl,
+    });
+    await seed.createModel({
+      display_name: "aliyun-reqid-msg-e2e",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: anthropicPk.id,
+    });
+
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
-      allowed_models: ["aliyun-reqid-e2e", "aliyun-reqid-stream-e2e"],
+      allowed_models: [
+        "aliyun-reqid-e2e",
+        "aliyun-reqid-stream-e2e",
+        "aliyun-reqid-msg-e2e",
+      ],
     });
 
     await seed.createGuardrail({
@@ -231,21 +287,9 @@ describe("aliyun guardrail e2e: upstream RequestId is preserved and correlatable
       window_size: 16,
       window_overlap_size: 4,
     });
-  });
 
-  afterAll(async () => {
-    await app?.exit();
-    await benignUpstream?.close();
-    await streamUpstream?.close();
-    await aliyun?.close();
-  });
-
-  test("input block: one log line joins x-aisix-request-id to Aliyun's RequestId", async (ctx) => {
-    if (!etcdReachable || !app) {
-      ctx.skip();
-      return;
-    }
-
+    // Gate the whole suite on the guardrail being live, so no test depends on
+    // an earlier one having waited.
     await waitConfigPropagation(async () => {
       const probe = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
         method: "POST",
@@ -260,6 +304,21 @@ describe("aliyun guardrail e2e: upstream RequestId is preserved and correlatable
       });
       return probe.status === 422;
     });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await benignUpstream?.close();
+    await streamUpstream?.close();
+    await anthropicStreamUpstream?.close();
+    await aliyun?.close();
+  });
+
+  test("input block: one log line joins x-aisix-request-id to Aliyun's RequestId", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
 
     const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
       method: "POST",
@@ -333,6 +392,9 @@ describe("aliyun guardrail e2e: upstream RequestId is preserved and correlatable
     const wire = await res.text();
     expect(wire).toContain("event: error");
     expect(wire).not.toContain(RISK_WORDS);
+    // Same envelope contract as the non-streaming path: the upstream id is
+    // ours to log, not the caller's to see.
+    expect(wire).not.toContain(OUTPUT_REQUEST_ID);
 
     // The output check runs inside the SSE generator, which hyper polls
     // after `ensure_request_id` has already returned. Without the span being
@@ -344,6 +406,43 @@ describe("aliyun guardrail e2e: upstream RequestId is preserved and correlatable
         l.includes(`request_id=${gatewayRequestId}`) &&
         l.includes(`aliyun_request_id=${OUTPUT_REQUEST_ID}`),
       "the streamed-output block line joining the gateway and Aliyun request ids",
+    );
+  });
+
+  // A second, structurally different generator. Chat's builder passing does
+  // not prove /v1/messages' does — each is a separate call site, and a missing
+  // one fails silently (uncorrelated logs, green tests).
+  test("streamed /v1/messages output block keeps the request span too", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": CALLER_PLAINTEXT },
+      body: JSON.stringify({
+        model: "aliyun-reqid-msg-e2e",
+        max_tokens: 64,
+        messages: [{ role: "user", content: "tell me something" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const gatewayRequestId = res.headers.get("x-aisix-request-id");
+    expect(gatewayRequestId).toBeTruthy();
+
+    const wire = await res.text();
+    expect(wire).not.toContain(RISK_WORDS);
+    expect(wire).not.toContain(OUTPUT_REQUEST_ID);
+
+    await waitForLogLine(
+      app,
+      (l) =>
+        l.includes(`request_id=${gatewayRequestId}`) &&
+        l.includes(`aliyun_request_id=${OUTPUT_REQUEST_ID}`),
+      "the /v1/messages streamed-output block line joining both request ids",
     );
   });
 });


### PR DESCRIPTION
## Problem

The `aliyun_text_moderation` guardrail dropped everything Aliyun reported about a moderation call. `AliyunResponse` never deserialized `RequestId`, so a caller's `422 content_filter` could not be traced to a record in the Aliyun console.

Two things had to be true to fix that, and neither was:

1. The Aliyun `RequestId` had to be captured and logged.
2. It had to be joinable to the `x-aisix-request-id` the caller holds — otherwise the operator has an id they cannot look anything up with.

## Where the RequestId comes from

Read `x-acs-request-id` off the **response headers**, falling back to the body's `RequestId`.

Verified against the live green-cip endpoint: the header is present on 2xx, on a JSON business error, and on 400/404 responses whose body is **XML** — it survives exactly the cases where the body is unreachable. The body alone would not, because Aliyun types `Code` inconsistently:

| | HTTP status | `Code` |
| --- | --- | --- |
| success / business error | 200 | int (`200`, `400`) |
| transport/auth error | 4xx | string (`"InvalidAccessKeyId.NotFound"`) |

So the documented shape does not deserialize on the error path. Only the HTTP-200 shape is parsed; the error shape keeps its existing raw capped-body log, now with the header-sourced id alongside.

Timeouts and connection failures yield no id at all — those log an empty `aliyun_request_id` plus the failure bucket, so \"Aliyun never answered\" stays distinguishable from \"we forgot to log it\". An HTTP 200 with a non-JSON body now reports `MalformedResponse` rather than being bucketed as `ServerError`; the two want different fixes, and the bypass tag `aliyun_bad_response` is new.

## Correlation

Nothing in the data plane put a `request_id` on a log line. `ensure_request_id` minted the id for the response header and telemetry, but no tracing span carried it — so all 38 guardrail log sites, across all six providers, were uncorrelated. This is a whole-class gap, not an Aliyun one.

`ensure_request_id` now opens a `request{request_id=…}` span that every guardrail inherits. Two places fall outside it and re-attach explicitly:

- the four SSE generators, whose bodies hyper polls after the middleware returns;
- the realtime session, which axum runs on a detached task.

The invariant is recorded in a new `crates/aisix-proxy/AGENTS.md`, because forgetting it on a future stream builder fails silently.

## Log searchability

The fmt subscriber colorized unconditionally. On a piped stderr — every real deployment — the ANSI escapes land *between* a field's name and its value, so `grep 'aliyun_request_id=<id>'` matched nothing and fields were searchable only by bare value. Colorize only when stderr is a terminal.

## Log-format change (worth a release note)

Two visible changes to what the gateway writes to stderr, both intended:

- Every log line emitted while serving a request gains a `request{request_id=…}:` prefix, between the level and the target. A downstream parser anchored on the target still matches; one anchored on `level target:` as adjacent tokens would need adjusting.
- Colour escapes disappear from piped/redirected stderr (they stay for a terminal). Anything that was stripping ANSI keeps working; anything that was matching `field=value` starts working.

## Behavior for callers

Unchanged. Aliyun's `RequestId` is deliberately **not** exposed in the response envelope or a header: callers get `x-aisix-request-id` and quote it, operators resolve the rest from the log. This discloses no moderation vendor and adds no wire contract to maintain.

## Content safety

Two leaks, one of them live before this PR.

**The moderation result.** A real `high` response echoes the offending text back:

```json
{ "Label": "inappropriate_oral", "RiskWords": "傻逼,弄死你,死你全家",
  "RiskPositions": [{ "StartPos": 3, "EndPos": 5, "RiskWord": "傻逼" }] }
```

Only `Label` is deserialized, so per #153 there is nowhere for matched content to leak.

**The 4xx error body — a pre-existing leak, found in review.** A wrong access-key *secret* makes green-cip answer `SignatureDoesNotMatch` quoting the whole StringToSign, which embeds our percent-encoded `ServiceParameters` — the caller's prompt — plus the AccessKey id. RPC v1 signature errors echo the canonicalized request by design. The 4xx path (added in #773) logged that body verbatim, so one fat-fingered credential wrote **every moderated prompt** into the gateway log.

Now only the error `Code` is logged (`SignatureDoesNotMatch`, `InvalidAccessKeyId.NotFound`, `InvalidAction.NotFound`). It is a symbolic error class from a closed vocabulary, so it structurally cannot carry request content, and it still answers what the body log was for: telling a wrong key from a wrong region/endpoint. The body is read (capped) to extract the code, never logged; the code arrives as JSON from the RPC layer and XML from the endpoint layer, so both shapes are handled, with nothing emitted for an unrecognized body.

Extracting the code needs its own read budget, separate from the crate's 2 KiB log-snippet cap — a snippet can stop anywhere, a parse cannot. `Code` is the **last** member of the error object, sitting after the StringToSign echo, so the bigger the caller's prompt the further out it lands. Measured live: a 1 980-char Chinese prompt gives a 30 457-byte body with `Code` at offset 30 426 (the content is percent-encoded twice inbound, ~15 bytes per source char). At 2 KiB the JSON truncated mid-`Message` and `aliyun_code` came back empty — i.e. the most common misconfiguration would have reported no diagnosis. The parse budget is 64 KiB, covering the 2 000-char content cap at 4 bytes per char.

## What an operator now sees

\`\`\`text
INFO request{request_id=12179fb5-5c3c-4a2a-a411-d73746379cc6}: aisix_guardrails::aliyun:
aliyun text moderation blocked content row=aliyun-live-guard service=\"llm_query_moderation\"
aliyun_request_id=019F6EF3-6F9A-5A25-9EED-256CB0E26448 aliyun_code=200
aliyun_risk_level=high aliyun_labels=inappropriate_oral,inappropriate_profanity,violent_incidents
\`\`\`

A block logs at `info` (the default level); a clean pass logs the same fields at `debug`, so a per-request line is not spent by default.

## Tests

- Unit: 2xx block (incl. the no-leak assertion against a real body), 2xx clean pass, timeout, malformed JSON, 5xx, 4xx, and a header-less business error.
- Unit: the `SignatureDoesNotMatch` body from a live response, asserting the canary prompt / AccessKey id / StringToSign never reach a log; plus `extract_error_code` against both live error shapes.
- E2E (`guardrail-aliyun-request-id-e2e.test.ts`): asserts **one** log line carries both ids — two lines each holding one would not let an operator join them — across the non-streaming path, chat SSE, and /v1/messages streamed output (a second, structurally different generator).
- The live smoke test (`--ignored`) now also asserts the real endpoint yields the diagnostics we log.

## Baseline

LiteLLM has no Aliyun guardrail, so there is no direct baseline. Against its general moderation guardrails, all three decisions align with or exceed it: its Bedrock hook redacts matched spans while keeping labels (`redact_nested_match_and_regex_keys`, \"only non-sensitive labels + scores (no offsets / raw input)\"); it correlates guardrail events via a request-root span; and it does not expose guardrail providers' request ids to callers.

Docs: paired PR against api7/docs.

Fixes api7/AISIX-Cloud#1060
Fixes api7/AISIX-Cloud#1092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Aliyun moderation logs now include request IDs, moderation codes, risk levels, and labels across successful and failed requests.
  - Malformed moderation responses are reported distinctly from upstream server errors.
  - Request correlation is preserved for streaming responses and realtime connections, improving troubleshooting.
  - Terminal logs now automatically enable colors only when supported.
- **Privacy**
  - Sensitive provider content, including matched risk words and positions, is excluded from logs and streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



