### PR TITLE
test(e2e): pin the proxy health endpoints under admin-off

### DIFF
--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -931,6 +931,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn readyz_503s_when_the_config_probe_reports_no_apply_yet() {
+        // Pins the config_apply_age plumbing through the router: a wired
+        // probe reporting "no apply yet" must gate readiness with a 503.
+        // Without this, dropping the probe wiring would leave readyz
+        // reporting `[+]config ok` unconditionally (the field-None path),
+        // byte-identical to wired-and-fresh — a silent downgrade of
+        // readiness to shutdown-only that no other test would notice.
+        let hub = Arc::new(Hub::new());
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");
+        let state = build_state(snap, hub).with_config_apply_age(Arc::new(|| None));
+        let app = build_router(state);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/readyz?verbose")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert!(text.contains("[-]config failed: not ready"));
+    }
+
+    #[tokio::test]
     async fn health_route_is_not_found() {
         let hub = Arc::new(Hub::new());
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], "http://unused");

--- a/tests/e2e/src/cases/admin-disabled-e2e.test.ts
+++ b/tests/e2e/src/cases/admin-disabled-e2e.test.ts
@@ -144,6 +144,37 @@ describe("admin disabled, etcd source: gateway serves seeded-via-etcd config wit
     expect(counts.api_keys).toBe(1);
   });
 
+  test("the proxy health endpoints serve with the admin listener off", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // /livez and /readyz live on the proxy listener — the health surface
+    // that survives the Admin API's removal. /readyz carries the full
+    // readiness semantics (config freshness from the watch + shutdown),
+    // so once the seeded config has applied it must report ready.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/readyz`);
+        await r.text();
+        return r.status === 200;
+      } catch {
+        return false;
+      }
+    });
+
+    const livez = await fetch(`${app!.proxyUrl}/livez`);
+    expect(livez.status).toBe(200);
+    expect(await livez.text()).toBe("ok");
+
+    const verbose = await fetch(`${app!.proxyUrl}/readyz?verbose`);
+    expect(verbose.status).toBe(200);
+    const body = await verbose.text();
+    expect(body).toContain("[+]shutdown ok");
+    expect(body).toContain("[+]config ok");
+  });
+
   test("no admin listener is bound", async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();
@@ -247,6 +278,32 @@ api_keys:
     expect(rows[0]?.display_name).toBe("admin-off-file-model");
     expect(rows[0]?.kind).toBe("direct");
     expect(rows[0]?.status).toBe("healthy");
+  });
+
+  test("the proxy health endpoints serve in file mode with the admin listener off", async () => {
+    if (!app) throw new Error("setup failed");
+
+    // File mode loads at boot and has no watch to go stale, so /readyz on
+    // the proxy listener reports ready as soon as the file has applied.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(`${app!.proxyUrl}/readyz`);
+        await r.text();
+        return r.status === 200;
+      } catch {
+        return false;
+      }
+    });
+
+    const livez = await fetch(`${app!.proxyUrl}/livez`);
+    expect(livez.status).toBe(200);
+    expect(await livez.text()).toBe("ok");
+
+    const verbose = await fetch(`${app!.proxyUrl}/readyz?verbose`);
+    expect(verbose.status).toBe(200);
+    const body = await verbose.text();
+    expect(body).toContain("[+]shutdown ok");
+    expect(body).toContain("[+]config ok");
   });
 
   test("no admin listener is bound in file mode", async () => {

--- a/tests/e2e/src/cases/admin-disabled-e2e.test.ts
+++ b/tests/e2e/src/cases/admin-disabled-e2e.test.ts
@@ -152,8 +152,9 @@ describe("admin disabled, etcd source: gateway serves seeded-via-etcd config wit
 
     // /livez and /readyz live on the proxy listener — the health surface
     // that survives the Admin API's removal. /readyz carries the full
-    // readiness semantics (config freshness from the watch + shutdown),
-    // so once the seeded config has applied it must report ready.
+    // readiness semantics (config freshness from the watch + shutdown);
+    // it reports ready once the initial load applies (an empty prefix
+    // counts), so it settles at 200 regardless of seed timing.
     await waitConfigPropagation(async () => {
       try {
         const r = await fetch(`${app!.proxyUrl}/readyz`);


### PR DESCRIPTION
## What

Pin the **proxy listener's health endpoints under admin-off** — the health surface that survives the Admin API's removal. Two e2e legs added to `admin-disabled-e2e` (etcd + file source): wait for `/readyz` to report ready, then assert `/livez` → 200 `ok` and `/readyz?verbose` lists `[+]shutdown ok` + `[+]config ok`, all with **no admin listener bound**.

## Why — a premise correction

The Admin-API-removal roadmap listed "`/readyz` relocation + deployment-probe repointing" as a prerequisite, on the premise that `/readyz` existed only on the admin listener. Investigation shows the premise is wrong:

- The **proxy listener already serves both `/livez` and `/readyz`** (`aisix-proxy` `build_router`), via the same shared `health::livez_response`/`readyz_response` the admin handlers call.
- The proxy `/readyz` carries the **full readiness semantics**: its config-freshness block is wired from the **same** `supervisor.watch_status()` the admin handler reads (etcd and managed modes), and an always-fresh probe in file mode (no watch to go stale) — `crates/aisix-server/src/main.rs` wires `with_config_apply_age` in every mode.
- A sweep of every deployment artifact — this repo's `Dockerfile` (no `HEALTHCHECK`), `docker/entrypoint.sh`, CI docker smoke (already probes the **proxy** `/livez`), and the control-plane repo's entire `deploy/` tree — found **no health probe pointing at the admin listener**. There is nothing to relocate and nothing to repoint.

So the only real gap was a **regression pin**: nothing asserted that the surviving health surface works with the admin listener off. This PR adds that pin, so the eventual admin-listener removal PR cannot silently regress `/livez`/`/readyz` on the proxy.

The operational readiness story after removal is unchanged and now fully covered: proxy `/livez` (liveness) + proxy `/readyz` (readiness incl. config freshness/drain) + metrics listener `/status/ready` (config-only readiness) — the latter already pinned by `status-config-e2e`.

## Verification

`admin-disabled-e2e` 9/9 green (7 existing + 2 new health legs); the new legs do their own readiness wait so they hold under test filtering. `npx tsc --noEmit` clean on the changed file; `health-minimal` (held-back admin health surface) untouched and green.

## Follow-up (not this PR)

The repo README still leads with "configure through the admin API on `:3001`" and points at the rewritten docs quickstart — stale against the deprecation story; belongs with the coexistence-release communication pass. Docs-side, the proxy `/livez`/`/readyz` could be listed on the ports/proxy-api reference pages as the surviving health surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for proxy health checks when the Admin listener is disabled.
  * Verified readiness and liveness endpoints across both etcd-backed and file-based configurations.
  * Confirmed readiness details report successful shutdown and configuration checks, while liveness returns the expected healthy response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->