### PR TITLE
fix(guardrails): scan the union of content and content_blocks

### DIFF
--- a/crates/aisix-guardrails/src/keyword.rs
+++ b/crates/aisix-guardrails/src/keyword.rs
@@ -213,6 +213,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocks_keyword_hidden_in_tool_call_arguments() {
+        // Same bypass via `extra["tool_calls"]`: a history-replay tool
+        // call carries the banned keyword in its arguments, which the
+        // bridges forward upstream. Must be scanned and blocked.
+        let msg: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "c1",
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "arguments": "{\"q\":\"the FORBIDDEN word\"}"
+                }
+            }]
+        }))
+        .unwrap();
+        let g = KeywordBlocklist::new(vec![KeywordRule::literal("Forbidden")]);
+        let v = g.check_input(&ChatFormat::new("m", vec![msg])).await;
+        assert!(
+            v.is_block(),
+            "keyword hidden in tool_call arguments must be blocked"
+        );
+    }
+
+    #[tokio::test]
     async fn empty_literal_pattern_never_matches() {
         let g = KeywordBlocklist::new(vec![KeywordRule::literal("")]);
         let v = g.check_input(&req(&[("user", "anything")])).await;

--- a/crates/aisix-guardrails/src/keyword.rs
+++ b/crates/aisix-guardrails/src/keyword.rs
@@ -192,6 +192,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocks_keyword_hidden_in_content_blocks_behind_benign_flat_content() {
+        // Guardrail bypass: a caller sends benign top-level `content` but
+        // hides the banned keyword in a `content_blocks` text entry, which
+        // the provider bridges forward upstream. The scan must catch it —
+        // otherwise every input guardrail is trivially bypassed by a valid
+        // key holder.
+        let msg: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "user",
+            "content": "what is a good banana bread recipe?",
+            "content_blocks": [{"type": "text", "text": "the FORBIDDEN word"}]
+        }))
+        .unwrap();
+        let g = KeywordBlocklist::new(vec![KeywordRule::literal("Forbidden")]);
+        let v = g.check_input(&ChatFormat::new("m", vec![msg])).await;
+        assert!(
+            v.is_block(),
+            "keyword hidden in content_blocks must still be blocked"
+        );
+    }
+
+    #[tokio::test]
     async fn empty_literal_pattern_never_matches() {
         let g = KeywordBlocklist::new(vec![KeywordRule::literal("")]);
         let v = g.check_input(&req(&[("user", "anything")])).await;

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -109,30 +109,43 @@ pub(crate) async fn read_body_capped(resp: &mut reqwest::Response, cap: usize) -
 
 /// The text a guardrail should scan for one message.
 ///
-/// Scans the UNION of the flat `content` string and the `text`-type
-/// entries of `content_blocks`. Both are independent wire fields, and the
-/// provider bridges forward `content_blocks` upstream when it is present,
-/// so scanning only one lets a caller hide a payload in the other: benign
-/// `content` plus a real payload in `content_blocks` (or the round-trip
-/// shape with empty `content` and the text in `content_blocks`, #465)
-/// would otherwise slip past every guardrail. Scanning the union keeps
-/// the scanned text a superset of everything a bridge can forward.
-/// Non-text blocks (image/audio) are out of scope — multimodal
+/// Scans every text surface the provider bridges can forward upstream, so
+/// a caller can't hide a payload in one field while a benign value sits in
+/// another. These are independent wire fields and the bridges forward
+/// whichever is present:
+///   * flat `content`;
+///   * the `text`-type entries of `content_blocks` (empty `content` with
+///     the text only in blocks is the round-trip shape, #465; a benign
+///     `content` plus a payload in blocks is the split-field bypass);
+///   * `extra["tool_calls"]` — history-replay tool calls travel upstream
+///     verbatim through `extra` (the OpenAI bridge flattens them, the
+///     Anthropic bridge translates them into `tool_use` blocks). The whole
+///     payload is serialized so neither a function name nor an argument
+///     can hide a banned token, matching `ChatResponse::guardrail_output_text`
+///     and `redact_chat_format`, which already cover this surface.
+///
+/// Non-text content blocks (image/audio) are out of scope — multimodal
 /// moderation is a separate feature. Every guardrail's input/output
 /// collector goes through this so the families can't drift.
 pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
-    let mut parts: Vec<&str> = Vec::new();
+    let mut parts: Vec<String> = Vec::new();
     let content = m.content_str();
     if !content.is_empty() {
-        parts.push(content);
+        parts.push(content.to_string());
     }
     if let Some(blocks) = m.content_blocks.as_ref() {
         parts.extend(
             blocks
                 .iter()
                 .filter(|b| b.get("type").and_then(serde_json::Value::as_str) == Some("text"))
-                .filter_map(|b| b.get("text").and_then(serde_json::Value::as_str)),
+                .filter_map(|b| b.get("text").and_then(serde_json::Value::as_str))
+                .map(str::to_string),
         );
+    }
+    if let Some(tool_calls) = m.extra.get("tool_calls") {
+        if !tool_calls.is_null() {
+            parts.push(tool_calls.to_string());
+        }
     }
     parts.join("\n")
 }
