### PR TITLE
test(e2e): migrate the seed-tail tests off the Admin API onto etcd/status

### DIFF
--- a/tests/e2e/src/cases/background-health-e2e.test.ts
+++ b/tests/e2e/src/cases/background-health-e2e.test.ts
@@ -59,7 +59,10 @@ describe("background health e2e", () => {
       },
     });
 
-    app = await spawnApp();
+    // The admin listener is off; `admin` here is used only for
+    // listModelStatuses, which reads GET /status/models on the metrics
+    // listener. Resources are seeded straight to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 

--- a/tests/e2e/src/cases/cache-ttl-eviction-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-ttl-eviction-e2e.test.ts
@@ -57,7 +57,8 @@ describe("cache TTL eviction e2e: entry expires after ttl_seconds", () => {
     if (!etcdReachable) return;
 
     upstream = await startOpenAiUpstream();
-    app = await spawnApp();
+    // No admin listener: every resource here is seeded straight to etcd.
+    app = await spawnApp({ admin: false });
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const pk = await seed.createProviderKey({

--- a/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
@@ -74,7 +74,9 @@ describe("cooldown contract (H1) — 401 cools down despite being non-retryable"
       },
     });
 
-    app = await spawnApp();
+    // Admin listener off; `admin` reads only /status/models on the metrics
+    // listener, and every resource is seeded to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -225,7 +227,9 @@ describe("cooldown contract (M1) — 429 cools down even when retry_on_429=false
       },
     });
 
-    app = await spawnApp();
+    // Admin listener off; `admin` reads only /status/models on the metrics
+    // listener, and every resource is seeded to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -378,7 +382,9 @@ describe("cooldown contract (H2) — Retry-After header from upstream drives TTL
       },
     });
 
-    app = await spawnApp();
+    // Admin listener off; `admin` reads only /status/models on the metrics
+    // listener, and every resource is seeded to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -516,7 +522,9 @@ describe("filter contract (H3) — all candidates unhealthy returns 503", () => 
       errorBody: { error: { message: "all-down B", type: "server_error" } },
     });
 
-    app = await spawnApp();
+    // Admin listener off; `admin` reads only /status/models on the metrics
+    // listener, and every resource is seeded to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -646,7 +654,9 @@ describe("filter contract (H3 escape hatch) — try_anyway sends to known-bad", 
       errorBody: { error: { message: "still down", type: "server_error" } },
     });
 
-    app = await spawnApp();
+    // Admin listener off; `admin` reads only /status/models on the metrics
+    // listener, and every resource is seeded to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -765,7 +775,9 @@ describe("cooldown observability — a cooldown transition emits aisix_deploymen
       },
     });
 
-    app = await spawnApp();
+    // Admin listener off; `admin` reads only /status/models on the metrics
+    // listener, and every resource is seeded to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -958,7 +970,9 @@ describe("cooldown observability — the state gauge follows a target back into 
       },
     });
 
-    app = await spawnApp();
+    // Admin listener off; `admin` reads only /status/models on the metrics
+    // listener, and every resource is seeded to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 

--- a/tests/e2e/src/cases/datadog-exporter-e2e.test.ts
+++ b/tests/e2e/src/cases/datadog-exporter-e2e.test.ts
@@ -3,8 +3,8 @@ import { createServer, type IncomingMessage, type Server } from "node:http";
 import { gunzipSync } from "node:zlib";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
-  AdminClient,
   EtcdClient,
+  SeedClient,
   pickFreePort,
   spawnApp,
   startOpenAiUpstream,
@@ -126,19 +126,19 @@ async function startMockDatadog(): Promise<MockDatadog> {
   };
 }
 
