### PR TITLE
ci(release): lead draft release notes with a Get started + Download header

### DIFF
--- a/.github/release-notes-header.md
+++ b/.github/release-notes-header.md
@@ -16,3 +16,22 @@ docker pull ghcr.io/api7/aisix:__VERSION__
 Rolling tags (`__MINOR__`, `latest`) and the `docker.io/api7/aisix` mirror for private/offline deployments are listed on the [package page](https://github.com/orgs/api7/packages/container/package/aisix).
 
 ---
+
+<!-- ─────────────────────────────────────────────────────────────────────────
+     RELEASE NOTES — polish this section before publishing, then delete this
+     comment. Full house style + examples: RELEASING.md §2.
+
+     1. Headline (optional, one line) — the story of the release, if it has one.
+        e.g. "AISIX becomes a gateway for AI agents, not just LLM calls."
+     2. Highlights — 3–6 plain-language bullets, most important first.
+     3. Themed sections — keep only the ones that apply, e.g.:
+          ## 🧭 Routing              ## 🛡️ Guardrails       ## 🔭 Observability
+          ## 🔐 Security & isolation ## 🔌 API surface       ## 🧩 MCP & A2A
+        Cite PRs as (#123); describe each feature by its own function — no
+        comparisons to other products.
+     4. ## ⚠️ Breaking changes — its own section: old → new spelling + what to
+        update.
+
+     The auto-generated "What's Changed" list below is the raw commit index:
+     fold it into the sections above, then trim it or keep it as a full log.
+     ───────────────────────────────────────────────────────────────────────── -->

--- a/.github/release-notes-header.md
+++ b/.github/release-notes-header.md
@@ -13,7 +13,7 @@ Pull the container image from the GitHub Container Registry:
 docker pull ghcr.io/api7/aisix:__VERSION__
 ```
 
-Rolling tags (`__MINOR__`, `latest`) and the `docker.io/api7/aisix` mirror for private/offline deployments are listed on the [package page](https://github.com/orgs/api7/packages/container/package/aisix).
+__ROLLING_TAGS__
 
 ---
 

--- a/.github/release-notes-header.md
+++ b/.github/release-notes-header.md
@@ -1,0 +1,18 @@
+## 🚀 Get started
+
+New to AISIX? Get the gateway running and route your first LLM request in minutes:
+
+- 📖 **Documentation** — https://docs.api7.ai/ai-gateway/
+- ⚡ **Self-hosted quickstart** (gateway + etcd via Docker Compose) — https://docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart
+
+## 📦 Download
+
+Pull the container image from the GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/api7/aisix:__VERSION__
+```
+
+Rolling tags (`__MINOR__`, `latest`) and the `docker.io/api7/aisix` mirror for private/offline deployments are listed on the [package page](https://github.com/orgs/api7/packages/container/package/aisix).
+
+---

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -6,8 +6,9 @@ name: release-draft
 # out until a human publishes.
 #
 # The draft body leads with a fixed "Get started + Download" header
-# (.github/release-notes-header.md, version-stamped from the tag), followed by
-# GitHub's auto-generated "What's Changed" list.
+# (.github/release-notes-header.md, version-stamped from the tag), then a
+# commented curated-notes scaffold (themed-section skeleton the maintainer
+# fills in), then GitHub's auto-generated "What's Changed" list.
 #
 # No-op if a release for the tag already exists (e.g. created manually).
 

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,9 +1,13 @@
 name: release-draft
 
-# Create a draft GitHub Release with auto-generated notes whenever a
-# release tag (vX.Y.Z) is pushed — the skeleton a maintainer polishes into
-# curated notes before publishing (see RELEASING.md). Draft releases do
-# not notify watchers, so nothing goes out until a human publishes.
+# Create a draft GitHub Release whenever a release tag (vX.Y.Z) is pushed —
+# the skeleton a maintainer polishes into curated notes before publishing
+# (see RELEASING.md). Draft releases do not notify watchers, so nothing goes
+# out until a human publishes.
+#
+# The draft body leads with a fixed "Get started + Download" header
+# (.github/release-notes-header.md, version-stamped from the tag), followed by
+# GitHub's auto-generated "What's Changed" list.
 #
 # No-op if a release for the tag already exists (e.g. created manually).
 
@@ -23,7 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Create draft release with generated notes
+      - name: Check out the release-notes header template
+        uses: actions/checkout@v4
+
+      - name: Create draft release with header + generated notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
@@ -33,9 +40,22 @@ jobs:
             echo "release for $TAG already exists — nothing to do"
             exit 0
           fi
+
+          VERSION="${TAG#v}"            # v0.4.0 -> 0.4.0 (image tags carry no leading v)
+          MINOR="${VERSION%.*}"         # 0.4.0 -> 0.4  (0.4.0-rc.1 -> 0.4.0-rc, close enough)
+
+          # Version-stamped docs + download header every release should lead with.
+          sed -e "s/__VERSION__/$VERSION/g" -e "s/__MINOR__/$MINOR/g" \
+            .github/release-notes-header.md > release-body.md
+
+          # GitHub's auto-generated "What's Changed" skeleton, appended below the header.
+          gh api "repos/$REPO/releases/generate-notes" \
+            -f tag_name="$TAG" --jq .body >> release-body.md
+
           # Pre-release tags (v0.4.0-rc.1) get the prerelease flag.
           case "$TAG" in *-*) PRE=--prerelease ;; *) PRE= ;; esac
+
           gh release create "$TAG" -R "$REPO" $PRE \
             --draft \
-            --generate-notes \
+            --notes-file release-body.md \
             --title "$TAG"

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out the release-notes header template
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create draft release with header + generated notes
         env:
@@ -43,15 +43,33 @@ jobs:
           fi
 
           VERSION="${TAG#v}"            # v0.4.0 -> 0.4.0 (image tags carry no leading v)
-          MINOR="${VERSION%.*}"         # 0.4.0 -> 0.4  (0.4.0-rc.1 -> 0.4.0-rc, close enough)
+
+          # Rolling-tags sentence. docker-image.yml publishes the :X.Y (and
+          # :latest) tags only for stable releases; docker/metadata-action skips
+          # major.minor for pre-release semver, so a -rc draft must not advertise
+          # an :X.Y tag that never gets pushed.
+          PKG="https://github.com/orgs/api7/packages/container/package/aisix"
+          case "$TAG" in
+            *-*)
+              ROLLING="Other image tags and the \`docker.io/api7/aisix\` mirror for private/offline deployments are listed on the [package page]($PKG)."
+              ;;
+            *)
+              MINOR="${VERSION%.*}"     # 0.4.0 -> 0.4
+              ROLLING="Rolling tags (\`$MINOR\`, \`latest\`) and the \`docker.io/api7/aisix\` mirror for private/offline deployments are listed on the [package page]($PKG)."
+              ;;
+          esac
 
           # Version-stamped docs + download header every release should lead with.
