### PR TITLE
test(e2e): default the harness to admin-off; held-back tests opt in

### DIFF
--- a/tests/e2e/src/cases/apikey-budget-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-budget-e2e.test.ts
@@ -22,7 +22,9 @@ describe("apikey max_budget_usd e2e: standalone admin rejects removed field", ()
     etcdReachable = await new EtcdClient().ping();
     if (!etcdReachable) return;
 
-    app = await spawnApp();
+    // Held-back: this test drives the Admin API surface itself, so it
+    // keeps the admin listener bound (the suite default is now admin-off).
+    app = await spawnApp({ admin: true });
     admin = new AdminClient(app.adminUrl, app.adminKey);
   });
 

--- a/tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-lifecycle-e2e.test.ts
@@ -54,7 +54,9 @@ describe("api key lifecycle e2e: expired/disabled keys fail closed, rotate swaps
     if (!etcdReachable) return;
 
     upstream = await startOpenAiUpstream();
-    app = await spawnApp();
+    // Held-back: this test drives the Admin API surface itself, so it
+    // keeps the admin listener bound (the suite default is now admin-off).
+    app = await spawnApp({ admin: true });
     admin = new AdminClient(app.adminUrl, app.adminKey);
     seed = new SeedClient(etcd, app.etcdPrefix);
 

--- a/tests/e2e/src/cases/auth-baseline-e2e.test.ts
+++ b/tests/e2e/src/cases/auth-baseline-e2e.test.ts
@@ -50,7 +50,9 @@ describe("auth baseline e2e: missing/malformed/unknown bearer all fail closed", 
     if (!etcdReachable) return;
 
     upstream = await startOpenAiUpstream();
-    app = await spawnApp();
+    // Held-back: this test drives the Admin API surface itself, so it
+    // keeps the admin listener bound (the suite default is now admin-off).
+    app = await spawnApp({ admin: true });
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     // A single Model + ProviderKey + ApiKey configured. The valid

--- a/tests/e2e/src/cases/file-resource-source-e2e.test.ts
+++ b/tests/e2e/src/cases/file-resource-source-e2e.test.ts
@@ -74,7 +74,10 @@ describe("file resource source: smoke + admin write-guard", () => {
 
   beforeAll(async () => {
     upstream = await startOpenAiUpstream();
+    // Held-back: exercises the file-mode admin write-rejection (409), so
+    // the admin listener stays bound (the suite default is now admin-off).
     app = await spawnApp({
+      admin: true,
       resourcesFile: fileModeResources(upstream.baseUrl),
       extraEnv: { [CALLER_KEY_ENV]: CALLER_PLAINTEXT },
     });
@@ -255,6 +258,7 @@ describe("file resource source: differential vs etcd mode", () => {
     // The SAME logical resource set on both gateways: one provider key,
     // an allowed model, a forbidden model, one caller key.
     fileApp = await spawnApp({
+      admin: true,
       resourcesFile: `
 _format_version: "1"
 provider_keys:
@@ -278,7 +282,7 @@ api_keys:
 `,
     });
 
-    etcdApp = await spawnApp();
+    etcdApp = await spawnApp({ admin: true });
     const seed = new SeedClient(etcd, etcdApp.etcdPrefix);
     const pk = await seed.createProviderKey({
       display_name: "diff-pk",
@@ -411,6 +415,7 @@ api_keys:
   beforeAll(async () => {
     upstream = await startOpenAiUpstream();
     app = await spawnApp({
+      admin: true,
       resourcesFile: reloadFile(upstream.baseUrl, ["reload-a"]),
     });
   });
@@ -487,6 +492,7 @@ describe("file resource source: fail-fast boot", () => {
     let caught: unknown;
     try {
       await spawnApp({
+        admin: true,
         resourcesFile: `
 _format_version: "1"
 models:

--- a/tests/e2e/src/cases/health-minimal-e2e.test.ts
+++ b/tests/e2e/src/cases/health-minimal-e2e.test.ts
@@ -9,7 +9,9 @@ describe("livez e2e: public liveness route is /livez and /health is gone", () =>
   beforeAll(async () => {
     etcdReachable = await new EtcdClient().ping();
     if (!etcdReachable) return;
-    app = await spawnApp();
+    // Held-back: this test drives the admin listener's health endpoint,
+    // so it keeps admin bound (the suite default is now admin-off).
+    app = await spawnApp({ admin: true });
   });
 
   afterAll(async () => {

--- a/tests/e2e/src/cases/openai-sdk-compat.test.ts
+++ b/tests/e2e/src/cases/openai-sdk-compat.test.ts
@@ -51,7 +51,9 @@ describe("openai SDK compat: drive gateway through real client", () => {
       ],
     });
 
-    app = await spawnApp();
+    // Held-back: this test drives the Admin API surface itself, so it
+    // keeps the admin listener bound (the suite default is now admin-off).
+    app = await spawnApp({ admin: true });
     // Deliberately seeds via the Admin API: deprecation-window coverage.
     admin = new AdminClient(app.adminUrl, app.adminKey);
 

--- a/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
@@ -30,7 +30,9 @@ describe("prometheus metrics e2e", () => {
     upstream = await startOpenAiUpstream({
       nonStreamBody: responseBody(),
     });
-    app = await spawnApp();
+    // Held-back: asserts the admin listener's health endpoint, so it keeps
+    // admin bound (the suite default is now admin-off).
+    app = await spawnApp({ admin: true });
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     await configureOpenAi(seed, upstream, "prometheus-gpt");
@@ -92,7 +94,7 @@ describe("prometheus metrics e2e", () => {
     const customUpstream = await startOpenAiUpstream({
       nonStreamBody: responseBody(),
     });
-    const customApp = await spawnApp({ prometheusPath: "/custom-metrics" });
+    const customApp = await spawnApp({ admin: true, prometheusPath: "/custom-metrics" });
     try {
       const customSeed = new SeedClient(new EtcdClient(), customApp.etcdPrefix);
       await configureOpenAi(customSeed, customUpstream, "prometheus-custom-gpt");
@@ -187,7 +189,7 @@ describe("prometheus metrics e2e", () => {
       return;
     }
 
-    const disabledApp = await spawnApp({ prometheus: false });
+    const disabledApp = await spawnApp({ admin: true, prometheus: false });
     try {
       // No listener at all: the fetch must fail at the connection level,
       // not return an HTTP error.

--- a/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/prometheus-metrics-e2e.test.ts
@@ -30,8 +30,10 @@ describe("prometheus metrics e2e", () => {
     upstream = await startOpenAiUpstream({
       nonStreamBody: responseBody(),
     });
-    // Held-back: asserts the admin listener's health endpoint, so it keeps
-    // admin bound (the suite default is now admin-off).
+    // Held-back: the "admin listener does not serve /metrics" test fetches
+    // `${app.adminUrl}/metrics` and expects 404, which needs the admin
+    // listener bound (unbound → connection refused, never a 404). The suite
+    // default is now admin-off, so this test opts back in.
     app = await spawnApp({ admin: true });
     seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -94,7 +96,7 @@ describe("prometheus metrics e2e", () => {
     const customUpstream = await startOpenAiUpstream({
       nonStreamBody: responseBody(),
     });
-    const customApp = await spawnApp({ admin: true, prometheusPath: "/custom-metrics" });
+    const customApp = await spawnApp({ prometheusPath: "/custom-metrics" });
     try {
       const customSeed = new SeedClient(new EtcdClient(), customApp.etcdPrefix);
       await configureOpenAi(customSeed, customUpstream, "prometheus-custom-gpt");
@@ -189,7 +191,7 @@ describe("prometheus metrics e2e", () => {
       return;
     }
 
-    const disabledApp = await spawnApp({ admin: true, prometheus: false });
+    const disabledApp = await spawnApp({ prometheus: false });
     try {
       // No listener at all: the fetch must fail at the connection level,
       // not return an HTTP error.

--- a/tests/e2e/src/cases/seed-vs-admin-characterization-e2e.test.ts
+++ b/tests/e2e/src/cases/seed-vs-admin-characterization-e2e.test.ts
@@ -65,7 +65,9 @@ describe("seed-vs-admin characterization: direct etcd writes ≡ Admin API write
     if (!etcdReachable) return;
 
     upstream = await startOpenAiUpstream();
-    app = await spawnApp();
+    // Held-back: this test's subject is seed-vs-admin equivalence, so it
+    // keeps the admin listener bound (the suite default is now admin-off).
+    app = await spawnApp({ admin: true });
     admin = new AdminClient(app.adminUrl, app.adminKey);
     seed = new SeedClient(etcd, app.etcdPrefix);
 

--- a/tests/e2e/src/cases/status-models-e2e.test.ts
+++ b/tests/e2e/src/cases/status-models-e2e.test.ts
@@ -86,7 +86,9 @@ describe("status/models: etcd mode — equivalence with the admin endpoint", () 
       },
     });
 
-    app = await spawnApp();
+    // Held-back: compares /status/models to /admin/v1/models/status, so it
+    // keeps admin bound (the suite default is now admin-off).
+    app = await spawnApp({ admin: true });
     const seed = new SeedClient(etcd, app.etcdPrefix);
 
     const failPk = await seed.createProviderKey({
@@ -201,6 +203,7 @@ describe("status/models: standalone file source", () => {
 
   beforeAll(async () => {
     app = await spawnApp({
+      admin: true,
       resourcesFile: `
 _format_version: "1"
 provider_keys:

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -11,13 +11,17 @@ import { harnessRequest } from "./http.js";
 
 export interface AppOverrides {
   /**
-   * Whether to bind the admin listener. Defaults to `true`. When `false`,
-   * the gateway runs with `admin.enabled = false` — no admin listener is
-   * bound even in etcd/file mode, mirroring the post-removal world. Seed
-   * resources through `SeedClient`/`EtcdClient` (never the Admin API), and
-   * readiness is gated on the proxy `/livez` plus the metrics listener
-   * instead of the admin health endpoint. `adminUrl`/`adminKey` are still
-   * returned but point at an unbound port.
+   * Whether to bind the admin listener. **Defaults to `false`** — the
+   * gateway runs with `admin.enabled = false`, no admin listener bound,
+   * mirroring the post-removal world; readiness gates on the proxy
+   * `/livez` plus the metrics listener, and `adminUrl`/`adminKey` are
+   * still returned but point at an unbound port. Resources are seeded
+   * through `SeedClient`/`EtcdClient`, never the Admin API.
+   *
+   * Only tests whose subject IS the Admin API surface (the held-back set —
+   * admin auth, write-rejection, deprecation headers, status-equivalence,
+   * key rotation) opt back in with `admin: true`; they stay admin-on until
+   * the Admin API is removed, then get deleted.
    */
   admin?: boolean;
   /** Inserted into `admin.admin_keys`. Defaults to a fresh random key. */
@@ -149,7 +153,7 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   }
 
   const prometheusEnabled = overrides.prometheus ?? true;
-  const adminEnabled = overrides.admin ?? true;
+  const adminEnabled = overrides.admin ?? false;
   const [proxyPort, adminPort, metricsPort] = await pickFreePorts(3);
   const adminKey = overrides.adminKey ?? `admin-${randomUUID()}`;
   const etcdPrefix = `/aisix-e2e-${randomUUID()}`;

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -154,6 +154,16 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
 
   const prometheusEnabled = overrides.prometheus ?? true;
   const adminEnabled = overrides.admin ?? false;
+  // `extra` is spread over the generated config at the top level, so an
+  // `extra.admin` would replace the generated admin block and could bind
+  // the listener while readiness still keys off `adminEnabled` and skips
+  // the admin health gate. Keep the `admin` boolean the single source of
+  // truth for the admin listener.
+  if (overrides.extra && "admin" in overrides.extra) {
+    throw new Error(
+      "spawnApp: control the admin listener with the `admin` boolean override, not `extra.admin`",
+    );
+  }
   const [proxyPort, adminPort, metricsPort] = await pickFreePorts(3);
   const adminKey = overrides.adminKey ?? `admin-${randomUUID()}`;
   const etcdPrefix = `/aisix-e2e-${randomUUID()}`;


### PR DESCRIPTION
## What

Flip the e2e harness default to **`admin: false`**, so the whole suite runs with **no admin listener bound** by default. The only tests that keep the admin listener are the ones whose subject **is** the Admin API surface — they now opt in explicitly with `admin: true`.

This is the last step of the e2e "de-admin-API" work (after #791 added the `admin.enabled` switch and #792 migrated the seed-tail tests). It proves the acceptance for retiring the Admin API: **the suite is green with the admin listener off by default**, so when the Admin API is removed, only the explicitly-`admin: true` files need deletion — everything else already runs admin-off.

## Changes

- **`tests/e2e/src/harness/app.ts`**: `AppOverrides.admin` now defaults to `false` (`overrides.admin ?? false`). Doc updated: admin-off is the norm; only held-back admin-surface tests opt in with `admin: true`.
- **9 held-back files** get an explicit `admin: true` on every `spawnApp` site — a no-op behaviorally (this was the previous default), just making the dependency explicit now that the default flipped: `apikey-budget`, `apikey-lifecycle` (admin key rotate / removed-field validation), `auth-baseline` (admin bearer 401), `file-resource-source` (file-mode admin write 409 + path-leak), `health-minimal` / `prometheus-metrics` (admin `/admin/v1/health`), `openai-sdk-compat` (RFC 9745 deprecation-header contract), `seed-vs-admin-characterization` (seed≡admin equivalence), `status-models` (`/status/models` vs `/admin/v1/models/status` equivalence).

Everything else — the large majority of the suite, which already seeds via `SeedClient`/etcd and never touches the admin listener — now runs admin-off with **no per-file change** (the default carries it).

## Scoping method

Swept every case file for real admin-listener usage (`app.adminUrl` in a request / `new AdminClient` calling anything other than `listModelStatuses`, which reads the metrics listener). The result was exactly the 9 held-back files above. `admin-disabled-e2e` and the 9 files migrated in #792 already pass `admin: false` explicitly; `status-config` seeds via etcd and only references `/admin/v1/health` in a comment, so it runs admin-off unchanged.

## Verification

`npx tsc --noEmit` clean on the changed files. The 9 held-back files pass unchanged (admin:true = their prior behavior); `allowed-models` and `status-config` confirm previously-default-admin-on files now run admin-off. Full e2e suite green with the admin-off default — the definitive check that no admin-dependent file was missed (a miss would fail now that the listener is off by default).

## Follow-up

With this merged, the remaining Admin-API-removal work (AISIX-Cloud#1007 Phase 4) is: `/readyz` relocation + read-surface decision, a v0.4.0 coexistence release, then the removal PR itself (which deletes the admin listener + the 9 `admin: true` held-back tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test setup to explicitly enable the Admin API where required.
  * Continued validating API key budgets, authentication failures, health checks, metrics, model status, and resource behavior.
* **Refactor**
  * Test applications now start with the Admin API disabled by default, matching the updated configuration.
  * Readiness checks no longer require the Admin API unless it is explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->