### PR TITLE
test(e2e): fix propagation race in status-config resource-count asserts

### DIFF
--- a/tests/e2e/src/cases/status-config-e2e.test.ts
+++ b/tests/e2e/src/cases/status-config-e2e.test.ts
@@ -125,9 +125,18 @@ describe("status/config: etcd watch source", () => {
     }
 
     let cfg: StatusConfig | undefined;
+    // "synced" alone races the seed: the state flips synced on an EARLY
+    // revision before all three seeded resources are applied, and the
+    // count asserts below then read undefined. Wait until the applied
+    // snapshot actually contains the seeded resources.
     await waitConfigPropagation(async () => {
       cfg = await getStatusConfig(app!);
-      return cfg.state === "synced";
+      return (
+        cfg.state === "synced" &&
+        cfg.applied?.resource_counts.models === 1 &&
+        cfg.applied?.resource_counts.provider_keys === 1 &&
+        cfg.applied?.resource_counts.api_keys === 1
+      );
     });
 
     expect(cfg!.source.type).toBe("etcd");


### PR DESCRIPTION
Main's CI run for 7295ff9c failed `status-config-e2e > clean config reports synced with revisions and resource counts` with `expected undefined to be 1`: the test waits only for `state === "synced"`, but synced flips on an early revision before all three seeded resources are applied — the count asserts then race propagation on a loaded runner.

Fold the resource counts into the `waitConfigPropagation` condition (the asserts below keep pinning the exact values). Same class as #795's fix; verified locally (file's 7 tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by waiting for configuration resources to be fully applied before validating clean synchronization.
  * Reduced race conditions when confirming synced models, provider keys, and API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->