-          sed -e "s/__VERSION__/$VERSION/g" -e "s/__MINOR__/$MINOR/g" \
+          # '#' delimiter for __ROLLING_TAGS__ so the URL's slashes don't clash.
+          sed -e "s/__VERSION__/$VERSION/g" -e "s#__ROLLING_TAGS__#${ROLLING}#" \
             .github/release-notes-header.md > release-body.md
 
-          # GitHub's auto-generated "What's Changed" skeleton, appended below the header.
+          # GitHub's auto-generated "What's Changed" skeleton, appended below the
+          # header. Fall back to a bare heading so a transient API failure still
+          # produces a draft (with the header) instead of no release at all.
           gh api "repos/$REPO/releases/generate-notes" \
-            -f tag_name="$TAG" --jq .body >> release-body.md
+            -f tag_name="$TAG" --jq .body >> release-body.md \
+            || printf '## What'"'"'s Changed\n' >> release-body.md
 
           # Pre-release tags (v0.4.0-rc.1) get the prerelease flag.
           case "$TAG" in *-*) PRE=--prerelease ;; *) PRE= ;; esac

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,9 +28,9 @@ Pushing the tag triggers two workflows:
 ## 2. Polish the release notes
 
 Edit the draft before publishing. The Get-started/Download header and the
