### PR TITLE
feat(anthropic): auto-inject prompt-cache breakpoints when enabled on a model

### DIFF
--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -158,6 +158,47 @@ impl CooldownConfig {
     }
 }
 
+/// Cache lifetime for gateway-injected prompt-cache breakpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub enum CacheTtl {
+    #[serde(rename = "5m")]
+    FiveMinutes,
+    #[serde(rename = "1h")]
+    OneHour,
+}
+
+impl CacheTtl {
+    /// The value emitted on the upstream `cache_control.ttl` field.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            CacheTtl::FiveMinutes => "5m",
+            CacheTtl::OneHour => "1h",
+        }
+    }
+}
+
+/// Automatic prompt-cache breakpoint injection for a direct Anthropic
+/// model. When enabled, the gateway adds cache-control markers to
+/// requests that carry none of their own, so callers get provider-side
+/// prompt-cache discounts without changing their requests. Requests that
+/// already set their own cache-control markers are forwarded unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AutoPromptCaching {
+    /// Whether automatic prompt-cache injection is active for this model.
+    pub enabled: bool,
+    /// Cache lifetime for injected breakpoints: `5m` (default when omitted) or `1h`. A `1h` cache write costs 2x the base input rate versus 1.25x for `5m`, so it pays off only when the cached prefix is reused across a longer session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<CacheTtl>,
+}
+
+impl AutoPromptCaching {
+    /// Effective TTL — operator override or the built-in 5-minute default.
+    pub fn ttl_or_default(&self) -> CacheTtl {
+        self.ttl.unwrap_or(CacheTtl::FiveMinutes)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Model {
@@ -237,6 +278,10 @@ pub struct Model {
     /// Direct-model-only request-path cooldown configuration. Omit this field to use the built-in cooldown behavior.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cooldown: Option<CooldownConfig>,
+
+    /// Automatic prompt-cache breakpoint injection for direct Anthropic models. Omit to leave injection off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_prompt_caching: Option<AutoPromptCaching>,
 
     /// Non-schema runtime id. Not part of the JSON payload — filled in by
     /// the snapshot loader from the etcd key path. Kept here so `Resource`

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -409,6 +409,135 @@ mod tests {
         BridgeContext::new("req-1", sample_model(), sample_provider_key(base))
     }
 
+    /// A ctx whose Model has `auto_prompt_caching` set to the given JSON
+    /// (e.g. `{"enabled":true,"ttl":"1h"}` or `{"enabled":false}`).
+    fn caching_ctx(base: &str, apc: serde_json::Value) -> BridgeContext {
+        let model: Model = serde_json::from_value(serde_json::json!({
+            "display_name": "my-claude",
+            "provider": "anthropic",
+            "model_name": "claude-sonnet-4-5",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111",
+            "auto_prompt_caching": apc,
+        }))
+        .unwrap();
+        BridgeContext::new("req-1", Arc::new(model), sample_provider_key(base))
+    }
+
+    /// Capture the single body the bridge POSTed to the mock upstream.
+    async fn captured_body(server: &MockServer) -> serde_json::Value {
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1, "expected exactly one upstream request");
+        serde_json::from_slice(&reqs[0].body).unwrap()
+    }
+
+    /// Mount a minimal non-streaming 200 so `chat` completes.
+    async fn mount_ok_nonstream(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "msg_x", "type": "message", "role": "assistant",
+                "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            })))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn non_streaming_injects_breakpoints_when_enabled() {
+        let server = MockServer::start().await;
+        mount_ok_nonstream(&server).await;
+        let ctx = caching_ctx(
+            &server.uri(),
+            serde_json::json!({"enabled": true, "ttl": "1h"}),
+        );
+        // req() is system("you are helpful") + user("hi") — no markers.
+        AnthropicBridge::new().chat(&req(), &ctx).await.unwrap();
+
+        let body = captured_body(&server).await;
+        assert_eq!(
+            body["system"],
+            serde_json::json!([
+                {"type": "text", "text": "you are helpful",
+                 "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ])
+        );
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(
+            msgs.last().unwrap()["content"]
+                .as_array()
+                .unwrap()
+                .last()
+                .unwrap()["cache_control"],
+            serde_json::json!({"type": "ephemeral", "ttl": "1h"})
+        );
+    }
+
+    #[tokio::test]
+    async fn non_streaming_does_not_inject_when_disabled() {
+        // Field present but enabled:false must inject nothing — distinct
+        // from the field-absent case sample_ctx covers.
+        let server = MockServer::start().await;
+        mount_ok_nonstream(&server).await;
+        let ctx = caching_ctx(&server.uri(), serde_json::json!({"enabled": false}));
+        AnthropicBridge::new().chat(&req(), &ctx).await.unwrap();
+
+        let body = captured_body(&server).await;
+        // Plain-string system, no markers anywhere.
+        assert_eq!(body["system"], serde_json::json!("you are helpful"));
+        assert!(body["messages"][0]["content"][0]
+            .get("cache_control")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn streaming_injects_breakpoints_when_enabled() {
+        // The streaming path must inject identically to the
+        // non-streaming path (handler-families lockstep). Capture the
+        // outbound body, not just the streamed chunks.
+        let server = MockServer::start().await;
+        let sse = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"m\",\"model\":\"claude-sonnet-4-5\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":1}}}\n\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&server)
+            .await;
+        let ctx = caching_ctx(
+            &server.uri(),
+            serde_json::json!({"enabled": true, "ttl": "1h"}),
+        );
+        let mut stream = AnthropicBridge::new()
+            .chat_stream(&req(), &ctx)
+            .await
+            .unwrap();
+        while stream.next().await.is_some() {}
+
+        let body = captured_body(&server).await;
+        assert_eq!(
+            body["system"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral", "ttl": "1h"})
+        );
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(
+            msgs.last().unwrap()["content"]
+                .as_array()
+                .unwrap()
+                .last()
+                .unwrap()["cache_control"],
+            serde_json::json!({"type": "ephemeral", "ttl": "1h"})
+        );
+    }
+
     fn req() -> ChatFormat {
         ChatFormat::new(
             "my-claude",

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -24,8 +24,8 @@ use reqwest::{header, Client, StatusCode};
 use std::time::{Duration, Instant};
 
 use crate::wire::{
-    build_request, response_into_chat_response, split_system, AnthropicResponse,
-    AnthropicStreamEvent, StreamState,
+    build_request, inject_cache_breakpoints, response_into_chat_response, split_system,
+    AnthropicResponse, AnthropicStreamEvent, StreamState,
 };
 
 /// Matches the API header that Anthropic bakes backwards-compat into.
@@ -171,6 +171,25 @@ fn upstream_model(ctx: &BridgeContext) -> Result<&str, BridgeError> {
         .ok_or_else(|| BridgeError::InvalidUpstreamConfig("model.model_name missing".into()))
 }
 
+/// Apply the Model's `auto_prompt_caching` setting to the outbound
+/// request. A no-op unless the operator enabled it; the wire-level
+/// stand-down (a caller who set their own markers wins) lives in
+/// [`inject_cache_breakpoints`]. Shared by the streaming and
+/// non-streaming paths so they can't drift.
+fn maybe_inject_cache_breakpoints(
+    body: &mut crate::wire::AnthropicRequest<'_>,
+    ctx: &BridgeContext,
+) {
+    if let Some(apc) = ctx
+        .model
+        .auto_prompt_caching
+        .as_ref()
+        .filter(|apc| apc.enabled)
+    {
+        inject_cache_breakpoints(body, apc.ttl_or_default().as_wire_str());
+    }
+}
+
 async fn map_http_error(status: StatusCode, resp: reqwest::Response) -> BridgeError {
     aisix_gateway::capture_upstream_error_http(
         status,
@@ -248,7 +267,8 @@ impl Bridge for AnthropicBridge {
 
         let (system, messages) =
             split_system(req).map_err(|e| BridgeError::InvalidUpstreamConfig(e.to_string()))?;
-        let body = build_request(req, upstream, system, messages, false);
+        let mut body = build_request(req, upstream, system, messages, false);
+        maybe_inject_cache_breakpoints(&mut body, ctx);
         let url = format!("{base}/v1/messages");
         let client = self.client.clone();
         let api_version = self.api_version;
@@ -292,7 +312,8 @@ impl Bridge for AnthropicBridge {
 
         let (system, messages) =
             split_system(req).map_err(|e| BridgeError::InvalidUpstreamConfig(e.to_string()))?;
-        let body = build_request(req, upstream, system, messages, true);
+        let mut body = build_request(req, upstream, system, messages, true);
+        maybe_inject_cache_breakpoints(&mut body, ctx);
         let url = format!("{base}/v1/messages");
         let client = self.client.clone();
         let api_version = self.api_version;

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -51,9 +51,9 @@ pub enum AnthropicSystem {
 impl AnthropicSystem {
     /// Attach a `cache_control` marker to the last system block,
     /// promoting the string form to a single text block so the marker
-    /// has somewhere to live. A no-op only if the block form is somehow
-    /// empty (unreachable in practice — a system prompt always has at
-    /// least one block).
+    /// has somewhere to live. Skips an empty/whitespace-only last block
+    /// (a blank system prompt promotes to `{"type":"text","text":""}`),
+    /// which Anthropic rejects with a 400 — see [`is_empty_text_block`].
     fn mark_last_block(&mut self, marker: serde_json::Value) {
         if let AnthropicSystem::Text(s) = self {
             let text = std::mem::take(s);
@@ -61,7 +61,11 @@ impl AnthropicSystem {
                 AnthropicSystem::Blocks(vec![serde_json::json!({"type": "text", "text": text})]);
         }
         if let AnthropicSystem::Blocks(blocks) = self {
-            if let Some(obj) = blocks.last_mut().and_then(|b| b.as_object_mut()) {
+            if let Some(obj) = blocks
+                .last_mut()
+                .filter(|b| !is_empty_text_block(b))
+                .and_then(|b| b.as_object_mut())
+            {
                 obj.insert("cache_control".into(), marker);
             }
         }
@@ -470,8 +474,13 @@ pub fn build_request<'a>(
 ///
 /// `ttl` is the wire value for the injected markers (`5m` or `1h`); `5m`
 /// is emitted as the bare `{"type":"ephemeral"}` Anthropic treats as the
-/// five-minute default. Below-minimum prompts are a documented silent
-/// no-op upstream, so no length gate is applied here.
+/// five-minute default. A *below-minimum-length* prompt is a documented
+/// silent no-op upstream, so no length gate is applied — but an *empty*
+/// text block is a different case Anthropic rejects with a 400
+/// (`cache_control cannot be set for empty text blocks`), so the marker
+/// is never attached to one. The empty-text degrade shape is reachable
+/// on the final turn (an image-only user message flattens to a single
+/// `{"type":"text","text":""}` block) and on a blank system prompt.
 pub fn inject_cache_breakpoints(req: &mut AnthropicRequest<'_>, ttl: &str) {
     if request_has_cache_control(req) {
         return;
@@ -484,10 +493,23 @@ pub fn inject_cache_breakpoints(req: &mut AnthropicRequest<'_>, ttl: &str) {
         .messages
         .last_mut()
         .and_then(|m| m.content.last_mut())
+        .filter(|b| !is_empty_text_block(b))
         .and_then(|b| b.as_object_mut())
     {
         block.insert("cache_control".into(), marker);
     }
+}
+
+/// Whether a content block is a text block with empty or whitespace-only
+/// text. Anthropic rejects `cache_control` on such a block with a 400
+/// (`cache_control cannot be set for empty text blocks`), so the
+/// injector must skip it — it cannot be cached anyway.
+fn is_empty_text_block(block: &serde_json::Value) -> bool {
+    block.get("type").and_then(|t| t.as_str()) == Some("text")
+        && block
+            .get("text")
+            .and_then(|t| t.as_str())
+            .is_none_or(|t| t.trim().is_empty())
 }
 
 /// The marker written by [`inject_cache_breakpoints`]. `1h` carries the
@@ -2542,6 +2564,84 @@ mod tests {
         assert!(wire["messages"][0]["content"][0]
             .get("cache_control")
             .is_none());
+    }
+
+    #[test]
+    fn inject_skips_empty_text_final_block() {
+        // An image-only final user turn flattens to a single empty text
+        // block (images dropped on this bridge). Anthropic 400s on
+        // cache_control attached to an empty text block, so the injector
+        // must leave it unmarked.
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::system("prefix"),
+                block_message(
+                    Role::User,
+                    serde_json::json!([
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,xyz"}},
+                    ]),
+                ),
+            ],
+        );
+        let wire = injected_wire(&req, "5m");
+        // System still gets its marker (non-empty), but the degraded
+        // empty final block does not.
+        assert_eq!(
+            wire["system"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+        assert_eq!(
+            wire["messages"][0]["content"][0],
+            serde_json::json!({"type": "text", "text": ""})
+        );
+    }
+
+    #[test]
+    fn inject_skips_blank_system_prompt() {
+        // A whitespace-only system message promotes to an empty text
+        // block; it must not be marked (same 400 hazard).
+        let req = ChatFormat::new(
+            "claude",
+            vec![ChatMessage::system("   "), ChatMessage::user("hi")],
+        );
+        let wire = injected_wire(&req, "5m");
+        // System, if emitted as blocks, carries no marker on the empty
+        // block; the trailing user message still gets one.
+        if let Some(sys) = wire.get("system").filter(|v| v.is_array()) {
+            assert!(sys[0].get("cache_control").is_none());
+        }
+        assert_eq!(
+            wire["messages"][0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+    }
+
+    #[test]
+    fn inject_marks_only_the_last_block_of_a_multi_block_final_message() {
+        // Final message with several content blocks: only the LAST is
+        // marked (a marker means "cache through here"), earlier blocks
+        // stay clean — guards against marking the first or every block.
+        let req = ChatFormat::new(
+            "claude",
+            vec![block_message(
+                Role::User,
+                serde_json::json!([
+                    {"type": "text", "text": "block A"},
+                    {"type": "text", "text": "block B"},
+                    {"type": "text", "text": "block C"},
+                ]),
+            )],
+        );
+        let wire = injected_wire(&req, "5m");
+        let content = wire["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 3);
+        assert!(content[0].get("cache_control").is_none());
+        assert!(content[1].get("cache_control").is_none());
+        assert_eq!(
+            content[2]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -48,6 +48,26 @@ pub enum AnthropicSystem {
     Blocks(Vec<serde_json::Value>),
 }
 
+impl AnthropicSystem {
+    /// Attach a `cache_control` marker to the last system block,
+    /// promoting the string form to a single text block so the marker
+    /// has somewhere to live. A no-op only if the block form is somehow
+    /// empty (unreachable in practice — a system prompt always has at
+    /// least one block).
+    fn mark_last_block(&mut self, marker: serde_json::Value) {
+        if let AnthropicSystem::Text(s) = self {
+            let text = std::mem::take(s);
+            *self =
+                AnthropicSystem::Blocks(vec![serde_json::json!({"type": "text", "text": text})]);
+        }
+        if let AnthropicSystem::Blocks(blocks) = self {
+            if let Some(obj) = blocks.last_mut().and_then(|b| b.as_object_mut()) {
+                obj.insert("cache_control".into(), marker);
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AnthropicRequest<'a> {
     pub model: &'a str,
@@ -434,6 +454,73 @@ pub fn build_request<'a>(
         tool_choice,
         extra: extras,
     }
+}
+
+/// Inject a pair of prompt-cache breakpoints into a request that carries
+/// none of its own — one on the last system block, one on the last
+/// content block of the final message — so the stable tools+system
+/// prefix and the whole conversation prefix are cached
+/// (<https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>).
+///
+/// Standing down entirely when the caller already supplied any
+/// `cache_control` marker (on system, messages, or tools) is deliberate:
+/// it never overrides the caller's own strategy, and it is what keeps the
+/// request within Anthropic's four-breakpoint cap — this function adds at
+/// most two markers, and only to a request that had zero.
+///
+/// `ttl` is the wire value for the injected markers (`5m` or `1h`); `5m`
+/// is emitted as the bare `{"type":"ephemeral"}` Anthropic treats as the
+/// five-minute default. Below-minimum prompts are a documented silent
+/// no-op upstream, so no length gate is applied here.
+pub fn inject_cache_breakpoints(req: &mut AnthropicRequest<'_>, ttl: &str) {
+    if request_has_cache_control(req) {
+        return;
+    }
+    let marker = cache_control_marker(ttl);
+    if let Some(system) = req.system.as_mut() {
+        system.mark_last_block(marker.clone());
+    }
+    if let Some(block) = req
+        .messages
+        .last_mut()
+        .and_then(|m| m.content.last_mut())
+        .and_then(|b| b.as_object_mut())
+    {
+        block.insert("cache_control".into(), marker);
+    }
+}
+
+/// The marker written by [`inject_cache_breakpoints`]. `1h` carries the
+/// explicit `ttl`; `5m` (and any other value) uses the bare ephemeral
+/// form that defaults to five minutes.
+fn cache_control_marker(ttl: &str) -> serde_json::Value {
+    if ttl == "1h" {
+        serde_json::json!({"type": "ephemeral", "ttl": "1h"})
+    } else {
+        serde_json::json!({"type": "ephemeral"})
+    }
+}
+
+/// Whether the request already carries any caller-supplied `cache_control`
+/// marker on a system block, a message content block, or a tool
+/// definition — the stand-down signal for [`inject_cache_breakpoints`].
+/// The string-form system prompt cannot carry a marker, so only the
+/// block form is scanned.
+fn request_has_cache_control(req: &AnthropicRequest<'_>) -> bool {
+    let system_marked = matches!(&req.system, Some(AnthropicSystem::Blocks(b)) if b.iter().any(block_has_cache_control));
+    system_marked
+        || req
+            .messages
+            .iter()
+            .any(|m| m.content.iter().any(block_has_cache_control))
+        || req
+            .tools
+            .as_ref()
+            .is_some_and(|tools| tools.iter().any(block_has_cache_control))
+}
+
+fn block_has_cache_control(block: &serde_json::Value) -> bool {
+    block.get("cache_control").is_some()
 }
 
 /// Translate the caller's OpenAI-shape `tools` array into
@@ -2346,6 +2433,142 @@ mod tests {
             serde_json::json!({"type": "ephemeral", "ttl": "1h"})
         );
         assert!(translated[2].get("cache_control").is_none());
+    }
+
+    /// Build a request from `req`, run injection with `ttl`, and return
+    /// the serialized wire body — what the upstream actually receives.
+    fn injected_wire(req: &ChatFormat, ttl: &str) -> serde_json::Value {
+        let (system, messages) = split_system(req).unwrap();
+        let mut built = build_request(req, "claude-sonnet-4-5", system, messages, false);
+        inject_cache_breakpoints(&mut built, ttl);
+        serde_json::to_value(&built).unwrap()
+    }
+
+    #[test]
+    fn inject_marks_last_system_block_and_final_message_block() {
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::system("big stable prefix"),
+                ChatMessage::user("first"),
+                ChatMessage::assistant("answer"),
+                ChatMessage::user("latest"),
+            ],
+        );
+        let wire = injected_wire(&req, "5m");
+        // Plain-string system promotes to a one-block array carrying the
+        // 5m marker (bare ephemeral form).
+        assert_eq!(
+            wire["system"],
+            serde_json::json!([
+                {"type": "text", "text": "big stable prefix",
+                 "cache_control": {"type": "ephemeral"}},
+            ])
+        );
+        // Only the final message's last block is marked; earlier turns
+        // stay clean.
+        let msgs = wire["messages"].as_array().unwrap();
+        assert!(msgs[0]["content"][0].get("cache_control").is_none());
+        let last = msgs.last().unwrap();
+        assert_eq!(last["role"], "user");
+        assert_eq!(
+            last["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+    }
+
+    #[test]
+    fn inject_one_hour_ttl_carries_explicit_ttl() {
+        let req = ChatFormat::new("claude", vec![ChatMessage::user("hi")]);
+        let wire = injected_wire(&req, "1h");
+        let msgs = wire["messages"].as_array().unwrap();
+        assert_eq!(
+            msgs[0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral", "ttl": "1h"})
+        );
+    }
+
+    #[test]
+    fn inject_with_no_system_marks_only_the_trailing_message() {
+        let req = ChatFormat::new("claude", vec![ChatMessage::user("hi")]);
+        let wire = injected_wire(&req, "5m");
+        assert!(wire.get("system").is_none() || wire["system"].is_null());
+        assert_eq!(
+            wire["messages"][0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+    }
+
+    #[test]
+    fn inject_stands_down_when_client_marked_a_message_block() {
+        // Client set its own marker → gateway injects nothing, anywhere.
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::system("prefix"),
+                block_message(
+                    Role::User,
+                    serde_json::json!([
+                        {"type": "text", "text": "hi",
+                         "cache_control": {"type": "ephemeral"}},
+                    ]),
+                ),
+            ],
+        );
+        let wire = injected_wire(&req, "5m");
+        // System stayed the plain string form (never promoted / marked).
+        assert_eq!(wire["system"], serde_json::json!("prefix"));
+        // The one marker present is the client's; no second one added.
+        assert_eq!(
+            wire["messages"][0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+    }
+
+    #[test]
+    fn inject_stands_down_when_client_marked_a_tool() {
+        // A marker on a tool definition also suppresses injection — the
+        // stand-down scan covers tools, not just messages/system.
+        let mut req = ChatFormat::new("claude", vec![ChatMessage::user("hi")]);
+        req.extra.insert(
+            "tools".into(),
+            serde_json::json!([{
+                "type": "function",
+                "function": {"name": "f", "parameters": {"type": "object"}},
+                "cache_control": {"type": "ephemeral"},
+            }]),
+        );
+        let wire = injected_wire(&req, "5m");
+        assert!(wire["messages"][0]["content"][0]
+            .get("cache_control")
+            .is_none());
+    }
+
+    #[test]
+    fn inject_appends_marker_to_client_block_form_system() {
+        // Client sent a block-form system with NO marker of its own:
+        // injection marks its last block in place (no string promotion).
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                block_message(
+                    Role::System,
+                    serde_json::json!([
+                        {"type": "text", "text": "line one"},
+                        {"type": "text", "text": "line two"},
+                    ]),
+                ),
+                ChatMessage::user("hi"),
+            ],
+        );
+        let wire = injected_wire(&req, "5m");
+        let sys = wire["system"].as_array().unwrap();
+        assert_eq!(sys.len(), 2);
+        assert!(sys[0].get("cache_control").is_none());
+        assert_eq!(
+            sys[1]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
     }
 
     #[test]

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -14,6 +14,28 @@
         }
       ]
     },
+    "AutoPromptCaching": {
+      "additionalProperties": false,
+      "description": "Automatic prompt-cache breakpoint injection for a direct Anthropic model. When enabled, the gateway adds cache-control markers to requests that carry none of their own, so callers get provider-side prompt-cache discounts without changing their requests. Requests that already set their own cache-control markers are forwarded unchanged.",
+      "properties": {
+        "enabled": {
+          "description": "Whether automatic prompt-cache injection is active for this model.",
+          "type": "boolean"
+        },
+        "ttl": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/CacheTtl"
+            }
+          ],
+          "description": "Cache lifetime for injected breakpoints: `5m` (default when omitted) or `1h`. A `1h` cache write costs 2x the base input rate versus 1.25x for `5m`, so it pays off only when the cached prefix is reused across a longer session."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": "object"
+    },
     "BackgroundModelCheck": {
       "additionalProperties": false,
       "properties": {
@@ -70,6 +92,14 @@
         "timeout_seconds"
       ],
       "type": "object"
+    },
+    "CacheTtl": {
+      "description": "Cache lifetime for gateway-injected prompt-cache breakpoints.",
+      "enum": [
+        "5m",
+        "1h"
+      ],
+      "type": "string"
     },
     "CooldownConfig": {
       "additionalProperties": false,
@@ -830,6 +860,14 @@
         "type": "string"
       },
       "type": "array"
+    },
+    "auto_prompt_caching": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AutoPromptCaching"
+        }
+      ],
+      "description": "Automatic prompt-cache breakpoint injection for direct Anthropic models. Omit to leave injection off."
     },
     "background_model_check": {
       "allOf": [

--- a/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-upstream-e2e.test.ts
@@ -620,3 +620,191 @@ describe("anthropic upstream e2e: client cache_control markers survive translati
     ]);
   });
 });
+
+// E2E (AISIX-Cloud#1110 Phase 1): a model with `auto_prompt_caching`
+// enabled makes the gateway INJECT cache_control breakpoints into
+// requests that carry none of their own — one on the last system block,
+// one on the last content block of the final message — so callers get
+// provider-side prompt-cache discounts without changing their requests.
+// A caller that set its own markers wins (stand-down).
+const INJ_CALLER_PLAINTEXT = "sk-an-e2e-inject-caller";
+const INJ_CALLER_KEY_HASH = createHash("sha256")
+  .update(INJ_CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("anthropic upstream e2e: auto_prompt_caching injects breakpoints (AISIX-Cloud#1110)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_inj_01",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        model: "claude-3-5-haiku-20241022",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 5, output_tokens: 1 },
+      },
+    });
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "an-e2e-inject-pk",
+      provider: "anthropic",
+      adapter: "anthropic",
+      secret: "sk-ant-mock",
+      api_base: upstream.baseUrl,
+    });
+    await seed.createModel({
+      display_name: "an-e2e-inject",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: pk.id,
+      auto_prompt_caching: { enabled: true, ttl: "1h" },
+    });
+    await seed.createApiKey({
+      key_hash: INJ_CALLER_KEY_HASH,
+      allowed_models: ["an-e2e-inject"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("plain request gets breakpoints on system + final message, at the configured ttl", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const proxy = new ProxyClient(app.proxyUrl, INJ_CALLER_PLAINTEXT);
+
+    await waitConfigPropagation(async () => {
+      const r = await proxy.chat({
+        model: "an-e2e-inject",
+        messages: [{ role: "user", content: "ready-probe" }],
+      });
+      return r.status === 200;
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    // A plain OpenAI-shape request with NO cache_control anywhere.
+    const { status } = await proxy.chat({
+      model: "an-e2e-inject",
+      messages: [
+        { role: "system", content: "big stable system prefix" },
+        { role: "user", content: "first turn" },
+        { role: "assistant", content: "prior answer" },
+        { role: "user", content: "latest turn" },
+      ],
+    });
+    expect(status).toBe(200);
+
+    const messagesReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path.startsWith("/v1/messages"));
+    expect(messagesReq).toBeDefined();
+    const sentBody = JSON.parse(messagesReq!.body) as {
+      system?: unknown;
+      messages?: Array<{ role?: string; content?: Array<Record<string, unknown>> }>;
+    };
+
+    // System breakpoint: the plain-string system promotes to a
+    // one-block array carrying the injected marker at the configured
+    // 1h ttl.
+    expect(sentBody.system).toEqual([
+      {
+        type: "text",
+        text: "big stable system prefix",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
+
+    // Trailing breakpoint: ONLY the final message's last block is
+    // marked — earlier turns stay clean (the marker advances with the
+    // conversation, it doesn't blanket every turn).
+    const msgs = sentBody.messages!;
+    expect(msgs).toHaveLength(3);
+    expect(msgs[0]?.content?.[0]?.cache_control).toBeUndefined();
+    expect(msgs[1]?.content?.[0]?.cache_control).toBeUndefined();
+    expect(msgs[2]?.role).toBe("user");
+    expect(msgs[2]?.content?.[0]).toEqual({
+      type: "text",
+      text: "latest turn",
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    });
+  });
+
+  test("stand-down: a caller that set its own marker gets nothing injected", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const proxy = new ProxyClient(app.proxyUrl, INJ_CALLER_PLAINTEXT);
+
+    await waitConfigPropagation(async () => {
+      const r = await proxy.chat({
+        model: "an-e2e-inject",
+        messages: [{ role: "user", content: "ready-probe" }],
+      });
+      return r.status === 200;
+    });
+
+    const baseline = upstream.receivedRequests.length;
+
+    // Caller marks its own system prefix. The gateway must not add a
+    // second system marker, and must not mark the trailing message —
+    // exceeding Anthropic's 4-breakpoint cap or overriding the caller's
+    // strategy would be the bug.
+    const { status } = await proxy.chat({
+      model: "an-e2e-inject",
+      messages: [
+        {
+          role: "system",
+          content: [
+            {
+              type: "text",
+              text: "caller-managed prefix",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+        { role: "user", content: "hello" },
+      ],
+    });
+    expect(status).toBe(200);
+
+    const messagesReq = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path.startsWith("/v1/messages"));
+    expect(messagesReq).toBeDefined();
+    const sentBody = JSON.parse(messagesReq!.body) as {
+      system?: Array<Record<string, unknown>>;
+      messages?: Array<{ content?: Array<Record<string, unknown>> }>;
+    };
+
+    // Exactly the caller's one marker survives; the trailing user
+    // message is untouched.
+    expect(sentBody.system).toEqual([
+      {
+        type: "text",
+        text: "caller-managed prefix",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+    expect(sentBody.messages?.[0]?.content?.[0]?.cache_control).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

When a direct Anthropic model has `auto_prompt_caching` enabled, the gateway now **injects prompt-cache breakpoints** into requests that carry none of their own — one on the last system block, one on the last content block of the final message. Callers get provider-side prompt-cache discounts (0.1× input on cache reads) and faster TTFT with **zero client changes**. Callers that set their own `cache_control` markers are forwarded unchanged (stand-down).

Phase 1 (DP half) of AISIX-Cloud#1110. Builds on #804 (Phase 0 — marker preservation), which this PR is stacked on.

## Why two breakpoints, why these positions

Per the Anthropic prompt-cache prefix hierarchy (tools → system → messages, [docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)):
- **Last system block** → caches the stable tools+system prefix.
- **Last content block of the final message** → caches the whole conversation prefix; because it rides the final turn, it advances as the conversation grows, so each turn re-caches incrementally.

This is the convergent strategy across the mainstream gateways that auto-inject (a system+trailing pair, trailing marker advancing with the dialogue). We inject at most two markers and only into a request that had zero, so Anthropic's 4-breakpoint cap can never be breached.

## Scope — direct Anthropic only

Injection is applied **only in the Anthropic bridge** (`chat` + `chat_stream`), not in the shared `build_request` — so the Bedrock-invoke and Vertex `:rawPredict` paths (which also call `build_request`) do **not** inject. That's deliberate: gateway-authored markers on Bedrock/Vertex carry provider-specific hazards (per-model 5m-only TTL tiers on Bedrock; Vertex's per-project "explicit caching disabled → reject" mode) that pass-through fidelity doesn't. Bedrock injection is AISIX-Cloud#1110 Phase 2; Vertex is deferred there. Marker **preservation** (Phase 0, #804) already covers all three.

## Changes

**DP config (`aisix-core`)**
- `Model.auto_prompt_caching: Option<AutoPromptCaching>` — nested `{ enabled: bool, ttl: Option<CacheTtl> }`, following the `CooldownConfig` house pattern. `CacheTtl` = `5m | 1h` (default `5m`). Regenerated `schemas/resources/model.schema.json`.

**DP injection (`aisix-provider-anthropic`)**
- `inject_cache_breakpoints(req, ttl)` in `wire.rs`: stand-down scan (any `cache_control` on system/messages/tools → inject nothing), else mark the last system block (promoting a string-form system to a one-block array so the marker has somewhere to live) and the last content block of the final message. `5m` emits the bare `{"type":"ephemeral"}` Anthropic treats as the 5-minute default; `1h` carries the explicit `ttl`.
- `maybe_inject_cache_breakpoints(body, ctx)` in `bridge.rs`: reads `ctx.model.auto_prompt_caching`, gates on `enabled`, shared by the streaming and non-streaming paths so they can't drift.

No min-token gate: below-minimum-*length* prompts are a documented silent no-op upstream (no error, normal billing, both cache counters 0), so speculative injection on short prompts is harmless. An *empty* text block is a different case — Anthropic 400s on `cache_control` attached to one — so injection skips empty/whitespace-only blocks (reachable via the image-only-turn degrade shape and a blank system prompt); see `is_empty_text_block`.

## Billing / observability — already wired

No usage-plumbing change needed: the response path already parses `cache_creation_input_tokens` / `cache_read_input_tokens` (`wire.rs`), and the control plane already prices them at distinct `cache_read` / `cache_write` rates — so budgets, spend reports, and the dashboard reflect injected-cache economics for free.

## Paired CP work (required before this is user-reachable) — AISIX-Cloud#1110

Per the repo's config-knob rule, this DP PR is **one half**. The `auto_prompt_caching` knob is not reachable until the control plane exposes it: `cp-admin.yaml` schema + Go model/validation/kine projection + dashboard form + en/zh i18n. That is a **paired CP PR**, tracked in AISIX-Cloud#1110.

**Rollout ordering (blocking constraint):** DP `Model` is `#[serde(deny_unknown_fields)]`, so this DP PR — which teaches the DP to *read* `auto_prompt_caching` — **must deploy before** the CP PR that *writes* it. If the CP shipped the field first, any model carrying it would be silently dropped from the DP snapshot and 404. This PR is the safe-to-land-first half by construction.

## Testing

- `wire.rs` unit tests (9): system+trailing marking, 1h ttl, no-system case, stand-down on a client message marker, stand-down on a client tool marker, in-place marking of a client block-form system, **empty-text final block skipped, blank system skipped, only-last-of-multi-block marked**.
- `bridge.rs` tests (3): non-streaming injects when enabled, **streaming injects when enabled** (captures the outbound body, closing the chat_stream coverage gap), does-not-inject when `enabled:false`.
- e2e (`anthropic-upstream-e2e.test.ts`, 2 new): black-box wire-shape — an `auto_prompt_caching`-enabled model injects markers on system (block-array form) + final message at the configured `1h` ttl with earlier turns clean and a message-count pin; and a stand-down case where a caller-marked request comes out with exactly its own single marker.
- Full workspace `cargo test` + Phase-0 e2e green (injection e2e run 3×, stable); `cargo fmt` + clippy clean.

## Audit round

Independent 6-angle cold audit (5 confirmed / 2 rejected), all addressed in the follow-up commit:
- **HIGH (spec):** injection stamped `cache_control` onto an empty text block (image-only/caption-less final turn, or blank system) → Anthropic 400. Fixed with `is_empty_text_block` guard on both injection sites + 2 unit tests.
- **MEDIUM ×2 (reliability + e2e):** `chat_stream` injection had zero test coverage. Added a bridge-level streaming test capturing the outbound body.
- **MEDIUM (e2e):** only-last-block-marked was asserted only against single-block final messages. Added a 3-block unit test.
- **LOW (e2e):** `enabled:false` gate untested. Added a bridge test.
- **Rejected:** an "empty block is a silent no-op not a 400" LOW (superseded — the guard is correct either way) and a default-on cache-tenancy side-channel LOW (feature is opt-in default-off; the provider-credential cache boundary is already noted in AISIX-Cloud#1110 for the customer docs).

## Deliberately out of scope

- CP knob exposure — paired PR, AISIX-Cloud#1110 (see above).
- Bedrock (Phase 2) / Vertex (deferred) injection — AISIX-Cloud#1110.
- Native `/v1/messages` passthrough injection: those callers are cache-aware and send their own markers (→ stand-down), so injection targets the OpenAI-shape callers who don't; tracked in AISIX-Cloud#1110 if a gap emerges.
- The newer `usage.cache_creation.{ephemeral_5m,ephemeral_1h}_input_tokens` breakdown (verifies 5m-vs-1h write billing) — AISIX-Cloud#1110 follow-up.
