### PR TITLE
fix(anthropic): preserve client cache_control through the OpenAI-to-Anthropic bridge

### DIFF
--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -6,13 +6,14 @@
 //!
 //! - System prompt is a top-level `system` field, not a message with
 //!   `role: "system"` — we collapse all leading system messages into one
-//!   string and forward it there.
+//!   string (or an array of text blocks when the caller sent typed
+//!   blocks, so `cache_control` markers survive) and forward it there.
 //! - Only `user` and `assistant` roles on the wire. `tool` messages from
 //!   ChatFormat are rejected at the bridge boundary rather than being
 //!   silently re-classified.
 //! - Content is an array of blocks — we emit a single `{"type":"text",…}`
-//!   block per message and read the concatenation of text blocks on the
-//!   way back.
+//!   block per message (typed caller blocks forward their text blocks
+//!   verbatim) and read the concatenation of text blocks on the way back.
 //! - `max_tokens` is required by Anthropic. We default to a safe ceiling
 //!   when the client didn't set one, but log the fallback so operators
 //!   can tune the default if desired.
@@ -30,13 +31,30 @@ use serde::{Deserialize, Serialize};
 /// enough that a runaway prompt doesn't burn tokens silently.
 pub const DEFAULT_MAX_TOKENS: u32 = 4096;
 
+/// The top-level `system` field — Anthropic accepts a plain string or an
+/// array of text content blocks, documented as equivalent shapes
+/// (<https://docs.anthropic.com/en/api/messages#parameter-system>).
+///
+/// The gateway emits the string form whenever every system message came
+/// in as plain text (byte-identical to what it has always sent), and
+/// switches to the block-array form only when a caller's system message
+/// itself carried typed blocks — whose block-level fields (notably
+/// `cache_control` prompt-cache markers) must survive translation
+/// (AISIX-Cloud#1110 Gap A).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum AnthropicSystem {
+    Text(String),
+    Blocks(Vec<serde_json::Value>),
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AnthropicRequest<'a> {
     pub model: &'a str,
     pub messages: Vec<AnthropicMessage<'a>>,
     pub max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub system: Option<String>,
+    pub system: Option<AnthropicSystem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -112,17 +130,49 @@ impl<'a> AnthropicMessage<'a> {
         }
     }
 
+    /// Message content built from a caller's typed content blocks
+    /// ([`ChatMessage::content_blocks`]): text blocks forward verbatim —
+    /// OpenAI and Anthropic share the `{type:"text", text}` shape, and
+    /// block-level fields the caller attached (notably `cache_control`
+    /// prompt-cache markers) ride along unchanged. Flattening through the
+    /// concatenated-text path would silently strip them (AISIX-Cloud#1110
+    /// Gap A). Non-text blocks (images/audio) are skipped — the same
+    /// cross-provider content limitation as the text path. Degrades to a
+    /// single empty text block when nothing survives, because Anthropic
+    /// rejects an empty `content` array.
+    pub(crate) fn from_blocks(role: &'a str, blocks: &[serde_json::Value]) -> Self {
+        let mut content = text_blocks_verbatim(blocks);
+        if content.is_empty() {
+            content.push(serde_json::json!({"type": "text", "text": ""}));
+        }
+        Self {
+            role,
+            content,
+            _lifetime: std::marker::PhantomData,
+        }
+    }
+
     /// Assistant turn replayed from conversation history, carrying its
     /// text (when any) plus any OpenAI-shape `tool_calls` translated into
     /// Anthropic `tool_use` blocks. An agent loop replays the assistant's
     /// prior tool calls before sending the matching tool results; without
     /// translating `tool_calls` here the following `tool_result` would