-full-changelog link are already in place — polish the middle: insert the
-narrative and highlights **between the header's `---` divider and the
-What's Changed list**. House style (see the
+full-changelog link are already in place, and a commented **curated-notes
+scaffold** sits between the header's `---` divider and the What's Changed list —
+fill it in, then delete the comment. House style (see the
 [published releases](https://github.com/api7/aisix/releases) for examples):
 
 - Lead with a short narrative line when the release has one (e.g. "AISIX

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,12 +19,18 @@ Pushing the tag triggers two workflows:
   deployments, signs the images with cosign, and stamps the version into the
   binary so a running gateway self-reports `X.Y.Z` (`--version`, `Server`
   header) and `X.Y.Z+sha-<short>` in its managed-mode heartbeat.
-- **`release-draft.yml`** creates a **draft** GitHub Release for the tag with
-  auto-generated notes as a starting skeleton.
+- **`release-draft.yml`** creates a **draft** GitHub Release for the tag. The
+  draft already leads with a version-stamped **Get started + Download** header
+  (from [`.github/release-notes-header.md`](.github/release-notes-header.md):
+  docs, self-hosted quickstart, and the `docker pull` command), followed by
+  GitHub's auto-generated **What's Changed** list as a starting skeleton.
 
 ## 2. Polish the release notes
 
-Edit the draft before publishing. House style (see the
+Edit the draft before publishing. The Get-started/Download header and the
+full-changelog link are already in place — polish the middle: insert the
+narrative and highlights **between the header's `---` divider and the
+What's Changed list**. House style (see the
 [published releases](https://github.com/api7/aisix/releases) for examples):
 
 - Lead with a short narrative line when the release has one (e.g. "AISIX
@@ -37,13 +43,11 @@ Edit the draft before publishing. House style (see the
   cite internal issue trackers.
 - Describe each feature by its own function — no comparisons against other
   products.
-- End with the install snippet and a full-changelog compare link:
+- Keep the download/install details in the header block; don't hand-add a
+  second install snippet at the bottom.
 
-  ```bash
-  docker pull ghcr.io/api7/aisix:X.Y.Z
-  ```
-
-  `**Full changelog**: https://github.com/api7/aisix/compare/<previous release tag>...vX.Y.Z`
+If the header text itself needs to change (new docs URL, extra image
+registry), edit `.github/release-notes-header.md` — not each release by hand.
 
 ## 3. Publish
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,8 +22,9 @@ Pushing the tag triggers two workflows:
 - **`release-draft.yml`** creates a **draft** GitHub Release for the tag. The
   draft already leads with a version-stamped **Get started + Download** header
   (from [`.github/release-notes-header.md`](.github/release-notes-header.md):
-  docs, self-hosted quickstart, and the `docker pull` command), followed by
-  GitHub's auto-generated **What's Changed** list as a starting skeleton.
+  docs, self-hosted quickstart, and the `docker pull` command), then a commented
+  curated-notes scaffold to fill in, then GitHub's auto-generated **What's
+  Changed** list as a starting skeleton.
 
 ## 2. Polish the release notes
 


### PR DESCRIPTION
## What & why

Follow-up to the v0.4.0 release: its notes were a bare auto-generated `What's Changed` list, so I hand-added a **Get started + Download** header (docs, self-hosted quickstart, `docker pull`) — the same Kong-style entry points our published releases show. This PR makes that header **automatic** for every future draft instead of a manual step.

## Changes

- **`.github/release-notes-header.md`** (new) — the header template: Documentation + self-hosted quickstart links, and a version-stamped `docker pull ghcr.io/api7/aisix:__VERSION__` block. `__VERSION__`/`__MINOR__` are substituted from the tag.
- **`.github/workflows/release-draft.yml`** — now checks out the repo, stamps the tag version into the template, appends GitHub's generated notes (via the `releases/generate-notes` API), and creates the draft with `--notes-file`. Behavior otherwise unchanged: still draft-only, still no-op if a release already exists, still flags `--prerelease` for `-rc` tags.
- **`RELEASING.md`** — step 2 updated: the header + full-changelog link are pre-filled, so polishing = inserting highlights in the middle; change the header via the template, not per release.

## Notes / accuracy

- Image tag carries **no** leading `v` (`0.4.0`), matching `docker-image.yml`'s output; the git tag stays `v0.4.0`.
- `__MINOR__` is `${VERSION%.*}` — exact for stable (`0.4.0`→`0.4`); for `-rc` tags it's approximate, which is why the header phrases rolling tags as "listed on the package page" rather than hard-claiming them.
- Verified locally: YAML lints clean, and the assembled body for `v0.4.0` renders correctly (header → `---` → What's Changed → Full Changelog).

## Test plan

- [ ] Next `vX.Y.Z` tag push produces a draft whose body leads with the Get started + Download header above What's Changed.
- [ ] `docker pull` line in the draft resolves (image tag published by `docker-image.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)