### PR TITLE
feat(metrics): extend client_type coverage and add operator UA mapping rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "object_store",
  "parking_lot",
+ "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -72,6 +72,21 @@ observability:
     otlp:
       enabled: false
       endpoint: "http://127.0.0.1:4317"
+    # Optional User-Agent -> client_type mapping rules for the
+    # aisix_llm_tokens_by_client_total metric. Tried in order (first match
+    # wins) BEFORE the built-in client allowlist, so you can classify
+    # in-house tools or re-bucket a built-in match. `pattern` is a regex,
+    # matched case-insensitively and unanchored against the raw User-Agent;
+    # `client` is the fixed label value emitted on match
+    # ([a-z0-9][a-z0-9._-]*, max 64 chars; max 64 rules). Validated at
+    # boot; changes require a restart. The metric label set stays bounded:
+    # only these fixed values (plus built-ins / "other" / "unknown") are
+    # ever emitted — never the raw User-Agent.
+    # client_type_rules:
+    #   - pattern: "^py-billing-batcher/"
+    #     client: billing-batcher
+    #   - pattern: "internal-eval-harness"
+    #     client: eval-harness
   tracing:
     otlp:
       enabled: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,10 +75,10 @@ observability:
     # Optional User-Agent -> client_type mapping rules for the
     # aisix_llm_tokens_by_client_total metric. Tried in order (first match
     # wins) BEFORE the built-in client allowlist, so you can classify
-    # in-house tools or re-bucket a built-in match. `pattern` is a regex,
-    # matched case-insensitively and unanchored against the raw User-Agent;
-    # `client` is the fixed label value emitted on match
-    # ([a-z0-9][a-z0-9._-]*, max 64 chars; max 64 rules). Validated at
+    # in-house tools or re-bucket a built-in match. `pattern` is a regex
+    # (max 512 bytes), matched case-insensitively and unanchored against
+    # the raw User-Agent; `client` is the fixed label value emitted on
+    # match ([a-z0-9][a-z0-9._-]*, max 64 chars; max 64 rules). Validated at
     # boot; changes require a restart. The metric label set stays bounded:
     # only these fixed values (plus built-ins / "other" / "unknown") are
     # ever emitted — never the raw User-Agent.

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -66,6 +66,13 @@ observability:
       addr: "0.0.0.0:9090"
     otlp:
       enabled: false
