### PR TITLE
docs(agents): mark member-scoped guardrails as an open gap, not a design

### DIFF
--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -31,9 +31,16 @@ requests keep succeeding on a target that should have been excluded.
 **The default is that a per-model gate binds each target.** Anything an operator
 configures ON a model — rate limits, `allowed_cidrs`, cooldown, health, timeouts —
 is a statement about that model, and reaching it through a group must not strip it.
-Two gates are deliberately entry-scoped instead: guardrail attachment (resolved
-from `model_id` before dispatch, by design) and the group's own copy of any of the
+The only deliberately entry-scoped gate is the group's own copy of any of the
 above. Anything else that only checks `model_entry` / `virtual_entry` is a bug.
+
+Guardrail attachment is the **known open exception, not a settled design**: the
+chain resolves from `RequestContext.model_id` before dispatch, so a guardrail
+scoped to a member never runs for group traffic (measured: direct 422, via group
+200). It is unfixed because the semantics are undecided, not because entry scope
+is correct — input guardrails run before a target is picked, and under failover
+there is no single "winning member" to resolve against. Tracked in
+AISIX-Cloud#1090; do not cite it as precedent for scoping a new gate to the entry.
 
 Two shapes, both already implemented — copy the nearest one:
 


### PR DESCRIPTION
The per-model-gate rule added alongside #783/#786 listed guardrail attachment as a *deliberate* entry-scoped exception. That is wrong and actively misleading: a guardrail scoped to a member model silently never runs when the model is reached through a Model Group (measured — direct request `422`, same request via the group `200`, content forwarded upstream), and it stays unfixed only because the semantics are undecided, not because entry scope is correct.

Input guardrails resolve before a target is picked, and under failover there is no single "winning member" to resolve against — so the fix needs a product call (union of candidate members vs. entry scope) rather than the mechanical treatment `allowed_cidrs` and rate limits got. Tracked in api7/AISIX-Cloud#1090.

Left as written, the rule would tell the next author to scope a new gate to the requested entry and cite guardrails as precedent.

Ref api7/AISIX-Cloud#1090