### PR TITLE
fix(routing): honour routing.retries on the streaming chat path

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1155,6 +1155,19 @@ async fn dispatch(
     // the remaining chunks, so a mid-stream stall terminates the response
     // (no fallback once the 200 is committed).
     if req.is_streaming() {
+        // `routing.retries` — how many times to re-hit the SAME target (with
+        // backoff) on a retryable failure before failing over to the next one.
+        // Read here for the same reason the non-streaming loop below reads it:
+        // the two loops are written separately, and streaming used to skip
+        // `retries` entirely (AISIX-Cloud#1119), so a retryable first-chunk
+        // failure fell straight over to the next target — or, with a single
+        // target, failed the request outright.
+        let retries = virtual_entry
+            .value
+            .routing
+            .as_ref()
+            .map(|r| r.retries_or_default())
+            .unwrap_or(0);
         let retry_on_429 = virtual_entry
             .value
             .routing
@@ -1209,54 +1222,6 @@ async fn dispatch(
                 ));
                 continue 'targets;
             };
-            let (idx, kind) = stream_routing.begin_attempt(&model.display_name);
-            let target_model = if is_routing_request {
-                model.display_name.clone()
-            } else {
-                String::new()
-            };
-            // Reserve THIS target's own model rate-limit layers before
-            // dispatching to it (AISIX-Cloud#1087). Over-limit → record a
-            // 429 attempt and move on to the remaining targets in strategy
-            // order (same-target retries can't help — the window won't
-            // reset mid-loop).
-            let member_reservation = match crate::quota::reserve_routing_target(
-                state,
-                is_routing_request,
-                &model.display_name,
-                &attempt.id,
-                model,
-            )
-            .await
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    stream_routing.attempts.push(AttemptRecord {
-                        index: idx,
-                        kind,
-                        target_model,
-                        target_model_id: attempt.id.clone(),
-                        provider_key_id: pk_entry.id.clone(),
-                        status: 429,
-                        success: false,
-                        error_class: "rate_limit_exceeded".to_string(),
-                        error_message: e.to_string(),
-                        latency_ms: 0,
-                    });
-                    // Keep the limiter's own Retry-After hint on the wire:
-                    // when every target is exhausted this error becomes the
-                    // client's 429, and SDKs back off on that header.
-                    last_err = Some(BridgeError::upstream_status_with_retry_after(
-                        429,
-                        format!(
-                            "routing target {:?} is over its model rate limit: {e}",
-                            model.display_name
-                        ),
-                        crate::quota::retry_after_of(&e).map(Duration::from_secs),
-                    ));
-                    continue 'targets;
-                }
-            };
             let model_arc = Arc::new(model.clone());
             let pk_arc = Arc::new(pk_entry.value.clone());
             // Streaming deadline (#554): bound the connect by the effective
