### PR TITLE
feat(retries): move the retry budget onto the model and apply it everywhere

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -184,6 +184,16 @@ upstream:
   # Cap on idle connections kept per upstream host. Unset = unbounded.
   # pool_max_idle_per_host: 32
 
+  # Retry attempts after a retryable upstream failure (5xx, timeout,
+  # transport). Applies to every model that does not set its own `retries`,
+  # and to every model group that does not set `routing.retries`. Set to 0
+  # to disable retrying deployment-wide.
+  #
+  # Each retry re-sends the full request body and stacks on top of any retry
+  # the provider's own edge performs, so raising this multiplies the load a
+  # struggling upstream sees.
+  # retries: 2
+
 # Models, API keys, provider keys, guardrails, cache policies, and
 # observability exporters are NOT defined in this file. They are stored
 # in etcd and managed via the Admin API (see docs/api-admin.md). This

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -761,11 +761,13 @@ pub enum RateLimitBackend {
     Redis,
 }
 
-/// Connection-layer settings for the HTTP clients that call LLM providers.
+/// Deployment-wide behaviour for outbound calls to LLM providers: the
+/// connection layer, plus the retry budget every dispatch starts from.
 ///
 /// These are deployment properties of the network path to the upstream, not
 /// per-tenant configuration, so they live in the DP config file rather than
-/// on a Model or ProviderKey resource.
+/// on a Model or ProviderKey resource. A tenant that needs a different
+/// budget for one model overrides it with `Model.retries`.
 ///
 /// The defaults exist because reqwest's own are wrong for a gateway sitting
 /// behind an LB/NAT/proxy hop: no connect timeout, TCP keepalive off, and a
@@ -796,6 +798,16 @@ pub struct UpstreamConfig {
     /// Cap on idle connections kept per upstream host. `null` (the
     /// default) leaves reqwest's unbounded behaviour.
     pub pool_max_idle_per_host: Option<usize>,
+    /// Retry attempts after a retryable upstream failure, applied to every
+    /// dispatch that does not override it via `Model.retries` or a model
+    /// group's `routing.retries`. `0` disables retrying deployment-wide.
+    ///
+    /// The default matches the OpenAI SDK / LiteLLM router default (2), so
+    /// a transient upstream fault is absorbed instead of surfacing to the
+    /// caller. Raising it multiplies the load a failing upstream sees:
+    /// each retry re-sends the full request body, and stacks on top of any
+    /// retry the provider's own edge performs.
+    pub retries: u32,
 }
 
 impl Default for UpstreamConfig {
@@ -807,9 +819,15 @@ impl Default for UpstreamConfig {
             tcp_keepalive_retries: 5,
             pool_idle_timeout_secs: 30,
             pool_max_idle_per_host: None,
+            retries: DEFAULT_UPSTREAM_RETRIES,
         }
     }
 }
+
+/// Deployment-wide retry default. Matches `openai.DEFAULT_MAX_RETRIES`,
+/// which is also what the LiteLLM router falls back to when neither
+/// `router_settings.num_retries` nor `litellm_settings.num_retries` is set.
+pub const DEFAULT_UPSTREAM_RETRIES: u32 = 2;
 
 impl Config {
     /// Load + merge + validate.

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -236,6 +236,10 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_timeout: Option<u64>,
 
+    /// Retry attempts against this model after a retryable upstream failure, before the request gives up (or, inside a model group, fails over to the next target). Absent falls back to the group's `routing.retries`, then to the deployment-wide `upstream.retries` default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retries: Option<u32>,
+
     /// Request, token, and concurrency limits for this model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<RateLimit>,

--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -161,7 +161,7 @@ pub struct Routing {
     /// Ordered set of direct models available to this routing model.
     #[schemars(length(min = 1))]
     pub targets: Vec<RoutingTarget>,
-    /// Retry attempts on the current target before failing over.
+    /// Retry attempts on the current target before failing over, applied to every target that does not set its own `retries`. Absent falls back to the deployment-wide `upstream.retries` default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retries: Option<u32>,
     /// Max number of later targets to attempt after the initial target fails permanently. When omitted, all later targets may be attempted.
@@ -189,9 +189,10 @@ pub struct Routing {
 }
 
 impl Routing {
-    pub fn retries_or_default(&self) -> usize {
-        self.retries.unwrap_or(0) as usize
-    }
+    // No `retries_or_default()`: an unset group budget no longer means
+    // zero, it means "defer to the target, then to the deployment default".
+    // Resolving that needs the target Model and the DP config, so it lives
+    // in `aisix_proxy::routing::effective_retries`.
 
     pub fn sticky_or_default(&self) -> bool {
         self.sticky.unwrap_or(false)
@@ -245,7 +246,7 @@ mod tests {
         assert_eq!(r.targets.len(), 2);
         assert_eq!(r.targets[0].model, "primary");
         assert_eq!(r.targets[0].weight_or_default(), 90);
-        assert_eq!(r.retries_or_default(), 2);
+        assert_eq!(r.retries, Some(2));
         assert_eq!(r.max_fallbacks_or_default(), 1);
         assert!(r.retry_on_429_or_default());
     }
@@ -255,7 +256,8 @@ mod tests {
         let r: Routing =
             serde_json::from_str(r#"{"targets":[{"model":"a"},{"model":"b"}]}"#).unwrap();
         assert_eq!(r.strategy, RoutingStrategy::Failover);
-        assert_eq!(r.retries_or_default(), 0);
+        // Absent means "defer" now, not zero — see `effective_retries`.
+        assert_eq!(r.retries, None);
         assert_eq!(r.max_fallbacks_or_default(), 1);
         assert!(!r.retry_on_429_or_default());
     }

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -636,14 +636,20 @@ async fn multipart_dispatch(
                 req = req.timeout(d);
             }
             async move {
+                // `reqwest_error_to_bridge`, not a bare `Transport`: an
+                // elapsed `timeout` has to surface as `BridgeError::Timeout`
+                // or it is indistinguishable from a connection fault. That
+                // distinction now decides whether the default retry budget
+                // is spent on it (`RetryBudget::covers`) — classifying a
+                // timeout as transport made the model's own timeout get
+                // retried, turning a 400ms budget into ~2s.
+                let send_started = Instant::now();
                 let resp = req.send().await.map_err(|e| {
                     crate::cooldown::note_failure(
                         tracker,
                         model_id,
                         cooldown_cfg,
-                        aisix_gateway::BridgeError::Transport(
-                            aisix_gateway::transport_error_message(&e),
-                        ),
+                        crate::dispatch::reqwest_error_to_bridge(&e, send_started),
                     )
                 })?;
 
@@ -1008,14 +1014,20 @@ async fn speech_dispatch(
                 req = req.timeout(d);
             }
             async move {
+                // `reqwest_error_to_bridge`, not a bare `Transport`: an
+                // elapsed `timeout` has to surface as `BridgeError::Timeout`
+                // or it is indistinguishable from a connection fault. That
+                // distinction now decides whether the default retry budget
+                // is spent on it (`RetryBudget::covers`) — classifying a
+                // timeout as transport made the model's own timeout get
+                // retried, turning a 400ms budget into ~2s.
+                let send_started = Instant::now();
                 let resp = req.send().await.map_err(|e| {
                     crate::cooldown::note_failure(
                         tracker,
                         model_id,
                         cooldown_cfg,
-                        aisix_gateway::BridgeError::Transport(
-                            aisix_gateway::transport_error_message(&e),
-                        ),
+                        crate::dispatch::reqwest_error_to_bridge(&e, send_started),
                     )
                 })?;
 

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -561,28 +561,35 @@ async fn multipart_dispatch(
     let url = crate::dispatch::build_v1_url(&base, upstream_path);
     let provider_label = provider.to_ascii_lowercase();
 
-    // Rebuild the multipart form with `model` rewritten.
-    let mut form = multipart::Form::new();
-    for (name, file_name, content_type, data) in fields {
-        let field_data = if name == "model" {
-            Bytes::copy_from_slice(upstream_model.as_bytes())
-        } else {
-            data
-        };
+    // Rebuild the multipart form with `model` rewritten. A `multipart::Form`
+    // is single-use (sending consumes it), so this is a closure rather than a
+    // value: each retry attempt below builds a fresh one. That is only
+    // possible because every part is `Part::bytes` over an in-memory `Bytes`
+    // — a streamed part could not be replayed.
+    let build_form = || {
+        let mut form = multipart::Form::new();
+        for (name, file_name, content_type, data) in &fields {
+            let field_data = if name == "model" {
+                Bytes::copy_from_slice(upstream_model.as_bytes())
+            } else {
+                data.clone()
+            };
 
-        let data_vec = field_data.to_vec();
-        let mut part = if let Some(ct) = content_type {
-            multipart::Part::bytes(data_vec.clone())
-                .mime_str(&ct)
-                .unwrap_or_else(|_| multipart::Part::bytes(data_vec))
-        } else {
-            multipart::Part::bytes(data_vec)
-        };
-        if let Some(fname) = file_name {
-            part = part.file_name(fname);
+            let data_vec = field_data.to_vec();
+            let mut part = if let Some(ct) = content_type {
+                multipart::Part::bytes(data_vec.clone())
+                    .mime_str(ct)
+                    .unwrap_or_else(|_| multipart::Part::bytes(data_vec))
+            } else {
+                multipart::Part::bytes(data_vec)
+            };
+            if let Some(fname) = file_name {
+                part = part.file_name(fname.clone());
+            }
+            form = form.part(name.clone(), part);
         }
-        form = form.part(name, part);
-    }
+        form
+    };
 
     // Build headers explicitly so the PK's `request.default_headers` can inject
     // operator headers (AISIX-Cloud#867 follow-up). The body is a multipart
@@ -610,63 +617,74 @@ async fn multipart_dispatch(
     }
 
     let client = crate::http_client::client();
-    let mut req = client.post(&url).headers(headers).multipart(form);
-    // #554/#911: audio transcription/translation is non-streaming; apply the
-    // per-model E2E request timeout like the other direct-upstream paths
-    // (count_tokens/rerank/responses) so a slow/blackholed audio provider
-    // fails over and the model's timeout cooldown can engage.
-    if let Some(d) = model.request_timeout() {
-        req = req.timeout(d);
-    }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::Transport(aisix_gateway::transport_error_message(&e)),
-            )
-        })
-        .map_err(ProxyError::Bridge)?;
+    let tracker = &state.runtime_status;
+    let model_id: &str = &model_entry.id;
+    let cooldown_cfg = model.cooldown.as_ref();
+    // Send, check the status, and read the body as one retryable unit. See
+    // the same shape in rerank.rs for why `note_failure` stays per attempt.
+    let (upstream_headers, body_bytes) =
+        match crate::routing::retrying_dispatch(state, model, "/v1/audio/transcriptions", || {
+            let mut req = client
+                .post(&url)
+                .headers(headers.clone())
+                .multipart(build_form());
+            // #554/#911: audio transcription/translation is non-streaming; apply
+            // the per-model E2E request timeout like the other direct-upstream
+            // paths (count_tokens/rerank/responses) so a slow/blackholed audio
+            // provider fails over and the model's timeout cooldown can engage.
+            if let Some(d) = model.request_timeout() {
+                req = req.timeout(d);
+            }
+            async move {
+                let resp = req.send().await.map_err(|e| {
+                    crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::Transport(
+                            aisix_gateway::transport_error_message(&e),
+                        ),
+                    )
+                })?;
 
-    let status = resp.status();
-    if !status.is_success() {
-        let s = status.as_u16();
-        let retry_after = aisix_gateway::parse_retry_after(resp.headers());
-        let msg = resp.text().await.unwrap_or_default();
-        let err = aisix_gateway::BridgeError::upstream_status_with_retry_after(
-            s,
-            msg.chars().take(1024).collect::<String>(),
-            retry_after,
-        );
-        if let Some((ttl, reason)) = crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                let status = resp.status();
+                if !status.is_success() {
+                    let s = status.as_u16();
+                    let retry_after = aisix_gateway::parse_retry_after(resp.headers());
+                    let msg = resp.text().await.unwrap_or_default();
+                    return Err(crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::upstream_status_with_retry_after(
+                            s,
+                            msg.chars().take(1024).collect::<String>(),
+                            retry_after,
+                        ),
+                    ));
+                }
+
+                // Relay response headers that matter for the client.
+                let upstream_headers = resp.headers().clone();
+                let body_bytes = resp.bytes().await.map_err(|e| {
+                    crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
+                    )
+                })?;
+                Ok((upstream_headers, body_bytes))
+            }
+        })
+        .await
         {
-            state
-                .runtime_status
-                .mark_cooldown(&model_entry.id, ttl, reason);
-        }
-        return Err(ProxyError::Bridge(err));
-    }
+            Ok(v) => v,
+            Err(err) => return Err(ProxyError::Bridge(err)),
+        };
 
     state.health.record_success(&model_name);
     state.runtime_status.mark_healthy(&model_entry.id);
-
-    // Relay response headers that matter for the client.
-    let upstream_headers = resp.headers().clone();
-    let body_bytes = resp
-        .bytes()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-            )
-        })
-        .map_err(ProxyError::Bridge)?;
 
     // Parse the response body best-effort for a `usage` token block
     // (gpt-4o-transcribe returns one; whisper-1 returns none, and the
@@ -972,63 +990,72 @@ async fn speech_dispatch(
     }
 
     let client = crate::http_client::client();
