### PR TITLE
test(e2e): fix propagation race in background-health short-stale-window case

### DIFF
--- a/tests/e2e/src/cases/background-health-e2e.test.ts
+++ b/tests/e2e/src/cases/background-health-e2e.test.ts
@@ -249,9 +249,14 @@ describe("background health e2e", () => {
       },
     });
 
-    const statuses = await admin.listModelStatuses();
-    const staleModel = statuses.find((row) => row.display_name === "bg-stale-short");
-    expect(staleModel).toBeTruthy();
+    // Config propagation is asynchronous: the model seeded above reaches
+    // the status listing only after the snapshot refresh. Poll for the
+    // row instead of asserting eagerly — on a loaded CI runner the
+    // immediate read raced the watch and failed with `undefined`.
+    await waitConfigPropagation(async () => {
+      const rows = await admin!.listModelStatuses();
+      return rows.some((row) => row.display_name === "bg-stale-short");
+    });
 
     await waitConfigPropagation(async () => {
       const rows = await admin!.listModelStatuses();


### PR DESCRIPTION
The short-stale-window case reads `/admin/v1/models/status` immediately after seeding the model and asserts the row exists. Config propagation is asynchronous, so on a loaded CI runner the immediate read races the snapshot refresh and fails with `expected undefined to be truthy` — hit on an unrelated PR's e2e run (#794's `e2e (vitest) + coverage` job, where the only delta was a `cargo fmt` commit).

Fix: poll for the row via `waitConfigPropagation`, exactly like the unhealthy-transition check a few lines below already does. The scenario is unchanged — the row must appear and then go unhealthy; only the eager, un-waited existence assert is gone.

Verified locally: the file's 2 tests pass; the fix only touches the racy setup assert.