+    # Optional User-Agent -> client_type mapping rules for the
+    # aisix_llm_tokens_by_client_total metric (first match wins, tried
+    # before the built-in allowlist; regex, case-insensitive). See
+    # config.example.yaml for the full annotation.
+    # client_type_rules:
+    #   - pattern: "^py-billing-batcher/"
+    #     client: billing-batcher
   tracing:
     otlp:
       enabled: false

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -500,6 +500,26 @@ impl ObservabilityConfig {
 pub struct MetricsConfig {
     pub prometheus: PrometheusConfig,
     pub otlp: OtlpConfig,
+    /// Operator-defined User-Agent → `client_type` mapping rules
+    /// (AISIX-Cloud#1045), consulted BEFORE the built-in allowlist so a
+    /// deployment can classify in-house tools (or re-bucket a built-in
+    /// match). Deployment-scoped on purpose: the labels these rules mint
+    /// go to this DP's own Prometheus scrape surface, so the operator who
+    /// owns the scrape owns the label set. Order matters (first match
+    /// wins); compiled + validated at boot (fail-fast), never hot-reloaded.
+    pub client_type_rules: Vec<ClientTypeRule>,
+}
+
+/// One `client_type_rules` entry: a regex tried against the raw inbound
+/// `User-Agent` (case-insensitive, unanchored — anchor with `^` yourself),
+/// and the bounded label value emitted on match. The label — not the UA —
+/// becomes the Prometheus `client_type` value, so cardinality stays capped
+/// by the rule count.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClientTypeRule {
+    pub pattern: String,
+    pub client: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -27,9 +27,9 @@ pub mod version;
 pub mod wildcard;
 
 pub use config::{
-    AdminConfig, CacheBackend, CacheConfig, Config, EtcdConfig, EtcdTlsConfig, ManagedConfig,
-    ObservabilityConfig, ProxyConfig, RateLimitBackend, RateLimitConfig, RealIpConfig,
-    RedisConnConfig, RedisMode, TlsConfig,
+    AdminConfig, CacheBackend, CacheConfig, ClientTypeRule, Config, EtcdConfig, EtcdTlsConfig,
+    ManagedConfig, ObservabilityConfig, ProxyConfig, RateLimitBackend, RateLimitConfig,
+    RealIpConfig, RedisConnConfig, RedisMode, TlsConfig,
 };
 pub use config_status::{
     hash_bytes, hash_entries, AppliedSnapshot, ConfigMetricsView, ConfigState, ConfigStatus,

--- a/crates/aisix-obs/Cargo.toml
+++ b/crates/aisix-obs/Cargo.toml
@@ -15,6 +15,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
+regex.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 serde.workspace = true

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -29,8 +29,9 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 pub use access_log::AccessLog;
 pub use metrics::{
-    client_type_from_user_agent, BudgetGauges, BudgetLabels, DeploymentLabels, DeploymentState,
-    LatencyLabels, LlmUsage, Metrics, RequestLabels, RequestOutcome, UsageLabels,
+    client_type_from_user_agent, BudgetGauges, BudgetLabels, ClientTypeClassifier,
+    DeploymentLabels, DeploymentState, LatencyLabels, LlmUsage, Metrics, RequestLabels,
+    RequestOutcome, UsageLabels,
 };
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::{content_capture_cap, OtlpHttpFanOut, OtlpSink};

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -513,9 +513,11 @@ impl Metrics {
     }
 
     /// #890 req-4: record token volume for the inbound `client_type` on the
-    /// dedicated [`M_LLM_TOKENS_BY_CLIENT_TOTAL`] series. `client_type` is a
-    /// `&'static str` from [`client_type_from_user_agent`] so cardinality is
-    /// bounded; zero dims are skipped to keep the series sparse.
+    /// dedicated [`M_LLM_TOKENS_BY_CLIENT_TOTAL`] series. `client_type` MUST
+    /// come from [`ClientTypeClassifier::classify`] (or the built-in
+    /// [`client_type_from_user_agent`]) — never raw client input — so the
+    /// value set stays bounded by built-ins ∪ boot-validated operator rules
+    /// (AISIX-Cloud#1045); zero dims are skipped to keep the series sparse.
     ///
     /// `model` (AISIX-Cloud#1044) is the requested logical model — callers
     /// MUST pass the same value they put in [`UsageLabels::model`] (or its
@@ -533,7 +535,7 @@ impl Metrics {
     /// and the `aisix_llm_total_tokens_total` fix in #679).
     pub fn record_llm_tokens_by_client(
         &self,
-        client_type: &'static str,
+        client_type: &str,
         model: &str,
         input_tokens: u64,
         output_tokens: u64,
@@ -546,7 +548,7 @@ impl Metrics {
             if input_tokens > 0 {
                 metrics::counter!(
                     M_LLM_TOKENS_BY_CLIENT_TOTAL,
-                    "client_type" => client_type,
+                    "client_type" => client_type.to_string(),
                     "model" => model.to_string(),
                     "token_type" => "input",
                 )
@@ -555,7 +557,7 @@ impl Metrics {
             if output_tokens > 0 {
                 metrics::counter!(
                     M_LLM_TOKENS_BY_CLIENT_TOTAL,
-                    "client_type" => client_type,
+                    "client_type" => client_type.to_string(),
                     "model" => model.to_string(),
                     "token_type" => "output",
                 )
@@ -564,7 +566,7 @@ impl Metrics {
             if total_tokens > 0 {
                 metrics::counter!(
                     M_LLM_TOKENS_BY_CLIENT_TOTAL,
-                    "client_type" => client_type,
+                    "client_type" => client_type.to_string(),
                     "model" => model.to_string(),
                     "token_type" => "total",
                 )
@@ -839,6 +841,37 @@ pub fn client_type_from_user_agent(user_agent: &str) -> &'static str {
         ("claude-code", "claude-code"),
         ("codex", "codex"),
         ("cline", "cline"),
+        // Cline-family forks (AISIX-Cloud#1045). Each sends `<Product>/<ver>`
+        // on its OpenAI-compatible provider path (Roo since PR #5492,
+        // Kilo ≤5.16.2, Zoo ≥3.54.0); the second spelling covers the
+        // `roo-code/<ver> (<os>; <arch>)`-style native-path variants.
+        ("roo-code", "roo-code"),
+        ("roocode", "roo-code"),
+        ("kilo-code", "kilocode"),
+        ("kilocode", "kilocode"),
+        ("zoo-code", "zoo-code"),
+        ("zoocode", "zoo-code"),
+        // VS Code Copilot Chat BYOK sends `GitHubCopilotChat/<ver>` from
+        // the user's machine; the broader needle also catches other
+        // `GitHubCopilot*` variants should they surface in a UA.
+        ("githubcopilot", "github-copilot"),
+        // Cursor routes BYO-endpoint traffic through its own backend,
+        // which presents `Cursor/1.0` (version segment is fixed).
+        ("cursor", "cursor"),
+        // Terminal agents / editors (AISIX-Cloud#1045). opencode PREFIXES
+        // the Vercel AI SDK UA (`opencode/<ver> ai-sdk/…`), so it must
+        // stay ahead of the `ai-sdk/provider-utils` bucket below. Qwen
+        // Code sends `QwenCode/<ver> (<os>; <arch>)` on OpenAI paths but
+        // masquerades as `claude-cli/…` toward non-Anthropic hosts on its
+        // Anthropic path — that traffic lands in `claude-code`, which a
+        // substring table cannot untangle. Gemini CLI embeds the surface
+        // (`GeminiCLI-tui/<ver>/<model> (…)`). `zed/` keeps the slash so
+        // the needle requires the `Zed/<ver>` token form.
+        ("opencode", "opencode"),
+        ("qwencode", "qwen-code"),
+        ("geminicli", "gemini-cli"),
+        ("charm-crush", "crush"),
+        ("zed/", "zed"),
         ("aider", "aider"),
         ("openai-python", "openai-python"),
         ("openai/python", "openai-python"),
@@ -853,6 +886,10 @@ pub fn client_type_from_user_agent(user_agent: &str) -> &'static str {
         ("llama_index", "llamaindex"),
         ("llamaindex", "llamaindex"),
         ("litellm", "litellm"),
+        // Vercel AI SDK default UA (`ai/<v> ai-sdk/provider-utils/<v>
+        // runtime/<rt>`) — the whole-SDK bucket for tools that don't
+        // override it (Cline 4.x, Kilo Code 7.x, …).
+        ("ai-sdk/provider-utils", "vercel-ai-sdk"),
         ("curl", "curl"),
         ("python-requests", "python-requests"),
         ("python-httpx", "httpx"),
@@ -872,6 +909,96 @@ pub fn client_type_from_user_agent(user_agent: &str) -> &'static str {
         }
     }
     "other"
+}
+
+/// Boot-compiled `client_type` classifier: operator rules from
+/// `observability.metrics.client_type_rules` (AISIX-Cloud#1045) tried in
+/// config order first, then the built-in
+/// [`client_type_from_user_agent`] allowlist. Custom rules deliberately
+/// outrank built-ins so a deployment can re-bucket anything — e.g. an
+/// in-house tool whose UA embeds `axios` and would otherwise land in
+/// `node`. Cardinality stays bounded: a match emits the rule's fixed
+/// `client` value (validated at compile), never request-derived text.
+#[derive(Debug, Default)]
+pub struct ClientTypeClassifier {
+    rules: Vec<(regex::Regex, String)>,
+}
+
+impl ClientTypeClassifier {
+    pub const MAX_RULES: usize = 64;
+    pub const MAX_PATTERN_LEN: usize = 512;
+    pub const MAX_CLIENT_LEN: usize = 64;
+
+    /// Built-ins only — the behaviour of every deployment without
+    /// `client_type_rules` configured.
+    pub fn builtin() -> Self {
+        Self::default()
+    }
+
+    /// Compile + validate operator rules. Errors are boot-fatal by design
+    /// (a silently dropped rule would misattribute traffic until someone
+    /// notices the label is missing).
+    pub fn compile(rules: &[aisix_core::ClientTypeRule]) -> Result<Self, String> {
+        if rules.len() > Self::MAX_RULES {
+            return Err(format!(
+                "observability.metrics.client_type_rules: {} rules exceed the limit of {}",
+                rules.len(),
+                Self::MAX_RULES
+            ));
+        }
+        let mut compiled = Vec::with_capacity(rules.len());
+        for (i, rule) in rules.iter().enumerate() {
+            let ctx = format!("observability.metrics.client_type_rules[{i}]");
+            if rule.pattern.is_empty() || rule.pattern.len() > Self::MAX_PATTERN_LEN {
+                return Err(format!(
+                    "{ctx}: pattern must be 1..={} bytes",
+                    Self::MAX_PATTERN_LEN
+                ));
+            }
+            if !valid_client_label(&rule.client) {
+                return Err(format!(
+                    "{ctx}: client {:?} must match [a-z0-9][a-z0-9._-]* and be at most {} chars",
+                    rule.client,
+                    Self::MAX_CLIENT_LEN
+                ));
+            }
+            let re = regex::RegexBuilder::new(&rule.pattern)
+                .case_insensitive(true)
+                .build()
+                .map_err(|e| format!("{ctx}: invalid pattern: {e}"))?;
+            compiled.push((re, rule.client.clone()));
+        }
+        Ok(Self { rules: compiled })
+    }
+
+    /// Classify a raw inbound `User-Agent`. Empty/whitespace UA is always
+    /// `unknown` (custom rules never see it — `unknown` keeps meaning "the
+    /// client sent nothing"); then custom rules in config order (first
+    /// match wins); then the built-in table; then `other`.
+    pub fn classify<'a>(&'a self, user_agent: &str) -> &'a str {
+        let ua = user_agent.trim();
+        if ua.is_empty() {
+            return "unknown";
+        }
+        for (re, client) in &self.rules {
+            if re.is_match(ua) {
+                return client;
+            }
+        }
+        client_type_from_user_agent(ua)
+    }
+}
+
+/// Prometheus-safe label value: lowercase alnum start, then alnum/`.`/`_`/`-`.
+fn valid_client_label(label: &str) -> bool {
+    if label.is_empty() || label.len() > ClientTypeClassifier::MAX_CLIENT_LEN {
+        return false;
+    }
+    let mut chars = label.chars();
+    let first = chars.next().expect("non-empty checked above");
+    (first.is_ascii_lowercase() || first.is_ascii_digit())
+        && chars
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1430,6 +1557,174 @@ mod tests {
             client_type_from_user_agent("SomeRandomBespokeClient/9.9"),
             "other"
         );
+    }
+
+    /// AISIX-Cloud#1045: coding clients added from source-verified UA
+    /// samples (real formats quoted from each product's provider code —
+    /// see the issue's evidence table).
+    #[test]
+    fn client_type_recognises_coding_clients_1045() {
+        // Cline v3.56+ sends `Cline/<ver>` on both BYO paths (PR #8872).
+        assert_eq!(client_type_from_user_agent("Cline/3.89.2"), "cline");
+        // Roo Code OpenAI-compatible path (DEFAULT_HEADERS since PR #5492)
+        // and its `roo-code/<ver> (<os>; <arch>)` native-path variant.
+        assert_eq!(client_type_from_user_agent("RooCode/3.54.0"), "roo-code");
+        assert_eq!(
+            client_type_from_user_agent("roo-code/3.54.0 (darwin 23.5.0; arm64) node/20.19.0"),
+            "roo-code"
+        );
+        // Kilo Code ≤5.16.2 (legacy Roo fork lineage).
+        assert_eq!(client_type_from_user_agent("Kilo-Code/5.16.2"), "kilocode");
+        // Zoo Code — the community continuation of archived Roo Code;
+        // marketplace builds carry large patch numbers.
+        assert_eq!(
+            client_type_from_user_agent("ZooCode/3.71.100268"),
+            "zoo-code"
+        );
+        // Vercel AI SDK default UA — the bucket for AI-SDK-based tools
+        // that don't override it (Cline 4.x on node, Kilo 7.x on bun).
+        assert_eq!(
+            client_type_from_user_agent(
+                "ai/6.0.144 ai-sdk/provider-utils/4.0.22 runtime/node.js/26"
+            ),
+            "vercel-ai-sdk"
+        );
+        assert_eq!(
+            client_type_from_user_agent(
+                "ai/6.0.168 ai-sdk/provider-utils/4.0.29 runtime/bun/1.3.6"
+            ),
+            "vercel-ai-sdk"
+        );
+        // VS Code Copilot Chat BYOK (nodeFetcher.ts default UA).
+        assert_eq!(
+            client_type_from_user_agent("GitHubCopilotChat/0.44.0"),
+            "github-copilot"
+        );
+        // Cursor's backend presents a fixed version segment.
+        assert_eq!(client_type_from_user_agent("Cursor/1.0"), "cursor");
+        // Copilot CLI BYOK exposes only the SDK UA — classified as the
+        // SDK, not as Copilot (identification limit recorded in #1045).
+        assert_eq!(
+            client_type_from_user_agent("OpenAI/JS 5.20.1"),
+            "openai-node"
+        );
+        // opencode prefixes the AI-SDK UA — the product token must win
+        // over the `ai-sdk/provider-utils` bucket also present in the UA.
+        assert_eq!(
+            client_type_from_user_agent(
+                "opencode/1.18.3 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14"
+            ),
+            "opencode"
+        );
+        // Qwen Code, OpenAI-compatible path (live-captured format).
+        assert_eq!(
+            client_type_from_user_agent("QwenCode/0.20.0 (linux; x64)"),
+            "qwen-code"
+        );
+        // Qwen Code's Anthropic path masquerades as Claude Code toward
+        // gateways — a KNOWN collision: it lands in `claude-code`.
+        assert_eq!(
+            client_type_from_user_agent("claude-cli/0.20.0 (external, cli)"),
+            "claude-code"
+        );
+        // Gemini CLI (Gemini-protocol only today; UA still recognised).
+        assert_eq!(
+            client_type_from_user_agent(
+                "GeminiCLI-tui/0.51.0/gemini-3.1-pro-preview (linux; x64; terminal)"
+            ),
+            "gemini-cli"
+        );
+        // Crush and Zed set product UAs on their shared HTTP clients.
+        assert_eq!(
+            client_type_from_user_agent("Charm-Crush/1.0.0 (https://charm.land/crush)"),
+            "crush"
+        );
+        assert_eq!(
+            client_type_from_user_agent("Zed/0.198.0 (linux; x86_64)"),
+            "zed"
+        );
+    }
+
+    /// AISIX-Cloud#1045: operator rules outrank built-ins, first match
+    /// wins, non-matches fall back to the built-in table, and empty UA
+    /// stays `unknown` even under a match-anything rule.
+    #[test]
+    fn classifier_custom_rules_first_match_then_builtin_fallback() {
+        let rule = |pattern: &str, client: &str| aisix_core::ClientTypeRule {
+            pattern: pattern.into(),
+            client: client.into(),
+        };
+        let c = ClientTypeClassifier::compile(&[
+            rule("^internal-agent/", "internal-agent"),
+            // Overlaps the rule above — order decides (first match wins).
+            rule("internal", "internal-other"),
+            // Re-buckets a UA the built-in table would call "node".
+            rule("billing-batcher", "billing-batcher"),
+            rule(".*", "catch-all"),
+        ])
+        .expect("valid rules");
+
+        assert_eq!(c.classify("internal-agent/2.1"), "internal-agent");
+        assert_eq!(c.classify("acme-internal-tool/1.0"), "internal-other");
+        // Case-insensitive by default.
+        assert_eq!(c.classify("Internal-Agent/9.9"), "internal-agent");
+        // axios UA would be built-in "node"; the custom rule outranks it.
+        assert_eq!(
+            c.classify("billing-batcher/3.0 axios/1.6.0"),
+            "billing-batcher"
+        );
+        // Empty/whitespace UA never reaches custom rules — even ".*".
+        assert_eq!(c.classify(""), "unknown");
+        assert_eq!(c.classify("   "), "unknown");
+        // The ".*" rule shadows the built-in fallback for everything else.
+        assert_eq!(c.classify("curl/8.4.0"), "catch-all");
+
+        // Without a catch-all, non-matching UAs use the built-in table.
+        let c = ClientTypeClassifier::compile(&[rule("^internal-agent/", "internal-agent")])
+            .expect("valid rules");
+        assert_eq!(c.classify("curl/8.4.0"), "curl");
+        assert_eq!(c.classify("SomeRandomBespokeClient/9.9"), "other");
+
+        // Built-ins only (no config) — same behaviour as the free function.
+        let c = ClientTypeClassifier::builtin();
+        assert_eq!(c.classify("claude-cli/1.2.3"), "claude-code");
+        assert_eq!(c.classify(""), "unknown");
+    }
+
+    /// AISIX-Cloud#1045: invalid rule sets are rejected at compile (boot)
+    /// time — count cap, pattern syntax/length, label charset/length.
+    #[test]
+    fn classifier_rejects_invalid_rule_sets() {
+        let rule = |pattern: &str, client: &str| aisix_core::ClientTypeRule {
+            pattern: pattern.into(),
+            client: client.into(),
+        };
+        // Broken regex syntax.
+        assert!(ClientTypeClassifier::compile(&[rule("([unclosed", "x")])
+            .unwrap_err()
+            .contains("invalid pattern"));
+        // Empty and oversized patterns.
+        assert!(ClientTypeClassifier::compile(&[rule("", "x")]).is_err());
+        let oversized = "a".repeat(ClientTypeClassifier::MAX_PATTERN_LEN + 1);
+        assert!(ClientTypeClassifier::compile(&[rule(&oversized, "x")]).is_err());
+        // Label charset: uppercase, leading dash, spaces, empty, too long.
+        for bad in ["Upper", "-lead", "has space", "", "田"] {
+            assert!(
+                ClientTypeClassifier::compile(&[rule("ok", bad)]).is_err(),
+                "label {bad:?} should be rejected"
+            );
+        }
+        let long_label = "a".repeat(ClientTypeClassifier::MAX_CLIENT_LEN + 1);
+        assert!(ClientTypeClassifier::compile(&[rule("ok", &long_label)]).is_err());
+        // Valid edge labels pass.
+        assert!(ClientTypeClassifier::compile(&[rule("ok", "0-tool_v2.beta")]).is_ok());
+        // Rule-count cap.
+        let too_many: Vec<_> = (0..=ClientTypeClassifier::MAX_RULES)
+            .map(|i| rule(&format!("tool-{i}"), "tool"))
+            .collect();
+        assert!(ClientTypeClassifier::compile(&too_many)
+            .unwrap_err()
+            .contains("exceed"));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -157,7 +157,7 @@ pub async fn chat_completions(
                 let snap = state.snapshot.load();
                 crate::usage_attr::provider_key_metric_name(&snap, &success.provider_key_id)
             };
-            let client_type = aisix_obs::client_type_from_user_agent(&client.user_agent);
+            let client_type = state.client_classifier.classify(&client.user_agent);
             record_success(
                 &state.metrics,
                 &success.provider,
@@ -1399,7 +1399,10 @@ async fn dispatch(
             crate::usage_attr::provider_key_metric_name(&snap, &pk_id)
         };
         let user_name_for_metrics = auth.key().user_name.clone();
-        let client_type_for_metrics = aisix_obs::client_type_from_user_agent(&client.user_agent);
+        let client_type_for_metrics = state
+            .client_classifier
+            .classify(&client.user_agent)
+            .to_string();
         // Captured for the stream-end telemetry closure so
         // emit_usage_event can look up `telemetry_tags` for per-PK
         // attribution (#302 M17 / AISIX-Cloud#436). The metrics
@@ -1583,7 +1586,7 @@ async fn dispatch(
                 // AISIX-Cloud#1044: same requested logical model as the
                 // UsageLabels above.
                 metrics_for_stream.record_llm_tokens_by_client(
-                    client_type_for_metrics,
+                    &client_type_for_metrics,
                     &model_for_metrics,
                     u64::from(comp.prompt_tokens),
                     u64::from(comp.completion_tokens),
@@ -3151,7 +3154,7 @@ fn record_success(
     // #890 req-3 readable name + req-4 client type + req-1/req-2 dimensions.
     user_name: Option<&str>,
     provider_key_name: &str,
-    client_type: &'static str,
+    client_type: &str,
     stream: bool,
     is_fallback: bool,
     status: u16,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -2534,7 +2534,7 @@ fn emit_anthropic_usage_event(
     // #1002: total_tokens_all folds in the Anthropic cache counters.
     // AISIX-Cloud#1044: same requested logical model as the UsageLabels above.
     state.metrics.record_llm_tokens_by_client(
-        aisix_obs::client_type_from_user_agent(&client.user_agent),
+        state.client_classifier.classify(&client.user_agent),
         model,
         u64::from(metrics.prompt_tokens),
         u64::from(metrics.completion_tokens),

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -2559,7 +2559,7 @@ fn emit_usage_event(
     // #1002: cache-inclusive total via the shared helper — cache counters are
     // non-zero only on the #825 Anthropic bridge path.
     state.metrics.record_llm_tokens_by_client(
-        aisix_obs::client_type_from_user_agent(&client.user_agent),
+        state.client_classifier.classify(&client.user_agent),
         requested_model,
         u64::from(usage.prompt_tokens),
         u64::from(usage.completion_tokens),

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -20,7 +20,7 @@ use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
 use aisix_guardrails::LiveGuardrailIndex;
-use aisix_obs::{Metrics, OtlpHttpFanOut, UsageSink};
+use aisix_obs::{ClientTypeClassifier, Metrics, OtlpHttpFanOut, UsageSink};
 use aisix_ratelimit::Limiter;
 use dashmap::DashSet;
 use std::sync::Arc;
@@ -148,6 +148,11 @@ pub struct ProxyState {
     /// deterministic `request_id = "batch-<id>"` on the emitted events is
     /// what keeps cross-restart re-emission idempotent on the cp-api side.
     pub billed_batches: Arc<dashmap::DashSet<String>>,
+    /// Boot-compiled User-Agent → `client_type` classifier: operator
+    /// rules from `observability.metrics.client_type_rules` first, then
+    /// the built-in allowlist (AISIX-Cloud#1045). Default = built-ins
+    /// only; the server bootstrap swaps in the compiled config rules.
+    pub client_classifier: Arc<ClientTypeClassifier>,
 }
 
 impl ProxyState {
@@ -172,6 +177,7 @@ impl ProxyState {
             request_body_limit_bytes: cfg.request_body_limit_bytes,
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
             billed_batches: Arc::new(dashmap::DashSet::new()),
+            client_classifier: Arc::new(ClientTypeClassifier::builtin()),
         }
     }
 
@@ -203,6 +209,7 @@ impl ProxyState {
             request_body_limit_bytes: cfg.request_body_limit_bytes,
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
             billed_batches: Arc::new(dashmap::DashSet::new()),
+            client_classifier: Arc::new(ClientTypeClassifier::builtin()),
         }
     }
 
@@ -245,6 +252,7 @@ impl ProxyState {
             request_body_limit_bytes: cfg.request_body_limit_bytes,
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
             billed_batches: Arc::new(dashmap::DashSet::new()),
+            client_classifier: Arc::new(ClientTypeClassifier::builtin()),
         }
     }
 
@@ -260,6 +268,14 @@ impl ProxyState {
     /// deterministic one via `LiveGuardrailIndex::new(stub_handle, None)`.
     pub fn with_guardrail_index(mut self, index: Arc<LiveGuardrailIndex>) -> Self {
         self.guardrail_index = index;
+        self
+    }
+
+    /// Swap in the classifier compiled from
+    /// `observability.metrics.client_type_rules` (AISIX-Cloud#1045).
+    /// Default is built-ins only.
+    pub fn with_client_classifier(mut self, classifier: Arc<ClientTypeClassifier>) -> Self {
+        self.client_classifier = classifier;
         self
     }
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -686,6 +686,12 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // so a real DP scrape surfaces UsageEvent throughput without
     // needing cp-api or an OTLP receiver in the loop.
     proxy_state = proxy_state.with_usage_sink(usage_sink.with_metrics((*metrics).clone()));
+    // AISIX-Cloud#1045: operator UA→client_type rules. Compile errors are
+    // boot-fatal — a dropped rule would silently misattribute traffic.
+    let client_classifier =
+        aisix_obs::ClientTypeClassifier::compile(&cfg.observability.metrics.client_type_rules)
+            .map_err(|e| anyhow::anyhow!(e))?;
+    proxy_state = proxy_state.with_client_classifier(Arc::new(client_classifier));
     if let Some(client) = budget_client {
         proxy_state = proxy_state.with_budget_client(client);
     }

--- a/tests/e2e/src/cases/client-type-1045-e2e.test.ts
+++ b/tests/e2e/src/cases/client-type-1045-e2e.test.ts
@@ -1,0 +1,231 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for AISIX-Cloud#1045: client_type coverage of common AI coding
+// clients + operator-defined `observability.metrics.client_type_rules`.
+//
+// Pinned here:
+//   1. Real User-Agents of newly supported built-in clients produce their
+//      own stable client_type series on /metrics (acceptance: ≥2 new
+//      clients exercised end-to-end).
+//   2. Operator rules classify an in-house UA the built-ins would bucket
+//      as "other" — and outrank a generic built-in match (an axios-embedded
+//      UA that would land in "node").
+//   3. Unmatched UAs still fall back to the built-in table ("other"), so
+//      custom rules never change baseline behaviour for other traffic.
+
+const CALLER = "sk-1045-client-type-caller";
+const CALLER_HASH = createHash("sha256").update(CALLER).digest("hex");
+
+const MODEL = "ct1045-chat";
+const USAGE = { prompt_tokens: 9, completion_tokens: 4, total_tokens: 13 };
+
+/** Real captured/source-verified UAs of newly supported built-in clients. */
+const BUILTIN_CASES: Array<{ ua: string; clientType: string }> = [
+  { ua: "RooCode/3.54.0", clientType: "roo-code" },
+  { ua: "Kilo-Code/5.16.2", clientType: "kilocode" },
+  { ua: "ZooCode/3.71.100268", clientType: "zoo-code" },
+  { ua: "GitHubCopilotChat/0.44.0", clientType: "github-copilot" },
+  // Also pins product-before-SDK precedence: this UA embeds the
+  // `ai-sdk/provider-utils` needle of the vercel-ai-sdk bucket.
+  {
+    ua: "opencode/1.18.3 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14",
+    clientType: "opencode",
+  },
+];
+
+const CUSTOM_RULES = [
+  { pattern: "^internal-agent/", client: "internal-agent" },
+  // Deliberately overlaps the built-in `axios` → "node" bucket to pin
+  // custom-before-builtin precedence.
+  { pattern: "billing-batcher", client: "billing-batcher" },
+];
+
+function seriesValue(
+  text: string,
+  clientType: string,
+  tokenType: string,
+): number | undefined {
+  for (const line of text.split("\n")) {
+    if (
+      line.startsWith("aisix_llm_tokens_by_client_total{") &&
+      line.includes(`client_type="${clientType}"`) &&
+      line.includes(`model="${MODEL}"`) &&
+      line.includes(`token_type="${tokenType}"`)
+    ) {
+      return Number(line.trim().split(/\s+/).pop());
+    }
+  }
+  return undefined;
+}
+
+async function scrape(app: SpawnedApp): Promise<string> {
+  const res = await fetch(`${app.metricsUrl}/metrics`);
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+/** Poll the scrape until `probe` passes (metric emits race the scrape). */
+async function pollSeries(
+  app: SpawnedApp,
+  probe: (text: string) => boolean,
+): Promise<string> {
+  let text = "";
+  for (let i = 0; i < 60; i++) {
+    text = await scrape(app);
+    if (probe(text)) break;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return text;
+}
+
+async function chatWithUa(app: SpawnedApp, ua: string): Promise<void> {
+  const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER}`,
+      "content-type": "application/json",
+      "user-agent": ua,
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+  expect(res.status).toBe(200);
+}
+
+describe("client_type built-ins + operator rules (AISIX-Cloud#1045)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "chatcmpl-1045",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "hello" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: USAGE,
+      },
+    });
+
+    app = await spawnApp({ clientTypeRules: CUSTOM_RULES });
+    const seed = new SeedClient(new EtcdClient(), app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "ct1045-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_HASH,
+      allowed_models: [MODEL],
+    });
+
+    const probe = new ProxyClient(app.proxyUrl, CALLER);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((d) => d.id === MODEL);
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("new built-in clients: real UAs produce their own client_type series", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    for (const { ua } of BUILTIN_CASES) {
+      await chatWithUa(app, ua);
+    }
+    const text = await pollSeries(app, (t) =>
+      BUILTIN_CASES.every(
+        (c) => seriesValue(t, c.clientType, "total") !== undefined,
+      ),
+    );
+    for (const { clientType } of BUILTIN_CASES) {
+      expect(seriesValue(text, clientType, "input")).toBe(USAGE.prompt_tokens);
+      expect(seriesValue(text, clientType, "output")).toBe(
+        USAGE.completion_tokens,
+      );
+      expect(seriesValue(text, clientType, "total")).toBe(USAGE.total_tokens);
+    }
+  });
+
+  test("operator rules classify in-house UAs and outrank generic built-ins", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // Would be "other" without the rule.
+    await chatWithUa(app, "internal-agent/2.1");
+    // Embeds axios — the built-in table alone would bucket it as "node".
+    await chatWithUa(app, "billing-batcher/3.0 axios/1.6.0");
+
+    const text = await pollSeries(
+      app,
+      (t) =>
+        seriesValue(t, "internal-agent", "total") !== undefined &&
+        seriesValue(t, "billing-batcher", "total") !== undefined,
+    );
+    expect(seriesValue(text, "internal-agent", "total")).toBe(
+      USAGE.total_tokens,
+    );
+    expect(seriesValue(text, "billing-batcher", "total")).toBe(
+      USAGE.total_tokens,
+    );
+    // The raw UA never becomes a label value.
+    expect(text).not.toContain('client_type="internal-agent/2.1"');
+  });
+
+  test("unmatched UAs keep built-in behaviour (other/unknown intact)", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    await chatWithUa(app, "SomeRandomBespokeClient/9.9");
+    const text = await pollSeries(
+      app,
+      (t) => seriesValue(t, "other", "total") !== undefined,
+    );
+    expect(seriesValue(text, "other", "total")).toBe(USAGE.total_tokens);
+  });
+});

--- a/tests/e2e/src/cases/client-type-1045-e2e.test.ts
+++ b/tests/e2e/src/cases/client-type-1045-e2e.test.ts
@@ -222,10 +222,16 @@ describe("client_type built-ins + operator rules (AISIX-Cloud#1045)", () => {
     }
 
     await chatWithUa(app, "SomeRandomBespokeClient/9.9");
+    // Empty UA must stay `unknown` even though a match-anything custom
+    // rule set could otherwise claim it.
+    await chatWithUa(app, "");
     const text = await pollSeries(
       app,
-      (t) => seriesValue(t, "other", "total") !== undefined,
+      (t) =>
+        seriesValue(t, "other", "total") !== undefined &&
+        seriesValue(t, "unknown", "total") !== undefined,
     );
     expect(seriesValue(text, "other", "total")).toBe(USAGE.total_tokens);
+    expect(seriesValue(text, "unknown", "total")).toBe(USAGE.total_tokens);
   });
 });

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -37,6 +37,13 @@ export interface AppOverrides {
    */
   extraEnv?: Record<string, string>;
   /**
+   * `observability.metrics.client_type_rules` (AISIX-Cloud#1045): operator
+   * UA→client_type regex rules, tried before the built-in allowlist.
+   * A dedicated override because `extra` replaces whole top-level blocks
+   * and the observability block carries the harness-picked metrics port.
+   */
+  clientTypeRules?: Array<{ pattern: string; client: string }>;
+  /**
    * FILE MODE: contents of a standalone `resources.yaml`. When set, the
    * generated config carries `resources_file` (pointing at this content
    * written into the tmp dir) and NO `etcd` section — the gateway loads
@@ -172,6 +179,9 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
           addr: `127.0.0.1:${metricsPort}`,
         },
         otlp: { enabled: false, endpoint: "http://127.0.0.1:4317" },
+        ...(overrides.clientTypeRules
+          ? { client_type_rules: overrides.clientTypeRules }
+          : {}),
       },
       tracing: { otlp: { enabled: false, endpoint: "http://127.0.0.1:4317", sample_ratio: 1 } },
     },


### PR DESCRIPTION
## What

Extends the bounded `client_type` classifier behind `aisix_llm_tokens_by_client_total` (#890 req-4) in two ways:

1. **New built-in clients**, each backed by source-permalink or live-capture evidence (table below).
2. **Operator-defined mapping rules** — `observability.metrics.client_type_rules`: ordered `{pattern, client}` regex rules (case-insensitive, unanchored), tried **before** the built-in table, first match wins, so a deployment can classify in-house tools or re-bucket a generic match (e.g. a UA embedding `axios` that would land in `node`). Compiled and validated at boot, fail-fast: max 64 rules, pattern ≤ 512 bytes, label `[a-z0-9][a-z0-9._-]*` ≤ 64 chars. The rule's fixed label — never the raw UA — is emitted, so the label set stays bounded by built-ins ∪ validated config. Rust `regex` is linear-time (no backtracking), so operator patterns cannot ReDoS the request path.

`client_type` remains metrics-only: usage events and logs keep the full raw `User-Agent`, unchanged. Empty UA stays `unknown` (custom rules never see it), unmatched stays `other`. Rules are boot-time config (restart to change), same category as the other `observability.metrics` knobs.

## Built-in additions and evidence

| client_type | UA sample (verified) | evidence |
|---|---|---|
| `roo-code` | `RooCode/3.54.0`; native path `roo-code/<ver> (<os>; <arch>) node/<v>` | [DEFAULT_HEADERS](https://github.com/RooCodeInc/Roo-Code/blob/b867ec9145750d0ae1ff7f02d35406e9bf2a0b16/src/api/providers/constants.ts#L3-L7), introduced in RooCodeInc/Roo-Code#5492 |
| `kilocode` | `Kilo-Code/5.16.2` (legacy ≤ 5.16.2) | [constants.ts](https://github.com/Kilo-Org/kilocode-legacy/blob/bc7823c6365eb13cdf35d32a7460a0e72363c836/src/api/providers/constants.ts#L4-L11) + shipped VSIX decompile |
| `zoo-code` | `ZooCode/3.71.100268` | [constants.ts](https://github.com/Zoo-Code-Org/Zoo-Code/blob/6e05ae951db1a0493d883c8cf7fb735d1b5a97e8/src/api/providers/constants.ts#L3-L7) (community continuation of archived Roo Code) |
| `github-copilot` | `GitHubCopilotChat/0.44.0` (VS Code BYOK, direct from user machine) | [nodeFetcher.ts](https://github.com/microsoft/vscode-copilot-chat/blob/5863f5a/src/platform/networking/node/nodeFetcher.ts#L32-L33), same code in microsoft/vscode `extensions/copilot/` |
| `cursor` | `Cursor/1.0` (fixed version segment; sent by Cursor's backend — BYO traffic is vendor-proxied) | [official docs](https://cursor.com/help/models-and-usage/api-keys) + [forum capture 2026-06](https://forum.cursor.com/t/requests-are-sent-to-incorrect-endpoint-when-using-base-url-override/144894/33) |
| `cline` (existing) | `Cline/3.89.2` (v3.56–3.89.2 sends it on both BYO paths) | [EnvUtils.ts](https://github.com/cline/cline/blob/v3.89.2/apps/vscode/src/services/EnvUtils.ts#L18-L22), cline/cline#8872 |
| `opencode` | `opencode/1.18.3 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14` (live-captured) | [request.ts](https://github.com/sst/opencode/blob/a19b52e85bf2630b86157030e2cf7c9fc20ce552/packages/opencode/src/session/llm/request.ts#L18) |
| `qwen-code` | `QwenCode/0.20.0 (linux; x64)` (live-captured) | [provider/default.ts](https://github.com/QwenLM/qwen-code/blob/5e183dda18f2d6b28ecee28337f6b3bb9f7c98ea/packages/core/src/core/openaiContentGenerator/provider/default.ts#L63-L74) |
| `gemini-cli` | `GeminiCLI-tui/0.51.0/<model> (linux; x64; terminal)` (live-captured; Gemini-protocol only today) | [contentGenerator.ts](https://github.com/google-gemini/gemini-cli/blob/acae7124bdd849e554eaa5e090199a0cf08cd782/packages/core/src/core/contentGenerator.ts#L266-L280) |
| `crush` | `Charm-Crush/<ver> (https://charm.land/crush)` | [agent.go](https://github.com/charmbracelet/crush/blob/d1626158d058f96b91aaf9ffce7cdf48a94579db/internal/agent/agent.go#L62) |
| `zed` | `Zed/0.198.0 (linux; x86_64)` (needle keeps the `/` so only the `Zed/<ver>` token form matches) | [main.rs](https://github.com/zed-industries/zed/blob/f7d9ae33b5ce1debd2b5962aacc6f7641de2bb0e/crates/zed/src/main.rs#L505-L515) |
| `vercel-ai-sdk` | `ai/6.0.144 ai-sdk/provider-utils/4.0.22 runtime/node.js/26` (node) / `runtime/bun/1.3.x` (bun) | AI SDK default UA, live-captured; the bucket for AI-SDK tools that keep it (Cline 4.x, Kilo Code 7.x) |

Ordering: product needles sit before SDK buckets, which sit before generic HTTP-library buckets — `opencode` must precede `ai-sdk/provider-utils` because its UA embeds both (pinned by a unit test and an E2E case).

## Known identification limits (UA-only classifier; also recorded on the issue)

- **Cline 4.x / Kilo Code 7.x** moved to the Vercel AI SDK and no longer send a product UA on BYO paths → they land in `vercel-ai-sdk`.
- **Copilot CLI** BYOK sends only the SDK UA (`OpenAI/JS x` / `Anthropic/JS x`); its product signal is headers (`x-interaction-type`, `x-initiator`), not the UA.
- **Qwen Code's Anthropic path masquerades as `claude-cli/<ver> (external, cli)`** toward any non-`api.anthropic.com` host — indistinguishable from real Claude Code by UA; that traffic lands in `claude-code`.
- **Continue** exposes a minified SDK UA (`ls/JS 5.23.2`) / `node-fetch` — no product signal. **Goose** sends no UA at all → `unknown`. **Windsurf** cannot target custom endpoints. **Amp / Factory Droid**: unverified.
- Roo/Kilo-legacy/Zoo send their product UA only on the OpenAI-compatible path; their Anthropic path is the plain Anthropic SDK UA.

## Why a DP config knob (not a CP resource)

The by-client series is scraped from the DP's own dedicated Prometheus listener — the operator who owns the scrape owns the label set. Deployment-scoped rules keep the bounded-cardinality guarantee enforceable locally and ship without a CP/dashboard surface. Org/env-scoped custom classification (CP storage, projection, dashboard, audit) is deliberately deferred; the design conclusion and revisit conditions are recorded on the issue. LiteLLM baseline: no equivalent bounded classifier exists (it stores raw UA prefixes as DB tags and exposes raw `user_agent` as an opt-in Prometheus label); its `tag_regex` deployment routing establishes the admin-regex-on-UA precedent. Our bounded-allowlist divergence was settled in #890/AISIX-Cloud#1044.

## Cardinality

11 new possible `client_type` values (fixed set), on the one dedicated `aisix_llm_tokens_by_client_total` family (`client_type × model × token_type`); operator rules can add at most 64 admin-approved values. Release notes for the next OP version should list the new label values (AISIX-Cloud#1044 interplay).

## Tests

- Unit (`aisix-obs`): real-UA cases for every new client incl. the precedence traps (opencode vs `ai-sdk` needle, `claude-cli` collision, Copilot CLI → `openai-node`), custom-rule semantics (first-match-wins, override-builtin, empty-UA `unknown`, builtin fallback), and boot-time validation rejections (bad regex, oversized pattern, bad/oversized labels, rule-count cap).
- E2E (`tests/e2e/src/cases/client-type-1045-e2e.test.ts`): real `aisix` binary + etcd + mock upstream — five real built-in UAs each produce their own series on `/metrics` with exact per-token-type counts; operator rules classify an in-house UA and outrank the `axios`→`node` built-in; unmatched UA still falls back to `other`; raw UA never appears as a label value. Existing #890/#1002/#1044 by-client suites pass unchanged.

Fixes api7/AISIX-Cloud#1045


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable User-Agent rules for labeling client types in usage metrics.
  * Expanded built-in client recognition, including coding tools, IDE integrations, and SDKs.
  * Custom rules support case-insensitive matching, ordered precedence, and safe label validation.
* **Bug Fixes**
  * Improved client attribution across chat, responses, and Anthropic usage metrics.
  * Unmatched or empty User-Agent values continue to receive safe fallback labels.
* **Documentation**
  * Added commented configuration examples describing the new client-type rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->