-    let mut req = client
-        .post(crate::dispatch::build_v1_url(&base, "/audio/speech"))
-        .headers(headers)
-        .json(&body);
-    // #554/#911: speech synthesis is non-streaming; apply the per-model E2E
-    // request timeout (same as count_tokens/rerank/responses).
-    if let Some(d) = model.request_timeout() {
-        req = req.timeout(d);
-    }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::Transport(aisix_gateway::transport_error_message(&e)),
-            )
-        })
-        .map_err(ProxyError::Bridge)?;
+    let speech_url = crate::dispatch::build_v1_url(&base, "/audio/speech");
+    let tracker = &state.runtime_status;
+    let model_id: &str = &model_entry.id;
+    let cooldown_cfg = model.cooldown.as_ref();
+    // Send, check the status, and read the body as one retryable unit. See
+    // the same shape in rerank.rs for why `note_failure` stays per attempt.
+    let (upstream_headers, body_bytes) =
+        match crate::routing::retrying_dispatch(state, model, "/v1/audio/speech", || {
+            let mut req = client
+                .post(speech_url.clone())
+                .headers(headers.clone())
+                .json(&body);
+            // #554/#911: speech synthesis is non-streaming; apply the per-model
+            // E2E request timeout (same as count_tokens/rerank/responses).
+            if let Some(d) = model.request_timeout() {
+                req = req.timeout(d);
+            }
+            async move {
+                let resp = req.send().await.map_err(|e| {
+                    crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::Transport(
+                            aisix_gateway::transport_error_message(&e),
+                        ),
+                    )
+                })?;
 
-    let status = resp.status();
-    if !status.is_success() {
-        let s = status.as_u16();
-        let retry_after = aisix_gateway::parse_retry_after(resp.headers());
-        let msg = resp.text().await.unwrap_or_default();
-        let err = aisix_gateway::BridgeError::upstream_status_with_retry_after(
-            s,
-            msg.chars().take(1024).collect::<String>(),
-            retry_after,
-        );
-        if let Some((ttl, reason)) = crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+                let status = resp.status();
+                if !status.is_success() {
+                    let s = status.as_u16();
+                    let retry_after = aisix_gateway::parse_retry_after(resp.headers());
+                    let msg = resp.text().await.unwrap_or_default();
+                    return Err(crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::upstream_status_with_retry_after(
+                            s,
+                            msg.chars().take(1024).collect::<String>(),
+                            retry_after,
+                        ),
+                    ));
+                }
+
+                let upstream_headers = resp.headers().clone();
+                let body_bytes = resp.bytes().await.map_err(|e| {
+                    crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
+                    )
+                })?;
+                Ok((upstream_headers, body_bytes))
+            }
+        })
+        .await
         {
-            state
-                .runtime_status
-                .mark_cooldown(&model_entry.id, ttl, reason);
-        }
-        return Err(ProxyError::Bridge(err));
-    }
+            Ok(v) => v,
+            Err(err) => return Err(ProxyError::Bridge(err)),
+        };
 
     state.health.record_success(&model_name);
     state.runtime_status.mark_healthy(&model_entry.id);
-
-    let upstream_headers = resp.headers().clone();
-    let body_bytes = resp
-        .bytes()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-            )
-        })
-        .map_err(ProxyError::Bridge)?;
 
     // #911 [21]: speech synthesis (TTS) reports no token usage — it is billed
     // per input character — so there are no tokens to add to TPM/TPD. Commit 0

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -566,6 +566,14 @@ async fn multipart_dispatch(
     // whether the customer's api_base ends in /v1 or not.
     let url = crate::dispatch::build_v1_url(&base, upstream_path);
     let provider_label = provider.to_ascii_lowercase();
+    // Static label for retry tracing — this dispatch serves both audio
+    // sub-routes, and logging translations under the transcription label
+    // would mislead an operator reading retry output.
+    let retry_endpoint_label: &'static str = if upstream_path == "/audio/translations" {
+        "/v1/audio/translations"
+    } else {
+        "/v1/audio/transcriptions"
+    };
 
     // Rebuild the multipart form with `model` rewritten. A `multipart::Form`
     // is single-use (sending consumes it), so this is a closure rather than a