-    /// reference a `tool_use` the upstream never saw and 400. Empty text
-    /// with no tool calls degrades to an empty text block so the message
-    /// isn't dropped (Anthropic rejects an empty `content` array).
-    pub(crate) fn assistant(text: &str, tool_calls: Option<&[serde_json::Value]>) -> Self {
-        let mut content: Vec<serde_json::Value> = Vec::new();
-        if !text.is_empty() {
+    /// reference a `tool_use` the upstream never saw and 400. When the
+    /// caller sent typed content blocks, their text blocks forward
+    /// verbatim (preserving `cache_control` markers) instead of the
+    /// flattened text. Empty content with no tool calls degrades to an
+    /// empty text block so the message isn't dropped (Anthropic rejects
+    /// an empty `content` array).
+    pub(crate) fn assistant(
+        text: &str,
+        blocks: Option<&[serde_json::Value]>,
+        tool_calls: Option<&[serde_json::Value]>,
+    ) -> Self {
+        let mut content: Vec<serde_json::Value> = match blocks {
+            Some(blocks) => text_blocks_verbatim(blocks),
+            None => Vec::new(),
+        };
+        if content.is_empty() && !text.is_empty() {
             content.push(serde_json::json!({"type": "text", "text": text}));
         }
         if let Some(tcs) = tool_calls {
@@ -137,6 +187,19 @@ impl<'a> AnthropicMessage<'a> {
             _lifetime: std::marker::PhantomData,
         }
     }
+}
+
+/// Forward the `{type:"text", …}` blocks of an OpenAI-shape content
+/// array verbatim onto the Anthropic wire, preserving block-level
+/// fields such as `cache_control`. Non-text blocks are dropped —
+/// callers needing image/audio input on this bridge hit the documented
+/// cross-provider content limitation, unchanged by this helper.
+fn text_blocks_verbatim(blocks: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
+        .cloned()
+        .collect()
 }
 
 /// Translate an array of OpenAI-shape `tool_calls`
@@ -201,9 +264,13 @@ pub enum TranslateError {
 }
 
 /// Split the gateway's flat ChatFormat into Anthropic's (system, messages)
-/// shape. Consecutive system messages at the head are concatenated with
-/// a blank line, matching how users typically compose multi-paragraph
-/// system prompts in the OpenAI format.
+/// shape. Consecutive plain-text system messages at the head are
+/// concatenated with a blank line into the string form, matching how
+/// users typically compose multi-paragraph system prompts in the OpenAI
+/// format; when any head system message carried typed content blocks,
+/// the whole system prompt switches to Anthropic's block-array form so
+/// block-level fields (`cache_control` prompt-cache markers) survive —
+/// see [`AnthropicSystem`].
 ///
 /// Role::Tool turns translate to Anthropic's `{role:"user", content:
 /// [{type:"tool_result", tool_use_id, content}]}` shape per
@@ -211,8 +278,8 @@ pub enum TranslateError {
 /// (caller sends the tool's output back to the model) round-trips.
 pub fn split_system<'a>(
     req: &'a ChatFormat,
-) -> Result<(Option<String>, Vec<AnthropicMessage<'a>>), TranslateError> {
-    let mut system_parts: Vec<&'a str> = Vec::new();
+) -> Result<(Option<AnthropicSystem>, Vec<AnthropicMessage<'a>>), TranslateError> {
+    let mut system_msgs: Vec<&'a ChatMessage> = Vec::new();
     let mut messages: Vec<AnthropicMessage<'a>> = Vec::new();
     let mut seen_non_system = false;
 
@@ -223,14 +290,14 @@ pub fn split_system<'a>(
                     // System messages interleaved with user/assistant
                     // turns don't map cleanly; append as a user turn to
                     // preserve semantics without silently dropping them.
-                    messages.push(AnthropicMessage::text("user", m.content_str()));
+                    messages.push(user_turn(m));
                 } else {
-                    system_parts.push(m.content_str());
+                    system_msgs.push(m);
                 }
             }
             Role::User => {
                 seen_non_system = true;
-                messages.push(AnthropicMessage::text("user", m.content_str()));
+                messages.push(user_turn(m));
             }
             Role::Assistant => {
                 seen_non_system = true;
@@ -239,7 +306,11 @@ pub fn split_system<'a>(
                     .get("tool_calls")
                     .and_then(|v| v.as_array())
                     .map(Vec::as_slice);
-                messages.push(AnthropicMessage::assistant(m.content_str(), tool_calls));
+                messages.push(AnthropicMessage::assistant(
+                    m.content_str(),
+                    m.content_blocks.as_deref(),
+                    tool_calls,
+                ));
             }
             Role::Tool => {
                 seen_non_system = true;
@@ -252,21 +323,63 @@ pub fn split_system<'a>(
         }
     }
 
-    let system = if system_parts.is_empty() {
-        None
-    } else {
-        Some(system_parts.join("\n\n"))
-    };
     // Fold consecutive same-role turns so the alternating-role invariant
     // Anthropic enforces holds for multi-turn tool loops and parallel
     // tool calls.
-    Ok((system, merge_consecutive_roles(messages)))
+    Ok((
+        build_system(&system_msgs),
+        merge_consecutive_roles(messages),
+    ))
+}
+
+/// A user-role turn: forward typed content blocks verbatim when the
+/// caller sent them (preserving `cache_control` markers), else the
+/// single-text-block shape from the flattened text.
+fn user_turn(m: &ChatMessage) -> AnthropicMessage<'_> {
+    match m.content_blocks.as_deref() {
+        Some(blocks) => AnthropicMessage::from_blocks("user", blocks),
+        None => AnthropicMessage::text("user", m.content_str()),
+    }
+}
+
+/// Collapse the leading system messages into the top-level `system`
+/// field. All-plain-text input keeps the historical `"\n\n"`-joined
+/// string form byte-for-byte; any block-carrying message switches the
+/// whole prompt to the block-array form, plain parts becoming their own
+/// text blocks in order. Falls back to the string form when no text
+/// block survives (e.g. image-only blocks), matching the flattened-text
+/// behavior for that degenerate input.
+fn build_system(system_msgs: &[&ChatMessage]) -> Option<AnthropicSystem> {
+    if system_msgs.is_empty() {
+        return None;
+    }
+    let joined = || {
+        system_msgs
+            .iter()
+            .map(|m| m.content_str())
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    };
+    if system_msgs.iter().all(|m| m.content_blocks.is_none()) {
+        return Some(AnthropicSystem::Text(joined()));
+    }
+    let blocks: Vec<serde_json::Value> = system_msgs
+        .iter()
+        .flat_map(|m| match m.content_blocks.as_deref() {
+            Some(blocks) => text_blocks_verbatim(blocks),
+            None => vec![serde_json::json!({"type": "text", "text": m.content_str()})],
+        })
+        .collect();
+    if blocks.is_empty() {
+        return Some(AnthropicSystem::Text(joined()));
+    }
+    Some(AnthropicSystem::Blocks(blocks))
 }
 
 pub fn build_request<'a>(
     req: &'a ChatFormat,
     upstream_model: &'a str,
