### PR TITLE
fix(passthrough): enforce the body model's rate limit on the raw tunnel

### DIFF
--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -2565,6 +2565,152 @@ data: [DONE]\n\n"
         assert_eq!(v["error"]["type"], "rate_limit_exceeded");
     }
 
+    // ---- regression coverage for api7/AISIX-Cloud#1116 --------------
+    // Pre-fix the passthrough tunnel passed `None` to quota::enforce, so
+    // a Model's inline rate_limit (and model-scope policies) never
+    // applied to passthrough traffic — for provider endpoints with no
+    // typed surface (e.g. video generation) the model limit was
+    // unenforceable everywhere. Post-fix the top-level `model` field of
+    // a JSON passthrough body is matched against the addressed
+    // provider's configured Models and its limits reserved like the
+    // typed endpoints.
+
+    fn model_entry_with_rate_limit(
+        name: &str,
+        rate_limit: serde_json::Value,
+    ) -> ResourceEntry<Model> {
+        let cfg = format!(
+            r#"{{
+                "display_name": "{name}",
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "{PK_ID}",
+                "rate_limit": {rate_limit}
+            }}"#
+        );
+        let model: Model = serde_json::from_str(&cfg).unwrap();
+        ResourceEntry::new("model-id-1", model, 1)
+    }
+
+    #[tokio::test]
+    async fn passthrough_enforces_model_rate_limit_from_body_model_field() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/api/v1/services/aigc/video-generation/video-synthesis",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output": {"task_id": "t-1", "task_status": "PENDING"}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry_with_rate_limit(
+            "my-video-model",
+            serde_json::json!({"rpm": 1}),
+        ));
+        snap.apikeys
+            .insert(apikey_entry("sk-caller", &["my-video-model"]));
+        let state = build_state(snap, hub);
+
+        let body = serde_json::json!({
+            "model": "my-video-model",
+            "input": {"prompt": "a cardboard city at night"},
+            "parameters": {"resolution": "720P"}
+        });
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/passthrough/openai/api/v1/services/aigc/video-generation/video-synthesis")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        // First request consumes the model's only RPM slot.
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Pre-fix: 200 again (model layer skipped on passthrough).
+        // Post-fix: 429 — the body's `model` resolved the configured
+        // Model and its rpm=1 cap now gates the tunnel.
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "passthrough must enforce the body model's rate limit (api7/AISIX-Cloud#1116)",
+        );
+        let body_bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(v["error"]["type"], "rate_limit_exceeded");
+    }
+
+    #[tokio::test]
+    async fn passthrough_unregistered_or_absent_body_model_keeps_key_layer_only() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/anything"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        // Model has rpm=1, but requests below never name it — its bucket
+        // must stay untouched. The API key carries rpm=2 to pin that the
+        // key layer still gates the tunnel (and 429s on the 3rd call).
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry_with_rate_limit(
+            "my-video-model",
+            serde_json::json!({"rpm": 1}),
+        ));
+        snap.apikeys.insert(apikey_entry_with_limits(
+            "sk-caller",
+            &["my-video-model"],
+            Some(serde_json::json!({"rpm": 2})),
+        ));
+        let state = build_state(snap, hub);
+
+        let make_req = |body: &'static str| {
+            Request::builder()
+                .method("POST")
+                .uri("/passthrough/openai/anything")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap()
+        };
+
+        // Unregistered model name → no model-layer reservation, passes.
+        let resp = run(
+            build_router(state.clone()),
+            make_req(r#"{"model":"not-a-configured-model","input":"x"}"#),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Non-JSON body → tolerated, no model-layer reservation.
+        let resp = run(build_router(state.clone()), make_req("plain text body")).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Third call trips the KEY-level rpm=2 — the request-level
+        // layers keep gating the tunnel exactly as before the fix.
+        let resp = run(
+            build_router(state.clone()),
+            make_req(r#"{"model":"not-a-configured-model","input":"x"}"#),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "key-level rate limit must keep applying to passthrough",
+        );
+    }
+
     /// Regression for issue #108: streaming chat used to commit
     /// `0` tokens up front and never look at the upstream's terminal
     /// usage frame. TPM caps were silently bypassed for all streaming

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -2579,11 +2579,19 @@ data: [DONE]\n\n"
         name: &str,
         rate_limit: serde_json::Value,
     ) -> ResourceEntry<Model> {
+        model_entry_named(name, "gpt-4o", rate_limit)
+    }
+
+    fn model_entry_named(
+        display_name: &str,
+        model_name: &str,
+        rate_limit: serde_json::Value,
+    ) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
-                "display_name": "{name}",
+                "display_name": "{display_name}",
                 "provider": "openai",
-                "model_name": "gpt-4o",
+                "model_name": "{model_name}",
                 "provider_key_id": "{PK_ID}",
                 "rate_limit": {rate_limit}
             }}"#