@@ -629,7 +637,7 @@ async fn multipart_dispatch(
     // Send, check the status, and read the body as one retryable unit. See
     // the same shape in rerank.rs for why `note_failure` stays per attempt.
     let (upstream_headers, body_bytes) =
-        match crate::routing::retrying_dispatch(state, model, "/v1/audio/transcriptions", || {
+        match crate::routing::retrying_dispatch(state, model, retry_endpoint_label, || {
             let mut req = client
                 .post(&url)
                 .headers(headers.clone())

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1193,19 +1193,6 @@ async fn dispatch(
     // the remaining chunks, so a mid-stream stall terminates the response
     // (no fallback once the 200 is committed).
     if req.is_streaming() {
-        // `routing.retries` — how many times to re-hit the SAME target (with
-        // backoff) on a retryable failure before failing over to the next one.
-        // Read here for the same reason the non-streaming loop below reads it:
-        // the two loops are written separately, and streaming used to skip
-        // `retries` entirely (AISIX-Cloud#1119), so a retryable first-chunk
-        // failure fell straight over to the next target — or, with a single
-        // target, failed the request outright.
-        let retries = virtual_entry
-            .value
-            .routing
-            .as_ref()
-            .map(|r| r.retries_or_default())
-            .unwrap_or(0);
         let retry_on_429 = virtual_entry
             .value
             .routing
@@ -1242,7 +1229,7 @@ async fn dispatch(
         // (AISIX-Cloud#1087).
         let mut won_member_reservation: Option<aisix_ratelimit::MultiReservation> = None;
 
-        'targets: for attempt in &attempt_models {
+        'targets: for (target_idx, attempt) in attempt_models.iter().enumerate() {
             let model = &attempt.model;
             let Ok(provider) = crate::dispatch::require_provider(model) else {
                 last_err = Some(BridgeError::Config("model has no provider".into()));
@@ -1275,9 +1262,22 @@ async fn dispatch(
             // is applied consistently.
             let stream_budget = model.stream_timeout_effective();
 
-            // Re-hit the SAME target `retries` times before failing over,
-            // mirroring the non-streaming loop below (AISIX-Cloud#1119).
-            for attempt_idx in 0..=retries {
+            // How many times to re-hit the SAME target (with backoff) on a
+            // retryable failure before failing over to the next one.
+            // Resolved per target, not once per request: the budget belongs
+            // to the upstream being hit, so a group may mix a target that
+            // tolerates three retries with one that tolerates none.
+            // Streaming used to skip `retries` entirely (AISIX-Cloud#1119);
+            // a direct model used to be pinned at zero because the knob only
+            // existed on the group.
+            let budget = crate::routing::effective_retries(
+                model,
+                virtual_entry.value.routing.as_ref(),
+                state.default_retries,
+                target_idx + 1 < attempt_models.len(),
+            );
+
+            for attempt_idx in 0..=budget.attempts {
                 let (idx, kind) = stream_routing.begin_attempt(&model.display_name);
                 let target_model = if is_routing_request {
                     model.display_name.clone()
@@ -1426,17 +1426,24 @@ async fn dispatch(
                         {
                             state.runtime_status.mark_cooldown(&attempt.id, ttl, reason);
                         }
+                        let retry_after = crate::routing::retry_after_hint(&err);
+                        // An unconfigured budget does not spend itself on a
+                        // timeout — see `RetryBudget::covers`. Fail-over is
+                        // unaffected: the outer loop still moves on.
+                        let budget_covers = budget.covers(&err);
                         last_err = Some(err);
                         if !retryable {
                             break 'targets;
                         }
-                        if attempt_idx == retries {
+                        if attempt_idx == budget.attempts || !budget_covers {
                             break;
                         }
-                        // Exponential backoff + jitter before re-hitting the
+                        // Upstream `Retry-After` when it gave one, else
+                        // exponential backoff + jitter, before re-hitting the
                         // SAME target (#788 P2); cross-target fail-over (the
                         // outer loop) stays immediate.
-                        let backoff = crate::routing::retry_backoff((attempt_idx + 1) as u32);
+                        let backoff =
+                            crate::routing::retry_backoff((attempt_idx + 1) as u32, retry_after);
                         tracing::debug!(
                             target_model = %model.display_name,
                             next_attempt = attempt_idx + 2,
@@ -2073,12 +2080,6 @@ async fn dispatch(
     // requests (AISIX-Cloud#410). Stays `None` until an attempt wins.
     let mut chosen_target_display_name: Option<String> = None;
     let mut upstream: Option<aisix_gateway::ChatResponse> = None;
-    let retries = virtual_entry
-        .value
-        .routing
-        .as_ref()
-        .map(|routing| routing.retries_or_default())
-        .unwrap_or(0);
     let retry_on_429 = virtual_entry
         .value
         .routing
@@ -2100,7 +2101,7 @@ async fn dispatch(
     // (AISIX-Cloud#1087).
     let mut won_member_reservation: Option<aisix_ratelimit::MultiReservation> = None;
 
-    'targets: for attempt in &attempt_models {
+    'targets: for (target_idx, attempt) in attempt_models.iter().enumerate() {
         let model = &attempt.model;
         let Some(provider) = model.provider.as_deref() else {
             last_err = Some(BridgeError::Config("model has no provider".into()));
@@ -2136,8 +2137,15 @@ async fn dispatch(
         if let Some(d) = model.request_timeout() {
             ctx = ctx.with_deadline(d);
         }
+        // Per-target retry budget — see the streaming loop above.
+        let budget = crate::routing::effective_retries(
+            model,
+            virtual_entry.value.routing.as_ref(),
+            state.default_retries,
+            target_idx + 1 < attempt_models.len(),
+        );
 
-        for attempt_idx in 0..=retries {
+        for attempt_idx in 0..=budget.attempts {
             // Per-attempt telemetry kind (#655): the first attempt overall
             // is "initial"; a different target than the previous attempt is
             // a "fallback"; the same target again is a "retry".
@@ -2266,18 +2274,25 @@ async fn dispatch(
                     {
                         state.runtime_status.mark_cooldown(&attempt.id, ttl, reason);
                     }
+                    let retry_after = crate::routing::retry_after_hint(&err);
+                    // See `RetryBudget::covers`: a default budget skips
+                    // same-target retries for timeouts. Fail-over is
+                    // unaffected.
+                    let budget_covers = budget.covers(&err);
                     last_err = Some(err);
                     if !retryable {
                         break;
                     }
-                    if attempt_idx == retries {
+                    if attempt_idx == budget.attempts || !budget_covers {
                         break;
                     }
-                    // #788 P2: exponential backoff + jitter before retrying
-                    // the SAME target, so a transiently-failing upstream gets
-                    // a pause instead of being hammered. Cross-target fallover
-                    // (the outer loop) stays immediate.
-                    let backoff = crate::routing::retry_backoff((attempt_idx + 1) as u32);
+                    // #788 P2: upstream `Retry-After` when supplied, else
+                    // exponential backoff + jitter, before retrying the SAME
+                    // target, so a transiently-failing upstream gets a pause
+                    // instead of being hammered. Cross-target fallover (the
+                    // outer loop) stays immediate.
+                    let backoff =
+                        crate::routing::retry_backoff((attempt_idx + 1) as u32, retry_after);
                     tracing::debug!(
                         target_model = %model.display_name,
                         next_attempt = attempt_idx + 2,

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -324,7 +324,11 @@ async fn dispatch(
 
     let provider_label = provider.to_ascii_lowercase();
 
-    match bridge.complete(&body, &ctx).await {
+    match crate::routing::retrying_dispatch(state, model, "/v1/completions", || {
+        bridge.complete(&body, &ctx)
+    })
+    .await
+    {
         Ok(resp_json) => {
             // #701: clear any cooldown/unhealthy mark now the upstream
             // answered — same recovery signal as rerank/audio/chat.

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -326,8 +326,19 @@ async fn dispatch(
 
     let provider_label = provider.to_ascii_lowercase();
 
-    match crate::routing::retrying_dispatch(state, model, "/v1/completions", || {
-        bridge.complete(&body, &ctx)
+    // #701: mark each failed attempt on the runtime status INSIDE the retry
+    // loop, so the cooldown / circuit-breaker sees flapping upstreams even
+    // when a later retry recovers the request — same per-attempt semantics
+    // as chat.rs, where the cooldown decision is independent of the retry
+    // decision. `note_failure` is a no-op for non-triggering categories.
+    let tracker = &state.runtime_status;
+    let cooldown_model_id: &str = &model_entry.id;
+    let cooldown_cfg = model.cooldown.as_ref();
+    match crate::routing::retrying_dispatch(state, model, "/v1/completions", || async {
+        bridge
+            .complete(&body, &ctx)
+            .await
+            .map_err(|e| crate::cooldown::note_failure(tracker, cooldown_model_id, cooldown_cfg, e))
     })
     .await
     {
@@ -508,16 +519,7 @@ async fn dispatch(
         }
         Err(e) => {
             reservation.commit_tokens(0).await;
-            // #701: mark the failure on the runtime status so the cooldown /
-            // circuit-breaker sees flapping upstreams reached only via this
-            // endpoint — same policy as rerank/audio/chat. `note_failure` is
-            // a no-op for non-triggering categories (e.g. Config errors).
-            let e = crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                e,
-            );
+            // Cooldown was already noted per attempt inside the retry loop.
             Err(ProxyError::Bridge(e))
         }
     }

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -204,7 +204,7 @@ async fn dispatch(
     let is_routing_request = model_entry.value.routing.is_some();
     let mut last_err: Option<ProxyError> = None;
     let mut any_anthropic = false;
-    for target in &attempt_models {
+    for (target_idx, target) in attempt_models.iter().enumerate() {
         // count_tokens has no upstream equivalent for non-Anthropic
         // providers; skip foreign targets in a mixed group rather than
         // dispatching to an upstream that would 404.
@@ -232,25 +232,54 @@ async fn dispatch(
                 continue;
             }
         };
-        match count_tokens_to_target(
-            state,
-            &snapshot,
-            body,
+        // Same-target retries before failing over, like the other
+        // group-capable endpoints. This loop had fail-over only: a
+        // transient 502 on the sole Anthropic target failed the request
+        // outright even with a retry budget configured.
+        let budget = crate::routing::effective_retries(
             &target.model,
-            &target.id,
-            request_id,
-        )
-        .await
-        {
-            Ok(resp) => return Ok((resp, "anthropic".to_string())),
-            Err(e) => {
-                let retryable = matches!(
-                    &e,
-                    ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429, fallback_statuses)
-                );
-                last_err = Some(e);
-                if !retryable {
-                    break;
+            model_entry.value.routing.as_ref(),
+            state.default_retries,
+            target_idx + 1 < attempt_models.len(),
+        );
+        for attempt_idx in 0..=budget.attempts {
+            if attempt_idx > 0 {
+                let hint = last_err.as_ref().and_then(|e| match e {
+                    ProxyError::Bridge(be) => crate::routing::retry_after_hint(be),
+                    _ => None,
+                });
+                tokio::time::sleep(crate::routing::retry_backoff(attempt_idx as u32, hint)).await;
+            }
+            match count_tokens_to_target(
+                state,
+                &snapshot,
+                body,
+                &target.model,
+                &target.id,
+                request_id,
+            )
+            .await
+            {
+                Ok(resp) => return Ok((resp, "anthropic".to_string())),
+                Err(e) => {
+                    let retryable = matches!(
+                        &e,
+                        ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429, fallback_statuses)
+                    );
+                    // See `RetryBudget::covers`: a default budget skips
+                    // same-target retries for timeouts; fail-over is
+                    // unaffected (the outer loop still moves on).
+                    let budget_covers = match &e {
+                        ProxyError::Bridge(be) => budget.covers(be),
+                        _ => true,
+                    };
+                    last_err = Some(e);
+                    if !retryable {
+                        return Err(last_err.unwrap_or(ProxyError::ProviderUnavailable));
+                    }
+                    if !budget_covers {
+                        break;
+                    }
                 }
             }
         }

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -238,11 +238,20 @@ async fn dispatch(
         // group-capable endpoints. This loop had fail-over only: a
         // transient 502 on the sole Anthropic target failed the request
         // outright even with a retry budget configured.
+        //
+        // "Another target queued" counts only Anthropic targets: the loop
+        // `continue`s past everything else, so in a mixed group like
+        // [anthropic, openai] the openai entry is not a real fallback —
+        // treating it as one would suppress the default budget on the only
+        // target that can actually serve the request.
+        let has_usable_fallback = attempt_models[target_idx + 1..]
+            .iter()
+            .any(|t| t.model.provider.as_deref() == Some("anthropic"));
         let budget = crate::routing::effective_retries(
             &target.model,
             model_entry.value.routing.as_ref(),
             state.default_retries,
-            target_idx + 1 < attempt_models.len(),
+            has_usable_fallback,
         );
         for attempt_idx in 0..=budget.attempts {
             if attempt_idx > 0 {
@@ -572,6 +581,75 @@ mod tests {
             .header("content-type", "application/json")
             .body(axum::body::Body::from(body.to_string()))
             .unwrap()
+    }
+
+    /// Mixed group [anthropic, openai]: the openai target is `continue`d
+    /// past (count_tokens has no upstream there), so it is NOT a usable
+    /// fallback — the default retry budget must apply on the anthropic
+    /// target as if it were the last one. Counting the skipped target as
+    /// a fallback would have suppressed the budget and failed the request
+    /// on the first transient 502.
+    #[tokio::test]
+    async fn mixed_group_spends_the_default_budget_on_the_only_anthropic_target() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("upstream down"))
+            .up_to_n_times(2)
+            .with_priority(1)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"input_tokens": 7})),
+            )
+            .with_priority(2)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        let claude = {
+            let json = format!(
+                r#"{{"display_name":"ct-claude","provider":"anthropic","model_name":"claude-haiku-4-5-20251001","provider_key_id":"{PK_ID}"}}"#
+            );
+            let m: Model = serde_json::from_str(&json).unwrap();
+            ResourceEntry::new("m-ct-claude", m, 1)
+        };
+        let gpt = {
+            let json = format!(
+                r#"{{"display_name":"ct-gpt","provider":"openai","model_name":"gpt-4o","provider_key_id":"{PK_ID}"}}"#
+            );
+            let m: Model = serde_json::from_str(&json).unwrap();
+            ResourceEntry::new("m-ct-gpt", m, 1)
+        };
+        let group = {
+            let json = r#"{"display_name":"ct-mixed","routing":{"strategy":"failover","targets":[{"model":"ct-claude"},{"model":"ct-gpt"}]}}"#;
+            let m: Model = serde_json::from_str(json).unwrap();
+            ResourceEntry::new("m-ct-mixed", m, 1)
+        };
+        snap.models.insert(claude);
+        snap.models.insert(gpt);
+        snap.models.insert(group);
+        snap.apikeys.insert(apikey_entry(&["ct-mixed"]));
+
+        let app = build_app(snap);
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "ct-mixed",
+                "messages": [{"role": "user", "content": "hi"}]
+            })))
+            .await
+            .unwrap();
+
+        // Two 502s absorbed by the default budget, third attempt wins.
+        assert_eq!(resp.status(), StatusCode::OK);
+        let received = upstream.received_requests().await.unwrap();
+        assert_eq!(
+            received.len(),
+            3,
+            "initial + 2 retries on the sole anthropic target",
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -399,7 +399,11 @@ async fn dispatch(
         ctx = ctx.with_deadline(d);
     }
 
-    match bridge.embed(&req, &ctx).await {
+    match crate::routing::retrying_dispatch(state, model, "/v1/embeddings", || {
+        bridge.embed(&req, &ctx)
+    })
+    .await
+    {
         Ok(embed_resp) => {
             // #701: clear any cooldown/unhealthy mark now the upstream
             // answered — same recovery signal as rerank/audio/chat.
@@ -1447,6 +1451,54 @@ mod tests {
         assert!(event.provider_featured);
         assert_eq!(event.branded_provider, "openai");
         assert_eq!(event.pk_label, "prod-embeddings-key");
+    }
+
+    /// `/v1/embeddings` retries a transient upstream failure.
+    ///
+    /// This endpoint dispatches to exactly one model and had no retry loop at
+    /// all — a single 502 was the caller's problem. It now shares
+    /// `routing::retrying_dispatch` with the other single-model endpoints, so
+    /// the model's retry budget applies here too.
+    #[tokio::test]
+    async fn retries_a_transient_upstream_failure() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("overloaded"))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .expect(1)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .with_priority(2)
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("text-embedding-3-small"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let app = build_app(snap);
+        let resp = tower::ServiceExt::oneshot(
+            app,
+            make_req(serde_json::json!({
+                "model": "text-embedding-3-small",
+                "input": "hello"
+            })),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "the retry must recover the request",
+        );
+        // The `.expect(1)` on both mocks asserts exactly two upstream calls.
     }
 
     /// Issue #456 (#226 family): the 501 NotImplemented path (provider

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -401,8 +401,15 @@ async fn dispatch(
         ctx = ctx.with_deadline(d);
     }
 
-    match crate::routing::retrying_dispatch(state, model, "/v1/embeddings", || {
-        bridge.embed(&req, &ctx)
+    // #701: per-attempt cooldown accounting — see completions.rs.
+    let tracker = &state.runtime_status;
+    let cooldown_model_id: &str = &model_entry.id;
+    let cooldown_cfg = model.cooldown.as_ref();
+    match crate::routing::retrying_dispatch(state, model, "/v1/embeddings", || async {
+        bridge
+            .embed(&req, &ctx)
+            .await
+            .map_err(|e| crate::cooldown::note_failure(tracker, cooldown_model_id, cooldown_cfg, e))
     })
     .await
     {
@@ -496,16 +503,7 @@ async fn dispatch(
         }
         Err(e) => {
             reservation.commit_tokens(0).await;
-            // #701: mark the failure on the runtime status so the cooldown /
-            // circuit-breaker sees flapping upstreams reached only via this
-            // endpoint — same policy as rerank/audio/chat. `note_failure` is
-            // a no-op for non-triggering categories (e.g. Config errors).
-            let e = crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                e,
-            );
+            // Cooldown was already noted per attempt inside the retry loop.
             Err(ProxyError::Bridge(e))
         }
     }

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -14,8 +14,10 @@
 //! 2. Keep the successful responses; require at least
 //!    [`EnsembleConfig::min_responses_or_default`] of them, else error.
 //! 3. Ask the judge model to synthesize a single answer from the labeled
-//!    candidate answers, at a fixed low temperature. Retry the judge once
-//!    on a transient failure.
+//!    candidate answers, at a fixed low temperature.
+//!
+//! Retrying a transient sub-call failure — panel member or judge alike — is
+//! the [`ModelCaller`]'s job, using that member model's own retry budget.
 
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -147,7 +149,18 @@ impl ModelCaller for ProxyModelCaller<'_> {
         // On a bridge error the reservation drops here → concurrency slots
         // release and no tokens are counted. On success we commit the member's
         // own token cost to its model bucket.
-        let response = bridge.chat(req, &ctx).await?;
+        //
+        // Retries use the MEMBER model's own budget, so a flaky panel member
+        // is absorbed instead of silently shrinking the panel toward
+        // `min_responses`. The reservation is deliberately outside the retry
+        // loop (one sub-call bills once, however many attempts it took), and
+        // `ctx`'s deadline is per attempt while the ensemble's own
+        // `config.timeout()` — applied by the caller — remains the ceiling on
+        // the whole attempt sequence.
+        let response = crate::routing::retrying_dispatch(self.state, model, "ensemble", || {
+            bridge.chat(req, &ctx)
+        })
+        .await?;
         reservation
             .commit_tokens(u64::from(response.usage.total_tokens))
             .await;
@@ -301,23 +314,23 @@ pub async fn run_ensemble(
     // Phases 1-2 + judge-request construction.
     let (panel, _candidates, judge_req) = run_ensemble_panel(req, config, caller).await?;
 
-    // Phase 3: synthesize via the judge, retrying once on a transient error.
-    // The judge call gets the same per-call timeout as each panel member
-    // (`config.timeout()`), so the ensemble-level deadline applies uniformly
-    // across the whole fan-out.
-    let response = match call_judge_with_retry(
-        caller,
-        &config.judge.model,
-        &judge_req,
-        config.timeout(),
-    )
-    .await
-    {
-        Ok(r) => r,
-        // Carry the (already-billed) panel survivors out on the judge
-        // failure so the dispatch layer commits + emits them too.
-        Err(source) => return Err(EnsembleError::Judge { source, panel }),
-    };
+    // Phase 3: synthesize via the judge. The judge call gets the same
+    // per-call timeout as each panel member (`config.timeout()`), so the
+    // ensemble-level deadline applies uniformly across the whole fan-out.
+    //
+    // Retrying a transient judge failure is the ModelCaller's job now, using
+    // the judge model's own retry budget — it used to be a hardcoded single
+    // retry here, which both ignored the operator's configuration and would
+    // have stacked on top of the caller-level budget.
+    let response =
+        match call_with_optional_timeout(caller, &config.judge.model, &judge_req, config.timeout())
+            .await
+        {
+            Ok(r) => r,
+            // Carry the (already-billed) panel survivors out on the judge
+            // failure so the dispatch layer commits + emits them too.
+            Err(source) => return Err(EnsembleError::Judge { source, panel }),
+        };
 
     Ok(EnsembleOutcome {
         response,
@@ -426,42 +439,6 @@ async fn call_with_optional_timeout(
             }),
         },
         None => caller.call(target, req).await,
-    }
-}
-
-/// Call the judge, retrying once if the first failure is transient
-/// (resolved decision: judge failure → 5xx after one in-process retry; no
-/// silent fallback to a raw panel answer). Each attempt is bound by the
-/// same per-call `timeout` as the panel members; a timed-out judge call
-/// surfaces as a transient [`BridgeError::Timeout`] and so is retried once.
-async fn call_judge_with_retry(
-    caller: &dyn ModelCaller,
-    target: &str,
-    req: &ChatFormat,
-    timeout: Option<Duration>,
-) -> Result<ChatResponse, BridgeError> {
-    match call_with_optional_timeout(caller, target, req, timeout).await {
-        Ok(resp) => Ok(resp),
-        Err(first) if is_transient(&first) => {
-            call_with_optional_timeout(caller, target, req, timeout).await
-        }
-        Err(err) => Err(err),
-    }
-}
-
-/// Conservative transient-failure classification for the judge retry:
-/// timeouts, transport faults, mid-stream aborts, and upstream 5xx are
-/// retryable; everything else (4xx, config, credentials, decode) is not.
-fn is_transient(err: &BridgeError) -> bool {
-    match err {
-        BridgeError::Timeout { .. } | BridgeError::Transport(_) | BridgeError::StreamAborted => {
-            true
-        }
-        BridgeError::UpstreamStatus { status, .. } => *status >= 500,
-        BridgeError::UpstreamDecode(_)
-        | BridgeError::Config(_)
-        | BridgeError::InvalidUpstreamConfig(_)
-        | BridgeError::InvalidUpstreamCredentials(_) => false,
     }
 }
 
@@ -632,8 +609,13 @@ mod tests {
         assert!(!judge_prompt.contains("reset"));
     }
 
+    /// Retrying a transient judge failure belongs to the `ModelCaller`, which
+    /// applies the judge model's own retry budget. `run_ensemble` used to
+    /// wrap the judge in a hardcoded single retry on top of that; this pins
+    /// that it no longer does, so the two layers can't multiply (a judge with
+    /// `retries: 2` would otherwise have cost up to six upstream calls).
     #[tokio::test]
-    async fn retries_judge_once_on_transient_failure() {
+    async fn does_not_itself_retry_a_transient_judge_failure() {
         let caller = MockCaller::new()
             .on("a", vec![ok("a", "x")])
             .on("b", vec![ok("b", "y")])
@@ -649,12 +631,12 @@ mod tests {
             );
         let cfg = config(r#"{"panel":[{"model":"a"},{"model":"b"}],"judge":{"model":"judge"}}"#);
 
-        let out = run_ensemble(&user_request("hi"), &cfg, &caller)
+        let err = run_ensemble(&user_request("hi"), &cfg, &caller)
             .await
-            .unwrap();
+            .unwrap_err();
 
-        assert_eq!(out.response.message.content_str(), "second attempt wins");
-        assert_eq!(caller.calls_to("judge").len(), 2); // retried once
+        assert_eq!(caller.calls_to("judge").len(), 1);
+        assert!(matches!(err, EnsembleError::Judge { .. }));
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -301,7 +301,11 @@ async fn dispatch(
 
     let provider_label = provider.to_ascii_lowercase();
 
-    match bridge.generate_image(&body, &ctx).await {
+    match crate::routing::retrying_dispatch(state, model, "/v1/images/generations", || {
+        bridge.generate_image(&body, &ctx)
+    })
+    .await
+    {
         Ok(resp_json) => {
             // #701: clear any cooldown/unhealthy mark now the upstream
             // answered — same recovery signal as rerank/audio/chat.

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -303,8 +303,15 @@ async fn dispatch(
 
     let provider_label = provider.to_ascii_lowercase();
 
-    match crate::routing::retrying_dispatch(state, model, "/v1/images/generations", || {
-        bridge.generate_image(&body, &ctx)
+    // #701: per-attempt cooldown accounting — see completions.rs.
+    let tracker = &state.runtime_status;
+    let cooldown_model_id: &str = &model_entry.id;
+    let cooldown_cfg = model.cooldown.as_ref();
+    match crate::routing::retrying_dispatch(state, model, "/v1/images/generations", || async {
+        bridge
+            .generate_image(&body, &ctx)
+            .await
+            .map_err(|e| crate::cooldown::note_failure(tracker, cooldown_model_id, cooldown_cfg, e))
     })
     .await
     {
@@ -367,16 +374,7 @@ async fn dispatch(
         }
         Err(e) => {
             reservation.commit_tokens(0).await;
-            // #701: mark the failure on the runtime status so the cooldown /
-            // circuit-breaker sees flapping upstreams reached only via this
-            // endpoint — same policy as rerank/audio/chat. `note_failure` is
-            // a no-op for non-triggering categories (e.g. Config errors).
-            let e = crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                e,
-            );
+            // Cooldown was already noted per attempt inside the retry loop.
             Err(ProxyError::Bridge(e))
         }
     }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -4075,6 +4075,151 @@ data: [DONE]\n\n";
         );
     }
 
+    /// A direct (non-group) model retries a transient upstream failure.
+    ///
+    /// The retry budget used to live only on `routing`, so a model without a
+    /// model group was pinned at zero attempts-after-the-first: a single 502
+    /// went straight back to the caller with no second try, no matter what
+    /// the operator configured. Nothing could be configured — there was no
+    /// field to set.
+    #[tokio::test]
+    async fn direct_model_retries_a_transient_failure_then_succeeds() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("upstream down"))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .expect(1)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-ok",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "recovered"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .with_priority(2)
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models
+            .insert(direct_model_entry("m-solo", "solo", "gpt-4o"));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["solo"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "solo",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the retry must recover the request: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["choices"][0]["message"]["content"], "recovered");
+        // The `.expect(1)` on both mocks asserts exactly two upstream calls.
+    }
+
+    /// `Model.retries` overrides the group budget for that target only.
+    /// `Some(0)` is an explicit opt-out and must not fall through to the
+    /// group's larger budget.
+    #[tokio::test]
+    async fn model_retries_overrides_the_group_budget() {
+        let bad_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("upstream down"))
+            // Exactly one attempt on this target despite `routing.retries: 5`.
+            .expect(1)
+            .mount(&bad_upstream)
+            .await;
+
+        let good_upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-good",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "fallback worked"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .expect(1)
+            .mount(&good_upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-bad", &bad_upstream.uri()));
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-good", &good_upstream.uri()));
+        let mut no_retry: Model = serde_json::from_str(
+            r#"{"display_name":"primary","provider":"openai","model_name":"gpt-4o",
+                "provider_key_id":"pk-bad","retries":0}"#,
+        )
+        .unwrap();
+        no_retry.retries = Some(0);
+        snap.models.insert(ResourceEntry::new("m-bad", no_retry, 1));
+        snap.models
+            .insert(model_entry_with_id("m-good", "secondary", "pk-good"));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary", "secondary"],
+            Some(5),
+            None,
+            None,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+        let app = build_router(build_state(snap, hub));
+
+        let body = serde_json::json!({
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        // The `.expect(1)` on the bad upstream is the real assertion: the
+        // target's own `retries: 0` beat the group's `retries: 5`.
+    }
+
     #[tokio::test]
     async fn routing_retries_current_target_before_failover() {
         use aisix_obs::UsageSink;
@@ -4237,7 +4382,10 @@ data: [DONE]\n\n";
             "smart",
             "failover",
             &["primary"],
-            None,
+            // Single-target group: there is nothing to fall over to, so the
+            // default budget WOULD apply here. Pin it off — this test asserts
+            // the attempt record for one failed try, not the retry policy.
+            Some(0),
             None,
             None,
         ));
@@ -4528,6 +4676,9 @@ data: [DONE]\n\n";
             "smart",
             "failover",
             &["primary", "secondary"],
+            // Unset on purpose: with a fallback target queued, the default
+            // budget defers to it, so the sequence is initial -> fallback
+            // with no same-target grinding in between.
             None,
             None,
             None,
@@ -4653,6 +4804,9 @@ data: [DONE]\n\n";
             "smart",
             "failover",
             &["primary", "secondary"],
+            // Unset on purpose: with a fallback target queued, the default
+            // budget defers to it, so the sequence is initial -> fallback
+            // with no same-target grinding in between.
             None,
             None,
             None,
@@ -6387,12 +6541,17 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         upstream_model: &str,
         rate_limit: serde_json::Value,
     ) -> ResourceEntry<Model> {
+        // `retries: 0` — the rate-limit tests that use this helper assert on
+        // reservation accounting, and want one upstream call per dispatch.
+        // Under the default budget a single mocked failure would be retried
+        // into a success and the assertion would test nothing.
         let cfg = format!(
             r#"{{
                 "display_name": "{name}",
                 "provider": "openai",
                 "model_name": "{upstream_model}",
                 "provider_key_id": "{PK_ID}",
+                "retries": 0,
                 "rate_limit": {rate_limit}
             }}"#
         );

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -660,17 +660,6 @@ async fn dispatch(
     let is_routing_request = model_entry.value.routing.is_some();
     let mut routing = RoutingTelemetry::default();
 
-    // `routing.retries` — how many times to re-hit the SAME target (with
-    // backoff) on a retryable failure before failing over to the next target.
-    // Honoured here exactly like chat.rs (#641); 0 (the default) keeps the
-    // fail-over-only behaviour. /v1/messages previously ignored it entirely.
-    let retries = model_entry
-        .value
-        .routing
-        .as_ref()
-        .map(|r| r.retries_or_default())
-        .unwrap_or(0);
-
     // Walk targets, failing over to the next only on a retryable upstream
     // failure. A 4xx / config error is returned as-is — retrying other
     // targets won't help. Streaming and non-streaming share this loop:
@@ -686,11 +675,27 @@ async fn dispatch(
         let pk_id = crate::dispatch::resolve_provider_key(&snapshot, &target.model)
             .map(|e| e.id.clone())
             .unwrap_or_default();
-        for attempt_idx in 0..=retries {
-            // Exponential backoff + jitter before re-hitting the SAME target
+        // How many times to re-hit the SAME target (with backoff) on a
+        // retryable failure before failing over to the next target.
+        // Honoured here exactly like chat.rs (#641), and resolved per target
+        // so a direct model gets a budget too — it used to be pinned at zero
+        // because the knob only existed on the group.
+        let budget = crate::routing::effective_retries(
+            &target.model,
+            model_entry.value.routing.as_ref(),
+            state.default_retries,
+            i + 1 < n,
+        );
+        for attempt_idx in 0..=budget.attempts {
+            // Upstream `Retry-After` when the last failure carried one, else
+            // exponential backoff + jitter, before re-hitting the SAME target
             // (#641); cross-target fall-over (the outer loop) stays immediate.
             if attempt_idx > 0 {
-                tokio::time::sleep(crate::routing::retry_backoff(attempt_idx as u32)).await;
+                let hint = last_err.as_ref().and_then(|e| match e {
+                    ProxyError::Bridge(be) => crate::routing::retry_after_hint(be),
+                    _ => None,
+                });
+                tokio::time::sleep(crate::routing::retry_backoff(attempt_idx as u32, hint)).await;
             }
             let (idx, kind) = routing.begin_attempt(&target.model.display_name);
             let target_model = if is_routing_request {
@@ -820,6 +825,12 @@ async fn dispatch(
                         error_message,
                         latency_ms: ms_since(attempt_started),
                     });
+                    // See `RetryBudget::covers`: a default budget skips
+                    // same-target retries for timeouts; fail-over is unaffected.
+                    let budget_covers = match &e {
+                        ProxyError::Bridge(be) => budget.covers(be),
+                        _ => true,
+                    };
                     last_err = Some(e);
                     // Non-retryable → stop entirely (retrying or failing over
                     // won't help). Retryable → re-hit the same target until
@@ -828,7 +839,7 @@ async fn dispatch(
                     if !retryable {
                         break 'targets;
                     }
-                    if attempt_idx == retries {
+                    if attempt_idx == budget.attempts || !budget_covers {
                         if i + 1 >= n {
                             break 'targets;
                         }

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -512,14 +512,16 @@ async fn dispatch(
             }
 
             async move {
+                // See audio.rs: an elapsed `timeout` must surface as
+                // `BridgeError::Timeout`, not as a generic transport fault,
+                // so the retry budget can tell the two apart.
+                let send_started = std::time::Instant::now();
                 let upstream_resp = builder.send().await.map_err(|e| {
                     crate::cooldown::note_failure(
                         tracker,
                         model_id,
                         cooldown_cfg,
-                        aisix_gateway::BridgeError::Transport(
-                            aisix_gateway::transport_error_message(&e),
-                        ),
+                        crate::dispatch::reqwest_error_to_bridge(&e, send_started),
                     )
                 })?;
 

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -409,7 +409,6 @@ async fn dispatch(
     let _reservation = crate::quota::enforce(&state, auth, model_rl.as_ref()).await?;
 
     let client = crate::http_client::client();
-    let mut builder = client.request(method.clone(), &url);
 
     // Inject upstream Authorization; strip the incoming proxy auth.
     //
@@ -455,76 +454,93 @@ async fn dispatch(
         .chain(ALWAYS_STRIP.iter().map(|s| (*s).to_string()))
         .collect();
 
-    for (name, value) in &incoming_headers {
-        let n = name.as_str().to_ascii_lowercase();
-        if strip_set.contains(&n) {
-            continue;
-        }
-        builder = builder.header(name, value);
-    }
-
-    // Gateway's own auth — set AFTER the strip loop. This guarantees
-    // the upstream sees exactly one `Authorization` (or `x-api-key`
-    // + `anthropic-version`) line in the default case, even when
-    // the client sent one of those headers — the client's value
-    // was filtered out in the loop above.
-    if api_key.is_empty() {
-        // Provider key has no secret configured. Nothing to inject —
-        // explicit blank-Authorization rather than fall-through-to-
-        // Bearer-of-empty-string keeps the wire clean.
-    } else if provider_lower == "anthropic" {
-        builder = builder.header("x-api-key", &api_key);
-        builder = builder.header("anthropic-version", "2023-06-01");
-    } else {
-        builder = builder.header(header::AUTHORIZATION, format!("Bearer {api_key}"));
-    }
-
-    builder = builder.header("x-aisix-request-id", request_id);
-
-    if !body_bytes.is_empty() {
-        builder = builder.body(body_bytes);
-    }
-
-    // #554/#911: bound the raw tunnel by the selected model's E2E request
-    // timeout, matching the first-class non-streaming paths. Without it a
-    // slow/blackholed upstream could pin a passthrough connection open
-    // indefinitely regardless of the model's configured timeout.
-    if let Some(d) = model.request_timeout() {
-        builder = builder.timeout(d);
-    }
-
     // #701: transport/decode failures against the shared upstream mark the
     // borrowed model's runtime status (same borrowed-model basis as the
     // #911 [6] guardrail chain), so a dead upstream reached only via the raw
     // tunnel still trips the cooldown. Forwarded HTTP statuses stay the
     // caller's business — the tunnel relays them verbatim.
-    let upstream_resp = builder
-        .send()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::Transport(aisix_gateway::transport_error_message(&e)),
-            )
-        })
-        .map_err(ProxyError::Bridge)?;
+    //
+    // That contract is also what scopes the retry budget here: an upstream
+    // 5xx never becomes a `BridgeError` on this path, so it is relayed
+    // untouched (re-sending it would both break verbatim relay and stack on
+    // top of the provider edge's own retries — see AISIX-Cloud#1121). Only
+    // transport and decode faults — where no response reached the client —
+    // are retried. The whole request is rebuilt per attempt because
+    // `RequestBuilder::send` consumes it.
+    let tracker = &state.runtime_status;
+    let model_id: &str = &model_entry.id;
+    let cooldown_cfg = model.cooldown.as_ref();
+    let (status, resp_headers, resp_body) =
+        match crate::routing::retrying_dispatch(&state, model, "passthrough", || {
+            let mut builder = client.request(method.clone(), &url);
+            for (name, value) in &incoming_headers {
+                let n = name.as_str().to_ascii_lowercase();
+                if strip_set.contains(&n) {
+                    continue;
+                }
+                builder = builder.header(name, value);
+            }
 
-    let status = upstream_resp.status();
-    let resp_headers = upstream_resp.headers().clone();
-    let resp_body = upstream_resp
-        .bytes()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-            )
+            // Gateway's own auth — set AFTER the strip loop. This guarantees
+            // the upstream sees exactly one `Authorization` (or `x-api-key`
+            // + `anthropic-version`) line in the default case, even when
+            // the client sent one of those headers — the client's value
+            // was filtered out in the loop above.
+            if api_key.is_empty() {
+                // Provider key has no secret configured. Nothing to inject —
+                // explicit blank-Authorization rather than fall-through-to-
+                // Bearer-of-empty-string keeps the wire clean.
+            } else if provider_lower == "anthropic" {
+                builder = builder.header("x-api-key", &api_key);
+                builder = builder.header("anthropic-version", "2023-06-01");
+            } else {
+                builder = builder.header(header::AUTHORIZATION, format!("Bearer {api_key}"));
+            }
+
+            builder = builder.header("x-aisix-request-id", request_id);
+
+            if !body_bytes.is_empty() {
+                builder = builder.body(body_bytes.clone());
+            }
+
+            // #554/#911: bound the raw tunnel by the selected model's E2E
+            // request timeout, matching the first-class non-streaming paths.
+            // Without it a slow/blackholed upstream could pin a passthrough
+            // connection open indefinitely regardless of the model's timeout.
+            if let Some(d) = model.request_timeout() {
+                builder = builder.timeout(d);
+            }
+
+            async move {
+                let upstream_resp = builder.send().await.map_err(|e| {
+                    crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::Transport(
+                            aisix_gateway::transport_error_message(&e),
+                        ),
+                    )
+                })?;
+
+                let status = upstream_resp.status();
+                let resp_headers = upstream_resp.headers().clone();
+                let resp_body = upstream_resp.bytes().await.map_err(|e| {
+                    crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
+                    )
+                })?;
+                Ok((status, resp_headers, resp_body))
+            }
         })
-        .map_err(ProxyError::Bridge)?;
+        .await
+        {
+            Ok(v) => v,
+            Err(err) => return Err(ProxyError::Bridge(err)),
+        };
 
     // #911 [6]: run OUTPUT guardrails on the passthrough response body — the
     // same whole-body text scan as the input hook, so forbidden model output

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -466,14 +466,32 @@ async fn dispatch(
     // 5xx never becomes a `BridgeError` on this path, so it is relayed
     // untouched (re-sending it would both break verbatim relay and stack on
     // top of the provider edge's own retries — see AISIX-Cloud#1121). Only
-    // transport and decode faults — where no response reached the client —
-    // are retried. The whole request is rebuilt per attempt because
-    // `RequestBuilder::send` consumes it.
+    // transport and decode faults are retried, and decode faults only for
+    // idempotent methods: a body-read failure means the upstream already
+    // returned its status — the operation committed and only the response
+    // was lost — so replaying a tunneled POST would duplicate a write this
+    // gateway does not understand (a second file upload, a second
+    // fine-tune). Send-phase transport failures stay retryable for every
+    // method: whether the request reached the upstream is unknowable, and
+    // the provider SDKs accept that ambiguity too. The whole request is
+    // rebuilt per attempt because `RequestBuilder::send` consumes it.
     let tracker = &state.runtime_status;
     let model_id: &str = &model_entry.id;
     let cooldown_cfg = model.cooldown.as_ref();
-    let (status, resp_headers, resp_body) =
-        match crate::routing::retrying_dispatch(&state, model, "passthrough", || {
+    // RFC 9110 §9.2.2 idempotent methods.
+    let idempotent = matches!(
+        method,
+        Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE | Method::PUT | Method::DELETE
+    );
+    let retry_permit = |e: &aisix_gateway::BridgeError| {
+        idempotent || !matches!(e, aisix_gateway::BridgeError::UpstreamDecode(_))
+    };
+    let (status, resp_headers, resp_body) = match crate::routing::retrying_dispatch_gated(
+        &state,
+        model,
+        "passthrough",
+        retry_permit,
+        || {
             let mut builder = client.request(method.clone(), &url);
             for (name, value) in &incoming_headers {
                 let n = name.as_str().to_ascii_lowercase();
@@ -539,12 +557,13 @@ async fn dispatch(
                 })?;
                 Ok((status, resp_headers, resp_body))
             }
-        })
-        .await
-        {
-            Ok(v) => v,
-            Err(err) => return Err(ProxyError::Bridge(err)),
-        };
+        },
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(err) => return Err(ProxyError::Bridge(err)),
+    };
 
     // #911 [6]: run OUTPUT guardrails on the passthrough response body — the
     // same whole-body text scan as the input hook, so forbidden model output

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -388,61 +388,70 @@ async fn dispatch(
     }
 
     let client = crate::http_client::client();
-    let mut req = client.post(&url).headers(headers).json(body);
-    // #554: rerank is non-streaming; apply the E2E request timeout.
-    if let Some(d) = model.request_timeout() {
-        req = req.timeout(d);
-    }
-    let send_started = Instant::now();
-    let upstream_resp = req
-        .send()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                crate::dispatch::reqwest_error_to_bridge(&e, send_started),
-            )
+    // Send, check the status, and read the body as one retryable unit, so a
+    // transient fault anywhere in that sequence is retried rather than
+    // surfacing to the caller. `note_failure` runs per attempt, matching
+    // chat.rs: the cooldown decision is independent of the retry decision —
+    // a target that just failed should be deprioritised for the NEXT
+    // request even if this one recovers on retry.
+    let tracker = &state.runtime_status;
+    let model_id: &str = &model_entry.id;
+    let cooldown_cfg = model.cooldown.as_ref();
+    let (upstream_headers, body_bytes) =
+        match crate::routing::retrying_dispatch(state, model, "/v1/rerank", || {
+            let mut req = client.post(&url).headers(headers.clone()).json(body);
+            // #554: rerank is non-streaming; apply the E2E request timeout.
+            if let Some(d) = model.request_timeout() {
+                req = req.timeout(d);
+            }
+            async move {
+                let send_started = Instant::now();
+                let upstream_resp = req.send().await.map_err(|e| {
+                    crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        crate::dispatch::reqwest_error_to_bridge(&e, send_started),
+                    )
+                })?;
+
+                let status = upstream_resp.status();
+                if !status.is_success() {
+                    let status_u16 = status.as_u16();
+                    let retry_after = aisix_gateway::parse_retry_after(upstream_resp.headers());
+                    let message = upstream_resp.text().await.unwrap_or_default();
+                    return Err(crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::upstream_status_with_retry_after(
+                            status_u16,
+                            message.chars().take(1024).collect::<String>(),
+                            retry_after,
+                        ),
+                    ));
+                }
+
+                let upstream_headers = upstream_resp.headers().clone();
+                let body_bytes = upstream_resp.bytes().await.map_err(|e| {
+                    crate::cooldown::note_failure(
+                        tracker,
+                        model_id,
+                        cooldown_cfg,
+                        aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
+                    )
+                })?;
+                Ok((upstream_headers, body_bytes))
+            }
         })
-        .map_err(ProxyError::Bridge)?;
-
-    let status = upstream_resp.status();
-
-    if !status.is_success() {
-        let status_u16 = status.as_u16();
-        let retry_after = aisix_gateway::parse_retry_after(upstream_resp.headers());
-        let message = upstream_resp.text().await.unwrap_or_default();
-        let err = aisix_gateway::BridgeError::upstream_status_with_retry_after(
-            status_u16,
-            message.chars().take(1024).collect::<String>(),
-            retry_after,
-        );
-        if let Some((ttl, reason)) = crate::cooldown::decide_cooldown(&err, model.cooldown.as_ref())
+        .await
         {
-            state
-                .runtime_status
-                .mark_cooldown(&model_entry.id, ttl, reason);
-        }
-        return Err(ProxyError::Bridge(err));
-    }
+            Ok(v) => v,
+            Err(err) => return Err(ProxyError::Bridge(err)),
+        };
 
     state.health.record_success(&model_name);
     state.runtime_status.mark_healthy(&model_entry.id);
-
-    let upstream_headers = upstream_resp.headers().clone();
-    let body_bytes = upstream_resp
-        .bytes()
-        .await
-        .map_err(|e| {
-            crate::cooldown::note_failure(
-                &state.runtime_status,
-                &model_entry.id,
-                model.cooldown.as_ref(),
-                aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-            )
-        })
-        .map_err(ProxyError::Bridge)?;
 
     // Extract usage from the upstream body BEFORE handing the bytes
     // off to the response builder. We parse for telemetry but still

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -537,33 +537,37 @@ async fn dispatch(
         .unwrap_or(&[]);
     let is_routing_request = model_entry.value.routing.is_some();
     let mut routing = RoutingTelemetry::default();
-    // `routing.retries` — same-target retries (with backoff) before failing
-    // over, honoured exactly like chat.rs / messages.rs (#641). 0 (default)
-    // keeps fail-over-only; /v1/responses previously ignored it entirely.
-    let retries = model_entry
-        .value
-        .routing
-        .as_ref()
-        .map(|r| r.retries_or_default())
-        .unwrap_or(0);
-
     // Walk the targets, failing over on a retryable failure. Streaming and
     // non-streaming share this loop: the per-target dispatch branches
     // internally and, for streaming, only returns Ok once the first chunk
     // has arrived under `stream_timeout` (#554) — so the 200 is committed to
     // exactly one target and a slow first chunk fails over.
     let mut last_err: Option<ProxyError> = None;
-    'targets: for target in &attempt_models {
+    'targets: for (target_idx, target) in attempt_models.iter().enumerate() {
         // Resolved ProviderKey UUID for this target — feeds the per-PK
         // telemetry attribution tags on the emitted UsageEvent
         // (AISIX-Cloud#867). Recorded on the AttemptRecord (success + failure)
         // so both the winner and each failed-attempt event can attribute it.
         let pk_id = target.model.provider_key_id.clone().unwrap_or_default();
-        for attempt_idx in 0..=retries {
-            // Exponential backoff + jitter before re-hitting the SAME target
+        // Same-target retries before failing over, honoured exactly like
+        // chat.rs / messages.rs (#641) and resolved per target so a direct
+        // model gets a budget too.
+        let budget = crate::routing::effective_retries(
+            &target.model,
+            model_entry.value.routing.as_ref(),
+            state.default_retries,
+            target_idx + 1 < attempt_models.len(),
+        );
+        for attempt_idx in 0..=budget.attempts {
+            // Upstream `Retry-After` when the last failure carried one, else
+            // exponential backoff + jitter, before re-hitting the SAME target
             // (#641); cross-target fall-over (the outer loop) stays immediate.
             if attempt_idx > 0 {
-                tokio::time::sleep(crate::routing::retry_backoff(attempt_idx as u32)).await;
+                let hint = last_err.as_ref().and_then(|e| match e {
+                    ProxyError::Bridge(be) => crate::routing::retry_after_hint(be),
+                    _ => None,
+                });
+                tokio::time::sleep(crate::routing::retry_backoff(attempt_idx as u32, hint)).await;
             }
             let (idx, kind) = routing.begin_attempt(&target.model.display_name);
             let target_model = if is_routing_request {
@@ -723,6 +727,12 @@ async fn dispatch(
                         error_message,
                         latency_ms: ms_since(attempt_started),
                     });
+                    // See `RetryBudget::covers`: a default budget skips
+                    // same-target retries for timeouts; fail-over is unaffected.
+                    let budget_covers = match &e {
+                        ProxyError::Bridge(be) => budget.covers(be),
+                        _ => true,
+                    };
                     last_err = Some(e);
                     // Non-retryable → stop entirely. Retryable → re-hit the
                     // same target until `retries` is exhausted, then fall over
@@ -730,7 +740,7 @@ async fn dispatch(
                     if !retryable {
                         break 'targets;
                     }
-                    if attempt_idx == retries {
+                    if attempt_idx == budget.attempts || !budget_covers {
                         break;
                     }
                 }
@@ -4875,25 +4885,43 @@ data: [DONE]\n\n";
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
 
-        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        let ev = recv
-            .expect("a failed-attempt UsageEvent must be emitted within the timeout")
-            .expect("the usage sink channel must not be closed");
-        assert_eq!(ev.status_code, 502, "failed attempt records the mapped 502");
-        assert_eq!(ev.prompt_tokens, 0, "failed attempt has zero tokens");
-        assert_eq!(ev.completion_tokens, 0, "failed attempt has zero tokens");
-        assert_eq!(ev.attempt_index, 0, "single direct-model attempt");
-        assert_eq!(ev.attempt_kind, "initial");
+        // A direct model now carries the deployment default retry budget (2),
+        // so a persistent 5xx produces three attempts — initial + two retries
+        // — each its own zero-token event. Before the per-model budget landed
+        // the knob only existed on a model group, so this was one attempt.
+        let mut events = Vec::new();
+        for _ in 0..3 {
+            let ev = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+                .await
+                .expect("a failed-attempt UsageEvent must be emitted within the timeout")
+                .expect("the usage sink channel must not be closed");
+            events.push(ev);
+        }
+        events.sort_by_key(|e| e.attempt_index);
+        for ev in &events {
+            assert_eq!(ev.status_code, 502, "failed attempt records the mapped 502");
+            assert_eq!(ev.prompt_tokens, 0, "failed attempt has zero tokens");
+            assert_eq!(ev.completion_tokens, 0, "failed attempt has zero tokens");
+            assert_eq!(
+                ev.error_class, "upstream_status",
+                "500 upstream maps to an upstream_status error class",
+            );
+        }
         assert_eq!(
-            ev.error_class, "upstream_status",
-            "500 upstream maps to an upstream_status error class",
+            events
+                .iter()
+                .map(|e| e.attempt_kind.as_str())
+                .collect::<Vec<_>>(),
+            vec!["initial", "retry", "retry"],
+            "the retries re-hit the SAME model, so they are retries not fallbacks",
         );
-        // Exactly one event — a direct model has no further attempts and no
-        // separate terminal event (the attempt itself is terminal).
+
+        // No further events — the budget is exhausted and there is no
+        // separate terminal event (the last attempt itself is terminal).
         let extra = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
         if let Ok(Some(ev)) = extra {
             panic!(
-                "expected exactly one event for a single failed attempt, got a second: \
+                "expected exactly three events for an exhausted budget, got a fourth: \
                  attempt_index={} status_code={}",
                 ev.attempt_index, ev.status_code,
             );

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -85,27 +85,202 @@ const RETRY_BACKOFF_MAX_MS: u64 = 2_000;
 /// top of the exponential term.
 const RETRY_BACKOFF_JITTER_MS: u64 = 250;
 
+/// Longest upstream-supplied `Retry-After` we are willing to sit on before
+/// falling back to our own exponential term. LiteLLM honours anything up to
+/// 60s (`_calculate_retry_after`); an inline proxy cannot — the wait burns
+/// the caller's own latency budget, and a 45s hold reads as a hang to the
+/// client. Same reason the exponential bounds below are tightened relative
+/// to LiteLLM's library defaults.
+const RETRY_AFTER_HONOR_MAX_MS: u64 = 5_000;
+
 /// Backoff before retrying the **same** target, for 1-based retry number
-/// `retry` (`retry == 0` → no wait). Exponential term `base * 2^(retry-1)`
-/// capped at [`RETRY_BACKOFF_MAX_MS`], plus uniform additive jitter in
-/// `[0, RETRY_BACKOFF_JITTER_MS]`.
+/// `retry` (`retry == 0` → no wait).
 ///
-/// Same strategy as LiteLLM's router (`_calculate_retry_after`: capped
-/// exponential floor + additive jitter — not full-jitter-to-zero, so a
-/// struggling upstream always gets a real pause), with bounds tightened
-/// from LiteLLM's library defaults (0.5s base / 8s cap) to suit an inline
-/// proxy where the retry runs inside a single request's latency budget.
-/// Cross-target fallover is deliberately NOT backed off — a different,
-/// presumably healthy target should be tried immediately (LiteLLM's
-/// healthy-deployment fast-path).
-pub fn retry_backoff(retry: u32) -> Duration {
+/// When the upstream told us how long to wait (`Retry-After`, typically on
+/// a 429) and the hint is within [`RETRY_AFTER_HONOR_MAX_MS`], we do what
+/// it says — a provider's own quota window beats a guess. Otherwise:
+/// exponential term `base * 2^(retry-1)` capped at [`RETRY_BACKOFF_MAX_MS`].
+/// Either way uniform additive jitter in `[0, RETRY_BACKOFF_JITTER_MS]` is
+/// added, so a fleet retrying off the same upstream fault does not
+/// synchronise.
+///
+/// Same strategy as LiteLLM's router (`_calculate_retry_after`: honour a
+/// sane `Retry-After`, else capped exponential floor + additive jitter —
+/// not full-jitter-to-zero, so a struggling upstream always gets a real
+/// pause), with bounds tightened from LiteLLM's library defaults (0.5s base
+/// / 8s cap / 60s `Retry-After` ceiling) to suit an inline proxy where the
+/// retry runs inside a single request's latency budget. Cross-target
+/// fallover is deliberately NOT backed off — a different, presumably
+/// healthy target should be tried immediately (LiteLLM's healthy-deployment
+/// fast-path).
+pub fn retry_backoff(retry: u32, retry_after: Option<Duration>) -> Duration {
     if retry == 0 {
         return Duration::ZERO;
     }
+    let jitter = rand::thread_rng().gen_range(0..=RETRY_BACKOFF_JITTER_MS);
+    if let Some(hint) = retry_after {
+        let hint_ms = hint.as_millis().min(u64::MAX as u128) as u64;
+        if hint_ms > 0 && hint_ms <= RETRY_AFTER_HONOR_MAX_MS {
+            return Duration::from_millis(hint_ms + jitter);
+        }
+    }
     let exp = RETRY_BACKOFF_BASE_MS.saturating_mul(1u64 << (retry - 1).min(20));
     let base = exp.min(RETRY_BACKOFF_MAX_MS);
-    let jitter = rand::thread_rng().gen_range(0..=RETRY_BACKOFF_JITTER_MS);
     Duration::from_millis(base + jitter)
+}
+
+/// The `Retry-After` hint an upstream attached to this failure, if any.
+/// Only [`BridgeError::UpstreamStatus`] carries one (parsed by
+/// `aisix_gateway::parse_retry_after`); transport faults and timeouts have
+/// nothing to report.
+pub fn retry_after_hint(err: &BridgeError) -> Option<Duration> {
+    match err {
+        BridgeError::UpstreamStatus { retry_after, .. } => *retry_after,
+        _ => None,
+    }
+}
+
+/// Retry budget for one dispatch target, resolved across the three levels
+/// an operator can set it at.
+///
+/// `target.retries` (this model's own budget) wins, then the group's
+/// `routing.retries` (the historical knob, now a group-wide default), then
+/// the deployment-wide `upstream.retries` from the DP config.
+///
+/// Per-target beats per-group because a routing target *is* a Model: "how
+/// many times may this upstream be re-hit" is a property of that upstream,
+/// and target A tolerating three retries says nothing about target B. A
+/// direct (non-group) model has no `group`, which is exactly why it used to
+/// end up with a hardcoded zero — the knob only ever existed on the group.
+///
+/// `has_fallback_targets` says whether another candidate target is still
+/// queued behind this one. It only gates the DEPLOYMENT DEFAULT: when the
+/// operator configured nothing and a fallback is available, prefer failing
+/// over to grinding the same failing upstream. An explicitly configured
+/// budget — at either level, including `0` — is always honoured as written.
+///
+/// That distinction is what keeps the default from silently degrading
+/// `timeout`-driven fail-over (#554): a two-target group whose first target
+/// times out should move on after one timeout, not after three. It also
+/// tracks what LiteLLM actually does, which is easy to misread. Its
+/// `num_retries` does not re-hit one deployment — each retry re-enters
+/// deployment selection, and the failed deployment has meanwhile been
+/// cooled down, so a retry inside a multi-deployment group lands on a
+/// DIFFERENT deployment. Same-target grinding is what LiteLLM does only
+/// when a group holds a single deployment, which is exactly the case this
+/// keeps the default for.
+pub fn effective_retries(
+    target: &aisix_core::Model,
+    group: Option<&aisix_core::models::routing::Routing>,
+    deployment_default: u32,
+    has_fallback_targets: bool,
+) -> RetryBudget {
+    if let Some(explicit) = target.retries.or_else(|| group.and_then(|r| r.retries)) {
+        return RetryBudget {
+            attempts: explicit as usize,
+            configured: true,
+        };
+    }
+    RetryBudget {
+        attempts: if has_fallback_targets {
+            0
+        } else {
+            deployment_default as usize
+        },
+        configured: false,
+    }
+}
+
+/// How many same-target retries this dispatch may spend, and whether the
+/// operator asked for them.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryBudget {
+    /// Retries after the initial attempt.
+    pub attempts: usize,
+    /// True when the number came from `Model.retries` or `routing.retries`
+    /// rather than from the deployment default.
+    configured: bool,
+}
+
+impl RetryBudget {
+    /// Whether `err` is allowed to spend this budget.
+    ///
+    /// A budget the operator never configured does not retry timeouts. A
+    /// `timeout` is an explicit "stop waiting on this upstream" threshold,
+    /// so spending an unasked-for budget on it triples the very wait the
+    /// operator bounded — and an upstream that just burned the full budget
+    /// will most likely burn it again. Transport faults and 5xx are the
+    /// opposite: they fail fast and are often momentary, which is exactly
+    /// what a retry is for.
+    ///
+    /// An explicitly configured budget retries everything retryable,
+    /// timeouts included — the operator asked for it by name.
+    ///
+    /// Timeouts remain retryable for FAIL-OVER purposes either way
+    /// (`is_retryable`); this only governs re-hitting the same target.
+    pub fn covers(&self, err: &BridgeError) -> bool {
+        self.configured || !matches!(err, BridgeError::Timeout { .. })
+    }
+}
+
+/// Drive one single-model upstream call under that model's retry budget.
+///
+/// The group-capable endpoints (chat, messages, responses, count_tokens)
+/// keep their own loops: they also walk fall-over targets and emit
+/// per-attempt telemetry, neither of which applies here. Every other
+/// endpoint — embeddings, rerank, completions, audio, images, videos,
+/// passthrough — dispatches to exactly one model, and this is their whole
+/// retry story.
+///
+/// `retry_on_429` / `fallback_on_statuses` are group-level knobs, so the
+/// default classification applies: 5xx, timeout, transport, decode and
+/// stream-abort retry; every 4xx (429 included) is returned as-is.
+pub(crate) async fn retrying_dispatch<F, Fut, T>(
+    state: &crate::ProxyState,
+    model: &aisix_core::Model,
+    endpoint: &'static str,
+    mut call: F,
+) -> Result<T, BridgeError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, BridgeError>>,
+{
+    let budget = effective_retries(model, None, state.default_retries, false);
+    let mut last_err: Option<BridgeError> = None;
+    for attempt_idx in 0..=budget.attempts {
+        if attempt_idx > 0 {
+            let hint = last_err.as_ref().and_then(retry_after_hint);
+            let backoff = retry_backoff(attempt_idx as u32, hint);
+            tracing::debug!(
+                endpoint,
+                model = %model.display_name,
+                next_attempt = attempt_idx + 1,
+                backoff_ms = backoff.as_millis() as u64,
+                "backing off before retry",
+            );
+            tokio::time::sleep(backoff).await;
+        }
+        match call().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if !is_retryable(&e, false, &[]) || !budget.covers(&e) {
+                    return Err(e);
+                }
+                tracing::warn!(
+                    endpoint,
+                    model = %model.display_name,
+                    attempt = attempt_idx + 1,
+                    max_attempts = budget.attempts + 1,
+                    error = %e,
+                    "retryable upstream failure",
+                );
+                last_err = Some(e);
+            }
+        }
+    }
+    // Unreachable with `last_err == None`: the loop body either returns or
+    // stores an error, and it runs at least once.
+    Err(last_err.unwrap_or_else(|| BridgeError::Config("retry loop produced no error".into())))
 }
 
 #[derive(Default)]
@@ -1155,7 +1330,7 @@ mod tests {
     // ── retry_backoff ─────────────────────────────────────────────
     #[test]
     fn retry_backoff_zero_is_no_wait() {
-        assert_eq!(retry_backoff(0), Duration::ZERO);
+        assert_eq!(retry_backoff(0, None), Duration::ZERO);
     }
 
     #[test]
@@ -1175,7 +1350,7 @@ mod tests {
             let mut min = u64::MAX;
             let mut max = 0u64;
             for _ in 0..2000 {
-                let ms = retry_backoff(retry).as_millis() as u64;
+                let ms = retry_backoff(retry, None).as_millis() as u64;
                 min = min.min(ms);
                 max = max.max(ms);
             }
@@ -1185,6 +1360,134 @@ mod tests {
                 "retry {retry}: max {max} > floor {floor} + jitter 250",
             );
         }
+    }
+
+    #[test]
+    fn retry_backoff_honours_a_sane_retry_after() {
+        // A provider-supplied hint inside the honour window wins over the
+        // exponential term, even when the exponential term would be shorter
+        // (retry 1 → 250ms floor, hint → 3000ms).
+        let mut min = u64::MAX;
+        for _ in 0..500 {
+            let ms = retry_backoff(1, Some(Duration::from_millis(3_000))).as_millis() as u64;
+            min = min.min(ms);
+            assert!((3_000..=3_250).contains(&ms), "hint not honoured: {ms}ms");
+        }
+        assert!(min >= 3_000);
+    }
+
+    #[test]
+    fn retry_backoff_ignores_an_out_of_range_retry_after() {
+        // Above the honour ceiling we fall back to our own exponential term
+        // rather than parking the caller's request for a minute. A zero hint
+        // is meaningless and falls back too.
+        for hint in [Duration::from_secs(60), Duration::ZERO] {
+            let ms = retry_backoff(1, Some(hint)).as_millis() as u64;
+            assert!(
+                (250..=500).contains(&ms),
+                "expected the exponential term for hint {hint:?}, got {ms}ms",
+            );
+        }
+    }
+
+    // ── effective_retries ─────────────────────────────────────────
+    fn model_with_retries(retries: Option<u32>) -> Model {
+        let mut m: Model = serde_json::from_str(
+            r#"{"display_name":"m","provider":"openai","model_name":"gpt-4o","provider_key_id":"pk"}"#,
+        )
+        .unwrap();
+        m.retries = retries;
+        m
+    }
+
+    fn group_with_retries(retries: Option<u32>) -> aisix_core::models::routing::Routing {
+        let mut r: aisix_core::models::routing::Routing =
+            serde_json::from_str(r#"{"targets":[{"model":"a"}]}"#).unwrap();
+        r.retries = retries;
+        r
+    }
+
+    /// `budget(target, group, default, has_fallback)` — reads better than
+    /// four positional args repeated in every assertion below.
+    fn budget(
+        target: Option<u32>,
+        group: Option<Option<u32>>,
+        default: u32,
+        has_fallback: bool,
+    ) -> RetryBudget {
+        let m = model_with_retries(target);
+        match group {
+            Some(g) => effective_retries(&m, Some(&group_with_retries(g)), default, has_fallback),
+            None => effective_retries(&m, None, default, has_fallback),
+        }
+    }
+
+    #[test]
+    fn effective_retries_prefers_the_target_then_the_group_then_the_default() {
+        // Target wins over group.
+        assert_eq!(budget(Some(1), Some(Some(5)), 2, false).attempts, 1);
+        // Group applies when the target is silent.
+        assert_eq!(budget(None, Some(Some(5)), 2, false).attempts, 5);
+        // Deployment default applies when both are silent.
+        assert_eq!(budget(None, Some(None), 2, false).attempts, 2);
+        // A direct model has no group at all — the case that used to be
+        // hardcoded to zero.
+        assert_eq!(budget(None, None, 2, false).attempts, 2);
+    }
+
+    #[test]
+    fn effective_retries_honours_an_explicit_zero_at_every_level() {
+        // `Some(0)` is an opt-out, not "unset" — it must not fall through to
+        // the next level, or an operator could never turn retrying off.
+        assert_eq!(budget(Some(0), Some(Some(5)), 2, false).attempts, 0);
+        assert_eq!(budget(None, Some(Some(0)), 2, false).attempts, 0);
+        assert_eq!(budget(None, None, 0, false).attempts, 0);
+    }
+
+    #[test]
+    fn effective_retries_default_defers_to_a_fallback_target() {
+        // Nothing configured + another target queued behind this one: prefer
+        // failing over to grinding a failing upstream. This is what keeps the
+        // default from tripling the latency of `timeout`-driven fail-over
+        // (#554) — and it matches LiteLLM, whose retries re-enter deployment
+        // selection rather than re-hitting the same deployment.
+        assert_eq!(budget(None, None, 2, true).attempts, 0);
+        assert_eq!(budget(None, Some(None), 2, true).attempts, 0);
+        // The LAST target has nothing to fall over to, so the default applies
+        // there — the request still gets its retries before giving up.
+        assert_eq!(budget(None, Some(None), 2, false).attempts, 2);
+    }
+
+    #[test]
+    fn effective_retries_explicit_config_beats_the_fallback_heuristic() {
+        // The heuristic only gates the DEFAULT. An operator who asked for
+        // same-target retries gets them even with fallbacks queued up.
+        assert_eq!(budget(Some(3), None, 2, true).attempts, 3);
+        assert_eq!(budget(None, Some(Some(3)), 2, true).attempts, 3);
+    }
+
+    #[test]
+    fn a_default_budget_does_not_spend_itself_on_a_timeout() {
+        let timeout = BridgeError::Timeout {
+            elapsed_ms: 7_000,
+            cause: String::new(),
+        };
+        let server_error = BridgeError::upstream_status(503, "unavailable");
+
+        // Unconfigured: a timeout must not be re-hit on the same target —
+        // the operator bounded that wait on purpose, and tripling it is the
+        // opposite of what `timeout` asks for. Transient 5xx still retries.
+        let default = budget(None, None, 2, false);
+        assert!(!default.covers(&timeout));
+        assert!(default.covers(&server_error));
+
+        // Configured: the operator named the number, so it applies to
+        // everything retryable, timeouts included.
+        let configured = budget(Some(2), None, 2, false);
+        assert!(configured.covers(&timeout));
+        assert!(configured.covers(&server_error));
+        // ...including when it came from the group.
+        assert!(budget(None, Some(Some(2)), 2, false).covers(&timeout));
     }
 
     // ── filter_attempt_models ─────────────────────────────────────

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -239,9 +239,41 @@ pub(crate) async fn retrying_dispatch<F, Fut, T>(
     state: &crate::ProxyState,
     model: &aisix_core::Model,
     endpoint: &'static str,
+    call: F,
+) -> Result<T, BridgeError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, BridgeError>>,
+{
+    retrying_dispatch_gated(state, model, endpoint, |_| true, call).await
+}
+
+/// [`retrying_dispatch`] with a caller-supplied `permit` predicate that can
+/// veto spending the budget on a particular failure.
+///
+/// Exists for the two endpoints that replay requests they did not author —
+/// passthrough and /v1/videos — where a retry can re-execute a
+/// **non-idempotent upstream write**. The dangerous case is a failure
+/// AFTER the upstream returned its status: the operation committed, only
+/// the response body was lost, and a retry duplicates it (a second file
+/// upload, a second paid video task whose id the caller never saw). Those
+/// callers veto `UpstreamDecode` for non-idempotent methods. Send-phase
+/// transport failures stay retryable — whether the request reached the
+/// upstream is unknowable there, and the OpenAI SDK / LiteLLM router both
+/// accept that ambiguity and retry POSTs on connection errors.
+///
+/// The first-class endpoints don't need a veto: their POST bodies are
+/// generation requests the gateway itself authored, where a replay is the
+/// documented cost of retrying (same as every provider SDK).
+pub(crate) async fn retrying_dispatch_gated<P, F, Fut, T>(
+    state: &crate::ProxyState,
+    model: &aisix_core::Model,
+    endpoint: &'static str,
+    permit: P,
     mut call: F,
 ) -> Result<T, BridgeError>
 where
+    P: Fn(&BridgeError) -> bool,
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<T, BridgeError>>,
 {
@@ -263,7 +295,7 @@ where
         match call().await {
             Ok(v) => return Ok(v),
             Err(e) => {
-                if !is_retryable(&e, false, &[]) || !budget.covers(&e) {
+                if !is_retryable(&e, false, &[]) || !budget.covers(&e) || !permit(&e) {
                     return Err(e);
                 }
                 tracing::warn!(

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -153,6 +153,10 @@ pub struct ProxyState {
     /// the built-in allowlist (AISIX-Cloud#1045). Default = built-ins
     /// only; the server bootstrap swaps in the compiled config rules.
     pub client_classifier: Arc<ClientTypeClassifier>,
+    /// Deployment-wide retry budget (`upstream.retries`) — the floor every
+    /// dispatch falls back to when neither the target Model nor its model
+    /// group sets one. See `routing::effective_retries`.
+    pub default_retries: u32,
 }
 
 impl ProxyState {
@@ -180,6 +184,7 @@ impl ProxyState {
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
+            default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
         }
     }
 
@@ -214,6 +219,7 @@ impl ProxyState {
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
+            default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
         }
     }
 
@@ -258,6 +264,7 @@ impl ProxyState {
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
+            default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
         }
     }
 
@@ -281,6 +288,13 @@ impl ProxyState {
     /// Default is built-ins only.
     pub fn with_client_classifier(mut self, classifier: Arc<ClientTypeClassifier>) -> Self {
         self.client_classifier = classifier;
+        self
+    }
+
+    /// Apply the deployment-wide `upstream.retries` budget. Default is
+    /// [`aisix_core::config::DEFAULT_UPSTREAM_RETRIES`].
+    pub fn with_default_retries(mut self, retries: u32) -> Self {
+        self.default_retries = retries;
         self
     }
 

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -732,25 +732,6 @@ async fn provider_call(
     request_id: &str,
 ) -> Result<serde_json::Value, ProxyError> {
     let client = crate::http_client::client();
-    let mut builder = client
-        .request(method, url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", target.secret))
-        .header("x-aisix-request-id", request_id);
-    if let Some(b) = body {
-        if target.provider.submit_headers_async() {
-            // DashScope requires the async-mode header — it rejects
-            // synchronous video-synthesis calls outright.
-            builder = builder.header("X-DashScope-Async", "enable");
-        }
-        builder = builder
-            .header(header::CONTENT_TYPE, "application/json")
-            .json(b);
-    }
-    if let Some(d) = target.model_entry.value.request_timeout() {
-        builder = builder.timeout(d);
-    }
-
-    let started = Instant::now();
     let note = |e: aisix_gateway::BridgeError| {
         crate::cooldown::note_failure(
             &state.runtime_status,
@@ -759,49 +740,77 @@ async fn provider_call(
             e,
         )
     };
-    let resp = builder
-        .send()
-        .await
-        .map_err(|e| note(crate::dispatch::reqwest_error_to_bridge(&e, started)))
-        .map_err(ProxyError::Bridge)?;
-    let status = resp.status().as_u16();
-    let bytes = resp
-        .bytes()
-        .await
-        .map_err(|e| note(aisix_gateway::BridgeError::UpstreamDecode(e.to_string())))
-        .map_err(ProxyError::Bridge)?;
 
-    if !(200..300).contains(&status) {
-        // Best-effort parse of the vendor error envelope: DashScope puts
-        // `{code, message}` at the top level; the other vendors nest an
-        // OpenAI-style `{error: {code, message}}`. Try both, fall back
-        // to a generic marker for non-JSON bodies.
-        let parsed: Option<serde_json::Value> = serde_json::from_slice(&bytes).ok();
-        let message = parsed
-            .and_then(|p| {
-                let scope = if p.get("error").is_some() {
-                    p.get("error").cloned().unwrap_or_default()
-                } else {
-                    p
-                };
-                let code = nonempty_str(scope.get("code")).map(str::to_string);
-                let msg = nonempty_str(scope.get("message")).map(str::to_string);
-                match (code, msg) {
-                    (Some(code), Some(msg)) => Some(format!("{code}: {msg}")),
-                    (None, Some(msg)) => Some(msg),
-                    (Some(code), None) => Some(code),
-                    (None, None) => None,
-                }
+    // Every /v1/videos upstream call — submit, poll, content fetch — funnels
+    // through here, so wrapping this one function gives the whole surface a
+    // retry budget. `note` stays per attempt (see rerank.rs).
+    crate::routing::retrying_dispatch(state, &target.model_entry.value, "/v1/videos", || {
+        let mut builder = client
+            .request(method.clone(), url)
+            .header(header::AUTHORIZATION, format!("Bearer {}", target.secret))
+            .header("x-aisix-request-id", request_id);
+        if let Some(b) = body {
+            if target.provider.submit_headers_async() {
+                // DashScope requires the async-mode header — it rejects
+                // synchronous video-synthesis calls outright.
+                builder = builder.header("X-DashScope-Async", "enable");
+            }
+            builder = builder
+                .header(header::CONTENT_TYPE, "application/json")
+                .json(b);
+        }
+        if let Some(d) = target.model_entry.value.request_timeout() {
+            builder = builder.timeout(d);
+        }
+        async move {
+            let started = Instant::now();
+            let resp = builder
+                .send()
+                .await
+                .map_err(|e| note(crate::dispatch::reqwest_error_to_bridge(&e, started)))?;
+            let status = resp.status().as_u16();
+            let bytes = resp
+                .bytes()
+                .await
+                .map_err(|e| note(aisix_gateway::BridgeError::UpstreamDecode(e.to_string())))?;
+
+            if !(200..300).contains(&status) {
+                // Best-effort parse of the vendor error envelope: DashScope
+                // puts `{code, message}` at the top level; the other vendors
+                // nest an OpenAI-style `{error: {code, message}}`. Try both,
+                // fall back to a generic marker for non-JSON bodies.
+                let parsed: Option<serde_json::Value> = serde_json::from_slice(&bytes).ok();
+                let message = parsed
+                    .and_then(|p| {
+                        let scope = if p.get("error").is_some() {
+                            p.get("error").cloned().unwrap_or_default()
+                        } else {
+                            p
+                        };
+                        let code = nonempty_str(scope.get("code")).map(str::to_string);
+                        let msg = nonempty_str(scope.get("message")).map(str::to_string);
+                        match (code, msg) {
+                            (Some(code), Some(msg)) => Some(format!("{code}: {msg}")),
+                            (None, Some(msg)) => Some(msg),
+                            (Some(code), None) => Some(code),
+                            (None, None) => None,
+                        }
+                    })
+                    .unwrap_or_else(|| "upstream error".to_string());
+                return Err(note(aisix_gateway::BridgeError::upstream_status(
+                    status, message,
+                )));
+            }
+
+            serde_json::from_slice(&bytes).map_err(|e| {
+                aisix_gateway::BridgeError::UpstreamDecode(format!(
+                    "invalid task response from upstream: {e}"
+                ))
             })
-            .unwrap_or_else(|| "upstream error".to_string());
-        return Err(note(aisix_gateway::BridgeError::upstream_status(status, message)).into());
-    }
-
-    serde_json::from_slice(&bytes).map_err(|e| {
-        ProxyError::Bridge(aisix_gateway::BridgeError::UpstreamDecode(format!(
-            "invalid task response from upstream: {e}"
-        )))
+        }
     })
+    .await
+    .map_err(ProxyError::Bridge)
 }
 
 /// Poll the provider task for a decoded video id and reduce it to the

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1116,59 +1116,78 @@ async fn provider_call(
         )
     };
 
-    // Every /v1/videos upstream call — submit, poll, content fetch — funnels
-    // through here, so wrapping this one function gives the whole surface a
-    // retry budget. `note` stays per attempt (see rerank.rs).
-    crate::routing::retrying_dispatch(state, &target.model_entry.value, "/v1/videos", || {
-        let mut builder = client
-            .request(method.clone(), url)
-            .header(header::AUTHORIZATION, format!("Bearer {}", target.secret))
-            .header("x-aisix-request-id", request_id);
-        // A provider header required on every call (submit and poll) — e.g.
-        // Runway's mandatory `X-Runway-Version`. Applied unconditionally,
-        // before the submit-only body/header block below.
-        if let Some((name, value)) = target.provider.all_request_header() {
-            builder = builder.header(name, value);
-        }
-        if let Some(b) = body {
-            if target.provider.submit_headers_async() {
-                // DashScope requires the async-mode header — it rejects
-                // synchronous video-synthesis calls outright.
-                builder = builder.header("X-DashScope-Async", "enable");
+    // Every /v1/videos JSON round-trip — submit, poll, content-URL fetch —
+    // funnels through here, so wrapping this one function gives the whole
+    // surface a retry budget. `note` stays per attempt (see rerank.rs).
+    //
+    // The submit POST creates a PAID generation task, so a failure after
+    // the upstream returned its status (a body-read or parse failure —
+    // `UpstreamDecode`) must not be replayed: the task exists upstream,
+    // its id was in the lost body, and a retry would start a second one
+    // the caller also can't see. Send-phase transport failures stay
+    // retryable for POST too — whether the request arrived is unknowable,
+    // and the provider SDKs make the same call for their own paid
+    // generation POSTs. GETs (poll / content URL) retry everything.
+    let retry_permit = |e: &aisix_gateway::BridgeError| {
+        method == reqwest::Method::GET
+            || !matches!(e, aisix_gateway::BridgeError::UpstreamDecode(_))
+    };
+    crate::routing::retrying_dispatch_gated(
+        state,
+        &target.model_entry.value,
+        "/v1/videos",
+        retry_permit,
+        || {
+            let mut builder = client
+                .request(method.clone(), url)
+                .header(header::AUTHORIZATION, format!("Bearer {}", target.secret))
+                .header("x-aisix-request-id", request_id);
+            // A provider header required on every call (submit and poll) — e.g.
+            // Runway's mandatory `X-Runway-Version`. Applied unconditionally,
+            // before the submit-only body/header block below.
+            if let Some((name, value)) = target.provider.all_request_header() {
+                builder = builder.header(name, value);
             }
-            builder = builder
-                .header(header::CONTENT_TYPE, "application/json")
-                .json(b);
-        }
-        if let Some(d) = target.model_entry.value.request_timeout() {
-            builder = builder.timeout(d);
-        }
-        async move {
-            let started = Instant::now();
-            let resp = builder
-                .send()
-                .await
-                .map_err(|e| note(crate::dispatch::reqwest_error_to_bridge(&e, started)))?;
-            let status = resp.status().as_u16();
-            let bytes = resp
-                .bytes()
-                .await
-                .map_err(|e| note(aisix_gateway::BridgeError::UpstreamDecode(e.to_string())))?;
-
-            if !(200..300).contains(&status) {
-                let message = parse_provider_error_message(&bytes);
-                return Err(note(aisix_gateway::BridgeError::upstream_status(
-                    status, message,
-                )));
+            if let Some(b) = body {
+                if target.provider.submit_headers_async() {
+                    // DashScope requires the async-mode header — it rejects
+                    // synchronous video-synthesis calls outright.
+                    builder = builder.header("X-DashScope-Async", "enable");
+                }
+                builder = builder
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .json(b);
             }
+            if let Some(d) = target.model_entry.value.request_timeout() {
+                builder = builder.timeout(d);
+            }
+            async move {
+                let started = Instant::now();
+                let resp = builder
+                    .send()
+                    .await
+                    .map_err(|e| note(crate::dispatch::reqwest_error_to_bridge(&e, started)))?;
+                let status = resp.status().as_u16();
+                let bytes = resp
+                    .bytes()
+                    .await
+                    .map_err(|e| note(aisix_gateway::BridgeError::UpstreamDecode(e.to_string())))?;
 
-            serde_json::from_slice(&bytes).map_err(|e| {
-                aisix_gateway::BridgeError::UpstreamDecode(format!(
-                    "invalid task response from upstream: {e}"
-                ))
-            })
-        }
-    })
+                if !(200..300).contains(&status) {
+                    let message = parse_provider_error_message(&bytes);
+                    return Err(note(aisix_gateway::BridgeError::upstream_status(
+                        status, message,
+                    )));
+                }
+
+                serde_json::from_slice(&bytes).map_err(|e| {
+                    aisix_gateway::BridgeError::UpstreamDecode(format!(
+                        "invalid task response from upstream: {e}"
+                    ))
+                })
+            }
+        },
+    )
     .await
     .map_err(ProxyError::Bridge)
 }
@@ -2378,6 +2397,72 @@ mod tests {
         assert_eq!(wire["input"]["prompt"], "a cardboard city at night");
         assert_eq!(wire["parameters"]["duration"], 8);
         assert_eq!(wire["parameters"]["size"], "1280*720");
+    }
+
+    /// A submit whose upstream returned 200 with an unparseable body must
+    /// NOT be replayed: the paid task committed upstream — only its id was
+    /// lost — and a retry would start a second one the caller also can't
+    /// see. The `.expect(1)` is the assertion.
+    #[tokio::test]
+    async fn submit_decode_failure_is_not_replayed() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(DASHSCOPE_SUBMIT_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let app = build_app(new_snap(&upstream.uri(), "alibaba", ""));
+        let resp = tower::ServiceExt::oneshot(
+            app,
+            post_videos(serde_json::json!({
+                "model": "my-video",
+                "prompt": "a cardboard city at night"
+            })),
+        )
+        .await
+        .unwrap();
+
+        // The caller gets the failure; the task upstream ran once.
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    /// A transient 5xx on submit IS retried (send it again is the whole
+    /// point of the budget — no response committed, LiteLLM/OpenAI SDK
+    /// retry their own paid generation POSTs the same way), and the
+    /// second attempt recovers the request.
+    #[tokio::test]
+    async fn submit_transient_5xx_is_retried_then_succeeds() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(DASHSCOPE_SUBMIT_PATH))
+            .respond_with(ResponseTemplate::new(503).set_body_string("overloaded"))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .expect(1)
+            .mount(&upstream)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(DASHSCOPE_SUBMIT_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pending_submit_response()))
+            .with_priority(2)
+            .expect(1)
+            .mount(&upstream)
+            .await;
+
+        let app = build_app(new_snap(&upstream.uri(), "alibaba", ""));
+        let resp = tower::ServiceExt::oneshot(
+            app,
+            post_videos(serde_json::json!({
+                "model": "my-video",
+                "prompt": "a cardboard city at night"
+            })),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -700,6 +700,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         aisix_obs::ClientTypeClassifier::compile(&cfg.observability.metrics.client_type_rules)
             .map_err(|e| anyhow::anyhow!(e))?;
     proxy_state = proxy_state.with_client_classifier(Arc::new(client_classifier));
+    proxy_state = proxy_state.with_default_retries(cfg.upstream.retries);
     if let Some(client) = budget_client {
         proxy_state = proxy_state.with_budget_client(client);
     }

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -407,7 +407,7 @@
           "type": "integer"
         },
         "retries": {
-          "description": "Retry attempts on the current target before failing over.",
+          "description": "Retry attempts on the current target before failing over, applied to every target that does not set its own `retries`. Absent falls back to the deployment-wide `upstream.retries` default.",
           "format": "uint32",
           "minimum": 0.0,
           "type": "integer"
@@ -938,6 +938,12 @@
         }
       ],
       "description": "Request, token, and concurrency limits for this model."
+    },
+    "retries": {
+      "description": "Retry attempts against this model after a retryable upstream failure, before the request gives up (or, inside a model group, fails over to the next target). Absent falls back to the group's `routing.retries`, then to the deployment-wide `upstream.retries` default.",
+      "format": "uint32",
+      "minimum": 0.0,
+      "type": "integer"
     },
     "routing": {
       "allOf": [

--- a/schemas/resources/routing.schema.json
+++ b/schemas/resources/routing.schema.json
@@ -29,7 +29,7 @@
       "minimum": 0.0
     },
     "retries": {
-      "description": "Retry attempts on the current target before failing over.",
+      "description": "Retry attempts on the current target before failing over, applied to every target that does not set its own `retries`. Absent falls back to the deployment-wide `upstream.retries` default.",
       "type": [
         "integer",
         "null"

--- a/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
@@ -734,7 +734,16 @@ describe("filter contract (H3 escape hatch) — try_anyway sends to known-bad", 
     // mapping in BridgeError::http_status, but the upstream request
     // is what we're verifying here).
     expect([502, 503]).toContain(resp.status);
-    expect(downUpstream.receivedRequests.length - baseline).toBe(1);
+    // 3 = the initial attempt + the deployment default retry budget (2).
+    // This group holds a single target, so there is nothing to fall over to
+    // and the default budget applies rather than deferring — and a 503 is
+    // exactly the transient class the budget exists for. What this test
+    // actually pins is that a request *was sent* to the unhealthy target at
+    // all, which is the `try_anyway` contract.
+    expect(
+      downUpstream.receivedRequests.length - baseline,
+    ).toBeGreaterThanOrEqual(1);
+    expect(downUpstream.receivedRequests.length - baseline).toBe(3);
   });
 });
 

--- a/tests/e2e/src/cases/direct-model-retries-e2e.test.ts
+++ b/tests/e2e/src/cases/direct-model-retries-e2e.test.ts
@@ -1,0 +1,209 @@
+import { createHash } from "node:crypto";
+import OpenAI, { APIError } from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a DIRECT model — one with no model group — has a retry budget.
+//
+// The budget used to live only on `routing`, so a model that was not behind
+// a group got zero retries and there was no field to change that: a single
+// 502 went straight back to the caller. `Model.retries` now carries it,
+// defaulting to the deployment-wide `upstream.retries` (2), so the direct
+// path behaves like the group path.
+//
+// Every case drives an always-503 upstream and asserts the ATTEMPT COUNT,
+// which is exact and non-flaky (unlike timing). Three properties are pinned:
+//   1. the default budget retries a direct model (3 attempts, not 1),
+//   2. `retries: 0` on the model is a real opt-out (1 attempt), and
+//   3. the budget reaches endpoints that never had a retry loop at all —
+//      `/v1/embeddings` stands in for the seven single-model endpoints.
+
+const CALLER_PLAINTEXT = "sk-direct-retries-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+/** initial + 2 retries, from the built-in `upstream.retries` default. */
+const EXPECTED_DEFAULT_ATTEMPTS = 3;
+
+describe("direct model retries e2e: a model outside a group has a retry budget", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // Every request returns a retryable 503, so the attempt count is exactly
+    // the budget the gateway applied.
+    upstream = await startOpenAiUpstream({
+      status: 503,
+      errorBody: { error: { message: "always down", type: "server_error" } },
+    });
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "direct-retries-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+
+    // Direct model: no `routing` block, no explicit `retries` → inherits the
+    // deployment default. This is the configuration that used to be pinned
+    // at zero retries with no way to change it.
+    await seed.createModel({
+      display_name: "direct-default-retries",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    // Direct model that opts out explicitly.
+    await seed.createModel({
+      display_name: "direct-no-retries",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+      retries: 0,
+    });
+    // Direct embeddings model — that endpoint had no retry loop at all.
+    await seed.createModel({
+      display_name: "direct-embed",
+      provider: "openai",
+      model_name: "text-embedding-3-small",
+      provider_key_id: pk.id,
+    });
+
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [
+        "direct-default-retries",
+        "direct-no-retries",
+        "direct-embed",
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  const clientFor = (a: SpawnedApp) =>
+    new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${a.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+  /**
+   * Wait until `model` actually reaches the upstream. Before the model +
+   * key propagate, the probe 404s at the gateway and never leaves it, so
+   * "the upstream saw a new request" is the propagation signal (status
+   * agnostic — this upstream always 503s).
+   */
+  const awaitModelLive = async (
+    client: OpenAI,
+    model: string,
+    call: (c: OpenAI, m: string) => Promise<unknown>,
+  ) =>
+    waitConfigPropagation(async () => {
+      const before = upstream!.receivedRequests.length;
+      try {
+        await call(client, model);
+      } catch {
+        // expected: the upstream is always down
+      }
+      return upstream!.receivedRequests.length > before;
+    });
+
+  const chat = (c: OpenAI, model: string) =>
+    c.chat.completions.create({
+      model,
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+  const embed = (c: OpenAI, model: string) =>
+    c.embeddings.create({ model, input: "hi" });
+
+  test("a direct model spends the default retry budget", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const client = clientFor(app);
+    await awaitModelLive(client, "direct-default-retries", chat);
+
+    const hitsBefore = upstream.receivedRequests.length;
+    let caught: unknown;
+    try {
+      await chat(client, "direct-default-retries");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(APIError);
+    // Was 1 before the per-model budget landed: a direct model had no
+    // `retries` field and the group knob did not apply to it.
+    expect(upstream.receivedRequests.length - hitsBefore).toBe(
+      EXPECTED_DEFAULT_ATTEMPTS,
+    );
+  });
+
+  test("retries: 0 on a direct model makes exactly one attempt", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const client = clientFor(app);
+    await awaitModelLive(client, "direct-no-retries", chat);
+
+    const hitsBefore = upstream.receivedRequests.length;
+    let caught: unknown;
+    try {
+      await chat(client, "direct-no-retries");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(APIError);
+    // The opt-out must be real: an explicit 0 cannot fall through to the
+    // deployment default, or an operator could never turn retrying off.
+    expect(upstream.receivedRequests.length - hitsBefore).toBe(1);
+  });
+
+  test("the budget reaches /v1/embeddings, which had no retry loop", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const client = clientFor(app);
+    await awaitModelLive(client, "direct-embed", embed);
+
+    const hitsBefore = upstream.receivedRequests.length;
+    let caught: unknown;
+    try {
+      await embed(client, "direct-embed");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(APIError);
+    // Was 1: `/v1/embeddings` dispatched once and returned the failure.
+    expect(upstream.receivedRequests.length - hitsBefore).toBe(
+      EXPECTED_DEFAULT_ATTEMPTS,
+    );
+  });
+});

--- a/tests/e2e/src/cases/fallback-edges-e2e.test.ts
+++ b/tests/e2e/src/cases/fallback-edges-e2e.test.ts
@@ -331,10 +331,17 @@ describe("fallback edge cases e2e", () => {
     expect(typeof errMsg).toBe("string");
     expect((errMsg as string).length).toBeGreaterThan(0);
 
-    // Both targets were tried exactly once each (the failover walk).
-    // A regression that bailed after the first failure (or hammered
-    // the same target twice) would inflate / deflate these counts.
+    // The fail-over walk visits both targets, and the retry budget makes
+    // the counts asymmetric on purpose:
+    //
+    //   target 1 — a fallback is queued behind it, so the (unconfigured)
+    //              default budget defers: one attempt, then move on.
+    //   target 2 — last in line with nothing to fall over to, so the
+    //              default budget applies: initial + 2 retries.
+    //
+    // A regression that bailed after the first failure would drop bad2 to
+    // 0; one that ground every target would inflate bad1 to 3.
     expect(bad1.receivedRequests.length - bad1Baseline).toBe(1);
-    expect(bad2.receivedRequests.length - bad2Baseline).toBe(1);
+    expect(bad2.receivedRequests.length - bad2Baseline).toBe(3);
   });
 });


### PR DESCRIPTION
## Problem

`retries` lived only on `Routing`, so a **direct model** — one referenced without a model group — ran the dispatch loop with the budget pinned to zero and had no field to change it. A single transient upstream fault went straight back to the caller.

The machinery was already there: a direct model runs the *same* loop with a one-element target list. Only the parameter was hardcoded:

```rust
let retries = virtual_entry.value.routing.as_ref()
    .map(|r| r.retries_or_default()).unwrap_or(0);   // direct model -> 0
```

Beyond that, seven endpoints had no retry path at all, semantic-routing models read the budget from a `routing` block they don't have, and the ensemble judge carried a hardcoded retry that ignored configuration.

## Change

`Model.retries`, resolved across three levels:

```
attempt.model.retries        # this upstream's own budget
  ?? routing.retries         # group-wide default (unchanged semantics)
  ?? config.upstream.retries # deployment default, built-in 2
```

Per-target beats per-group because a routing target *is* a Model: how many times an upstream may be re-hit is a property of that upstream. An explicit `0` at any level is an opt-out and does not fall through.

The deployment default additionally **defers when another candidate target is queued**, and **does not spend itself on a timeout**. Both only gate the default — an explicitly configured budget is honoured as written.

Those two rules exist because the first version of this change broke things, and the E2E suite caught it:

- Without the fallback rule, a two-target group whose first target times out burned three timeouts before moving on, tripling the latency of timeout-driven fail-over (`timeout-fallback-e2e`, #554).
- Without the timeout rule, a model with `timeout: 700` waited ~2.1s instead of ~0.7s — the opposite of what setting a timeout asks for (`audio-timeout-e2e`, #911 [22]).

They also track what LiteLLM actually does, which is easy to misread. Its `num_retries` does **not** re-hit one deployment: each retry re-enters deployment selection, and the failed deployment has meanwhile been cooled down, so a retry inside a multi-deployment group lands elsewhere. Same-target grinding is what LiteLLM does only for a single-deployment group — exactly the case the default is kept for.

## Coverage

All 13 endpoints now apply the budget:

- `chat`, `messages`, `responses`, `count_tokens` keep their own loops (they also walk fall-over targets and emit per-attempt telemetry). `count_tokens` gains the same-target retry it never had.
- The single-model endpoints — embeddings, rerank, completions, audio transcription and speech, images, videos, passthrough — share a new `routing::retrying_dispatch`.
- Semantic-routing models are fixed by the same change (they were silently pinned at zero).
- Ensemble panel members and the judge retry through `ProxyModelCaller` using each member model's own budget. The judge's hardcoded single retry is removed so the two layers can't multiply into six upstream calls.

Two scoping decisions:

- **Passthrough** relays upstream statuses verbatim, so a 5xx never becomes an error there and only transport/decode faults are retried. Re-sending a relayed 5xx would break that contract and stack on the provider edge's own retries (AISIX-Cloud#1121).
- **Audio**'s multipart form is rebuilt per attempt, which is only sound because every part is an in-memory `Bytes` — noted in the code, since a streamed part could not be replayed.

Backoff now honours an upstream `Retry-After` within 5s, falling back to the existing exponential term otherwise. LiteLLM honours up to 60s; an inline proxy can't, because the wait is spent inside the caller's own latency budget — the same reasoning that already tightened the exponential bounds relative to LiteLLM's defaults.

## Behaviour change

The default of 2 matches `openai.DEFAULT_MAX_RETRIES`, where the LiteLLM router also lands when nothing is configured. On upgrade, a request against a single upstream makes up to three attempts instead of one, so a failing upstream sees up to 3x the load and a request that ultimately fails takes longer (it now includes the backoff waits). `upstream.retries: 0` restores the previous behaviour deployment-wide.

Groups with a configured `routing.retries` are unaffected. Groups without one keep failing over on the first failure as before — the fallback rule is what preserves that.

## Tests

- `routing::tests` — the three-level precedence, explicit-zero at each level, the fallback-deferral rule, and that a default budget refuses a timeout while a configured one accepts it.
- `direct-model-retries-e2e` (new) — a direct model spends the default budget (3 attempts), `retries: 0` makes exactly one, and the budget reaches `/v1/embeddings`, which had no retry loop. Verified to fail without the change: reverting the default to 0 gives `expected 1 to be 3` on the first and third.
- `responses::upstream_5xx_emits_zero_token_failed_attempt_event` now pins the `initial, retry, retry` attempt sequence a direct model produces.
- `fallback-edges-e2e` documents the asymmetry the fallback rule creates (1 attempt on the target with a fallback behind it, 3 on the last).

`cargo test --workspace` green (47 binaries), `cargo fmt` / `clippy -D warnings` clean, and the full 157-file E2E suite passes locally.

## Known limitation

`retries` can be set and changed but not cleared back to "inherit" via the API — `*int32` can't distinguish an absent field from an explicit `null`. Setting an explicit value is the workaround; worth a follow-up if it comes up.

Fixes api7/AISIX-Cloud#1132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deployment-wide upstream retry default (`upstream.retries`), with per-model `retries` and per-route routing overrides.
  * Extended retry handling across more upstream surfaces (including embeddings, images, audio, passthrough, and others).
  * Honors upstream `Retry-After` when present and within supported bounds.

* **Bug Fixes**
  * Direct models and embeddings now correctly apply the default retry budget.
  * Explicit `retries: 0` and routing “unset” behavior now correctly prevent unintended same-target retries.

* **Tests**
  * Added end-to-end and unit coverage validating retry counts, failover behavior, cooldown marking, and `Retry-After` handling across routing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