@@ -1266,110 +1231,181 @@ async fn dispatch(
             if let Some(d) = model.stream_timeout_effective() {
                 ctx = ctx.with_deadline(d);
             }
-            let attempt_started = Instant::now();
             // Effective streaming budget: `stream_timeout`, falling back to
             // `timeout`. Used for the connect deadline (above) AND the
-            // per-chunk read timeout + first-chunk peek here, so the budget
+            // per-chunk read timeout + first-chunk peek below, so the budget
             // is applied consistently.
             let stream_budget = model.stream_timeout_effective();
-            // Connect, then — only when a streaming budget is configured —
-            // peek the first chunk so a slow or erroring first token fails
-            // over before the 200 is committed. Without a budget there is
-            // nothing to gate on, so the stream is committed directly (a
-            // first-chunk error then surfaces in-band, exactly like the
-            // pre-#554 behavior). The read-timeout wrapper is a no-op when
-            // the budget is None.
-            let attempt_stream: Result<aisix_gateway::ChatChunkStream, BridgeError> =
-                match bridge.chat_stream(req, &ctx).await {
-                    Err(e) => Err(e),
-                    Ok(up) => {
-                        let up = crate::stream_timeout::with_read_timeout(up, stream_budget);
-                        if stream_budget.is_some() {
-                            let mut up = up;
-                            match up.next().await {
-                                // Re-prepend the peeked chunk so the SSE pump
-                                // sees the whole stream (and records TTFT on
-                                // the first content chunk); the wrapper keeps
-                                // enforcing the read timeout on the rest.
-                                Some(Ok(chunk)) => Ok(Box::pin(
-                                    futures::stream::once(std::future::ready(
-                                        Ok::<_, BridgeError>(chunk),
-                                    ))
-                                    .chain(up),
-                                )
-                                    as aisix_gateway::ChatChunkStream),
-                                Some(Err(e)) => Err(e),
-                                None => Err(BridgeError::StreamAborted),
-                            }
-                        } else {
-                            Ok(up)
-                        }
+
+            // Re-hit the SAME target `retries` times before failing over,
+            // mirroring the non-streaming loop below (AISIX-Cloud#1119).
+            for attempt_idx in 0..=retries {
+                let (idx, kind) = stream_routing.begin_attempt(&model.display_name);
+                let target_model = if is_routing_request {
+                    model.display_name.clone()
+                } else {
+                    String::new()
+                };
+                // Reserve THIS target's own model rate-limit layers before
+                // dispatching to it (AISIX-Cloud#1087). Over-limit → record a
+                // 429 attempt and move on to the remaining targets in strategy
+                // order (same-target retries can't help — the window won't
+                // reset mid-loop).
+                let member_reservation = match crate::quota::reserve_routing_target(
+                    state,
+                    is_routing_request,
+                    &model.display_name,
+                    &attempt.id,
+                    model,
+                )
+                .await
+                {
+                    Ok(r) => r,
+                    Err(e) => {
+                        stream_routing.attempts.push(AttemptRecord {
+                            index: idx,
+                            kind,
+                            target_model,
+                            target_model_id: attempt.id.clone(),
+                            provider_key_id: pk_entry.id.clone(),
+                            status: 429,
+                            success: false,
+                            error_class: "rate_limit_exceeded".to_string(),
+                            error_message: e.to_string(),
+                            latency_ms: 0,
+                        });
+                        // Keep the limiter's own Retry-After hint on the wire:
+                        // when every target is exhausted this error becomes the
+                        // client's 429, and SDKs back off on that header.
+                        last_err = Some(BridgeError::upstream_status_with_retry_after(
+                            429,
+                            format!(
+                                "routing target {:?} is over its model rate limit: {e}",
+                                model.display_name
+                            ),
+                            crate::quota::retry_after_of(&e).map(Duration::from_secs),
+                        ));
+                        continue 'targets;
                     }
                 };
-            let latency_ms = attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
-            match attempt_stream {
-                Ok(upstream) => {
-                    state.health.record_success(&model.display_name);
-                    state.runtime_status.mark_healthy(&attempt.id);
-                    // Feed the least_latency EWMA. For streaming this is
-                    // time-to-first-response (upstream stream established) —
-                    // the routing-relevant latency signal.
-                    state.runtime_status.record_latency(&attempt.id, latency_ms);
-                    stream_routing.attempts.push(AttemptRecord {
-                        index: idx,
-                        kind,
-                        target_model,
-                        target_model_id: attempt.id.clone(),
-                        provider_key_id: pk_entry.id.clone(),
-                        status: 200,
-                        success: true,
-                        error_class: String::new(),
-                        error_message: String::new(),
-                        latency_ms,
-                    });
-                    won = Some(StreamWin {
-                        model: model.clone(),
-                        target_id: attempt.id.clone(),
-                        provider_lc: provider.to_ascii_lowercase(),
-                        pk_id: pk_entry.id.clone(),
-                        upstream,
-                        idx,
-                        kind,
-                    });
-                    won_member_reservation = member_reservation;
-                    break 'targets;
-                }
-                Err(err) => {
-                    stream_routing.attempts.push(AttemptRecord {
-                        index: idx,
-                        kind,
-                        target_model,
-                        target_model_id: attempt.id.clone(),
-                        provider_key_id: pk_entry.id.clone(),
-                        status: err.http_status(),
-                        success: false,
-                        error_class: routing_error_class(&err).to_string(),
-                        error_message: attempt_error_message(&err),
-                        latency_ms,
-                    });
-                    let retryable = is_retryable(&err, retry_on_429, fallback_statuses);
-                    tracing::warn!(
-                        target_model = %model.display_name,
-                        error = %err,
-                        retryable,
-                        "streaming routing target attempt failed",
-                    );
-                    if retryable {
-                        state.health.record_failure(&model.display_name);
-                    }
-                    if let Some((ttl, reason)) =
-                        decide_cooldown(&err, attempt.model.cooldown.as_ref())
-                    {
-                        state.runtime_status.mark_cooldown(&attempt.id, ttl, reason);
-                    }
-                    last_err = Some(err);
-                    if !retryable {
+                let attempt_started = Instant::now();
+                // Connect, then — only when a streaming budget is configured —
+                // peek the first chunk so a slow or erroring first token fails
+                // over before the 200 is committed. Without a budget there is
+                // nothing to gate on, so the stream is committed directly (a
+                // first-chunk error then surfaces in-band, exactly like the
+                // pre-#554 behavior). The read-timeout wrapper is a no-op when
+                // the budget is None.
+                let attempt_stream: Result<aisix_gateway::ChatChunkStream, BridgeError> =
+                    match bridge.chat_stream(req, &ctx).await {
+                        Err(e) => Err(e),
+                        Ok(up) => {
+                            let up = crate::stream_timeout::with_read_timeout(up, stream_budget);
+                            if stream_budget.is_some() {
+                                let mut up = up;
+                                match up.next().await {
+                                    // Re-prepend the peeked chunk so the SSE pump
+                                    // sees the whole stream (and records TTFT on
+                                    // the first content chunk); the wrapper keeps
+                                    // enforcing the read timeout on the rest.
+                                    Some(Ok(chunk)) => Ok(Box::pin(
+                                        futures::stream::once(std::future::ready(Ok::<
+                                            _,
+                                            BridgeError,
+                                        >(
+                                            chunk
+                                        )))
+                                        .chain(up),
+                                    )
+                                        as aisix_gateway::ChatChunkStream),
+                                    Some(Err(e)) => Err(e),
+                                    None => Err(BridgeError::StreamAborted),
+                                }
+                            } else {
+                                Ok(up)
+                            }
+                        }
+                    };
+                let latency_ms = attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+                match attempt_stream {
+                    Ok(upstream) => {
+                        state.health.record_success(&model.display_name);
+                        state.runtime_status.mark_healthy(&attempt.id);
+                        // Feed the least_latency EWMA. For streaming this is
+                        // time-to-first-response (upstream stream established) —
+                        // the routing-relevant latency signal.
+                        state.runtime_status.record_latency(&attempt.id, latency_ms);
+                        stream_routing.attempts.push(AttemptRecord {
+                            index: idx,
+                            kind,
+                            target_model,
+                            target_model_id: attempt.id.clone(),
+                            provider_key_id: pk_entry.id.clone(),
+                            status: 200,
+                            success: true,
+                            error_class: String::new(),
+                            error_message: String::new(),
+                            latency_ms,
+                        });
+                        won = Some(StreamWin {
+                            model: model.clone(),
+                            target_id: attempt.id.clone(),
+                            provider_lc: provider.to_ascii_lowercase(),
+                            pk_id: pk_entry.id.clone(),
+                            upstream,
+                            idx,
+                            kind,
+                        });
+                        won_member_reservation = member_reservation;
                         break 'targets;
+                    }
+                    Err(err) => {
+                        stream_routing.attempts.push(AttemptRecord {
+                            index: idx,
+                            kind,
+                            target_model,
+                            target_model_id: attempt.id.clone(),
+                            provider_key_id: pk_entry.id.clone(),
+                            status: err.http_status(),
+                            success: false,
+                            error_class: routing_error_class(&err).to_string(),
+                            error_message: attempt_error_message(&err),
+                            latency_ms,
+                        });
+                        let retryable = is_retryable(&err, retry_on_429, fallback_statuses);
+                        tracing::warn!(
+                            target_model = %model.display_name,
+                            target_attempt = attempt_idx + 1,
+                            error = %err,
+                            retryable,
+                            "streaming routing target attempt failed",
+                        );
+                        if retryable {
+                            state.health.record_failure(&model.display_name);
+                        }
+                        if let Some((ttl, reason)) =
+                            decide_cooldown(&err, attempt.model.cooldown.as_ref())
+                        {
+                            state.runtime_status.mark_cooldown(&attempt.id, ttl, reason);
+                        }
+                        last_err = Some(err);
+                        if !retryable {
+                            break 'targets;
+                        }
+                        if attempt_idx == retries {
+                            break;
+                        }
+                        // Exponential backoff + jitter before re-hitting the
+                        // SAME target (#788 P2); cross-target fail-over (the
+                        // outer loop) stays immediate.
+                        let backoff = crate::routing::retry_backoff((attempt_idx + 1) as u32);
+                        tracing::debug!(
+                            target_model = %model.display_name,
+                            next_attempt = attempt_idx + 2,
+                            backoff_ms = backoff.as_millis() as u64,
+                            "backing off before same-target retry",
+                        );
+                        tokio::time::sleep(backoff).await;
                     }
                 }
             }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -4253,8 +4253,8 @@ data: [DONE]\n\n";
         let resp = run(app, req).await;
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
 
-        // Streaming attempts only the first target (#655): the single
-        // failed initial attempt is emitted as one per-attempt event.
+        // Single target, `retries` unset (defaults to 0): exactly one
+        // attempt, emitted as one per-attempt event (#655).
         let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
             .await
             .expect("usage event was never emitted")
@@ -4282,6 +4282,193 @@ data: [DONE]\n\n";
                 extra.error_class
             );
         }
+    }
+
+    /// AISIX-Cloud#1119: the streaming path must honour `routing.retries`
+    /// exactly like the non-streaming one. Before the fix the streaming
+    /// loop walked targets once and never re-hit the same target, so a
+    /// retryable failure fell straight over — the operator saw
+    /// `initial → fallback` with the configured `retry #1` missing.
+    /// `retries=1` on an always-502 primary must make TWO attempts on it
+    /// before the secondary is tried.
+    #[tokio::test]
+    async fn streaming_routing_honors_same_target_retries() {
+        use aisix_obs::UsageSink;
+
+        let flaky_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("try again"))
+            // initial + one same-target retry. Pre-fix this was 1.
+            .expect(2)
+            .mount(&flaky_upstream)
+            .await;
+
+        let good_upstream = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"after retries\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"up-1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .expect(1)
+            .mount(&good_upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-flaky", &flaky_upstream.uri()));
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-good", &good_upstream.uri()));
+        snap.models
+            .insert(model_entry_with_id("m-flaky", "primary", "pk-flaky"));
+        snap.models
+            .insert(model_entry_with_id("m-good", "secondary", "pk-good"));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary", "secondary"],
+            Some(1),
+            Some(1),
+            None,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_router(build_state(snap, hub).with_usage_sink(UsageSink::new(tx)));
+        let body = serde_json::json!({
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Drain the stream — the winning attempt's UsageEvent is emitted
+        // by the end-of-stream Drop guard, so it isn't observable until
+        // the body is fully consumed.
+        let mut body_stream = resp.into_body().into_data_stream();
+        let mut decoder = SseDecoder::new();
+        let mut sse_events = Vec::new();
+        while let Some(chunk) = body_stream.next().await {
+            sse_events.extend(decoder.feed(chunk.unwrap().as_ref()));
+        }
+        assert!(sse_events.contains(&SseEvent::Done), "missing [DONE]");
+
+        // initial (primary 502) → retry (primary 502) → fallback (secondary 200)
+        let mut events = Vec::new();
+        for _ in 0..3 {
+            let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+                .await
+                .expect("usage event was never emitted")
+                .expect("sender dropped");
+            events.push(ev);
+        }
+        events.sort_by_key(|e| e.attempt_index);
+
+        assert_eq!(events[0].attempt_kind, "initial");
+        assert_eq!(events[0].attempt_model, "primary");
+        assert_eq!(events[0].status_code, 502);
+
+        // The attempt the operator reported missing in #1119.
+        assert_eq!(
+            events[1].attempt_kind, "retry",
+            "same-target retry must precede fail-over"
+        );
+        assert_eq!(events[1].attempt_model, "primary");
+        assert_eq!(events[1].model_id, "m-flaky");
+        assert_eq!(events[1].status_code, 502);
+
+        assert_eq!(events[2].attempt_kind, "fallback");
+        assert_eq!(events[2].attempt_model, "secondary");
+        assert_eq!(events[2].status_code, 200);
+    }
+
+    /// AISIX-Cloud#1119 / #1122: with a SINGLE target there is nothing to
+    /// fail over to, so `routing.retries` is the only thing standing
+    /// between a transient upstream blip and a failed request. The
+    /// streaming path used to attempt once and give up.
+    #[tokio::test]
+    async fn streaming_routing_retries_single_target_before_failing() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("transient"))
+            // initial + two same-target retries. Pre-fix this was 1.
+            .expect(3)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-only", &upstream.uri()));
+        snap.models
+            .insert(model_entry_with_id("m-only", "primary", "pk-only"));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary"],
+            Some(2),
+            None,
+            None,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_router(build_state(snap, hub).with_usage_sink(UsageSink::new(tx)));
+        let body = serde_json::json!({
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+        let mut events = Vec::new();
+        for _ in 0..3 {
+            let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+                .await
+                .expect("usage event was never emitted")
+                .expect("sender dropped");
+            events.push(ev);
+        }
+        events.sort_by_key(|e| e.attempt_index);
+        assert_eq!(events[0].attempt_kind, "initial");
+        assert_eq!(events[1].attempt_kind, "retry");
+        assert_eq!(events[2].attempt_kind, "retry");
+        assert!(
+            events.iter().all(|e| e.attempt_model == "primary"),
+            "all attempts stay on the single configured target"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/src/cases/retry-backoff-e2e.test.ts
+++ b/tests/e2e/src/cases/retry-backoff-e2e.test.ts
@@ -21,6 +21,10 @@ import {
 //
 // The assertion is a LOWER bound on elapsed time, which the exponential
 // floor makes non-flaky.
+//
+// The same router is exercised twice — non-streaming and `stream: true` —
+// because the two dispatch loops are written separately in chat.rs and the
+// streaming one used to ignore `retries` outright (AISIX-Cloud#1119).
 
 const CALLER_PLAINTEXT = "sk-retry-backoff-caller";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -128,6 +132,59 @@ describe("retry backoff e2e: same-target retries wait before re-hitting upstream
     // Three attempts to the single target (initial + 2 retries).
     expect(upstream.receivedRequests.length - hitsBefore).toBe(3);
     // ...and the two inter-retry backoffs make it take at least the floor.
+    expect(elapsed).toBeGreaterThanOrEqual(MIN_EXPECTED_MS);
+  });
+
+  // AISIX-Cloud#1119: the streaming dispatch loop walked the target list
+  // once and never read `routing.retries`, so a retryable failure went
+  // straight to fail-over — and with a single target (this router) the
+  // request just failed. Same router, same upstream, `stream: true`: the
+  // attempt count and the backoff floor must match the non-streaming case.
+  test("retries=2 applies to streaming requests too", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    await waitConfigPropagation(async () => {
+      const before = upstream!.receivedRequests.length;
+      try {
+        await client.chat.completions.create({
+          model: "retry-backoff-router",
+          messages: [{ role: "user", content: "probe" }],
+        });
+      } catch {
+        // expected: upstream is always 503.
+      }
+      return upstream!.receivedRequests.length > before;
+    });
+
+    const hitsBefore = upstream.receivedRequests.length;
+    const start = Date.now();
+    let caught: unknown;
+    try {
+      const stream = await client.chat.completions.create({
+        model: "retry-backoff-router",
+        messages: [{ role: "user", content: "drive the streaming retries" }],
+        stream: true,
+      });
+      for await (const _chunk of stream) {
+        // Drain; the upstream never gets far enough to emit one.
+      }
+    } catch (e) {
+      caught = e;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(caught).toBeInstanceOf(APIError);
+    // Pre-fix this was 1: streaming attempted the single target once.
+    expect(upstream.receivedRequests.length - hitsBefore).toBe(3);
     expect(elapsed).toBeGreaterThanOrEqual(MIN_EXPECTED_MS);
   });
 });


### PR DESCRIPTION
## Problem

`/v1/chat/completions` dispatches streaming and non-streaming requests through two separately-written loops in `crates/aisix-proxy/src/chat.rs`.

The non-streaming loop wraps each target in `for attempt_idx in 0..=retries` with exponential backoff. The streaming loop never read `routing.retries` at all — it walked `attempt_models` once and, on a retryable failure, went straight to the next target:

```
target A initial fails -> fallback to target B     (actual)
target A initial fails -> A retry #1 -> fallback   (configured)
```

With a **single** target there is nothing to fall over to, so one transient upstream error failed the request outright — `retries` was the only thing that could have saved it.

`/v1/messages` and `/v1/responses` don't have this gap: both run streaming and non-streaming through one loop (`dispatch_to_target` branches internally) that already honours `retries`. The streaming chat path was the only one that had drifted.

## Change

Nest the same-target retry loop inside the streaming target walk, mirroring the non-streaming loop:

- read `routing.retries` (default `0`, so behaviour is unchanged for anyone not configuring it);
- retryable failure → back off (`retry_backoff`, exponential + jitter) and re-hit the same target until `retries` is exhausted, then fall over;
- non-retryable failure → stop immediately, as before;
- target-invariant setup (`model_arc` / `pk_arc` / `BridgeContext` / stream budget) hoists above the retry loop; the per-attempt rate-limit reservation, telemetry record, and dispatch stay inside it.

## Behaviour change

Per-attempt telemetry now emits a `retry`-kind record for each extra same-target attempt, so the Logs view shows `initial → retry #1 → fallback` instead of `initial → fallback`. The attempt-failed warning gains `target_attempt`, matching the non-streaming log line.

Only requests on a routing model with `retries > 0` are affected. `retries` is read from the routing block, so a direct (non-group) model is still a single attempt.

## Tests

- `streaming_routing_honors_same_target_retries` — multi-target group, `retries=1`, always-502 primary: asserts the primary is hit twice and the attempt sequence is `initial → retry → fallback`.
- `streaming_routing_retries_single_target_before_failing` — single target, `retries=2`: asserts three attempts all on that target before the request fails.
- `retry-backoff-e2e.test.ts` gains a `stream: true` case asserting the same upstream hit count (3) and backoff floor as the existing non-streaming case.

All three fail before this change and pass after. Full `aisix-proxy` suite: 662 passed.

Fixes api7/AISIX-Cloud#1119
Fixes api7/AISIX-Cloud#1122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming requests now honor configured per-model retry counts before failing over to another target.
  * Retry attempts use exponential backoff and preserve accurate attempt and usage tracking.

* **Bug Fixes**
  * Streaming timeouts are applied consistently when connecting and reading response chunks.
  * Retry behavior now correctly handles single-target and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->