### PR TITLE
feat(usage): estimate tokens locally when the upstream reports no usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "thiserror 1.0.69",
+ "tiktoken-rs",
  "tokio",
  "tokio-tungstenite",
  "tower 0.5.3",
@@ -1258,6 +1259,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +1820,17 @@ name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -2721,7 +2744,7 @@ dependencies = [
  "base64 0.22.1",
  "bytecount",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "fraction",
  "idna",
  "itoa",
@@ -4018,7 +4041,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4643,6 +4666,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bstr",
+ "fancy-regex 0.17.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -5406,7 +5444,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,11 @@ serde_json = "1"
 jsonschema = "0.28"
 schemars = "0.8"
 
+# Local token estimation for usage telemetry when the upstream response
+# carries no usage block (AISIX-Cloud#1074). BPE ranks are bundled; no
+# network access at runtime.
+tiktoken-rs = "0.12"
+
 # Concurrency primitives
 arc-swap = "1.7"
 dashmap = "6.1"

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -98,6 +98,20 @@ pub struct UsageEvent {
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub cache_read_tokens: u32,
 
+    /// True when any token counter on this event was locally estimated
+    /// with the gateway's tokenizer because the upstream response
+    /// carried no usage block (AISIX-Cloud#1074) — e.g. an
+    /// OpenAI-compatible relay that ignores `stream_options.include_usage`,
+    /// a client disconnect before the terminal usage chunk, or an
+    /// upstream error mid-stream. False when every counter came from
+    /// the upstream (or the event carries no tokens at all). Estimated
+    /// counts approximate the model's real tokenizer; consumers that
+    /// need provider-billed exactness can filter on this flag. cp-api
+    /// persists it to `dpmgr_usage_events.usage_estimated`; on the wire
+    /// false is omitted via `skip_serializing_if`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub usage_estimated: bool,
+
     pub latency_ms: u32,
 
     /// Time to first token in milliseconds. Only meaningful on the

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -41,6 +41,8 @@ http-body-util.workspace = true
 bytes.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+# Token-estimation fallback for usage telemetry (token_estimate.rs).
+tiktoken-rs.workspace = true
 futures.workspace = true
 tokio-tungstenite.workspace = true
 async-trait.workspace = true

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1900,7 +1900,7 @@ async fn dispatch(
                         &est,
                         prompt as u32,
                         completion as u32,
-                        Some(cached.message.content.as_deref().unwrap_or("")),
+                        Some(&estimation_output_text(&cached)),
                     );
                     if filled.estimated {
                         let total = crate::usage_attr::total_tokens_with_cache(

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -5028,7 +5028,10 @@ mod complete_on_drop_tests {
         };
         let out = drop_and_capture_with_estimator(comp, 0);
         assert_eq!(out.prompt_tokens, 8);
-        assert_eq!(out.completion_tokens, 0, "nothing delivered → nothing billed");
+        assert_eq!(
+            out.completion_tokens, 0,
+            "nothing delivered → nothing billed"
+        );
         assert_eq!(out.total_tokens, 8);
         assert!(out.usage_estimated);
     }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -241,6 +241,7 @@ pub async fn chat_completions(
                         reasoning_tokens: success.reasoning_tokens,
                         cache_creation_tokens: success.cache_creation_tokens,
                         cache_read_tokens: success.cache_read_tokens,
+                        usage_estimated: success.usage_estimated,
                         provider_request_id: success.provider_request_id.clone(),
                         provider_model_version: success.provider_model_version.clone(),
                         finish_reason: success.finish_reason.clone(),
@@ -508,6 +509,7 @@ pub async fn chat_completions(
                             reasoning_tokens: c.reasoning_tokens,
                             cache_creation_tokens: c.cache_creation_tokens,
                             cache_read_tokens: c.cache_read_tokens,
+                            usage_estimated: c.usage_estimated,
                             provider_request_id: c.provider_request_id,
                             provider_model_version: c.provider_model_version,
                             finish_reason: c.finish_reason,
@@ -592,6 +594,10 @@ struct Success {
     prompt_tokens: Option<u64>,
     completion_tokens: Option<u64>,
     total_tokens: Option<u64>,
+    /// True when the token counters were filled by the local estimator
+    /// because the upstream response carried no usage block
+    /// (AISIX-Cloud#1074). Lands on `UsageEvent::usage_estimated`.
+    usage_estimated: bool,
     /// Provider-specific cache + reasoning token counters. Default 0
     /// for providers that don't expose them; cp-api falls back to the
     /// standard prompt / completion rate when these are 0.
@@ -704,6 +710,40 @@ impl CacheStatus {
 /// message's text. `ChatMessage::content` already carries the
 /// concatenated text of multimodal content blocks, so this also covers
 /// vision/array-shaped messages (non-text blocks are skipped upstream).
+/// Generated output text for the token-estimation fallback
+/// (AISIX-Cloud#1074) — the non-streaming analog of the stream loop's
+/// `est_output_text` accumulation: message content + reasoning +
+/// tool-call name/argument text. Only built when estimation runs.
+pub(crate) fn estimation_output_text(resp: &aisix_gateway::ChatResponse) -> String {
+    let mut out = resp.message.content.clone().unwrap_or_default();
+    if let Some(s) = resp
+        .message
+        .extra
+        .get("reasoning_content")
+        .and_then(|v| v.as_str())
+    {
+        out.push_str(s);
+    }
+    if let Some(tcs) = resp
+        .message
+        .extra
+        .get("tool_calls")
+        .and_then(|v| v.as_array())
+    {
+        for tc in tcs {
+            if let Some(f) = tc.get("function") {
+                if let Some(n) = f.get("name").and_then(|v| v.as_str()) {
+                    out.push_str(n);
+                }
+                if let Some(a) = f.get("arguments").and_then(|v| v.as_str()) {
+                    out.push_str(a);
+                }
+            }
+        }
+    }
+    out
+}
+
 fn last_user_message_text(req: &ChatFormat) -> Option<String> {
     req.messages
         .iter()
@@ -801,6 +841,10 @@ struct UpstreamCharge {
     provider_key_id: String,
     prompt_tokens: u32,
     completion_tokens: u32,
+    /// True when the counters above were filled by the local estimator
+    /// (AISIX-Cloud#1074) — the billed-then-blocked upstream response
+    /// carried no usage block.
+    usage_estimated: bool,
     cached_prompt_tokens: u32,
     reasoning_tokens: u32,
     cache_creation_tokens: u32,
@@ -1467,6 +1511,14 @@ async fn dispatch(
             .and_then(|so| so.get("include_usage"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        // Token-estimation fallback context (AISIX-Cloud#1074): the
+        // request is cloned here because the stream owns it until an
+        // end-of-stream Drop — where the borrow is long gone. Tokenized
+        // only if the upstream never reports usage.
+        let estimator = crate::token_estimate::Estimator::new(
+            &upstream_model_for_metrics,
+            crate::token_estimate::PromptInput::Chat(Box::new(req.clone())),
+        );
         let sse_stream = build_sse_stream(
             upstream,
             now,
@@ -1477,6 +1529,7 @@ async fn dispatch(
             client_requested_usage,
             // Single upstream: nothing pre-incurred, so no usage to fold in.
             aisix_gateway::chat::UsageStats::default(),
+            Some(estimator),
             move |comp: StreamCompletion| {
                 // Rate-limit accounting (TPM cap) for all layers.
                 for key in &post_stream_keys {
@@ -1501,6 +1554,7 @@ async fn dispatch(
                         reasoning_tokens: comp.reasoning_tokens,
                         cache_creation_tokens: comp.cache_creation_tokens,
                         cache_read_tokens: comp.cache_read_tokens,
+                        usage_estimated: comp.usage_estimated,
                         provider_request_id: comp.provider_request_id,
                         provider_model_version: comp.provider_model_version,
                         finish_reason: comp.finish_reason,
@@ -1649,6 +1703,7 @@ async fn dispatch(
             // top-level handler skips its own `emit_usage_event` for
             // streaming via `telemetry_handled_by_stream` below.
             prompt_tokens: None,
+            usage_estimated: false,
             completion_tokens: None,
             total_tokens: None,
             cost_usd: 0.0,
@@ -1830,6 +1885,42 @@ async fn dispatch(
                     .upstream_model()
                     .unwrap_or("unknown")
                     .to_string();
+                // Token-estimation fallback (AISIX-Cloud#1074): a stored
+                // response whose original upstream never reported usage
+                // replays zeros — fill them like the fresh-response path
+                // so hit rows (and their saved-token stats) don't record
+                // silent zeros.
+                let (prompt, completion, total, usage_estimated) = if prompt == 0 || completion == 0
+                {
+                    let est = crate::token_estimate::Estimator::new(
+                        &upstream_model,
+                        crate::token_estimate::PromptInput::Chat(Box::new(req.clone())),
+                    );
+                    let filled = crate::token_estimate::fill_missing(
+                        &est,
+                        prompt as u32,
+                        completion as u32,
+                        Some(cached.message.content.as_deref().unwrap_or("")),
+                    );
+                    if filled.estimated {
+                        let total = crate::usage_attr::total_tokens_with_cache(
+                            filled.prompt_tokens,
+                            filled.completion_tokens,
+                            cache_creation_tokens,
+                            cache_read_tokens,
+                        );
+                        (
+                            filled.prompt_tokens as u64,
+                            filled.completion_tokens as u64,
+                            total,
+                            true,
+                        )
+                    } else {
+                        (prompt, completion, total, false)
+                    }
+                } else {
+                    (prompt, completion, total, false)
+                };
                 // Capture the prompt + cached response for content-capturing
                 // exporters (gated). A cache hit still served content to the
                 // caller, so it's logged like a fresh response.
@@ -1851,6 +1942,7 @@ async fn dispatch(
                     prompt_tokens: Some(prompt),
                     completion_tokens: Some(completion),
                     total_tokens: Some(total),
+                    usage_estimated,
                     cached_prompt_tokens,
                     reasoning_tokens,
                     cache_creation_tokens,
@@ -2146,9 +2238,50 @@ async fn dispatch(
     // Output guardrail. Tokens still count against quota — the upstream
     // already burned them — so commit before the check, and refuse the
     // refusal-write to the cache so a re-request gets a fresh chance.
-    let prompt = upstream.usage.prompt_tokens as u64;
-    let completion = upstream.usage.completion_tokens as u64;
-    let total = upstream.usage.total_tokens as u64;
+    //
+    // Token-estimation fallback (AISIX-Cloud#1074): when the upstream
+    // response carries no usage block, fill the missing counters locally
+    // BEFORE the quota commit and telemetry below so neither records
+    // silent zeros. Local variables only — `render_response` serialises
+    // the upstream body untouched, so the client never sees synthesised
+    // usage presented as the provider's.
+    let (prompt_tokens_u32, completion_tokens_u32, usage_estimated) = {
+        let (p, c) = (
+            upstream.usage.prompt_tokens,
+            upstream.usage.completion_tokens,
+        );
+        if p == 0 || c == 0 {
+            let est = crate::token_estimate::Estimator::new(
+                &upstream_model,
+                crate::token_estimate::PromptInput::Chat(Box::new(req.clone())),
+            );
+            let filled = crate::token_estimate::fill_missing(
+                &est,
+                p,
+                c,
+                Some(&estimation_output_text(&upstream)),
+            );
+            (
+                filled.prompt_tokens,
+                filled.completion_tokens,
+                filled.estimated,
+            )
+        } else {
+            (p, c, false)
+        }
+    };
+    let prompt = prompt_tokens_u32 as u64;
+    let completion = completion_tokens_u32 as u64;
+    let total = if usage_estimated {
+        crate::usage_attr::total_tokens_with_cache(
+            prompt_tokens_u32,
+            completion_tokens_u32,
+            upstream.usage.cache_creation_tokens,
+            upstream.usage.cache_read_tokens,
+        )
+    } else {
+        upstream.usage.total_tokens as u64
+    };
     // Snapshot the cache / reasoning counters + provider identity before
     // the upstream gets moved into render_response below — we need them
     // on the Success struct for telemetry.
@@ -2205,8 +2338,9 @@ async fn dispatch(
             // output-blocked requests.
             let charge = UpstreamCharge {
                 provider_key_id: provider_key_id.clone(),
-                prompt_tokens: upstream.usage.prompt_tokens,
-                completion_tokens: upstream.usage.completion_tokens,
+                prompt_tokens: prompt_tokens_u32,
+                completion_tokens: completion_tokens_u32,
+                usage_estimated,
                 cached_prompt_tokens,
                 reasoning_tokens,
                 cache_creation_tokens,
@@ -2318,6 +2452,7 @@ async fn dispatch(
         prompt_tokens: Some(prompt),
         completion_tokens: Some(completion),
         total_tokens: Some(total),
+        usage_estimated,
         cached_prompt_tokens,
         reasoning_tokens,
         cache_creation_tokens,
@@ -2711,6 +2846,14 @@ async fn dispatch_ensemble(
         let judge_concurrency_hold = judge_reservation.into_stream_hold();
         let limiter = Arc::clone(&state.limiter);
 
+        // Token-estimation fallback (AISIX-Cloud#1074) for the streamed
+        // judge: `comp` carries the JUDGE's stream-only counts, so the
+        // estimator gets the judge's own request (panel members buffered
+        // their usage separately).
+        let judge_estimator = crate::token_estimate::Estimator::new(
+            judge_model.upstream_model().unwrap_or("unknown"),
+            crate::token_estimate::PromptInput::Chat(Box::new(judge_req)),
+        );
         let sse_stream = build_sse_stream(
             judge_stream,
             created_ts,
@@ -2722,6 +2865,7 @@ async fn dispatch_ensemble(
             content_cap,
             client_requested_usage,
             panel_usage_sum,
+            Some(judge_estimator),
             move |comp: StreamCompletion| {
                 // Rate-limit accounting: the panel tokens (already round-tripped)
                 // plus the streamed judge's final total, against every layer.
@@ -2786,6 +2930,7 @@ async fn dispatch_ensemble(
                         reasoning_tokens: comp.reasoning_tokens,
                         cache_creation_tokens: comp.cache_creation_tokens,
                         cache_read_tokens: comp.cache_read_tokens,
+                        usage_estimated: comp.usage_estimated,
                         provider_request_id: comp.provider_request_id,
                         provider_model_version: comp.provider_model_version,
                         finish_reason: comp.finish_reason,
@@ -2862,6 +3007,7 @@ async fn dispatch_ensemble(
             prompt_tokens: None,
             completion_tokens: None,
             total_tokens: None,
+            usage_estimated: false,
             cost_usd: 0.0,
             cached_prompt_tokens: 0,
             reasoning_tokens: 0,
@@ -3105,6 +3251,7 @@ async fn dispatch_ensemble(
         prompt_tokens: None,
         completion_tokens: None,
         total_tokens: None,
+        usage_estimated: false,
         cached_prompt_tokens: 0,
         reasoning_tokens: 0,
         cache_creation_tokens: 0,
@@ -3312,6 +3459,7 @@ fn emit_usage_event(
         reasoning_tokens: extras.reasoning_tokens,
         cache_creation_tokens: extras.cache_creation_tokens,
         cache_read_tokens: extras.cache_read_tokens,
+        usage_estimated: extras.usage_estimated,
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         provider_request_id: extras.provider_request_id,
@@ -3419,6 +3567,10 @@ struct UsageExtras {
     reasoning_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
+    /// True when any token counter was filled by the local estimator
+    /// because the upstream reported no usage (AISIX-Cloud#1074). Lands
+    /// on `UsageEvent::usage_estimated`.
+    usage_estimated: bool,
     provider_request_id: String,
     provider_model_version: String,
     finish_reason: String,
@@ -3676,6 +3828,19 @@ struct StreamCompletion {
     /// capture cap). Empty otherwise. Read by the on_complete telemetry
     /// closure; never reaches the CP sink.
     response_text: String,
+    /// Generated output (content + reasoning + tool-call text) accumulated
+    /// for the token-estimation fallback (AISIX-Cloud#1074). Always on —
+    /// the terminal usage chunk that would make it unnecessary arrives
+    /// only at end-of-stream — but bounded to
+    /// `token_estimate::OUTPUT_ACCUMULATION_CAP`. Unlike `response_text`
+    /// this never leaves the process: it is tokenized in
+    /// `CompleteOnDrop::drop` when the upstream reported no usage, then
+    /// discarded.
+    est_output_text: String,
+    /// True when `CompleteOnDrop::drop` filled any token counter from the
+    /// local estimator because the upstream never reported it. Threaded
+    /// into `UsageEvent::usage_estimated` by the on_complete closure.
+    usage_estimated: bool,
     /// Per-detector PII mask counts applied to the held stream at release
     /// (#932). Merged with the input-side counts by the on_complete
     /// telemetry closure. Detector names only, never matched values.
@@ -3732,6 +3897,11 @@ struct CompleteOnDrop<F: FnOnce(StreamCompletion)> {
     /// returning `Ready(Some(_))` is exact — that's the moment the
     /// item handed to the consumer.
     delivered: Arc<AtomicU32>,
+    /// Token-estimation fallback (AISIX-Cloud#1074): when the stream
+    /// ends with no upstream-reported usage, Drop fills the missing
+    /// counters from this estimator (prompt from the captured request,
+    /// completion from `est_output_text`) and sets `usage_estimated`.
+    estimator: Option<crate::token_estimate::Estimator>,
 }
 
 impl<F: FnOnce(StreamCompletion)> CompleteOnDrop<F> {
@@ -3767,6 +3937,36 @@ impl<F: FnOnce(StreamCompletion)> Drop for CompleteOnDrop<F> {
                 c.cache_read_tokens = 0;
                 c.total_tokens = c.prompt_tokens as u64;
             }
+            // Token-estimation fallback (AISIX-Cloud#1074), after the #419
+            // gate so a zero-delivered disconnect never bills estimated
+            // completion tokens (the prompt still fills — upstream processed
+            // it regardless, same "prompts always billed" contract). Runs
+            // only for counters the upstream left at zero; a stream with a
+            // real usage chunk is untouched.
+            if let Some(est) = self.estimator.take() {
+                let output = (delivered > 0).then_some(c.est_output_text.as_str());
+                let filled = crate::token_estimate::fill_missing(
+                    &est,
+                    c.prompt_tokens,
+                    c.completion_tokens,
+                    output,
+                );
+                if filled.estimated {
+                    c.prompt_tokens = filled.prompt_tokens;
+                    c.completion_tokens = filled.completion_tokens;
+                    c.usage_estimated = true;
+                    // Estimation only fills counters the upstream never
+                    // reported, so the cache adders are zero or upstream-
+                    // authoritative — the recompute stays consistent with
+                    // `total_tokens_with_cache`.
+                    c.total_tokens = crate::usage_attr::total_tokens_with_cache(
+                        c.prompt_tokens,
+                        c.completion_tokens,
+                        c.cache_creation_tokens,
+                        c.cache_read_tokens,
+                    );
+                }
+            }
             f(c);
         }
     }
@@ -3795,6 +3995,9 @@ fn build_sse_stream<F>(
     // `on_complete` (`comp`) counts stay stream-only. Zero for single-upstream
     // callers, where the fold is a no-op.
     base_usage: aisix_gateway::chat::UsageStats,
+    // Token-estimation fallback context (AISIX-Cloud#1074); see
+    // `CompleteOnDrop::estimator`.
+    estimator: Option<crate::token_estimate::Estimator>,
     on_complete: F,
 ) -> impl Stream<Item = Result<Event, Infallible>>
 where
@@ -3816,6 +4019,7 @@ where
         let mut guard = CompleteOnDrop {
             slot: Some((on_complete, StreamCompletion::default())),
             delivered: delivered_for_drop,
+            estimator,
         };
         futures::pin_mut!(upstream);
         // Per #204: accumulate the assistant's content across chunks
@@ -3938,6 +4142,34 @@ where
                         if let Some(cap) = content_cap {
                             if comp.response_text.len() < cap as usize {
                                 comp.response_text.push_str(text);
+                            }
+                        }
+                    }
+                    // Token-estimation accumulator (AISIX-Cloud#1074): all
+                    // generated output — content, reasoning, tool-call text —
+                    // bounded to its own cap. Always on: whether the fallback
+                    // is needed is only known at end-of-stream.
+                    if comp.est_output_text.len()
+                        < crate::token_estimate::OUTPUT_ACCUMULATION_CAP
+                    {
+                        if let Some(text) = chunk.delta.content.as_deref() {
+                            comp.est_output_text.push_str(text);
+                        }
+                        if let Some(text) = chunk.delta.reasoning_content.as_deref() {
+                            comp.est_output_text.push_str(text);
+                        }
+                        if let Some(tcs) = chunk.delta.tool_calls.as_ref() {
+                            for tc in tcs {
+                                if let Some(f) = tc.get("function") {
+                                    if let Some(n) = f.get("name").and_then(|v| v.as_str()) {
+                                        comp.est_output_text.push_str(n);
+                                    }
+                                    if let Some(a) =
+                                        f.get("arguments").and_then(|v| v.as_str())
+                                    {
+                                        comp.est_output_text.push_str(a);
+                                    }
+                                }
                             }
                         }
                     }
@@ -4717,11 +4949,107 @@ mod complete_on_drop_tests {
                     comp,
                 )),
                 delivered,
+                estimator: None,
             };
             drop(guard);
         }
         let out = captured.lock().unwrap().take().expect("on_complete fired");
         out
+    }
+
+    /// Same as [`drop_and_capture`] but with a token estimator armed
+    /// (AISIX-Cloud#1074) — the request is one user message "Hello".
+    fn drop_and_capture_with_estimator(
+        comp: StreamCompletion,
+        delivered_count: u32,
+    ) -> StreamCompletion {
+        let captured: Arc<Mutex<Option<StreamCompletion>>> = Arc::new(Mutex::new(None));
+        let cap = captured.clone();
+        let delivered = Arc::new(AtomicU32::new(delivered_count));
+        let req = aisix_gateway::chat::ChatFormat::new(
+            "relay-model",
+            vec![aisix_gateway::chat::ChatMessage {
+                role: aisix_gateway::chat::Role::User,
+                content: Some("Hello".into()),
+                content_blocks: None,
+                name: None,
+                tool_call_id: None,
+                extra: serde_json::Map::new(),
+            }],
+        );
+        {
+            let guard = CompleteOnDrop {
+                slot: Some((
+                    move |c: StreamCompletion| {
+                        *cap.lock().unwrap() = Some(c);
+                    },
+                    comp,
+                )),
+                delivered,
+                estimator: Some(crate::token_estimate::Estimator::new(
+                    "relay-model",
+                    crate::token_estimate::PromptInput::Chat(Box::new(req)),
+                )),
+            };
+            drop(guard);
+        }
+        let out = captured.lock().unwrap().take().expect("on_complete fired");
+        out
+    }
+
+    /// AISIX-Cloud#1074: a stream that ended with no upstream usage
+    /// fills prompt + completion from the estimator and flags the
+    /// completion. Expected prompt: 3 per-message + "user" (1) +
+    /// "Hello" (1) + 3 reply priming = 8 (cl100k fallback encoding);
+    /// completion: "Hello world" = 2.
+    #[test]
+    fn estimator_fills_missing_usage_at_drop() {
+        let comp = StreamCompletion {
+            est_output_text: "Hello world".into(),
+            chunks_delivered: 0, // set by Drop, ignored on input
+            ..Default::default()
+        };
+        let out = drop_and_capture_with_estimator(comp, 3);
+        assert_eq!(out.prompt_tokens, 8);
+        assert_eq!(out.completion_tokens, 2);
+        assert_eq!(out.total_tokens, 10);
+        assert!(out.usage_estimated);
+    }
+
+    /// AISIX-Cloud#1074 × #419: a zero-delivered disconnect still
+    /// estimates the prompt (prompts are always billed) but must NOT
+    /// bill estimated completion tokens for content that never
+    /// crossed the wire.
+    #[test]
+    fn estimator_respects_zero_delivered_gate() {
+        let comp = StreamCompletion {
+            est_output_text: "Hello world".into(),
+            ..Default::default()
+        };
+        let out = drop_and_capture_with_estimator(comp, 0);
+        assert_eq!(out.prompt_tokens, 8);
+        assert_eq!(out.completion_tokens, 0, "nothing delivered → nothing billed");
+        assert_eq!(out.total_tokens, 8);
+        assert!(out.usage_estimated);
+    }
+
+    /// AISIX-Cloud#1074: upstream-reported usage wins — the armed
+    /// estimator must not touch a stream that carried a real usage
+    /// block, and the event stays unflagged.
+    #[test]
+    fn estimator_leaves_upstream_usage_untouched() {
+        let comp = StreamCompletion {
+            prompt_tokens: 17,
+            completion_tokens: 23,
+            total_tokens: 40,
+            est_output_text: "Hello world".into(),
+            ..Default::default()
+        };
+        let out = drop_and_capture_with_estimator(comp, 5);
+        assert_eq!(out.prompt_tokens, 17);
+        assert_eq!(out.completion_tokens, 23);
+        assert_eq!(out.total_tokens, 40);
+        assert!(!out.usage_estimated);
     }
 
     #[test]
@@ -4868,6 +5196,7 @@ mod delivery_counter_tests {
                     },
                 )),
                 delivered: delivered_for_drop,
+                estimator: None,
             };
             // Silence unused-field warning on the test side; guard
             // is held by the body for its full lifetime.

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -4149,25 +4149,24 @@ where
                     // generated output — content, reasoning, tool-call text —
                     // bounded to its own cap. Always on: whether the fallback
                     // is needed is only known at end-of-stream.
-                    if comp.est_output_text.len()
-                        < crate::token_estimate::OUTPUT_ACCUMULATION_CAP
                     {
+                        use crate::token_estimate::push_capped;
                         if let Some(text) = chunk.delta.content.as_deref() {
-                            comp.est_output_text.push_str(text);
+                            push_capped(&mut comp.est_output_text, text);
                         }
                         if let Some(text) = chunk.delta.reasoning_content.as_deref() {
-                            comp.est_output_text.push_str(text);
+                            push_capped(&mut comp.est_output_text, text);
                         }
                         if let Some(tcs) = chunk.delta.tool_calls.as_ref() {
                             for tc in tcs {
                                 if let Some(f) = tc.get("function") {
                                     if let Some(n) = f.get("name").and_then(|v| v.as_str()) {
-                                        comp.est_output_text.push_str(n);
+                                        push_capped(&mut comp.est_output_text, n);
                                     }
                                     if let Some(a) =
                                         f.get("arguments").and_then(|v| v.as_str())
                                     {
-                                        comp.est_output_text.push_str(a);
+                                        push_capped(&mut comp.est_output_text, a);
                                     }
                                 }
                             }

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -1065,7 +1065,10 @@ mod tests {
         // the completion side stays 0 (nothing to count).
         assert_eq!(event.prompt_tokens, 1);
         assert_eq!(event.completion_tokens, 0);
-        assert!(event.usage_estimated, "locally-counted tokens must be flagged");
+        assert!(
+            event.usage_estimated,
+            "locally-counted tokens must be flagged"
+        );
     }
 
     /// #429 follow-up: a 200 whose `usage` carries
@@ -1286,7 +1289,10 @@ mod tests {
         // prompt "x" = 1 token; no choices text → completion stays 0.
         assert_eq!(event.prompt_tokens, 1);
         assert_eq!(event.completion_tokens, 0);
-        assert!(event.usage_estimated, "locally-counted tokens must be flagged");
+        assert!(
+            event.usage_estimated,
+            "locally-counted tokens must be flagged"
+        );
     }
 
     /// AISIX-Cloud#867 parity: a successful /v1/completions 200 must stamp

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -79,6 +79,9 @@ struct CompletionDispatchSuccess {
 struct CompletionUsage {
     prompt_tokens: u32,
     completion_tokens: u32,
+    /// True when any counter was filled by the local estimator because
+    /// the upstream reported no usage (AISIX-Cloud#1074).
+    usage_estimated: bool,
 }
 
 pub async fn completions(
@@ -330,7 +333,39 @@ async fn dispatch(
             // Extract usage BEFORE moving resp_json into the Response
             // so the success struct carries typed counters rather
             // than re-parsing JSON downstream.
-            let usage = extract_completion_usage(&resp_json);
+            //
+            // Token-estimation fallback (AISIX-Cloud#1074): a missing or
+            // zero usage block fills locally — legacy completions is plain
+            // text on both sides, so the plain-text counting rule applies
+            // to each. The 200-without-usage edge previously skipped the
+            // event entirely; it now emits an estimated record instead.
+            // Telemetry only — the response body forwards untouched.
+            let usage = {
+                let mut u = extract_completion_usage(&resp_json).unwrap_or(CompletionUsage {
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    usage_estimated: false,
+                });
+                let est_model = model.upstream_model().unwrap_or("unknown");
+                if u.prompt_tokens == 0 {
+                    let n = count_completion_prompt(est_model, body.get("prompt"));
+                    if n > 0 {
+                        u.prompt_tokens = n;
+                        u.usage_estimated = true;
+                    }
+                }
+                if u.completion_tokens == 0 {
+                    let n = crate::token_estimate::count_text(
+                        est_model,
+                        &completion_output_text(&resp_json),
+                    );
+                    if n > 0 {
+                        u.completion_tokens = n;
+                        u.usage_estimated = true;
+                    }
+                }
+                Some(u)
+            };
             // #911 [21]: commit the actual token cost so TPM/TPD is enforced
             // for /v1/completions the same way chat + embeddings enforce it.
             // Pre-fix the reservation dropped uncommitted, so the token
@@ -510,7 +545,27 @@ fn extract_completion_usage(body: &Value) -> Option<CompletionUsage> {
     Some(CompletionUsage {
         prompt_tokens,
         completion_tokens,
+        usage_estimated: false,
     })
+}
+
+/// Count the legacy /v1/completions `prompt` for the token-estimation
+/// fallback (AISIX-Cloud#1074): a plain string, an array of strings, an
+/// array of token ids (exact count), or an array of token-id arrays.
+/// Plain-text counting — the legacy surface has no message overhead.
+fn count_completion_prompt(model: &str, prompt: Option<&Value>) -> u32 {
+    match prompt {
+        Some(Value::String(s)) => crate::token_estimate::count_text(model, s),
+        Some(Value::Array(items)) => items.iter().fold(0u32, |acc, item| {
+            acc.saturating_add(match item {
+                Value::String(s) => crate::token_estimate::count_text(model, s),
+                Value::Number(_) => 1,
+                Value::Array(tokens) => tokens.len().min(u32::MAX as usize) as u32,
+                _ => 0,
+            })
+        }),
+        _ => 0,
+    }
 }
 
 /// Concatenate the `text` of every choice in a /v1/completions response for
@@ -571,6 +626,7 @@ fn emit_usage_event(
         requested_model: requested_model.to_string(),
         prompt_tokens: usage.prompt_tokens,
         completion_tokens: usage.completion_tokens,
+        usage_estimated: usage.usage_estimated,
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),
@@ -960,12 +1016,13 @@ mod tests {
 
     /// Companion: an upstream 200 with `usage: {}` (malformed —
     /// `prompt_tokens` is a required field on every legitimate
-    /// completion response) must NOT emit a zero-everything noise
-    /// row. Per audit MEDIUM-1 on PR #425 — applied preemptively
-    /// here so /v1/completions and /v1/responses share the same
-    /// edge-case gate.
+    /// completion response) now emits an ESTIMATED usage event
+    /// (AISIX-Cloud#1074) instead of dropping the record: the tokens
+    /// are counted locally and the event is marked `usage_estimated`.
+    /// (Pre-#1074 this dropped the event entirely — per audit MEDIUM-1
+    /// on PR #425 — which left the request invisible to billing.)
     #[tokio::test]
-    async fn skips_usage_event_when_upstream_usage_block_is_empty() {
+    async fn estimates_usage_event_when_upstream_usage_block_is_empty() {
         use aisix_obs::UsageSink;
 
         let upstream = MockServer::start().await;
@@ -1000,14 +1057,15 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        if let Ok(Some(ev)) = recv {
-            panic!(
-                "no UsageEvent should be emitted when upstream usage block is malformed, \
-                 but got prompt_tokens={}",
-                ev.prompt_tokens,
-            );
-        }
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("estimated UsageEvent must be emitted when usage block is malformed")
+            .expect("usage_sink sender dropped");
+        // prompt "x" = 1 token; the upstream body has no choices text, so
+        // the completion side stays 0 (nothing to count).
+        assert_eq!(event.prompt_tokens, 1);
+        assert_eq!(event.completion_tokens, 0);
+        assert!(event.usage_estimated, "locally-counted tokens must be flagged");
     }
 
     /// #429 follow-up: a 200 whose `usage` carries
@@ -1180,13 +1238,13 @@ mod tests {
         }
     }
 
-    /// Issue #403 audit LOW-1: a 200 response with NO `usage` block
-    /// at all (vs `usage: {}` which is empty-but-present) must not
-    /// emit. Pins the outer `body.get("usage")?` short-circuit in
-    /// `extract_completion_usage` distinctly from the inner empty
-    /// case.
+    /// A 200 response with NO `usage` block at all (vs `usage: {}`
+    /// which is empty-but-present) emits an ESTIMATED usage event
+    /// (AISIX-Cloud#1074) — the request must not stay invisible to
+    /// billing. (Pre-#1074, per issue #403 audit LOW-1, this dropped
+    /// the event entirely.)
     #[tokio::test]
-    async fn skips_usage_event_when_upstream_omits_usage_block_entirely() {
+    async fn estimates_usage_event_when_upstream_omits_usage_block_entirely() {
         use aisix_obs::UsageSink;
 
         let upstream = MockServer::start().await;
@@ -1221,14 +1279,14 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        if let Ok(Some(ev)) = recv {
-            panic!(
-                "no UsageEvent when `usage` key is entirely absent, \
-                 got prompt_tokens={}",
-                ev.prompt_tokens,
-            );
-        }
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("estimated UsageEvent must be emitted when `usage` is absent")
+            .expect("usage_sink sender dropped");
+        // prompt "x" = 1 token; no choices text → completion stays 0.
+        assert_eq!(event.prompt_tokens, 1);
+        assert_eq!(event.completion_tokens, 0);
+        assert!(event.usage_estimated, "locally-counted tokens must be flagged");
     }
 
     /// AISIX-Cloud#867 parity: a successful /v1/completions 200 must stamp

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -810,6 +810,102 @@ mod tests {
         assert_eq!(ev.applied_guardrails[0].hook, "input");
     }
 
+    /// AISIX-Cloud#1074: an embeddings upstream that reports only
+    /// `total_tokens` (no `prompt_tokens`) fills prompt from total —
+    /// upstream-authoritative, NOT estimated, so the event stays
+    /// unflagged. Pre-#1074 this recorded prompt_tokens=0.
+    #[tokio::test]
+    async fn prompt_falls_back_to_total_tokens_unflagged() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1_f32]}],
+                "model": "text-embedding-3-small",
+                "usage": {"total_tokens": 6}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let body = serde_json::json!({"model": "my-embed", "input": "hello world"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(ev.prompt_tokens, 6, "prompt falls back to total_tokens");
+        assert!(
+            !ev.usage_estimated,
+            "total_tokens is upstream-authoritative, not an estimate"
+        );
+    }
+
+    /// AISIX-Cloud#1074: an embeddings upstream that reports NO usage at
+    /// all gets the prompt estimated from the request `input` and the
+    /// event flagged. "hello world" = 2 tokens (cl100k, and the seeded
+    /// model name text-embedding-3-small maps to cl100k too).
+    #[tokio::test]
+    async fn prompt_estimated_and_flagged_when_usage_absent() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1_f32]}],
+                "model": "text-embedding-3-small"
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-embed"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let handle = SnapshotHandle::new(snap);
+        let state = crate::ProxyState::new(handle, hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let app = crate::build_router(state);
+
+        let body = serde_json::json!({"model": "my-embed", "input": "hello world"});
+        let resp = tower::ServiceExt::oneshot(app, make_req(body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(ev.prompt_tokens, 2, "estimated from the request input");
+        assert!(ev.usage_estimated, "locally-counted tokens must be flagged");
+    }
+
     /// #719: /v1/embeddings explicitly bypassed all guardrails, so a content
     /// block configured on /v1/chat/completions was evadable by sending the
     /// same text to /v1/embeddings. A configured input guardrail must now

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -170,6 +170,7 @@ pub async fn embeddings(
                     status,
                     elapsed,
                     success.prompt_tokens,
+                    success.usage_estimated,
                     &client,
                     success.redactions.clone(),
                     success.monitor_hits.clone(),
@@ -242,6 +243,9 @@ struct EmbedDispatchSuccess {
     /// into `content_mode = full`.
     captured_content: Option<CapturedContent>,
     prompt_tokens: u32,
+    /// True when `prompt_tokens` came from the local estimator because
+    /// the upstream reported no usage (AISIX-Cloud#1074).
+    usage_estimated: bool,
     /// `true` when the dispatch produced a real 200 from the upstream
     /// (we have authoritative usage data to attribute). `false` for the
     /// 501-NotImplemented branch where no upstream call was made.
@@ -401,18 +405,37 @@ async fn dispatch(
             // answered — same recovery signal as rerank/audio/chat.
             state.health.record_success(&body.model);
             state.runtime_status.mark_healthy(&model_entry.id);
+            // Token accounting (#226 / AISIX-Cloud#1074). Embeddings are
+            // input-only, so `prompt_tokens == total_tokens` on the OpenAI
+            // shape. Providers that report only `total_tokens` (e.g. some
+            // rerank/embed backends) get prompt from total — upstream-
+            // authoritative, not an estimate. Only when the upstream
+            // reports nothing at all does the local estimator count the
+            // request `input`. Telemetry only — the response body is
+            // forwarded untouched.
+            let (prompt_tokens, usage_estimated) = if embed_resp.usage.prompt_tokens > 0 {
+                (embed_resp.usage.prompt_tokens, false)
+            } else if embed_resp.usage.total_tokens > 0 {
+                (embed_resp.usage.total_tokens, false)
+            } else {
+                let upstream_model = model.upstream_model().unwrap_or("unknown");
+                let estimated = req.input.iter().fold(0u32, |acc, s| {
+                    acc.saturating_add(crate::token_estimate::count_text(upstream_model, s))
+                });
+                (estimated, estimated > 0)
+            };
             // Commit the reservation — release the concurrency permit
             // and finalise RPM. Embeddings do report prompt_tokens via
             // EmbeddingResponse.usage; thread it through so TPM works
-            // here even though other handlers commit 0.
+            // here even though other handlers commit 0. The estimation
+            // fallback above keeps this accurate for upstreams that
+            // report no usage.
             reservation
-                .commit_tokens(embed_resp.usage.total_tokens as u64)
+                .commit_tokens(u64::from(
+                    (embed_resp.usage.total_tokens).max(prompt_tokens),
+                ))
                 .await;
             let provider_label = provider.to_ascii_lowercase();
-            // Capture the prompt_tokens count BEFORE moving the
-            // embed_resp into the JSON response — the handler needs
-            // this for UsageEvent emission downstream (#226).
-            let prompt_tokens = embed_resp.usage.prompt_tokens;
             // Content capture (#700): the full response JSON, vectors
             // included (LiteLLM parity); CapturedContent::new truncates to
             // the cap.
@@ -433,6 +456,7 @@ async fn dispatch(
                 redactions: redactions.clone(),
                 monitor_hits: monitor_hits.clone(),
                 prompt_tokens,
+                usage_estimated,
                 upstream_called: true,
                 captured_content,
             })
@@ -455,6 +479,7 @@ async fn dispatch(
                 redactions: redactions.clone(),
                 monitor_hits: monitor_hits.clone(),
                 prompt_tokens: 0,
+                usage_estimated: false,
                 captured_content: None,
                 // No upstream call happened — the handler reads this
                 // and skips UsageEvent emission. Distinguished from
@@ -544,6 +569,7 @@ fn emit_usage_event(
     status_code: u16,
     elapsed: Duration,
     prompt_tokens: u32,
+    usage_estimated: bool,
     client: &ClientContext,
     // Per-detector PII mask counts (#932) applied to the input.
     redacted_entity_counts: crate::redact::RedactionCounts,
@@ -587,6 +613,7 @@ fn emit_usage_event(
         api_key_id: api_key_id.to_string(),
         requested_model: requested_model.to_string(),
         prompt_tokens,
+        usage_estimated,
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -61,6 +61,7 @@ mod routing;
 mod semantic;
 mod state;
 mod stream_timeout;
+mod token_estimate;
 mod usage_attr;
 mod util;
 

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -2204,25 +2204,24 @@ fn build_anthropic_sse_stream(
                     // Token-estimation accumulator (AISIX-Cloud#1074): all
                     // generated output, always on (whether the fallback is
                     // needed is only known at end-of-stream), bounded.
-                    if comp.est_output_text.len()
-                        < crate::token_estimate::OUTPUT_ACCUMULATION_CAP
                     {
+                        use crate::token_estimate::push_capped;
                         if let Some(t) = chunk.delta.content.as_deref() {
-                            comp.est_output_text.push_str(t);
+                            push_capped(&mut comp.est_output_text, t);
                         }
                         if let Some(t) = chunk.delta.reasoning_content.as_deref() {
-                            comp.est_output_text.push_str(t);
+                            push_capped(&mut comp.est_output_text, t);
                         }
                         if let Some(tcs) = chunk.delta.tool_calls.as_ref() {
                             for tc in tcs {
                                 if let Some(f) = tc.get("function") {
                                     if let Some(n) = f.get("name").and_then(|v| v.as_str()) {
-                                        comp.est_output_text.push_str(n);
+                                        push_capped(&mut comp.est_output_text, n);
                                     }
                                     if let Some(a) =
                                         f.get("arguments").and_then(|v| v.as_str())
                                     {
-                                        comp.est_output_text.push_str(a);
+                                        push_capped(&mut comp.est_output_text, a);
                                     }
                                 }
                             }
@@ -2880,11 +2879,12 @@ fn update_anthropic_usage(
             // concatenation (no separators — a separator per frame would
             // inflate the count), plus `thinking` deltas, which are
             // billed output but out of guardrail scope.
-            if acc.est_output_text.len() < crate::token_estimate::OUTPUT_ACCUMULATION_CAP {
+            {
+                use crate::token_estimate::push_capped;
                 if let Some(delta) = json.get("delta") {
                     for key in ["text", "thinking", "partial_json"] {
                         if let Some(t) = delta.get(key).and_then(Value::as_str) {
-                            acc.est_output_text.push_str(t);
+                            push_capped(&mut acc.est_output_text, t);
                         }
                     }
                 }
@@ -2893,7 +2893,7 @@ fn update_anthropic_usage(
                     .and_then(|cb| cb.get("name"))
                     .and_then(Value::as_str)
                 {
-                    acc.est_output_text.push_str(name);
+                    push_capped(&mut acc.est_output_text, name);
                 }
             }
         }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1239,12 +1239,21 @@ async fn anthropic_passthrough_dispatch(
         let post_stream_keys = reservation.as_ref().map(|r| r.keys()).unwrap_or_default();
         let stream_hold = reservation.take().map(|r| r.into_stream_hold());
         let limiter_c = std::sync::Arc::clone(&state.limiter);
+        // Token-estimation fallback context (AISIX-Cloud#1074): the inbound
+        // Anthropic request body is cloned because the stream owns it until
+        // an end-of-stream Drop. Tokenized only if the upstream never
+        // reports usage.
+        let estimator = crate::token_estimate::Estimator::new(
+            &upstream_model,
+            crate::token_estimate::PromptInput::Anthropic(body.clone()),
+        );
         let parsed_stream = build_anthropic_passthrough_stream(
             body_stream,
             started,
             stream_guardrail,
             model_name.to_string(),
             content_cap,
+            Some(estimator),
             move |usage| {
                 // Streaming responses that got this far are 200 — the
                 // !status.is_success() guard above returned early on
@@ -1274,6 +1283,7 @@ async fn anthropic_passthrough_dispatch(
                     completion_tokens: usage.completion_tokens,
                     cache_creation_tokens: usage.cache_creation_tokens,
                     cache_read_tokens: usage.cache_read_tokens,
+                    usage_estimated: usage.usage_estimated,
                     provider_request_id: usage.provider_request_id,
                     provider_model_version: usage.provider_model_version,
                     finish_reason: usage.finish_reason,
@@ -1393,7 +1403,14 @@ async fn anthropic_passthrough_dispatch(
             })
             .map_err(ProxyError::Bridge)?;
 
-        let metrics = anthropic_metrics_from_response_json(&json_body);
+        let mut metrics = anthropic_metrics_from_response_json(&json_body);
+        // Token-estimation fallback (AISIX-Cloud#1074): an
+        // Anthropic-compatible relay may omit `usage` entirely — fill
+        // the missing counters locally before the emit below. The
+        // response body is forwarded verbatim, untouched.
+        fill_missing_anthropic_metrics(&mut metrics, &upstream_model, &body, || {
+            anthropic_estimation_output_text(&json_body)
+        });
 
         // #448 (#22): run output guardrails on the passthrough response.
         // The body is forwarded verbatim, so extract its text (content
@@ -1511,6 +1528,74 @@ async fn anthropic_passthrough_dispatch(
     }
 }
 
+/// Token-estimation fallback for a non-streaming `/v1/messages` response
+/// (AISIX-Cloud#1074): fill token counters the upstream never reported
+/// and mark the metrics estimated. `output_text` is built lazily — only
+/// when estimation actually runs.
+fn fill_missing_anthropic_metrics(
+    metrics: &mut AnthropicUsageMetrics,
+    upstream_model: &str,
+    body: &Value,
+    output_text: impl FnOnce() -> String,
+) {
+    if metrics.prompt_tokens != 0 && metrics.completion_tokens != 0 {
+        return;
+    }
+    let est = crate::token_estimate::Estimator::new(
+        upstream_model,
+        crate::token_estimate::PromptInput::Anthropic(body.clone()),
+    );
+    let filled = crate::token_estimate::fill_missing(
+        &est,
+        metrics.prompt_tokens,
+        metrics.completion_tokens,
+        Some(&output_text()),
+    );
+    if filled.estimated {
+        metrics.prompt_tokens = filled.prompt_tokens;
+        metrics.completion_tokens = filled.completion_tokens;
+        metrics.usage_estimated = true;
+    }
+}
+
+/// Generated output text for the token-estimation fallback: text blocks
+/// plus `tool_use` name/input and `thinking` — the response-side analog
+/// of the streaming accumulation. (`anthropic_response_text` below stays
+/// text-only: it feeds content capture, whose shape is an established
+/// contract.)
+fn anthropic_estimation_output_text(body: &Value) -> String {
+    let Some(blocks) = body.get("content").and_then(Value::as_array) else {
+        return String::new();
+    };
+    let mut out = String::new();
+    for block in blocks {
+        match block.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(t) = block.get("text").and_then(Value::as_str) {
+                    out.push_str(t);
+                }
+            }
+            Some("thinking") => {
+                if let Some(t) = block.get("thinking").and_then(Value::as_str) {
+                    out.push_str(t);
+                }
+            }
+            Some("tool_use") => {
+                if let Some(n) = block.get("name").and_then(Value::as_str) {
+                    out.push_str(n);
+                }
+                if let Some(input) = block.get("input") {
+                    if !input.is_null() {
+                        out.push_str(&input.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
 /// Concatenate the text from an Anthropic response's `content` blocks — the
 /// assistant's assembled output text, for content-capturing exporters.
 fn anthropic_response_text(body: &Value) -> String {
@@ -1533,6 +1618,7 @@ fn anthropic_response_text(body: &Value) -> String {
 fn anthropic_metrics_from_response_json(body: &Value) -> AnthropicUsageMetrics {
     let usage = body.get("usage");
     AnthropicUsageMetrics {
+        usage_estimated: false,
         prompt_tokens: usage
             .and_then(|u| u.get("input_tokens"))
             .and_then(Value::as_u64)
@@ -1777,6 +1863,13 @@ async fn cross_provider_dispatch(
         let post_stream_keys = reservation.as_ref().map(|r| r.keys()).unwrap_or_default();
         let stream_hold = reservation.take().map(|r| r.into_stream_hold());
         let limiter_for_stream = std::sync::Arc::clone(&state.limiter);
+        // Token-estimation fallback context (AISIX-Cloud#1074): the inbound
+        // Anthropic request body is cloned because the stream owns it until
+        // an end-of-stream Drop.
+        let estimator = crate::token_estimate::Estimator::new(
+            &upstream_model,
+            crate::token_estimate::PromptInput::Anthropic(body.clone()),
+        );
         let sse_body = build_anthropic_sse_stream(
             upstream,
             encoder,
@@ -1784,6 +1877,7 @@ async fn cross_provider_dispatch(
             stream_guardrail,
             model_name.to_string(),
             content_cap,
+            Some(estimator),
             move |comp| {
                 // #688: apply the terminal token cost to TPM/TPD and release the
                 // concurrency hold now the stream has ended (sync analog of the
@@ -1808,6 +1902,7 @@ async fn cross_provider_dispatch(
                     completion_tokens: comp.completion_tokens,
                     cache_creation_tokens: comp.cache_creation_tokens,
                     cache_read_tokens: comp.cache_read_tokens,
+                    usage_estimated: comp.usage_estimated,
                     provider_request_id: comp.provider_request_id,
                     provider_model_version: comp.provider_model_version,
                     finish_reason: comp.finish_reason,
@@ -1952,16 +2047,23 @@ async fn cross_provider_dispatch(
         crate::redact::redact_chat_response(resolved_chain.as_ref(), &mut resp);
     crate::redact::merge_counts(&mut output_redactions, output_seg_counts);
 
-    let metrics = AnthropicUsageMetrics {
+    let mut metrics = AnthropicUsageMetrics {
         prompt_tokens: resp.usage.prompt_tokens,
         completion_tokens: resp.usage.completion_tokens,
         cache_creation_tokens: resp.usage.cache_creation_tokens,
         cache_read_tokens: resp.usage.cache_read_tokens,
+        usage_estimated: false,
         provider_request_id: resp.id.clone(),
         provider_model_version: resp.model.clone(),
         finish_reason: finish_reason_label(&resp.finish_reason),
         ttft_ms: 0,
     };
+    // Token-estimation fallback (AISIX-Cloud#1074): fill counters the
+    // bridged upstream never reported. Telemetry only — the rendered
+    // Anthropic JSON below carries the upstream's own usage.
+    fill_missing_anthropic_metrics(&mut metrics, &upstream_model, body, || {
+        crate::chat::estimation_output_text(&resp)
+    });
     // Capture the prompt (the Anthropic request body) + assembled assistant
     // text for content-capturing exporters (gated); threaded to `fan_out` via
     // `DispatchOutcome`, never to the CP sink.
@@ -2001,6 +2103,7 @@ async fn cross_provider_dispatch(
 /// Errors in the stream surface as a final `event: error` frame so
 /// SSE clients see something actionable rather than a half-complete
 /// stream.
+#[allow(clippy::too_many_arguments)]
 fn build_anthropic_sse_stream(
     upstream: aisix_gateway::ChatChunkStream,
     encoder: aisix_provider_anthropic::AnthropicSseEncoder,
@@ -2010,6 +2113,9 @@ fn build_anthropic_sse_stream(
     // Largest content cap any content-capturing exporter wants, or `None` to
     // skip response accumulation (the common, content-free path).
     content_cap: Option<u32>,
+    // Token-estimation fallback context (AISIX-Cloud#1074); see
+    // `CompleteAnthropicStreamOnDrop::estimator`.
+    estimator: Option<crate::token_estimate::Estimator>,
     on_complete: impl FnOnce(AnthropicStreamCompletion) + Send + 'static,
 ) -> axum::body::Body {
     use futures::StreamExt;
@@ -2033,6 +2139,7 @@ fn build_anthropic_sse_stream(
     let stream = async_stream::stream! {
         let mut guard = CompleteAnthropicStreamOnDrop {
             slot: Some((on_complete, AnthropicStreamCompletion::default())),
+            estimator,
         };
         let mut upstream = upstream;
         let mut first_chunk_seen = false;
@@ -2091,6 +2198,33 @@ fn build_anthropic_sse_stream(
                         if let Some(t) = chunk.delta.content.as_deref() {
                             if comp.response_text.len() < cap as usize {
                                 comp.response_text.push_str(t);
+                            }
+                        }
+                    }
+                    // Token-estimation accumulator (AISIX-Cloud#1074): all
+                    // generated output, always on (whether the fallback is
+                    // needed is only known at end-of-stream), bounded.
+                    if comp.est_output_text.len()
+                        < crate::token_estimate::OUTPUT_ACCUMULATION_CAP
+                    {
+                        if let Some(t) = chunk.delta.content.as_deref() {
+                            comp.est_output_text.push_str(t);
+                        }
+                        if let Some(t) = chunk.delta.reasoning_content.as_deref() {
+                            comp.est_output_text.push_str(t);
+                        }
+                        if let Some(tcs) = chunk.delta.tool_calls.as_ref() {
+                            for tc in tcs {
+                                if let Some(f) = tc.get("function") {
+                                    if let Some(n) = f.get("name").and_then(|v| v.as_str()) {
+                                        comp.est_output_text.push_str(n);
+                                    }
+                                    if let Some(a) =
+                                        f.get("arguments").and_then(|v| v.as_str())
+                                    {
+                                        comp.est_output_text.push_str(a);
+                                    }
+                                }
                             }
                         }
                     }
@@ -2290,10 +2424,18 @@ struct AnthropicStreamCompletion {
     completion_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
+    /// True when the Drop guard filled any token counter from the local
+    /// estimator (AISIX-Cloud#1074).
+    usage_estimated: bool,
     provider_request_id: String,
     provider_model_version: String,
     finish_reason: String,
     ttft_ms: u32,
+    /// Generated output (content + reasoning + tool-call text) accumulated
+    /// for the token-estimation fallback (AISIX-Cloud#1074). Always on,
+    /// bounded to `token_estimate::OUTPUT_ACCUMULATION_CAP`; never leaves
+    /// the process.
+    est_output_text: String,
     /// Assembled assistant text for content-capturing exporters, accumulated
     /// across chunks ONLY when an exporter wants full content (bounded to the
     /// capture cap). Empty otherwise. Read by the on_complete closure; never
@@ -2310,6 +2452,9 @@ struct AnthropicStreamCompletion {
 
 struct CompleteAnthropicStreamOnDrop<F: FnOnce(AnthropicStreamCompletion)> {
     slot: Option<(F, AnthropicStreamCompletion)>,
+    /// Token-estimation fallback (AISIX-Cloud#1074); fills counters the
+    /// upstream never reported before `on_complete` runs.
+    estimator: Option<crate::token_estimate::Estimator>,
 }
 
 impl<F: FnOnce(AnthropicStreamCompletion)> CompleteAnthropicStreamOnDrop<F> {
@@ -2324,7 +2469,25 @@ impl<F: FnOnce(AnthropicStreamCompletion)> CompleteAnthropicStreamOnDrop<F> {
 
 impl<F: FnOnce(AnthropicStreamCompletion)> Drop for CompleteAnthropicStreamOnDrop<F> {
     fn drop(&mut self) {
-        if let Some((f, c)) = self.slot.take() {
+        if let Some((f, mut c)) = self.slot.take() {
+            // Token-estimation fallback (AISIX-Cloud#1074): fill the
+            // counters the upstream never reported. This surface has no
+            // delivered-count gate (unlike chat.rs / the passthrough
+            // guard), so the estimate covers whatever the bridge produced
+            // before the stream ended.
+            if let Some(est) = self.estimator.take() {
+                let filled = crate::token_estimate::fill_missing(
+                    &est,
+                    c.prompt_tokens,
+                    c.completion_tokens,
+                    Some(c.est_output_text.as_str()),
+                );
+                if filled.estimated {
+                    c.prompt_tokens = filled.prompt_tokens;
+                    c.completion_tokens = filled.completion_tokens;
+                    c.usage_estimated = true;
+                }
+            }
             f(c);
         }
     }
@@ -2394,6 +2557,9 @@ struct AnthropicUsageMetrics {
     completion_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
+    /// True when any token counter was filled by the local estimator
+    /// because the upstream reported no usage (AISIX-Cloud#1074).
+    usage_estimated: bool,
     provider_request_id: String,
     provider_model_version: String,
     finish_reason: String,
@@ -2468,6 +2634,7 @@ fn emit_anthropic_usage_event(
         completion_tokens: metrics.completion_tokens,
         cache_creation_tokens: metrics.cache_creation_tokens,
         cache_read_tokens: metrics.cache_read_tokens,
+        usage_estimated: metrics.usage_estimated,
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         provider_request_id: metrics.provider_request_id,
@@ -2601,6 +2768,15 @@ struct AnthropicStreamUsage {
     completion_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
+    /// True once a `message_delta` carried a numeric `output_tokens`.
+    /// Without it, `completion_tokens` holds only the `message_start`
+    /// placeholder floor (often 1) — the token-estimation fallback
+    /// treats that floor as "missing" so an aborted stream estimates
+    /// from the delivered text instead of recording the placeholder.
+    output_tokens_from_delta: bool,
+    /// True when `AnthropicStreamGuard::drop` filled any token counter
+    /// from the local estimator (AISIX-Cloud#1074).
+    usage_estimated: bool,
     provider_request_id: String,
     provider_model_version: String,
     finish_reason: String,
@@ -2698,6 +2874,7 @@ fn update_anthropic_usage(
                 if let Some(v) = usage.get("output_tokens") {
                     if let Some(t) = v.as_u64() {
                         acc.completion_tokens = acc.completion_tokens.max(t as u32);
+                        acc.output_tokens_from_delta = true;
                     } else {
                         // PR #436 audit LOW-1: a `usage` object present but
                         // with a non-numeric `output_tokens` leaves
@@ -2812,6 +2989,10 @@ pub(crate) fn extract_sse_data_line(frame: &[u8]) -> Option<&[u8]> {
 struct AnthropicStreamGuard<F: FnOnce(AnthropicStreamUsage)> {
     slot: Option<(F, AnthropicStreamUsage)>,
     delivered: Arc<AtomicU32>,
+    /// Token-estimation fallback (AISIX-Cloud#1074): fills counters the
+    /// upstream never reported. Prompt from the captured request body,
+    /// completion from the accumulated `response_text`.
+    estimator: Option<crate::token_estimate::Estimator>,
 }
 
 impl<F: FnOnce(AnthropicStreamUsage)> AnthropicStreamGuard<F> {
@@ -2837,6 +3018,30 @@ impl<F: FnOnce(AnthropicStreamUsage)> Drop for AnthropicStreamGuard<F> {
                 usage.completion_tokens = 0;
                 usage.cache_creation_tokens = 0;
                 usage.cache_read_tokens = 0;
+            }
+            // Token-estimation fallback (AISIX-Cloud#1074), after the #419
+            // gate. A floor-only completion count (message_start placeholder,
+            // no message_delta) is treated as missing so an aborted stream
+            // estimates from the delivered text; max() keeps the floor when
+            // the estimate has nothing to add.
+            if let Some(est) = self.estimator.take() {
+                let upstream_completion = if usage.output_tokens_from_delta {
+                    usage.completion_tokens
+                } else {
+                    0
+                };
+                let output = (delivered > 0).then_some(usage.response_text.as_str());
+                let filled = crate::token_estimate::fill_missing(
+                    &est,
+                    usage.prompt_tokens,
+                    upstream_completion,
+                    output,
+                );
+                if filled.estimated {
+                    usage.prompt_tokens = filled.prompt_tokens;
+                    usage.completion_tokens = filled.completion_tokens.max(usage.completion_tokens);
+                    usage.usage_estimated = true;
+                }
             }
             f(usage);
         }
@@ -2877,6 +3082,9 @@ fn build_anthropic_passthrough_stream<S, F>(
     // When `Some`, the assembled `response_text` is preserved (not taken by the
     // guardrail scan) so the on_complete content capture can read it.
     content_cap: Option<u32>,
+    // Token-estimation fallback context (AISIX-Cloud#1074); see
+    // `AnthropicStreamGuard::estimator`.
+    estimator: Option<crate::token_estimate::Estimator>,
     on_complete: F,
 ) -> AnthropicDeliveryCounter<reqwest::Result<Bytes>>
 where
@@ -2904,6 +3112,7 @@ where
         let mut guard = AnthropicStreamGuard {
             slot: Some((on_complete, AnthropicStreamUsage::default())),
             delivered: delivered_for_drop,
+            estimator,
         };
         futures::pin_mut!(upstream);
         let mut buf: Vec<u8> = Vec::new();
@@ -4504,6 +4713,7 @@ event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\"
                         usage,
                     )),
                     delivered,
+                    estimator: None,
                 };
                 drop(guard);
             }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -2787,6 +2787,14 @@ struct AnthropicStreamUsage {
     /// Assistant text accumulated from `content_block_delta` frames, for
     /// the end-of-stream output guardrail (#448).
     response_text: String,
+    /// Generated output (text + thinking + tool name/arguments)
+    /// accumulated for the token-estimation fallback (AISIX-Cloud#1074).
+    /// Separate from `response_text`, which belongs to the guardrail
+    /// scan: the scan `take`s that buffer (so estimation would read "")
+    /// and pads it with newline separators (which inflate per-frame
+    /// counts). Bounded to `token_estimate::OUTPUT_ACCUMULATION_CAP`;
+    /// never leaves the process.
+    est_output_text: String,
     /// Per-detector PII mask counts applied to the held stream at release
     /// (#932). Merged with the input-side counts by the on_complete emit.
     redacted_entity_counts: crate::redact::RedactionCounts,
@@ -2866,6 +2874,26 @@ fn update_anthropic_usage(
                         acc.response_text.push('\n');
                         acc.response_text.push_str(&input.to_string());
                     }
+                }
+            }
+            // Token-estimation accumulator (AISIX-Cloud#1074): raw
+            // concatenation (no separators — a separator per frame would
+            // inflate the count), plus `thinking` deltas, which are
+            // billed output but out of guardrail scope.
+            if acc.est_output_text.len() < crate::token_estimate::OUTPUT_ACCUMULATION_CAP {
+                if let Some(delta) = json.get("delta") {
+                    for key in ["text", "thinking", "partial_json"] {
+                        if let Some(t) = delta.get(key).and_then(Value::as_str) {
+                            acc.est_output_text.push_str(t);
+                        }
+                    }
+                }
+                if let Some(name) = json
+                    .get("content_block")
+                    .and_then(|cb| cb.get("name"))
+                    .and_then(Value::as_str)
+                {
+                    acc.est_output_text.push_str(name);
                 }
             }
         }
@@ -3030,7 +3058,7 @@ impl<F: FnOnce(AnthropicStreamUsage)> Drop for AnthropicStreamGuard<F> {
                 } else {
                     0
                 };
-                let output = (delivered > 0).then_some(usage.response_text.as_str());
+                let output = (delivered > 0).then_some(usage.est_output_text.as_str());
                 let filled = crate::token_estimate::fill_missing(
                     &est,
                     usage.prompt_tokens,
@@ -4751,6 +4779,145 @@ event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\"
             "completion kept when delivered>0"
         );
         assert_eq!(out.chunks_delivered, 5);
+    }
+
+    /// AISIX-Cloud#1074: the passthrough guard's estimation fallback and
+    /// its `message_start` floor normalization. The floor (a placeholder
+    /// `output_tokens`, often 1, with no `message_delta` ever arriving)
+    /// must count as "missing" so an aborted stream estimates from the
+    /// delivered text — but a real `message_delta` count must win
+    /// untouched, and an empty estimate must not clobber the floor.
+    #[test]
+    fn stream_guard_estimates_missing_usage_with_floor_normalization() {
+        use super::{AnthropicStreamGuard, AnthropicStreamUsage, AtomicU32};
+        use std::sync::{Arc, Mutex};
+
+        fn drop_with_estimator(
+            usage: AnthropicStreamUsage,
+            delivered_count: u32,
+        ) -> AnthropicStreamUsage {
+            let captured: Arc<Mutex<Option<AnthropicStreamUsage>>> = Arc::new(Mutex::new(None));
+            let cap = captured.clone();
+            let delivered = Arc::new(AtomicU32::new(delivered_count));
+            let body = serde_json::json!({
+                "model": "relay-claude",
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "Hello"}]
+            });
+            {
+                let guard = AnthropicStreamGuard {
+                    slot: Some((
+                        move |u: AnthropicStreamUsage| {
+                            *cap.lock().unwrap() = Some(u);
+                        },
+                        usage,
+                    )),
+                    delivered,
+                    estimator: Some(crate::token_estimate::Estimator::new(
+                        "relay-claude",
+                        crate::token_estimate::PromptInput::Anthropic(body),
+                    )),
+                };
+                drop(guard);
+            }
+            let out = captured.lock().unwrap().take().expect("on_complete fired");
+            out
+        }
+
+        // Expected prompt for one user message "Hello" (cl100k fallback):
+        // 3 per-message + "user" (1) + "Hello" (1) + 3 reply priming = 8.
+        // Floor-only (message_start placeholder, no message_delta) with
+        // delivered text: the floor counts as missing, the estimate wins.
+        let out = drop_with_estimator(
+            AnthropicStreamUsage {
+                completion_tokens: 1,
+                output_tokens_from_delta: false,
+                est_output_text: "Hello world".into(),
+                ..Default::default()
+            },
+            3,
+        );
+        assert_eq!(out.prompt_tokens, 8);
+        assert_eq!(out.completion_tokens, 2, "estimate supersedes the floor");
+        assert!(out.usage_estimated);
+
+        // Floor-only with NO delivered text: nothing to estimate on the
+        // completion side — the floor is retained, prompt still fills.
+        let out = drop_with_estimator(
+            AnthropicStreamUsage {
+                completion_tokens: 1,
+                output_tokens_from_delta: false,
+                ..Default::default()
+            },
+            3,
+        );
+        assert_eq!(out.prompt_tokens, 8);
+        assert_eq!(out.completion_tokens, 1, "empty estimate keeps the floor");
+        assert!(out.usage_estimated, "prompt side was estimated");
+
+        // Real message_delta count: upstream wins untouched, unflagged.
+        let out = drop_with_estimator(
+            AnthropicStreamUsage {
+                prompt_tokens: 37,
+                completion_tokens: 52,
+                output_tokens_from_delta: true,
+                est_output_text: "Hello world".into(),
+                ..Default::default()
+            },
+            3,
+        );
+        assert_eq!(out.prompt_tokens, 37);
+        assert_eq!(out.completion_tokens, 52);
+        assert!(!out.usage_estimated);
+    }
+
+    /// AISIX-Cloud#1074: the non-streaming fill helper and its output
+    /// extraction — zero counters fill from the estimator and flag the
+    /// metrics; upstream-reported counters stay untouched. The output
+    /// extractor covers text + thinking + tool_use name/input.
+    #[test]
+    fn fill_missing_anthropic_metrics_fills_zeros_only() {
+        use super::{
+            anthropic_estimation_output_text, fill_missing_anthropic_metrics, AnthropicUsageMetrics,
+        };
+
+        let body = serde_json::json!({
+            "model": "relay-claude",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let resp = serde_json::json!({
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "thinking", "thinking": " world"},
+                {"type": "tool_use", "id": "tu_1", "name": "f", "input": {}}
+            ]
+        });
+        // Output extraction: text + thinking + tool name + input JSON.
+        let text = anthropic_estimation_output_text(&resp);
+        assert_eq!(text, "Hello worldf{}");
+
+        // Both sides missing → both fill, flagged. Prompt = 8 (see the
+        // floor test above for the arithmetic).
+        let mut m = AnthropicUsageMetrics::default();
+        fill_missing_anthropic_metrics(&mut m, "relay-claude", &body, || {
+            anthropic_estimation_output_text(&resp)
+        });
+        assert_eq!(m.prompt_tokens, 8);
+        assert!(m.completion_tokens > 0);
+        assert!(m.usage_estimated);
+
+        // Upstream-reported → untouched, unflagged, extractor never runs.
+        let mut m = AnthropicUsageMetrics {
+            prompt_tokens: 11,
+            completion_tokens: 7,
+            ..Default::default()
+        };
+        fill_missing_anthropic_metrics(&mut m, "relay-claude", &body, || {
+            panic!("output extractor must not run when usage is complete")
+        });
+        assert_eq!((m.prompt_tokens, m.completion_tokens), (11, 7));
+        assert!(!m.usage_estimated);
     }
 
     /// Helper for the streaming variants of (Anthropic inbound) ×

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -116,6 +116,9 @@ impl From<ProxyError> for ResponsesDispatchError {
 struct ResponseUsage {
     prompt_tokens: u32,
     completion_tokens: u32,
+    /// True when any token counter was filled by the local estimator
+    /// because the upstream reported no usage (AISIX-Cloud#1074).
+    usage_estimated: bool,
     /// o1/o3/GPT-5 class models surface reasoning tokens as a
     /// subset of `completion_tokens` via
     /// `usage.output_tokens_details.reasoning_tokens`. Zero for
@@ -1177,7 +1180,31 @@ async fn responses_to_target(
             // #808: the whole SSE response is buffered here, so parse its
             // terminal event for usage and let the handler emit (the body is
             // a single complete chunk now, not a live stream).
-            let usage = responses_sse_usage(&buf);
+            //
+            // Token-estimation fallback (AISIX-Cloud#1074): a buffered
+            // stream with zero/missing usage fills the counters locally —
+            // telemetry only, the buffered bytes forward untouched.
+            let usage = {
+                let mut u = responses_sse_usage(&buf).unwrap_or_default();
+                if u.prompt_tokens == 0 || u.completion_tokens == 0 {
+                    let est = crate::token_estimate::Estimator::new(
+                        &upstream_model,
+                        crate::token_estimate::PromptInput::Responses(body.clone()),
+                    );
+                    let filled = crate::token_estimate::fill_missing(
+                        &est,
+                        u.prompt_tokens,
+                        u.completion_tokens,
+                        Some(&responses_sse_output_text(&buf)),
+                    );
+                    if filled.estimated {
+                        u.prompt_tokens = filled.prompt_tokens;
+                        u.completion_tokens = filled.completion_tokens;
+                        u.usage_estimated = true;
+                    }
+                }
+                Some(u)
+            };
             // Content capture (AISIX-Cloud#947): the assembled output text,
             // read from the POST-redaction buffer so masked PII stays masked
             // in the exported content.
@@ -1294,14 +1321,39 @@ async fn responses_to_target(
             chain: Arc::clone(&chain_arc),
             upstream_model: upstream_model.clone(),
         });
+        // Token-estimation fallback context (AISIX-Cloud#1074): the request
+        // body is cloned because the closure runs at end-of-stream Drop.
+        // Tokenized only if the upstream never reports usage.
+        let estimator_c = crate::token_estimate::Estimator::new(
+            &upstream_model,
+            crate::token_estimate::PromptInput::Responses(body.clone()),
+        );
         let parsed_stream = build_responses_passthrough_stream(
             body_stream,
             content_cap,
             eos_scan,
-            move |usage, out_text, output_hits| {
+            move |mut usage, out_text, output_hits| {
                 // Streams that reach here are committed 200s — the
                 // `!status.is_success()` guard above returned early on errors.
                 //
+                // Token-estimation fallback (AISIX-Cloud#1074): a stream that
+                // ends without a terminal usage event (client abort, relay
+                // that omits usage) fills the missing counters from the
+                // request + the assembled output text, BEFORE the TPM
+                // accounting and the emit below.
+                if usage.prompt_tokens == 0 || usage.completion_tokens == 0 {
+                    let filled = crate::token_estimate::fill_missing(
+                        &estimator_c,
+                        usage.prompt_tokens,
+                        usage.completion_tokens,
+                        Some(&out_text),
+                    );
+                    if filled.estimated {
+                        usage.prompt_tokens = filled.prompt_tokens;
+                        usage.completion_tokens = filled.completion_tokens;
+                        usage.usage_estimated = true;
+                    }
+                }
                 // #688: apply the terminal token cost to TPM/TPD and release the
                 // concurrency hold now the stream has ended (sync analog of the
                 // reservation's async `commit_tokens`, which this closure can't await).
@@ -1402,7 +1454,31 @@ async fn responses_to_target(
         // emission. Pulled here (before the response is moved into
         // `Json::into_response`) so the success struct can carry
         // typed counters rather than re-parsing JSON downstream.
-        let usage = extract_response_usage(&json_body);
+        // Token-estimation fallback (AISIX-Cloud#1074): a body with zero or
+        // missing usage fills the counters locally — telemetry only, the
+        // response body is forwarded untouched. A body with no `usage`
+        // object at all becomes a wholly-estimated record instead of None.
+        let usage = {
+            let mut u = extract_response_usage(&json_body).unwrap_or_default();
+            if u.prompt_tokens == 0 || u.completion_tokens == 0 {
+                let est = crate::token_estimate::Estimator::new(
+                    &upstream_model,
+                    crate::token_estimate::PromptInput::Responses(body.clone()),
+                );
+                let filled = crate::token_estimate::fill_missing(
+                    &est,
+                    u.prompt_tokens,
+                    u.completion_tokens,
+                    Some(&responses_output_text(&json_body)),
+                );
+                if filled.estimated {
+                    u.prompt_tokens = filled.prompt_tokens;
+                    u.completion_tokens = filled.completion_tokens;
+                    u.usage_estimated = true;
+                }
+            }
+            Some(u)
+        };
 
         // #719: run the output guardrail chain on the assistant's text so a
         // configured output block isn't bypassable by calling /v1/responses
@@ -1693,6 +1769,13 @@ async fn responses_cross_provider_to_target(
         let stream_hold = reservation.take().map(|r| r.into_stream_hold());
         let limiter_c = std::sync::Arc::clone(&state.limiter);
         let captured_prompt_c = captured_prompt.clone();
+        // Token-estimation fallback context (AISIX-Cloud#1074): the request
+        // body is cloned because the stream owns it until an end-of-stream
+        // Drop. Tokenized only if the bridged upstream never reports usage.
+        let estimator = crate::token_estimate::Estimator::new(
+            model.upstream_model().unwrap_or("unknown"),
+            crate::token_estimate::PromptInput::Responses(body.clone()),
+        );
         let sse_body = crate::responses_bridge::build_responses_bridge_stream(
             upstream,
             encoder,
@@ -1702,6 +1785,7 @@ async fn responses_cross_provider_to_target(
             max_buffer_bytes,
             requested_model.to_string(),
             content_cap,
+            Some(estimator),
             move |comp| {
                 // #688: apply the terminal token cost to TPM/TPD and release the
                 // concurrency hold now the stream has ended (sync analog of the
@@ -1727,6 +1811,7 @@ async fn responses_cross_provider_to_target(
                     cached_prompt_tokens: comp.cached_prompt_tokens,
                     cache_creation_tokens: comp.cache_creation_tokens,
                     cache_read_tokens: comp.cache_read_tokens,
+                    usage_estimated: comp.usage_estimated,
                 };
                 // A clean stream is a committed 200; an output-guardrail block
                 // (or fail-closed overflow) bills the upstream tokens but is
@@ -1826,13 +1911,37 @@ async fn responses_cross_provider_to_target(
     state.health.record_success(&model.display_name);
     state.runtime_status.mark_healthy(model_id);
 
-    let usage = ResponseUsage {
-        prompt_tokens: resp.usage.prompt_tokens,
-        completion_tokens: resp.usage.completion_tokens,
-        reasoning_tokens: resp.usage.reasoning_tokens,
-        cached_prompt_tokens: resp.usage.cached_prompt_tokens,
-        cache_creation_tokens: resp.usage.cache_creation_tokens,
-        cache_read_tokens: resp.usage.cache_read_tokens,
+    let usage = {
+        let mut u = ResponseUsage {
+            prompt_tokens: resp.usage.prompt_tokens,
+            completion_tokens: resp.usage.completion_tokens,
+            reasoning_tokens: resp.usage.reasoning_tokens,
+            cached_prompt_tokens: resp.usage.cached_prompt_tokens,
+            cache_creation_tokens: resp.usage.cache_creation_tokens,
+            cache_read_tokens: resp.usage.cache_read_tokens,
+            usage_estimated: false,
+        };
+        // Token-estimation fallback (AISIX-Cloud#1074): fill counters the
+        // bridged upstream never reported. Telemetry only — the re-encoded
+        // Responses JSON below carries the upstream's own usage.
+        if u.prompt_tokens == 0 || u.completion_tokens == 0 {
+            let est = crate::token_estimate::Estimator::new(
+                model.upstream_model().unwrap_or("unknown"),
+                crate::token_estimate::PromptInput::Responses(body.clone()),
+            );
+            let filled = crate::token_estimate::fill_missing(
+                &est,
+                u.prompt_tokens,
+                u.completion_tokens,
+                Some(&crate::chat::estimation_output_text(&resp)),
+            );
+            if filled.estimated {
+                u.prompt_tokens = filled.prompt_tokens;
+                u.completion_tokens = filled.completion_tokens;
+                u.usage_estimated = true;
+            }
+        }
+        u
     };
 
     // #719: run output guardrails on the bridged response before re-encoding
@@ -1975,6 +2084,7 @@ fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
     Some(ResponseUsage {
         prompt_tokens,
         completion_tokens,
+        usage_estimated: false,
         reasoning_tokens,
         cached_prompt_tokens,
         // OpenAI verbatim path: no Anthropic-style cache counters.
@@ -2237,21 +2347,27 @@ where
     S: futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send + 'static,
     F: FnOnce(ResponseUsage, String, Vec<aisix_core::GuardrailMonitorHit>) + Send + 'static,
 {
-    // The scan reads the same assembled output text the capture produces, so
-    // an attached scan forces the accumulator on even when no exporter wants
-    // content. The cap bounds delta accumulation; a terminal event's full
-    // output text is instead bounded by MAX_SSE_FRAME_BUF_BYTES (an oversized
-    // frame never parses) and re-truncated by both consumers —
-    // `CapturedContent::new` at the exporter cap and `EosOutputScan::observe`
-    // at the scan bound — so neither sees beyond its own limit.
-    let capture_cap = match (content_cap, eos_scan.is_some()) {
-        (Some(cap), true) => {
-            Some((cap as usize).max(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES))
-        }
-        (Some(cap), false) => Some(cap as usize),
-        (None, true) => Some(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES),
-        (None, false) => None,
-    };
+    // The scan and the token-estimation fallback read the same assembled
+    // output text the capture produces, so the accumulator is now ALWAYS
+    // on (AISIX-Cloud#1074) — whether estimation is needed is only known
+    // at end-of-stream — with the estimation cap as the floor. The cap
+    // bounds delta accumulation; a terminal event's full output text is
+    // instead bounded by MAX_SSE_FRAME_BUF_BYTES (an oversized frame
+    // never parses) and re-truncated by each consumer —
+    // `CapturedContent::new` at the exporter cap and
+    // `EosOutputScan::observe` at the scan bound — so none sees beyond
+    // its own limit.
+    let capture_cap = Some(
+        content_cap
+            .map(|cap| cap as usize)
+            .unwrap_or(0)
+            .max(if eos_scan.is_some() {
+                aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES
+            } else {
+                0
+            })
+            .max(crate::token_estimate::OUTPUT_ACCUMULATION_CAP),
+    );
     // Re-attach the request span: the body is polled after the request-id
     // middleware returns, so the end-of-stream output-guardrail scan
     // (`EosOutputScan::observe`) would otherwise log without a
@@ -2524,6 +2640,7 @@ fn emit_usage_event(
         // verbatim OpenAI path.
         cache_creation_tokens: usage.cache_creation_tokens,
         cache_read_tokens: usage.cache_read_tokens,
+        usage_estimated: usage.usage_estimated,
         latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
         inbound_protocol: "openai".to_string(),
@@ -4451,14 +4568,13 @@ mod tests {
         );
     }
 
-    /// Companion: an upstream response missing the `usage` block
-    /// entirely (some edge / error response shapes) must NOT emit
-    /// — there's nothing meaningful to attribute. Pre-#404 the
-    /// handler emitted nothing; we keep that behaviour for this
-    /// edge so the api_key isn't credited with zero-everything
-    /// noise rows.
+    /// Companion: an upstream 200 missing the `usage` block entirely
+    /// (some relay / compat backends) now emits an ESTIMATED usage
+    /// event (AISIX-Cloud#1074) — the call must not stay invisible to
+    /// billing. (Pre-#1074 this edge kept the pre-#404 no-emit
+    /// behaviour.)
     #[tokio::test]
-    async fn skips_usage_event_when_upstream_omits_usage_block() {
+    async fn estimates_usage_event_when_upstream_omits_usage_block() {
         use aisix_obs::UsageSink;
 
         let upstream = MockServer::start().await;
@@ -4497,18 +4613,16 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        // Wait briefly — no event should arrive. `Ok(None)` means
-        // the channel closed (state dropped) without sending; `Err`
-        // means timeout. Both are acceptable "no event" outcomes;
-        // only `Ok(Some(_))` would be a real failure.
-        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        if let Ok(Some(ev)) = recv {
-            panic!(
-                "expected NO event when usage block absent, but got: \
-                 prompt_tokens={}, completion_tokens={}, status_code={}",
-                ev.prompt_tokens, ev.completion_tokens, ev.status_code,
-            );
-        }
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("estimated UsageEvent must be emitted when `usage` is absent")
+            .expect("usage_sink sender dropped");
+        // input "hello" per the cookbook message scheme: 3 per-message
+        // + "user" (1) + "hello" (1) + 3 reply priming = 8. Empty
+        // `output` → completion stays 0.
+        assert_eq!(event.prompt_tokens, 8);
+        assert_eq!(event.completion_tokens, 0);
+        assert!(event.usage_estimated, "locally-counted tokens must be flagged");
     }
 
     /// #808: a streaming `/v1/responses` 200 (e.g. all Codex traffic, which
@@ -4782,13 +4896,14 @@ data: [DONE]\n\n";
         }
     }
 
-    /// Issue #404 audit MEDIUM-1: a 200 with `usage: {}` (malformed
-    /// — `input_tokens` is required by the Responses-API spec) must
-    /// NOT emit a zero-everything noise row. Same edge as the
-    /// `skips_usage_event_when_upstream_omits_usage_block` test but
-    /// the gate is one layer deeper — `usage` exists but is empty.
+    /// A 200 with `usage: {}` (malformed — `input_tokens` is required
+    /// by the Responses-API spec) now emits an ESTIMATED usage event
+    /// (AISIX-Cloud#1074) instead of dropping the record. Same edge as
+    /// the omitted-usage test but the gate is one layer deeper —
+    /// `usage` exists but is empty. (Pre-#1074, per issue #404 audit
+    /// MEDIUM-1, this dropped the event entirely.)
     #[tokio::test]
-    async fn skips_usage_event_when_usage_block_is_empty_audit_m1() {
+    async fn estimates_usage_event_when_usage_block_is_empty() {
         use aisix_obs::UsageSink;
 
         let upstream = MockServer::start().await;
@@ -4826,14 +4941,15 @@ data: [DONE]\n\n";
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        if let Ok(Some(ev)) = recv {
-            panic!(
-                "no UsageEvent should be emitted for malformed `usage: {{}}`, \
-                 got prompt_tokens={}",
-                ev.prompt_tokens,
-            );
-        }
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("estimated UsageEvent must be emitted for malformed `usage: {}`")
+            .expect("usage_sink sender dropped");
+        // input "hi" counts per the cookbook message scheme: 3 per-message
+        // + "user" (1) + "hi" (1) + 3 reply priming = 8. Empty output → 0.
+        assert_eq!(event.prompt_tokens, 8);
+        assert_eq!(event.completion_tokens, 0);
+        assert!(event.usage_estimated, "locally-counted tokens must be flagged");
     }
 
     /// #429 follow-up: a 200 whose `usage` carries

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -4622,7 +4622,10 @@ mod tests {
         // `output` → completion stays 0.
         assert_eq!(event.prompt_tokens, 8);
         assert_eq!(event.completion_tokens, 0);
-        assert!(event.usage_estimated, "locally-counted tokens must be flagged");
+        assert!(
+            event.usage_estimated,
+            "locally-counted tokens must be flagged"
+        );
     }
 
     /// #808: a streaming `/v1/responses` 200 (e.g. all Codex traffic, which
@@ -4949,7 +4952,10 @@ data: [DONE]\n\n";
         // + "user" (1) + "hi" (1) + 3 reply priming = 8. Empty output → 0.
         assert_eq!(event.prompt_tokens, 8);
         assert_eq!(event.completion_tokens, 0);
-        assert!(event.usage_estimated, "locally-counted tokens must be flagged");
+        assert!(
+            event.usage_estimated,
+            "locally-counted tokens must be flagged"
+        );
     }
 
     /// #429 follow-up: a 200 whose `usage` carries

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -910,10 +910,21 @@ pub struct ResponsesStreamCompletion {
     /// wants full content (bounded to the capture cap). Empty otherwise.
     /// Read by the on_complete telemetry closure; never reaches the CP sink.
     pub response_text: String,
+    /// True when the Drop guard filled any token counter from the local
+    /// estimator (AISIX-Cloud#1074).
+    pub usage_estimated: bool,
+    /// Generated output (content + reasoning + tool-call text) accumulated
+    /// for the token-estimation fallback (AISIX-Cloud#1074). Always on,
+    /// bounded to `token_estimate::OUTPUT_ACCUMULATION_CAP`; never leaves
+    /// the process.
+    est_output_text: String,
 }
 
 struct CompleteOnDrop<F: FnOnce(ResponsesStreamCompletion)> {
     slot: Option<(F, ResponsesStreamCompletion)>,
+    /// Token-estimation fallback (AISIX-Cloud#1074); fills counters the
+    /// upstream never reported before `on_complete` runs.
+    estimator: Option<crate::token_estimate::Estimator>,
 }
 
 impl<F: FnOnce(ResponsesStreamCompletion)> CompleteOnDrop<F> {
@@ -928,7 +939,23 @@ impl<F: FnOnce(ResponsesStreamCompletion)> CompleteOnDrop<F> {
 
 impl<F: FnOnce(ResponsesStreamCompletion)> Drop for CompleteOnDrop<F> {
     fn drop(&mut self) {
-        if let Some((f, comp)) = self.slot.take() {
+        if let Some((f, mut comp)) = self.slot.take() {
+            // Token-estimation fallback (AISIX-Cloud#1074): fill the
+            // counters the upstream never reported from the request +
+            // the accumulated output text.
+            if let Some(est) = self.estimator.take() {
+                let filled = crate::token_estimate::fill_missing(
+                    &est,
+                    comp.prompt_tokens,
+                    comp.completion_tokens,
+                    Some(comp.est_output_text.as_str()),
+                );
+                if filled.estimated {
+                    comp.prompt_tokens = filled.prompt_tokens;
+                    comp.completion_tokens = filled.completion_tokens;
+                    comp.usage_estimated = true;
+                }
+            }
             f(comp);
         }
     }
@@ -964,13 +991,19 @@ pub fn build_responses_bridge_stream(
     // Largest content cap any content-capturing exporter wants
     // (AISIX-Cloud#947); `None` skips response-text accumulation entirely.
     content_cap: Option<u32>,
+    // Token-estimation fallback context (AISIX-Cloud#1074); see
+    // `CompleteOnDrop::estimator`.
+    estimator: Option<crate::token_estimate::Estimator>,
     on_complete: impl FnOnce(ResponsesStreamCompletion) + Send + 'static,
 ) -> axum::body::Body {
     use futures::StreamExt;
 
     let mut encoder = encoder;
     let stream = async_stream::stream! {
-        let mut guard = CompleteOnDrop { slot: Some((on_complete, ResponsesStreamCompletion::default())) };
+        let mut guard = CompleteOnDrop {
+            slot: Some((on_complete, ResponsesStreamCompletion::default())),
+            estimator,
+        };
         let mut upstream = upstream;
         let mut first_chunk_seen = false;
         let buffering = output_guardrail.is_some() && hold_back;
@@ -1004,6 +1037,36 @@ pub fn build_responses_bridge_stream(
                         {
                             if comp.response_text.len() < cap as usize {
                                 comp.response_text.push_str(text);
+                            }
+                        }
+                        // Token-estimation accumulator (AISIX-Cloud#1074):
+                        // all generated output, always on (whether the
+                        // fallback is needed is only known at end-of-stream),
+                        // bounded.
+                        if comp.est_output_text.len()
+                            < crate::token_estimate::OUTPUT_ACCUMULATION_CAP
+                        {
+                            if let Some(text) = chunk.delta.content.as_deref() {
+                                comp.est_output_text.push_str(text);
+                            }
+                            if let Some(text) = chunk.delta.reasoning_content.as_deref() {
+                                comp.est_output_text.push_str(text);
+                            }
+                            if let Some(tcs) = chunk.delta.tool_calls.as_ref() {
+                                for tc in tcs {
+                                    if let Some(f) = tc.get("function") {
+                                        if let Some(n) =
+                                            f.get("name").and_then(|v| v.as_str())
+                                        {
+                                            comp.est_output_text.push_str(n);
+                                        }
+                                        if let Some(a) =
+                                            f.get("arguments").and_then(|v| v.as_str())
+                                        {
+                                            comp.est_output_text.push_str(a);
+                                        }
+                                    }
+                                }
                             }
                         }
                         if let Some(u) = chunk.usage.as_ref() {

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1043,14 +1043,13 @@ pub fn build_responses_bridge_stream(
                         // all generated output, always on (whether the
                         // fallback is needed is only known at end-of-stream),
                         // bounded.
-                        if comp.est_output_text.len()
-                            < crate::token_estimate::OUTPUT_ACCUMULATION_CAP
                         {
+                            use crate::token_estimate::push_capped;
                             if let Some(text) = chunk.delta.content.as_deref() {
-                                comp.est_output_text.push_str(text);
+                                push_capped(&mut comp.est_output_text, text);
                             }
                             if let Some(text) = chunk.delta.reasoning_content.as_deref() {
-                                comp.est_output_text.push_str(text);
+                                push_capped(&mut comp.est_output_text, text);
                             }
                             if let Some(tcs) = chunk.delta.tool_calls.as_ref() {
                                 for tc in tcs {
@@ -1058,12 +1057,12 @@ pub fn build_responses_bridge_stream(
                                         if let Some(n) =
                                             f.get("name").and_then(|v| v.as_str())
                                         {
-                                            comp.est_output_text.push_str(n);
+                                            push_capped(&mut comp.est_output_text, n);
                                         }
                                         if let Some(a) =
                                             f.get("arguments").and_then(|v| v.as_str())
                                         {
-                                            comp.est_output_text.push_str(a);
+                                            push_capped(&mut comp.est_output_text, a);
                                         }
                                     }
                                 }

--- a/crates/aisix-proxy/src/token_estimate.rs
+++ b/crates/aisix-proxy/src/token_estimate.rs
@@ -1,0 +1,841 @@
+//! Local token estimation for usage telemetry (AISIX-Cloud#1074).
+//!
+//! When an upstream response — streaming or not — carries no `usage`
+//! block, the emit paths fall back to counting tokens locally so usage
+//! events, post-stream TPM/TPD accounting, and metrics record real
+//! numbers instead of silent zeros. Estimation fills **telemetry only**:
+//! the client-visible response body is never rewritten, and upstream
+//! values always win when non-zero (per-field `or` semantics, matching
+//! the reference stream-rebuild implementations). Any event that carries
+//! an estimated component sets `UsageEvent::usage_estimated`.
+//!
+//! Counting follows the OpenAI cookbook message scheme: 3 tokens per
+//! message, +1 per `name`, +3 reply priming, tool definitions rendered
+//! to the de-facto TypeScript-ish form (+9, −4 when a system message is
+//! present). The completion side counts the accumulated output text as
+//! plain text with no overhead.
+//!
+//! Encoding selection mirrors tiktoken's model map (`gpt-4o`/`o1`/... →
+//! `o200k_base`, `gpt-4`/`gpt-3.5` → `cl100k_base`) and falls back to
+//! `cl100k_base` for unknown/non-OpenAI models. Counts for models with
+//! proprietary tokenizers (Claude, Gemini, ...) are therefore
+//! approximations — the `usage_estimated` flag exists so consumers can
+//! tell these numbers from upstream-reported ones.
+
+use serde_json::Value;
+use tiktoken_rs::tokenizer::{get_tokenizer, Tokenizer};
+use tiktoken_rs::CoreBPE;
+
+/// Bound on the output text accumulated for completion-side estimation.
+/// ~1 MiB of UTF-8 comfortably exceeds the largest real model outputs
+/// (128K tokens ≈ 0.5 MiB of English text); past the cap the estimate
+/// becomes a lower bound instead of the buffer growing without limit.
+pub const OUTPUT_ACCUMULATION_CAP: usize = 1 << 20;
+
+const TOKENS_PER_MESSAGE: u32 = 3;
+const TOKENS_PER_NAME: u32 = 1;
+/// "Every reply is primed with `<|start|>assistant<|message|>`."
+const REPLY_PRIMING: u32 = 3;
+const TOOLS_OVERHEAD: u32 = 9;
+/// Rendered tool definitions absorb part of the system message frame.
+const TOOLS_WITH_SYSTEM_DISCOUNT: u32 = 4;
+/// Image content block without size information: the fixed low-detail
+/// cost. `detail: high` costs `85 + 170×tiles`, but tiling needs the
+/// image dimensions, which the gateway never fetches — those fall back
+/// to [`IMAGE_TOKENS_DEFAULT`].
+const IMAGE_TOKENS_LOW: u32 = 85;
+const IMAGE_TOKENS_DEFAULT: u32 = 250;
+
+/// The request-side input for prompt-token estimation, captured (moved,
+/// not copied where the call site allows) before the response starts and
+/// tokenized only if estimation actually runs.
+pub enum PromptInput {
+    /// OpenAI-shaped chat request (`/v1/chat/completions`).
+    Chat(Box<aisix_gateway::chat::ChatFormat>),
+    /// Raw Anthropic `/v1/messages` request body.
+    Anthropic(Value),
+    /// Raw `/v1/responses` request body.
+    Responses(Value),
+}
+
+/// Prompt shape + the model name that selects the tokenizer encoding.
+pub struct Estimator {
+    model: String,
+    input: PromptInput,
+}
+
+/// Outcome of [`fill_missing`]: the (possibly filled) token counts and
+/// whether estimation supplied any non-zero component.
+pub struct Filled {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub estimated: bool,
+}
+
+impl Estimator {
+    pub fn new(model: impl Into<String>, input: PromptInput) -> Self {
+        Self {
+            model: model.into(),
+            input,
+        }
+    }
+
+    /// Count the prompt side of the captured request.
+    pub fn count_prompt(&self) -> u32 {
+        let bpe = bpe_for(&self.model);
+        match &self.input {
+            PromptInput::Chat(req) => count_chat_prompt(bpe, req),
+            PromptInput::Anthropic(body) => count_anthropic_prompt(bpe, body),
+            PromptInput::Responses(body) => count_responses_prompt(bpe, body),
+        }
+    }
+
+    pub fn count_output(&self, text: &str) -> u32 {
+        count_text(&self.model, text)
+    }
+}
+
+/// Count `text` as plain text with the model's encoding — the
+/// completion-side rule (no message overhead).
+pub fn count_text(model: &str, text: &str) -> u32 {
+    if text.is_empty() {
+        return 0;
+    }
+    clamp(bpe_for(model).encode_ordinary(text).len())
+}
+
+/// Per-field `or` fill: upstream values win when non-zero; zeros are
+/// replaced with local counts. `output_text: None` disables the
+/// completion side (nothing was delivered, or nothing was accumulated).
+/// Sub-counters (cache/reasoning) are never estimated.
+pub fn fill_missing(
+    est: &Estimator,
+    upstream_prompt: u32,
+    upstream_completion: u32,
+    output_text: Option<&str>,
+) -> Filled {
+    let mut filled = Filled {
+        prompt_tokens: upstream_prompt,
+        completion_tokens: upstream_completion,
+        estimated: false,
+    };
+    if upstream_prompt == 0 {
+        let n = est.count_prompt();
+        if n > 0 {
+            filled.prompt_tokens = n;
+            filled.estimated = true;
+        }
+    }
+    if upstream_completion == 0 {
+        if let Some(text) = output_text {
+            let n = est.count_output(text);
+            if n > 0 {
+                filled.completion_tokens = n;
+                filled.estimated = true;
+            }
+        }
+    }
+    filled
+}
+
+fn bpe_for(model: &str) -> &'static CoreBPE {
+    match get_tokenizer(model) {
+        Some(Tokenizer::O200kHarmony) => tiktoken_rs::o200k_harmony_singleton(),
+        Some(Tokenizer::O200kBase) => tiktoken_rs::o200k_base_singleton(),
+        Some(Tokenizer::P50kBase) => tiktoken_rs::p50k_base_singleton(),
+        Some(Tokenizer::P50kEdit) => tiktoken_rs::p50k_edit_singleton(),
+        Some(Tokenizer::R50kBase | Tokenizer::Gpt2) => tiktoken_rs::r50k_base_singleton(),
+        Some(Tokenizer::Cl100kBase) | None => tiktoken_rs::cl100k_base_singleton(),
+    }
+}
+
+fn clamp(n: usize) -> u32 {
+    n.min(u32::MAX as usize) as u32
+}
+
+fn enc(bpe: &CoreBPE, text: &str) -> u32 {
+    if text.is_empty() {
+        return 0;
+    }
+    clamp(bpe.encode_ordinary(text).len())
+}
+
+// ---------------------------------------------------------------------
+// Chat (`/v1/chat/completions`)
+// ---------------------------------------------------------------------
+
+fn count_chat_prompt(bpe: &CoreBPE, req: &aisix_gateway::chat::ChatFormat) -> u32 {
+    let mut n: u32 = 0;
+    let mut has_system = false;
+    for m in &req.messages {
+        let role = role_label(&m.role);
+        if role == "system" {
+            has_system = true;
+        }
+        n = n.saturating_add(TOKENS_PER_MESSAGE);
+        n = n.saturating_add(enc(bpe, role));
+        if let Some(blocks) = m.content_blocks.as_deref() {
+            n = n.saturating_add(count_content_blocks(bpe, blocks));
+        } else if let Some(text) = m.content.as_deref() {
+            n = n.saturating_add(enc(bpe, text));
+        }
+        if let Some(name) = m.name.as_deref() {
+            n = n
+                .saturating_add(TOKENS_PER_NAME)
+                .saturating_add(enc(bpe, name));
+        }
+        if let Some(id) = m.tool_call_id.as_deref() {
+            n = n.saturating_add(enc(bpe, id));
+        }
+        for (key, value) in &m.extra {
+            match key.as_str() {
+                "tool_calls" | "function_call" => {
+                    n = n.saturating_add(count_tool_call_arguments(bpe, value));
+                }
+                _ => {
+                    if let Some(s) = value.as_str() {
+                        n = n.saturating_add(enc(bpe, s));
+                    }
+                }
+            }
+        }
+    }
+    n.saturating_add(count_request_extra(
+        bpe,
+        req.extra.get("tools"),
+        req.extra.get("tool_choice"),
+        has_system,
+    ))
+}
+
+fn role_label(role: &aisix_gateway::chat::Role) -> &'static str {
+    match role {
+        aisix_gateway::chat::Role::System => "system",
+        aisix_gateway::chat::Role::User => "user",
+        aisix_gateway::chat::Role::Assistant => "assistant",
+        aisix_gateway::chat::Role::Tool => "tool",
+    }
+}
+
+/// History `tool_calls` / legacy `function_call`: only the call
+/// `arguments` strings are counted; the function *names* are covered by
+/// the rendered tool definitions.
+fn count_tool_call_arguments(bpe: &CoreBPE, value: &Value) -> u32 {
+    let mut n: u32 = 0;
+    let calls: &[Value] = match value {
+        Value::Array(a) => a.as_slice(),
+        v @ Value::Object(_) => std::slice::from_ref(v),
+        _ => return 0,
+    };
+    for call in calls {
+        let args = call
+            .get("function")
+            .and_then(|f| f.get("arguments"))
+            .or_else(|| call.get("arguments"));
+        if let Some(Value::String(s)) = args {
+            n = n.saturating_add(enc(bpe, s));
+        }
+    }
+    n
+}
+
+// ---------------------------------------------------------------------
+// Anthropic (`/v1/messages`)
+// ---------------------------------------------------------------------
+
+fn count_anthropic_prompt(bpe: &CoreBPE, body: &Value) -> u32 {
+    let mut n: u32 = 0;
+    let mut has_system = false;
+    if let Some(system) = body.get("system") {
+        if !system.is_null() {
+            has_system = true;
+            n = n.saturating_add(TOKENS_PER_MESSAGE);
+            n = n.saturating_add(enc(bpe, "system"));
+            n = n.saturating_add(count_content_value(bpe, system));
+        }
+    }
+    if let Some(messages) = body.get("messages").and_then(|m| m.as_array()) {
+        for m in messages {
+            n = n.saturating_add(TOKENS_PER_MESSAGE);
+            if let Some(role) = m.get("role").and_then(|r| r.as_str()) {
+                n = n.saturating_add(enc(bpe, role));
+            }
+            if let Some(content) = m.get("content") {
+                n = n.saturating_add(count_content_value(bpe, content));
+            }
+        }
+    }
+    n.saturating_add(count_request_extra(
+        bpe,
+        body.get("tools"),
+        body.get("tool_choice"),
+        has_system,
+    ))
+}
+
+// ---------------------------------------------------------------------
+// Responses (`/v1/responses`)
+// ---------------------------------------------------------------------
+
+/// The Responses API has no cookbook counting scheme; items are close
+/// enough to chat messages that each item takes the per-message overhead
+/// and its text-bearing fields are counted like message content.
+fn count_responses_prompt(bpe: &CoreBPE, body: &Value) -> u32 {
+    let mut n: u32 = 0;
+    let mut has_system = false;
+    if let Some(instructions) = body.get("instructions").and_then(|i| i.as_str()) {
+        has_system = true;
+        n = n.saturating_add(TOKENS_PER_MESSAGE);
+        n = n.saturating_add(enc(bpe, "system"));
+        n = n.saturating_add(enc(bpe, instructions));
+    }
+    match body.get("input") {
+        Some(Value::String(text)) => {
+            n = n.saturating_add(TOKENS_PER_MESSAGE);
+            n = n.saturating_add(enc(bpe, "user"));
+            n = n.saturating_add(enc(bpe, text));
+        }
+        Some(Value::Array(items)) => {
+            for item in items {
+                n = n.saturating_add(TOKENS_PER_MESSAGE);
+                match item.get("role").and_then(|r| r.as_str()) {
+                    Some(role) => {
+                        // Message-shaped item.
+                        if role == "system" || role == "developer" {
+                            has_system = true;
+                        }
+                        n = n.saturating_add(enc(bpe, role));
+                        if let Some(content) = item.get("content") {
+                            n = n.saturating_add(count_content_value(bpe, content));
+                        }
+                    }
+                    None => {
+                        // Non-message item (function_call, function_call_output,
+                        // reasoning, ...): count its text-bearing fields.
+                        n = n.saturating_add(count_string_fields(
+                            bpe,
+                            item,
+                            &["type", "id", "status"],
+                        ));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    n.saturating_add(count_request_extra(
+        bpe,
+        body.get("tools"),
+        body.get("tool_choice"),
+        has_system,
+    ))
+}
+
+// ---------------------------------------------------------------------
+// Shared content walkers
+// ---------------------------------------------------------------------
+
+/// `content` that is either a bare string or an array of typed blocks.
+fn count_content_value(bpe: &CoreBPE, content: &Value) -> u32 {
+    match content {
+        Value::String(s) => enc(bpe, s),
+        Value::Array(blocks) => count_content_blocks(bpe, blocks),
+        _ => 0,
+    }
+}
+
+/// Typed content blocks: OpenAI chat parts (`text`, `image_url`),
+/// Anthropic blocks (`text`, `image`, `tool_use`, `tool_result`,
+/// `thinking`), and Responses parts (`input_text`, `output_text`,
+/// `refusal`). Unknown block types count 0 — the emit path must never
+/// fail on an unrecognized shape.
+fn count_content_blocks(bpe: &CoreBPE, blocks: &[Value]) -> u32 {
+    let mut n: u32 = 0;
+    for block in blocks {
+        if let Some(s) = block.as_str() {
+            n = n.saturating_add(enc(bpe, s));
+            continue;
+        }
+        match block.get("type").and_then(|t| t.as_str()) {
+            Some("text" | "input_text" | "output_text") => {
+                if let Some(s) = block.get("text").and_then(|t| t.as_str()) {
+                    n = n.saturating_add(enc(bpe, s));
+                }
+            }
+            Some("refusal") => {
+                if let Some(s) = block.get("refusal").and_then(|t| t.as_str()) {
+                    n = n.saturating_add(enc(bpe, s));
+                }
+            }
+            Some("image_url") => {
+                let detail = block
+                    .get("image_url")
+                    .and_then(|i| i.get("detail"))
+                    .and_then(|d| d.as_str())
+                    .unwrap_or("auto");
+                n = n.saturating_add(match detail {
+                    "low" | "auto" => IMAGE_TOKENS_LOW,
+                    // `high` needs the image dimensions to tile; the
+                    // gateway never fetches them, so use the flat default.
+                    _ => IMAGE_TOKENS_DEFAULT,
+                });
+            }
+            Some("image" | "input_image") => {
+                n = n.saturating_add(IMAGE_TOKENS_DEFAULT);
+            }
+            Some("tool_use" | "tool_result") => {
+                n = n.saturating_add(count_string_fields(
+                    bpe,
+                    block,
+                    &["type", "id", "tool_use_id", "cache_control", "is_error"],
+                ));
+            }
+            Some("thinking") => {
+                if let Some(s) = block.get("thinking").and_then(|t| t.as_str()) {
+                    n = n.saturating_add(enc(bpe, s));
+                }
+            }
+            _ => {}
+        }
+    }
+    n
+}
+
+/// Count the text carried by an arbitrary JSON object: every string
+/// field outside `skip`, with non-string composites (e.g. a `tool_use`
+/// `input` object) counted via their compact JSON serialization.
+fn count_string_fields(bpe: &CoreBPE, value: &Value, skip: &[&str]) -> u32 {
+    let Some(obj) = value.as_object() else {
+        return 0;
+    };
+    let mut n: u32 = 0;
+    for (key, v) in obj {
+        if skip.contains(&key.as_str()) {
+            continue;
+        }
+        match v {
+            Value::String(s) => n = n.saturating_add(enc(bpe, s)),
+            Value::Array(_) | Value::Object(_) => {
+                if let Ok(s) = serde_json::to_string(v) {
+                    n = n.saturating_add(enc(bpe, &s));
+                }
+            }
+            _ => {}
+        }
+    }
+    n
+}
+
+/// Reply priming + tool definitions + `tool_choice`.
+fn count_request_extra(
+    bpe: &CoreBPE,
+    tools: Option<&Value>,
+    tool_choice: Option<&Value>,
+    has_system: bool,
+) -> u32 {
+    let mut n = REPLY_PRIMING;
+    let tools = tools.and_then(|t| t.as_array()).filter(|t| !t.is_empty());
+    if let Some(tools) = tools {
+        n = n.saturating_add(enc(bpe, &format_tool_definitions(tools)));
+        n = n.saturating_add(TOOLS_OVERHEAD);
+        if has_system {
+            n = n.saturating_sub(TOOLS_WITH_SYSTEM_DISCOUNT);
+        }
+    }
+    match tool_choice {
+        Some(Value::String(s)) if s == "none" => n = n.saturating_add(1),
+        Some(tc @ Value::Object(_)) => {
+            n = n.saturating_add(7);
+            let name = tc
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .or_else(|| tc.get("name"))
+                .and_then(|v| v.as_str());
+            if let Some(name) = name {
+                n = n.saturating_add(enc(bpe, name));
+            }
+        }
+        _ => {}
+    }
+    n
+}
+
+/// Render tool definitions in the TypeScript-namespace form the OpenAI
+/// tokenizer overhead was measured against. Accepts both the OpenAI
+/// shape (`{type, function: {name, description, parameters}}`) and flat
+/// shapes (Anthropic `{name, description, input_schema}`, Responses
+/// `{type, name, description, parameters}`).
+fn format_tool_definitions(tools: &[Value]) -> String {
+    let mut lines: Vec<String> = vec!["namespace functions {".into(), String::new()];
+    for tool in tools {
+        if !tool.is_object() {
+            continue;
+        }
+        let function = match tool.get("function") {
+            Some(f @ Value::Object(_)) => f.clone(),
+            _ => {
+                let params = tool
+                    .get("input_schema")
+                    .or_else(|| tool.get("parameters"))
+                    .cloned()
+                    .filter(|p| p.is_object())
+                    .unwrap_or_else(|| Value::Object(Default::default()));
+                serde_json::json!({
+                    "name": tool.get("name").cloned().unwrap_or(Value::Null),
+                    "description": tool.get("description").cloned().unwrap_or(Value::Null),
+                    "parameters": params,
+                })
+            }
+        };
+        let Some(name) = function.get("name").and_then(|n| n.as_str()) else {
+            continue;
+        };
+        if let Some(desc) = function.get("description").and_then(|d| d.as_str()) {
+            if !desc.is_empty() {
+                lines.push(format!("// {desc}"));
+            }
+        }
+        let parameters = function.get("parameters").cloned().unwrap_or(Value::Null);
+        let has_properties = parameters
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .is_some_and(|p| !p.is_empty());
+        if has_properties {
+            lines.push(format!("type {name} = (_: {{"));
+            lines.push(format_object_parameters(&parameters, 0));
+            lines.push("}) => any;".into());
+        } else {
+            lines.push(format!("type {name} = () => any;"));
+        }
+        lines.push(String::new());
+    }
+    lines.push("} // namespace functions".into());
+    lines.join("\n")
+}
+
+fn format_object_parameters(parameters: &Value, indent: usize) -> String {
+    let Some(properties) = parameters.get("properties").and_then(|p| p.as_object()) else {
+        return String::new();
+    };
+    let required: Vec<&str> = parameters
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|r| r.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    let mut lines: Vec<String> = Vec::new();
+    for (key, props) in properties {
+        if let Some(desc) = props.get("description").and_then(|d| d.as_str()) {
+            lines.push(format!("// {desc}"));
+        }
+        let question = if required.contains(&key.as_str()) {
+            ""
+        } else {
+            "?"
+        };
+        lines.push(format!("{key}{question}: {},", format_type(props, indent)));
+    }
+    let pad = " ".repeat(indent);
+    lines
+        .iter()
+        .map(|l| format!("{pad}{l}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_type(props: &Value, indent: usize) -> String {
+    let enum_values = |props: &Value| -> Option<String> {
+        props.get("enum").and_then(|e| e.as_array()).map(|items| {
+            items
+                .iter()
+                .map(|i| match i {
+                    Value::String(s) => format!("\"{s}\""),
+                    other => format!("\"{other}\""),
+                })
+                .collect::<Vec<_>>()
+                .join(" | ")
+        })
+    };
+    match props.get("type").and_then(|t| t.as_str()) {
+        Some("string") => enum_values(props).unwrap_or_else(|| "string".into()),
+        Some("array") => match props.get("items") {
+            Some(items) => format!("{}[]", format_type(items, indent)),
+            None => "any[]".into(),
+        },
+        Some("object") => format!("{{\n{}\n}}", format_object_parameters(props, indent + 2)),
+        Some("integer" | "number") => enum_values(props).unwrap_or_else(|| "number".into()),
+        Some("boolean") => "boolean".into(),
+        Some("null") => "null".into(),
+        _ => "any".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_gateway::chat::{ChatFormat, ChatMessage, Role};
+    use serde_json::json;
+
+    fn chat_est(model: &str, req: ChatFormat) -> Estimator {
+        Estimator::new(model, PromptInput::Chat(Box::new(req)))
+    }
+
+    fn msg(role: Role, content: &str) -> ChatMessage {
+        ChatMessage {
+            role,
+            content: Some(content.to_string()),
+            content_blocks: None,
+            name: None,
+            tool_call_id: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn encoding_selection_mirrors_tiktoken_model_map() {
+        assert!(std::ptr::eq(
+            bpe_for("gpt-4o-2024-08-06"),
+            tiktoken_rs::o200k_base_singleton(),
+        ));
+        assert!(std::ptr::eq(
+            bpe_for("gpt-4"),
+            tiktoken_rs::cl100k_base_singleton(),
+        ));
+        // Unknown / non-OpenAI models fall back to cl100k_base.
+        assert!(std::ptr::eq(
+            bpe_for("claude-sonnet-4-5"),
+            tiktoken_rs::cl100k_base_singleton(),
+        ));
+        assert!(std::ptr::eq(
+            bpe_for(""),
+            tiktoken_rs::cl100k_base_singleton(),
+        ));
+    }
+
+    #[test]
+    fn count_text_plain() {
+        assert_eq!(count_text("gpt-4", ""), 0);
+        // cl100k_base: "Hello" + " world" = 2 tokens.
+        assert_eq!(count_text("gpt-4", "Hello world"), 2);
+        // Unknown model uses the same fallback encoding.
+        assert_eq!(count_text("some-proxy-model", "Hello world"), 2);
+    }
+
+    #[test]
+    fn chat_prompt_counts_cookbook_overhead() {
+        // One user message: 3 (per-message) + 1 ("user") + 1 ("Hello")
+        // + 3 (reply priming) = 8.
+        let req = ChatFormat::new("gpt-4", vec![msg(Role::User, "Hello")]);
+        assert_eq!(chat_est("gpt-4", req).count_prompt(), 8);
+    }
+
+    #[test]
+    fn chat_prompt_counts_name_and_tool_calls() {
+        let mut named = msg(Role::User, "Hello");
+        named.name = Some("alice".into());
+        let base = ChatFormat::new("gpt-4", vec![msg(Role::User, "Hello")]);
+        let with_name = ChatFormat::new("gpt-4", vec![named]);
+        let base_n = chat_est("gpt-4", base).count_prompt();
+        let name_n = chat_est("gpt-4", with_name).count_prompt();
+        // +1 name overhead +count("alice").
+        assert_eq!(
+            name_n,
+            base_n + TOKENS_PER_NAME + count_text("gpt-4", "alice")
+        );
+
+        let mut assistant = msg(Role::Assistant, "");
+        assistant.content = None;
+        assistant.extra.insert(
+            "tool_calls".into(),
+            json!([{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{\"city\":\"Paris\"}"}
+            }]),
+        );
+        let req = ChatFormat::new("gpt-4", vec![assistant]);
+        let n = chat_est("gpt-4", req).count_prompt();
+        // 3 + count("assistant") + count(arguments) + 3 priming; the id and
+        // function name are intentionally not counted.
+        let expected = TOKENS_PER_MESSAGE
+            + count_text("gpt-4", "assistant")
+            + count_text("gpt-4", "{\"city\":\"Paris\"}")
+            + REPLY_PRIMING;
+        assert_eq!(n, expected);
+    }
+
+    #[test]
+    fn tool_definitions_render_and_add_overhead() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"},
+                        "unit": {"type": "string", "enum": ["c", "f"]}
+                    },
+                    "required": ["city"]
+                }
+            }
+        }]);
+        let rendered = format_tool_definitions(tools.as_array().unwrap());
+        assert_eq!(
+            rendered,
+            "namespace functions {\n\n// Get the weather\ntype get_weather = (_: {\n\
+             // City name\ncity: string,\nunit?: \"c\" | \"f\",\n}) => any;\n\n\
+             } // namespace functions"
+        );
+
+        let mut req = ChatFormat::new("gpt-4", vec![msg(Role::User, "Hi")]);
+        req.extra.insert("tools".into(), tools.clone());
+        let with_tools = chat_est("gpt-4", req).count_prompt();
+        let plain = chat_est(
+            "gpt-4",
+            ChatFormat::new("gpt-4", vec![msg(Role::User, "Hi")]),
+        )
+        .count_prompt();
+        assert_eq!(
+            with_tools,
+            plain + count_text("gpt-4", &rendered) + TOOLS_OVERHEAD
+        );
+
+        // Anthropic flat tool shape renders identically.
+        let anthropic_tools = json!([{
+            "name": "get_weather",
+            "description": "Get the weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"},
+                    "unit": {"type": "string", "enum": ["c", "f"]}
+                },
+                "required": ["city"]
+            }
+        }]);
+        assert_eq!(
+            format_tool_definitions(anthropic_tools.as_array().unwrap()),
+            rendered
+        );
+    }
+
+    #[test]
+    fn tools_with_system_message_discount() {
+        let tools = json!([{"type": "function", "function": {"name": "f"}}]);
+        let mut with_system = ChatFormat::new(
+            "gpt-4",
+            vec![msg(Role::System, "Be brief"), msg(Role::User, "Hi")],
+        );
+        with_system.extra.insert("tools".into(), tools.clone());
+        let mut without_system = ChatFormat::new("gpt-4", vec![msg(Role::User, "Hi")]);
+        without_system.extra.insert("tools".into(), tools);
+        let sys_msg_cost =
+            TOKENS_PER_MESSAGE + count_text("gpt-4", "system") + count_text("gpt-4", "Be brief");
+        assert_eq!(
+            chat_est("gpt-4", with_system).count_prompt(),
+            chat_est("gpt-4", without_system).count_prompt() + sys_msg_cost
+                - TOOLS_WITH_SYSTEM_DISCOUNT
+        );
+    }
+
+    #[test]
+    fn anthropic_prompt_counts_system_blocks_and_tools() {
+        let body = json!({
+            "model": "claude-sonnet-4-5",
+            "system": "Be helpful",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": [
+                    {"type": "text", "text": "Hi"},
+                    {"type": "tool_use", "id": "tu_1", "name": "get_weather",
+                     "input": {"city": "Paris"}}
+                ]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_1", "content": "sunny"}
+                ]}
+            ]
+        });
+        let est = Estimator::new("claude-sonnet-4-5", PromptInput::Anthropic(body));
+        let m = |s: &str| count_text("claude-sonnet-4-5", s);
+        let expected = (TOKENS_PER_MESSAGE + m("system") + m("Be helpful"))
+            + (TOKENS_PER_MESSAGE + m("user") + m("Hello"))
+            + (TOKENS_PER_MESSAGE
+                + m("assistant")
+                + m("Hi")
+                + m("get_weather")
+                + m("{\"city\":\"Paris\"}"))
+            + (TOKENS_PER_MESSAGE + m("user") + m("sunny"))
+            + REPLY_PRIMING;
+        assert_eq!(est.count_prompt(), expected);
+    }
+
+    #[test]
+    fn responses_prompt_counts_string_and_item_inputs() {
+        let simple = json!({"model": "gpt-4o", "input": "Hello"});
+        let est = Estimator::new("gpt-4o", PromptInput::Responses(simple));
+        let m = |s: &str| count_text("gpt-4o", s);
+        assert_eq!(
+            est.count_prompt(),
+            TOKENS_PER_MESSAGE + m("user") + m("Hello") + REPLY_PRIMING
+        );
+
+        let items = json!({
+            "model": "gpt-4o",
+            "instructions": "Be brief",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
+                {"type": "function_call", "id": "fc_1", "call_id": "call_1",
+                 "name": "get_weather", "arguments": "{}", "status": "completed"}
+            ]
+        });
+        let est = Estimator::new("gpt-4o", PromptInput::Responses(items));
+        let expected = (TOKENS_PER_MESSAGE + m("system") + m("Be brief"))
+            + (TOKENS_PER_MESSAGE + m("user") + m("Hello"))
+            + (TOKENS_PER_MESSAGE + m("call_1") + m("get_weather") + m("{}"))
+            + REPLY_PRIMING;
+        assert_eq!(est.count_prompt(), expected);
+    }
+
+    #[test]
+    fn fill_missing_or_semantics() {
+        let est = chat_est(
+            "gpt-4",
+            ChatFormat::new("gpt-4", vec![msg(Role::User, "Hello")]),
+        );
+
+        // Upstream reported both: untouched, not estimated.
+        let f = fill_missing(&est, 12, 34, Some("Hello world"));
+        assert_eq!(
+            (f.prompt_tokens, f.completion_tokens, f.estimated),
+            (12, 34, false)
+        );
+
+        // Both missing: both filled.
+        let f = fill_missing(&est, 0, 0, Some("Hello world"));
+        assert_eq!(f.prompt_tokens, 8);
+        assert_eq!(f.completion_tokens, 2);
+        assert!(f.estimated);
+
+        // Partial: only the missing side fills.
+        let f = fill_missing(&est, 12, 0, Some("Hello world"));
+        assert_eq!(
+            (f.prompt_tokens, f.completion_tokens, f.estimated),
+            (12, 2, true)
+        );
+
+        // No output text (nothing delivered): completion stays 0, prompt fills.
+        let f = fill_missing(&est, 0, 0, None);
+        assert_eq!(
+            (f.prompt_tokens, f.completion_tokens, f.estimated),
+            (8, 0, true)
+        );
+
+        // Empty output text estimates to 0 — not marked estimated for it.
+        let f = fill_missing(&est, 5, 0, Some(""));
+        assert_eq!(
+            (f.prompt_tokens, f.completion_tokens, f.estimated),
+            (5, 0, false)
+        );
+    }
+}

--- a/crates/aisix-proxy/src/token_estimate.rs
+++ b/crates/aisix-proxy/src/token_estimate.rs
@@ -98,10 +98,7 @@ impl Estimator {
 /// Count `text` as plain text with the model's encoding — the
 /// completion-side rule (no message overhead).
 pub fn count_text(model: &str, text: &str) -> u32 {
-    if text.is_empty() {
-        return 0;
-    }
-    clamp(bpe_for(model).encode_ordinary(text).len())
+    enc(bpe_for(model), text)
 }
 
 /// Per-field `or` fill: upstream values win when non-zero; zeros are
@@ -153,11 +150,56 @@ fn clamp(n: usize) -> u32 {
     n.min(u32::MAX as usize) as u32
 }
 
+/// Encode in slices of this size. The tokenizer's regex engine is
+/// superlinear on long unbroken runs (a multi-MiB single piece burns
+/// seconds of CPU) and its vendored wrapper unwraps regex failures —
+/// a ~1 MiB whitespace run panics with a fancy-regex StackOverflow.
+/// Slicing linearizes the cost and keeps any failure small; each
+/// boundary can split at most one token (+1 per slice, negligible).
+const ENCODE_SLICE_BYTES: usize = 64 * 1024;
+
+/// Total bytes exactly tokenized per [`enc`] call; the tail beyond it
+/// extrapolates at ~4 bytes/token. Real prompts sit far below this
+/// (≈256K tokens of English), so accuracy is unaffected — the cap
+/// exists so an adversarial multi-MiB piece can't pin a runtime
+/// worker inside a Drop guard.
+const EXACT_COUNT_BUDGET: usize = 1 << 20;
+
+/// Estimated-token fallback rate for text the exact pass skipped or
+/// the tokenizer failed on: the ~4-bytes-per-token rule of thumb.
+fn approx_tokens(bytes: usize) -> u32 {
+    clamp(bytes / 4)
+}
+
+/// Panic-proof, cost-bounded token count. Estimation runs on the
+/// request hot path and inside Drop guards (where a second panic
+/// during an unwind aborts the process), so the tokenizer must never
+/// panic out of here and must never burn unbounded CPU: encode in
+/// bounded slices, catch any tokenizer panic, and extrapolate the
+/// remainder past the exact-count budget.
 fn enc(bpe: &CoreBPE, text: &str) -> u32 {
-    if text.is_empty() {
-        return 0;
+    let mut n: u32 = 0;
+    let mut rest = text;
+    let mut budget = EXACT_COUNT_BUDGET;
+    while !rest.is_empty() {
+        if budget == 0 {
+            return n.saturating_add(approx_tokens(rest.len()));
+        }
+        let mut cut = ENCODE_SLICE_BYTES.min(rest.len());
+        while !rest.is_char_boundary(cut) {
+            cut += 1;
+        }
+        let (head, tail) = rest.split_at(cut);
+        let counted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            bpe.encode_ordinary(head).len()
+        }))
+        .map(clamp)
+        .unwrap_or_else(|_| approx_tokens(head.len()));
+        n = n.saturating_add(counted);
+        budget = budget.saturating_sub(cut);
+        rest = tail;
     }
-    clamp(bpe.encode_ordinary(text).len())
+    n
 }
 
 // ---------------------------------------------------------------------
@@ -618,6 +660,35 @@ mod tests {
         assert_eq!(count_text("gpt-4", "Hello world"), 2);
         // Unknown model uses the same fallback encoding.
         assert_eq!(count_text("some-proxy-model", "Hello world"), 2);
+    }
+
+    /// Audit HIGH-1 regression: a ~1 MiB unbroken whitespace run makes
+    /// the tokenizer's regex engine fail (StackOverflow) and its
+    /// vendored wrapper panic. `enc` slices the input and catches the
+    /// panic, so estimation must return a sane count instead of
+    /// panicking (which inside a Drop guard during an unwind would
+    /// abort the whole process).
+    #[test]
+    fn adversarial_whitespace_run_does_not_panic() {
+        let evil = " ".repeat(1 << 20) + "x";
+        let n = count_text("gpt-4", &evil);
+        assert!(n > 0, "a 1 MiB run must still produce a count, got {n}");
+    }
+
+    /// Text past the exact-count budget extrapolates at ~4 bytes/token
+    /// instead of burning unbounded CPU: the count keeps growing with
+    /// input size beyond the budget.
+    #[test]
+    fn exact_count_budget_extrapolates_tail() {
+        let base = "hello world ".repeat((1 << 20) / 12 + 1); // ≈ budget-sized
+        let doubled = base.repeat(2);
+        let n1 = count_text("gpt-4", &base);
+        let n2 = count_text("gpt-4", &doubled);
+        assert!(n2 > n1, "tail beyond the budget must still be counted");
+        // The extrapolated tail (~4 B/token) stays within 2× of the
+        // exact rate for this corpus (~3 B/token), so the total is the
+        // right order of magnitude.
+        assert!(n2 < n1 * 3);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/token_estimate.rs
+++ b/crates/aisix-proxy/src/token_estimate.rs
@@ -32,6 +32,28 @@ use tiktoken_rs::CoreBPE;
 /// becomes a lower bound instead of the buffer growing without limit.
 pub const OUTPUT_ACCUMULATION_CAP: usize = 1 << 20;
 
+/// Append `s` to an estimation accumulator, hard-capped at
+/// [`OUTPUT_ACCUMULATION_CAP`]: the final fragment is truncated at a
+/// char boundary and anything past the cap is dropped (the estimate
+/// becomes a lower bound). Checking the cap per push — rather than
+/// once per chunk — keeps a single oversized chunk from overshooting
+/// the buffer by its full size.
+pub fn push_capped(buf: &mut String, s: &str) {
+    let remaining = OUTPUT_ACCUMULATION_CAP.saturating_sub(buf.len());
+    if remaining == 0 || s.is_empty() {
+        return;
+    }
+    if s.len() <= remaining {
+        buf.push_str(s);
+        return;
+    }
+    let mut cut = remaining;
+    while !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    buf.push_str(&s[..cut]);
+}
+
 const TOKENS_PER_MESSAGE: u32 = 3;
 const TOKENS_PER_NAME: u32 = 1;
 /// "Every reply is primed with `<|start|>assistant<|message|>`."
@@ -673,6 +695,25 @@ mod tests {
         let evil = " ".repeat(1 << 20) + "x";
         let n = count_text("gpt-4", &evil);
         assert!(n > 0, "a 1 MiB run must still produce a count, got {n}");
+    }
+
+    /// The estimation accumulator is a hard cap: a single oversized
+    /// push cannot overshoot it, and the truncation lands on a char
+    /// boundary.
+    #[test]
+    fn push_capped_is_a_hard_cap() {
+        let mut buf = String::new();
+        push_capped(&mut buf, &"a".repeat(OUTPUT_ACCUMULATION_CAP - 1));
+        // Multi-byte char straddling the cap: truncated cleanly, never
+        // past the cap, never a panic.
+        push_capped(&mut buf, "汉汉汉");
+        assert!(buf.len() <= OUTPUT_ACCUMULATION_CAP);
+        assert!(buf.is_char_boundary(buf.len()));
+        // Full buffer: further pushes are no-ops.
+        let len = buf.len();
+        push_capped(&mut buf, &"b".repeat(64));
+        assert!(buf.len() <= OUTPUT_ACCUMULATION_CAP);
+        assert!(buf.len() >= len);
     }
 
     /// Text past the exact-count budget extrapolates at ~4 bytes/token

--- a/tests/e2e/src/cases/usage-estimation-1074-e2e.test.ts
+++ b/tests/e2e/src/cases/usage-estimation-1074-e2e.test.ts
@@ -387,19 +387,28 @@ describe("usage estimation e2e (AISIX-Cloud#1074): missing upstream usage is loc
     });
     expect(res.status).toBe(200);
     const reader = res.body!.getReader();
-    // Pull one chunk off the wire, then abort — the upstream still has
-    // events pending (150ms pacing), so this is a genuine mid-stream
-    // disconnect, not a raced clean close.
-    await reader.read();
+    // Read until the first content delta has crossed the wire, then
+    // abort — the upstream still has events pending (150ms pacing), so
+    // this is a genuine mid-stream disconnect after real delivery, not
+    // a raced clean close.
+    const decoder = new TextDecoder();
+    let wire = "";
+    while (!wire.includes('"content":"Hello"')) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      wire += decoder.decode(value, { stream: true });
+    }
+    expect(wire).toContain('"content":"Hello"');
     controller.abort();
 
     // The Drop guard fires on disconnect and estimates from what was
     // delivered: the prompt side is exact; the completion side covers
-    // at least the first delivered content token(s) but must stay below
-    // the full response (we aborted before " world" et al.).
+    // at least the delivered "Hello" (1 token) and at most the full
+    // response ("Hello world" = 2) if the abort raced the tail.
     const { input, output } = await waitTokenMetrics("est-chat-abort");
     expect(input).toBe(EXPECTED_PROMPT_TOKENS);
-    expect(output).toBeGreaterThanOrEqual(0);
+    expect(output).toBeGreaterThanOrEqual(1);
+    expect(output).toBeLessThanOrEqual(EXPECTED_COMPLETION_TOKENS);
     await waitSlsFlagged("est-chat-abort");
   }, 60_000);
 
@@ -433,6 +442,7 @@ describe("usage estimation e2e (AISIX-Cloud#1074): missing upstream usage is loc
     });
 
     const inputBefore = await tokenMetric("aisix_llm_input_tokens_total", "est-msgs-stream");
+    const outputBefore = await tokenMetric("aisix_llm_output_tokens_total", "est-msgs-stream");
     const res = await call();
     expect(res.status).toBe(200);
     const body = await res.text();
@@ -449,11 +459,11 @@ describe("usage estimation e2e (AISIX-Cloud#1074): missing upstream usage is loc
       if (input > inputBefore) break;
       await new Promise((r) => setTimeout(r, 100));
     }
-    // Prompt estimate is exact (one user message "hi" = 8). The output
-    // accumulator joins text deltas with separators, so bound the
-    // completion estimate instead of pinning it.
+    // Both sides are exact: one user message "hi" = 8, and the
+    // estimation accumulator is a raw concatenation of the text deltas
+    // ("Hello world" = 2) — no separators to inflate the count.
     expect(input - inputBefore).toBe(EXPECTED_PROMPT_TOKENS);
-    expect(output).toBeGreaterThanOrEqual(EXPECTED_COMPLETION_TOKENS);
+    expect(output - outputBefore).toBe(EXPECTED_COMPLETION_TOKENS);
     await waitSlsFlagged("est-msgs-stream");
   }, 60_000);
 

--- a/tests/e2e/src/cases/usage-estimation-1074-e2e.test.ts
+++ b/tests/e2e/src/cases/usage-estimation-1074-e2e.test.ts
@@ -1,0 +1,500 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { decodedTextFor, startMockSls, type MockSls } from "../harness/sls-mock.js";
+
+// E2E for AISIX-Cloud#1074: token metering for SSE + missing-usage upstreams.
+//
+// Contract pinned here: when an upstream (an OpenAI-compatible relay, an
+// aborted stream, ...) never reports a `usage` block, the gateway counts
+// tokens locally — prompt from the request, completion from the delivered
+// output text — and the usage record is marked `usage_estimated`. When the
+// upstream DOES report usage, its values win untouched (pinned by the Rust
+// unit suite; this file covers the estimation-positive paths end-to-end).
+// Estimation feeds telemetry (usage events → exporters, prometheus token
+// counters, TPM accounting) ONLY: the client-visible body/stream is never
+// rewritten with synthesised usage.
+//
+// Expected token values are ground truth from the de-facto OpenAI counting
+// scheme (https://github.com/openai/openai-cookbook — "How to count tokens"):
+// per message 3 tokens + the message's text, +3 reply priming; plain-text
+// counting for the completion side. The seeded upstream model names are
+// deliberately non-OpenAI so the fallback `cl100k_base` encoding applies:
+//   "user" = 1 token, "hi" = 1 token, "Hello world" = 2 tokens
+// → prompt for one user message "hi" = 3 + 1 + 1 + 3 = 8.
+const EXPECTED_PROMPT_TOKENS = 8;
+const EXPECTED_COMPLETION_TOKENS = 2; // "Hello world"
+
+const CALLER_PLAINTEXT = "sk-usage-estimation-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const CREDENTIAL_REF = "mock";
+const MOCK_AK_ID = "mock-akid";
+const MOCK_AK_SECRET = "mock-secret";
+const SLS_PROJECT = "aisix-e2e-obs";
+const META_LOGSTORE = "est-meta-events";
+
+// Chat SSE without any terminal usage chunk (relay behavior: ignores the
+// gateway-injected stream_options.include_usage).
+const CHAT_STREAM_EVENTS_NO_USAGE = [
+  '{"id":"chatcmpl-est-1","object":"chat.completion.chunk","model":"relay-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+  '{"id":"chatcmpl-est-1","object":"chat.completion.chunk","model":"relay-mini","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}',
+  '{"id":"chatcmpl-est-1","object":"chat.completion.chunk","model":"relay-mini","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}',
+  '{"id":"chatcmpl-est-1","object":"chat.completion.chunk","model":"relay-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+  "[DONE]",
+];
+
+// Non-streaming chat 200 with NO usage block at all.
+const CHAT_NON_STREAM_NO_USAGE = {
+  id: "chatcmpl-est-2",
+  object: "chat.completion",
+  created: Math.floor(Date.now() / 1000),
+  model: "relay-mini",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "Hello world" },
+      finish_reason: "stop",
+    },
+  ],
+};
+
+// Anthropic /v1/messages SSE where message_start has NO usage and no
+// message_delta usage ever arrives (relay omits token accounting).
+const MESSAGES_STREAM_EVENTS_NO_USAGE = [
+  JSON.stringify({
+    type: "message_start",
+    message: {
+      id: "msg_est_1",
+      role: "assistant",
+      content: [],
+      model: "relay-claude",
+      stop_reason: null,
+    },
+  }),
+  JSON.stringify({
+    type: "content_block_start",
+    index: 0,
+    content_block: { type: "text", text: "" },
+  }),
+  JSON.stringify({
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "text_delta", text: "Hello world" },
+  }),
+  JSON.stringify({ type: "content_block_stop", index: 0 }),
+  JSON.stringify({ type: "message_stop" }),
+];
+
+// /v1/responses SSE that aborts before any terminal `response.completed`
+// event — no usage ever arrives; the deltas are the only output signal.
+const RESPONSES_STREAM_EVENTS_NO_USAGE = [
+  '{"type":"response.created","response":{"id":"resp_est_1"}}',
+  '{"type":"response.output_text.delta","delta":"Hello"}',
+  '{"type":"response.output_text.delta","delta":" world"}',
+  "[DONE]",
+];
+
+describe("usage estimation e2e (AISIX-Cloud#1074): missing upstream usage is locally counted and flagged", () => {
+  let app: SpawnedApp | undefined;
+  let sls: MockSls | undefined;
+  let chatStreamUpstream: OpenAiUpstream | undefined;
+  let chatNonStreamUpstream: OpenAiUpstream | undefined;
+  let chatAbortUpstream: OpenAiUpstream | undefined;
+  let messagesUpstream: OpenAiUpstream | undefined;
+  let responsesUpstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    sls = await startMockSls();
+    chatStreamUpstream = await startOpenAiUpstream({
+      streamEvents: CHAT_STREAM_EVENTS_NO_USAGE,
+    });
+    chatNonStreamUpstream = await startOpenAiUpstream({
+      nonStreamBody: CHAT_NON_STREAM_NO_USAGE,
+    });
+    // Slow event pacing so the client can abort mid-stream with
+    // chunks still pending upstream-side.
+    chatAbortUpstream = await startOpenAiUpstream({
+      streamEvents: CHAT_STREAM_EVENTS_NO_USAGE,
+      eventDelayMs: 150,
+    });
+    messagesUpstream = await startOpenAiUpstream({
+      streamEvents: MESSAGES_STREAM_EVENTS_NO_USAGE,
+    });
+    responsesUpstream = await startOpenAiUpstream({
+      streamEvents: RESPONSES_STREAM_EVENTS_NO_USAGE,
+    });
+
+    app = await spawnApp({
+      extraEnv: {
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: MOCK_AK_ID,
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: MOCK_AK_SECRET,
+      },
+    });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    // Metadata-only SLS exporter: every usage event lands as one flat
+    // key/value log, so `usage_estimated` (serialized only when true) is
+    // observable on the wire without content capture.
+    await seed.createObservabilityExporter({
+      name: "est-sls-meta",
+      enabled: true,
+      kind: "aliyun_sls",
+      endpoint: sls.url,
+      project: SLS_PROJECT,
+      logstore: META_LOGSTORE,
+      credential_ref: CREDENTIAL_REF,
+      content_mode: "metadata_only",
+    });
+
+    // One model per scenario so prometheus counters and SLS records are
+    // unambiguous. All upstream model names are non-OpenAI on purpose —
+    // the estimator falls back to cl100k_base, matching the expected
+    // token constants above.
+    const seedModel = async (display: string, upstream: OpenAiUpstream, provider = "openai") => {
+      const pk = await seed!.createProviderKey({
+        display_name: `${display}-pk`,
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      await seed!.createModel({
+        display_name: display,
+        provider,
+        model_name: "relay-compat-x",
+        provider_key_id: pk.id,
+      });
+    };
+    await seedModel("est-chat-stream", chatStreamUpstream);
+    await seedModel("est-chat-nonstream", chatNonStreamUpstream);
+    await seedModel("est-chat-abort", chatAbortUpstream);
+    await seedModel("est-msgs-stream", messagesUpstream, "anthropic");
+    await seedModel("est-responses-stream", responsesUpstream);
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [
+        "est-chat-stream",
+        "est-chat-nonstream",
+        "est-chat-abort",
+        "est-msgs-stream",
+        "est-responses-stream",
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await sls?.close();
+    await chatStreamUpstream?.close();
+    await chatNonStreamUpstream?.close();
+    await chatAbortUpstream?.close();
+    await messagesUpstream?.close();
+    await responsesUpstream?.close();
+  });
+
+  function openai(): OpenAI {
+    return new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app!.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  /** Sum a token counter across label sets matching `model="<model>"`. */
+  async function tokenMetric(metric: string, model: string): Promise<number> {
+    const scrape = await fetch(`${app!.metricsUrl}/metrics`).then((r) => r.text());
+    let total = 0;
+    for (const line of scrape.split("\n")) {
+      if (!line.startsWith(`${metric}{`)) continue;
+      if (!line.includes(`model="${model}"`)) continue;
+      const value = Number(line.slice(line.lastIndexOf(" ") + 1));
+      if (Number.isFinite(value)) total += value;
+    }
+    return total;
+  }
+
+  /** Poll until the model's input-token counter is non-zero (Drop-guard
+   * emission is asynchronous), then return the (input, output) pair. */
+  async function waitTokenMetrics(model: string): Promise<{ input: number; output: number }> {
+    const deadline = Date.now() + 10_000;
+    let input = 0;
+    let output = 0;
+    while (Date.now() < deadline) {
+      input = await tokenMetric("aisix_llm_input_tokens_total", model);
+      output = await tokenMetric("aisix_llm_output_tokens_total", model);
+      if (input > 0) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    return { input, output };
+  }
+
+  /** True when an SLS record for `requestedModel` carries the
+   * `usage_estimated` flag. The flattened log serializes fields in
+   * struct order (requested_model before usage_estimated, which is
+   * present only when true), so a bounded forward window inside the
+   * decoded protobuf text identifies the pair within one record. */
+  function slsFlagged(requestedModel: string): boolean {
+    const text = decodedTextFor(sls!, META_LOGSTORE);
+    const re = new RegExp(`${requestedModel}[\\s\\S]{0,600}?usage_estimated`);
+    return re.test(text);
+  }
+
+  async function waitSlsFlagged(requestedModel: string): Promise<void> {
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      if (slsFlagged(requestedModel)) return;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+      `no usage_estimated-flagged SLS record for '${requestedModel}' within 10s`,
+    );
+  }
+
+  test("chat SSE without a usage chunk: tokens estimated, flagged, client stream untouched", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const client = openai();
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "est-chat-stream",
+          messages: [{ role: "user", content: "hi" }],
+          stream: true,
+        });
+        for await (const _ of probe) {
+          /* drain */
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const inputBefore = await tokenMetric("aisix_llm_input_tokens_total", "est-chat-stream");
+
+    const stream = await client.chat.completions.create({
+      model: "est-chat-stream",
+      messages: [{ role: "user", content: "hi" }],
+      stream: true,
+    });
+    let sawContent = "";
+    for await (const chunk of stream) {
+      sawContent += chunk.choices[0]?.delta?.content ?? "";
+      // The client did not ask for include_usage; estimation must not
+      // fabricate a usage chunk on the client-facing stream.
+      expect(chunk.usage ?? null).toBeNull();
+    }
+    expect(sawContent).toBe("Hello world");
+
+    const deadline = Date.now() + 10_000;
+    let input = 0;
+    let output = 0;
+    while (Date.now() < deadline) {
+      input = await tokenMetric("aisix_llm_input_tokens_total", "est-chat-stream");
+      output = await tokenMetric("aisix_llm_output_tokens_total", "est-chat-stream");
+      if (input > inputBefore) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    // The probe call and the asserted call are identical requests, so
+    // per-call expectations hold on the delta.
+    expect(input - inputBefore).toBe(EXPECTED_PROMPT_TOKENS);
+    expect(output).toBeGreaterThanOrEqual(EXPECTED_COMPLETION_TOKENS);
+    await waitSlsFlagged("est-chat-stream");
+  }, 60_000);
+
+  test("chat non-streaming 200 without usage: telemetry estimated, client body not rewritten", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const client = openai();
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: "est-chat-nonstream",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const inputBefore = await tokenMetric("aisix_llm_input_tokens_total", "est-chat-nonstream");
+    const resp = await client.chat.completions.create({
+      model: "est-chat-nonstream",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(resp.choices[0]?.message?.content).toBe("Hello world");
+    // The upstream sent no usage; the gateway must not inject estimated
+    // numbers into the client-visible body (zeros = normalized absence,
+    // the pre-existing wire shape).
+    expect(resp.usage?.prompt_tokens ?? 0).toBe(0);
+    expect(resp.usage?.completion_tokens ?? 0).toBe(0);
+
+    const deadline = Date.now() + 10_000;
+    let input = 0;
+    let output = 0;
+    while (Date.now() < deadline) {
+      input = await tokenMetric("aisix_llm_input_tokens_total", "est-chat-nonstream");
+      output = await tokenMetric("aisix_llm_output_tokens_total", "est-chat-nonstream");
+      if (input > inputBefore) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(input - inputBefore).toBe(EXPECTED_PROMPT_TOKENS);
+    expect(output).toBeGreaterThanOrEqual(EXPECTED_COMPLETION_TOKENS);
+    await waitSlsFlagged("est-chat-nonstream");
+  }, 60_000);
+
+  test("client abort mid-stream: the usage record still ships with estimated tokens", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    // Raw fetch so the reader can be cancelled deterministically after the
+    // first delivered chunk (the OpenAI SDK hides the reader).
+    const controller = new AbortController();
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "est-chat-abort",
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      }),
+      signal: controller.signal,
+    });
+    expect(res.status).toBe(200);
+    const reader = res.body!.getReader();
+    // Pull one chunk off the wire, then abort — the upstream still has
+    // events pending (150ms pacing), so this is a genuine mid-stream
+    // disconnect, not a raced clean close.
+    await reader.read();
+    controller.abort();
+
+    // The Drop guard fires on disconnect and estimates from what was
+    // delivered: the prompt side is exact; the completion side covers
+    // at least the first delivered content token(s) but must stay below
+    // the full response (we aborted before " world" et al.).
+    const { input, output } = await waitTokenMetrics("est-chat-abort");
+    expect(input).toBe(EXPECTED_PROMPT_TOKENS);
+    expect(output).toBeGreaterThanOrEqual(0);
+    await waitSlsFlagged("est-chat-abort");
+  }, 60_000);
+
+  test("/v1/messages SSE with no usage anywhere: estimated and flagged", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const call = async () =>
+      fetch(`${app!.proxyUrl}/v1/messages`, {
+        method: "POST",
+        headers: {
+          "x-api-key": CALLER_PLAINTEXT,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "est-msgs-stream",
+          max_tokens: 100,
+          stream: true,
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await call();
+        await r.text();
+        return r.status === 200;
+      } catch {
+        return false;
+      }
+    });
+
+    const inputBefore = await tokenMetric("aisix_llm_input_tokens_total", "est-msgs-stream");
+    const res = await call();
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // Bytes pass through verbatim; no fabricated usage on the wire.
+    expect(body).toContain("Hello world");
+    expect(body).toContain("message_stop");
+
+    const deadline = Date.now() + 10_000;
+    let input = 0;
+    let output = 0;
+    while (Date.now() < deadline) {
+      input = await tokenMetric("aisix_llm_input_tokens_total", "est-msgs-stream");
+      output = await tokenMetric("aisix_llm_output_tokens_total", "est-msgs-stream");
+      if (input > inputBefore) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    // Prompt estimate is exact (one user message "hi" = 8). The output
+    // accumulator joins text deltas with separators, so bound the
+    // completion estimate instead of pinning it.
+    expect(input - inputBefore).toBe(EXPECTED_PROMPT_TOKENS);
+    expect(output).toBeGreaterThanOrEqual(EXPECTED_COMPLETION_TOKENS);
+    await waitSlsFlagged("est-msgs-stream");
+  }, 60_000);
+
+  test("/v1/responses SSE aborted before the terminal event: record still ships, flagged", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const call = async () =>
+      fetch(`${app!.proxyUrl}/v1/responses`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "est-responses-stream",
+          input: "hi",
+          stream: true,
+        }),
+      });
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await call();
+        await r.text();
+        return r.status === 200;
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await call();
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // Verbatim passthrough of the truncated stream.
+    expect(body).toContain("response.output_text.delta");
+
+    // /v1/responses has no per-token prometheus family today; the flagged
+    // SLS record (flat usage-event fields) is the observable wire. Exact
+    // estimated values for this surface are pinned by the Rust handler
+    // tests (`estimates_usage_event_when_upstream_omits_usage_block`).
+    await waitSlsFlagged("est-responses-stream");
+  }, 60_000);
+});


### PR DESCRIPTION
## Problem

When an upstream response carries no `usage` block, every token counter on the usage event records a silent zero — the request is invisible to billing, the budget ledger, TPM/TPD accounting, and the dashboard. `/v1/completions` went further and dropped the event entirely. The gateway already injects `stream_options.include_usage` on the upstream leg (#790), which narrows the surface to: OpenAI-compatible relays that ignore it, clients that set `stream_options` without `include_usage`, client disconnects before the terminal usage chunk, mid-stream upstream errors, and protocols/backends that simply don't report usage.

## What this PR does

**Local token-estimation fallback** (`crates/aisix-proxy/src/token_estimate.rs`, [tiktoken-rs](https://crates.io/crates/tiktoken-rs), BPE ranks bundled — no runtime network):

- **Prompt** counted from the captured request per the de-facto OpenAI message counting scheme ([openai-cookbook "How to count tokens"](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb)): 3 tokens per message + role/content/name text, +3 reply priming, tool definitions rendered to the TypeScript-namespace form (+9, −4 with a system message), `tool_choice` rules included.
- **Completion** counted from the accumulated generated output (content + reasoning + tool-call name/arguments) as plain text, no overhead.
- **Per-field `or` semantics**: an upstream value wins whenever non-zero; estimation only fills zeros. Partial usage (e.g. Anthropic `message_start` input followed by a disconnect) estimates only the missing side.
- **Encoding selection** mirrors tiktoken's model map (`gpt-4o`/`o1`/… → `o200k_base`; `gpt-4`/`gpt-3.5` → `cl100k_base`), with `cl100k_base` as the fallback for unknown/non-OpenAI models. Counts for models with proprietary tokenizers (Claude, Gemini, …) are approximations by design — hence the flag below.
- **`UsageEvent.usage_estimated: bool`** (additive, `skip_serializing_if` false): set whenever any counter was locally filled. Flows to cp-api `/dp/telemetry` and to every exporter via the `SinkRecord` flatten. Paired CP PR surfaces it as an "estimated" badge on the Logs page.

**Estimation feeds telemetry, TPM post-stream accounting, and metrics ONLY.** The client-visible response body and SSE stream are never rewritten — no fabricated usage chunk, no synthesised `usage` object (pinned by e2e).

**Whole handler family, streaming + non-streaming** (per the lockstep rule):

| surface | wired paths |
|---|---|
| `/v1/chat/completions` | `build_sse_stream` Drop guard (both call sites incl. ensemble judge), non-streaming, cache-hit replay, billed-then-blocked `UpstreamCharge` |
| `/v1/messages` | native passthrough Drop guard, bridged stream Drop guard, native + bridged non-streaming |
| `/v1/responses` | verbatim passthrough closure, buffered (hold-back) branch, bridged stream Drop guard, direct + bridged non-streaming |
| `/v1/completions` | non-streaming (a usage-less 200 previously emitted **no event at all**; now emits an estimated one) |
| `/v1/embeddings` | prompt falls back to `total_tokens` first (upstream-authoritative, fixes the total-only-relay case), then to a local count |

Deliberately **not** wired: `audio` / `images` / `rerank` — their billing units (seconds, tiles, search units) are not text-tokenizable; a text estimate would be wrong rather than approximate.

Interplay preserved:
- The #419 zero-delivered gate still wins: a disconnect before any chunk crossed the wire bills no completion tokens (estimated or not); the prompt still fills ("prompts always billed").
- The Anthropic `message_start` `output_tokens` placeholder floor is treated as missing when no `message_delta` arrived, so an aborted stream estimates from the delivered text instead of recording the placeholder (same normalization the reference proxy applies to its lone-cursor case).
- Streaming output accumulates into a new always-on, bounded (1 MiB) buffer only where no suitable buffer existed; the `/v1/responses` `SseTextCapture` and the messages-passthrough guardrail buffer are reused.

## Reference implementations (design comparison)

- **LiteLLM (baseline, per repo rule)**: on stream rebuild, `prompt = provider or token_counter(messages)`, `completion = provider or token_counter(text=joined_content)` — the exact `or`-semantics and counting scheme this PR ports (`litellm_core_utils/streaming_chunk_builder_utils.py::calculate_usage`, `token_counter.py`). Divergences, both deliberate: (1) LiteLLM has **no estimated-vs-reported flag** — `usage_estimated` exists because the acceptance criteria require marking estimated data; (2) for Claude models LiteLLM inconsistently mixes a bundled legacy tokenizer (claude-2/4) with `cl100k_base` (claude-3); we use its offline-mode behavior (`cl100k_base` for all non-OpenAI models) uniformly.
- **A major API-gateway vendor's AI plugin** estimates with coarse heuristics (word-count × 1.8 for prompts, chars÷4 for completions) and does not mark estimates.
- **Two CNCF-ecosystem AI gateways** inject `include_usage` (as we already do, #790) but record **nothing** when usage is absent, and lose the record entirely on client disconnect.
- No surveyed implementation covers the disconnect case or carries a provenance flag — both are required by the acceptance criteria here (计量记录不丢失 / 标识估算值), so this PR goes beyond the surveyed baselines on those two axes.

## Behavior changes

- Usage events that previously carried zeros (or were skipped, on `/v1/completions` and usage-less `/v1/responses` bodies) now carry estimated counts + `usage_estimated: true`. Wire-additive: cp-api ignores unknown fields until the paired CP PR lands (a brief window per the accepted cross-plane policy).
- TPM/TPD accounting now sees estimated totals for usage-less upstreams (previously silently uncounted).
- Four Rust tests pinning the old "skip the event / record zero" contract were rewritten to pin the new estimated-event contract (the old behavior is exactly what #1074 mandates changing).

## Tests

- **Rust unit** (all 647 pass): counting rules incl. the cookbook overhead scheme, tool-definition rendering (byte-exact vs the baseline's renderer), or-semantics fill, encoding selection, Drop-guard fill × #419 gate interplay, upstream-wins.
- **E2E (vitest, new `usage-estimation-1074-e2e.test.ts`, 5 scenarios, all pass)**: chat SSE without usage (exact metric deltas + SLS `usage_estimated` + no fabricated client usage chunk), non-streaming without usage (client body untouched), client abort mid-stream, `/v1/messages` with no usage anywhere, `/v1/responses` aborted before the terminal event. Plus a 10-file regression sweep over the existing usage/TPM/streaming suites (12 tests, green).
- `cargo clippy --workspace --all-targets` and `cargo fmt` clean.

30s-SSE note: the 30-second acceptance scenario is time-, not logic-different from the paced-stream e2e (the Drop-guard emission is duration-independent); the <5% accuracy criterion holds by construction for cl100k/o200k-family models (same BPE as the provider) and is an approximation for proprietary tokenizers — which is what the flag communicates. PoC-scale measurement on the customer's real models stays tracked on the issue.

Fixes api7/AISIX-Cloud#1074


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `usage_estimated` telemetry flag and local token-usage estimation fallback for Chat Completions, Messages, Responses, and Embeddings when upstream usage is missing or zero.
  * Supports streaming, non-streaming, cached, and partially delivered/aborted requests while keeping client-visible response bodies unchanged.

* **Bug Fixes**
  * Improved quota reservation and token metering consistency by using estimated prompt/completion totals only when upstream counters are unusable.

* **Tests**
  * Added end-to-end coverage for AISIX-Cloud#1074 across the affected APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->