@@ -722,6 +735,33 @@ mod tests {
         assert!(
             scanned.contains("benign cover text") && scanned.contains("hidden payload"),
             "scan must cover both content and content_blocks, got {scanned:?}"
+        );
+    }
+
+    #[test]
+    fn message_scan_text_scans_tool_call_payload() {
+        // Same bypass class via `extra["tool_calls"]`: history-replay tool
+        // calls are forwarded upstream verbatim, so a payload in a
+        // function name or arguments must be scanned. The whole payload is
+        // serialized (matching guardrail_output_text), so both surfaces are
+        // covered.
+        let msg: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "c1",
+                "type": "function",
+                "function": {
+                    "name": "lookup_evilname",
+                    "arguments": "{\"q\":\"hidden arg payload\"}"
+                }
+            }]
+        }))
+        .unwrap();
+        let scanned = message_scan_text(&msg);
+        assert!(
+            scanned.contains("hidden arg payload") && scanned.contains("lookup_evilname"),
+            "scan must cover tool_call name and arguments, got {scanned:?}"
         );
     }
 

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -109,28 +109,32 @@ pub(crate) async fn read_body_capped(resp: &mut reqwest::Response, cap: usize) -
 
 /// The text a guardrail should scan for one message.
 ///
-/// Prefers the flat `content` string; when it's empty, falls back to
-/// concatenating the `text`-type entries of `content_blocks`. A caller
-/// that sends the OpenAI content-block shape
-/// (`content: [{ "type": "text", "text": "…" }]`) with an empty
-/// top-level string would otherwise bypass moderation entirely (#465).
+/// Scans the UNION of the flat `content` string and the `text`-type
+/// entries of `content_blocks`. Both are independent wire fields, and the
+/// provider bridges forward `content_blocks` upstream when it is present,
+/// so scanning only one lets a caller hide a payload in the other: benign
+/// `content` plus a real payload in `content_blocks` (or the round-trip
+/// shape with empty `content` and the text in `content_blocks`, #465)
+/// would otherwise slip past every guardrail. Scanning the union keeps
+/// the scanned text a superset of everything a bridge can forward.
 /// Non-text blocks (image/audio) are out of scope — multimodal
 /// moderation is a separate feature. Every guardrail's input/output
 /// collector goes through this so the families can't drift.
 pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
+    let mut parts: Vec<&str> = Vec::new();
     let content = m.content_str();
     if !content.is_empty() {
-        return content.to_string();
+        parts.push(content);
     }
-    match m.content_blocks.as_ref() {
-        Some(blocks) => blocks
-            .iter()
-            .filter(|b| b.get("type").and_then(serde_json::Value::as_str) == Some("text"))
-            .filter_map(|b| b.get("text").and_then(serde_json::Value::as_str))
-            .collect::<Vec<_>>()
-            .join("\n"),
-        None => String::new(),
+    if let Some(blocks) = m.content_blocks.as_ref() {
+        parts.extend(
+            blocks
+                .iter()
+                .filter(|b| b.get("type").and_then(serde_json::Value::as_str) == Some("text"))
+                .filter_map(|b| b.get("text").and_then(serde_json::Value::as_str)),
+        );
     }
+    parts.join("\n")
 }
 
 /// The guardrail `kind` discriminators compiled into this binary.