-    system: Option<String>,
+    system: Option<AnthropicSystem>,
     messages: Vec<AnthropicMessage<'a>>,
     stream: bool,
 ) -> AnthropicRequest<'a> {
@@ -337,6 +450,20 @@ pub fn translate_openai_tools_to_anthropic(
             // `input_schema` verbatim — both are JSON Schema.
             if let Some(params) = function.get("parameters") {
                 anthropic_tool.insert("input_schema".into(), params.clone());
+            }
+            // Anthropic tools accept a `cache_control` prompt-cache
+            // marker on the tool entry
+            // (<https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>).
+            // OpenAI-shape callers attach it at the tool's top level or
+            // inside `function`; forward either spelling — tool
+            // definitions sit first in the prompt-cache prefix
+            // hierarchy, so a stripped marker silently disables the
+            // caller's whole caching strategy (AISIX-Cloud#1110 Gap A).
+            if let Some(cc) = t
+                .get("cache_control")
+                .or_else(|| function.get("cache_control"))
+            {
+                anthropic_tool.insert("cache_control".into(), cc.clone());
             }
             Some(serde_json::Value::Object(anthropic_tool))
         })
@@ -1738,8 +1865,10 @@ mod tests {
         );
         let (system, msgs) = split_system(&req).unwrap();
         assert_eq!(
-            system.as_deref(),
-            Some("you are helpful\n\nrespond concisely")
+            system,
+            Some(AnthropicSystem::Text(
+                "you are helpful\n\nrespond concisely".into()
+            ))
         );
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "user");
@@ -1930,6 +2059,210 @@ mod tests {
         assert_eq!(msgs[2].content.len(), 2);
         assert_eq!(msgs[2].content[0]["tool_use_id"], "t1");
         assert_eq!(msgs[2].content[1]["tool_use_id"], "t2");
+    }
+
+    /// Serialize a built request and return the JSON value of its
+    /// `system` field (Value::Null when absent) — the wire shape the
+    /// Anthropic upstream actually sees.
+    fn wire_system(req: &ChatFormat) -> serde_json::Value {
+        let (system, messages) = split_system(req).unwrap();
+        let built = build_request(req, "claude-sonnet-4-5", system, messages, false);
+        serde_json::to_value(&built).unwrap()["system"].clone()
+    }
+
+    /// ChatMessage carrying a typed content-block array, as produced by
+    /// deserializing the OpenAI array-form `content` (blocks land in
+    /// `content_blocks`, concatenated text in `content`).
+    fn block_message(role: Role, blocks: serde_json::Value) -> ChatMessage {
+        let raw = serde_json::json!({"role": role, "content": blocks});
+        serde_json::from_value(raw).unwrap()
+    }
+
+    #[test]
+    fn split_system_plain_system_messages_stay_string_on_the_wire() {
+        // Byte-stability pin: callers sending plain-string system
+        // messages must keep getting the exact string form the gateway
+        // has always emitted — the block-array form is reserved for
+        // callers that themselves sent typed blocks.
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::system("you are helpful"),
+                ChatMessage::system("respond concisely"),
+                ChatMessage::user("hi"),
+            ],
+        );
+        assert_eq!(
+            wire_system(&req),
+            serde_json::json!("you are helpful\n\nrespond concisely")
+        );
+    }
+
+    #[test]
+    fn split_system_preserves_cache_control_on_system_blocks() {
+        // A caller marking its system prompt for provider-side prompt
+        // caching sends array-form content with a `cache_control`
+        // marker. The marker must reach the upstream — flattening to
+        // the concatenated string silently strips it and the caller
+        // pays full input price every turn (AISIX-Cloud#1110 Gap A).
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                block_message(
+                    Role::System,
+                    serde_json::json!([
+                        {"type": "text", "text": "big stable prefix",
+                         "cache_control": {"type": "ephemeral"}},
+                    ]),
+                ),
+                ChatMessage::user("hi"),
+            ],
+        );
+        assert_eq!(
+            wire_system(&req),
+            serde_json::json!([
+                {"type": "text", "text": "big stable prefix",
+                 "cache_control": {"type": "ephemeral"}},
+            ])
+        );
+    }
+
+    #[test]
+    fn split_system_mixed_plain_and_block_system_messages_become_blocks() {
+        // One plain system message + one block-form system message:
+        // the whole system prompt goes to array form, the plain part
+        // becoming its own text block, order preserved.
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::system("you are helpful"),
+                block_message(
+                    Role::System,
+                    serde_json::json!([
+                        {"type": "text", "text": "cached tail",
+                         "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+                    ]),
+                ),
+                ChatMessage::user("hi"),
+            ],
+        );
+        assert_eq!(
+            wire_system(&req),
+            serde_json::json!([
+                {"type": "text", "text": "you are helpful"},
+                {"type": "text", "text": "cached tail",
+                 "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ])
+        );
+    }
+
+    #[test]
+    fn split_system_preserves_cache_control_on_user_content_blocks() {
+        // Per-block structure must survive: a marker on block 2 of 2
+        // means "cache through here" — concatenating the blocks into
+        // one loses the position along with the marker.
+        let req = ChatFormat::new(
+            "claude",
+            vec![block_message(
+                Role::User,
+                serde_json::json!([
+                    {"type": "text", "text": "conversation so far"},
+                    {"type": "text", "text": "latest turn",
+                     "cache_control": {"type": "ephemeral"}},
+                ]),
+            )],
+        );
+        let (_system, msgs) = split_system(&req).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[0].content.len(), 2);
+        assert_eq!(msgs[0].content[0]["text"], "conversation so far");
+        assert!(msgs[0].content[0].get("cache_control").is_none());
+        assert_eq!(
+            msgs[0].content[1]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+    }
+
+    #[test]
+    fn split_system_preserves_cache_control_on_assistant_content_blocks() {
+        // Markers on replayed assistant history turns must survive too
+        // — and tool_calls translation still appends its tool_use
+        // blocks after the text blocks.
+        let mut msg = block_message(
+            Role::Assistant,
+            serde_json::json!([
+                {"type": "text", "text": "prior answer",
+                 "cache_control": {"type": "ephemeral"}},
+            ]),
+        );
+        msg.extra.insert(
+            "tool_calls".into(),
+            serde_json::json!([{
+                "id": "t1", "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }]),
+        );
+        let req = ChatFormat::new("claude", vec![ChatMessage::user("hi"), msg]);
+        let (_system, msgs) = split_system(&req).unwrap();
+        assert_eq!(msgs[1].role, "assistant");
+        assert_eq!(msgs[1].content.len(), 2);
+        assert_eq!(
+            msgs[1].content[0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+        assert_eq!(msgs[1].content[1]["type"], "tool_use");
+    }
+
+    #[test]
+    fn user_message_with_only_non_text_blocks_degrades_to_empty_text_block() {
+        // Image-only content: non-text blocks are skipped on this
+        // bridge (documented cross-provider limitation), and the
+        // message must still carry a non-empty content array —
+        // Anthropic rejects `content: []`.
+        let req = ChatFormat::new(
+            "claude",
+            vec![block_message(
+                Role::User,
+                serde_json::json!([
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,xyz"}},
+                ]),
+            )],
+        );
+        let (_system, msgs) = split_system(&req).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(
+            msgs[0].content,
+            vec![serde_json::json!({"type": "text", "text": ""})]
+        );
+    }
+
+    #[test]
+    fn translate_tools_preserves_cache_control_marker() {
+        // Anthropic tools accept a `cache_control` marker on the tool
+        // entry; OpenAI-shape callers attach it at the tool's top
+        // level (or inside `function`). Both spellings must survive —
+        // tool definitions sit first in the prompt-cache prefix
+        // hierarchy, so a stripped marker silently disables the
+        // caller's whole caching strategy.
+        let tools = serde_json::json!([
+            {"type": "function",
+             "function": {"name": "a", "parameters": {"type": "object"}},
+             "cache_control": {"type": "ephemeral"}},
+            {"type": "function",
+             "function": {"name": "b", "cache_control": {"type": "ephemeral", "ttl": "1h"}}},
+            {"type": "function", "function": {"name": "c"}},
+        ]);
+        let translated = translate_openai_tools_to_anthropic(tools).unwrap();
+        assert_eq!(
+            translated[0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+        assert_eq!(
+            translated[1]["cache_control"],
+            serde_json::json!({"type": "ephemeral", "ttl": "1h"})
+        );
+        assert!(translated[2].get("cache_control").is_none());
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -131,17 +131,16 @@ impl<'a> AnthropicMessage<'a> {
     }
 
     /// Message content built from a caller's typed content blocks
-    /// ([`ChatMessage::content_blocks`]): text blocks forward verbatim —
-    /// OpenAI and Anthropic share the `{type:"text", text}` shape, and
-    /// block-level fields the caller attached (notably `cache_control`
-    /// prompt-cache markers) ride along unchanged. Flattening through the
+    /// ([`ChatMessage::content_blocks`]): text blocks map 1:1 — OpenAI
+    /// and Anthropic share the `{type:"text", text}` shape, and the
+    /// block-level fields Anthropic accepts (notably `cache_control`
+    /// prompt-cache markers) ride along in place. Flattening through the
     /// concatenated-text path would silently strip them (AISIX-Cloud#1110
-    /// Gap A). Non-text blocks (images/audio) are skipped — the same
-    /// cross-provider content limitation as the text path. Degrades to a
-    /// single empty text block when nothing survives, because Anthropic
-    /// rejects an empty `content` array.
+    /// Gap A); see [`anthropic_text_blocks`] for the per-block filter.
+    /// Degrades to a single empty text block when nothing survives,
+    /// because Anthropic rejects an empty `content` array.
     pub(crate) fn from_blocks(role: &'a str, blocks: &[serde_json::Value]) -> Self {
-        let mut content = text_blocks_verbatim(blocks);
+        let mut content = anthropic_text_blocks(blocks);
         if content.is_empty() {
             content.push(serde_json::json!({"type": "text", "text": ""}));
         }
@@ -158,8 +157,8 @@ impl<'a> AnthropicMessage<'a> {
     /// prior tool calls before sending the matching tool results; without
     /// translating `tool_calls` here the following `tool_result` would
     /// reference a `tool_use` the upstream never saw and 400. When the
-    /// caller sent typed content blocks, their text blocks forward
-    /// verbatim (preserving `cache_control` markers) instead of the
+    /// caller sent typed content blocks, their text blocks map 1:1
+    /// (preserving `cache_control` markers) instead of the
     /// flattened text. Empty content with no tool calls degrades to an
     /// empty text block so the message isn't dropped (Anthropic rejects
     /// an empty `content` array).
@@ -169,7 +168,7 @@ impl<'a> AnthropicMessage<'a> {
         tool_calls: Option<&[serde_json::Value]>,
     ) -> Self {
         let mut content: Vec<serde_json::Value> = match blocks {
-            Some(blocks) => text_blocks_verbatim(blocks),
+            Some(blocks) => anthropic_text_blocks(blocks),
             None => Vec::new(),
         };
         if content.is_empty() && !text.is_empty() {
@@ -190,15 +189,42 @@ impl<'a> AnthropicMessage<'a> {
 }
 
 /// Forward the `{type:"text", …}` blocks of an OpenAI-shape content
-/// array verbatim onto the Anthropic wire, preserving block-level
-/// fields such as `cache_control`. Non-text blocks are dropped —
-/// callers needing image/audio input on this bridge hit the documented
+/// array onto the Anthropic wire. Two guarantees per block:
+///
+/// * **Marker fidelity** — the fields Anthropic accepts on a text block
+///   (`text`, `cache_control`, `citations`) forward unchanged, so a
+///   caller's prompt-cache markers survive translation with their
+///   block positions intact.
+/// * **Clean-block guarantee** — everything else is dropped, matching
+///   what the flattened-text path always guaranteed: stray caller
+///   metadata (e.g. an OpenAI streaming `index` replayed from assembled
+///   history) 400s at Anthropic's strict request validator, and
+///   degenerate blocks (missing or whitespace-only `text`) are rejected
+///   per-block upstream — both previously vanished in the flatten, so
+///   forwarding them would break requests that worked before.
+///
+/// Non-text blocks (images/audio) are dropped — the documented
 /// cross-provider content limitation, unchanged by this helper.
-fn text_blocks_verbatim(blocks: &[serde_json::Value]) -> Vec<serde_json::Value> {
+fn anthropic_text_blocks(blocks: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    const KEEP: &[&str] = &["type", "text", "cache_control", "citations"];
     blocks
         .iter()
         .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
-        .cloned()
+        .filter(|b| {
+            b.get("text")
+                .and_then(|t| t.as_str())
+                .is_some_and(|t| !t.trim().is_empty())
+        })
+        .map(|b| {
+            let kept: serde_json::Map<String, serde_json::Value> = b
+                .as_object()
+                .into_iter()
+                .flatten()
+                .filter(|(k, _)| KEEP.contains(&k.as_str()))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            serde_json::Value::Object(kept)
+        })
         .collect()
 }
 
@@ -366,7 +392,7 @@ fn build_system(system_msgs: &[&ChatMessage]) -> Option<AnthropicSystem> {
     let blocks: Vec<serde_json::Value> = system_msgs
         .iter()
         .flat_map(|m| match m.content_blocks.as_deref() {
-            Some(blocks) => text_blocks_verbatim(blocks),
+            Some(blocks) => anthropic_text_blocks(blocks),
             None => vec![serde_json::json!({"type": "text", "text": m.content_str()})],
         })
         .collect();
@@ -2234,6 +2260,63 @@ mod tests {
         assert_eq!(
             msgs[0].content,
             vec![serde_json::json!({"type": "text", "text": ""})]
+        );
+    }
+
+    #[test]
+    fn split_system_drops_degenerate_text_blocks_but_keeps_marked_ones() {
+        // Empty / missing-text segments are common from templating code
+        // and vanished in the old flatten; Anthropic rejects them
+        // per-block, so forwarding them would 400 requests that worked
+        // before. They must be filtered while the marked block survives.
+        let req = ChatFormat::new(
+            "claude",
+            vec![block_message(
+                Role::User,
+                serde_json::json!([
+                    {"type": "text", "text": ""},
+                    {"type": "text"},
+                    {"type": "text", "text": "   "},
+                    {"type": "text", "text": "hi",
+                     "cache_control": {"type": "ephemeral"}},
+                ]),
+            )],
+        );
+        let (_system, msgs) = split_system(&req).unwrap();
+        assert_eq!(
+            msgs[0].content,
+            vec![serde_json::json!({
+                "type": "text", "text": "hi",
+                "cache_control": {"type": "ephemeral"},
+            })]
+        );
+    }
+
+    #[test]
+    fn split_system_strips_stray_fields_from_forwarded_blocks() {
+        // Callers built against lax OpenAI-compatible upstreams replay
+        // assembled history carrying per-part metadata (e.g. a
+        // streaming `index`). Anthropic's strict validator rejects
+        // unknown block fields, and the old flatten path absorbed them
+        // — only the fields Anthropic accepts may forward.
+        let req = ChatFormat::new(
+            "claude",
+            vec![block_message(
+                Role::User,
+                serde_json::json!([
+                    {"type": "text", "text": "hi", "index": 0,
+                     "annotations": [],
+                     "cache_control": {"type": "ephemeral"}},
+                ]),
+            )],
+        );
+        let (_system, msgs) = split_system(&req).unwrap();
+        assert_eq!(
+            msgs[0].content,
+            vec![serde_json::json!({
+                "type": "text", "text": "hi",
+                "cache_control": {"type": "ephemeral"},
+            })]
         );
     }
 

--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -3,6 +3,7 @@ import OpenAI from "openai";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
@@ -396,5 +397,166 @@ describe("anthropic upstream e2e: cache tokens fold into total_tokens (#906)", (
     expect(completion.usage?.prompt_tokens).toBe(10);
     expect(completion.usage?.completion_tokens).toBe(4);
     expect(completion.usage?.total_tokens).toBe(10 + 4 + 200 + 800);
+  });
+});
+
+// E2E (AISIX-Cloud#1110 Gap A): a caller managing its own provider-side
+// prompt caching attaches `cache_control` markers to content blocks (and
+// tool definitions) in the OpenAI shape. Those markers MUST reach the
+// Anthropic upstream — a translation that flattens blocks to
+// concatenated text silently strips them, the upstream caches nothing,
+// and the caller pays full input price every turn while believing its
+// caching strategy is active. Marker shape per
+// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>.
+const CC_CALLER_PLAINTEXT = "sk-an-e2e-cachectl-caller";
+const CC_CALLER_KEY_HASH = createHash("sha256")
+  .update(CC_CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("anthropic upstream e2e: client cache_control markers survive translation", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_cc_01",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        model: "claude-3-5-haiku-20241022",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 5, output_tokens: 1 },
+      },
+    });
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "an-e2e-cachectl-pk",
+      provider: "anthropic",
+      adapter: "anthropic",
+      secret: "sk-ant-mock",
+      api_base: upstream.baseUrl,
+    });
+    await seed.createModel({
+      display_name: "an-e2e-cachectl",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CC_CALLER_KEY_HASH,
+      allowed_models: ["an-e2e-cachectl"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("system/message/tool cache_control markers reach the upstream body", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const proxy = new ProxyClient(app.proxyUrl, CC_CALLER_PLAINTEXT);
+
+    await waitConfigPropagation(async () => {
+      const r = await proxy.chat({
+        model: "an-e2e-cachectl",
+        messages: [{ role: "user", content: "ready-probe" }],
+      });
+      return r.status === 200;
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    const { status } = await proxy.chat({
+      model: "an-e2e-cachectl",
+      messages: [
+        {
+          role: "system",
+          content: [
+            {
+              type: "text",
+              text: "big stable system prefix",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "conversation history" },
+            {
+              type: "text",
+              text: "latest question",
+              cache_control: { type: "ephemeral", ttl: "1h" },
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            parameters: { type: "object", properties: {} },
+          },
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    });
+    expect(status).toBe(200);
+
+    const messagesReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path.startsWith("/v1/messages"));
+    expect(messagesReq).toBeDefined();
+    const sentBody = JSON.parse(messagesReq!.body) as {
+      system?: unknown;
+      messages?: Array<{ role?: string; content?: unknown }>;
+      tools?: Array<Record<string, unknown>>;
+    };
+
+    // System marker: the block-form system prompt must go out as
+    // Anthropic's block-array `system`, marker intact — not flattened
+    // to a plain string.
+    expect(sentBody.system).toEqual([
+      {
+        type: "text",
+        text: "big stable system prefix",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+
+    // Message markers: per-block structure preserved (2 blocks stay 2
+    // blocks — a marker means "cache through here", so its position is
+    // the payload), marker on the block the caller marked, TTL intact.
+    expect(sentBody.messages?.[0]?.role).toBe("user");
+    expect(sentBody.messages?.[0]?.content).toEqual([
+      { type: "text", text: "conversation history" },
+      {
+        type: "text",
+        text: "latest question",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
+
+    // Tool marker: tool definitions sit first in the prompt-cache
+    // prefix hierarchy; the marker must ride the translated tool.
+    expect(sentBody.tools?.[0]).toMatchObject({
+      name: "get_weather",
+      cache_control: { type: "ephemeral" },
+    });
   });
 });

--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -126,7 +126,10 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
 
     const completion = await client.chat.completions.create({
       model: "an-e2e",
-      messages: [{ role: "user", content: "hi" }],
+      messages: [
+        { role: "system", content: "you are terse" },
+        { role: "user", content: "hi" },
+      ],
     });
 
     // Response wire shape: must be OpenAI-shaped on the way out.
@@ -159,11 +162,19 @@ describe("anthropic upstream e2e: OpenAI in, Anthropic out, OpenAI back to calle
     const sentBody = JSON.parse(messagesReq!.body) as {
       model?: string;
       max_tokens?: unknown;
+      system?: unknown;
       messages?: Array<{ role?: string; content?: unknown }>;
     };
     // model_name from the Model resource (Anthropic's id), not the
     // gateway's display_name "an-e2e".
     expect(sentBody.model).toBe("claude-3-5-haiku-20241022");
+    // A plain-string system message must go out in Anthropic's STRING
+    // `system` form — byte-identical to what the gateway has always
+    // sent. The block-array form is reserved for callers that sent
+    // typed blocks themselves (covered by the cache_control scenario
+    // below); flipping plain-text callers to array form would change
+    // the wire bytes for every existing caller.
+    expect(sentBody.system).toBe("you are terse");
     // Anthropic's API requires `max_tokens`; OpenAI's doesn't. The
     // gateway must inject a value when crossing the boundary.
     expect(typeof sentBody.max_tokens).toBe("number");
@@ -499,7 +510,31 @@ describe("anthropic upstream e2e: client cache_control markers survive translati
             { type: "text", text: "conversation history" },
             {
               type: "text",
+              text: "first question",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "prior answer",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
               text: "latest question",
+              // Stray per-part metadata (an OpenAI streaming index
+              // replayed from assembled history) must NOT reach the
+              // strict Anthropic validator.
+              index: 0,
               cache_control: { type: "ephemeral", ttl: "1h" },
             },
           ],
@@ -539,12 +574,31 @@ describe("anthropic upstream e2e: client cache_control markers survive translati
       },
     ]);
 
-    // Message markers: per-block structure preserved (2 blocks stay 2
-    // blocks — a marker means "cache through here", so its position is
-    // the payload), marker on the block the caller marked, TTL intact.
+    // Message markers on EVERY turn, not just the first: per-block
+    // structure preserved (2 blocks stay 2 blocks — a marker means
+    // "cache through here", so its position is the payload), markers on
+    // user AND replayed-assistant turns, TTL intact, and the stray
+    // `index` field stripped before the strict upstream validator.
+    expect(sentBody.messages).toHaveLength(3);
     expect(sentBody.messages?.[0]?.role).toBe("user");
     expect(sentBody.messages?.[0]?.content).toEqual([
       { type: "text", text: "conversation history" },
+      {
+        type: "text",
+        text: "first question",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+    expect(sentBody.messages?.[1]?.role).toBe("assistant");
+    expect(sentBody.messages?.[1]?.content).toEqual([
+      {
+        type: "text",
+        text: "prior answer",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+    expect(sentBody.messages?.[2]?.role).toBe("user");
+    expect(sentBody.messages?.[2]?.content).toEqual([
       {
         type: "text",
         text: "latest question",
@@ -552,11 +606,17 @@ describe("anthropic upstream e2e: client cache_control markers survive translati
       },
     ]);
 
-    // Tool marker: tool definitions sit first in the prompt-cache
-    // prefix hierarchy; the marker must ride the translated tool.
-    expect(sentBody.tools?.[0]).toMatchObject({
-      name: "get_weather",
-      cache_control: { type: "ephemeral" },
-    });
+    // Tool translation, exact shape: Anthropic's `{name, input_schema}`
+    // — no OpenAI `type`/`function` wrapper riding along (the strict
+    // upstream rejects unknown tool fields), `input_schema` translated
+    // from `parameters`, marker intact. Tool definitions sit first in
+    // the prompt-cache prefix hierarchy.
+    expect(sentBody.tools).toEqual([
+      {
+        name: "get_weather",
+        input_schema: { type: "object", properties: {} },
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## What

Client-supplied `cache_control` prompt-cache markers now survive the OpenAI→Anthropic bridge translation. Previously the bridge flattened every message through the concatenated-text path (`content_str()`) and rebuilt content as fresh `{"type":"text"}` blocks, silently stripping the markers a caller attached to its system prompt, message blocks, or tool definitions — the upstream cached nothing while the caller believed its caching strategy was active, paying full input price every turn.

Phase 0 of the prompt-caching work tracked in AISIX-Cloud#1110 (Gap A).

## Changes

- **`AnthropicSystem` enum** (`wire.rs`): the top-level `system` field is now `string | block-array`, per Anthropic's documented equivalence ([Messages API — system](https://docs.anthropic.com/en/api/messages)). All-plain-text system messages keep the historical `"\n\n"`-joined **string form byte-for-byte**; the block-array form is emitted only when a caller's system message itself carried typed blocks.
- **Message content blocks map 1:1**: when a caller sent array-form content, its `{type:"text", …}` blocks now map 1:1 onto the Anthropic wire — block-level fields and block *positions* ride along (a marker means "cache through here", so its position is the payload). Two per-block guarantees, preserving what the old flatten path guaranteed implicitly:
  - **Marker fidelity**: the fields Anthropic accepts on a text block (`text`, `cache_control`, `citations`) forward unchanged.
  - **Clean-block guarantee**: everything else is stripped — stray caller metadata (e.g. an OpenAI streaming `index` replayed from assembled history) would 400 at Anthropic's strict request validator, and degenerate blocks (missing or whitespace-only `text`) are rejected per-block upstream; both vanished in the old flatten, so forwarding them would break requests that worked before.

  Non-text blocks (images/audio) are still skipped — the pre-existing, documented cross-provider content limitation, unchanged. Empty survivors degrade to a single empty text block (Anthropic rejects `content: []`).
- **Tool definitions preserve `cache_control`** (`translate_openai_tools_to_anthropic`): callers attach the marker at the tool's top level or inside `function`; either spelling is forwarded. Tool definitions sit first in the prompt-cache prefix hierarchy (tools → system → messages, per the [prompt-caching doc](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)), so a stripped tool marker disables the caller's whole cache.

**Chokepoint coverage — precise scope**: `split_system` + `build_request` serve the OpenAI-shape bridge to three upstream families — Anthropic direct, Bedrock Anthropic-invoke (`chat_anthropic`), and Vertex Anthropic `:rawPredict`/`:streamRawPredict` — so **OpenAI-shape `/v1/chat/completions` callers** routed to any of them keep their markers. Two entry points do **not** yet benefit, because their ingress flattens block structure *before* the chokepoint (pre-existing, unchanged by this PR): the `/v1/responses` input translation (`responses_bridge.rs` builds every message with `content_blocks: None`) and the native `/v1/messages` inbound parse when bridged cross-provider to Bedrock/Vertex Claude (`parse_inbound_request` rebuilds clean blocks). Both are tracked as Phase-0 follow-ups in AISIX-Cloud#1110. The native `/v1/messages` **passthrough** (direct Anthropic upstream) already preserved these fields byte-for-byte and is untouched.

## Ecosystem comparison (per repo rule 7)

Marker-stripping in the OpenAI→Anthropic transform is a recurring bug class across mainstream AI gateways: among the gateways surveyed, one shipped and fixed exactly this drop on a model-ID edge case, one still drops the caller's TTL on its transformed route (with an open issue for markers vanishing on a second provider path), and one drops markers entirely on its OpenAI-format path while supporting them elsewhere. Gateways that avoid the class do so the way this PR does: forward the caller's typed blocks verbatim instead of rebuilding content from flattened text. Our design lands on verbatim block forwarding for `type:"text"` blocks only, keeping the string-form `system` byte-stable when no blocks were sent — a divergence from gateways that always emit array form, chosen to keep existing traffic's wire bytes (and any provider-side cache prefixes built on them) unchanged.

## Testing

- `wire.rs` unit tests (7 new): system-marker preservation (pure/mixed), user/assistant block preservation incl. positions, image-only degrade invariant, tool markers (both spellings + absence), byte-stability pin for the plain-string `system` form.
- e2e (`anthropic-upstream-e2e.test.ts`, new scenario): black-box wire-shape assertion — OpenAI-shape request in, captured gateway→upstream `/v1/messages` body must carry the markers on system (block-array form), the exact marked message block (with `ttl`), and the translated tool.
- Full workspace `cargo test` + full local e2e suite green; `cargo fmt` + clippy clean.

## Deliberately out of scope

- **Injection** of gateway-authored breakpoints (that's AISIX-Cloud#1110 Phase 1 — this PR is the fidelity prerequisite).
- Markers inside `role:"tool"` (tool_result) message content — no clean OpenAI-shape spelling exists for that position; the flattened-string path there is unchanged.
- Non-text block translation (vision on this bridge) — pre-existing limitation, tracked separately.
- Bedrock Converse `cachePoint` (streaming path) — AISIX-Cloud#1110 Phase 2.
- `/v1/responses` ingress and native-`/v1/messages`-cross-provider ingress marker preservation — flattened upstream of this chokepoint; Phase-0 follow-ups in AISIX-Cloud#1110 (see coverage scope above).
- TTL validity per upstream: a forwarded `ttl:"1h"` marker reaches Bedrock-invoke/Vertex models that may support only the 5-minute tier — the marker is the caller's own request content and per-model TTL gating belongs to the Phase-1 injector (AISIX-Cloud#1110), not to pass-through fidelity.

## Audit round

An independent multi-angle cold audit (12 confirmed findings) drove three changes after the initial push: (1) the per-block whitelist + degenerate-block filter above — the initial verbatim clone would have forwarded empty text blocks and stray caller metadata that Anthropic's strict validator 400s, breaking previously-working array-form traffic; (2) e2e strengthened — exact tool-shape equality (no OpenAI wrapper leakage, `input_schema` presence), markers asserted on every turn incl. replayed-assistant blocks, message-count pin, stray-field strip, and a plain-string `system` byte-stability assertion on the live wire; (3) this coverage-scope section corrected — the initial body overclaimed `/v1/responses` benefit and omitted the Vertex paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Preserved typed content blocks and metadata when translating requests to Anthropic.
  - Improved system prompt handling to support both plain text and structured, typed block formats while keeping plain-text behavior unchanged.
  - Ensured `cache_control` markers are carried through for system content, message blocks, and translated tool/function definitions.

- **Tests**
  - Extended Anthropic upstream E2E coverage to validate structured system content, metadata/TTL preservation, safe handling when no usable text blocks remain, and correct tool translation shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->