### PR TITLE
feat(admin): add admin.enabled switch to run without the admin listener

### DIFF
--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -545,6 +545,7 @@ mod tests {
 
     fn cfg() -> AdminConfig {
         AdminConfig {
+            enabled: true,
             addr: "127.0.0.1:0".into(),
             admin_keys: vec!["admin-secret".into()],
             tls: None,

--- a/crates/aisix-admin/src/playground_handler.rs
+++ b/crates/aisix-admin/src/playground_handler.rs
@@ -68,6 +68,7 @@ mod tests {
 
     fn admin_cfg() -> AdminConfig {
         AdminConfig {
+            enabled: true,
             addr: "127.0.0.1:0".into(),
             admin_keys: vec!["admin-key".into()],
             tls: None,

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -57,6 +57,7 @@ async fn build_state_with_real_etcd(url: &str, prefix: &str) -> AdminState {
     let store: Arc<dyn ConfigStore> = Arc::new(EtcdConfigStore::new(client, prefix));
     let handle = SnapshotHandle::new(AisixSnapshot::new());
     let cfg = AdminConfig {
+        enabled: true,
         addr: "127.0.0.1:0".into(),
         admin_keys: vec![ADMIN_KEY.into()],
         tls: None,

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -434,6 +434,15 @@ impl RealIpConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AdminConfig {
+    /// When `false`, the admin listener is not bound even in standalone
+    /// (etcd or file) mode. The proxy and the metrics/status listener are
+    /// unaffected, so resources are managed declaratively — a resources
+    /// file, or direct writes to the configuration store — with
+    /// `GET /status/config` and the proxy `GET /livez` as the operational
+    /// feedback. Managed mode never binds the admin listener regardless.
+    /// Defaults to `true`.
+    #[serde(default = "AdminConfig::default_enabled")]
+    pub enabled: bool,
     #[serde(default = "AdminConfig::default_addr")]
     pub addr: String,
     /// Statically-provisioned admin keys. A request is authorised if it
@@ -451,11 +460,16 @@ impl AdminConfig {
         // if they leave it at the default without overriding.
         "127.0.0.1:0".into()
     }
+
+    fn default_enabled() -> bool {
+        true
+    }
 }
 
 impl Default for AdminConfig {
     fn default() -> Self {
         Self {
+            enabled: Self::default_enabled(),
             addr: Self::default_addr(),
             admin_keys: Vec::new(),
             tls: None,
@@ -827,11 +841,12 @@ impl Config {
                     .into(),
             ));
         }
-        // In managed mode the admin listener is not bound, so requiring
-        // admin_keys or a valid admin.addr would be punishing the user
-        // for fields that aren't going to be used. In standalone mode
-        // we keep the original invariants.
-        if !self.managed.is_managed() {
+        // The admin listener is not bound in managed mode, nor when
+        // `admin.enabled = false`, so requiring admin_keys or a valid
+        // admin.addr in those cases would be punishing the user for
+        // fields that aren't going to be used. When it will bind, keep
+        // the original invariants.
+        if !self.managed.is_managed() && self.admin.enabled {
             if self.admin.admin_keys.is_empty() {
                 return Err(BootstrapError::Config(
                     "admin.admin_keys must contain at least one key \
@@ -1105,6 +1120,45 @@ admin:
         );
         let err = Config::load_from_path(Some(f.path())).unwrap_err();
         assert!(err.to_string().contains("admin.admin_keys"));
+    }
+
+    #[test]
+    fn admin_enabled_defaults_to_true() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert!(cfg.admin.enabled);
+    }
+
+    #[test]
+    fn admin_disabled_relaxes_admin_key_requirement() {
+        // With the admin listener switched off, there is no bound surface
+        // to authenticate, so an empty admin_keys is no longer an error —
+        // resources are managed declaratively (etcd here).
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  enabled: false
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert!(!cfg.admin.enabled);
+        assert!(cfg.admin.admin_keys.is_empty());
     }
 
     #[test]

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -1162,6 +1162,26 @@ admin:
     }
 
     #[test]
+    fn admin_disabled_relaxes_admin_key_requirement_in_file_mode() {
+        // File mode routes through a distinct admin store variant, and it
+        // too binds a read-only admin surface by default. With the admin
+        // listener switched off, the same relaxation applies — no
+        // admin_keys required.
+        let f = write_yaml(
+            r#"
+resources_file: "/etc/aisix/resources.yaml"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  enabled: false
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert!(!cfg.admin.enabled);
+        assert!(cfg.admin.admin_keys.is_empty());
+    }
+
+    #[test]
     fn rejects_empty_etcd_endpoints() {
         let f = write_yaml(
             r#"

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -828,7 +828,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         },
         runtime_status_tracker: Some(runtime_status_tracker.clone()),
     };
-    let admin_serve_handle = if let Some(admin_store) = admin_store {
+    let admin_serve_handle = if let Some(admin_store) = admin_store.filter(|_| cfg.admin.enabled) {
         let mut admin_state = AdminState::new(snapshot_handle.clone(), admin_store, &cfg.admin)
             // Share the health tracker so /admin/v1/health reflects live
             // per-model upstream failure counts.
@@ -865,10 +865,14 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         )))
     } else {
         // Drop unused shared components so the compiler can see they
-        // don't escape managed mode. The health tracker exists on
+        // don't escape the admin-less paths. The health tracker exists on
         // proxy_state and keeps working regardless.
         let _ = (&health_tracker, &livez_state, &runtime_status_tracker);
-        tracing::info!("managed mode enabled — admin surface not bound");
+        if cfg.managed.is_managed() {
+            tracing::info!("managed mode enabled — admin surface not bound");
+        } else {
+            tracing::info!("admin.enabled = false — admin surface not bound");
+        }
         None
     };
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -522,8 +522,11 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // admin surface is bound. We could share a single underlying
             // connection via `Client::clone()` but keeping two is cleaner:
             // writes and the watch stream don't contend on the same mutex.
-            // In managed mode this client is simply skipped.
-            let admin_client = if cfg.managed.is_managed() {
+            // Skipped whenever the admin listener is not bound — managed mode,
+            // or `admin.enabled = false` — so admin-off doesn't pay for (or
+            // fail boot on) a connection it immediately drops; `/status/models`
+            // then reads through the snapshot, as it does in managed mode.
+            let admin_client = if cfg.managed.is_managed() || !cfg.admin.enabled {
                 None
             } else {
                 Some((

--- a/tests/e2e/src/cases/admin-disabled-e2e.test.ts
+++ b/tests/e2e/src/cases/admin-disabled-e2e.test.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the gateway runs with the admin listener switched off
+// (`admin.enabled = false`), the shape it takes once the Admin API is
+// removed. Resources are seeded straight to etcd — never the Admin API —
+// and the full request path must still work, with the metrics/status
+// listener as the only feedback surface. This pins that the admin
+// listener is genuinely not required to serve traffic.
+
+const CALLER_PLAINTEXT = "sk-admin-off-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("admin disabled: gateway serves seeded-via-etcd config with no admin listener", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    // No admin listener is bound — spawnApp gates readiness on the proxy
+    // and the metrics listener instead of the admin health endpoint.
+    app = await spawnApp({ admin: false });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "admin-off-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "admin-off-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["admin-off-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("a request seeded only through etcd succeeds with the admin listener off", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // A 200 means the ProviderKey + Model + ApiKey — all written to etcd,
+    // none through the Admin API — propagated into the snapshot and the
+    // proxy dispatched to the upstream.
+    let responded = false;
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.chat.completions.create({
+          model: "admin-off-model",
+          messages: [{ role: "user", content: "admin-off-probe" }],
+        });
+        responded = r.choices[0]?.message.role === "assistant";
+        return responded;
+      } catch {
+        return false;
+      }
+    });
+    expect(responded).toBe(true);
+    expect(upstream!.receivedRequests.length).toBeGreaterThan(0);
+  });
+
+  test("the metrics/status listener still reports the applied configuration", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // The load-observability contract is the operational feedback that
+    // replaces admin reads: it is served on the metrics listener, so it
+    // stays available with the admin listener off.
+    const res = await fetch(`${app.metricsUrl}/status/config`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      state?: string;
+      applied?: { resource_counts?: Record<string, number> };
+    };
+    expect(typeof body.state).toBe("string");
+    expect(body.applied?.resource_counts?.models).toBeGreaterThanOrEqual(1);
+  });
+
+  test("no admin listener is bound", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // With `admin.enabled = false` the admin port is never bound, so a
+    // connection to it is refused. (The port was reserved by the harness
+    // but nothing listens on it.)
+    await expect(
+      fetch(`${app.adminUrl}/admin/v1/health`),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/e2e/src/cases/admin-disabled-e2e.test.ts
+++ b/tests/e2e/src/cases/admin-disabled-e2e.test.ts
@@ -230,6 +230,25 @@ api_keys:
     expect(body.applied?.resource_counts?.models).toBe(1);
   });
 
+  test("the runtime health view serves from the file snapshot on the status listener", async () => {
+    if (!app) throw new Error("setup failed");
+
+    // /status/models reads through the file-mode FileManagedStore — the
+    // exact read surface that must stay live with the admin listener off
+    // (the admin endpoint that used to back this view is unbound here).
+    const res = await fetch(`${app.metricsUrl}/status/models`);
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as Array<{
+      display_name?: string;
+      kind?: string;
+      status?: string;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.display_name).toBe("admin-off-file-model");
+    expect(rows[0]?.kind).toBe("direct");
+    expect(rows[0]?.status).toBe("healthy");
+  });
+
   test("no admin listener is bound in file mode", async () => {
     if (!app) throw new Error("setup failed");
     await expectAdminPortRefused(app.adminUrl);

--- a/tests/e2e/src/cases/admin-disabled-e2e.test.ts
+++ b/tests/e2e/src/cases/admin-disabled-e2e.test.ts
@@ -13,17 +13,45 @@ import {
 
 // E2E: the gateway runs with the admin listener switched off
 // (`admin.enabled = false`), the shape it takes once the Admin API is
-// removed. Resources are seeded straight to etcd — never the Admin API —
-// and the full request path must still work, with the metrics/status
-// listener as the only feedback surface. This pins that the admin
-// listener is genuinely not required to serve traffic.
+// removed. Resources reach the gateway declaratively — never the Admin
+// API — and the full request path must still work, with the
+// metrics/status listener as the only feedback surface. Both resource
+// sources are covered, because they bind the admin surface through
+// distinct store variants (etcd vs the file-managed snapshot):
+//   - etcd source, seeded straight to etcd via SeedClient;
+//   - standalone `resources_file`, loaded from a declarative file.
 
-const CALLER_PLAINTEXT = "sk-admin-off-caller";
-const CALLER_KEY_HASH = createHash("sha256")
-  .update(CALLER_PLAINTEXT)
+const ETCD_CALLER_PLAINTEXT = "sk-admin-off-etcd-caller";
+const ETCD_CALLER_KEY_HASH = createHash("sha256")
+  .update(ETCD_CALLER_PLAINTEXT)
   .digest("hex");
 
-describe("admin disabled: gateway serves seeded-via-etcd config with no admin listener", () => {
+const FILE_CALLER_PLAINTEXT = "sk-admin-off-file-caller";
+// `key_env` sugar: the plaintext travels to the gateway via this env var
+// (never `AISIX_`-prefixed — the config loader claims that namespace).
+const FILE_CALLER_KEY_ENV = "ADMIN_OFF_FILE_CALLER_KEY";
+
+/**
+ * With `admin.enabled = false` the admin port is never bound, so a
+ * connection to it is refused (the port was reserved by the harness, but
+ * nothing listens). Assert the specific connection-refused cause rather
+ * than any throw, so a wrongly-bound listener — or a DNS/abort error —
+ * can't satisfy the check.
+ */
+async function expectAdminPortRefused(adminUrl: string): Promise<void> {
+  let caught: unknown;
+  try {
+    await fetch(`${adminUrl}/admin/v1/health`);
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeDefined();
+  const code = (caught as { cause?: { code?: string } } | undefined)?.cause
+    ?.code;
+  expect(code).toBe("ECONNREFUSED");
+}
+
+describe("admin disabled, etcd source: gateway serves seeded-via-etcd config with no admin listener", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
   let etcdReachable = false;
@@ -51,7 +79,7 @@ describe("admin disabled: gateway serves seeded-via-etcd config with no admin li
       provider_key_id: pk.id,
     });
     await seed.createApiKey({
-      key_hash: CALLER_KEY_HASH,
+      key_hash: ETCD_CALLER_KEY_HASH,
       allowed_models: ["admin-off-model"],
     });
   });
@@ -68,7 +96,7 @@ describe("admin disabled: gateway serves seeded-via-etcd config with no admin li
     }
 
     const client = new OpenAI({
-      apiKey: CALLER_PLAINTEXT,
+      apiKey: ETCD_CALLER_PLAINTEXT,
       baseURL: `${app.proxyUrl}/v1`,
       maxRetries: 0,
     });
@@ -93,15 +121,16 @@ describe("admin disabled: gateway serves seeded-via-etcd config with no admin li
     expect(upstream!.receivedRequests.length).toBeGreaterThan(0);
   });
 
-  test("the metrics/status listener still reports the applied configuration", async (ctx) => {
+  test("the metrics/status listener reports exactly the applied configuration", async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();
       return;
     }
 
     // The load-observability contract is the operational feedback that
-    // replaces admin reads: it is served on the metrics listener, so it
-    // stays available with the admin listener off.
+    // replaces admin reads: served on the metrics listener, so it stays
+    // available with the admin listener off. The etcd prefix is unique to
+    // this spawn, so the seeded one-of-each is the whole population.
     const res = await fetch(`${app.metricsUrl}/status/config`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -109,7 +138,10 @@ describe("admin disabled: gateway serves seeded-via-etcd config with no admin li
       applied?: { resource_counts?: Record<string, number> };
     };
     expect(typeof body.state).toBe("string");
-    expect(body.applied?.resource_counts?.models).toBeGreaterThanOrEqual(1);
+    const counts = body.applied?.resource_counts ?? {};
+    expect(counts.models).toBe(1);
+    expect(counts.provider_keys).toBe(1);
+    expect(counts.api_keys).toBe(1);
   });
 
   test("no admin listener is bound", async (ctx) => {
@@ -117,12 +149,89 @@ describe("admin disabled: gateway serves seeded-via-etcd config with no admin li
       ctx.skip();
       return;
     }
+    await expectAdminPortRefused(app.adminUrl);
+  });
+});
 
-    // With `admin.enabled = false` the admin port is never bound, so a
-    // connection to it is refused. (The port was reserved by the harness
-    // but nothing listens on it.)
-    await expect(
-      fetch(`${app.adminUrl}/admin/v1/health`),
-    ).rejects.toThrow();
+describe("admin disabled, file source: gateway serves a declarative resources.yaml with no admin listener", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    upstream = await startOpenAiUpstream();
+    // File mode never contacts etcd; combined with admin off, the gateway
+    // has neither an admin surface nor a configuration store — the shape a
+    // single-container standalone gateway takes post-removal.
+    app = await spawnApp({
+      admin: false,
+      resourcesFile: `
+_format_version: "1"
+provider_keys:
+  - display_name: admin-off-file-pk
+    provider: openai
+    api_key: sk-mock
+    api_base: ${upstream.baseUrl}/v1
+models:
+  - display_name: admin-off-file-model
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: admin-off-file-pk
+api_keys:
+  - display_name: admin-off-file-caller
+    key_env: ${FILE_CALLER_KEY_ENV}
+    allowed_models: ["admin-off-file-model"]
+`,
+      extraEnv: { [FILE_CALLER_KEY_ENV]: FILE_CALLER_PLAINTEXT },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("a request from a declarative file serves with the admin listener off", async () => {
+    if (!app || !upstream) throw new Error("setup failed");
+
+    const client = new OpenAI({
+      apiKey: FILE_CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    let responded = false;
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await client.chat.completions.create({
+          model: "admin-off-file-model",
+          messages: [{ role: "user", content: "admin-off-file-probe" }],
+        });
+        responded = r.choices[0]?.message.role === "assistant";
+        return responded;
+      } catch {
+        return false;
+      }
+    });
+    expect(responded).toBe(true);
+    expect(upstream.receivedRequests.length).toBeGreaterThan(0);
+  });
+
+  test("the metrics/status listener reports the file-loaded configuration", async () => {
+    if (!app) throw new Error("setup failed");
+
+    const res = await fetch(`${app.metricsUrl}/status/config`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      state?: string;
+      source?: { type?: string };
+      applied?: { resource_counts?: Record<string, number> };
+    };
+    expect(body.source?.type).toBe("file");
+    expect(body.applied?.resource_counts?.models).toBe(1);
+  });
+
+  test("no admin listener is bound in file mode", async () => {
+    if (!app) throw new Error("setup failed");
+    await expectAdminPortRefused(app.adminUrl);
   });
 });

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -262,7 +262,10 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
         waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
         // The admin health endpoint only exists when the admin listener is
         // bound; with `admin: false` there is no admin surface, so gate on
-        // the proxy `/livez` and the metrics listener alone.
+        // the proxy `/livez` and the metrics listener alone. (If both
+        // `admin` and `prometheus` are off, readiness reduces to the proxy
+        // `/livez` — liveness only; a case that needs config-propagation
+        // readiness should keep prometheus on, as the default does.)
         ...(adminEnabled
           ? [waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey)]
           : []),

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -10,6 +10,16 @@ import { EtcdClient } from "./etcd.js";
 import { harnessRequest } from "./http.js";
 
 export interface AppOverrides {
+  /**
+   * Whether to bind the admin listener. Defaults to `true`. When `false`,
+   * the gateway runs with `admin.enabled = false` — no admin listener is
+   * bound even in etcd/file mode, mirroring the post-removal world. Seed
+   * resources through `SeedClient`/`EtcdClient` (never the Admin API), and
+   * readiness is gated on the proxy `/livez` plus the metrics listener
+   * instead of the admin health endpoint. `adminUrl`/`adminKey` are still
+   * returned but point at an unbound port.
+   */
+  admin?: boolean;
   /** Inserted into `admin.admin_keys`. Defaults to a fresh random key. */
   adminKey?: string;
   /** Whether to enable the Prometheus scrape endpoint. Defaults to true. */
@@ -139,6 +149,7 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   }
 
   const prometheusEnabled = overrides.prometheus ?? true;
+  const adminEnabled = overrides.admin ?? true;
   const [proxyPort, adminPort, metricsPort] = await pickFreePorts(3);
   const adminKey = overrides.adminKey ?? `admin-${randomUUID()}`;
   const etcdPrefix = `/aisix-e2e-${randomUUID()}`;
@@ -167,7 +178,9 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
       request_body_limit_bytes: 10485760,
       ...(overrides.realIp ? { real_ip: overrides.realIp } : {}),
     },
-    admin: { addr: `127.0.0.1:${adminPort}`, admin_keys: [adminKey] },
+    admin: adminEnabled
+      ? { addr: `127.0.0.1:${adminPort}`, admin_keys: [adminKey] }
+      : { addr: `127.0.0.1:${adminPort}`, enabled: false },
     observability: {
       service_name: "aisix-e2e",
       log_level: "warn",
@@ -247,7 +260,12 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
     await Promise.race([
       Promise.all([
         waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
-        waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey),
+        // The admin health endpoint only exists when the admin listener is
+        // bound; with `admin: false` there is no admin surface, so gate on
+        // the proxy `/livez` and the metrics listener alone.
+        ...(adminEnabled
+          ? [waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey)]
+          : []),
         // Gate on the dedicated metrics listener too, so scrapes in the test
         // never race the listener coming up. Skipped when prometheus is
         // disabled — nothing binds the metrics port then.


### PR DESCRIPTION
## What

Add an `admin.enabled` startup-config switch (default `true`) that lets a standalone gateway run **without binding the admin listener**, and wire the e2e harness to spawn in that mode. This is the foundation for retiring the Admin API: it makes the admin-listener-off configuration a runnable, tested reality during the coexistence window, before any admin code is deleted.

## Why

The gateway already runs admin-less in managed mode (config comes from the control plane over etcd). But in standalone etcd/file mode the admin listener was always bound — there was no way to preview the post-removal world, and the e2e harness had no way to prove the request path works without it. `admin.enabled = false` closes that gap:

- Operators can run the admin-free configuration on the coexistence release, de-risking the eventual code removal.
- The e2e suite gains a spawn mode that exercises the declarative-only path (resources seeded straight to etcd via `SeedClient`, never the Admin API).

`admin.enabled` is a process-level startup-config toggle (like `proxy.addr`), not a per-resource setting, so it carries no control-plane/schema work.

## Changes

- **`AdminConfig.enabled: bool`** (`crates/aisix-core/src/config.rs`), defaults to `true`. When `false`, `Config::validate` no longer requires `admin_keys`/`admin.addr` (there is no surface to authenticate), mirroring the existing managed-mode relaxation.
- **Bind gating** (`crates/aisix-server/src/main.rs`): the admin listener is spawned only when its store is present **and** `admin.enabled`. `/status/config`, `/status/ready`, `/status/models`, `/metrics` (metrics listener) and the proxy `/livez` are unaffected — the metrics/status listener is bound independently and still reads models through the same store handle, so `/status/models` keeps working with the admin listener off.
- **Harness** (`tests/e2e/src/harness/app.ts`): `AppOverrides.admin?: boolean` (default `true`). With `admin: false`, the generated config carries `admin.enabled = false` and readiness gates on the proxy `/livez` + the metrics listener instead of `/admin/v1/health`.
- **New e2e** (`admin-disabled-e2e.test.ts`): spawns `admin: false`, seeds a provider key + model + caller key **only through etcd**, and asserts (1) a proxy chat request succeeds, (2) `/status/config` reports the applied config on the metrics listener, (3) the admin port is not bound (connection refused).
- Config unit tests: `enabled` defaults to `true`; `enabled: false` relaxes the `admin_keys` requirement.

## Verification

- `cargo fmt`, `cargo clippy -p aisix-core -p aisix-server -p aisix-admin --all-targets -D warnings`, `cargo test -p aisix-core --lib` (config, +2 new) and `-p aisix-admin --lib` (114) green.
- New `admin-disabled-e2e` green (3/3). Regression: `allowed-models` and `seed-vs-admin-characterization` (exercises both the admin and etcd-seed paths) green — with `admin` defaulting to `true`, the admin-on config + readiness are byte-identical to before, so existing tests are unaffected. Full e2e suite green locally.

## Scope / follow-ups (this is P0-1 step 1 of the Admin API removal — AISIX-Cloud#1007 Phase 4)

This PR delivers the **switch**. It does not yet flip the suite: several tests still seed through `AdminClient`, and a few deliberately exercise the Admin API (characterization, file-mode 409 rejection, key rotation, auth baseline). Follow-ups:

1. Migrate the remaining seed-only holdouts (`AdminClient` → `SeedClient`) and relocate the harness's default readiness probe off `/admin/v1/health`.
2. Segregate the Admin-API-testing cases as the held-back set that runs admin-on until removal, and add a suite lane that runs the rest admin-off.
3. Document `admin.enabled` in the configuration-files reference (api7/docs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable the admin listener while keeping the gateway operational.
  * Gateway readiness no longer depends on the admin health endpoint when the listener is disabled.
  * Configuration seeded through etcd remains available for requests and status reporting.

* **Bug Fixes**
  * Improved configuration validation so admin settings are only required when the admin listener is enabled.

* **Tests**
  * Added end-to-end coverage for gateway operation without the admin listener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->