### PR TITLE
fix(telemetry): stop clipping the per-attempt error message at 256 chars

### DIFF
--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -200,16 +200,20 @@ mod tests {
         }
     }
 
-    /// AISIX-Cloud#1065: a real upstream error long enough to matter
-    /// must survive into telemetry whole. Azure's content-management
-    /// policy message is ~260 chars — the old 256-char cap clipped its
-    /// tail (the doc link that says what to actually do about it).
+    /// AISIX-Cloud#1065: an upstream error long enough to matter must
+    /// survive into telemetry whole. A content-filter refusal — the
+    /// shape that provoked the issue — runs past 256 chars, and the old
+    /// cap clipped its tail, which is exactly where the actionable part
+    /// (the link explaining the policy) sits. Hence a fixture that is
+    /// prose ending in a URL, not a run of filler: what has to survive
+    /// is the END of a realistically long message.
     #[test]
     fn long_upstream_message_is_not_clipped() {
-        let upstream = "The response was filtered due to the prompt triggering \
-             Azure OpenAI's content management policy. Please modify your prompt \
-             and retry. To learn more about our content filtering policies please \
-             read our documentation: https://go.microsoft.com/fwlink/?linkid=2198766";
+        let upstream = "The response was filtered because the prompt triggered \
+             the provider's content management policy. Please modify your prompt \
+             and retry. To learn more about the content filtering policies that \
+             apply here, read the documentation at \
+             https://upstream.example/docs/content-filtering";
         assert!(
             upstream.len() > 256,
             "fixture must exceed the old cap to be a regression test"
@@ -218,7 +222,7 @@ mod tests {
         let got = attempt_error_message(&upstream_status(upstream));
 
         assert!(
-            got.ends_with("https://go.microsoft.com/fwlink/?linkid=2198766"),
+            got.ends_with("https://upstream.example/docs/content-filtering"),
             "message tail was clipped: {got}"
         );
         assert!(got.contains(upstream), "message body was altered: {got}");

--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -145,13 +145,24 @@ pub(crate) fn routing_error_class(err: &BridgeError) -> &'static str {
     }
 }
 
-/// Short, control-char-stripped error string for the per-attempt
-/// `error_message` telemetry field (#655). Capped like `sanitize_tag`.
+/// Upper bound on the per-attempt `error_message` telemetry field.
+///
+/// Sized as a backstop, not as the real limit: an `UpstreamStatus`
+/// message is already bounded to [`aisix_gateway::MAX_UPSTREAM_ERROR_MESSAGE_BYTES`]
+/// (1 KiB) by the bridge, so a cap above that byte budget leaves the
+/// bridge's bound as the only one that ever fires and the operator sees
+/// the whole message the bridge kept. A tighter cap silently clipped it
+/// a second time (AISIX-Cloud#1065).
+const MAX_ATTEMPT_ERROR_MESSAGE_CHARS: usize = 2048;
+
+/// Control-char-stripped error string for the per-attempt
+/// `error_message` telemetry field (#655), capped at
+/// [`MAX_ATTEMPT_ERROR_MESSAGE_CHARS`].
 pub(crate) fn attempt_error_message(err: &BridgeError) -> String {
     err.to_string()
         .chars()
         .filter(|c| !c.is_control())
-        .take(256)
+        .take(MAX_ATTEMPT_ERROR_MESSAGE_CHARS)
         .collect()
 }
 
@@ -172,4 +183,73 @@ pub(crate) fn attempt_error_from_proxy(err: &ProxyError) -> (String, String) {
 /// Milliseconds elapsed since `started`, saturating at `u32::MAX`.
 pub(crate) fn ms_since(started: Instant) -> u32 {
     started.elapsed().as_millis().min(u32::MAX as u128) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_gateway::{UpstreamWire, MAX_UPSTREAM_ERROR_MESSAGE_BYTES};
+
+    fn upstream_status(message: &str) -> BridgeError {
+        BridgeError::UpstreamStatus {
+            status: 400,
+            message: message.to_string(),
+            parsed: None,
+            wire: UpstreamWire::OpenAI,
+            retry_after: None,
+        }
+    }
+
+    /// AISIX-Cloud#1065: a real upstream error long enough to matter
+    /// must survive into telemetry whole. Azure's content-management
+    /// policy message is ~260 chars — the old 256-char cap clipped its
+    /// tail (the doc link that says what to actually do about it).
+    #[test]
+    fn long_upstream_message_is_not_clipped() {
+        let upstream = "The response was filtered due to the prompt triggering \
+             Azure OpenAI's content management policy. Please modify your prompt \
+             and retry. To learn more about our content filtering policies please \
+             read our documentation: https://go.microsoft.com/fwlink/?linkid=2198766";
+        assert!(
+            upstream.len() > 256,
+            "fixture must exceed the old cap to be a regression test"
+        );
+
+        let got = attempt_error_message(&upstream_status(upstream));
+
+        assert!(
+            got.ends_with("https://go.microsoft.com/fwlink/?linkid=2198766"),
+            "message tail was clipped: {got}"
+        );
+        assert!(got.contains(upstream), "message body was altered: {got}");
+    }
+
+    /// The cap sits above the bridge's own byte bound, so anything the
+    /// bridge already truncated passes through untouched — the bridge
+    /// stays the single limit that fires.
+    #[test]
+    fn cap_clears_the_bridge_message_bound() {
+        let bridge_capped = "x".repeat(MAX_UPSTREAM_ERROR_MESSAGE_BYTES);
+        let got = attempt_error_message(&upstream_status(&bridge_capped));
+        assert!(
+            got.contains(&bridge_capped),
+            "a bridge-bounded message must reach telemetry whole"
+        );
+    }
+
+    /// The cap is still a backstop: a bridge variant carrying an
+    /// unbounded string (`Config`, here) can't write unbounded telemetry.
+    #[test]
+    fn pathological_message_still_hits_the_backstop() {
+        let got = attempt_error_message(&BridgeError::Config("y".repeat(9000)));
+        assert_eq!(got.chars().count(), MAX_ATTEMPT_ERROR_MESSAGE_CHARS);
+    }
+
+    /// Control characters stay stripped — a multi-line upstream body
+    /// must not break the single-string telemetry field.
+    #[test]
+    fn control_chars_are_stripped() {
+        let got = attempt_error_message(&upstream_status("line one\nline\ttwo"));
+        assert!(got.ends_with("line onelinetwo"), "got: {got}");
+    }
 }


### PR DESCRIPTION
## Problem

The `error_message` an operator reads on the /logs page is truncated **before it is ever stored**. `attempt_error_message` caps the string at 256 chars — a bound copied from `sanitize_tag`, which exists to bound short provider tags (`branded_provider`, `pk_label`), not error text.

That cap sits on top of a bound that had already made the string safe to store: an `UpstreamStatus` message is bounded by the bridge at `MAX_UPSTREAM_ERROR_MESSAGE_BYTES` (1 KiB) in `capture_upstream_error_http`. So the 256-char cap was a second, tighter truncation with no budget of its own to defend.

Real upstream errors exceed it. A content-filter refusal — the shape that provoked the issue — runs ~260 chars on its own, so what reached telemetry ended mid-URL:

```
upstream returned HTTP 400: The response was filtered because the prompt triggered
the provider's content management policy. Please modify your prompt and retry. To
learn more about the content filtering policies that apply here, read the docum
```

— dropping exactly the part that tells the operator what to do about it.

## Implementation

Raise the cap to 2048 chars (`MAX_ATTEMPT_ERROR_MESSAGE_CHARS`), above the bridge's 1 KiB byte budget, so the bridge's bound is the only limit that fires and the operator sees the whole message the bridge kept. Chars-vs-bytes matters here: a 1 KiB ASCII message is 1024 chars, so a 1024-*char* cap would still have clipped the prefix `upstream returned HTTP 400: ` worth of tail.

The cap stays as a backstop — `BridgeError` variants that carry an unbounded string (e.g. `Config`) still can't write unbounded telemetry.

**Baseline.** Mainstream gateways bound this field an order of magnitude looser than we did: the closest comparable applies a 2048-char DB-storage cap to the stored error message (env-tunable), and truncates prompts on the same budget. 2048 matches that. None treat a short-tag-sized bound as adequate for error text.

## Behavior change

Failed-attempt `error_message` telemetry can now carry up to ~1 KiB (whatever the bridge kept) instead of 256 chars. Only failed attempts populate the field, and cp-api stores it in a `text` column with no cap of its own; per-org `usage_retention_days` pruning is unchanged.

## Tests

`crates/aisix-proxy/src/attempt.rs` — the two regression tests fail on the old cap and pass on the new one; verified by reverting the constant locally:

- `long_upstream_message_is_not_clipped` — a long refusal survives to its trailing doc URL. The fixture is prose ending in a URL rather than generated filler, because what has to survive is the END of a realistically long message.
- `cap_clears_the_bridge_message_bound` — a message already at the bridge's byte bound reaches telemetry whole.
- `pathological_message_still_hits_the_backstop` — an unbounded `Config` string is still capped.
- `control_chars_are_stripped` — unchanged sanitisation.

The paired dashboard fix (the detail panel renders this field with a `truncate` class, clipping it to one line regardless of length) ships separately in api7/AISIX-Cloud#1068.

Fixes api7/AISIX-Cloud#1065