### PR TITLE
fix(proxy): estimate ensemble panel + judge sub-call usage on missing-usage backends

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -749,11 +749,13 @@ pub(crate) fn estimation_output_text(resp: &aisix_gateway::ChatResponse) -> Stri
 /// silent zeros; estimate the prompt from that sub-call's own request
 /// (`req`: the client request for a panel member — every member shares the
 /// inbound messages — or the synthesis request for the judge) and the
-/// completion from the sub-call's answer text, tokenized with its model.
-/// Returns `(prompt, completion, usage_estimated)` under the #794
-/// or-semantics: a non-zero upstream value always wins, estimation fills
-/// only zeros. One helper so every sub-call emit site (non-streaming panel
-/// + judge, streaming panel) can't drift apart.
+/// completion from the sub-call's answer text. `model` is the sub-call's
+/// resolved **upstream** model (not the operator alias) so the tokenizer
+/// encoding matches the real backend, consistent with the direct and
+/// streaming-judge paths. Returns `(prompt, completion, usage_estimated)`
+/// under the #794 or-semantics: a non-zero upstream value always wins,
+/// estimation fills only zeros. One helper so every sub-call emit site
+/// (non-streaming panel + judge, streaming panel) can't drift apart.
 fn estimate_subcall_tokens(
     req: &ChatFormat,
     model: &str,
@@ -2584,16 +2586,26 @@ async fn dispatch_ensemble(
         ))
     })?;
 
