### PR TITLE
feat(downstream): configurable idle timeout and SSE heartbeat on the inbound side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ name = "aisix-a2a"
 version = "0.3.0"
 dependencies = [
  "aisix-core",
+ "aisix-gateway",
  "async-trait",
  "axum",
  "futures",
@@ -182,6 +183,7 @@ name = "aisix-mcp"
 version = "0.3.0"
 dependencies = [
  "aisix-core",
+ "aisix-gateway",
  "async-trait",
  "axum",
  "futures",
@@ -203,6 +205,7 @@ name = "aisix-obs"
 version = "0.3.0"
 dependencies = [
  "aisix-core",
+ "aisix-gateway",
  "aliyun-log-sdk-protobuf",
  "aliyun-log-sdk-sign",
  "async-trait",
@@ -423,6 +426,7 @@ dependencies = [
  "config",
  "etcd-client",
  "hostname",
+ "hyper-util",
  "rcgen",
  "reqwest 0.12.28",
  "rustls 0.23.38",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -184,6 +184,29 @@ upstream:
   # Cap on idle connections kept per upstream host. Unset = unbounded.
   # pool_max_idle_per_host: 32
 
+# Connection-layer settings for the inbound side — the clients, or the
+# gateway in front of this one, talking to the listeners above. The
+# mirror image of `upstream:`.
+downstream:
+  # How long an accepted connection may sit idle — response written, no
+  # next request started — before the gateway closes it. HTTP/1.1 only.
+  # An in-flight request or SSE stream is never interrupted, however long
+  # it runs; the timer only arms between requests.
+  #
+  # 0 (the default) never closes an idle connection and leaves that to
+  # the peer. Whatever sits in front pools its own connections, and
+  # closing first is what hands *it* a connection it thinks is still
+  # usable — the same failure this gateway avoids upstream by keeping
+  # pool_idle_timeout_secs low. If you set this, keep it ABOVE the pool
+  # idle timeout of the node in front.
+  idle_timeout_secs: 0
+
+  # Interval between SSE heartbeat comments (":\n\n") sent while a
+  # streaming response has produced nothing. Keeps a proxy in front from
+  # treating a model that is slow to its first token as an abandoned
+  # connection. 0 disables the heartbeat.
+  # sse_keepalive_interval_secs: 15
+
 # Models, API keys, provider keys, guardrails, cache policies, and
 # observability exporters are NOT defined in this file. They are stored
 # in etcd and managed via the Admin API (see docs/api-admin.md). This

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -113,3 +113,11 @@ upstream:
   # tcp_keepalive_retries: 5
   pool_idle_timeout_secs: 30
   # pool_max_idle_per_host: 32
+
+# Connection-layer settings for the inbound side. `idle_timeout_secs: 0`
+# (the default) never closes an idle client connection, leaving that to
+# the peer — set it only when a node in front pools connections for a
+# known, shorter time, and keep it above that value.
+downstream:
+  idle_timeout_secs: 0
+  # sse_keepalive_interval_secs: 15

--- a/crates/aisix-a2a/Cargo.toml
+++ b/crates/aisix-a2a/Cargo.toml
@@ -10,6 +10,10 @@ description = "aisix: A2A (Agent-to-Agent) gateway — upstream JSON-RPC client 
 
 [dependencies]
 aisix-core = { path = "../aisix-core" }
+# For `client_builder()`: the upstream connection settings (connect
+# timeout, TCP keepalive, pool expiry) are process-wide, so this
+# crate's outbound calls share them too.
+aisix-gateway = { path = "../aisix-gateway" }
 tokio.workspace = true
 async-trait.workspace = true
 futures.workspace = true

--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -62,7 +62,7 @@ fn shared_client() -> reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            reqwest::Client::builder()
+            aisix_gateway::client_builder()
                 .redirect(reqwest::redirect::Policy::none())
                 .build()
                 .expect("reqwest client (redirect-disabled) builds")

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -67,6 +67,11 @@ pub struct Config {
     /// see [`UpstreamConfig`].
     #[serde(default)]
     pub upstream: UpstreamConfig,
+    /// Connection-layer tuning for the inbound side: how long an idle
+    /// client connection is held, and how often a stalled SSE response
+    /// emits a heartbeat — see [`DownstreamConfig`].
+    #[serde(default)]
+    pub downstream: DownstreamConfig,
     /// Optional managed-mode configuration. When `managed.enabled = true`
     /// the admin API and Playground endpoints are **not** bound — the DP
     /// is a pure etcd reader driven by the aisix.cloud control plane.
@@ -811,6 +816,48 @@ impl Default for UpstreamConfig {
     }
 }
 
+/// Connection-layer settings for the inbound side — the client (or the
+/// gateway in front of this one) talking to the proxy and admin listeners.
+///
+/// The mirror image of [`UpstreamConfig`]: that one governs the pool the
+/// gateway *dials out* with, this one governs the connections it *accepts*.
+/// Both matter in a multi-hop chain, where the rule is that every node's
+/// client-side idle timeout must stay below the next node's server-side one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct DownstreamConfig {
+    /// How long an accepted connection may sit idle — response fully
+    /// written, no next request started — before the gateway closes it.
+    /// Applies to both listeners, and to HTTP/1.1 only.
+    ///
+    /// `0` (the default) never closes an idle connection, leaving that to
+    /// the peer. That default is deliberate: a gateway in front of this one
+    /// pools its own connections (Envoy's upstream idle default is an hour),
+    /// and closing first is exactly what hands *it* a stale connection. Set
+    /// this **above** the pool idle timeout of whatever sits in front, and
+    /// only when idle connections need reclaiming.
+    ///
+    /// An in-flight request is never interrupted, however long it runs: the
+    /// timer only arms once the connection is between requests.
+    pub idle_timeout_secs: u64,
+    /// Interval between SSE heartbeat comments (`:\n\n`) sent on a
+    /// streaming response while the upstream produces nothing.
+    ///
+    /// Keeps a proxy between the client and the gateway from treating a
+    /// model that is slow to its first token as an abandoned connection.
+    /// `0` disables the heartbeat.
+    pub sse_keepalive_interval_secs: u64,
+}
+
+impl Default for DownstreamConfig {
+    fn default() -> Self {
+        Self {
+            idle_timeout_secs: 0,
+            sse_keepalive_interval_secs: 15,
+        }
+    }
+}
+
 impl Config {
     /// Load + merge + validate.
     ///
@@ -1343,6 +1390,49 @@ upstream:
         assert_eq!(cfg.upstream.pool_max_idle_per_host, Some(16));
         // Unspecified knobs keep their defaults.
         assert_eq!(cfg.upstream.tcp_keepalive_interval_secs, 30);
+    }
+
+    /// The inbound side defaults to today's behaviour: idle connections are
+    /// held until the peer closes them (closing first is what hands the
+    /// node in front a stale connection), and SSE responses heartbeat every
+    /// 15s (AISIX-Cloud#1126).
+    #[test]
+    fn downstream_defaults_hold_idle_connections_and_keep_the_sse_heartbeat() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://localhost:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.downstream.idle_timeout_secs, 0);
+        assert_eq!(cfg.downstream.sse_keepalive_interval_secs, 15);
+    }
+
+    #[test]
+    fn downstream_block_overrides_individual_knobs() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://localhost:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+downstream:
+  idle_timeout_secs: 90
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.downstream.idle_timeout_secs, 90);
+        // Unspecified knobs keep their defaults.
+        assert_eq!(cfg.downstream.sse_keepalive_interval_secs, 15);
     }
 
     #[test]