-async function seedRouting(admin: AdminClient, upstream: OpenAiUpstream, model: string) {
-  const pk = await admin.createProviderKey({
+async function seedRouting(seed: SeedClient, upstream: OpenAiUpstream, model: string) {
+  const pk = await seed.createProviderKey({
     display_name: `${model}-pk`,
     secret: PROVIDER_SECRET,
     api_base: `${upstream.baseUrl}/v1`,
   });
-  await admin.createModel({
+  await seed.createModel({
     display_name: model,
     provider: "openai",
     model_name: "gpt-4o-mini",
     provider_key_id: pk.id,
   });
-  await admin.createApiKey({
+  await seed.createApiKey({
     key_hash: CALLER_KEY_HASH,
     allowed_models: [model],
   });
@@ -184,12 +184,14 @@ function asRecord(log: unknown): Record<string, unknown> {
 
 describe("datadog exporter e2e (#688): DP delivers a gzip JSON intake to Datadog", () => {
   let etcdReachable = false;
+  let etcd: EtcdClient | undefined;
   let upstream: OpenAiUpstream | undefined;
   let dd: MockDatadog | undefined;
   const apps: SpawnedApp[] = [];
 
   beforeAll(async () => {
-    etcdReachable = await new EtcdClient().ping();
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
     if (!etcdReachable) return;
     // Plant the response token in the mock upstream's assistant content so the
     // content-capture test can search for it in the `full` log body.
@@ -226,15 +228,15 @@ describe("datadog exporter e2e (#688): DP delivers a gzip JSON intake to Datadog
         return;
       }
       const app = await spawnApp({
+        admin: false,
         // The API key rides the DP's own env, never the kine config.
         extraEnv: {
           [`DD_CRED_${CREDENTIAL_REF.toUpperCase()}_API_KEY`]: DD_API_KEY,
         },
       });
       apps.push(app);
-      // Deliberately seeds via the Admin API: deprecation-window coverage.
-      const admin = new AdminClient(app.adminUrl, app.adminKey);
-      await admin.createObservabilityExporter({
+      const seed = new SeedClient(etcd!, app.etcdPrefix);
+      await seed.createObservabilityExporter({
         name: "mock-datadog",
         enabled: true,
         kind: "datadog",
@@ -245,7 +247,7 @@ describe("datadog exporter e2e (#688): DP delivers a gzip JSON intake to Datadog
         // Default privacy posture: operational metadata only, never content.
         content_mode: "metadata_only",
       });
-      await seedRouting(admin, upstream, "datadog-exporter-model");
+      await seedRouting(seed, upstream, "datadog-exporter-model");
 
       await waitConfigPropagation(async () => {
         try {
@@ -315,15 +317,16 @@ describe("datadog exporter e2e (#688): DP delivers a gzip JSON intake to Datadog
       const ddFull = await startMockDatadog();
       const ddMeta = await startMockDatadog();
       const app = await spawnApp({
+        admin: false,
         extraEnv: {
           [`DD_CRED_${CREDENTIAL_REF.toUpperCase()}_API_KEY`]: DD_API_KEY,
         },
       });
       apps.push(app);
       try {
-        const admin = new AdminClient(app.adminUrl, app.adminKey);
+        const seed = new SeedClient(etcd!, app.etcdPrefix);
         // Two exporters on the same DP: one captures content, one does not.
-        await admin.createObservabilityExporter({
+        await seed.createObservabilityExporter({
           name: "datadog-full",
           enabled: true,
           kind: "datadog",
@@ -332,7 +335,7 @@ describe("datadog exporter e2e (#688): DP delivers a gzip JSON intake to Datadog
           service: DD_SERVICE,
           content_mode: "full",
         });
-        await admin.createObservabilityExporter({
+        await seed.createObservabilityExporter({
           name: "datadog-meta",
           enabled: true,
           kind: "datadog",
@@ -341,7 +344,7 @@ describe("datadog exporter e2e (#688): DP delivers a gzip JSON intake to Datadog
           service: DD_SERVICE,
           content_mode: "metadata_only",
         });
-        await seedRouting(admin, upstream, "datadog-content-model");
+        await seedRouting(seed, upstream, "datadog-content-model");
 
         await waitConfigPropagation(async () => {
           try {

--- a/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import OpenAI, { APIError } from "openai";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
-  AdminClient,
   EtcdClient,
   SeedClient,
   spawnApp,
@@ -49,7 +48,6 @@ const FORBIDDEN_WORD = "supersecret";
 describe("guardrail disabled-bypass e2e: enabled:false → no block", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
-  let admin: AdminClient | undefined;
   let seed: SeedClient | undefined;
   let etcdReachable = false;
 
@@ -59,8 +57,9 @@ describe("guardrail disabled-bypass e2e: enabled:false → no block", () => {
     if (!etcdReachable) return;
 
     upstream = await startOpenAiUpstream();
-    app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    // No admin listener: resources are seeded to etcd and load-state is
+    // read from the metrics/status listener.
+    app = await spawnApp({ admin: false });
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const pk = await seed.createProviderKey({
@@ -113,33 +112,28 @@ describe("guardrail disabled-bypass e2e: enabled:false → no block", () => {
       // Readiness probe — two gates so the test cannot pass
       // vacuously.
       //
-      // Gate A: confirm the Guardrail row IS in the snapshot. Without
-      // this, the "forbidden literal arrives at upstream" assertion
-      // below would also pass if the rule simply hadn't propagated
-      // yet — indistinguishable from a real `enabled:false` bypass.
-      // Reading admin /v1/guardrails via the typed JSON helper is
-      // the cheapest way to verify the resource exists in the store
-      // the snapshot is built from.
+      // Gate A: confirm the Guardrail row IS in the applied snapshot.
+      // Without this, the "forbidden literal arrives at upstream"
+      // assertion below would also pass if the rule simply hadn't
+      // propagated yet — indistinguishable from a real `enabled:false`
+      // bypass. `/status/config`'s `resource_counts` reflects what the
+      // DP has LOADED (not merely what was written to etcd), served on
+      // the metrics listener — the admin-off equivalent of the old
+      // admin `/v1/guardrails` read.
       //
       // Gate B: confirm Model + ApiKey + ProviderKey are loaded by
       // driving a benign chat completion through the proxy. A 200
       // response means the dispatcher is ready.
       await waitConfigPropagation(async () => {
         try {
-          const list = (await admin!.json(
-            "GET",
-            "/admin/v1/guardrails",
-          )) as unknown as Array<Record<string, unknown>>;
-          const hasRule = list.some((entry) => {
-            // Admin list endpoints variably return bare values or
-            // {value: ...} wrappers; handle either shape generically.
-            const inner = (entry?.value ?? entry) as Record<
-              string,
-              unknown
-            >;
-            return inner?.name === "gr-disabled-keyword";
-          });
-          if (!hasRule) return false;
+          const cfg = (await (
+            await fetch(`${app!.metricsUrl}/status/config`)
+          ).json()) as {
+            applied?: { resource_counts?: Record<string, number> };
+          };
+          if ((cfg.applied?.resource_counts?.guardrails ?? 0) < 1) {
+            return false;
+          }
           await client.chat.completions.create({
             model: "gr-disabled-model",
             messages: [{ role: "user", content: "ready-probe" }],

--- a/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-disabled-bypass-e2e.test.ts
@@ -126,9 +126,9 @@ describe("guardrail disabled-bypass e2e: enabled:false → no block", () => {
       // response means the dispatcher is ready.
       await waitConfigPropagation(async () => {
         try {
-          const cfg = (await (
-            await fetch(`${app!.metricsUrl}/status/config`)
-          ).json()) as {
+          const res = await fetch(`${app!.metricsUrl}/status/config`);
+          if (!res.ok) return false;
+          const cfg = (await res.json()) as {
             applied?: { resource_counts?: Record<string, number> };
           };
           if ((cfg.applied?.resource_counts?.guardrails ?? 0) < 1) {

--- a/tests/e2e/src/cases/provider-key-rotation-e2e.test.ts
+++ b/tests/e2e/src/cases/provider-key-rotation-e2e.test.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import OpenAI from "openai";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
-  AdminClient,
   EtcdClient,
   SeedClient,
   spawnApp,
@@ -66,13 +65,13 @@ function errMsg(e: unknown): string {
 describe("provider_key rotation: zero in-flight disruption (#196 L3 / #271)", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
-  let admin: AdminClient | undefined;
+  let etcd: EtcdClient | undefined;
   let seed: SeedClient | undefined;
   let pkId = "";
   let etcdReachable = false;
 
   beforeAll(async () => {
-    const etcd = new EtcdClient();
+    etcd = new EtcdClient();
     etcdReachable = await etcd.ping();
     if (!etcdReachable) return;
 
@@ -89,8 +88,9 @@ describe("provider_key rotation: zero in-flight disruption (#196 L3 / #271)", ()
       },
     });
 
-    app = await spawnApp();
-    admin = new AdminClient(app.adminUrl, app.adminKey);
+    // No admin listener: the provider key is seeded and rotated straight
+    // in etcd, and the rotation is verified by reading the key back.
+    app = await spawnApp({ admin: false });
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const pk = await seed.createProviderKey({
@@ -117,7 +117,7 @@ describe("provider_key rotation: zero in-flight disruption (#196 L3 / #271)", ()
   });
 
   test("an in-place secret rotation under sustained load keeps dispatch serving and bumps revision", async (ctx) => {
-    if (!etcdReachable || !app || !upstream || !admin || !pkId) {
+    if (!etcdReachable || !app || !upstream || !etcd || !pkId) {
       ctx.skip();
       return;
     }
@@ -143,10 +143,6 @@ describe("provider_key rotation: zero in-flight disruption (#196 L3 / #271)", ()
         return false;
       }
     });
-
-    const revBefore = Number(
-      ((await admin.json("GET", `/admin/v1/provider_keys/${pkId}`)) as { revision?: number }).revision ?? 0,
-    );
 
     // Sustained concurrent load. One worker fires the in-place secret
     // rotation when it grabs index ROTATE_AT; the rest keep chatting,
@@ -199,10 +195,12 @@ describe("provider_key rotation: zero in-flight disruption (#196 L3 / #271)", ()
     ).toEqual([]);
     expect(success).toBe(TOTAL_REQUESTS);
 
-    // The rotation actually took effect (revision bumped).
-    const revAfter = Number(
-      ((await admin.json("GET", `/admin/v1/provider_keys/${pkId}`)) as { revision?: number }).revision ?? 0,
-    );
-    expect(revAfter).toBeGreaterThan(revBefore);
+    // The rotation actually took effect: the store now holds the rotated
+    // secret (guards the liveness assertion above against a no-op update —
+    // a rotation that silently did nothing would leave the original secret).
+    const rawAfter = await etcd.get(`${app.etcdPrefix}/provider_keys/${pkId}`);
+    expect(rawAfter, "provider_key missing from etcd after rotation").toBeDefined();
+    const pkAfter = JSON.parse(rawAfter!) as { secret?: string };
+    expect(pkAfter.secret).toBe("sk-mock-v2-rotated");
   }, 90_000);
 });

--- a/tests/e2e/src/cases/provider-key-rotation-e2e.test.ts
+++ b/tests/e2e/src/cases/provider-key-rotation-e2e.test.ts
@@ -20,20 +20,21 @@ import {
 // and must not wedge dispatch.
 //
 // What this pins: under sustained concurrency (8 workers, 80 requests),
-// an in-place secret rotation (PUT /admin/v1/provider_keys/:id) fired
-// mid-stream keeps every request serving and bumps the resource
-// revision. The caller's api_key and model alias are never touched.
+// an in-place secret rotation (a declarative update to the provider_key
+// document — same id + api_base, new secret) fired mid-stream keeps every
+// request serving, and the rotated secret lands in the store. The caller's
+// api_key and model alias are never touched.
 //
 // IMPORTANT scope note (from the #523 audit): "zero in-flight
 // disruption" is largely an ARCHITECTURAL guarantee here, NOT a property
 // this test could falsify. The DP holds one shared upstream client and
 // reads `pk.secret` / `pk.api_base` per-request from an atomic ArcSwap
 // snapshot; an in-flight request keeps its own snapshot Arc to
-// completion and a watch-applied PUT CAS-swaps a fresh snapshot — there
-// is no per-provider_key client or pool to tear down. So this is a
+// completion and a watch-applied update CAS-swaps a fresh snapshot —
+// there is no per-provider_key client or pool to tear down. So this is a
 // liveness/smoke pin over the rotate-under-load path (it would catch a
 // future regression that wedged dispatch or broke watch-apply on a PK
-// PUT) plus a revision-bump check — it is not a teardown-race probe.
+// update) plus a store read-back check — it is not a teardown-race probe.
 //
 // The real remaining facet is #220: asserting the rotated secret
 // actually reaches upstream (old rejected / new accepted). The mock
@@ -41,8 +42,8 @@ import {
 // tracked separately, not closed by this test.
 //
 // Reference: OpenAI Chat Completions shape the caller sees
-// (https://platform.openai.com/docs/api-reference/chat); admin
-// provider_key update is PUT /admin/v1/provider_keys/:id.
+// (https://platform.openai.com/docs/api-reference/chat). The rotation is
+// an in-place update of the provider_key document (same id, new secret).
 
 const CALLER_PLAINTEXT = "sk-pkrot-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")

--- a/tests/e2e/src/cases/retry-on-429-vs-background-ignore-e2e.test.ts
+++ b/tests/e2e/src/cases/retry-on-429-vs-background-ignore-e2e.test.ts
@@ -63,7 +63,10 @@ describe("retry_on_429 vs background ignore e2e", () => {
       },
     });
 
-    app = await spawnApp();
+    // The admin listener is off; `admin` here is used only for
+    // listModelStatuses, which reads GET /status/models on the metrics
+    // listener. Resources are seeded straight to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 

--- a/tests/e2e/src/cases/runtime-mixed-filtering-e2e.test.ts
+++ b/tests/e2e/src/cases/runtime-mixed-filtering-e2e.test.ts
@@ -76,7 +76,10 @@ describe("runtime mixed filtering e2e", () => {
       },
     });
 
-    app = await spawnApp();
+    // The admin listener is off; `admin` here is used only for
+    // listModelStatuses, which reads GET /status/models on the metrics
+    // listener. Resources are seeded straight to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 

--- a/tests/e2e/src/cases/runtime-status-e2e.test.ts
+++ b/tests/e2e/src/cases/runtime-status-e2e.test.ts
@@ -74,7 +74,10 @@ describe("runtime status e2e", () => {
       },
     });
 
-    app = await spawnApp();
+    // The admin listener is off; `admin` here is used only for
+    // listModelStatuses, which reads GET /status/models on the metrics
+    // listener. Resources are seeded straight to etcd via `seed`.
+    app = await spawnApp({ admin: false });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 


### PR DESCRIPTION
## What

Migrate the e2e tests that still depended on the **Admin API for setup or readiness** onto the direct-etcd `SeedClient` and the metrics/status listener, and run them with `admin: false`. This is step 2 of retiring the Admin API (after #791 landed the `admin.enabled` switch): it moves the tests that *don't test the Admin API itself* out of the admin-on world, shrinking the Admin API's remaining e2e footprint to only the tests whose subject is the admin surface.

9 files migrated (all now spawn `admin: false`):

**Seed-only (4)** — the Admin API was used purely to set up resources or as a removable oracle:
- `cache-ttl-eviction` — already seeded via `SeedClient`; only needed `admin: false`.
- `datadog-exporter` — `AdminClient` → `SeedClient` for the exporter + routing seed (the exporter delivery is the subject, not how it was seeded; the admin-write-path coverage lives in the held-back characterization test).
- `guardrail-disabled-bypass` — the Gate-A readiness probe (`GET /admin/v1/guardrails`, proving the rule *loaded*) becomes a `GET /status/config` check on `applied.resource_counts.guardrails`, which reflects the applied snapshot on the metrics listener — **stronger** than reading etcd back (which would only prove the write landed), preserving the anti-vacuous intent.
- `provider-key-rotation` — the revision oracle (`GET /admin/v1/provider_keys/:id` → `.revision` bumped) becomes an etcd read-back asserting the key now holds the **rotated secret** — a more direct no-op guard than a revision bump, using the existing `EtcdClient.get` (no shared-harness change).

**Mixed (5)** — seeding was already on `SeedClient`; the only remaining admin-shaped call is `listModelStatuses`, which reads `GET /status/models` on the **metrics listener** (not the admin API) and survives `admin: false`: `background-health`, `runtime-mixed-filtering`, `cooldown-contract` (7 spawn sites), `retry-on-429-vs-background-ignore`, `runtime-status`.

## Out of scope (deliberately unchanged)

Tests whose **subject is the Admin API surface** stay admin-on until the Admin API is removed, then get deleted or split — tracked on the removal checklist (AISIX-Cloud#1007 Phase 4): `seed-vs-admin-characterization` (seed≡admin equivalence), `file-resource-source` (file-mode write-409), `status-models` (`/status/models` vs `/admin/v1/models/status` equivalence), `health-minimal` (`/admin/v1/health`), `apikey-lifecycle`/`apikey-budget` (rotate/budget admin ops), `auth-baseline`, `openai-sdk-compat` (RFC 9745 Deprecation-header contract), `prometheus-metrics`. `status-config` only uses `/admin/v1/health` as a probe (it doesn't seed via admin) — left for the readiness-default step.

## Method

Classification (seed-only / mixed / held-back / probe-only) was done by fanning out one reader per candidate file, then synthesized into this migration plan — so each file's admin usage was read and classified individually rather than pattern-matched.

## Verification

`npx tsc --noEmit` adds no new type errors in the changed files. Each migrated file passes in isolation; full e2e suite green locally. No harness or Rust changes — the direct-etcd seed infra (`SeedClient`/`EtcdClient`) already existed, and `/status/models` / `/status/config` on the metrics listener already serve with the admin listener off (#791). The migrated tests keep their assertions; only the seed/readiness transport moved off the Admin API (two readiness/no-op guards were strengthened, noted above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test setups to run without the admin listener where it is not required.
  * Improved readiness and configuration checks using status endpoints and direct resource seeding.
  * Updated exporter, guardrail, and provider-key rotation scenarios to validate behavior through supported runtime and storage checks.
  * Preserved coverage for health, caching, routing, retries, filtering, and runtime status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->