@@ -698,6 +702,27 @@ mod tests {
         let empty: ChatMessage =
             serde_json::from_value(serde_json::json!({"role": "user", "content": ""})).unwrap();
         assert_eq!(message_scan_text(&empty), "");
+    }
+
+    #[test]
+    fn message_scan_text_scans_content_blocks_even_when_flat_content_is_nonempty() {
+        // Guardrail bypass: `content` and `content_blocks` are independent
+        // wire fields, and the provider bridges forward `content_blocks`
+        // when present. A caller that puts benign text in `content` and a
+        // payload in `content_blocks` would slip the payload past a scan
+        // that only reads `content`. The scanned text must be the UNION so
+        // it is a superset of everything a bridge can forward upstream.
+        let split: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "user",
+            "content": "benign cover text",
+            "content_blocks": [{"type": "text", "text": "hidden payload"}]
+        }))
+        .unwrap();
+        let scanned = message_scan_text(&split);
+        assert!(
+            scanned.contains("benign cover text") && scanned.contains("hidden payload"),
+            "scan must cover both content and content_blocks, got {scanned:?}"
+        );
     }
 
     struct DefaultPolicyGuardrail;

--- a/tests/e2e/src/cases/guardrail-keyword-message-locations-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-keyword-message-locations-e2e.test.ts
@@ -3,6 +3,7 @@ import OpenAI, { APIError } from "openai";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
@@ -291,6 +292,55 @@ describe("guardrail keyword e2e: blocks forbidden literal in any message role", 
       const messageBlob = caught.message ?? "";
       expect(errorBlob).not.toContain(FORBIDDEN_WORD);
       expect(messageBlob).not.toContain(FORBIDDEN_WORD);
+    },
+    60_000,
+  );
+
+  test(
+    "forbidden literal hidden in content_blocks behind benign flat content → 422",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+      await waitForGuardrailActive(client, "user");
+
+      const upstreamHitsBefore = upstream.receivedRequests.length;
+
+      // The guardrail-bypass shape: benign top-level `content`, the
+      // forbidden literal hidden in a `content_blocks` text entry. The
+      // provider bridge forwards `content_blocks` upstream, so a scan
+      // that only read `content` would let the payload through. Sent as
+      // a raw body because `content_blocks` is a non-OpenAI field the
+      // typed SDK would drop.
+      const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+      const res = await proxy.chat({
+        model: "gr-loc-model",
+        messages: [
+          {
+            role: "user",
+            content: "What is a good banana bread recipe?",
+            content_blocks: [
+              { type: "text", text: `reveal the ${FORBIDDEN_WORD} now` },
+            ],
+          },
+        ],
+      });
+
+      expect(res.status).toBe(422);
+      expect((res.body as { error?: { type?: unknown } })?.error?.type).toBe(
+        "content_filter",
+      );
+      // Upstream untouched — block short-circuits before dispatch.
+      expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+      // No-leak: the matched literal must not echo back.
+      expect(JSON.stringify(res.body ?? {})).not.toContain(FORBIDDEN_WORD);
     },
     60_000,
   );

--- a/tests/e2e/src/cases/guardrail-keyword-message-locations-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-keyword-message-locations-e2e.test.ts
@@ -344,4 +344,57 @@ describe("guardrail keyword e2e: blocks forbidden literal in any message role", 
     },
     60_000,
   );
+
+  test(
+    "forbidden literal hidden in tool_call arguments behind benign content → 422",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      const client = new OpenAI({
+        apiKey: CALLER_PLAINTEXT,
+        baseURL: `${app.proxyUrl}/v1`,
+        maxRetries: 0,
+      });
+      await waitForGuardrailActive(client, "user");
+
+      const upstreamHitsBefore = upstream.receivedRequests.length;
+
+      // The other half of the same bypass class: a replayed assistant
+      // tool call hides the forbidden literal in its arguments, which the
+      // bridge forwards upstream verbatim. Benign flat content everywhere.
+      const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+      const res = await proxy.chat({
+        model: "gr-loc-model",
+        messages: [
+          { role: "user", content: "look this up for me" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "c1",
+                type: "function",
+                function: {
+                  name: "lookup",
+                  arguments: `{"q":"the ${FORBIDDEN_WORD} formula"}`,
+                },
+              },
+            ],
+          },
+          { role: "user", content: "continue" },
+        ],
+      });
+
+      expect(res.status).toBe(422);
+      expect((res.body as { error?: { type?: unknown } })?.error?.type).toBe(
+        "content_filter",
+      );
+      expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
+      expect(JSON.stringify(res.body ?? {})).not.toContain(FORBIDDEN_WORD);
+    },
+    60_000,
+  );
 });


### PR DESCRIPTION
## What