-    // Resolve a sub-call's target by display_name → (model_id, provider_key_id)
-    // for telemetry; empty pair if the target was deleted between dispatch and
-    // emit (cp-api stores NULL). Shared by both the success and 502 paths.
-    let resolve_sub = |display_name: &str| -> (String, String) {
+    // Resolve a sub-call's target by display_name → (model_id, provider_key_id,
+    // upstream_model). The first two are telemetry attribution; the third is
+    // the tokenizer key for the #1074 estimation fallback — the estimator keys
+    // off the real upstream model, not the operator alias, exactly as the
+    // direct and streaming-judge paths do (a `gpt-4o` alias must select
+    // o200k_base, not the cl100k default an unrecognised alias falls back to).
+    // Empty ids if the target was deleted between dispatch and emit (cp-api
+    // stores NULL); the tokenizer then degrades to the display name.
+    let resolve_sub = |display_name: &str| -> (String, String, String) {
         match snapshot.models.get_by_name(display_name) {
             Some(entry) => (
                 entry.id.clone(),
                 entry.value.provider_key_id.clone().unwrap_or_default(),
+                entry
+                    .value
+                    .upstream_model()
+                    .unwrap_or(display_name)
+                    .to_string(),
             ),
-            None => (String::new(), String::new()),
+            None => (String::new(), String::new(), display_name.to_string()),
         }
     };
     // Emit one usage event for a single (already-billed) panel member.
@@ -2604,12 +2616,18 @@ async fn dispatch_ensemble(
     // 0-based slot; `blocked` sets the event's `guardrail_blocked` flag.
     let emit_panel_member =
         |member: &crate::ensemble::PanelOutcome, index: usize, blocked: bool, bypass: &str| {
-            let (sub_model_id, sub_provider_key_id) = resolve_sub(&member.model);
+            let (sub_model_id, sub_provider_key_id, sub_upstream_model) =
+                resolve_sub(&member.model);
             // #1074: a member backend that omitted usage gets its prompt
             // estimated from the shared client request and its completion
-            // from the member's own answer text.
-            let (prompt_tokens, completion_tokens, usage_estimated) =
-                estimate_subcall_tokens(req, &member.model, &member.usage, &member.est_output_text);
+            // from the member's own answer text, tokenized with the member's
+            // resolved upstream model.
+            let (prompt_tokens, completion_tokens, usage_estimated) = estimate_subcall_tokens(
+                req,
+                &sub_upstream_model,
+                &member.usage,
+                &member.est_output_text,
+            );
             emit_usage_event(
                 state,
                 request_id,
@@ -2811,17 +2829,22 @@ async fn dispatch_ensemble(
             attempt_model: String,
             usage: aisix_gateway::chat::UsageStats,
             est_output_text: String,
+            /// Resolved upstream model — the tokenizer key for the #1074
+            /// estimate, pre-resolved here because the `'static` closure
+            /// can't reach the snapshot (mirrors `model_id`).
+            est_model: String,
         }
         let panel_telem: Vec<PanelTelem> = panel
             .iter()
             .map(|p| {
-                let (model_id, provider_key_id) = resolve_sub(&p.model);
+                let (model_id, provider_key_id, est_model) = resolve_sub(&p.model);
                 PanelTelem {
                     model_id,
                     provider_key_id,
                     attempt_model: p.model.clone(),
                     usage: p.usage.clone(),
                     est_output_text: p.est_output_text.clone(),
+                    est_model,
                 }
             })
             .collect();
@@ -2840,7 +2863,9 @@ async fn dispatch_ensemble(
             .fold(aisix_gateway::chat::UsageStats::default(), |acc, p| {
                 acc.saturating_add(&p.usage)
             });
-        let (judge_model_id, judge_provider_key_id) = resolve_sub(&ensemble_cfg.judge.model);
+        // The streamed judge estimator keys off `judge_model.upstream_model()`
+        // directly (below), so resolve_sub's upstream_model is unused here.
+        let (judge_model_id, judge_provider_key_id, _) = resolve_sub(&ensemble_cfg.judge.model);
         let judge_attempt_model = ensemble_cfg.judge.model.clone();
         let judge_attempt_index = panel.len() as u32;
 
@@ -2941,7 +2966,7 @@ async fn dispatch_ensemble(
                     let (prompt_tokens, completion_tokens, usage_estimated) =
                         estimate_subcall_tokens(
                             &req_for_panel_est,
-                            &member.attempt_model,
+                            &member.est_model,
                             &member.usage,
                             &member.est_output_text,
                         );
@@ -3174,14 +3199,16 @@ async fn dispatch_ensemble(
         for (index, member) in outcome.panel.iter().enumerate() {
             emit_panel_member(member, index, blocked, bypass);
         }
-        let (judge_model_id, judge_provider_key_id) = resolve_sub(&outcome.judge_model);
+        let (judge_model_id, judge_provider_key_id, judge_upstream_model) =
+            resolve_sub(&outcome.judge_model);
         // #1074: estimate the judge sub-call when its backend omitted usage —
         // prompt from the judge's synthesis request, completion from the
         // synthesized answer text (read post-mask; token count is
-        // mask-invariant to within placeholder length).
+        // mask-invariant to within placeholder length), tokenized with the
+        // judge's resolved upstream model.
         let (judge_prompt, judge_completion, judge_estimated) = estimate_subcall_tokens(
             &outcome.judge_req,
-            &outcome.judge_model,
+            &judge_upstream_model,
             &judge_usage,
             &estimation_output_text(&outcome.response),
         );

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -744,6 +744,42 @@ pub(crate) fn estimation_output_text(resp: &aisix_gateway::ChatResponse) -> Stri
     out
 }
 
+/// #1074 ensemble sub-call token fallback. A sub-call backend (a panel
+/// member, or the judge) that reports no usage would otherwise record
+/// silent zeros; estimate the prompt from that sub-call's own request
+/// (`req`: the client request for a panel member — every member shares the
+/// inbound messages — or the synthesis request for the judge) and the
+/// completion from the sub-call's answer text, tokenized with its model.
+/// Returns `(prompt, completion, usage_estimated)` under the #794
+/// or-semantics: a non-zero upstream value always wins, estimation fills
+/// only zeros. One helper so every sub-call emit site (non-streaming panel
+/// + judge, streaming panel) can't drift apart.
+fn estimate_subcall_tokens(
+    req: &ChatFormat,
+    model: &str,
+    usage: &aisix_gateway::chat::UsageStats,
+    output_text: &str,
+) -> (u32, u32, bool) {
+    if usage.prompt_tokens != 0 && usage.completion_tokens != 0 {
+        return (usage.prompt_tokens, usage.completion_tokens, false);
+    }
+    let est = crate::token_estimate::Estimator::new(
+        model,
+        crate::token_estimate::PromptInput::Chat(Box::new(req.clone())),
+    );
+    let filled = crate::token_estimate::fill_missing(
+        &est,
+        usage.prompt_tokens,
+        usage.completion_tokens,
+        Some(output_text),
+    );
+    (
+        filled.prompt_tokens,
+        filled.completion_tokens,
+        filled.estimated,
+    )
+}
+
 fn last_user_message_text(req: &ChatFormat) -> Option<String> {
     req.messages
         .iter()
@@ -2569,6 +2605,11 @@ async fn dispatch_ensemble(
     let emit_panel_member =
         |member: &crate::ensemble::PanelOutcome, index: usize, blocked: bool, bypass: &str| {
             let (sub_model_id, sub_provider_key_id) = resolve_sub(&member.model);
+            // #1074: a member backend that omitted usage gets its prompt
+            // estimated from the shared client request and its completion
+            // from the member's own answer text.
+            let (prompt_tokens, completion_tokens, usage_estimated) =
+                estimate_subcall_tokens(req, &member.model, &member.usage, &member.est_output_text);
             emit_usage_event(
                 state,
                 request_id,
@@ -2577,13 +2618,14 @@ async fn dispatch_ensemble(
                 api_key_id,
                 200,
                 started.elapsed(),
-                member.usage.prompt_tokens,
-                member.usage.completion_tokens,
+                prompt_tokens,
+                completion_tokens,
                 UsageExtras {
                     cached_prompt_tokens: member.usage.cached_prompt_tokens,
                     reasoning_tokens: member.usage.reasoning_tokens,
                     cache_creation_tokens: member.usage.cache_creation_tokens,
                     cache_read_tokens: member.usage.cache_read_tokens,
+                    usage_estimated,
                     bypass_reason: bypass.to_string(),
                     cache_status: CacheStatus::Disabled.as_str().to_string(),
                     attempt_index: index as u32,
@@ -2768,6 +2810,7 @@ async fn dispatch_ensemble(
             provider_key_id: String,
             attempt_model: String,
             usage: aisix_gateway::chat::UsageStats,
+            est_output_text: String,
         }
         let panel_telem: Vec<PanelTelem> = panel
             .iter()
@@ -2778,9 +2821,15 @@ async fn dispatch_ensemble(
                     provider_key_id,
                     attempt_model: p.model.clone(),
                     usage: p.usage.clone(),
+                    est_output_text: p.est_output_text.clone(),
                 }
             })
             .collect();
+        // #1074: the `'static` on_complete closure cannot borrow `req`, so
+        // capture one clone for the panel-member prompt estimate (used only
+        // when a member backend omits usage — the guard in
+        // `estimate_subcall_tokens` skips the tokenizer otherwise).
+        let req_for_panel_est = req.clone();
         let panel_total: u64 = panel.iter().map(|p| u64::from(p.usage.total_tokens)).sum();
         // #614: field-wise panel usage sum (not just total_tokens) folded into
         // the client-facing terminal usage chunk via build_sse_stream's
@@ -2885,6 +2934,17 @@ async fn dispatch_ensemble(
                 // moved into on_complete because the judge counts only land on
                 // the terminal SSE chunk.
                 for (index, member) in panel_telem.iter().enumerate() {
+                    // #1074: same or-semantics fallback as the non-streaming
+                    // panel emit — estimate a member's tokens when its backend
+                    // omitted usage (members were buffered, so their answer
+                    // text is available even though the judge is streamed).
+                    let (prompt_tokens, completion_tokens, usage_estimated) =
+                        estimate_subcall_tokens(
+                            &req_for_panel_est,
+                            &member.attempt_model,
+                            &member.usage,
+                            &member.est_output_text,
+                        );
                     emit_usage_event(
                         &state_for_telem,
                         &request_id_for_telem,
@@ -2893,13 +2953,14 @@ async fn dispatch_ensemble(
                         &api_key_id_for_telem,
                         200,
                         started.elapsed(),
-                        member.usage.prompt_tokens,
-                        member.usage.completion_tokens,
+                        prompt_tokens,
+                        completion_tokens,
                         UsageExtras {
                             cached_prompt_tokens: member.usage.cached_prompt_tokens,
                             reasoning_tokens: member.usage.reasoning_tokens,
                             cache_creation_tokens: member.usage.cache_creation_tokens,
                             cache_read_tokens: member.usage.cache_read_tokens,
+                            usage_estimated,
                             bypass_reason: bypass_for_telem.clone(),
                             cache_status: CacheStatus::Disabled.as_str().to_string(),
                             attempt_index: index as u32,
@@ -3114,6 +3175,16 @@ async fn dispatch_ensemble(
             emit_panel_member(member, index, blocked, bypass);
         }
         let (judge_model_id, judge_provider_key_id) = resolve_sub(&outcome.judge_model);
+        // #1074: estimate the judge sub-call when its backend omitted usage —
+        // prompt from the judge's synthesis request, completion from the
+        // synthesized answer text (read post-mask; token count is
+        // mask-invariant to within placeholder length).
+        let (judge_prompt, judge_completion, judge_estimated) = estimate_subcall_tokens(
+            &outcome.judge_req,
+            &outcome.judge_model,
+            &judge_usage,
+            &estimation_output_text(&outcome.response),
+        );
         emit_usage_event(
             state,
             request_id,
@@ -3122,13 +3193,14 @@ async fn dispatch_ensemble(
             api_key_id,
             200,
             started.elapsed(),
-            judge_usage.prompt_tokens,
-            judge_usage.completion_tokens,
+            judge_prompt,
+            judge_completion,
             UsageExtras {
                 cached_prompt_tokens: judge_usage.cached_prompt_tokens,
                 reasoning_tokens: judge_usage.reasoning_tokens,
                 cache_creation_tokens: judge_usage.cache_creation_tokens,
                 cache_read_tokens: judge_usage.cache_read_tokens,
+                usage_estimated: judge_estimated,
                 provider_request_id: outcome.response.id.clone(),
                 provider_model_version: outcome.response.model.clone(),
                 finish_reason: finish_reason_label(&outcome.response.finish_reason),
@@ -4930,7 +5002,7 @@ mod complete_on_drop_tests {
     //! StreamCompletion, set the shared atomic to simulate "N
     //! chunks delivered to the consumer", drop, observe the
     //! callback args.
-    use super::{AtomicU32, CompleteOnDrop, StreamCompletion};
+    use super::{estimate_subcall_tokens, AtomicU32, CompleteOnDrop, StreamCompletion};
     use std::sync::{Arc, Mutex};
 
     /// Build the guard with `delivered_count` pre-set on the
@@ -5052,6 +5124,68 @@ mod complete_on_drop_tests {
         assert_eq!(out.completion_tokens, 23);
         assert_eq!(out.total_tokens, 40);
         assert!(!out.usage_estimated);
+    }
+
+    fn subcall_req(user: &str) -> aisix_gateway::chat::ChatFormat {
+        aisix_gateway::chat::ChatFormat::new(
+            "relay-model",
+            vec![aisix_gateway::chat::ChatMessage {
+                role: aisix_gateway::chat::Role::User,
+                content: Some(user.into()),
+                content_blocks: None,
+                name: None,
+                tool_call_id: None,
+                extra: serde_json::Map::new(),
+            }],
+        )
+    }
+
+    /// #796: the shared ensemble sub-call estimator fills a fully-missing
+    /// usage block — prompt from the sub-call's request (one user "Hello"
+    /// = 8 in the cl100k fallback), completion from its answer text
+    /// ("Hello world" = 2) — and flags it.
+    #[test]
+    fn estimate_subcall_fills_missing_usage() {
+        let usage = aisix_gateway::chat::UsageStats::default();
+        let (prompt, completion, estimated) =
+            estimate_subcall_tokens(&subcall_req("Hello"), "relay-model", &usage, "Hello world");
+        assert_eq!(prompt, 8);
+        assert_eq!(completion, 2);
+        assert!(estimated);
+    }
+
+    /// #796: a sub-call whose backend DID report usage is returned
+    /// verbatim and unflagged — the answer text is ignored.
+    #[test]
+    fn estimate_subcall_preserves_reported_usage() {
+        let usage = aisix_gateway::chat::UsageStats {
+            prompt_tokens: 17,
+            completion_tokens: 23,
+            total_tokens: 40,
+            ..Default::default()
+        };
+        let (prompt, completion, estimated) =
+            estimate_subcall_tokens(&subcall_req("Hello"), "relay-model", &usage, "Hello world");
+        assert_eq!(prompt, 17);
+        assert_eq!(completion, 23);
+        assert!(!estimated);
+    }
+
+    /// #796: per-field or-semantics — a reported prompt is kept while a
+    /// missing completion is estimated (and the record is flagged).
+    #[test]
+    fn estimate_subcall_fills_only_missing_side() {
+        let usage = aisix_gateway::chat::UsageStats {
+            prompt_tokens: 17,
+            completion_tokens: 0,
+            total_tokens: 17,
+            ..Default::default()
+        };
+        let (prompt, completion, estimated) =
+            estimate_subcall_tokens(&subcall_req("Hello"), "relay-model", &usage, "Hello world");
+        assert_eq!(prompt, 17, "reported prompt preserved");
+        assert_eq!(completion, 2, "missing completion estimated");
+        assert!(estimated);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -161,6 +161,11 @@ impl ModelCaller for ProxyModelCaller<'_> {
 pub struct PanelOutcome {
     pub model: String,
     pub usage: UsageStats,
+    /// The member's answer text (content + reasoning + tool-call text),
+    /// captured so the dispatch layer can estimate this sub-call's
+    /// completion tokens when the member backend reports no usage
+    /// (AISIX-Cloud#1074). Never billed directly — only a fallback.
+    pub est_output_text: String,
 }
 
 /// Everything the dispatch layer needs after an ensemble run: the judge's
@@ -172,6 +177,12 @@ pub struct EnsembleOutcome {
     pub response: ChatResponse,
     pub panel: Vec<PanelOutcome>,
     pub judge_model: String,
+    /// The judge's synthesis request, kept so the dispatch layer can
+    /// estimate the judge sub-call's prompt tokens when the judge backend
+    /// reports no usage (AISIX-Cloud#1074). The streaming path builds its
+    /// own judge estimator from `run_ensemble_panel`'s `judge_req`; this
+    /// field carries the same request out of the buffered path.
+    pub judge_req: ChatFormat,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -255,6 +266,7 @@ pub(crate) async fn run_ensemble_panel(
                 panel.push(PanelOutcome {
                     model,
                     usage: resp.usage.clone(),
+                    est_output_text: crate::chat::estimation_output_text(&resp),
                 });
                 candidates.push(resp);
             }
@@ -311,6 +323,7 @@ pub async fn run_ensemble(
         response,
         panel,
         judge_model: config.judge.model.clone(),
+        judge_req,
     })
 }
 

--- a/tests/e2e/src/cases/ensemble-usage-estimation-796-e2e.test.ts
+++ b/tests/e2e/src/cases/ensemble-usage-estimation-796-e2e.test.ts
@@ -1,0 +1,314 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { lz4DecompressBlock, startMockSls, type MockSls } from "../harness/sls-mock.js";
+
+// E2E for api7/aisix#796 (follow-up to AISIX-Cloud#1074): the non-streaming
+// ensemble sub-call events (every panel member + the judge) must run through
+// the token-estimation fallback, and so must the panel members on the
+// streaming path (the judge there was already wired by #794). With a
+// usage-less backend, each sub-call event previously recorded silent zeros;
+// now each is locally counted (prompt from the sub-call's own request,
+// completion from its answer text) and flagged `usage_estimated`.
+//
+// Observable contract: an ensemble fans out to one usage event per sub-call
+// (attempt_kind "panel" x N, then "judge"), all sharing the request_id and
+// carrying the ensemble model as requested_model. They are telemetry-only
+// (usage sink -> SLS), so the metadata_only SLS exporter is the wire we
+// assert on: a `usage_estimated` marker appears once per flagged record
+// (serialized only when true) and each sub-call's `attempt_model` is present.
+
+const CALLER_PLAINTEXT = "sk-ensemble-est-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const CREDENTIAL_REF = "mock";
+const MOCK_AK_ID = "mock-akid";
+const MOCK_AK_SECRET = "mock-secret";
+const SLS_PROJECT = "aisix-e2e-obs";
+const META_LOGSTORE = "ens-est-meta-events";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Non-streaming 200 with NO usage block — the relay/transit-backend shape
+// that #1074 targets. Panel members are always dispatched non-streaming
+// (the executor buffers them), and the non-streaming judge answers this way
+// too.
+const nonStreamNoUsage = (content: string) => ({
+  id: "chatcmpl-ens",
+  object: "chat.completion",
+  created: 0,
+  model: "relay-compat-x",
+  choices: [
+    { index: 0, message: { role: "assistant", content }, finish_reason: "stop" },
+  ],
+  // deliberately no `usage`
+});
+
+// Streaming judge answer with no terminal usage chunk (relay ignores the
+// gateway-injected stream_options.include_usage). Deltas are the only
+// completion signal → estimated from "Hello world".
+const JUDGE_STREAM_NO_USAGE = [
+  '{"id":"j","object":"chat.completion.chunk","model":"relay-compat-x","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+  '{"id":"j","object":"chat.completion.chunk","model":"relay-compat-x","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}',
+  '{"id":"j","object":"chat.completion.chunk","model":"relay-compat-x","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}',
+  '{"id":"j","object":"chat.completion.chunk","model":"relay-compat-x","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+  "[DONE]",
+];
+
+describe("ensemble usage estimation e2e (api7/aisix#796): every panel + judge sub-call is estimated and flagged when the backend omits usage", () => {
+  let app: SpawnedApp | undefined;
+  let sls: MockSls | undefined;
+  let memberAUp: OpenAiUpstream | undefined;
+  let memberBUp: OpenAiUpstream | undefined;
+  let judgeNsUp: OpenAiUpstream | undefined;
+  let judgeStUp: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    sls = await startMockSls();
+    memberAUp = await startOpenAiUpstream({
+      nonStreamBody: nonStreamNoUsage("Panel answer A"),
+    });
+    memberBUp = await startOpenAiUpstream({
+      nonStreamBody: nonStreamNoUsage("Panel answer B"),
+    });
+    judgeNsUp = await startOpenAiUpstream({
+      nonStreamBody: nonStreamNoUsage("Final synthesized answer"),
+    });
+    judgeStUp = await startOpenAiUpstream({
+      streamEvents: JUDGE_STREAM_NO_USAGE,
+    });
+
+    app = await spawnApp({
+      extraEnv: {
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: MOCK_AK_ID,
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: MOCK_AK_SECRET,
+      },
+    });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    await seed.createObservabilityExporter({
+      name: "ens-est-sls-meta",
+      enabled: true,
+      kind: "aliyun_sls",
+      endpoint: sls.url,
+      project: SLS_PROJECT,
+      logstore: META_LOGSTORE,
+      credential_ref: CREDENTIAL_REF,
+      content_mode: "metadata_only",
+    });
+
+    // Direct sub-call models. All upstream model names are non-OpenAI on
+    // purpose so the estimator falls back to cl100k_base.
+    const seedModel = async (display: string, upstream: OpenAiUpstream) => {
+      const pk = await seed!.createProviderKey({
+        display_name: `${display}-pk`,
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      await seed!.createModel({
+        display_name: display,
+        provider: "openai",
+        model_name: "relay-compat-x",
+        provider_key_id: pk.id,
+      });
+    };
+    await seedModel("est-ens-member-1", memberAUp);
+    await seedModel("est-ens-member-2", memberBUp);
+    await seedModel("est-ens-judge-ns", judgeNsUp);
+    await seedModel("est-ens-judge-st", judgeStUp);
+
+    // Two ensembles sharing the same panel; one judged non-streaming, one
+    // judged streaming — the two sub-call emit families #796 wires.
+    await seed.createModel({
+      display_name: "est-ens-nonstream",
+      ensemble: {
+        panel: [{ model: "est-ens-member-1" }, { model: "est-ens-member-2" }],
+        judge: { model: "est-ens-judge-ns" },
+        min_responses: 2,
+      },
+    });
+    await seed.createModel({
+      display_name: "est-ens-stream",
+      ensemble: {
+        panel: [{ model: "est-ens-member-1" }, { model: "est-ens-member-2" }],
+        judge: { model: "est-ens-judge-st" },
+        min_responses: 2,
+      },
+    });
+
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [
+        "est-ens-nonstream",
+        "est-ens-stream",
+        "est-ens-member-1",
+        "est-ens-member-2",
+        "est-ens-judge-ns",
+        "est-ens-judge-st",
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await sls?.close();
+    await memberAUp?.close();
+    await memberBUp?.close();
+    await judgeNsUp?.close();
+    await judgeStUp?.close();
+  });
+
+  function openai(): OpenAI {
+    return new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app!.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  /** Decode only the SLS PutLogs bodies appended at/after `startIndex`, so a
+   * per-call assertion sees that call's sub-call records rather than the
+   * shared logstore's whole history. */
+  function decodedSince(startIndex: number): string {
+    return sls!.requests
+      .slice(startIndex)
+      .filter((r) => r.logstore === META_LOGSTORE && r.rawSize > 0 && r.body.length > 0)
+      .map((r) => lz4DecompressBlock(r.body, r.rawSize).toString("utf8"))
+      .join(" ");
+  }
+
+  /** Split the decoded metadata into per-record chunks on the `schema_version`
+   * anchor (SinkRecord serializes it once per record, ahead of the flattened
+   * usage fields), so each chunk holds exactly one sub-call event. */
+  function records(text: string): string[] {
+    return text.split("schema_version").slice(1);
+  }
+
+  /** True when some record for `attemptModel` ALSO carries `usage_estimated`
+   * (serialized only when the record was flagged). Checked per-record so an
+   * already-flagged judge (via #794) cannot stand in for an unflagged panel
+   * member — the exact gap #796 closes. */
+  function subcallFlagged(text: string, attemptModel: string): boolean {
+    return records(text).some(
+      (r) => r.includes(attemptModel) && r.includes("usage_estimated"),
+    );
+  }
+
+  /** Poll until every named sub-call has its own flagged record among the
+   * events appended after `mark`. Pre-fix the non-streaming sub-calls carry
+   * no flag at all, and the streaming panel members carry none (only the
+   * #794 judge is flagged), so this fails until #796 wires them. */
+  async function waitEnsembleFlagged(mark: number, attemptModels: string[]): Promise<void> {
+    const deadline = Date.now() + 15_000;
+    let text = "";
+    while (Date.now() < deadline) {
+      text = decodedSince(mark);
+      if (attemptModels.every((m) => subcallFlagged(text, m))) return;
+      await sleep(100);
+    }
+    const flagged = attemptModels.filter((m) => subcallFlagged(text, m));
+    throw new Error(
+      `ensemble sub-calls not all flagged within 15s: flagged [${flagged.join(",")}] ` +
+        `of [${attemptModels.join(",")}]`,
+    );
+  }
+
+  test("non-streaming ensemble: panel members + judge all estimated and flagged", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const client = openai();
+    await waitConfigPropagation(async () => {
+      try {
+        await client.chat.completions.create({
+          model: "est-ens-nonstream",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const mark = sls!.requests.length;
+    const resp = await client.chat.completions.create({
+      model: "est-ens-nonstream",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    // The client-facing answer is the judge's synthesis; the aggregate usage
+    // stays zero (no upstream reported any, and the gateway never fabricates
+    // client-visible usage — estimation feeds telemetry only).
+    expect(resp.choices[0]?.message?.content).toBe("Final synthesized answer");
+    expect(resp.usage?.prompt_tokens ?? 0).toBe(0);
+    expect(resp.usage?.completion_tokens ?? 0).toBe(0);
+
+    await waitEnsembleFlagged(mark, [
+      "est-ens-member-1",
+      "est-ens-member-2",
+      "est-ens-judge-ns",
+    ]);
+  }, 60_000);
+
+  test("streaming ensemble: buffered panel members estimated alongside the streamed judge", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const client = openai();
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "est-ens-stream",
+          messages: [{ role: "user", content: "hi" }],
+          stream: true,
+        });
+        for await (const _ of probe) {
+          /* drain */
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    const mark = sls!.requests.length;
+    const stream = await client.chat.completions.create({
+      model: "est-ens-stream",
+      messages: [{ role: "user", content: "hi" }],
+      stream: true,
+    });
+    let content = "";
+    for await (const chunk of stream) {
+      content += chunk.choices[0]?.delta?.content ?? "";
+      // Estimation must never fabricate a usage chunk on the client stream.
+      expect(chunk.usage ?? null).toBeNull();
+    }
+    // The streamed answer is the judge's synthesis, restamped with the
+    // ensemble model name.
+    expect(content).toBe("Hello world");
+
+    // Panel members (buffered, emitted on stream drop) are the #796 lockstep
+    // extension; the judge was already flagged by #794. All three flagged.
+    await waitEnsembleFlagged(mark, [
+      "est-ens-member-1",
+      "est-ens-member-2",
+      "est-ens-judge-st",
+    ]);
+  }, 60_000);
+});


### PR DESCRIPTION
Follow-up to #794 (AISIX-Cloud#1074). An ensemble request fans out to one usage event per sub-call — each panel member plus the judge — but none of those events went through the #1074 token-estimation fallback. Against a backend that reports no `usage` (a relay/transit upstream), each sub-call recorded silent zeros. #794 wired only the **streaming judge** (via the SSE Drop guard); the non-streaming panel + judge, and the panel members on the streaming path, were still unflagged.

## What was missing

| sub-call emit site | before |
|---|---|
| non-streaming panel members (`emit_panel_member`) | ❌ zeros |
| non-streaming judge (`emit_subcalls`) | ❌ zeros |
| streaming-path panel members (`on_complete`) | ❌ zeros |
| streaming judge | ✅ #794 |

The panel members' answer texts and the judge's synthesis request lived only inside `ensemble.rs`, so the emit sites had nothing to estimate from — the refactor #794 explicitly deferred here.

## Change

- `PanelOutcome` carries `est_output_text` (the member's answer text) and `EnsembleOutcome` carries `judge_req` (the synthesis request), so every emit site has the request+output it needs.
- One shared helper `estimate_subcall_tokens(req, model, usage, output_text)` applies the #794 per-field or-semantics — a non-zero upstream value always wins; estimation fills only zeros (prompt from the sub-call's own request, completion from its answer text) — and returns the `usage_estimated` flag. Routing all four emit sites through it keeps the family from drifting again.

This closes the whole bug class, not just the non-streaming path named in the issue: the streaming-path panel members shared the identical gap and are fixed in the same PR.

Estimation feeds telemetry only (usage events → exporters / TPM / metrics). The client-facing response and SSE stream are never rewritten with synthesised usage. No CP or schema change — the sub-call events already carry `usage_estimated` on the existing `/dp/telemetry` wire.

LiteLLM has no ensemble (panel/judge) construct emitting per-sub-call usage, so there is no baseline to compare against here; the underlying token-counting semantics are unchanged from #794 (already LiteLLM-aligned).

## Tests

- **E2E** (`ensemble-usage-estimation-796-e2e.test.ts`): a real ensemble (2 panel members + judge) over usage-less mock upstreams, non-streaming and streaming. Asserts, per-record, that every sub-call (both panel members + judge) ships its own `usage_estimated`-flagged event. Verified failing before the fix (non-streaming: nothing flagged; streaming: only the judge flagged) and passing after.
- **Rust unit**: `estimate_subcall_tokens` or-semantics — fully-missing usage fills+flags, reported usage is preserved unflagged, and a reported prompt + missing completion fills only the completion.

Fixes #796


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage estimation for ensemble panel and judge calls when upstream usage data is missing or incomplete.
  * Ensured estimated usage is consistently recorded for both streaming and non-streaming ensemble requests.
  * Preserved client-facing usage behavior while improving telemetry accuracy.

* **Tests**
  * Added coverage for missing, complete, and partially missing usage data.
  * Added end-to-end validation for usage estimation across ensemble streaming modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->