@@ -2709,6 +2717,165 @@ data: [DONE]\n\n"
             StatusCode::TOO_MANY_REQUESTS,
             "key-level rate limit must keep applying to passthrough",
         );
+    }
+
+    /// A `model`-scope RateLimitPolicy row (no inline rate_limit on the
+    /// Model) must gate the tunnel too — the policy path matches by the
+    /// resolved entry id, which is only exercised when the body model
+    /// lookup propagates it.
+    #[tokio::test]
+    async fn passthrough_enforces_model_scope_policy_from_body_model_field() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/anything"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("my-video-model"));
+        snap.rate_limit_policies.insert(ResourceEntry::new(
+            "pol-1",
+            serde_json::from_value(serde_json::json!({
+                "name": "video-cap",
+                "scope": "model",
+                "scope_ref": "model-id-1",
+                "window": "minute",
+                "max_requests": 1
+            }))
+            .unwrap(),
+            1,
+        ));
+        snap.apikeys
+            .insert(apikey_entry("sk-caller", &["my-video-model"]));
+        let state = build_state(snap, hub);
+
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/passthrough/openai/anything")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"model":"my-video-model","input":"x"}"#))
+                .unwrap()
+        };
+
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "model-scope policy must gate passthrough via the body model",
+        );
+    }
+
+    /// The tunnel forwards bodies verbatim, so callers typically name the
+    /// provider-native id (`model_name`), not the gateway alias
+    /// (`display_name`). The limit must bind either way, and the bucket is
+    /// keyed by the alias so tunnel and typed traffic share one budget.
+    #[tokio::test]
+    async fn passthrough_matches_provider_native_model_name_for_rate_limit() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/anything"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry_named(
+            "ali-video-alias",
+            "happyhorse-1.1-t2v",
+            serde_json::json!({"rpm": 1}),
+        ));
+        snap.apikeys
+            .insert(apikey_entry("sk-caller", &["ali-video-alias"]));
+        let state = build_state(snap, hub);
+
+        // Caller names the upstream id, not the alias — the alias's cap
+        // must still bind.
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/passthrough/openai/anything")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"model":"happyhorse-1.1-t2v","input":"x"}"#))
+                .unwrap()
+        };
+
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "provider-native model_name must resolve the Model's rate limit",
+        );
+    }
+
+    /// A same-named Model registered under a DIFFERENT provider must not
+    /// be charged for this tunnel's traffic: the body name only matches
+    /// within the addressed provider.
+    #[tokio::test]
+    async fn passthrough_same_named_model_of_other_provider_is_not_limited() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/anything"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        // Credential-lending model for the addressed provider — unlimited.
+        snap.models.insert(model_entry("openai-lender"));
+        // Same body-name model under another provider, rpm=1. Its bucket
+        // must stay untouched by /passthrough/openai traffic.
+        let cross: Model = serde_json::from_str(&format!(
+            r#"{{
+                "display_name": "cross-model",
+                "provider": "anthropic",
+                "model_name": "cross-model",
+                "provider_key_id": "{PK_ID}",
+                "rate_limit": {{"rpm": 1}}
+            }}"#
+        ))
+        .unwrap();
+        snap.models
+            .insert(ResourceEntry::new("model-id-cross", cross, 1));
+        snap.apikeys
+            .insert(apikey_entry("sk-caller", &["openai-lender", "cross-model"]));
+        let state = build_state(snap, hub);
+
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/passthrough/openai/anything")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"model":"cross-model","input":"x"}"#))
+                .unwrap()
+        };
+
+        // Both calls pass: the anthropic model's rpm=1 bucket is never
+        // drawn from by the openai tunnel.
+        for _ in 0..2 {
+            let resp = run(build_router(state.clone()), make_req()).await;
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "cross-provider same-named model must not gate this tunnel",
+            );
+        }
     }
 
     /// Regression for issue #108: streaming chat used to commit

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -581,31 +581,58 @@ async fn dispatch(
 /// Model-level rate-limit identity for a passthrough request, resolved from
 /// the JSON body's top-level `model` field (api7/AISIX-Cloud#1116).
 ///
+/// The name is matched against the addressed provider's configured Models
+/// twice over: an exact `display_name` hit first (the gateway alias), then
+/// the provider-native `model_name` — the tunnel forwards bodies verbatim,
+/// so callers typically name the upstream id, not the gateway alias. Either
+/// way the reservation is keyed by the entry's `display_name`, so tunnel
+/// and typed traffic to the same Model draw from one bucket.
+///
 /// Returns `None` when the body is not JSON, carries no string `model`
-/// field, or the name doesn't match a configured Model of the addressed
-/// provider — the request then reserves only the request-level layers,
-/// mirroring the pre-fix behavior. The provider constraint keeps a
-/// same-named Model of a different provider from being charged for this
-/// tunnel's traffic. Exact `display_name` match only: wildcard Models are
-/// a typed-endpoint resolution feature, not replicated here.
+/// field, or nothing matches within the addressed provider — the request
+/// then reserves only the request-level layers, mirroring the pre-fix
+/// behavior. A same-named Model of a different provider never matches.
+/// Wildcard (`*`) display names are a typed-endpoint resolution feature,
+/// not replicated here.
 fn body_model_rate_limit(
     snapshot: &aisix_core::AisixSnapshot,
     provider_lower: &str,
     body: &[u8],
 ) -> Option<crate::quota::ModelRateLimit> {
-    let parsed: serde_json::Value = serde_json::from_slice(body).ok()?;
-    let name = parsed.get("model")?.as_str()?;
-    let entry = snapshot.models.get_by_name(name)?;
-    if !entry
-        .value
-        .provider
-        .as_deref()
-        .is_some_and(|p| p.eq_ignore_ascii_case(provider_lower))
-    {
-        return None;
+    // Field probe, not a full `Value` DOM: unknown fields are skipped
+    // without allocating, so a large tunnel body costs one `String` here,
+    // not a parsed copy of itself. A non-string `model` fails the whole
+    // deserialize and lands on the same `None` fallback.
+    #[derive(serde::Deserialize)]
+    struct BodyModelProbe {
+        model: Option<String>,
     }
+    let name = serde_json::from_slice::<BodyModelProbe>(body).ok()?.model?;
+    let matches_provider = |m: &aisix_core::Model| {
+        m.provider
+            .as_deref()
+            .is_some_and(|p| p.eq_ignore_ascii_case(provider_lower))
+    };
+    let entry = snapshot
+        .models
+        .get_by_name(&name)
+        .filter(|e| matches_provider(&e.value))
+        .or_else(|| {
+            // Provider-native id fallback. `min_by_key` keeps the pick
+            // deterministic when several Models pin the same upstream id.
+            snapshot
+                .models
+                .entries()
+                .into_iter()
+                .filter(|e| {
+                    matches_provider(&e.value)
+                        && e.value.model_name.as_deref() == Some(name.as_str())
+                        && !e.value.display_name.contains('*')
+                })
+                .min_by_key(|e| e.id.clone())
+        })?;
     Some(crate::quota::ModelRateLimit::from_model(
-        name,
+        &entry.value.display_name,
         &entry.id,
         &entry.value,
     ))

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -392,9 +392,21 @@ async fn dispatch(
     }
 
     // Reserve the rate-limit layers AFTER the input guardrail so a content
-    // block doesn't burn an RPM slot, matching the typed endpoints. Passthrough
-    // has no resolved model, so only the api-key/team/member layers apply.
-    let _reservation = crate::quota::enforce(&state, auth, None).await?;
+    // block doesn't burn an RPM slot, matching the typed endpoints.
+    //
+    // api7/AISIX-Cloud#1116: provider-native JSON envelopes carry the target
+    // model in a top-level `model` field (the shape shared by OpenAI-compatible
+    // and DashScope-style bodies). When that name is a configured Model of the
+    // addressed provider, reserve its model-level layers (inline `rate_limit`
+    // + `model`-scope policies) exactly like the typed endpoints — pre-fix the
+    // raw tunnel skipped them entirely, so e.g. a video model reachable only
+    // through passthrough had no enforceable model rate limit anywhere.
+    // Non-JSON bodies, bodies without a `model` field, and unregistered names
+    // keep the previous behavior: request-level layers only. The tunnel never
+    // parses usage (tokens stay 0), so only the request-count dimensions
+    // (rps/rpm/rph) ever draw from the model buckets here.
+    let model_rl = body_model_rate_limit(&snapshot, &provider_lower, &body_bytes);
+    let _reservation = crate::quota::enforce(&state, auth, model_rl.as_ref()).await?;
 
     let client = crate::http_client::client();
     let mut builder = client.request(method.clone(), &url);
@@ -564,6 +576,39 @@ async fn dispatch(
     }
 
     Ok((response, provider_lower, pk_entry.id.to_string()))
+}
+
+/// Model-level rate-limit identity for a passthrough request, resolved from
+/// the JSON body's top-level `model` field (api7/AISIX-Cloud#1116).
+///
+/// Returns `None` when the body is not JSON, carries no string `model`
+/// field, or the name doesn't match a configured Model of the addressed
+/// provider — the request then reserves only the request-level layers,
+/// mirroring the pre-fix behavior. The provider constraint keeps a
+/// same-named Model of a different provider from being charged for this
+/// tunnel's traffic. Exact `display_name` match only: wildcard Models are
+/// a typed-endpoint resolution feature, not replicated here.
+fn body_model_rate_limit(
+    snapshot: &aisix_core::AisixSnapshot,
+    provider_lower: &str,
+    body: &[u8],
+) -> Option<crate::quota::ModelRateLimit> {
+    let parsed: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let name = parsed.get("model")?.as_str()?;
+    let entry = snapshot.models.get_by_name(name)?;
+    if !entry
+        .value
+        .provider
+        .as_deref()
+        .is_some_and(|p| p.eq_ignore_ascii_case(provider_lower))
+    {
+        return None;
+    }
+    Some(crate::quota::ModelRateLimit::from_model(
+        name,
+        &entry.id,
+        &entry.value,
+    ))
 }
 
 /// #699: push one zero-token `UsageEvent` per passthrough request onto the

--- a/tests/e2e/src/cases/passthrough-model-rate-limit-e2e.test.ts
+++ b/tests/e2e/src/cases/passthrough-model-rate-limit-e2e.test.ts
@@ -148,6 +148,7 @@ describe("passthrough e2e: body-model rate limiting on the raw tunnel", () => {
 
     // Second submission must be rejected by the gateway — NOT reach
     // the upstream — with the standard rate-limit envelope.
+    const upstreamCallsBefore = upstreams[0]!.receivedRequests.length;
     const second = await callSynth(VIDEO_MODEL);
     expect(second.status).toBe(429);
     expect(second.headers.get("retry-after")).toBeTruthy();
@@ -155,6 +156,8 @@ describe("passthrough e2e: body-model rate limiting on the raw tunnel", () => {
       error?: { type?: unknown };
     };
     expect(err.error?.type).toBe("rate_limit_exceeded");
+    // The 429 was produced by the gateway: no upstream round-trip.
+    expect(upstreams[0]!.receivedRequests.length).toBe(upstreamCallsBefore);
 
     // Task polling — the second half of the provider's async journey —
     // is a bodyless GET carrying no `model` field, so the exhausted

--- a/tests/e2e/src/cases/passthrough-model-rate-limit-e2e.test.ts
+++ b/tests/e2e/src/cases/passthrough-model-rate-limit-e2e.test.ts
@@ -155,6 +155,20 @@ describe("passthrough e2e: body-model rate limiting on the raw tunnel", () => {
       error?: { type?: unknown };
     };
     expect(err.error?.type).toBe("rate_limit_exceeded");
+
+    // Task polling — the second half of the provider's async journey —
+    // is a bodyless GET carrying no `model` field, so the exhausted
+    // model bucket must NOT block it. A client that submitted a task
+    // right before hitting the cap must still be able to poll it to
+    // completion.
+    for (let i = 0; i < 3; i += 1) {
+      const poll = await fetch(
+        `${app!.proxyUrl}/passthrough/alibaba/api/v1/tasks/task-pt-rl-01`,
+        { method: "GET", headers: { authorization: headers.authorization } },
+      );
+      expect(poll.status).toBe(200);
+      await poll.text();
+    }
   });
 
   test("unregistered body model: repeated calls keep flowing (no model-layer cap)", async (ctx) => {

--- a/tests/e2e/src/cases/passthrough-model-rate-limit-e2e.test.ts
+++ b/tests/e2e/src/cases/passthrough-model-rate-limit-e2e.test.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: model-level rate limiting on /passthrough/{provider}/*rest.
+//
+// User journey (verbatim from a field report): an operator registers a
+// provider-native video model — reachable ONLY through passthrough,
+// since video generation has no typed endpoint — sets `rate_limit`
+// `{rpm: 1}` on the Model, and calls the provider's native
+// video-synthesis endpoint through the tunnel. The gateway must count
+// those calls against the model's cap and 429 past it. Pre-fix the
+// tunnel enforced only the API-key-level layers, so a model cap
+// configured in the dashboard was silently ignored — for
+// passthrough-only models that meant no enforceable model limit
+// anywhere in the product.
+//
+// The target model is identified from the JSON body's top-level
+// `model` field — the envelope shared by OpenAI-compatible bodies and
+// provider-native ones (e.g. the `model` + `input` + `parameters`
+// shape of Alibaba Model Studio's video/image synthesis APIs, see
+// <https://help.aliyun.com/zh/model-studio/text-to-image-v2-api-reference>).
+//
+// Two journeys pinned:
+//
+//   1. Registered body model → the Model's rpm cap gates the tunnel:
+//      request #2 inside the window is 429 `rate_limit_exceeded`
+//      with a Retry-After header.
+//   2. Unregistered body model → no model-layer cap applies; repeated
+//      calls keep flowing (the key-level layers, unset here, remain
+//      the only gate — pre-fix behavior preserved).
+
+const CALLER_PLAINTEXT = "sk-pt-mrl-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const VIDEO_MODEL = "pt-rl-video-model";
+const SYNTH_PATH = "api/v1/services/aigc/video-generation/video-synthesis";
+
+describe("passthrough e2e: body-model rate limiting on the raw tunnel", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  const headers = {
+    authorization: `Bearer ${CALLER_PLAINTEXT}`,
+    "content-type": "application/json",
+  };
+
+  const synthBody = (model: string) =>
+    JSON.stringify({
+      model,
+      input: { prompt: "a cardboard city at night" },
+      parameters: { resolution: "720P", duration: 5 },
+    });
+
+  const callSynth = async (model: string) =>
+    fetch(`${app!.proxyUrl}/passthrough/alibaba/${SYNTH_PATH}`, {
+      method: "POST",
+      headers,
+      body: synthBody(model),
+    });
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        output: { task_id: "task-pt-rl-01", task_status: "PENDING" },
+        request_id: "req-pt-rl-01",
+      },
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pt-rl-alibaba-pk",
+      secret: "sk-mock-dashscope",
+      api_base: upstream.baseUrl,
+      provider: "alibaba",
+    });
+    await seed.createModel({
+      display_name: VIDEO_MODEL,
+      provider: "alibaba",
+      model_name: VIDEO_MODEL,
+      provider_key_id: pk.id,
+      rate_limit: { rpm: 1 },
+    });
+    // Caller key carries NO rate limit of its own — the only cap in
+    // play is the Model's, which is exactly the layer under test.
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+
+    // Readiness probe uses an UNREGISTERED model name so it never
+    // draws from the video model's rpm=1 bucket.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await fetch(
+          `${app!.proxyUrl}/passthrough/alibaba/${SYNTH_PATH}`,
+          { method: "POST", headers, body: synthBody("probe-unregistered") },
+        );
+        if (r.status !== 200) {
+          await r.text();
+          return false;
+        }
+        const j = (await r.json()) as { output?: { task_id?: unknown } };
+        return j.output?.task_id === "task-pt-rl-01";
+      } catch {
+        return false;
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("registered body model: second call inside the window is 429 rate_limit_exceeded with Retry-After", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+
+    // First submission consumes the model's single rpm slot.
+    const first = await callSynth(VIDEO_MODEL);
+    expect(first.status).toBe(200);
+    const firstJson = (await first.json()) as {
+      output?: { task_id?: unknown };
+    };
+    expect(firstJson.output?.task_id).toBe("task-pt-rl-01");
+
+    // Second submission must be rejected by the gateway — NOT reach
+    // the upstream — with the standard rate-limit envelope.
+    const second = await callSynth(VIDEO_MODEL);
+    expect(second.status).toBe(429);
+    expect(second.headers.get("retry-after")).toBeTruthy();
+    const err = (await second.json()) as {
+      error?: { type?: unknown };
+    };
+    expect(err.error?.type).toBe("rate_limit_exceeded");
+  });
+
+  test("unregistered body model: repeated calls keep flowing (no model-layer cap)", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+
+    for (let i = 0; i < 3; i += 1) {
+      const r = await callSynth("some-unregistered-model");
+      expect(r.status).toBe(200);
+      await r.text();
+    }
+  });
+});


### PR DESCRIPTION
## What

`/passthrough/:provider/*rest` now enforces the **model-level** rate-limit layers (a Model's inline `rate_limit` plus `model`-scope rate-limit policies) for JSON bodies whose top-level `model` field names a configured Model of the addressed provider.

Tracking: `api7/AISIX-Cloud#1116` (field report: a video model's configured rate limit was silently ignored on passthrough).

## Why

Pre-fix, the tunnel called `quota::enforce(&state, auth, None)` — only the API-key / team / member layers applied. For provider endpoints with no typed surface (video generation being the reported case), the model cap configured in the dashboard was unenforceable **anywhere in the product**, and nothing surfaced that: the config was accepted and silently inert.

## How

- `body_model_rate_limit()` in `passthrough.rs`: best-effort parse of the buffered request body (already in memory for the input-guardrail scan), exact `display_name` lookup constrained to the addressed provider, then the existing `ModelRateLimit::from_model` → `quota::enforce(Some(&model_rl))` path used by every typed endpoint. Same bucket keys as typed traffic, so passthrough and typed calls to the same model share one budget.
- Fallbacks preserve pre-fix behavior exactly: non-JSON body, no `model` field, unregistered name, or a same-named Model of a *different* provider → request-level layers only, no error.
- The tunnel still parses no usage (tokens stay 0), so only request-count dimensions (rps/rpm/rph) draw from the model buckets — token-per-minute caps remain inert on passthrough, consistent with raw tunnels generally (documented in the tracking issue; docs follow-up noted there).

## Ecosystem comparison (per repo rule 7)

- The provider-native envelope carries the target model in a top-level `model` field — the shape shared by OpenAI-compatible bodies and e.g. Alibaba Model Studio's synthesis APIs (<https://help.aliyun.com/zh/model-studio/text-to-image-v2-api-reference>).
- Established gateways that run a pre-call policy hook on their passthrough routes resolve the target model the same way — from the request body's `model` field — and apply per-model request caps when the name matches a registered model; identity-level (key/team) limits apply on all routes regardless. None skip the model layer wholesale for lack of a "resolved model".
- Raw-tunnel token counting is universally degraded across gateways (post-hoc or next-request accounting at best); this PR deliberately does not attempt it.

## Scope notes

- `a2a.rs` / `mcp.rs` also pass `None`, but have no model concept — intentionally untouched.
- The issue's optional step 4 (preferring the body-named Model as the credential-lending target) is **deferred**; tracked in `api7/AISIX-Cloud#1116`. This PR changes rate limiting only — credential resolution and the #449 ACL semantics are untouched.
- No CP work needed: model `rate_limit` and `model`-scope policies are existing CP surfaces; this is a DP enforcement gap only.

## Audit remediation (cold audit: MERGE-WITH-CHANGES, 3 MEDIUM / 0 HIGH)

- **MEDIUM-1 fixed** — body `model` now also matches the provider-native `model_name` within the addressed provider (exact `display_name` first); the bucket is keyed by the entry's `display_name` either way, so tunnel and typed traffic share one budget. `min_by_key(id)` keeps duplicate-`model_name` picks deterministic.
- **MEDIUM-2 fixed** — full `serde_json::Value` DOM replaced by a `#[derive(Deserialize)]` field probe; unknown fields skip without allocation.
- **MEDIUM-3 fixed** — new unit test pins a `model`-scope `RateLimitPolicy` row gating the tunnel (no inline `rate_limit`).
- LOW-1 fixed (cross-provider same-name test), LOW-3(c) fixed (e2e asserts the 429 produced no upstream round-trip). LOW-2 (typed+tunnel shared-bucket cross-call test) not added: the sharing is now pinned structurally — both surfaces key by `display_name` through the same `ModelRateLimit::from_model` — and the alias test covers the bucket-key path.

**Accepted residuals (by design, per the fallback contract):** (a) a caller that omits or misnames the body `model` field draws only the key/team layers — model caps on the raw tunnel bind well-behaved clients; the polling leg of async APIs is intentionally exempt. (b) A key not ACL'd for model X can still drain X's shared bucket through the tunnel, because credential borrowing picks the first accessible model and the body model is not ACL-checked — pre-existing behavior, tracked with the deferred credential-resolution step in `api7/AISIX-Cloud#1116`.

## Tests

- Unit (`crates/aisix-proxy/src/lib.rs`):
  - `passthrough_enforces_model_rate_limit_from_body_model_field` — rpm=1 model, second tunnel call 429 `rate_limit_exceeded`.
  - `passthrough_unregistered_or_absent_body_model_keeps_key_layer_only` — unregistered name and non-JSON body pass; key-level cap still gates (pre-fix behavior pinned).
- E2E (`tests/e2e/src/cases/passthrough-model-rate-limit-e2e.test.ts`, source-blind, real gateway binary + etcd + mock upstream):
  - registered body model: 2nd call 429 with `Retry-After` and standard envelope;
  - unregistered body model: repeated calls keep flowing.
- Full `aisix-proxy` suite: 660 passed. Existing passthrough e2e family: green (one unrelated `/v1/responses` least-busy case flaked with ECONNRESET in a parallel run and passes alone; it does not traverse the changed code).