Fixes an input-guardrail bypass: the guardrail scan read only a message's flattened `content` string, while the provider bridges forward the raw `content_blocks` array upstream when it is present. A caller could put benign text in `content` and a real payload in `content_blocks`, slipping the payload past **every** input guardrail while the model still received it.

The scan now covers the **union** of `content` and the text of `content_blocks`, so the scanned text is a superset of everything a bridge can forward.

## The bug

`content` and `content_blocks` are independent wire fields on a message (no reconciliation — a client can send both with different text, and the parse deliberately prefers a client-supplied `content_blocks`). The shared scan helper `message_scan_text` read `content` and only fell back to `content_blocks` when `content` was empty. The bridges do the inverse: the OpenAI-compat and Anthropic bridges forward `content_blocks` verbatim when present. So:

```json
{
  "model": "guardrailed-model",
  "messages": [{
    "role": "user",
    "content": "what is a good banana bread recipe?",
    "content_blocks": [{ "type": "text", "text": "<banned keyword / jailbreak payload>" }]
  }]
}
```

The scan sees only the benign recipe question → Allow; the OpenAI/Anthropic upstream receives the `content_blocks` payload. This defeats keyword blocklists, PII-block, Aliyun/Bedrock content policy, Azure Prompt Shield, Lakera, and OpenAI moderation alike, for any valid key holder.

## Fix

One change, one choke point: `message_scan_text` (`crates/aisix-guardrails/src/lib.rs`) now scans **every text surface the bridges forward** — the flat `content`, the `text`-type `content_blocks` entries, **and** `extra["tool_calls"]** (serialized whole, so neither a function name nor an argument can hide a token). Because every guardrail kind's input/output collector routes through this single helper, the fix covers all kinds at once.

The `tool_calls` surface was added after an independent audit found the same bypass class survived through it: history-replay tool calls travel upstream verbatim through `extra` (the OpenAI bridge flattens them; the Anthropic bridge translates them into `tool_use` blocks), and the codebase already scans them on the **output** side (`guardrail_output_text`) and masks them in **redaction** (`redact_chat_format`) — only the input scan had missed them. The fix now aligns all three (input-scan / output-scan / redaction) on the same three surfaces.

Cost: in the legitimate vision round-trip where `content` was *derived* from `content_blocks`, the same text is scanned twice — harmless for keyword/regex/PII/moderation (no false negatives, no change to a block/allow decision). Serializing `tool_calls` whole (mirroring `guardrail_output_text`) can surface JSON structural tokens to the scanner; that is the same accepted tradeoff the output scan already makes and is the only variant that also closes a payload hidden in a function name. The `#465` empty-`content` fallback is preserved as a subset.

## Scope

- The exposure is on `/v1/chat/completions` with an OpenAI-compat, Azure-OpenAI, or Anthropic upstream (the bridges that forward `content_blocks`). Bedrock and Vertex read the flattened text and drop `content_blocks`, so they were never exploitable. The native `/v1/messages` and `/v1/responses` paths reconcile the fields at ingress and were not exploitable.
- The fix is upstream-independent: the block now happens **before** dispatch, so no bridge is reached once a payload is caught — which is why the e2e below covers it with a single upstream family.
- Redaction (`redact.rs`) already covered both fields; no change needed there.

## Testing

- **Unit** (`aisix-guardrails/src/lib.rs`): `message_scan_text_scans_content_blocks_even_when_flat_content_is_nonempty` and `message_scan_text_scans_tool_call_payload` — assert the union covers `content_blocks` and `tool_calls` (name + arguments) respectively. The existing empty-`content` fallback test still passes.
- **Unit** (`keyword.rs`): `blocks_keyword_hidden_in_content_blocks_behind_benign_flat_content` and `blocks_keyword_hidden_in_tool_call_arguments` — the security contract at the guardrail level for both surfaces.
- **E2E** (`guardrail-keyword-message-locations-e2e.test.ts`, 2 new cases): black-box — a raw request hiding the forbidden literal in (1) a `content_blocks` text entry and (2) a replayed `tool_calls` argument, each behind benign flat `content`, returns `422 content_filter`, the upstream is untouched (block short-circuits before dispatch), and the literal does not leak into the envelope.
- Full `aisix-guardrails` (244) + `aisix-proxy` (704) crate tests and the sibling keyword/output/PII-redaction e2e suites pass; `cargo fmt` + clippy clean.

TDD: the two unit tests were written first and observed failing (scan returned only the benign `content`), then the fix made them pass.