--- a/crates/aisix-gateway/src/upstream_http.rs
+++ b/crates/aisix-gateway/src/upstream_http.rs
@@ -236,6 +236,69 @@ mod tests {
         assert!(client.is_ok(), "{:?}", client.err());
     }
 
+    /// Every outbound HTTP client in the workspace must be built from
+    /// [`client_builder`], or it silently keeps reqwest's defaults — no
+    /// connect timeout, TCP keepalive off, and a 90s pooled-connection
+    /// lifetime that outlives a typical hop's idle timeout. Nothing else
+    /// catches that: such a client works fine until a load balancer
+    /// starts reaping connections it still considers usable.
+    ///
+    /// The first pass of this (AISIX-Cloud#1122) converted the provider
+    /// bridges only, leaving the guardrail, MCP, A2A, telemetry, and
+    /// exporter clients on the defaults — which is what this test exists
+    /// to stop repeating (AISIX-Cloud#1126).
+    #[test]
+    fn no_production_code_builds_a_bare_reqwest_client() {
+        let crates_dir = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/.."));
+        let mut offenders = Vec::new();
+        for file in rust_sources(crates_dir) {
+            let src = std::fs::read_to_string(&file).expect("read source");
+            // Tests build throwaway clients on purpose; only the
+            // production half of each file is in scope.
+            let production = match src.find("#[cfg(test)]") {
+                Some(i) => &src[..i],
+                None => &src[..],
+            };
+            for (n, line) in production.lines().enumerate() {
+                if line.contains("reqwest::Client::builder()")
+                    || line.contains("reqwest::Client::new()")
+                {
+                    offenders.push(format!("{}:{}", file.display(), n + 1));
+                }
+            }
+        }
+        // This module is where the shared builder is defined.
+        offenders.retain(|o| !o.contains("upstream_http.rs"));
+        assert!(
+            offenders.is_empty(),
+            "these build a reqwest client directly instead of \
+             `aisix_gateway::client_builder()`:\n{}",
+            offenders.join("\n"),
+        );
+    }
+
+    fn rust_sources(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut out = Vec::new();
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return out;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path
+                    .file_name()
+                    .is_some_and(|n| n == "tests" || n == "target")
+                {
+                    continue;
+                }
+                out.extend(rust_sources(&path));
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+        out
+    }
+
     #[test]
     fn redacts_credential_query_params_only() {
         let url = reqwest::Url::parse(

--- a/crates/aisix-guardrails/src/aliyun.rs
+++ b/crates/aisix-guardrails/src/aliyun.rs
@@ -103,9 +103,12 @@ impl AliyunTextModerationGuardrail {
         hook_point: GuardrailHookPoint,
         fail_open: bool,
     ) -> Self {
-        let client = reqwest::Client::builder()
+        // Same connection-layer settings as every provider call: a bound
+        // connect phase, TCP keepalive on, and pooled connections expired
+        // before a hop in front of the guardrail service reaps them.
+        let client = aisix_gateway::client_builder()
             .build()
-            .expect("reqwest::Client::builder() failed; this should never happen");
+            .expect("guardrail http client builds");
         let endpoint = cfg
             .endpoint
             .clone()

--- a/crates/aisix-guardrails/src/aliyun_ai_guardrail.rs
+++ b/crates/aisix-guardrails/src/aliyun_ai_guardrail.rs
@@ -125,9 +125,12 @@ impl AliyunAiGuardrail {
         hook_point: GuardrailHookPoint,
         fail_open: bool,
     ) -> Self {
-        let client = reqwest::Client::builder()
+        // Same connection-layer settings as every provider call: a bound
+        // connect phase, TCP keepalive on, and pooled connections expired
+        // before a hop in front of the guardrail service reaps them.
+        let client = aisix_gateway::client_builder()
             .build()
-            .expect("reqwest::Client::builder() failed; this should never happen");
+            .expect("guardrail http client builds");
         let endpoint = cfg
             .endpoint
             .clone()

--- a/crates/aisix-guardrails/src/lakera.rs
+++ b/crates/aisix-guardrails/src/lakera.rs
@@ -98,9 +98,12 @@ impl LakeraGuardrail {
         hook_point: GuardrailHookPoint,
         fail_open: bool,
     ) -> Self {
-        let client = reqwest::Client::builder()
+        // Same connection-layer settings as every provider call: a bound
+        // connect phase, TCP keepalive on, and pooled connections expired
+        // before a hop in front of the guardrail service reaps them.
+        let client = aisix_gateway::client_builder()
             .build()
-            .expect("reqwest::Client::builder() failed; this should never happen");
+            .expect("guardrail http client builds");
         Self {
             row_name: row_name.into(),
             endpoint: cfg

--- a/crates/aisix-guardrails/src/openai_moderation.rs
+++ b/crates/aisix-guardrails/src/openai_moderation.rs
@@ -94,9 +94,12 @@ impl OpenaiModerationGuardrail {
         hook_point: GuardrailHookPoint,
         fail_open: bool,
     ) -> Self {
-        let client = reqwest::Client::builder()
+        // Same connection-layer settings as every provider call: a bound
+        // connect phase, TCP keepalive on, and pooled connections expired
+        // before a hop in front of the guardrail service reaps them.
+        let client = aisix_gateway::client_builder()
             .build()
-            .expect("reqwest::Client::builder() failed; this should never happen");
+            .expect("guardrail http client builds");
         Self {
             row_name: row_name.into(),
             endpoint: cfg

--- a/crates/aisix-guardrails/src/presidio.rs
+++ b/crates/aisix-guardrails/src/presidio.rs
@@ -123,9 +123,12 @@ impl PresidioGuardrail {
         entity_actions: BTreeMap<String, PiiAction>,
         operator: serde_json::Value,
     ) -> Self {
-        let client = reqwest::Client::builder()
+        // Same connection-layer settings as every provider call: a bound
+        // connect phase, TCP keepalive on, and pooled connections expired
+        // before a hop in front of the guardrail service reaps them.
+        let client = aisix_gateway::client_builder()
             .build()
-            .expect("reqwest::Client::builder() failed; this should never happen");
+            .expect("guardrail http client builds");
         Self {
             row_name: row_name.into(),
             analyzer_url: cfg.analyzer_url.trim_end_matches('/').to_owned(),

--- a/crates/aisix-guardrails/src/prompt_shield.rs
+++ b/crates/aisix-guardrails/src/prompt_shield.rs
@@ -98,12 +98,12 @@ impl PromptShieldGuardrail {
         hook_point: GuardrailHookPoint,
         fail_open: bool,
     ) -> Self {
-        let client = reqwest::Client::builder()
-            // Per-call timeout is enforced via tokio::time::timeout in
-            // call_api(); the connection pool uses reqwest's default idle
-            // timeout (90 s). No pool customisation is needed here.
+        // Per-call timeout is enforced via tokio::time::timeout in
+        // call_api(); the connection layer is the shared one, so a pooled
+        // connection expires before a hop in front of the service reaps it.
+        let client = aisix_gateway::client_builder()
             .build()
-            .expect("reqwest::Client::builder() failed; this should never happen");
+            .expect("guardrail http client builds");
         Self {
             row_name: row_name.into(),
             // Strip trailing slash so we can always append SHIELD_PATH with

--- a/crates/aisix-guardrails/src/text_moderation.rs
+++ b/crates/aisix-guardrails/src/text_moderation.rs
@@ -97,9 +97,12 @@ impl TextModerationGuardrail {
         hook_point: GuardrailHookPoint,
         fail_open: bool,
     ) -> Self {
-        let client = reqwest::Client::builder()
+        // Same connection-layer settings as every provider call: a bound
+        // connect phase, TCP keepalive on, and pooled connections expired
+        // before a hop in front of the guardrail service reaps them.
+        let client = aisix_gateway::client_builder()
             .build()
-            .expect("reqwest::Client::builder() failed; this should never happen");
+            .expect("guardrail http client builds");
         Self {
             row_name: row_name.into(),
             endpoint: cfg.endpoint.trim_end_matches('/').to_owned(),

--- a/crates/aisix-mcp/Cargo.toml
+++ b/crates/aisix-mcp/Cargo.toml
@@ -10,6 +10,10 @@ description = "aisix: MCP gateway — upstream client + downstream-facing aggreg
 
 [dependencies]
 aisix-core = { path = "../aisix-core" }
+# For `client_builder()`: the upstream connection settings (connect
+# timeout, TCP keepalive, pool expiry) are process-wide, so this
+# crate's outbound calls share them too.
+aisix-gateway = { path = "../aisix-gateway" }
 tokio.workspace = true
 async-trait.workspace = true
 futures.workspace = true

--- a/crates/aisix-mcp/src/oauth.rs
+++ b/crates/aisix-mcp/src/oauth.rs
@@ -62,7 +62,7 @@ fn cache() -> &'static RwLock<HashMap<String, CachedToken>> {
 fn http_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
+        aisix_gateway::client_builder()
             .timeout(DEFAULT_UPSTREAM_TIMEOUT)
             .redirect(reqwest::redirect::Policy::none())
             .build()

--- a/crates/aisix-obs/Cargo.toml
+++ b/crates/aisix-obs/Cargo.toml
@@ -10,6 +10,9 @@ description = "aisix: observability (tracing, metrics, access log, OTLP export)"
 
 [dependencies]
 aisix-core = { path = "../aisix-core" }
+# For `client_builder()`: exporter HTTP clients share the process-wide
+# connection settings like every other outbound call.
+aisix-gateway = { path = "../aisix-gateway" }
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -105,7 +105,7 @@ fn exporter_pipeline_config() -> PipelineConfig {
 
 impl OtlpHttpFanOut {
     pub fn new() -> Self {
-        let client = reqwest::Client::builder()
+        let client = aisix_gateway::client_builder()
             .timeout(REQUEST_TIMEOUT)
             .user_agent(USER_AGENT)
             .build()

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -21,6 +21,13 @@ silently uncorrelated, which reads exactly like working code:
 Do not hold a span guard across an await to work around this — it leaks the span
 onto whatever the executor runs next on that thread.
 
+A `text/event-stream` body needs a second wrapper for the same reason — nothing
+errors when it is missed. Pass it through `sse_keepalive::with_heartbeat(…,
+sse_keepalive::interval())` (or, on an axum `Sse`, `keep_alive` with that
+interval) so a model that is slow to its first token doesn't look like an
+abandoned connection to a proxy in front. Only for SSE: the same wrapper on an
+opaque binary passthrough (audio, images) corrupts it.
+
 ## A per-model gate must say whether it binds the requested entry or each target
 
 `resolve_attempt_models` expands a routing model into targets, so `model_entry` /

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -68,7 +68,8 @@ uuid.workspace = true
 ipnet.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+# `test-util` drives the SSE-heartbeat tests on a paused clock.
+tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 # aisix-provider-anthropic + aisix-provider-openai moved to
 # [dependencies] so the /v1/messages handler can use their primitives
 # in non-test builds too.

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1766,8 +1766,10 @@ async fn dispatch(
                 drop(in_flight_hold);
             },
         );
-        let response =
-            Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
+        let mut response = Sse::new(sse_stream);
+        if let Some(d) = crate::sse_keepalive::interval() {
+            response = response.keep_alive(KeepAlive::new().interval(d));
+        }
         return Ok(Success {
             response: response.into_response(),
             provider: provider.to_ascii_lowercase(),
@@ -3116,8 +3118,10 @@ async fn dispatch_ensemble(
                 drop(judge_concurrency_hold);
             },
         );
-        let response =
-            Sse::new(sse_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)));
+        let mut response = Sse::new(sse_stream);
+        if let Some(d) = crate::sse_keepalive::interval() {
+            response = response.keep_alive(KeepAlive::new().interval(d));
+        }
         return Ok(Success {
             response: response.into_response(),
             // No single provider/model/key governs an ensemble response.

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -59,6 +59,7 @@ mod responses;
 mod responses_bridge;
 mod routing;
 mod semantic;
+pub mod sse_keepalive;
 mod state;
 mod stream_timeout;
 mod token_estimate;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1343,8 +1343,9 @@ async fn anthropic_passthrough_dispatch(
             },
         );
 
-        let mut response =
-            axum::response::Response::new(axum::body::Body::from_stream(parsed_stream));
+        let mut response = axum::response::Response::new(axum::body::Body::from_stream(
+            crate::sse_keepalive::with_heartbeat(parsed_stream, crate::sse_keepalive::interval()),
+        ));
 
         // Copy content-type from upstream (should be text/event-stream).
         if let Some(ct) = headers.get("content-type") {
@@ -2386,7 +2387,10 @@ fn build_anthropic_sse_stream(
     // Re-attach the request span: the body is polled after the request-id
     // middleware returns, so the end-of-stream output-guardrail check
     // would otherwise log without a `request_id` (AISIX-Cloud#1060).
-    axum::body::Body::from_stream(crate::request_id::in_request_span(stream))
+    axum::body::Body::from_stream(crate::sse_keepalive::with_heartbeat(
+        crate::request_id::in_request_span(stream),
+        crate::sse_keepalive::interval(),
+    ))
 }
 
 /// Anthropic-shape SSE error frame for a streaming guardrail block. Built

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1417,8 +1417,12 @@ async fn responses_to_target(
                 );
             },
         );
-        let mut response =
-            axum::response::Response::new(axum::body::Body::from_stream(Box::pin(parsed_stream)));
+        let mut response = axum::response::Response::new(axum::body::Body::from_stream(
+            crate::sse_keepalive::with_heartbeat(
+                Box::pin(parsed_stream),
+                crate::sse_keepalive::interval(),
+            ),
+        ));
         apply_passthrough_headers(&mut response, &headers, request_id);
 
         Ok(ResponseDispatchSuccess {

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1294,7 +1294,10 @@ pub fn build_responses_bridge_stream(
     // Re-attach the request span: the body is polled after the request-id
     // middleware returns, so the end-of-stream output-guardrail check
     // would otherwise log without a `request_id` (AISIX-Cloud#1060).
-    axum::body::Body::from_stream(crate::request_id::in_request_span(stream))
+    axum::body::Body::from_stream(crate::sse_keepalive::with_heartbeat(
+        crate::request_id::in_request_span(stream),
+        crate::sse_keepalive::interval(),
+    ))
 }
 
 /// Responses-API SSE `error` frame for an output-guardrail block. Carries the

--- a/crates/aisix-proxy/src/sse_keepalive.rs
+++ b/crates/aisix-proxy/src/sse_keepalive.rs
@@ -1,0 +1,149 @@
+//! Downstream SSE heartbeat for streaming responses (AISIX-Cloud#1126).
+//!
+//! A model that takes a long time to produce its first token leaves the
+//! response connection silent, and a proxy between the client and the
+//! gateway can decide the connection is idle and drop it. Emitting an SSE
+//! comment on that silence keeps bytes moving without changing what the
+//! client parses.
+//!
+//! The interval is a deployment property — it depends on what sits in
+//! front of the gateway, not on which model was asked — so it is process-
+//! wide, installed once at boot by [`init`], the same shape
+//! `aisix_gateway::upstream_http` uses for the outbound connection layer.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+
+/// An SSE comment line. Valid mid-stream, ignored by every conforming
+/// client, and the same bytes axum's `Sse` keep-alive writes by default,
+/// so a bridged and a passthrough stream heartbeat identically.
+const HEARTBEAT: &[u8] = b":\n\n";
+
+static INTERVAL: OnceLock<Option<Duration>> = OnceLock::new();
+
+/// Install the process-wide heartbeat interval. `None` disables it.
+/// Called once during boot, before any streaming response is built; later
+/// calls are ignored.
+pub fn init(interval: Option<Duration>) {
+    let _ = INTERVAL.set(interval);
+}
+
+/// The active interval, defaulting to `DownstreamConfig`'s 15s when
+/// [`init`] was never called (unit tests, embedded uses).
+pub(crate) fn interval() -> Option<Duration> {
+    *INTERVAL.get_or_init(|| Some(Duration::from_secs(15)))
+}
+
+/// Wrap an SSE byte stream so a silence longer than `interval` emits a
+/// heartbeat comment instead of nothing. `None` returns a pass-through.
+///
+/// Only for streams the client parses as `text/event-stream`; injecting a
+/// comment into an opaque binary passthrough (audio, images) would corrupt
+/// it.
+///
+/// Unlike [`crate::stream_timeout::with_read_timeout_bytes`], which ends
+/// the stream when the upstream goes quiet for too long, this keeps
+/// waiting — the two compose, with the read timeout deciding when a silent
+/// upstream has failed and this one keeping the connection warm until then.
+pub(crate) fn with_heartbeat<S, E>(
+    upstream: S,
+    interval: Option<Duration>,
+) -> impl Stream<Item = Result<Bytes, E>> + Send
+where
+    S: Stream<Item = Result<Bytes, E>> + Send + 'static,
+    E: Send + 'static,
+{
+    async_stream::stream! {
+        let mut upstream = std::pin::pin!(upstream);
+        loop {
+            match interval {
+                None => match upstream.next().await {
+                    Some(item) => yield item,
+                    None => break,
+                },
+                Some(d) => match tokio::time::timeout(d, upstream.next()).await {
+                    Ok(Some(item)) => yield item,
+                    Ok(None) => break,
+                    Err(_) => yield Ok(Bytes::from_static(HEARTBEAT)),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The point of the module: an upstream that says nothing for longer
+    /// than the interval still puts bytes on the wire.
+    #[tokio::test(start_paused = true)]
+    async fn silence_emits_heartbeats_until_the_chunk_arrives() {
+        let upstream = async_stream::stream! {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            yield Ok::<_, std::io::Error>(Bytes::from_static(b"data: hi\n\n"));
+        };
+        let out: Vec<_> = with_heartbeat(upstream, Some(Duration::from_millis(100)))
+            .collect()
+            .await;
+        let frames: Vec<Bytes> = out.into_iter().map(|r| r.unwrap()).collect();
+        assert_eq!(
+            frames,
+            vec![
+                Bytes::from_static(HEARTBEAT),
+                Bytes::from_static(HEARTBEAT),
+                Bytes::from_static(b"data: hi\n\n"),
+            ],
+        );
+    }
+
+    /// A stream that keeps producing must not have anything injected —
+    /// the heartbeat exists for silence only.
+    #[tokio::test(start_paused = true)]
+    async fn a_busy_stream_is_forwarded_verbatim() {
+        let upstream = async_stream::stream! {
+            for i in 0..3u8 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                yield Ok::<_, std::io::Error>(Bytes::from(vec![i]));
+            }
+        };
+        let out: Vec<_> = with_heartbeat(upstream, Some(Duration::from_millis(100)))
+            .collect()
+            .await;
+        let frames: Vec<Vec<u8>> = out.into_iter().map(|r| r.unwrap().to_vec()).collect();
+        assert_eq!(frames, vec![vec![0], vec![1], vec![2]]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disabled_interval_is_a_pass_through() {
+        let upstream = async_stream::stream! {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            yield Ok::<_, std::io::Error>(Bytes::from_static(b"data: hi\n\n"));
+        };
+        let out: Vec<_> = with_heartbeat(upstream, None).collect().await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].as_ref().unwrap(),
+            &Bytes::from_static(b"data: hi\n\n")
+        );
+    }
+
+    /// The heartbeat must not swallow the stream's terminal error — that
+    /// is what tells the client the response ended badly.
+    #[tokio::test(start_paused = true)]
+    async fn a_terminal_error_still_reaches_the_client() {
+        let upstream = async_stream::stream! {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            yield Err(std::io::Error::other("upstream died"));
+        };
+        let out: Vec<_> = with_heartbeat(upstream, Some(Duration::from_millis(100)))
+            .collect()
+            .await;
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].as_ref().unwrap(), &Bytes::from_static(HEARTBEAT));
+        assert!(out[1].is_err());
+    }
+}

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -46,6 +46,10 @@ rcgen.workspace = true
 uuid.workspace = true
 hostname.workspace = true
 x509-parser = "0.16"
+# Only for the hyper connection builder `axum_server::Server::http_builder()`
+# hands back — where `downstream.idle_timeout_secs` is applied. Same 0.1.x
+# axum-server itself depends on, so the builder types unify.
+hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -498,7 +498,7 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
 
     let ca = reqwest::Certificate::from_pem(&ca_pem).context("parse CA certificate")?;
 
-    let mut builder = reqwest::Client::builder()
+    let mut builder = aisix_gateway::client_builder()
         .timeout(Duration::from_secs(10))
         .user_agent(format!("aisix-dp/{}", &*BUILD_VERSION))
         .identity(identity)

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -154,11 +154,6 @@ async fn main() -> anyhow::Result<()> {
     // Before any bridge builds its `reqwest::Client` — the connection
     // pools are constructed once and can't be reconfigured afterwards.
     aisix_gateway::upstream_http::init(upstream_http_config(&cfg.upstream));
-    // Before the first streaming response is built.
-    aisix_proxy::sse_keepalive::init(
-        (cfg.downstream.sse_keepalive_interval_secs > 0)
-            .then(|| Duration::from_secs(cfg.downstream.sse_keepalive_interval_secs)),
-    );
 
     run(cfg).await
 }
@@ -319,6 +314,13 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // connections open until the peer closes them.
     let downstream_idle_timeout = (cfg.downstream.idle_timeout_secs > 0)
         .then(|| Duration::from_secs(cfg.downstream.idle_timeout_secs));
+    // Here rather than in `main` so anything that drives `run` directly —
+    // the integration tests — gets the configured interval instead of
+    // silently falling back to the default.
+    aisix_proxy::sse_keepalive::init(
+        (cfg.downstream.sse_keepalive_interval_secs > 0)
+            .then(|| Duration::from_secs(cfg.downstream.sse_keepalive_interval_secs)),
+    );
 
     // Operator-supplied extra trust root, threaded into every
     // outbound mTLS client (etcd, heartbeat, telemetry, BudgetClient).

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -154,6 +154,11 @@ async fn main() -> anyhow::Result<()> {
     // Before any bridge builds its `reqwest::Client` — the connection
     // pools are constructed once and can't be reconfigured afterwards.
     aisix_gateway::upstream_http::init(upstream_http_config(&cfg.upstream));
+    // Before the first streaming response is built.
+    aisix_proxy::sse_keepalive::init(
+        (cfg.downstream.sse_keepalive_interval_secs > 0)
+            .then(|| Duration::from_secs(cfg.downstream.sse_keepalive_interval_secs)),
+    );
 
     run(cfg).await
 }
@@ -310,6 +315,11 @@ fn select_managed_boot_path(bundle_on_disk: bool, bundle_provided: bool) -> Mana
 /// Factored out of `main` so the integration tests can drive the full
 /// startup with a real config struct and still use `#[tokio::test]`.
 async fn run(mut cfg: Config) -> anyhow::Result<()> {
+    // Applied to every listener. `0` (the default) keeps idle client
+    // connections open until the peer closes them.
+    let downstream_idle_timeout = (cfg.downstream.idle_timeout_secs > 0)
+        .then(|| Duration::from_secs(cfg.downstream.idle_timeout_secs));
+
     // Operator-supplied extra trust root, threaded into every
     // outbound mTLS client (etcd, heartbeat, telemetry, BudgetClient).
     // Needed for e2e / on-prem deployments where the
@@ -871,6 +881,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             admin_addr,
             admin_router,
             admin_tls,
+            downstream_idle_timeout,
             cancel_rx.clone(),
             "admin",
         )))
@@ -915,6 +926,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 metrics_addr,
                 metrics_router,
                 None,
+                downstream_idle_timeout,
                 cancel_rx.clone(),
                 "metrics",
             )))
@@ -930,6 +942,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         proxy_addr,
         proxy_router,
         proxy_tls,
+        downstream_idle_timeout,
         cancel_rx.clone(),
         "proxy",
     );
@@ -1300,54 +1313,97 @@ fn background_check_interval(snapshot: &aisix_core::AisixSnapshot) -> std::time:
 /// rest of the process. Wired for #473: `proxy.tls` / `admin.tls` were
 /// parsed but never reached the listener, so the documented config silently
 /// served plain HTTP.
+///
+/// Both variants run on `axum_server` rather than `axum::serve` because
+/// only the former exposes the hyper connection builder, which is where
+/// `downstream.idle_timeout_secs` has to be applied (AISIX-Cloud#1126).
 async fn serve_http(
     addr: std::net::SocketAddr,
     router: axum::Router,
     tls: Option<aisix_core::TlsConfig>,
+    idle_timeout: Option<Duration>,
     cancel: watch::Receiver<bool>,
     label: &'static str,
 ) -> anyhow::Result<()> {
-    match tls {
+    // Resolved before binding so a bad cert path still fails with the
+    // same error it always did, before a port is taken.
+    let tls_config = match tls {
+        Some(tls) => Some(
+            axum_server::tls_rustls::RustlsConfig::from_pem_file(&tls.cert_file, &tls.key_file)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "{label}.tls: failed to load cert_file={:?} / key_file={:?}: {e}",
+                        tls.cert_file,
+                        tls.key_file
+                    )
+                })?,
+        ),
+        None => None,
+    };
+
+    let listener = std::net::TcpListener::bind(addr)
+        .map_err(|e| anyhow::anyhow!("{label} listener bind {addr} failed: {e}"))?;
+    listener.set_nonblocking(true)?;
+
+    let handle = axum_server::Handle::new();
+    tokio::spawn({
+        let handle = handle.clone();
+        async move {
+            shutdown_signal(cancel, label).await;
+            // `None` = drain without a deadline: an in-flight LLM stream
+            // can run for minutes, and the platform (k8s
+            // terminationGracePeriodSeconds, systemd TimeoutStopSec)
+            // already caps how long that may take. Idle connections are
+            // closed immediately either way.
+            handle.graceful_shutdown(None);
+        }
+    });
+
+    // ConnectInfo<SocketAddr> exposes the TCP peer to the proxy's real-ip
+    // resolver (#492). Harmless for the admin listener, which ignores it.
+    let make_service = router.into_make_service_with_connect_info::<std::net::SocketAddr>();
+
+    match tls_config {
         None => {
-            let listener = tokio::net::TcpListener::bind(addr).await?;
             tracing::info!(%addr, label, "aisix listening (http)");
-            // ConnectInfo<SocketAddr> exposes the TCP peer to the proxy's
-            // real-ip resolver (#492). Harmless for the admin listener,
-            // which ignores it.
-            axum::serve(
-                listener,
-                router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-            )
-            .with_graceful_shutdown(shutdown_signal(cancel, label))
-            .await?;
-            Ok(())
+            let mut server = axum_server::from_tcp(listener).handle(handle);
+            apply_idle_timeout(server.http_builder(), idle_timeout);
+            server.serve(make_service).await?;
         }
-        Some(tls) => {
-            let tls_config =
-                axum_server::tls_rustls::RustlsConfig::from_pem_file(&tls.cert_file, &tls.key_file)
-                    .await
-                    .map_err(|e| {
-                        anyhow::anyhow!(
-                            "{label}.tls: failed to load cert_file={:?} / key_file={:?}: {e}",
-                            tls.cert_file,
-                            tls.key_file
-                        )
-                    })?;
-            let handle = axum_server::Handle::new();
-            tokio::spawn({
-                let handle = handle.clone();
-                async move {
-                    shutdown_signal(cancel, label).await;
-                    handle.graceful_shutdown(Some(std::time::Duration::from_secs(10)));
-                }
-            });
+        Some(tls_config) => {
             tracing::info!(%addr, label, "aisix listening (https)");
-            axum_server::bind_rustls(addr, tls_config)
-                .handle(handle)
-                .serve(router.into_make_service_with_connect_info::<std::net::SocketAddr>())
-                .await?;
-            Ok(())
+            let mut server = axum_server::from_tcp_rustls(listener, tls_config).handle(handle);
+            apply_idle_timeout(server.http_builder(), idle_timeout);
+            server.serve(make_service).await?;
         }
+    }
+    Ok(())
+}
+
+/// Close an accepted HTTP/1.1 connection that sits idle for `idle_timeout`.
+///
+/// hyper arms this timer only when it is waiting for a request head, and
+/// it only waits for one once the previous response has been fully written
+/// (`Conn::can_read_head` requires the read half to be back at `Init`,
+/// which `try_keep_alive` reaches only when reading *and* writing are
+/// done). So a slow model or a long SSE stream is never interrupted — the
+/// timer covers exactly the between-requests window.
+///
+/// hyper defaults this to 30s but drops the default unless a timer is
+/// installed, and neither axum nor axum_server installs one — which is why
+/// the gateway held idle connections forever before this.
+///
+/// HTTP/2 has no equivalent knob in hyper; h2 connections are unaffected.
+fn apply_idle_timeout(
+    builder: &mut hyper_util::server::conn::auto::Builder<hyper_util::rt::TokioExecutor>,
+    idle_timeout: Option<Duration>,
+) {
+    if let Some(d) = idle_timeout {
+        builder
+            .http1()
+            .timer(hyper_util::rt::TokioTimer::new())
+            .header_read_timeout(d);
     }
 }
 

--- a/crates/aisix-server/src/telemetry.rs
+++ b/crates/aisix-server/src/telemetry.rs
@@ -239,7 +239,7 @@ fn build_client(mtls: &MtlsBundle) -> anyhow::Result<reqwest::Client> {
 
     let ca = reqwest::Certificate::from_pem(&ca_pem).context("parse CA certificate")?;
 
-    let mut builder = reqwest::Client::builder()
+    let mut builder = aisix_gateway::client_builder()
         .timeout(Duration::from_secs(10))
         .user_agent(format!("aisix-dp/{}", &*crate::heartbeat::BUILD_VERSION))
         .identity(identity)

--- a/tests/e2e/src/cases/downstream-connection-e2e.test.ts
+++ b/tests/e2e/src/cases/downstream-connection-e2e.test.ts
@@ -1,0 +1,378 @@
+import { createHash } from "node:crypto";
+import { connect, type Socket } from "node:net";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for AISIX-Cloud#1126: the inbound half of the connection layer.
+//
+//   - `downstream.idle_timeout_secs` closes a client connection that sits
+//     idle *between* requests. The whole point of putting it on hyper's
+//     header-read timer is that it must never touch a request in flight,
+//     however long the model takes, so both halves are asserted here.
+//   - `downstream.sse_keepalive_interval_secs` keeps bytes moving on a
+//     streaming response while the model produces nothing, so a proxy in
+//     front doesn't call the connection abandoned. Asserted on all three
+//     SSE shapes, which reach the client through three different code
+//     paths: axum's `Sse` keep-alive (chat), the bridged Anthropic
+//     encoder (messages), and the raw byte passthrough (responses).
+
+const CALLER_PLAINTEXT = "sk-downstream-conn-1126";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const IDLE_TIMEOUT_S = 2;
+// Comfortably longer than the idle timeout: a request in flight for this
+// long must survive, which is exactly what the naive "close anything quiet"
+// implementation would get wrong.
+const UPSTREAM_THINK_MS = IDLE_TIMEOUT_S * 1000 + 1500;
+
+const HEARTBEAT_INTERVAL_S = 1;
+const FIRST_EVENT_DELAY_MS = 2500;
+
+function chatChunk(content: string): string {
+  return JSON.stringify({
+    id: "evt",
+    object: "chat.completion.chunk",
+    model: "gpt-4o-mini",
+    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+  });
+}
+
+function chatFinish(): string {
+  return JSON.stringify({
+    id: "evt",
+    object: "chat.completion.chunk",
+    model: "gpt-4o-mini",
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  });
+}
+
+const RESPONSES_EVENTS = [
+  JSON.stringify({ type: "response.created", response: { id: "resp_1126" } }),
+  JSON.stringify({ type: "response.output_text.delta", delta: "late" }),
+  JSON.stringify({
+    type: "response.completed",
+    response: {
+      id: "resp_1126",
+      status: "completed",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  }),
+  "[DONE]",
+];
+
+/**
+ * Send one keep-alive request on a raw socket, then report how long the
+ * server left the connection open afterwards. Resolves `null` if the
+ * connection was still open when `waitMs` elapsed.
+ */
+function idleUntilClose(port: number, waitMs: number): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    const socket: Socket = connect(port, "127.0.0.1");
+    let responded = false;
+    let idleStartedAt = 0;
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(null);
+    }, waitMs);
+
+    socket.on("connect", () => {
+      socket.write("GET /livez HTTP/1.1\r\nHost: e2e\r\nConnection: keep-alive\r\n\r\n");
+    });
+    socket.on("data", (buf) => {
+      if (responded) return;
+      responded = true;
+      expect(buf.toString("utf8")).toContain("HTTP/1.1 200");
+      idleStartedAt = Date.now();
+    });
+    socket.on("close", () => {
+      clearTimeout(timer);
+      if (!responded) {
+        reject(new Error("connection closed before the response arrived"));
+        return;
+      }
+      resolve(Date.now() - idleStartedAt);
+    });
+    socket.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/** Read a streaming response body to completion as text. */
+async function readStream(res: Response): Promise<string> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text;
+}
+
+/** SSE comment lines — the heartbeat frames, `:` with no field name. */
+function heartbeatCount(sse: string): number {
+  return sse.split("\n").filter((line) => line === ":").length;
+}
+
+describe("downstream idle timeout (AISIX-Cloud#1126)", () => {
+  let app: SpawnedApp | undefined;
+  let slow: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    slow = await startOpenAiUpstream({
+      // Headers and body both withheld: from the gateway's inbound side
+      // the connection is silent for the whole delay.
+      responseDelayMs: UPSTREAM_THINK_MS,
+      nonStreamBody: {
+        id: "cmpl-slow",
+        object: "chat.completion",
+        created: 0,
+        model: "gpt-4o-mini",
+        choices: [
+          { index: 0, message: { role: "assistant", content: "worth the wait" }, finish_reason: "stop" },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+
+    app = await spawnApp({
+      extra: { downstream: { idle_timeout_secs: IDLE_TIMEOUT_S } },
+    });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    const pk = (
+      await seed.createProviderKey({
+        display_name: "dc-slow-pk",
+        secret: "sk-mock",
+        api_base: `${slow.baseUrl}/v1`,
+      })
+    ).id;
+    await seed.createModel({
+      display_name: "dc-slow-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk,
+      timeout: 30_000,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["dc-slow-model"],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+      });
+      if (!res.ok) return false;
+      const body = (await res.json()) as { data?: Array<{ id: string }> };
+      return !!body.data?.some((m) => m.id === "dc-slow-model");
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await slow?.close();
+  });
+
+  test("an idle keep-alive connection is closed at the configured deadline", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const port = Number(new URL(app.proxyUrl).port);
+    const idleMs = await idleUntilClose(port, IDLE_TIMEOUT_S * 1000 + 4000);
+    expect(idleMs).not.toBeNull();
+    // Not early (the response had just been written) and not never.
+    expect(idleMs!).toBeGreaterThanOrEqual(IDLE_TIMEOUT_S * 1000 - 200);
+    expect(idleMs!).toBeLessThan(IDLE_TIMEOUT_S * 1000 + 3000);
+  });
+
+  // The regression that matters: an LLM call is quiet for far longer than
+  // any sane idle timeout, and cutting it would be a self-inflicted 502.
+  test("a request in flight past the idle timeout still completes", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const started = Date.now();
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "dc-slow-model",
+        messages: [{ role: "user", content: "take your time" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { choices: Array<{ message: { content: string } }> };
+    expect(body.choices[0]?.message.content).toBe("worth the wait");
+    expect(Date.now() - started).toBeGreaterThan(IDLE_TIMEOUT_S * 1000);
+  }, 30_000);
+});
+
+describe("downstream SSE heartbeat (AISIX-Cloud#1126)", () => {
+  let app: SpawnedApp | undefined;
+  let chatUpstream: OpenAiUpstream | undefined;
+  let responsesUpstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // Headers flush immediately, the first token arrives much later: the
+    // window a proxy in front would otherwise see as a dead connection.
+    chatUpstream = await startOpenAiUpstream({
+      firstEventDelayMs: FIRST_EVENT_DELAY_MS,
+      streamEvents: [chatChunk("late reply"), chatFinish(), "[DONE]"],
+    });
+    responsesUpstream = await startOpenAiUpstream({
+      firstEventDelayMs: FIRST_EVENT_DELAY_MS,
+      streamEvents: RESPONSES_EVENTS,
+    });
+
+    app = await spawnApp({
+      extra: { downstream: { sse_keepalive_interval_secs: HEARTBEAT_INTERVAL_S } },
+    });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    const chatPk = (
+      await seed.createProviderKey({
+        display_name: "hb-chat-pk",
+        secret: "sk-mock",
+        api_base: `${chatUpstream.baseUrl}/v1`,
+      })
+    ).id;
+    const responsesPk = (
+      await seed.createProviderKey({
+        display_name: "hb-responses-pk",
+        secret: "sk-mock",
+        api_base: `${responsesUpstream.baseUrl}/v1`,
+      })
+    ).id;
+    await seed.createModel({
+      display_name: "hb-chat-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: chatPk,
+    });
+    await seed.createModel({
+      display_name: "hb-responses-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: responsesPk,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["hb-chat-model", "hb-responses-model"],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+      });
+      if (!res.ok) return false;
+      const body = (await res.json()) as { data?: Array<{ id: string }> };
+      return (
+        !!body.data?.some((m) => m.id === "hb-chat-model") &&
+        !!body.data?.some((m) => m.id === "hb-responses-model")
+      );
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all([chatUpstream?.close(), responsesUpstream?.close()]);
+  });
+
+  test("chat completions heartbeat while the model is silent", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "hb-chat-model",
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const sse = await readStream(res);
+    expect(heartbeatCount(sse)).toBeGreaterThanOrEqual(1);
+    // The heartbeat must not disturb the payload it interleaves with.
+    expect(sse).toContain("late reply");
+    expect(sse).toContain("data: [DONE]");
+  }, 30_000);
+
+  test("bridged /v1/messages heartbeats while the model is silent", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "x-api-key": CALLER_PLAINTEXT,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "hb-chat-model",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const sse = await readStream(res);
+    expect(heartbeatCount(sse)).toBeGreaterThanOrEqual(1);
+    expect(sse).toContain("late reply");
+    expect(sse).toContain("message_stop");
+  }, 30_000);
+
+  test("passthrough /v1/responses heartbeats while the model is silent", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "hb-responses-model",
+        input: "hi",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const sse = await readStream(res);
+    expect(heartbeatCount(sse)).toBeGreaterThanOrEqual(1);
+    expect(sse).toContain("response.completed");
+  }, 30_000);
+});

--- a/tests/e2e/src/cases/upstream-pool-idle-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-pool-idle-e2e.test.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  waitConfigPropagation,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for `upstream.pool_idle_timeout_secs` (AISIX-Cloud#1122, #1126).
+//
+// The setting exists because a hop between the gateway and the provider
+// (load balancer, NAT gateway, service mesh) closes idle connections on
+// its own schedule. If the gateway's pool outlives that schedule, it
+// eventually hands out a connection the far end has already dropped and
+// the request fails with an opaque transport error.
+//
+// The failure itself only reproduces deterministically when the far end
+// disappears *silently* (a dropped NAT mapping, no FIN) — hyper detects a
+// clean FIN and discards the connection before reusing it. What is
+// testable, and what the fix actually turns on, is whether the pool
+// expires a connection at the configured deadline at all: with the knob
+// set, a request after the deadline must open a new connection; without
+// it, reqwest's own 90s default keeps the old one. An upstream that never
+// closes first isolates the gateway's behaviour from the peer's.
+
+const CALLER_PLAINTEXT = "sk-pool-idle-1126";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const POOL_IDLE_S = 1;
+const IDLE_GAP_MS = POOL_IDLE_S * 1000 + 1500;
+
+interface CountingUpstream {
+  baseUrl: string;
+  /** TCP connections accepted so far. */
+  connections(): number;
+  close(): Promise<void>;
+}
+
+/** An OpenAI-shaped upstream that counts accepted TCP connections and
+ *  never closes an idle one first. */
+async function startCountingUpstream(): Promise<CountingUpstream> {
+  let connections = 0;
+  const server: Server = createServer((_req, res) => {
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(
+      JSON.stringify({
+        id: "cmpl-pool",
+        object: "chat.completion",
+        created: 0,
+        model: "gpt-4o-mini",
+        choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+    );
+  });
+  // Well above the idle gap: whichever side closes, it is not this one.
+  server.keepAliveTimeout = 120_000;
+  server.headersTimeout = 125_000;
+  server.on("connection", () => {
+    connections += 1;
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    connections: () => connections,
+    close: () =>
+      new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve()))),
+  };
+}
+
+async function seedInto(app: SpawnedApp, etcd: EtcdClient, apiBase: string): Promise<void> {
+  const seed = new SeedClient(etcd, app.etcdPrefix);
+  const pk = (
+    await seed.createProviderKey({
+      display_name: "pool-idle-pk",
+      secret: "sk-mock",
+      api_base: `${apiBase}/v1`,
+    })
+  ).id;
+  await seed.createModel({
+    display_name: "pool-idle-model",
+    provider: "openai",
+    model_name: "gpt-4o-mini",
+    provider_key_id: pk,
+  });
+  await seed.createApiKey({ key_hash: CALLER_KEY_HASH, allowed_models: ["pool-idle-model"] });
+  await waitConfigPropagation(async () => {
+    const res = await fetch(`${app.proxyUrl}/v1/models`, {
+      headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+    });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { data?: Array<{ id: string }> };
+    return !!body.data?.some((m) => m.id === "pool-idle-model");
+  });
+}
+
+async function callOnce(app: SpawnedApp): Promise<void> {
+  const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "pool-idle-model",
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+  expect(res.status).toBe(200);
+  await res.json();
+}
+
+describe("upstream pool idle timeout", () => {
+  let expiring: SpawnedApp | undefined;
+  let holding: SpawnedApp | undefined;
+  let expiringUpstream: CountingUpstream | undefined;
+  let holdingUpstream: CountingUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    expiringUpstream = await startCountingUpstream();
+    holdingUpstream = await startCountingUpstream();
+
+    expiring = await spawnApp({ extra: { upstream: { pool_idle_timeout_secs: POOL_IDLE_S } } });
+    // 0 switches the knob off, leaving reqwest's own 90s pool lifetime.
+    holding = await spawnApp({ extra: { upstream: { pool_idle_timeout_secs: 0 } } });
+
+    await seedInto(expiring, etcd, expiringUpstream.baseUrl);
+    await seedInto(holding, etcd, holdingUpstream.baseUrl);
+  });
+
+  afterAll(async () => {
+    await Promise.all([expiring?.exit(), holding?.exit()]);
+    await Promise.all([expiringUpstream?.close(), holdingUpstream?.close()]);
+  });
+
+  test("a connection idle past the configured deadline is not reused", async (ctx) => {
+    if (!etcdReachable || !expiring || !expiringUpstream) {
+      ctx.skip();
+      return;
+    }
+    await callOnce(expiring);
+    expect(expiringUpstream.connections()).toBe(1);
+    await new Promise((r) => setTimeout(r, IDLE_GAP_MS));
+    await callOnce(expiring);
+    expect(expiringUpstream.connections()).toBe(2);
+  }, 30_000);
+
+  // The control: the same gap without the knob keeps the pooled
+  // connection, so the assertion above is measuring the setting and not
+  // something the upstream or the runtime does on its own.
+  test("with the knob off, the same gap reuses the pooled connection", async (ctx) => {
+    if (!etcdReachable || !holding || !holdingUpstream) {
+      ctx.skip();
+      return;
+    }
+    await callOnce(holding);
+    expect(holdingUpstream.connections()).toBe(1);
+    await new Promise((r) => setTimeout(r, IDLE_GAP_MS));
+    await callOnce(holding);
+    expect(holdingUpstream.connections()).toBe(1);
+  }, 30_000);
+});


### PR DESCRIPTION
## Problem

`upstream:` (#808) bounded the connections the gateway *dials out* with. The inbound half had nothing:

1. **No downstream idle timeout at all.** hyper 1.x defaults `header_read_timeout` to 30s, but `Time::check` silently drops a defaulted duration when no timer is installed — and neither `axum::serve` nor `axum_server` installs one. So an accepted connection was held open forever once it went idle.
2. **The SSE heartbeat only existed on `/v1/chat/completions`**, at a hardcoded 15s. `/v1/messages` and `/v1/responses` streams sent nothing while the model was silent.
3. **Half the outbound clients never got #808's settings.** Only the four provider bridges and the proxy's shared client used `client_builder()`; the 7 guardrail clients, MCP OAuth, A2A, telemetry, heartbeat and the OTLP exporter were still on reqwest's defaults (no connect timeout, TCP keepalive off, 90s pooled-connection lifetime).

## Implementation

New `downstream:` block, the mirror of `upstream:`:

```yaml
downstream:
  idle_timeout_secs: 0          # 0 = never close an idle connection
  # sse_keepalive_interval_secs: 15
```

**`idle_timeout_secs`** goes on hyper's header-read timer. That timer arms only while hyper is waiting for a request head, and hyper only waits for one once the previous response has been fully written (`Conn::can_read_head` needs the read half back at `Init`, which `try_keep_alive` reaches only when reading *and* writing are done). So it covers exactly the between-requests window — a slow model or a long SSE stream is never interrupted. Reaching the builder means the plain-HTTP listener moves from `axum::serve` to `axum_server`, which the TLS listener already used; `serve_connection_with_upgrades` and `ConnectInfo<SocketAddr>` are preserved, so WebSocket upgrades and real-ip resolution are unaffected. HTTP/1.1 only — hyper has no h2 equivalent.

Default `0` = today's behaviour. Closing first is what hands the node in front a connection it still considers usable — the same failure this gateway avoids upstream by keeping `pool_idle_timeout_secs` low — and a fronting Envoy pools for an hour by default. Set it *above* the pool idle timeout of whatever sits in front.

**`sse_keepalive_interval_secs`** (default 15, `0` disables) now drives every SSE surface: axum's `Sse` keep-alive on chat, and a `with_heartbeat` stream wrapper on bridged `/v1/messages`, bridged `/v1/responses`, and the `/v1/responses` byte passthrough. The frame is `:\n\n` — the same comment axum writes, ignored by every conforming SSE parser. Not applied to opaque binary passthroughs (audio, images), where it would corrupt the body.

**Uniform connection layer**: guardrails, MCP OAuth, A2A, telemetry, heartbeat and the OTLP exporter now build from `aisix_gateway::client_builder()`. A test walks every crate's production source and fails on a bare `reqwest::Client::builder()` / `::new()`, so the next client can't drift back (verified it catches a reintroduced offender).

## Which surfaces the heartbeat covers

Audited every response-body outlet in `aisix-proxy`, since the issue asks whether the raw passthrough paths need one too:

| Surface | Shape | Heartbeat |
| --- | --- | --- |
| `/v1/chat/completions` (both stream sites) | axum `Sse` | yes, now configurable |
| `/v1/messages` bridged + native passthrough | SSE byte stream | yes, new |
| `/v1/responses` bridged + native passthrough | SSE byte stream | yes, new |
| `/passthrough/:provider/*rest` | **not streaming** — buffers the whole upstream body (`bytes().await`) for the output-guardrail scan | n/a |
| `/v1/completions` | non-streaming, always `Json(...)` | n/a |
| audio / images / videos | binary or non-streaming | deliberately not — a comment frame would corrupt the body |
| `/v1/realtime` | WebSocket, has its own idle semantics (`stream_timeout`) and would need WS ping frames, not SSE comments | not covered |

Worth flagging from that audit: the raw tunnel buffers, so a slow provider call through `/passthrough/...` puts **zero** bytes on the client connection until the whole body has arrived — the same "looks idle" exposure the heartbeat fixes for SSE, and one that can't be fixed the same way because the content type is unknown. Out of scope here; noting it so it isn't assumed covered.

## Not implemented, deliberately

- **Per-provider overrides of the pool settings.** The pool idle timeout only has to be below the *shortest* hop on the path, so a single global value is sufficient; per-provider pools multiply FDs and memory for no reachability gain. LiteLLM and Portkey expose no equivalent either.
- **`max_requests_per_connection` / `max_connection_lifetime`.** reqwest exposes neither.
- **A separate upstream stream-idle timeout.** Per-model `stream_timeout` already bounds each inter-chunk gap (#554, corrected for Azure in #809); this would be a second name for it.

## Behaviour changes

- Graceful shutdown now drains without a deadline on both listeners (the TLS one previously capped at 10s). An in-flight stream can run for minutes and the platform already caps total shutdown time; idle connections are closed immediately either way.
- SSE responses on `/v1/messages` and `/v1/responses` now carry heartbeat comments during upstream silence.
- Guardrail/MCP/A2A/telemetry/exporter calls get a 5s connect timeout, TCP keepalive, and a 30s pool idle timeout.

## Tests

- `downstream-connection-e2e.test.ts`: an idle keep-alive connection is closed at the deadline; **a request in flight past the deadline still completes**; heartbeats appear on all three SSE code paths while the upstream is silent, without disturbing the payload. Mutation-checked — with the idle timeout un-applied and the interval hardcoded, 4 of the 5 fail (the in-flight case is the control and keeps passing).
- Unit tests for the heartbeat combinator (silence heartbeats, busy stream untouched, disabled = pass-through, terminal error preserved) and for the `downstream:` config defaults/overrides.
- `upstream-pool-idle-e2e.test.ts`: `pool_idle_timeout_secs` shipped in #808 without behavioural coverage. Against an upstream that never closes first, a request after the deadline opens a new TCP connection; the same gap with the knob off reuses the pooled one. The two cases are each other's control.
- Re-ran the listener-sensitive suites: TLS, real-ip/XFF, WebSocket realtime, SIGHUP reload, SIGTERM shutdown, admin-off, `#554` timeout fallback, audio timeout, streaming usage, guardrails.

Fixes api7/AISIX-Cloud#1126




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable downstream idle timeouts for HTTP connections.
  * Added configurable SSE heartbeats, enabled by default at 15 seconds, to keep quiet streams active.
  * Applied SSE keep-alives across supported chat, messages, and responses streaming endpoints.
  * Standardized outbound connection handling for improved reuse and timeout consistency.

* **Tests**
  * Added end-to-end coverage for downstream timeouts, SSE heartbeats, and upstream connection pooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->