### PR TITLE
feat(guardrails): per-execution latency histogram `aisix_guardrail_latency_seconds`

### DIFF
--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -43,11 +43,12 @@ pub use models::{
     validate_mcp_server, validate_model, validate_observability_exporter, validate_provider_key,
     validate_rate_limit_policy, A2aAgent, A2aAuthType, A2aProtocolVersion, Adapter, AisixSnapshot,
     ApiKey, AppliedGuardrail, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
-    GuardrailHookPoint, GuardrailKind, GuardrailMonitorHit, KeywordConfig, KeywordPattern,
-    McpAuthType, McpServer, McpTransport, Model, ObservabilityExporter, ParamConstraints,
-    PolicyScope, PolicyWindow, ProviderKey, RateLimit, RateLimitPolicy, RequestOverrides,
-    ResponseOverrides, Routing, RoutingStrategy, RoutingTarget, SchemaError, StreamDoneMarker,
-    TelemetryKind, TelemetryTags, WhenAllUnavailablePolicy, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
+    GuardrailExecution, GuardrailHookPoint, GuardrailKind, GuardrailMetricsSink,
+    GuardrailMonitorHit, KeywordConfig, KeywordPattern, McpAuthType, McpServer, McpTransport,
+    Model, ObservabilityExporter, ParamConstraints, PolicyScope, PolicyWindow, ProviderKey,
+    RateLimit, RateLimitPolicy, RequestOverrides, ResponseOverrides, Routing, RoutingStrategy,
+    RoutingTarget, SchemaError, StreamDoneMarker, TelemetryKind, TelemetryTags,
+    WhenAllUnavailablePolicy, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -753,6 +753,37 @@ pub struct GuardrailMonitorHit {
     pub counts: std::collections::BTreeMap<String, u32>,
 }
 
+/// One guardrail member execution as observed by the chain fold
+/// (AISIX-Cloud#1076): identity, phase, enforced outcome, and wall-clock
+/// duration. All fields are bounded values safe for metric labels — never
+/// matched content (#153 no-leak criterion).
+#[derive(Debug, Clone, Copy)]
+pub struct GuardrailExecution<'a> {
+    /// Configured (row) name of the guardrail.
+    pub guardrail_name: &'a str,
+    /// The `kind` discriminator (`GuardrailKind::kind_str`). `keyword` and
+    /// `pii` run in-process; every other kind calls a remote service.
+    pub kind: &'a str,
+    /// Which side ran: `input` or `output`.
+    pub phase: &'static str,
+    /// Enforced outcome: `allowed` / `blocked` / `masked` / `bypassed`
+    /// (remote failure + fail-open) / `would_block` / `would_mask`
+    /// (monitor mode).
+    pub result: &'static str,
+    /// Bounded failure tag (e.g. `lakera_timeout`) when the guardrail could
+    /// not evaluate and failed open (`result = bypassed`); `None` otherwise.
+    pub error_type: Option<&'a str>,
+    /// Wall-clock time the member call took.
+    pub elapsed: std::time::Duration,
+}
+
+/// Receiver for per-execution guardrail telemetry. Implemented by the
+/// metrics layer (aisix-obs) and injected into the resolved chain at
+/// build time, so aisix-guardrails stays free of a metrics dependency.
+pub trait GuardrailMetricsSink: Send + Sync + 'static {
+    fn record_guardrail_execution(&self, exec: &GuardrailExecution<'_>);
+}
+
 /// Content policy evaluated before or after upstream calls.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct Guardrail {

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -40,10 +40,10 @@ pub use ensemble::{EnsembleConfig, Judge, PanelMember};
 pub use guardrail::{
     AliyunTextModerationConfig, AppliedGuardrail, AzureContentSafetyConfig,
     AzureContentSafetyTextModerationConfig, BedrockAWSCredentials, BedrockConfig,
-    BedrockLatencyMode, Guardrail, GuardrailAttachment, GuardrailHookPoint, GuardrailKind,
-    GuardrailMonitorHit, GuardrailScopeType, KeywordConfig, KeywordPattern, LakeraConfig,
-    OpenaiModerationConfig, PiiConfig, PiiCustomPattern, PiiDetectorConfig, PresidioConfig,
-    PresidioEntityConfig,
+    BedrockLatencyMode, Guardrail, GuardrailAttachment, GuardrailExecution, GuardrailHookPoint,
+    GuardrailKind, GuardrailMetricsSink, GuardrailMonitorHit, GuardrailScopeType, KeywordConfig,
+    KeywordPattern, LakeraConfig, OpenaiModerationConfig, PiiConfig, PiiCustomPattern,
+    PiiDetectorConfig, PresidioConfig, PresidioEntityConfig,
 };
 pub use mcp_server::{McpAuthType, McpServer, McpTransport};
 pub use model::{

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1069,6 +1069,10 @@ pub fn build_index_from_snapshot(
 pub struct LiveGuardrailIndex {
     snapshot: SnapshotHandle<AisixSnapshot>,
     bedrock_endpoint_url: Option<String>,
+    /// Per-execution telemetry receiver, attached to every resolved chain
+    /// (AISIX-Cloud#1076). `None` (tests, standalone construction) records
+    /// nothing; the server bootstrap wires the metrics layer's sink.
+    metrics_sink: Option<Arc<dyn aisix_core::GuardrailMetricsSink>>,
     cache: Mutex<IndexCache>,
 }
 
@@ -1082,6 +1086,16 @@ impl LiveGuardrailIndex {
         snapshot: SnapshotHandle<AisixSnapshot>,
         bedrock_endpoint_url: Option<String>,
     ) -> Arc<Self> {
+        Self::new_with_sink(snapshot, bedrock_endpoint_url, None)
+    }
+
+    /// Like [`LiveGuardrailIndex::new`], also attaching a metrics sink to
+    /// every chain [`LiveGuardrailIndex::resolve`] hands out.
+    pub fn new_with_sink(
+        snapshot: SnapshotHandle<AisixSnapshot>,
+        bedrock_endpoint_url: Option<String>,
+        metrics_sink: Option<Arc<dyn aisix_core::GuardrailMetricsSink>>,
+    ) -> Arc<Self> {
         // Read version before load — same ordering discipline as LiveGuardrailChain.
         let last_version = snapshot.version();
         let snap = snapshot.load();
@@ -1093,6 +1107,7 @@ impl LiveGuardrailIndex {
         Arc::new(Self {
             snapshot,
             bedrock_endpoint_url,
+            metrics_sink,
             cache: Mutex::new(IndexCache {
                 last_version,
                 index,
@@ -1142,7 +1157,9 @@ impl LiveGuardrailIndex {
     /// arc clone + `O(n)` linear walk over attachment rows). Rebuilds only
     /// on snapshot version change.
     pub fn resolve(&self, ctx: &RequestContext<'_>) -> GuardrailChain {
-        self.current().resolve(ctx)
+        self.current()
+            .resolve(ctx)
+            .with_metrics_sink(self.metrics_sink.clone())
     }
 
     /// `true` when the resolved index has no guardrail entries — neither
@@ -2137,6 +2154,117 @@ mod tests {
             .await
             .is_block());
         assert!(!live.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // per-execution metrics sink (AISIX-Cloud#1076)
+    // -----------------------------------------------------------------------
+
+    #[derive(Default)]
+    struct RecordingSink(std::sync::Mutex<Vec<(String, String, &'static str, &'static str)>>);
+
+    impl aisix_core::GuardrailMetricsSink for RecordingSink {
+        fn record_guardrail_execution(&self, exec: &aisix_core::GuardrailExecution<'_>) {
+            self.0.lock().unwrap().push((
+                exec.guardrail_name.to_owned(),
+                exec.kind.to_owned(),
+                exec.phase,
+                exec.result,
+            ));
+        }
+    }
+
+    /// A sink attached via `LiveGuardrailIndex::new_with_sink` reaches every
+    /// resolved chain: executions carry the row name, the row `kind`, and
+    /// the enforced result — a monitor-mode member's suppressed outcome
+    /// records as `would_block`/`would_mask`, not `blocked`/`masked`.
+    #[tokio::test]
+    async fn live_index_sink_records_resolved_chain_executions() {
+        let snap = AisixSnapshot::new();
+        snap.guardrails.insert(entry(
+            "watch-pii",
+            "g-1",
+            parse(
+                r#"{
+                    "name": "watch-pii",
+                    "enforcement_mode": "monitor",
+                    "kind": "pii",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "detectors": [
+                        { "type": "email", "action": "mask" },
+                        { "type": "us_ssn", "action": "block" }
+                    ]
+                }"#,
+            ),
+        ));
+        snap.guardrails.insert(entry(
+            "block-secrets",
+            "g-2",
+            parse(
+                r#"{
+                    "name": "block-secrets",
+                    "kind": "keyword",
+                    "created_at": "2024-01-02T00:00:00Z",
+                    "patterns": [{ "kind": "literal", "value": "AKIA" }]
+                }"#,
+            ),
+        ));
+        let sink = Arc::new(RecordingSink::default());
+        let live =
+            LiveGuardrailIndex::new_with_sink(SnapshotHandle::new(snap), None, Some(sink.clone()));
+        let ctx = RequestContext {
+            model_id: "m1",
+            api_key_id: "k1",
+            team_id: None,
+        };
+
+        // Monitor-mode pii mask hit + keyword block: the suppressed mask
+        // records as would_mask; the enforcing keyword block as blocked.
+        let (v, _) = live
+            .resolve(&ctx)
+            .check_input_observed(&req("mail alice@example.com and AKIA"))
+            .await;
+        assert!(v.is_block());
+        assert_eq!(
+            std::mem::take(&mut *sink.0.lock().unwrap()),
+            vec![
+                (
+                    "watch-pii".to_owned(),
+                    "pii".to_owned(),
+                    "input",
+                    "would_mask",
+                ),
+                (
+                    "block-secrets".to_owned(),
+                    "keyword".to_owned(),
+                    "input",
+                    "blocked",
+                ),
+            ],
+        );
+
+        // Monitor-mode would_block: the suppressed pii Block records as
+        // would_block while the enforced verdict stays Allow.
+        let (v, _) = live
+            .resolve(&ctx)
+            .check_input_observed(&req("ssn 123-45-6789"))
+            .await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+        let records = std::mem::take(&mut *sink.0.lock().unwrap());
+        assert_eq!(
+            records[0],
+            (
+                "watch-pii".to_owned(),
+                "pii".to_owned(),
+                "input",
+                "would_block",
+            ),
+        );
+
+        // The plain `new` constructor keeps recording off.
+        let unsinked = LiveGuardrailIndex::new(SnapshotHandle::new(AisixSnapshot::new()), None);
+        let _ = unsinked.resolve(&ctx).check_input(&req("hi")).await;
+        assert!(sink.0.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -8,22 +8,25 @@
 //! proxy from a config-driven list.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use aisix_core::AppliedGuardrail;
 use aisix_gateway::{ChatFormat, ChatResponse};
 use async_trait::async_trait;
 
-use aisix_core::models::GuardrailMonitorHit;
+use aisix_core::models::{GuardrailExecution, GuardrailMetricsSink, GuardrailMonitorHit};
 
 use crate::{Guardrail, GuardrailVerdict, Redaction, SegmentsOutcome, StreamOutputPolicy};
 
 /// One chain member: the runtime guardrail plus the operator-facing name
-/// of the row it was built from. The name is what `Block` verdicts are
-/// attributed to; chains built without row context ([`GuardrailChain::new`])
-/// fall back to the impl's static [`Guardrail::name`].
+/// and `kind` of the row it was built from. The name is what `Block`
+/// verdicts are attributed to; chains built without row context
+/// ([`GuardrailChain::new`]) fall back to the impl's static
+/// [`Guardrail::name`] for both.
 #[derive(Clone)]
 struct ChainMember {
     name: String,
+    kind: String,
     guardrail: Arc<dyn Guardrail>,
 }
 
@@ -37,6 +40,11 @@ pub struct GuardrailChain {
     /// (the in-memory test path); populated by the snapshot build points
     /// (`build_chain_from_snapshot` and `GuardrailIndex::resolve`).
     applied: Vec<AppliedGuardrail>,
+    /// Per-execution telemetry receiver (AISIX-Cloud#1076). `None` (the
+    /// default) records nothing; `LiveGuardrailIndex::resolve` attaches
+    /// the metrics layer's sink so every fold below reports each member's
+    /// phase/result/duration.
+    sink: Option<Arc<dyn GuardrailMetricsSink>>,
 }
 
 impl std::fmt::Debug for GuardrailChain {
@@ -54,10 +62,12 @@ impl GuardrailChain {
                 .into_iter()
                 .map(|g| ChainMember {
                     name: g.name().to_owned(),
+                    kind: g.name().to_owned(),
                     guardrail: g,
                 })
                 .collect(),
             applied: Vec::new(),
+            sink: None,
         }
     }
 
@@ -65,8 +75,9 @@ impl GuardrailChain {
     /// — used for `Block` attribution (#519 B.4b) — and the `{kind, hook}`
     /// of each member for applied-guardrail telemetry (#379). Used by the
     /// snapshot build points; `applied` is expected to line up 1:1 with
-    /// `members`, but the chain's runtime behaviour does not depend on
-    /// that — `applied` is telemetry-only.
+    /// `members` (each member's `kind` label is taken from it), but the
+    /// chain's runtime behaviour does not depend on that — `applied` is
+    /// telemetry-only.
     pub fn new_with_applied(
         members: Vec<(String, Arc<dyn Guardrail>)>,
         applied: Vec<AppliedGuardrail>,
@@ -74,10 +85,27 @@ impl GuardrailChain {
         Self {
             members: members
                 .into_iter()
-                .map(|(name, guardrail)| ChainMember { name, guardrail })
+                .enumerate()
+                .map(|(i, (name, guardrail))| ChainMember {
+                    kind: applied
+                        .get(i)
+                        .map(|a| a.kind.clone())
+                        .unwrap_or_else(|| guardrail.name().to_owned()),
+                    name,
+                    guardrail,
+                })
                 .collect(),
             applied,
+            sink: None,
         }
+    }
+
+    /// Attach a per-execution telemetry sink (AISIX-Cloud#1076). Called by
+    /// `LiveGuardrailIndex::resolve` on every resolved chain; `None`
+    /// disables recording (the default for test-built chains).
+    pub fn with_metrics_sink(mut self, sink: Option<Arc<dyn GuardrailMetricsSink>>) -> Self {
+        self.sink = sink;
+        self
     }
 
     /// The `{kind, hook}` set of guardrails that governed this request,
@@ -106,6 +134,59 @@ impl GuardrailChain {
     pub fn is_empty(&self) -> bool {
         self.members.is_empty()
     }
+}
+
+/// Classify one member execution for the metrics sink (AISIX-Cloud#1076).
+///
+/// The result is the ENFORCED outcome: a monitor-mode member's downgraded
+/// Block surfaces as `would_block` (via its hits), not `blocked`. `masked`
+/// only arises on the segment pass — the sync per-field redactors are not
+/// timed here. The `error_type` is the bounded per-kind failure tag a
+/// `Bypass` carries (e.g. `lakera_timeout`); fail-closed failures surface
+/// as `blocked` with no tag (the tag only exists structured on `Bypass`).
+fn classify_execution<'v>(
+    verdict: &'v GuardrailVerdict,
+    masked: bool,
+    hits: &[GuardrailMonitorHit],
+) -> (&'static str, Option<&'v str>) {
+    match verdict {
+        GuardrailVerdict::Block { .. } => ("blocked", None),
+        GuardrailVerdict::Bypass { reason } => ("bypassed", Some(reason.as_str())),
+        GuardrailVerdict::Allow => {
+            if masked {
+                ("masked", None)
+            } else if hits.iter().any(|h| h.action == "would_block") {
+                ("would_block", None)
+            } else if hits.iter().any(|h| h.action == "would_mask") {
+                ("would_mask", None)
+            } else {
+                ("allowed", None)
+            }
+        }
+    }
+}
+
+/// Report one member execution to `sink` (no-op when `None`). `hits` are
+/// the MEMBER's own hits from this call, not the fold's accumulator.
+fn record_execution(
+    sink: Option<&dyn GuardrailMetricsSink>,
+    member: &ChainMember,
+    phase: &'static str,
+    started: Instant,
+    verdict: &GuardrailVerdict,
+    masked: bool,
+    hits: &[GuardrailMonitorHit],
+) {
+    let Some(sink) = sink else { return };
+    let (result, error_type) = classify_execution(verdict, masked, hits);
+    sink.record_guardrail_execution(&GuardrailExecution {
+        guardrail_name: &member.name,
+        kind: &member.kind,
+        phase,
+        result,
+        error_type,
+        elapsed: started.elapsed(),
+    });
 }
 
 /// Attribute a member's `Block` verdict to its configured name: fill
@@ -164,7 +245,18 @@ impl Guardrail for GuardrailChain {
     async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
         let mut bypass: Option<String> = None;
         for m in &self.members {
-            match m.guardrail.check_input(req).await {
+            let started = Instant::now();
+            let verdict = m.guardrail.check_input(req).await;
+            record_execution(
+                self.sink.as_deref(),
+                m,
+                "input",
+                started,
+                &verdict,
+                false,
+                &[],
+            );
+            match verdict {
                 GuardrailVerdict::Allow => continue,
                 GuardrailVerdict::Block {
                     reason,
@@ -188,7 +280,18 @@ impl Guardrail for GuardrailChain {
     async fn check_output(&self, resp: &ChatResponse) -> GuardrailVerdict {
         let mut bypass: Option<String> = None;
         for m in &self.members {
-            match m.guardrail.check_output(resp).await {
+            let started = Instant::now();
+            let verdict = m.guardrail.check_output(resp).await;
+            record_execution(
+                self.sink.as_deref(),
+                m,
+                "output",
+                started,
+                &verdict,
+                false,
+                &[],
+            );
+            match verdict {
                 GuardrailVerdict::Allow => continue,
                 GuardrailVerdict::Block {
                     reason,
@@ -218,7 +321,17 @@ impl Guardrail for GuardrailChain {
         let mut bypass: Option<String> = None;
         let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
         for m in &self.members {
+            let started = Instant::now();
             let (verdict, member_hits) = m.guardrail.check_input_observed(req).await;
+            record_execution(
+                self.sink.as_deref(),
+                m,
+                "input",
+                started,
+                &verdict,
+                false,
+                &member_hits,
+            );
             hits.extend(member_hits);
             match verdict {
                 GuardrailVerdict::Allow => continue,
@@ -247,7 +360,17 @@ impl Guardrail for GuardrailChain {
         let mut bypass: Option<String> = None;
         let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
         for m in &self.members {
+            let started = Instant::now();
             let (verdict, member_hits) = m.guardrail.check_output_observed(resp).await;
+            record_execution(
+                self.sink.as_deref(),
+                m,
+                "output",
+                started,
+                &verdict,
+                false,
+                &member_hits,
+            );
             hits.extend(member_hits);
             match verdict {
                 GuardrailVerdict::Allow => continue,
@@ -276,7 +399,23 @@ impl Guardrail for GuardrailChain {
         let mut bypass: Option<String> = None;
         let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
         for m in &self.members {
+            let started = Instant::now();
             let (verdict, member_hits) = m.guardrail.check_input_non_segment_observed(req).await;
+            // A segment-moderating member answers via the segment pass —
+            // this call is an instant Allow, not an execution; recording
+            // it would pollute the member's series with zero-length
+            // "allowed" samples.
+            if !m.guardrail.moderates_segments() {
+                record_execution(
+                    self.sink.as_deref(),
+                    m,
+                    "input",
+                    started,
+                    &verdict,
+                    false,
+                    &member_hits,
+                );
+            }
             hits.extend(member_hits);
             match verdict {
                 GuardrailVerdict::Allow => continue,
@@ -305,7 +444,19 @@ impl Guardrail for GuardrailChain {
         let mut bypass: Option<String> = None;
         let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
         for m in &self.members {
+            let started = Instant::now();
             let (verdict, member_hits) = m.guardrail.check_output_non_segment_observed(resp).await;
+            if !m.guardrail.moderates_segments() {
+                record_execution(
+                    self.sink.as_deref(),
+                    m,
+                    "output",
+                    started,
+                    &verdict,
+                    false,
+                    &member_hits,
+                );
+            }
             hits.extend(member_hits);
             match verdict {
                 GuardrailVerdict::Allow => continue,
@@ -338,11 +489,11 @@ impl Guardrail for GuardrailChain {
     /// member moderates the previous member's masked output, mirroring
     /// `fold_redactions`; the first Bypass reason sticks. Counts merge.
     async fn moderate_input_segments(&self, texts: &[String]) -> SegmentsOutcome {
-        fold_segments(&self.members, texts, true).await
+        fold_segments(&self.members, self.sink.as_deref(), texts, true).await
     }
 
     async fn moderate_output_segments(&self, texts: &[String]) -> SegmentsOutcome {
-        fold_segments(&self.members, texts, false).await
+        fold_segments(&self.members, self.sink.as_deref(), texts, false).await
     }
 
     /// The check fold minus segment-moderating members — the pass those
@@ -353,7 +504,20 @@ impl Guardrail for GuardrailChain {
     async fn check_input_non_segment(&self, req: &ChatFormat) -> GuardrailVerdict {
         let mut bypass: Option<String> = None;
         for m in &self.members {
-            match m.guardrail.check_input_non_segment(req).await {
+            let started = Instant::now();
+            let verdict = m.guardrail.check_input_non_segment(req).await;
+            if !m.guardrail.moderates_segments() {
+                record_execution(
+                    self.sink.as_deref(),
+                    m,
+                    "input",
+                    started,
+                    &verdict,
+                    false,
+                    &[],
+                );
+            }
+            match verdict {
                 GuardrailVerdict::Allow => continue,
                 GuardrailVerdict::Block {
                     reason,
@@ -375,7 +539,20 @@ impl Guardrail for GuardrailChain {
     async fn check_output_non_segment(&self, resp: &ChatResponse) -> GuardrailVerdict {
         let mut bypass: Option<String> = None;
         for m in &self.members {
-            match m.guardrail.check_output_non_segment(resp).await {
+            let started = Instant::now();
+            let verdict = m.guardrail.check_output_non_segment(resp).await;
+            if !m.guardrail.moderates_segments() {
+                record_execution(
+                    self.sink.as_deref(),
+                    m,
+                    "output",
+                    started,
+                    &verdict,
+                    false,
+                    &[],
+                );
+            }
+            match verdict {
                 GuardrailVerdict::Allow => continue,
                 GuardrailVerdict::Block {
                     reason,
@@ -430,7 +607,13 @@ impl Guardrail for GuardrailChain {
 /// check folds (first Block short-circuits with attribution, first Bypass
 /// reason sticks) plus mask composition: each member moderates the
 /// previous member's masked output. Counts merge across members.
-async fn fold_segments(members: &[ChainMember], texts: &[String], input: bool) -> SegmentsOutcome {
+async fn fold_segments(
+    members: &[ChainMember],
+    sink: Option<&dyn GuardrailMetricsSink>,
+    texts: &[String],
+    input: bool,
+) -> SegmentsOutcome {
+    let phase = if input { "input" } else { "output" };
     let mut masked: Option<Vec<String>> = None;
     let mut counts = std::collections::BTreeMap::new();
     let mut bypass: Option<String> = None;
@@ -440,11 +623,21 @@ async fn fold_segments(members: &[ChainMember], texts: &[String], input: bool) -
             continue;
         }
         let src: &[String] = masked.as_deref().unwrap_or(texts);
+        let started = Instant::now();
         let mut outcome = if input {
             m.guardrail.moderate_input_segments(src).await
         } else {
             m.guardrail.moderate_output_segments(src).await
         };
+        record_execution(
+            sink,
+            m,
+            phase,
+            started,
+            &outcome.verdict,
+            outcome.masked.is_some(),
+            &outcome.monitor_hits,
+        );
         monitor_hits.append(&mut outcome.monitor_hits);
         match outcome.verdict {
             GuardrailVerdict::Allow => {}
@@ -950,5 +1143,219 @@ mod tests {
         ];
         let chain = GuardrailChain::new_with_applied(vec![], applied.clone());
         assert_eq!(chain.applied(), applied.as_slice());
+    }
+
+    // --- per-execution metrics sink (AISIX-Cloud#1076) --------------------
+
+    /// Owned copy of one recorded execution, captured by [`RecordingSink`].
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Recorded {
+        guardrail: String,
+        kind: String,
+        phase: &'static str,
+        result: &'static str,
+        error_type: Option<String>,
+    }
+
+    #[derive(Default)]
+    struct RecordingSink(std::sync::Mutex<Vec<Recorded>>);
+
+    impl GuardrailMetricsSink for RecordingSink {
+        fn record_guardrail_execution(&self, exec: &GuardrailExecution<'_>) {
+            self.0.lock().unwrap().push(Recorded {
+                guardrail: exec.guardrail_name.to_owned(),
+                kind: exec.kind.to_owned(),
+                phase: exec.phase,
+                result: exec.result,
+                error_type: exec.error_type.map(str::to_owned),
+            });
+        }
+    }
+
+    impl RecordingSink {
+        fn take(&self) -> Vec<Recorded> {
+            std::mem::take(&mut self.0.lock().unwrap())
+        }
+    }
+
+    fn sinked_chain(
+        members: Vec<(String, Arc<dyn Guardrail>)>,
+        applied: Vec<AppliedGuardrail>,
+    ) -> (GuardrailChain, Arc<RecordingSink>) {
+        let sink = Arc::new(RecordingSink::default());
+        let chain = GuardrailChain::new_with_applied(members, applied)
+            .with_metrics_sink(Some(sink.clone()));
+        (chain, sink)
+    }
+
+    fn applied_kw() -> AppliedGuardrail {
+        AppliedGuardrail {
+            kind: "keyword".to_owned(),
+            hook: "both".to_owned(),
+        }
+    }
+
+    /// Every member consulted by a fold is recorded with its row name, the
+    /// `kind` from the 1:1 applied metadata, the fold's phase, and the
+    /// enforced result — including the member that short-circuits and the
+    /// members before it.
+    #[tokio::test]
+    async fn sink_records_each_member_with_name_kind_phase_result() {
+        let (chain, sink) = sinked_chain(
+            vec![
+                (
+                    "pass-through".to_owned(),
+                    Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal(
+                        "never-matches",
+                    )])) as Arc<dyn Guardrail>,
+                ),
+                (
+                    "block-secrets".to_owned(),
+                    Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("AKIA")])),
+                ),
+            ],
+            vec![applied_kw(), applied_kw()],
+        );
+
+        assert!(chain
+            .check_input_observed(&req("here is AKIAEXAMPLE"))
+            .await
+            .0
+            .is_block());
+        assert_eq!(
+            sink.take(),
+            vec![
+                Recorded {
+                    guardrail: "pass-through".to_owned(),
+                    kind: "keyword".to_owned(),
+                    phase: "input",
+                    result: "allowed",
+                    error_type: None,
+                },
+                Recorded {
+                    guardrail: "block-secrets".to_owned(),
+                    kind: "keyword".to_owned(),
+                    phase: "input",
+                    result: "blocked",
+                    error_type: None,
+                },
+            ],
+        );
+
+        // Output fold records phase="output"; a member AFTER the block is
+        // not consulted, so it must not be recorded.
+        assert!(chain
+            .check_output_observed(&resp("the AKIA"))
+            .await
+            .0
+            .is_block());
+        let records = sink.take();
+        assert_eq!(records.len(), 2);
+        assert!(records.iter().all(|r| r.phase == "output"));
+    }
+
+    /// A fail-open member's `Bypass` records `result=bypassed` with the
+    /// bounded failure tag as `error_type`.
+    #[tokio::test]
+    async fn sink_records_bypass_with_error_type() {
+        struct AlwaysBypass;
+        #[async_trait]
+        impl Guardrail for AlwaysBypass {
+            fn name(&self) -> &'static str {
+                "always-bypass"
+            }
+            async fn check_input(&self, _req: &ChatFormat) -> GuardrailVerdict {
+                GuardrailVerdict::Bypass {
+                    reason: "lakera_timeout".into(),
+                }
+            }
+        }
+        let (chain, sink) = sinked_chain(
+            vec![("remote".to_owned(), Arc::new(AlwaysBypass) as _)],
+            vec![AppliedGuardrail {
+                kind: "lakera".to_owned(),
+                hook: "both".to_owned(),
+            }],
+        );
+        assert!(chain.check_input_observed(&req("hi")).await.0.is_bypass());
+        assert_eq!(
+            sink.take(),
+            vec![Recorded {
+                guardrail: "remote".to_owned(),
+                kind: "lakera".to_owned(),
+                phase: "input",
+                result: "bypassed",
+                error_type: Some("lakera_timeout".to_owned()),
+            }],
+        );
+    }
+
+    /// The segment pass records its members too: a mask records
+    /// `result=masked`; the non-segment fold must NOT also record a
+    /// zero-length "allowed" execution for the same member.
+    #[tokio::test]
+    async fn sink_records_segment_mask_and_skips_segment_members_in_non_segment_fold() {
+        let (chain, sink) = sinked_chain(
+            vec![
+                (
+                    "seg-masker".to_owned(),
+                    Arc::new(StubSegments {
+                        verdict: GuardrailVerdict::Allow,
+                        mask: true,
+                    }) as Arc<dyn Guardrail>,
+                ),
+                (
+                    "kw".to_owned(),
+                    Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal(
+                        "never-matches",
+                    )])),
+                ),
+            ],
+            vec![
+                AppliedGuardrail {
+                    kind: "bedrock".to_owned(),
+                    hook: "both".to_owned(),
+                },
+                applied_kw(),
+            ],
+        );
+
+        // Non-segment pass: only the keyword member records.
+        let (v, _) = chain.check_input_non_segment_observed(&req("clean")).await;
+        assert_eq!(v, GuardrailVerdict::Allow);
+        assert_eq!(
+            sink.take(),
+            vec![Recorded {
+                guardrail: "kw".to_owned(),
+                kind: "keyword".to_owned(),
+                phase: "input",
+                result: "allowed",
+                error_type: None,
+            }],
+        );
+
+        // Segment pass: only the segment member records, as masked.
+        let out = chain.moderate_input_segments(&["hello".to_owned()]).await;
+        assert_eq!(out.verdict, GuardrailVerdict::Allow);
+        assert_eq!(
+            sink.take(),
+            vec![Recorded {
+                guardrail: "seg-masker".to_owned(),
+                kind: "bedrock".to_owned(),
+                phase: "input",
+                result: "masked",
+                error_type: None,
+            }],
+        );
+    }
+
+    /// A chain with no sink attached records nothing and behaves
+    /// identically — the default for test-built chains.
+    #[tokio::test]
+    async fn no_sink_is_a_no_op() {
+        let chain = GuardrailChain::new(vec![Arc::new(KeywordBlocklist::new(vec![
+            KeywordRule::literal("AKIA"),
+        ]))]);
+        assert!(chain.check_input(&req("AKIA")).await.is_block());
     }
 }

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -84,6 +84,27 @@ pub const M_USAGE_EVENT_DROPS_TOTAL: &str = "aisix_usage_event_drops_total";
 /// `/v1/messages` path in — read these as chat-path, not gateway-wide.
 pub const M_GUARDRAIL_BLOCKS_TOTAL: &str = "aisix_guardrail_blocks_total";
 pub const M_GUARDRAIL_BYPASSES_TOTAL: &str = "aisix_guardrail_bypasses_total";
+/// Per-execution guardrail latency histogram (AISIX-Cloud#1076), recorded
+/// by the chain fold for every member consulted on any handler — chat,
+/// messages, responses, embeddings, streaming end-of-stream/window scans,
+/// cache-hit output checks, and the segment (Bedrock-style) pass alike.
+/// Labels:
+/// - `env_id`: constant per DP process (`unknown` standalone).
+/// - `guardrail`: the configured (row) name.
+/// - `kind`: the guardrail kind discriminator (`keyword`/`pii` run
+///   in-process; every other kind calls a remote service, so this label
+///   splits local vs remote latency).
+/// - `phase`: `input` / `output`.
+/// - `result`: `allowed` / `blocked` / `masked` / `bypassed` (remote
+///   failure + fail-open) / `would_block` / `would_mask` (monitor mode).
+/// - `error_type`: bounded failure tag (e.g. `lakera_timeout`) when
+///   `result="bypassed"`, else `none`. Fail-closed failures surface as
+///   `blocked` (the timeout budget shows up in the latency distribution).
+///
+/// The `_count` series doubles as a per-guardrail execution counter, so
+/// there is no separate `aisix_guardrail_requests_total` (LiteLLM's
+/// `litellm_guardrail_requests_total` equivalent = `sum by (...)` of it).
+pub const M_GUARDRAIL_LATENCY_SECONDS: &str = "aisix_guardrail_latency_seconds";
 /// Issue #408: counter for UsageEvents successfully enqueued onto the
 /// `UsageSink` (i.e. handed off to the telemetry worker for delivery
 /// to cp-api + per-env OTLP exporters). Operators slice this by:
@@ -144,6 +165,15 @@ pub const LATENCY_HISTOGRAM_BUCKETS: &[f64] = &[
     0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
 ];
 
+/// Bucket edges for [`M_GUARDRAIL_LATENCY_SECONDS`] — shifted an order of
+/// magnitude below the SLO buckets: local (keyword/pii) checks run in
+/// microseconds, the added-latency budget under scrutiny is ~50 ms
+/// (AISIX-Cloud#1076), and remote guardrail timeouts default to 5 s. The
+/// 30 s top edge outlives any configurable guardrail timeout.
+pub const GUARDRAIL_LATENCY_BUCKETS: &[f64] = &[
+    0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+];
+
 /// Holds an isolated `PrometheusRecorder` plus its render handle.
 /// `metrics::*` macros talk to whatever recorder is in scope; we use
 /// `metrics::with_local_recorder` so each write lands on the instance
@@ -192,10 +222,10 @@ impl Metrics {
     /// histograms. Empty ids (standalone DP) collapse to `"unknown"`,
     /// matching the missing-dimension convention used elsewhere.
     pub fn new_with_env_id(env_id: &str) -> Self {
-        // Buckets ONLY for the two SLO histograms: with `metrics-exporter-
-        // prometheus`, a distribution without configured buckets renders as
-        // a summary — which is what every legacy `histogram!` series here
-        // intentionally stays as.
+        // Buckets ONLY for the SLO histograms and the guardrail latency
+        // histogram: with `metrics-exporter-prometheus`, a distribution
+        // without configured buckets renders as a summary — which is what
+        // every legacy `histogram!` series here intentionally stays as.
         let recorder = PrometheusBuilder::new()
             .set_buckets_for_metric(
                 Matcher::Full(M_REQUEST_E2E_LATENCY_SECONDS.to_string()),
@@ -205,6 +235,11 @@ impl Metrics {
             .set_buckets_for_metric(
                 Matcher::Full(M_REQUEST_TTFT_SECONDS.to_string()),
                 LATENCY_HISTOGRAM_BUCKETS,
+            )
+            .expect("static bucket list is non-empty")
+            .set_buckets_for_metric(
+                Matcher::Full(M_GUARDRAIL_LATENCY_SECONDS.to_string()),
+                GUARDRAIL_LATENCY_BUCKETS,
             )
             .expect("static bucket list is non-empty")
             .build_recorder();
@@ -350,6 +385,25 @@ impl Metrics {
                 )
                 .increment(1);
             }
+        });
+    }
+
+    /// Record one guardrail member execution on
+    /// [`M_GUARDRAIL_LATENCY_SECONDS`] (AISIX-Cloud#1076). Called by the
+    /// chain fold through the `GuardrailMetricsSink` impl below — once per
+    /// member per hook pass, on every handler.
+    pub fn record_guardrail_execution(&self, exec: &aisix_core::GuardrailExecution<'_>) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::histogram!(
+                M_GUARDRAIL_LATENCY_SECONDS,
+                "env_id" => self.inner.env_id.clone(),
+                "guardrail" => exec.guardrail_name.to_string(),
+                "kind" => exec.kind.to_string(),
+                "phase" => exec.phase.to_string(),
+                "result" => exec.result.to_string(),
+                "error_type" => exec.error_type.unwrap_or("none").to_string(),
+            )
+            .record(exec.elapsed.as_secs_f64());
         });
     }
 
@@ -766,6 +820,15 @@ impl Metrics {
             )
             .record(ttft.as_secs_f64());
         });
+    }
+}
+
+/// The injection point the guardrail chain records through
+/// (AISIX-Cloud#1076): `aisix-guardrails` sees only this core trait, so it
+/// stays free of a metrics dependency.
+impl aisix_core::GuardrailMetricsSink for Metrics {
+    fn record_guardrail_execution(&self, exec: &aisix_core::GuardrailExecution<'_>) {
+        Metrics::record_guardrail_execution(self, exec);
     }
 }
 
@@ -1329,6 +1392,48 @@ mod tests {
         assert!(rendered.contains("provider=\"openai\""));
         assert!(rendered.contains("outcome=\"success\""));
         assert!(rendered.contains(M_REQUEST_DURATION));
+    }
+
+    /// AISIX-Cloud#1076: the per-execution guardrail histogram renders with
+    /// real `_bucket{le=…}` series (quantile-aggregatable, not a summary)
+    /// and the full bounded label set; `error_type` defaults to `none`.
+    #[test]
+    fn guardrail_execution_renders_bucketed_histogram_with_labels() {
+        let m = Metrics::new_with_env_id("env-7");
+        m.record_guardrail_execution(&aisix_core::GuardrailExecution {
+            guardrail_name: "block-secrets",
+            kind: "keyword",
+            phase: "input",
+            result: "blocked",
+            error_type: None,
+            elapsed: Duration::from_micros(300),
+        });
+        m.record_guardrail_execution(&aisix_core::GuardrailExecution {
+            guardrail_name: "lakera-prod",
+            kind: "lakera",
+            phase: "output",
+            result: "bypassed",
+            error_type: Some("lakera_timeout"),
+            elapsed: Duration::from_secs(5),
+        });
+        let out = m.render();
+        assert!(
+            out.contains("aisix_guardrail_latency_seconds_bucket"),
+            "{out}"
+        );
+        // 0.3 ms lands in the first (1 ms) bucket — the sub-SLO edges exist.
+        assert!(out.contains("le=\"0.001\""), "{out}");
+        assert!(out.contains("env_id=\"env-7\""));
+        assert!(out.contains("guardrail=\"block-secrets\""));
+        assert!(out.contains("kind=\"keyword\""));
+        assert!(out.contains("phase=\"input\""));
+        assert!(out.contains("result=\"blocked\""));
+        assert!(out.contains("error_type=\"none\""));
+        assert!(out.contains("guardrail=\"lakera-prod\""));
+        assert!(out.contains("result=\"bypassed\""));
+        assert!(out.contains("error_type=\"lakera_timeout\""));
+        // No per-key/per-user dimension may ride a bucketed histogram.
+        assert!(!out.contains("api_key_id="));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -157,12 +157,14 @@ pub struct ProxyState {
 
 impl ProxyState {
     pub fn new(snapshot: SnapshotHandle<AisixSnapshot>, hub: Arc<Hub>, cfg: &ProxyConfig) -> Self {
-        let guardrail_index = LiveGuardrailIndex::new(snapshot.clone(), None);
+        let metrics = Arc::new(Metrics::new(false));
+        let guardrail_index =
+            LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
         Self {
             snapshot,
             hub,
             limiter: Arc::new(Limiter::new()),
-            metrics: Arc::new(Metrics::new(false)),
+            metrics,
             cache: Some(CacheBackends::memory_only()),
             routing: Arc::new(RoutingRegistry::new()),
             semantic_cache: Arc::new(crate::semantic::SemanticVectorCache::default()),
@@ -189,12 +191,14 @@ impl ProxyState {
         limiter: Arc<Limiter>,
         cfg: &ProxyConfig,
     ) -> Self {
-        let guardrail_index = LiveGuardrailIndex::new(snapshot.clone(), None);
+        let metrics = Arc::new(Metrics::new(false));
+        let guardrail_index =
+            LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
         Self {
             snapshot,
             hub,
             limiter,
-            metrics: Arc::new(Metrics::new(false)),
+            metrics,
             cache: Some(CacheBackends::memory_only()),
             routing: Arc::new(RoutingRegistry::new()),
             semantic_cache: Arc::new(crate::semantic::SemanticVectorCache::default()),
@@ -224,7 +228,8 @@ impl ProxyState {
         cache: Option<CacheBackends>,
         cfg: &ProxyConfig,
     ) -> Self {
-        let guardrail_index = LiveGuardrailIndex::new(snapshot.clone(), None);
+        let guardrail_index =
+            LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
         // The bootstrap constructor is the one place the tracker gets a
         // metrics sink + snapshot handle, so cooldown transitions emit
         // `aisix_deployment_*`. Clone both before they are moved into the

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -711,10 +711,13 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // `None` so a `docker run -e AISIX_BEDROCK_ENDPOINT_URL=`
     // doesn't accidentally redirect Bedrock calls into thin air.
     let bedrock_endpoint_url = cfg.bedrock_endpoint_url.clone().filter(|s| !s.is_empty());
-    proxy_state = proxy_state.with_guardrail_index(aisix_guardrails::LiveGuardrailIndex::new(
-        snapshot_handle.clone(),
-        bedrock_endpoint_url,
-    ));
+    let guardrail_metrics_sink = proxy_state.metrics.clone();
+    proxy_state =
+        proxy_state.with_guardrail_index(aisix_guardrails::LiveGuardrailIndex::new_with_sink(
+            snapshot_handle.clone(),
+            bedrock_endpoint_url,
+            Some(guardrail_metrics_sink),
+        ));
     // Heartbeat worker — spawned after proxy_state exists so it can read
     // the exporter fan-out's delivery counters. Each tick reports:
     //   - rejected_resources: the supervisor's loader rejections (#115)

--- a/tests/e2e/src/cases/guardrail-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-metrics-e2e.test.ts
@@ -1,0 +1,413 @@
+import { createServer, type Server } from "node:http";
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the per-execution guardrail latency histogram
+// `aisix_guardrail_latency_seconds` (AISIX-Cloud#1076). Every guardrail
+// consulted on a request must record one observation labelled with the
+// row name, kind, phase (input/output), enforced result, and — for
+// fail-open bypasses — the bounded error tag. Covered results: allowed,
+// blocked (local keyword, remote moderation, output hook), bypassed
+// (moderation 5xx + fail_open), and monitor-mode would_block. The series
+// must render as a real bucketed histogram (`_bucket{le=…}`), not a
+// summary, so operators can compute P50/P95/P99.
+
+const CALLER = "sk-guardrail-metrics-e2e-caller";
+const hash = (s: string) => createHash("sha256").update(s).digest("hex");
+
+const KW_BLOCK_MARKER = "kwblockmarker";
+const KW_MONITOR_MARKER = "kwmonitormarker";
+const OUTPUT_LEAK_MARKER = "outputleakmarker";
+const RISKY_MARKER = "moderationriskymarker";
+const ERROR_MARKER = "moderationfivehundredmarker";
+
+const MODEL_CLEAN = "guardrail-metrics-clean";
+const MODEL_LEAKY = "guardrail-metrics-leaky";
+
+interface ModerationMock {
+  baseUrl: string;
+  close(): Promise<void>;
+}
+
+/** Flags input containing RISKY_MARKER; 500s on ERROR_MARKER. */
+async function startModerationMock(): Promise<ModerationMock> {
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      let input = "";
+      try {
+        const body = JSON.parse(raw);
+        input = typeof body.input === "string" ? body.input : "";
+      } catch {
+        // leave defaults
+      }
+      if (input.includes(ERROR_MARKER)) {
+        res.statusCode = 500;
+        res.end("mock moderation outage");
+        return;
+      }
+      const risky = input.includes(RISKY_MARKER);
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          id: "modr-mock",
+          model: "omni-moderation-latest",
+          results: [
+            {
+              flagged: risky,
+              categories: { violence: risky },
+              category_scores: { violence: risky ? 0.97 : 0.01 },
+            },
+          ],
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+function chatCompletionBody(id: string, content: string) {
+  return {
+    id,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 5, completion_tokens: 8, total_tokens: 13 },
+  };
+}
+
+/**
+ * Sum the `aisix_guardrail_latency_seconds_count` values of every series
+ * matching all given label pairs (labels appear in arbitrary order in the
+ * exposition). 0 when no series matches yet.
+ */
+function guardrailCount(scrape: string, labels: Record<string, string>): number {
+  let sum = 0;
+  for (const line of scrape.split("\n")) {
+    if (!line.startsWith("aisix_guardrail_latency_seconds_count{")) continue;
+    if (
+      !Object.entries(labels).every(([k, v]) => line.includes(`${k}="${v}"`))
+    ) {
+      continue;
+    }
+    const v = parseFloat(line.split("}").at(-1)?.trim() ?? "");
+    if (!Number.isNaN(v)) sum += v;
+  }
+  return sum;
+}
+
+describe("guardrail latency metrics e2e: per-execution histogram", () => {
+  let app: SpawnedApp | undefined;
+  let cleanUpstream: OpenAiUpstream | undefined;
+  let leakyUpstream: OpenAiUpstream | undefined;
+  let moderation: ModerationMock | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    moderation = await startModerationMock();
+    cleanUpstream = await startOpenAiUpstream({
+      nonStreamBody: chatCompletionBody("cmpl-clean", "a safe and clean reply"),
+    });
+    leakyUpstream = await startOpenAiUpstream({
+      nonStreamBody: chatCompletionBody(
+        "cmpl-leaky",
+        `a reply leaking ${OUTPUT_LEAK_MARKER} content`,
+      ),
+    });
+
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    for (const [model, upstream] of [
+      [MODEL_CLEAN, cleanUpstream],
+      [MODEL_LEAKY, leakyUpstream],
+    ] as const) {
+      const pk = await seed.createProviderKey({
+        display_name: `${model}-pk`,
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      await seed.createModel({
+        display_name: model,
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+    }
+    await seed.createApiKey({
+      key_hash: hash(CALLER),
+      allowed_models: [MODEL_CLEAN, MODEL_LEAKY],
+    });
+
+    // Env-wide guardrails, distinct kinds/phases/modes. The blocking input
+    // keyword row is written LAST: etcd watch events apply in order, so
+    // once the propagation probe sees ITS 422, every row above is live too.
+    await seed.createGuardrail({
+      name: "metrics-moderation",
+      enabled: true,
+      hook_point: "input",
+      fail_open: true,
+      kind: "openai_moderation",
+      api_key: "sk-moderation-key",
+      endpoint: moderation.baseUrl,
+    });
+    await seed.createGuardrail({
+      name: "metrics-kw-monitor",
+      enabled: true,
+      enforcement_mode: "monitor",
+      hook_point: "input",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: KW_MONITOR_MARKER }],
+    });
+    await seed.createGuardrail({
+      name: "metrics-kw-output",
+      enabled: true,
+      hook_point: "output",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: OUTPUT_LEAK_MARKER }],
+    });
+    await seed.createGuardrail({
+      name: "metrics-kw-input",
+      enabled: true,
+      hook_point: "input",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: KW_BLOCK_MARKER }],
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        await client().chat.completions.create({
+          model: MODEL_CLEAN,
+          messages: [{ role: "user", content: `probe ${KW_BLOCK_MARKER}` }],
+        });
+        return false;
+      } catch (e) {
+        return e instanceof APIError && e.status === 422;
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await cleanUpstream?.close();
+    await leakyUpstream?.close();
+    await moderation?.close();
+  });
+
+  const client = () =>
+    new OpenAI({
+      apiKey: CALLER,
+      baseURL: `${app!.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+  const scrape = async (): Promise<string> => {
+    const res = await fetch(`${app!.metricsUrl}/metrics`);
+    expect(res.status).toBe(200);
+    return res.text();
+  };
+
+  const expect422 = async (model: string, content: string) => {
+    let caught: unknown;
+    try {
+      await client().chat.completions.create({
+        model,
+        messages: [{ role: "user", content }],
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    if (!(caught instanceof APIError)) throw new Error("unreachable");
+    expect(caught.status).toBe(422);
+  };
+
+  test("clean request records result=allowed for every consulted guardrail, as a real bucketed histogram", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    const resp = await client().chat.completions.create({
+      model: MODEL_CLEAN,
+      messages: [{ role: "user", content: "a perfectly clean question" }],
+    });
+    expect(resp.choices[0]?.message?.content).toContain("clean reply");
+
+    const after = await scrape();
+    for (const guardrail of [
+      "metrics-moderation",
+      "metrics-kw-monitor",
+      "metrics-kw-input",
+    ]) {
+      const labels = {
+        guardrail,
+        phase: "input",
+        result: "allowed",
+        error_type: "none",
+      };
+      expect(
+        guardrailCount(after, labels),
+        `${guardrail} input allowed`,
+      ).toBeGreaterThan(guardrailCount(before, labels));
+    }
+    // The output-hook keyword row runs on the clean reply too.
+    expect(
+      guardrailCount(after, {
+        guardrail: "metrics-kw-output",
+        phase: "output",
+        result: "allowed",
+      }),
+    ).toBeGreaterThan(0);
+
+    // Kind label distinguishes local vs remote; env_id follows the SLO
+    // histogram convention; `_bucket` + sub-millisecond edge prove the
+    // series is a quantile-aggregatable histogram, not a summary.
+    expect(after).toMatch(
+      /aisix_guardrail_latency_seconds_count\{[^}]*guardrail="metrics-moderation"[^}]*kind="openai_moderation"/,
+    );
+    expect(after).toMatch(
+      /aisix_guardrail_latency_seconds_count\{[^}]*guardrail="metrics-kw-input"[^}]*kind="keyword"/,
+    );
+    expect(after).toMatch(
+      /aisix_guardrail_latency_seconds_bucket\{[^}]*le="0.001"/,
+    );
+    expect(after).toMatch(/aisix_guardrail_latency_seconds_bucket\{[^}]*env_id="/);
+  });
+
+  test("local keyword block records result=blocked on the input phase", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    await expect422(MODEL_CLEAN, `please echo ${KW_BLOCK_MARKER}`);
+    const after = await scrape();
+    const labels = {
+      guardrail: "metrics-kw-input",
+      kind: "keyword",
+      phase: "input",
+      result: "blocked",
+    };
+    expect(guardrailCount(after, labels)).toBeGreaterThan(
+      guardrailCount(before, labels),
+    );
+  });
+
+  test("remote moderation block records result=blocked for the remote kind", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    await expect422(MODEL_CLEAN, `please describe ${RISKY_MARKER}`);
+    const after = await scrape();
+    const labels = {
+      guardrail: "metrics-moderation",
+      kind: "openai_moderation",
+      phase: "input",
+      result: "blocked",
+    };
+    expect(guardrailCount(after, labels)).toBeGreaterThan(
+      guardrailCount(before, labels),
+    );
+  });
+
+  test("fail-open on provider 5xx records result=bypassed with the bounded error tag", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    const resp = await client().chat.completions.create({
+      model: MODEL_CLEAN,
+      messages: [{ role: "user", content: `outage probe ${ERROR_MARKER}` }],
+    });
+    expect(resp.choices[0]?.message?.content).toContain("clean reply");
+    const after = await scrape();
+    const labels = {
+      guardrail: "metrics-moderation",
+      result: "bypassed",
+      error_type: "openai_moderation_5xx",
+    };
+    expect(guardrailCount(after, labels)).toBeGreaterThan(
+      guardrailCount(before, labels),
+    );
+  });
+
+  test("monitor-mode hit records result=would_block while the request succeeds", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    const resp = await client().chat.completions.create({
+      model: MODEL_CLEAN,
+      messages: [{ role: "user", content: `staged rule ${KW_MONITOR_MARKER}` }],
+    });
+    expect(resp.choices[0]?.message?.content).toContain("clean reply");
+    const after = await scrape();
+    const labels = {
+      guardrail: "metrics-kw-monitor",
+      result: "would_block",
+    };
+    expect(guardrailCount(after, labels)).toBeGreaterThan(
+      guardrailCount(before, labels),
+    );
+  });
+
+  test("output-hook block records result=blocked on the output phase", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    await expect422(MODEL_LEAKY, "a clean question to a leaky model");
+    const after = await scrape();
+    const labels = {
+      guardrail: "metrics-kw-output",
+      kind: "keyword",
+      phase: "output",
+      result: "blocked",
+    };
+    expect(guardrailCount(after, labels)).toBeGreaterThan(
+      guardrailCount(before, labels),
+    );
+  });
+});


### PR DESCRIPTION
## What

Implements the guardrail-observability-metrics part of api7/AISIX-Cloud#1076 (scope agreed in the issue comments: align capability with LiteLLM/Kong; the offline precision/recall eval set is out of scope per the Partner review note).

Today guardrail observability is two request-level aggregate counters — `aisix_guardrail_blocks_total` (no labels) and `aisix_guardrail_bypasses_total{reason}`, chat-completions only. There is no per-guardrail attribution, no phase/result split, and no latency measurement at all.

This PR adds **`aisix_guardrail_latency_seconds`** — a real bucketed histogram recorded once per consulted guardrail per hook pass, on **every** endpoint:

| label | values |
|---|---|
| `env_id` | constant per DP process (SLO-histogram convention) |
| `guardrail` | configured guardrail (row) name |
| `kind` | `keyword` / `pii` (local, in-process) vs `bedrock` / `lakera` / `presidio` / … (remote) |
| `phase` | `input` / `output` |
| `result` | `allowed` / `blocked` / `masked` / `bypassed` / `would_block` / `would_mask` |
| `error_type` | bounded failure tag (`lakera_timeout`, `openai_moderation_5xx`, …) when `result="bypassed"`, else `none` |

Buckets span 1 ms – 30 s (guardrail-scale, below the SLO buckets), so `histogram_quantile` yields P50/P95/P99 per guardrail/phase/result across instances, and the `_count` series doubles as an execution/block/bypass counter.

## How

- **Recording sits in the `GuardrailChain` folds** — the single point every handler's guardrail evaluation converges (chat, messages, responses, completions, embeddings, audio, streaming end-of-stream and window scans, cache-hit output checks, and the segment moderation pass). All endpoints are covered with zero handler churn, and the existing chat-only limitation of the aggregate counters does not carry over.
- **No new crate dependency**: `aisix-guardrails` records through a `GuardrailMetricsSink` trait defined in `aisix-core` (beside the existing `GuardrailMonitorHit`/`AppliedGuardrail` telemetry types). `aisix-obs` implements it on `Metrics`; the proxy/server bootstrap injects it via `LiveGuardrailIndex::new_with_sink`, and `resolve()` attaches it to every resolved chain.
- **`result` is the enforced outcome**: a monitor-mode member's suppressed decision records as `would_block`/`would_mask` (from its monitor hits) while the request proceeds — so a staged policy's hit rate and latency are measurable in Prometheus before flipping it to `block`. Non-segment folds skip segment-moderating members (they are consulted — and timed — via the segment pass), so each member records exactly once per pass.
- Each member's timing includes its decorators (monitor/mandatory) and internal timeout handling, i.e. the latency the request actually paid.

## LiteLLM comparison (baseline per repo policy, checked at BerriAI/litellm@5d4c4d0fce)

LiteLLM exposes `litellm_guardrail_latency_seconds{guardrail_name, status, error_type, hook_type}` plus `litellm_guardrail_requests_total` / `litellm_guardrail_errors_total`. Capability is matched or exceeded; the shape intentionally differs in three ways:

1. **One histogram instead of three metrics** — with real buckets, `_count` subsumes both counters (documented PromQL equivalents in the paired docs PR).
2. **Cleaner status taxonomy** — LiteLLM's Prometheus layer records every content-policy block as `status="error"` (only its logging layer distinguishes `guardrail_intervened` from `guardrail_failed_to_respond`). We follow the intent of its logging-layer taxonomy instead: `blocked` vs `bypassed(error_type)` are first-class results.
3. **Fail-open visibility** — LiteLLM has no fail-open signal at all; we record `bypassed` with the bounded failure tag (consistent with the existing `aisix_guardrail_bypasses_total{reason}` values).

Kong (the other alignment target) records per-plugin input/output processing latency and block reasons in audit logs only, with no dedicated guardrail Prometheus histogram — covered by this metric plus the existing usage-event fields.

## Known limits (deliberate)

- The synchronous per-field redactors (local `pii` mask rewrites, microsecond-scale) are not timed — their per-field call pattern would skew per-execution counts; detection/scan time for those kinds is still recorded via the check folds.
- A fail-closed remote failure records as `blocked` with `error_type="none"`: the structured failure tag only exists on `Bypass` verdicts, and threading it through `Block` would touch ~65 construction/destructure sites for a rare path. Its latency signature (clustering at the provider timeout) remains visible.
- Existing counters are unchanged (no dashboard/scrape breakage).

No config/schema surface is added (metrics are emitted unconditionally, gated only by the existing `observability.metrics.prometheus.enabled`), so no CP-side wiring is required.

## Tests

- `chain.rs` unit tests: per-member recording with name/kind/phase, enforced-result classification (allowed/blocked/bypassed+tag), segment-pass `masked`, non-segment skip of segment members, no-sink no-op.
- `build.rs` unit tests: sink injection through `LiveGuardrailIndex::new_with_sink` → resolved chains; monitor-mode `would_block`/`would_mask` recording end-to-end through the real decorators.
- `metrics.rs` unit test: rendered exposition has `_bucket{le=...}` series (not a summary) with the full label set and `error_type="none"` defaulting.
- New E2E `guardrail-metrics-e2e.test.ts` (real `aisix` + etcd + mock moderation endpoint + two mock upstreams): asserts `allowed`, local `blocked`, remote `blocked`, `bypassed` with `error_type="openai_moderation_5xx"`, monitor-mode `would_block`, and output-phase `blocked` series with correct counts, plus bucketed rendering and `env_id`/`kind` labels.

Fixes api7/AISIX-Cloud#1076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-guardrail execution telemetry, including latency, phase, outcome, guardrail type, and error classification.
  * Added Prometheus histogram metrics for guardrail execution latency.
  * Added optional metrics integration for guardrail processing across proxy and server configurations.
  * Added support for monitoring enforced, bypassed, masked, and monitor-mode outcomes.

* **Tests**
  * Added unit and end-to-end coverage for telemetry labels, latency buckets, and execution outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->