### PR TITLE
feat(auth): inbound OIDC/JWT authentication — trust providers + jwt_subject key binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "ipnet",
+ "jsonwebtoken",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "serde",

--- a/crates/aisix-core/src/bin/dump-schema.rs
+++ b/crates/aisix-core/src/bin/dump-schema.rs
@@ -65,6 +65,11 @@ fn main() {
     dump_value(&out_dir, "mcp_server", schema::mcp_server_root_schema());
     dump_value(&out_dir, "mcp_policy", schema::mcp_policy_root_schema());
     dump_value(&out_dir, "a2a_agent", schema::a2a_agent_root_schema());
+    dump_value(
+        &out_dir,
+        "oidc_provider",
+        schema::oidc_provider_root_schema(),
+    );
 
     dump::<EnsembleConfig>(&out_dir, "ensemble");
     dump::<RateLimit>(&out_dir, "rate_limit");

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -491,21 +491,36 @@ pub fn load_from_str(
         }
     }
 
-    // JWT authentication selects the key by `jwt_subject`, so two keys
-    // sharing one subject would silently tie-break at auth time. Reject
-    // the ambiguity at load, mirroring the key_hash uniqueness above.
-    let mut seen_subjects: BTreeMap<&str, &str> = BTreeMap::new();
+    // JWT authentication selects the key by (jwt_provider, jwt_subject),
+    // so a subject is set only alongside the provider allowed to assert
+    // it, and that pair must be unique — otherwise auth would silently
+    // tie-break, or (without a provider) a second trusted IdP could
+    // impersonate this identity. Reject both at load.
+    let mut seen_subjects: BTreeMap<(&str, &str), &str> = BTreeMap::new();
     for (_, scope, key) in &apikeys {
-        if let Some(subject) = key.jwt_subject.as_deref() {
-            if let Some(first) = seen_subjects.insert(subject, scope.as_str()) {
+        match (key.jwt_subject.as_deref(), key.jwt_provider.as_deref()) {
+            (Some(subject), Some(provider)) => {
+                if let Some(first) = seen_subjects.insert((provider, subject), scope.as_str()) {
+                    errors.push(LoadError {
+                        scope: scope.clone(),
+                        message: format!(
+                            "duplicate jwt binding {provider:?}/{subject:?}: already used by \
+                             {first} — every (jwt_provider, jwt_subject) pair must be distinct"
+                        ),
+                    });
+                }
+            }
+            (Some(subject), None) => {
                 errors.push(LoadError {
                     scope: scope.clone(),
                     message: format!(
-                        "duplicate jwt_subject {subject:?}: already used by {first} — \
-                         every api key must have a distinct jwt_subject"
+                        "jwt_subject {subject:?} is set without jwt_provider — a subject must \
+                         name the OIDC provider allowed to assert it, or a second trusted \
+                         provider could impersonate this identity"
                     ),
                 });
             }
+            _ => {}
         }
     }
 

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -46,9 +46,10 @@ use yaml_rust2::{Yaml, YamlLoader};
 
 use crate::models::{
     validate_a2a_agent, validate_apikey, validate_cache_policy, validate_guardrail,
-    validate_mcp_server, validate_model, validate_observability_exporter, validate_provider_key,
-    validate_rate_limit_policy, A2aAgent, ApiKey, CachePolicy, Guardrail, McpServer, Model,
-    ObservabilityExporter, ProviderKey, RateLimitPolicy, SchemaError,
+    validate_mcp_server, validate_model, validate_observability_exporter, validate_oidc_provider,
+    validate_provider_key, validate_rate_limit_policy, A2aAgent, ApiKey, CachePolicy, Guardrail,
+    McpServer, Model, ObservabilityExporter, OidcProvider, ProviderKey, RateLimitPolicy,
+    SchemaError,
 };
 use crate::resource::ResourceEntry;
 use crate::AisixSnapshot;
@@ -101,8 +102,8 @@ impl std::error::Error for FileSourceErrors {}
 /// change semantics without silently misreading old gateways' files.
 const SUPPORTED_FORMAT_VERSION: &str = "1";
 
-/// Fixed processing order for the nine resource collections.
-const KINDS: [(&str, IdentityField); 9] = [
+/// Fixed processing order for the ten resource collections.
+const KINDS: [(&str, IdentityField); 10] = [
     ("provider_keys", IdentityField::DisplayName),
     ("models", IdentityField::DisplayName),
     ("api_keys", IdentityField::DisplayName),
@@ -112,6 +113,7 @@ const KINDS: [(&str, IdentityField); 9] = [
     ("cache_policies", IdentityField::Name),
     ("observability_exporters", IdentityField::Name),
     ("rate_limit_policies", IdentityField::Name),
+    ("oidc_providers", IdentityField::Name),
 ];
 
 /// Load `path` into a fresh [`AisixSnapshot`], resolving `${VAR}`
@@ -315,6 +317,7 @@ pub fn load_from_str(
     let mut cache_policies: Vec<(String, String, CachePolicy)> = Vec::new();
     let mut observability_exporters: Vec<(String, String, ObservabilityExporter)> = Vec::new();
     let mut rate_limit_policies: Vec<(String, String, RateLimitPolicy)> = Vec::new();
+    let mut oidc_providers: Vec<(String, String, OidcProvider)> = Vec::new();
 
     for mut entry in prepared {
         let id = derive_id(entry.kind, &entry.identity);
@@ -400,6 +403,11 @@ pub fn load_from_str(
                     rate_limit_policies.push((id, scope, t));
                 }
             }
+            "oidc_providers" => {
+                if let Some(t) = finish(&scope, &entry.doc, validate_oidc_provider, &mut errors) {
+                    oidc_providers.push((id, scope, t));
+                }
+            }
             other => unreachable!("kind {other} is not in KINDS"),
         }
     }
@@ -483,6 +491,24 @@ pub fn load_from_str(
         }
     }
 
+    // JWT authentication selects the key by `jwt_subject`, so two keys
+    // sharing one subject would silently tie-break at auth time. Reject
+    // the ambiguity at load, mirroring the key_hash uniqueness above.
+    let mut seen_subjects: BTreeMap<&str, &str> = BTreeMap::new();
+    for (_, scope, key) in &apikeys {
+        if let Some(subject) = key.jwt_subject.as_deref() {
+            if let Some(first) = seen_subjects.insert(subject, scope.as_str()) {
+                errors.push(LoadError {
+                    scope: scope.clone(),
+                    message: format!(
+                        "duplicate jwt_subject {subject:?}: already used by {first} — \
+                         every api key must have a distinct jwt_subject"
+                    ),
+                });
+            }
+        }
+    }
+
     // An explicit `provider_key_id` must also resolve: in file mode every
     // provider-key id is derived from its name, so any other value is
     // guaranteed dangling and would only surface per-request.
@@ -552,6 +578,11 @@ pub fn load_from_str(
     for (id, _, v) in rate_limit_policies {
         snapshot
             .rate_limit_policies
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in oidc_providers {
+        snapshot
+            .oidc_providers
             .insert(ResourceEntry::new(id, v, revision));
     }
     Ok(snapshot)

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -102,6 +102,34 @@ impl std::error::Error for FileSourceErrors {}
 /// change semantics without silently misreading old gateways' files.
 const SUPPORTED_FORMAT_VERSION: &str = "1";
 
+/// True when a URL embeds credentials that must not sit in a public JWKS
+/// endpoint: userinfo (`user:pass@host`) or a credential-bearing query
+/// parameter. String-scanned rather than URL-parsed to avoid pulling a
+/// URL crate into `aisix-core`.
+pub(crate) fn url_has_credentials(url: &str) -> bool {
+    let after_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
+    // Authority ends at the first '/', '?', or '#'.
+    let authority_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    if after_scheme[..authority_end].contains('@') {
+        return true;
+    }
+    if let Some((_, query)) = url.split_once('?') {
+        let query = query.split('#').next().unwrap_or(query);
+        for pair in query.split('&') {
+            let key = pair.split('=').next().unwrap_or(pair).to_ascii_lowercase();
+            if matches!(
+                key.as_str(),
+                "access_token" | "token" | "client_secret" | "password" | "api_key" | "apikey"
+            ) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Fixed processing order for the ten resource collections.
 const KINDS: [(&str, IdentityField); 10] = [
     ("provider_keys", IdentityField::DisplayName),
@@ -521,6 +549,49 @@ pub fn load_from_str(
                 });
             }
             _ => {}
+        }
+    }
+
+    // Two enabled providers sharing one issuer are ambiguous: they carry
+    // different audience/scope/claim policies, and JWT auth would have to
+    // pick one. Reject the duplicate at load (the DP resolver also fails
+    // closed at runtime, but the file can and should surface it).
+    let mut seen_issuers: BTreeMap<&str, &str> = BTreeMap::new();
+    for (_, scope, provider) in &oidc_providers {
+        if !provider.enabled {
+            continue;
+        }
+        if let Some(first) = seen_issuers.insert(provider.issuer.as_str(), scope.as_str()) {
+            errors.push(LoadError {
+                scope: scope.clone(),
+                message: format!(
+                    "duplicate enabled OIDC issuer {:?}: already used by {first} — every \
+                     enabled provider must have a distinct issuer",
+                    provider.issuer
+                ),
+            });
+        }
+    }
+
+    // A JWKS/discovery URL must never carry embedded credentials
+    // (`user:pass@host` or a credential query): JWKS material is public,
+    // credentials there would only leak (e.g. through a snapshot export).
+    for (_, scope, provider) in &oidc_providers {
+        for (field, url) in [
+            ("issuer", Some(&provider.issuer)),
+            ("jwks_uri", provider.jwks_uri.as_ref()),
+        ] {
+            if let Some(url) = url {
+                if url_has_credentials(url) {
+                    errors.push(LoadError {
+                        scope: scope.clone(),
+                        message: format!(
+                            "OIDC provider {field} must not embed credentials (user info or a \
+                             token query parameter) — JWKS endpoints are public"
+                        ),
+                    });
+                }
+            }
         }
     }
 

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -56,6 +56,7 @@ api_keys:
   - display_name: ci-bot
     key_env: E2E_CI_BOT_KEY
     allowed_models: ["gpt-4o", "balanced"]
+    jwt_subject: agent-ci-bot
   - display_name: ops
     key_hash: 91ed2dbc407561556f3e7be98ba0bd2a57986d6a868c482d867d19c6d40d201c
     allowed_models: ["*"]
@@ -101,6 +102,12 @@ rate_limit_policies:
     scope_ref: team-uuid-1
     window: hour
     max_requests: 1000
+
+oidc_providers:
+  - name: corp-keycloak
+    issuer: https://sso.example.com/realms/agents
+    audiences: ["aisix-gateway"]
+    required_scopes: ["ai.access"]
 "#;
 
 fn full_env() -> HashMap<String, String> {
@@ -123,6 +130,25 @@ fn full_valid_file_loads_every_kind() {
     assert_eq!(snap.cache_policies.len(), 1);
     assert_eq!(snap.observability_exporters.len(), 1);
     assert_eq!(snap.rate_limit_policies.len(), 3);
+    assert_eq!(snap.oidc_providers.len(), 1);
+
+    // The OIDC provider loads with serde defaults filled.
+    let idp = snap.oidc_providers.get_by_name("corp-keycloak").unwrap();
+    assert_eq!(idp.value.issuer, "https://sso.example.com/realms/agents");
+    assert_eq!(idp.value.identity_claim, "sub");
+    assert!(idp.value.enabled);
+
+    // The ci-bot key carries its JWT identity binding.
+    let ci_bot_hash = crate::models::ApiKey::hash_bearer("sk-ci-plaintext");
+    assert_eq!(
+        snap.apikeys
+            .get_by_name(&ci_bot_hash)
+            .unwrap()
+            .value
+            .jwt_subject
+            .as_deref(),
+        Some("agent-ci-bot")
+    );
 
     // Interpolation landed in the provider key (full + partial).
     let pk = snap.provider_keys.get_by_name("openai-prod").unwrap();
@@ -462,6 +488,29 @@ api_keys:
     // …and never echoes the credential in either form.
     assert!(!errs[0].contains(plain), "plaintext leaked: {errs:?}");
     assert!(!errs[0].contains(&hash), "hash leaked: {errs:?}");
+}
+
+#[test]
+fn duplicate_jwt_subject_across_api_keys_is_a_load_error() {
+    // JWT auth selects the key by jwt_subject — a duplicate would
+    // silently tie-break at auth time, so it fails the load like the
+    // duplicate-credential rule above.
+    let contents = r#"
+_format_version: "1"
+api_keys:
+  - display_name: first
+    key_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+    allowed_models: ["*"]
+    jwt_subject: agent-shared
+  - display_name: second
+    key_hash: "2222222222222222222222222222222222222222222222222222222222222222"
+    allowed_models: ["*"]
+    jwt_subject: agent-shared
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(errs[0].contains("duplicate jwt_subject"), "{errs:?}");
+    assert!(errs[0].contains("agent-shared"), "{errs:?}");
 }
 
 #[test]

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -57,6 +57,7 @@ api_keys:
     key_env: E2E_CI_BOT_KEY
     allowed_models: ["gpt-4o", "balanced"]
     jwt_subject: agent-ci-bot
+    jwt_provider: corp-keycloak
   - display_name: ops
     key_hash: 91ed2dbc407561556f3e7be98ba0bd2a57986d6a868c482d867d19c6d40d201c
     allowed_models: ["*"]
@@ -140,15 +141,9 @@ fn full_valid_file_loads_every_kind() {
 
     // The ci-bot key carries its JWT identity binding.
     let ci_bot_hash = crate::models::ApiKey::hash_bearer("sk-ci-plaintext");
-    assert_eq!(
-        snap.apikeys
-            .get_by_name(&ci_bot_hash)
-            .unwrap()
-            .value
-            .jwt_subject
-            .as_deref(),
-        Some("agent-ci-bot")
-    );
+    let ci_bot = snap.apikeys.get_by_name(&ci_bot_hash).unwrap();
+    assert_eq!(ci_bot.value.jwt_subject.as_deref(), Some("agent-ci-bot"));
+    assert_eq!(ci_bot.value.jwt_provider.as_deref(), Some("corp-keycloak"));
 
     // Interpolation landed in the provider key (full + partial).
     let pk = snap.provider_keys.get_by_name("openai-prod").unwrap();
@@ -491,10 +486,11 @@ api_keys:
 }
 
 #[test]
-fn duplicate_jwt_subject_across_api_keys_is_a_load_error() {
-    // JWT auth selects the key by jwt_subject — a duplicate would
-    // silently tie-break at auth time, so it fails the load like the
-    // duplicate-credential rule above.
+fn duplicate_jwt_binding_across_api_keys_is_a_load_error() {
+    // JWT auth selects the key by (jwt_provider, jwt_subject) — a
+    // duplicate pair would silently tie-break at auth time, so it fails
+    // the load like the duplicate-credential rule above. The same
+    // subject under a DIFFERENT provider is allowed.
     let contents = r#"
 _format_version: "1"
 api_keys:
@@ -502,15 +498,39 @@ api_keys:
     key_hash: "1111111111111111111111111111111111111111111111111111111111111111"
     allowed_models: ["*"]
     jwt_subject: agent-shared
+    jwt_provider: corp
   - display_name: second
     key_hash: "2222222222222222222222222222222222222222222222222222222222222222"
     allowed_models: ["*"]
     jwt_subject: agent-shared
+    jwt_provider: corp
+  - display_name: third-other-provider
+    key_hash: "3333333333333333333333333333333333333333333333333333333333333333"
+    allowed_models: ["*"]
+    jwt_subject: agent-shared
+    jwt_provider: partner
 "#;
     let errs = errors_of(load(contents, &env_of(&[])));
     assert_eq!(errs.len(), 1, "{errs:?}");
-    assert!(errs[0].contains("duplicate jwt_subject"), "{errs:?}");
+    assert!(errs[0].contains("duplicate jwt binding"), "{errs:?}");
     assert!(errs[0].contains("agent-shared"), "{errs:?}");
+}
+
+#[test]
+fn jwt_subject_without_provider_is_a_load_error() {
+    // A subject must name the provider allowed to assert it, or a second
+    // trusted IdP could impersonate the identity (audit H1).
+    let contents = r#"
+_format_version: "1"
+api_keys:
+  - display_name: unqualified
+    key_hash: "4444444444444444444444444444444444444444444444444444444444444444"
+    allowed_models: ["*"]
+    jwt_subject: agent-x
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(errs[0].contains("without jwt_provider"), "{errs:?}");
 }
 
 #[test]

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -517,6 +517,44 @@ api_keys:
 }
 
 #[test]
+fn duplicate_enabled_oidc_issuer_is_a_load_error() {
+    let contents = r#"
+_format_version: "1"
+oidc_providers:
+  - name: corp-a
+    issuer: https://sso.example.com/realms/agents
+    audiences: ["aisix"]
+  - name: corp-b
+    issuer: https://sso.example.com/realms/agents
+    audiences: ["other"]
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("duplicate enabled OIDC issuer"),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn oidc_url_with_embedded_credentials_is_a_load_error() {
+    let contents = r#"
+_format_version: "1"
+oidc_providers:
+  - name: leaky
+    issuer: https://sso.example.com/realms/agents
+    audiences: ["aisix"]
+    jwks_uri: https://user:secret@sso.example.com/certs
+"#;
+    let errs = errors_of(load(contents, &env_of(&[])));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("must not embed credentials")),
+        "{errs:?}"
+    );
+}
+
+#[test]
 fn jwt_subject_without_provider_is_a_load_error() {
     // A subject must name the provider allowed to assert it, or a second
     // trusted IdP could impersonate the identity (audit H1).

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -50,16 +50,25 @@ pub struct ApiKey {
     pub user_name: Option<String>,
 
     /// External identity bound to this key for JWT authentication.
-    /// When a request presents a valid JWT issued by a configured
-    /// `oidc_providers` entry, the value of the provider's
-    /// `identity_claim` selects the key whose `jwt_subject` equals it,
-    /// and the request proceeds with this key's permissions, rate
-    /// limits, and budget. Values must be unique within the
-    /// environment. When omitted, the key is never selected by JWT
-    /// authentication.
+    /// When a request presents a valid JWT issued by the
+    /// `oidc_providers` entry named in `jwt_provider`, the value of
+    /// that provider's `identity_claim` selects the key whose
+    /// `jwt_subject` equals it, and the request proceeds with this
+    /// key's permissions, rate limits, and budget. The `(jwt_provider,
+    /// jwt_subject)` pair is unique within the environment. When
+    /// omitted, the key is never selected by JWT authentication.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(min = 1))]
     pub jwt_subject: Option<String>,
+
+    /// Name of the `oidc_providers` entry permitted to assert this
+    /// key's `jwt_subject`. A subject is only ever resolved for the
+    /// trust provider named here, so a second trusted provider cannot
+    /// mint a token impersonating this provider's identity of the same
+    /// name. Required whenever `jwt_subject` is set; ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub jwt_provider: Option<String>,
 
     /// MCP tools this key may call, as namespaced `<server>__<tool>` names
     /// (the form the gateway exposes). Entries are matched as single-`*`
@@ -262,6 +271,7 @@ mod tests {
             user_id: None,
             user_name: None,
             jwt_subject: None,
+            jwt_provider: None,
             allowed_tools: None,
             mcp_access: None,
             allowed_agents: None,
@@ -505,12 +515,14 @@ mod tests {
         assert!(v.get("jwt_subject").is_none());
 
         let k: ApiKey = serde_json::from_str(
-            r#"{"key_hash":"h","allowed_models":[],"jwt_subject":"agent-billing-01"}"#,
+            r#"{"key_hash":"h","allowed_models":[],"jwt_subject":"agent-billing-01","jwt_provider":"corp-idp"}"#,
         )
         .unwrap();
         assert_eq!(k.jwt_subject.as_deref(), Some("agent-billing-01"));
+        assert_eq!(k.jwt_provider.as_deref(), Some("corp-idp"));
         let v = serde_json::to_value(&k).unwrap();
         assert_eq!(v["jwt_subject"], "agent-billing-01");
+        assert_eq!(v["jwt_provider"], "corp-idp");
     }
 
     #[test]

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -49,6 +49,18 @@ pub struct ApiKey {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_name: Option<String>,
 
+    /// External identity bound to this key for JWT authentication.
+    /// When a request presents a valid JWT issued by a configured
+    /// `oidc_providers` entry, the value of the provider's
+    /// `identity_claim` selects the key whose `jwt_subject` equals it,
+    /// and the request proceeds with this key's permissions, rate
+    /// limits, and budget. Values must be unique within the
+    /// environment. When omitted, the key is never selected by JWT
+    /// authentication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub jwt_subject: Option<String>,
+
     /// MCP tools this key may call, as namespaced `<server>__<tool>` names
     /// (the form the gateway exposes). Entries are matched as single-`*`
     /// globs, mirroring `allowed_models`: `"*"` grants every tool and
@@ -249,6 +261,7 @@ mod tests {
             team_id: None,
             user_id: None,
             user_name: None,
+            jwt_subject: None,
             allowed_tools: None,
             mcp_access: None,
             allowed_agents: None,
@@ -479,6 +492,25 @@ mod tests {
         assert!(k.team_id.is_none());
         assert!(k.user_id.is_none());
         assert!(k.user_name.is_none());
+    }
+
+    #[test]
+    fn jwt_subject_roundtrips_and_defaults_absent() {
+        // Every pre-existing key payload lacks `jwt_subject`; it must load
+        // as None and stay off the wire so mixed-fleet DPs keep accepting
+        // the row.
+        let legacy = sample();
+        assert!(legacy.jwt_subject.is_none());
+        let v = serde_json::to_value(&legacy).unwrap();
+        assert!(v.get("jwt_subject").is_none());
+
+        let k: ApiKey = serde_json::from_str(
+            r#"{"key_hash":"h","allowed_models":[],"jwt_subject":"agent-billing-01"}"#,
+        )
+        .unwrap();
+        assert_eq!(k.jwt_subject.as_deref(), Some("agent-billing-01"));
+        let v = serde_json::to_value(&k).unwrap();
+        assert_eq!(v["jwt_subject"], "agent-billing-01");
     }
 
     #[test]

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -25,6 +25,7 @@ pub mod mcp_policy;
 pub mod mcp_server;
 pub mod model;
 pub mod observability_exporter;
+pub mod oidc_provider;
 pub mod provider_key;
 pub mod rate_limit;
 pub mod rate_limit_policy;
@@ -55,6 +56,7 @@ pub use observability_exporter::{
     AliyunSlsConfig, DatadogConfig, ExporterKind, ObjectStoreCompression, ObjectStoreConfig,
     ObjectStoreProvider, ObservabilityExporter, OtlpHttpConfig, SlsContentMode,
 };
+pub use oidc_provider::{BoundClaimExpect, OidcProvider};
 pub use provider_key::{
     ParamConstraints, ProviderKey, RequestOverrides, ResponseOverrides, StreamDoneMarker,
     TelemetryKind, TelemetryTags,
@@ -65,8 +67,8 @@ pub use routing::{Routing, RoutingStrategy, RoutingTarget, WhenAllUnavailablePol
 pub use schema::{
     validate_a2a_agent, validate_apikey, validate_cache_policy, validate_guardrail,
     validate_guardrail_attachment, validate_mcp_policy, validate_mcp_server, validate_model,
-    validate_observability_exporter, validate_provider_key, validate_rate_limit_policy,
-    SchemaError,
+    validate_observability_exporter, validate_oidc_provider, validate_provider_key,
+    validate_rate_limit_policy, SchemaError,
 };
 pub use semantic::{
     Aggregation, DistanceMetric, EmbeddingFailureMode, OnEmbeddingFailure, Semantic, SemanticMatch,

--- a/crates/aisix-core/src/models/oidc_provider.rs
+++ b/crates/aisix-core/src/models/oidc_provider.rs
@@ -1,0 +1,245 @@
+//! `OidcProvider` entity — an external identity provider the gateway
+//! trusts for inbound JWT authentication, stored in etcd under
+//! `oidc_providers/<uuid>`.
+//!
+//! When at least one enabled provider exists, a request whose bearer
+//! token is a JWT (instead of a gateway API key) is authenticated
+//! against the provider matching the token's `iss` claim: the token's
+//! signature is verified against the provider's JWKS, its registered
+//! claims (`exp`, `aud`) and the provider's scope/claim requirements
+//! are enforced, and the value of `identity_claim` selects the API key
+//! whose `jwt_subject` equals it. The request then proceeds with that
+//! key's permissions, rate limits, and budget — external identities
+//! never widen access beyond a key an operator explicitly created.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::resource::Resource;
+
+/// Expected value(s) for one bound claim: a single string, or a list
+/// matched as any-of.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum BoundClaimExpect {
+    /// The claim must equal (or, for array claims, contain) this value.
+    One(String),
+    /// The claim must equal (or, for array claims, contain) at least one
+    /// of these values.
+    #[schemars(length(min = 1))]
+    Any(Vec<String>),
+}
+
+impl BoundClaimExpect {
+    /// Iterate the accepted values regardless of form.
+    pub fn accepted(&self) -> impl Iterator<Item = &str> {
+        match self {
+            BoundClaimExpect::One(v) => std::slice::from_ref(v).iter().map(String::as_str),
+            BoundClaimExpect::Any(vs) => vs.as_slice().iter().map(String::as_str),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OidcProvider {
+    /// Human-readable provider name, unique within the environment
+    /// (e.g. `"corp-keycloak"`).
+    #[schemars(length(min = 1))]
+    pub name: String,
+
+    /// Expected `iss` claim, compared byte-for-byte against the token's
+    /// issuer. A JWT whose issuer matches no enabled provider is
+    /// rejected.
+    #[schemars(length(min = 1))]
+    pub issuer: String,
+
+    /// Accepted `aud` values. The token's audience (a string or an
+    /// array) must contain at least one of these. Every token must
+    /// carry an audience claim.
+    #[schemars(length(min = 1))]
+    pub audiences: Vec<String>,
+
+    /// JWKS endpoint URL the signing keys are fetched from. When
+    /// omitted, the endpoint is resolved once from the issuer's OIDC
+    /// discovery document (`<issuer>/.well-known/openid-configuration`)
+    /// and cached.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub jwks_uri: Option<String>,
+
+    /// Claim whose value selects the API key to act as: the request is
+    /// bound to the key whose `jwt_subject` equals this claim's value.
+    /// Dots traverse nested objects (e.g. `"resource_access.account"`).
+    /// Defaults to `sub`.
+    #[serde(default = "default_identity_claim")]
+    #[schemars(length(min = 1))]
+    pub identity_claim: String,
+
+    /// Scopes that must all be present in the token's `scope` claim
+    /// (a space-delimited string or an array of strings). An empty list
+    /// requires nothing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_scopes: Vec<String>,
+
+    /// Additional claim requirements, all of which must hold. Keys name
+    /// claims (dots traverse nested objects, e.g.
+    /// `"realm_access.roles"`); each requirement is satisfied when the
+    /// claim equals — or, for array claims, contains — one of the
+    /// expected values.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bound_claims: Option<BTreeMap<String, BoundClaimExpect>>,
+
+    /// Clock-skew allowance in seconds applied to time-based claims
+    /// (`exp`, `nbf`). Defaults to 0.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[schemars(range(max = 300))]
+    pub leeway_secs: u64,
+
+    /// Whether the provider participates in JWT authentication. A
+    /// disabled provider is kept but ignored. Treated as `true` when
+    /// omitted.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// etcd-key uuid. Filled by the loader and never included in the
+    /// JSON payload.
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+fn default_identity_claim() -> String {
+    "sub".to_string()
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn is_zero(v: &u64) -> bool {
+    *v == 0
+}
+
+impl Resource for OidcProvider {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    /// The by-name index key is the display name. Issuer lookups during
+    /// authentication iterate and filter on `issuer` rather than relying
+    /// on this index, so a duplicate name can never shadow a provider.
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn kind() -> &'static str {
+        "oidc_providers"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_minimal_provider_with_defaults() {
+        let p: OidcProvider = serde_json::from_str(
+            r#"{
+              "name": "corp-keycloak",
+              "issuer": "https://sso.example.com/realms/agents",
+              "audiences": ["aisix-gateway"]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(p.name, "corp-keycloak");
+        assert_eq!(p.issuer, "https://sso.example.com/realms/agents");
+        assert_eq!(p.audiences, vec!["aisix-gateway"]);
+        assert!(p.jwks_uri.is_none());
+        assert_eq!(p.identity_claim, "sub");
+        assert!(p.required_scopes.is_empty());
+        assert!(p.bound_claims.is_none());
+        assert_eq!(p.leeway_secs, 0);
+        assert!(p.enabled);
+    }
+
+    #[test]
+    fn deserialises_full_provider() {
+        let p: OidcProvider = serde_json::from_str(
+            r#"{
+              "name": "corp-keycloak",
+              "issuer": "https://sso.example.com/realms/agents",
+              "audiences": ["aisix-gateway", "aisix-alt"],
+              "jwks_uri": "https://sso.example.com/realms/agents/protocol/openid-connect/certs",
+              "identity_claim": "azp",
+              "required_scopes": ["ai.access"],
+              "bound_claims": {
+                "department": "ai-lab",
+                "realm_access.roles": ["agent", "batch-agent"]
+              },
+              "leeway_secs": 30,
+              "enabled": false
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(p.audiences.len(), 2);
+        assert_eq!(p.identity_claim, "azp");
+        assert_eq!(p.required_scopes, vec!["ai.access"]);
+        let bound = p.bound_claims.as_ref().unwrap();
+        assert_eq!(
+            bound.get("department"),
+            Some(&BoundClaimExpect::One("ai-lab".into()))
+        );
+        assert_eq!(
+            bound.get("realm_access.roles"),
+            Some(&BoundClaimExpect::Any(vec![
+                "agent".into(),
+                "batch-agent".into()
+            ]))
+        );
+        assert_eq!(p.leeway_secs, 30);
+        assert!(!p.enabled);
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let r: Result<OidcProvider, _> = serde_json::from_str(
+            r#"{"name":"x","issuer":"https://x","audiences":["a"],"extra":1}"#,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn defaults_stay_off_the_wire() {
+        let p: OidcProvider =
+            serde_json::from_str(r#"{"name":"x","issuer":"https://x","audiences":["a"]}"#).unwrap();
+        let v = serde_json::to_value(&p).unwrap();
+        assert!(v.get("jwks_uri").is_none());
+        assert!(v.get("required_scopes").is_none());
+        assert!(v.get("bound_claims").is_none());
+        assert!(v.get("leeway_secs").is_none());
+        // identity_claim and enabled serialize with their default values —
+        // both are meaningful to echo back through the Admin API.
+        assert_eq!(v["identity_claim"], "sub");
+        assert_eq!(v["enabled"], true);
+    }
+
+    #[test]
+    fn bound_claim_expect_accepted_iterates_both_forms() {
+        let one = BoundClaimExpect::One("a".into());
+        assert_eq!(one.accepted().collect::<Vec<_>>(), vec!["a"]);
+        let any = BoundClaimExpect::Any(vec!["a".into(), "b".into()]);
+        assert_eq!(any.accepted().collect::<Vec<_>>(), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn resource_trait_points_at_name_and_kind() {
+        assert_eq!(OidcProvider::kind(), "oidc_providers");
+        let mut p: OidcProvider =
+            serde_json::from_str(r#"{"name":"corp","issuer":"https://x","audiences":["a"]}"#)
+                .unwrap();
+        p.runtime_id = "op-1".into();
+        assert_eq!(p.id(), "op-1");
+        assert_eq!(p.name(), "corp");
+    }
+}

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -384,7 +384,27 @@ fn title_single_value_enum_variants(
 /// omits unset fields (`jwks_uri`, `bound_claims`) rather than sending an
 /// explicit `null`.
 pub fn oidc_provider_root_schema() -> Value {
-    struct_root_schema::<crate::models::OidcProvider>(false)
+    let mut schema = struct_root_schema::<crate::models::OidcProvider>(false);
+    // schemars does not propagate the `#[schemars(length(min = 1))]` on
+    // the `BoundClaimExpect::Any(Vec<String>)` variant into the untagged
+    // enum's array branch, so the generated schema would accept an empty
+    // `bound_claims` value list. Re-assert `minItems: 1` to match the
+    // model's non-empty contract.
+    if let Some(any_of) = schema
+        .get_mut("definitions")
+        .and_then(|d| d.get_mut("BoundClaimExpect"))
+        .and_then(|b| b.get_mut("anyOf"))
+        .and_then(Value::as_array_mut)
+    {
+        for branch in any_of.iter_mut() {
+            if branch.get("type").and_then(Value::as_str) == Some("array") {
+                if let Some(obj) = branch.as_object_mut() {
+                    obj.insert("minItems".to_string(), json!(1));
+                }
+            }
+        }
+    }
+    schema
 }
 
 /// Canonical JSON Schema for the `mcp_policy` resource, derived from the

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -33,6 +33,7 @@ pub struct Schemas {
     pub mcp_server: Validator,
     pub mcp_policy: Validator,
     pub a2a_agent: Validator,
+    pub oidc_provider: Validator,
 }
 
 pub static SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::compile()));
@@ -73,6 +74,9 @@ impl Schemas {
             a2a_agent: jsonschema::options()
                 .build(&a2a_agent_root_schema())
                 .expect("a2a_agent schema is well-formed"),
+            oidc_provider: jsonschema::options()
+                .build(&oidc_provider_root_schema())
+                .expect("oidc_provider schema is well-formed"),
         }
     }
 }
@@ -145,6 +149,10 @@ pub fn validate_a2a_agent(value: &Value) -> Result<(), SchemaError> {
 
 pub fn validate_mcp_policy(value: &Value) -> Result<(), SchemaError> {
     validate(&SCHEMAS.mcp_policy, value)
+}
+
+pub fn validate_oidc_provider(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.oidc_provider, value)
 }
 
 /// Build a resource's canonical JSON Schema from its struct via `schemars`,
@@ -368,6 +376,15 @@ fn title_single_value_enum_variants(
                 .or_insert_with(|| Value::String((*title).to_string()));
         }
     }
+}
+
+/// Canonical JSON Schema for the `oidc_provider` resource, derived from the
+/// [`OidcProvider`](crate::models::OidcProvider) struct. Uses the
+/// plain-but-absent `Option` representation (`false`): the control plane
+/// omits unset fields (`jwks_uri`, `bound_claims`) rather than sending an
+/// explicit `null`.
+pub fn oidc_provider_root_schema() -> Value {
+    struct_root_schema::<crate::models::OidcProvider>(false)
 }
 
 /// Canonical JSON Schema for the `mcp_policy` resource, derived from the

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -12,6 +12,7 @@ use super::mcp_policy::McpPolicy;
 use super::mcp_server::McpServer;
 use super::model::Model;
 use super::observability_exporter::ObservabilityExporter;
+use super::oidc_provider::OidcProvider;
 use super::provider_key::ProviderKey;
 use super::rate_limit_policy::RateLimitPolicy;
 use crate::snapshot::ResourceTable;
@@ -49,6 +50,12 @@ pub struct AisixSnapshot {
     /// A2A gateway endpoint fronts each enabled agent, forwarding JSON-RPC
     /// requests to it and serving its card with URLs rewritten to the gateway.
     pub a2a_agents: ResourceTable<A2aAgent>,
+    /// Trusted external identity providers for inbound JWT authentication:
+    /// `/aisix/<env>/oidc_providers/<uuid>`. The proxy auth path matches a
+    /// JWT bearer's `iss` against these rows and, on success, binds the
+    /// request to the API key whose `jwt_subject` equals the token's
+    /// identity claim.
+    pub oidc_providers: ResourceTable<OidcProvider>,
 }
 
 impl AisixSnapshot {
@@ -70,6 +77,7 @@ impl AisixSnapshot {
             + self.mcp_servers.len()
             + self.mcp_policies.len()
             + self.a2a_agents.len()
+            + self.oidc_providers.len()
     }
 }
 

--- a/crates/aisix-core/src/snapshot.rs
+++ b/crates/aisix-core/src/snapshot.rs
@@ -108,6 +108,33 @@ impl<T: Resource> ResourceTable<T> {
     pub fn entries(&self) -> Vec<Arc<ResourceEntry<T>>> {
         self.by_id.iter().map(|kv| kv.value().clone()).collect()
     }
+
+    /// True when any entry satisfies `pred`, without materialising the
+    /// table into a `Vec`. Cheaper than `entries().iter().any(...)` on the
+    /// hot path (no allocation, no per-row `Arc` clone). A DashMap shard
+    /// guard is held during the scan, so `pred` must not call back into
+    /// this table.
+    pub fn any(&self, pred: impl Fn(&ResourceEntry<T>) -> bool) -> bool {
+        self.by_id.iter().any(|kv| pred(kv.value()))
+    }
+
+    /// The lowest-`id` entry satisfying `pred`, without materialising the
+    /// table. The deterministic lowest-id tie-break matches the resolvers
+    /// that need a stable winner when duplicates exist transiently.
+    pub fn find_min_by_id(
+        &self,
+        pred: impl Fn(&ResourceEntry<T>) -> bool,
+    ) -> Option<Arc<ResourceEntry<T>>> {
+        self.by_id.iter().fold(None, |best, kv| {
+            if !pred(kv.value()) {
+                return best;
+            }
+            match &best {
+                Some(b) if b.id <= kv.value().id => best,
+                _ => Some(kv.value().clone()),
+            }
+        })
+    }
 }
 
 /// Handle consumers clone to reach the current snapshot.

--- a/crates/aisix-core/src/snapshot.rs
+++ b/crates/aisix-core/src/snapshot.rs
@@ -118,22 +118,27 @@ impl<T: Resource> ResourceTable<T> {
         self.by_id.iter().any(|kv| pred(kv.value()))
     }
 
-    /// The lowest-`id` entry satisfying `pred`, without materialising the
-    /// table. The deterministic lowest-id tie-break matches the resolvers
-    /// that need a stable winner when duplicates exist transiently.
-    pub fn find_min_by_id(
+    /// The single entry satisfying `pred`, without materialising the
+    /// table. Returns `(None, true)` when more than one entry matches so
+    /// the caller can fail closed on an ambiguous lookup and log the
+    /// misconfiguration — a security-sensitive resolver must never pick
+    /// one of several matches silently. `(Some(_), false)` on exactly
+    /// one match; `(None, false)` on none.
+    pub fn find_unique_by(
         &self,
         pred: impl Fn(&ResourceEntry<T>) -> bool,
-    ) -> Option<Arc<ResourceEntry<T>>> {
-        self.by_id.iter().fold(None, |best, kv| {
+    ) -> (Option<Arc<ResourceEntry<T>>>, bool) {
+        let mut found: Option<Arc<ResourceEntry<T>>> = None;
+        for kv in self.by_id.iter() {
             if !pred(kv.value()) {
-                return best;
+                continue;
             }
-            match &best {
-                Some(b) if b.id <= kv.value().id => best,
-                _ => Some(kv.value().clone()),
+            if found.is_some() {
+                return (None, true);
             }
-        })
+            found = Some(kv.value().clone());
+        }
+        (found, false)
     }
 }
 

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -14,9 +14,10 @@
 use aisix_core::models::{
     validate_a2a_agent, validate_apikey, validate_cache_policy, validate_guardrail,
     validate_guardrail_attachment, validate_mcp_policy, validate_mcp_server, validate_model,
-    validate_observability_exporter, validate_provider_key, validate_rate_limit_policy, A2aAgent,
-    ApiKey, CachePolicy, Guardrail, GuardrailAttachment, McpPolicy, McpServer, Model,
-    ObservabilityExporter, ProviderKey, RateLimitPolicy, SchemaError,
+    validate_observability_exporter, validate_oidc_provider, validate_provider_key,
+    validate_rate_limit_policy, A2aAgent, ApiKey, CachePolicy, Guardrail, GuardrailAttachment,
+    McpPolicy, McpServer, Model, ObservabilityExporter, OidcProvider, ProviderKey, RateLimitPolicy,
+    SchemaError,
 };
 use aisix_core::resource::ResourceEntry;
 use aisix_core::AisixSnapshot;
@@ -279,6 +280,18 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
                     &mut stats,
                 ) {
                     snapshot.a2a_agents.insert(entry);
+                }
+            }
+            "oidc_providers" => {
+                if let Some(entry) = validate_and_parse::<OidcProvider>(
+                    &raw.key,
+                    raw.revision,
+                    parsed,
+                    &value,
+                    validate_oidc_provider,
+                    &mut stats,
+                ) {
+                    snapshot.oidc_providers.insert(entry);
                 }
             }
             other => {

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -486,6 +486,9 @@ impl<P: ConfigProvider> Supervisor<P> {
             for e in tiny.a2a_agents.entries() {
                 new.a2a_agents.insert(clone_entry(&e));
             }
+            for e in tiny.oidc_providers.entries() {
+                new.oidc_providers.insert(clone_entry(&e));
+            }
             new
         });
         self.remove_rejection_for_key(&entry.key);
@@ -544,6 +547,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             "mcp_servers" => snap.mcp_servers.get_by_id(parsed.id).is_some(),
             "mcp_policies" => snap.mcp_policies.get_by_id(parsed.id).is_some(),
             "a2a_agents" => snap.a2a_agents.get_by_id(parsed.id).is_some(),
+            "oidc_providers" => snap.oidc_providers.get_by_id(parsed.id).is_some(),
             _ => false,
         };
         let removed_rejection = self.remove_rejection_for_key(key_str);
@@ -599,6 +603,9 @@ impl<P: ConfigProvider> Supervisor<P> {
                 }
                 "a2a_agents" => {
                     new.a2a_agents.remove(parsed.id);
+                }
+                "oidc_providers" => {
+                    new.oidc_providers.remove(parsed.id);
                 }
                 _ => {}
             }
@@ -850,6 +857,9 @@ fn clone_snapshot(src: &AisixSnapshot) -> AisixSnapshot {
     for e in src.a2a_agents.entries() {
         out.a2a_agents.insert(clone_entry(&e));
     }
+    for e in src.oidc_providers.entries() {
+        out.oidc_providers.insert(clone_entry(&e));
+    }
     out
 }
 
@@ -873,6 +883,7 @@ fn resource_counts(snap: &AisixSnapshot) -> BTreeMap<String, usize> {
         ("mcp_servers", snap.mcp_servers.len()),
         ("mcp_policies", snap.mcp_policies.len()),
         ("a2a_agents", snap.a2a_agents.len()),
+        ("oidc_providers", snap.oidc_providers.len()),
     ] {
         if n > 0 {
             counts.insert(kind.to_string(), n);
@@ -1015,6 +1026,15 @@ mod tests {
             "scope_id": "m-1",
             "priority": 100
         }"#;
+        // An OIDC trust provider created mid-run (AISIX-Cloud#1080).
+        // Same trap as #826: the kind existed in the loader but was
+        // initially missing from apply_put's merge loop, so enabling
+        // JWT auth via watch silently never took effect until resync.
+        const VALID_OIDC_PROVIDER: &[u8] = br#"{
+            "name": "watch-idp",
+            "issuer": "https://idp.example.com/realms/agents",
+            "audiences": ["aisix-gateway"]
+        }"#;
 
         let provider = Arc::new(FakeProvider::new(vec![], 0));
         let sup = Supervisor::new(provider, "/aisix");
@@ -1038,6 +1058,11 @@ mod tests {
                 VALID_OBSERVABILITY_EXPORTER,
                 "ObservabilityExporter",
             ),
+            (
+                "/aisix/oidc_providers/op-1",
+                VALID_OIDC_PROVIDER,
+                "OidcProvider",
+            ),
         ] {
             assert!(
                 sup.apply_put(&entry(key, body, 2)),
@@ -1059,6 +1084,7 @@ mod tests {
             1,
             "ObservabilityExporter not merged"
         );
+        assert_eq!(snap.oidc_providers.len(), 1, "OidcProvider not merged");
     }
 
     #[tokio::test]
@@ -1078,6 +1104,13 @@ mod tests {
                     br#"{"guardrail_id":"g-1","scope_type":"model","scope_id":"m-1","priority":100}"#,
                     1,
                 ),
+                // AISIX-Cloud#1080: deleting a trust provider must reach
+                // the snapshot, or revoking JWT auth never takes effect.
+                entry(
+                    "/aisix/oidc_providers/op-1",
+                    br#"{"name":"idp","issuer":"https://idp.example.com","audiences":["aisix"]}"#,
+                    1,
+                ),
             ],
             1,
         ));
@@ -1085,10 +1118,13 @@ mod tests {
         sup.load_once().await.unwrap();
         assert_eq!(sup.handle().load().provider_keys.len(), 1);
         assert_eq!(sup.handle().load().guardrail_attachments.len(), 1);
+        assert_eq!(sup.handle().load().oidc_providers.len(), 1);
         assert!(sup.apply_delete("/aisix/provider_keys/pk-1"));
         assert!(sup.handle().load().provider_keys.is_empty());
         assert!(sup.apply_delete("/aisix/guardrail_attachments/ga-1"));
         assert!(sup.handle().load().guardrail_attachments.is_empty());
+        assert!(sup.apply_delete("/aisix/oidc_providers/op-1"));
+        assert!(sup.handle().load().oidc_providers.is_empty());
     }
 
     #[tokio::test]

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -84,6 +84,17 @@ pub const M_USAGE_EVENT_DROPS_TOTAL: &str = "aisix_usage_event_drops_total";
 /// `/v1/messages` path in — read these as chat-path, not gateway-wide.
 pub const M_GUARDRAIL_BLOCKS_TOTAL: &str = "aisix_guardrail_blocks_total";
 pub const M_GUARDRAIL_BYPASSES_TOTAL: &str = "aisix_guardrail_bypasses_total";
+/// Per-request inbound authentication decisions
+/// (AISIX-Cloud#1080/#1081). Before this series, a rejected credential
+/// was invisible: the auth extractor short-circuits ahead of every
+/// handler, so no request counter and no access-log line ever fired
+/// for a 401. Labels, all bounded:
+/// - `method`: `api_key` / `jwt` / `none` (no credential presented).
+/// - `result`: `allowed` / `denied`.
+/// - `reason`: the DP-internal denial reason class (e.g. `unknown_key`,
+///   `key_expired`, `jwt_bad_signature`, `jwt_untrusted_issuer`,
+///   `jwt_identity_unmapped`); `none` when allowed.
+pub const M_AUTH_DECISIONS_TOTAL: &str = "aisix_auth_decisions_total";
 /// Per-execution guardrail latency histogram (AISIX-Cloud#1076), recorded
 /// by the chain fold for every member consulted on any handler — chat,
 /// messages, responses, embeddings, streaming end-of-stream/window scans,
@@ -366,6 +377,22 @@ impl Metrics {
                 "status" => status.to_string(),
             )
             .record(duration.as_secs_f64());
+        });
+    }
+
+    /// Record one inbound authentication decision on
+    /// [`M_AUTH_DECISIONS_TOTAL`] (AISIX-Cloud#1081). Called from the
+    /// proxy auth choke point for every credential judgment — allowed
+    /// or denied, API-key and JWT paths alike.
+    pub fn record_auth_decision(&self, method: &str, allowed: bool, reason: &str) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_AUTH_DECISIONS_TOTAL,
+                "method" => method.to_string(),
+                "result" => if allowed { "allowed" } else { "denied" }.to_string(),
+                "reason" => if reason.is_empty() { "none" } else { reason }.to_string(),
+            )
+            .increment(1);
         });
     }
 

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -35,6 +35,9 @@ aisix-guardrails = { path = "../aisix-guardrails" }
 tokio.workspace = true
 axum.workspace = true
 reqwest.workspace = true
+# Inbound OIDC/JWT verification on the proxy auth path (jwt.rs). Same
+# major as the vertex provider's service-account signer.
+jsonwebtoken = "9"
 tower.workspace = true
 tower-http.workspace = true
 http-body-util.workspace = true

--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -65,16 +65,13 @@ pub(crate) async fn authenticate_token(
     state: &ProxyState,
     token: &str,
 ) -> Result<AuthenticatedKey, ProxyError> {
-    if crate::jwt::looks_like_jwt(token) {
-        let has_providers = crate::jwt::any_enabled_provider(&state.snapshot.load());
-        if has_providers {
-            return crate::jwt::authenticate_jwt(state, token).await;
-        }
+    let snapshot = state.snapshot.load();
+    if crate::jwt::looks_like_jwt(token) && crate::jwt::any_enabled_provider(&snapshot) {
+        return crate::jwt::authenticate_jwt(state, &snapshot, token).await;
         // No enabled trust provider: fall through to the key path so a
         // custom-imported key that happens to look like a JWT keeps
         // authenticating on deployments that never enable JWT auth.
     }
-    let snapshot = state.snapshot.load();
     // Self-hosted CP (prd-09a §9A.7B.4): the snapshot stores
     // SHA-256 hashes of the plaintext bearer, never the plaintext
     // itself. Hash the incoming token via the canonical helper
@@ -104,14 +101,30 @@ pub(crate) async fn authenticate_token(
 /// short-circuits ahead of every handler, so neither the request
 /// counter nor the access log ever fired). The token itself is never
 /// logged.
+///
+/// `unknown_key` is the scanner-probe shape (`Bearer <junk>`) and
+/// carries no operator signal beyond the metric — same reasoning as the
+/// extractor's `missing_credentials`, which is also metric-only. It logs
+/// at `debug` so an internet-facing DP is not flooded. `key_disabled` /
+/// `key_expired` name a real key an operator provisioned, so they stay
+/// at `warn`.
 fn deny_key(state: &ProxyState, reason: &'static str, err: ProxyError) -> ProxyError {
     state.metrics.record_auth_decision("api_key", false, reason);
-    tracing::warn!(
-        target: "aisix::auth",
-        method = "api_key",
-        reason = %reason,
-        "rejected inbound credential",
-    );
+    if reason == "unknown_key" {
+        tracing::debug!(
+            target: "aisix::auth",
+            method = "api_key",
+            reason = %reason,
+            "rejected inbound credential",
+        );
+    } else {
+        tracing::warn!(
+            target: "aisix::auth",
+            method = "api_key",
+            reason = %reason,
+            "rejected inbound credential",
+        );
+    }
     err
 }
 

--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -36,20 +36,44 @@ where
     type Rejection = ProxyError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let token = extract_bearer(parts)?;
         let proxy_state = ProxyState::from_ref(state);
-        authenticate_token(&proxy_state, &token)
+        let token = match extract_bearer(parts) {
+            Ok(t) => t,
+            Err(e) => {
+                // No credential at all: metric only — logging every
+                // scanner probe would be noise (AISIX-Cloud#1081).
+                proxy_state
+                    .metrics
+                    .record_auth_decision("none", false, "missing_credentials");
+                return Err(e);
+            }
+        };
+        authenticate_token(&proxy_state, &token).await
     }
 }
 
-/// Look a plaintext bearer up in the snapshot and enforce key lifecycle.
-/// The single auth choke point behind the [`AuthenticatedKey`] extractor;
-/// also called directly by surfaces whose credentials arrive outside the
+/// Authenticate a plaintext bearer and enforce key lifecycle. The single
+/// auth choke point behind the [`AuthenticatedKey`] extractor; also
+/// called directly by surfaces whose credentials arrive outside the
 /// standard headers (WebSocket subprotocol auth on `/v1/realtime`).
-pub(crate) fn authenticate_token(
+///
+/// A JWT-shaped bearer takes the OIDC path (`crate::jwt`) whenever the
+/// environment has an enabled trust provider — with no fallback to the
+/// key lookup on failure, so a rejected JWT can never be retried as a
+/// key. Everything else is looked up as an API key by hash.
+pub(crate) async fn authenticate_token(
     state: &ProxyState,
     token: &str,
 ) -> Result<AuthenticatedKey, ProxyError> {
+    if crate::jwt::looks_like_jwt(token) {
+        let has_providers = crate::jwt::any_enabled_provider(&state.snapshot.load());
+        if has_providers {
+            return crate::jwt::authenticate_jwt(state, token).await;
+        }
+        // No enabled trust provider: fall through to the key path so a
+        // custom-imported key that happens to look like a JWT keeps
+        // authenticating on deployments that never enable JWT auth.
+    }
     let snapshot = state.snapshot.load();
     // Self-hosted CP (prd-09a §9A.7B.4): the snapshot stores
     // SHA-256 hashes of the plaintext bearer, never the plaintext
@@ -57,22 +81,38 @@ pub(crate) fn authenticate_token(
     // and look up by the hex digest. cp-api hashes with the same
     // function before persistence, so the two sides agree byte
     // for byte.
-    let entry = snapshot
-        .apikeys
-        .get_by_name(&ApiKey::hash_bearer(token))
-        .ok_or(ProxyError::InvalidApiKey)?;
+    let Some(entry) = snapshot.apikeys.get_by_name(&ApiKey::hash_bearer(token)) else {
+        return Err(deny_key(state, "unknown_key", ProxyError::InvalidApiKey));
+    };
     // Lifecycle enforcement (#933): a known key that is disabled or
     // past its expiry deadline must be rejected here, at the single
     // auth choke point, so every proxy surface (chat, messages,
     // responses, embeddings, audio, passthrough, MCP, …) inherits
     // the same 401 without per-handler checks.
     if entry.value.disabled {
-        return Err(ProxyError::ApiKeyDisabled);
+        return Err(deny_key(state, "key_disabled", ProxyError::ApiKeyDisabled));
     }
     if entry.value.is_expired_at(chrono::Utc::now()) {
-        return Err(ProxyError::ApiKeyExpired);
+        return Err(deny_key(state, "key_expired", ProxyError::ApiKeyExpired));
     }
+    state.metrics.record_auth_decision("api_key", true, "");
     Ok(AuthenticatedKey { entry })
+}
+
+/// Record an API-key denial on the decision metric + log
+/// (AISIX-Cloud#1081 — before this, a 401 was invisible: the extractor
+/// short-circuits ahead of every handler, so neither the request
+/// counter nor the access log ever fired). The token itself is never
+/// logged.
+fn deny_key(state: &ProxyState, reason: &'static str, err: ProxyError) -> ProxyError {
+    state.metrics.record_auth_decision("api_key", false, reason);
+    tracing::warn!(
+        target: "aisix::auth",
+        method = "api_key",
+        reason = %reason,
+        "rejected inbound credential",
+    );
+    err
 }
 
 fn extract_bearer(parts: &Parts) -> Result<String, ProxyError> {

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -155,6 +155,39 @@ pub enum ProxyError {
     /// (#933). Same disclosure reasoning as [`Self::ApiKeyExpired`].
     #[error("API key has been disabled")]
     ApiKeyDisabled,
+    /// The bearer was a JWT whose validation failed: malformed token,
+    /// untrusted issuer, bad signature, audience mismatch, or an
+    /// unresolvable signing key. Deliberately collapsed into one
+    /// caller-visible reason so a probe cannot use the taxonomy as an
+    /// oracle for which issuers this gateway trusts; the detailed
+    /// reason goes to the auth decision log only.
+    #[error("invalid JWT")]
+    JwtInvalid,
+    /// The JWT's `exp` deadline has passed. Caller-visible as
+    /// "expired" for the same reason as [`Self::ApiKeyExpired`]: the
+    /// caller already holds the token, and naming the reason tells
+    /// them to fetch a fresh one from their identity provider instead
+    /// of debugging a rejection.
+    #[error("JWT has expired")]
+    JwtExpired,
+    /// The JWT verified but does not satisfy the trust provider's
+    /// `required_scopes` / `bound_claims` requirements. 403: the
+    /// caller is authenticated, just not entitled.
+    #[error("JWT does not satisfy the required scopes or claims")]
+    JwtClaimsRejected,
+    /// The JWT verified but no API key carries a `jwt_subject` equal
+    /// to its identity claim. Named explicitly (not a generic invalid
+    /// credential) because the fix — binding a key to the identity —
+    /// belongs to the gateway operator, and the caller-visible code is
+    /// what they'll be shown when onboarding a fleet of agents.
+    #[error("no API key is bound to this JWT identity")]
+    JwtIdentityUnmapped,
+    /// The signing keys for the matched trust provider could not be
+    /// fetched (identity provider unreachable and nothing cached).
+    /// 503 rather than 401: the token was not judged invalid, the
+    /// gateway just cannot verify it right now — retryable.
+    #[error("unable to fetch the identity provider's signing keys")]
+    JwksUnavailable,
     #[error("model {0:?} not found")]
     ModelNotFound(String),
     /// A `/v1/videos/{video_id}` id that this gateway could not have
@@ -243,7 +276,12 @@ impl ProxyError {
             ProxyError::MissingAuth
             | ProxyError::InvalidApiKey
             | ProxyError::ApiKeyExpired
-            | ProxyError::ApiKeyDisabled => StatusCode::UNAUTHORIZED,
+            | ProxyError::ApiKeyDisabled
+            | ProxyError::JwtInvalid
+            | ProxyError::JwtExpired
+            | ProxyError::JwtIdentityUnmapped => StatusCode::UNAUTHORIZED,
+            ProxyError::JwtClaimsRejected => StatusCode::FORBIDDEN,
+            ProxyError::JwksUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             ProxyError::ModelForbidden(_) => StatusCode::FORBIDDEN,
             ProxyError::ModelIpRestricted(_) => StatusCode::FORBIDDEN,
             ProxyError::ModelNotFound(_) => StatusCode::NOT_FOUND,
@@ -266,7 +304,14 @@ impl ProxyError {
             ProxyError::MissingAuth
             | ProxyError::InvalidApiKey
             | ProxyError::ApiKeyExpired
-            | ProxyError::ApiKeyDisabled => "invalid_api_key",
+            | ProxyError::ApiKeyDisabled
+            | ProxyError::JwtInvalid
+            | ProxyError::JwtExpired
+            | ProxyError::JwtIdentityUnmapped => "invalid_api_key",
+            ProxyError::JwtClaimsRejected => "permission_denied",
+            // Auth infrastructure fault, not a credential judgment — the
+            // generic server-fault family, like a 5xx from dispatch.
+            ProxyError::JwksUnavailable => "api_error",
             ProxyError::ModelForbidden(_) => "permission_denied",
             ProxyError::ModelIpRestricted(_) => "permission_denied",
             ProxyError::ModelNotFound(_) => "model_not_found",
@@ -353,6 +398,18 @@ impl ProxyError {
             // `error.type` stays the family-wide `invalid_api_key`.
             ProxyError::ApiKeyExpired => env.with_code("api_key_expired"),
             ProxyError::ApiKeyDisabled => env.with_code("api_key_disabled"),
+            // Same stable-code convention for the JWT auth path
+            // (AISIX-Cloud#1080/#1081): SDKs and agent frameworks branch
+            // on `error.code` to decide between refreshing the token
+            // (`jwt_expired`), fixing the token request
+            // (`jwt_invalid` / `jwt_claims_rejected`), and asking the
+            // gateway operator to bind the identity to a key
+            // (`jwt_identity_unmapped`).
+            ProxyError::JwtInvalid => env.with_code("jwt_invalid"),
+            ProxyError::JwtExpired => env.with_code("jwt_expired"),
+            ProxyError::JwtClaimsRejected => env.with_code("jwt_claims_rejected"),
+            ProxyError::JwtIdentityUnmapped => env.with_code("jwt_identity_unmapped"),
+            ProxyError::JwksUnavailable => env.with_code("jwks_unavailable"),
             _ => env,
         }
     }

--- a/crates/aisix-proxy/src/jwt.rs
+++ b/crates/aisix-proxy/src/jwt.rs
@@ -128,35 +128,56 @@ fn unverified_issuer(token: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-/// The enabled provider matching `iss`, ties broken by lowest id so
-/// duplicate rows resolve deterministically (same discipline as the MCP
-/// policy resolver).
+/// The enabled provider matching `iss`. Fails closed on ambiguity: if
+/// two enabled providers claim the same issuer their audience/scope/
+/// claim policies differ, so silently picking one would apply the wrong
+/// policy — the request is denied instead. The control plane enforces
+/// per-environment issuer uniqueness and the file loader rejects
+/// duplicates, so this only guards a transient etcd race or a CP bug.
 fn provider_for_issuer(
     snapshot: &AisixSnapshot,
     iss: &str,
 ) -> Option<Arc<ResourceEntry<OidcProvider>>> {
-    snapshot
+    let (found, ambiguous) = snapshot
         .oidc_providers
-        .find_min_by_id(|e| e.value.enabled && e.value.issuer == iss)
+        .find_unique_by(|e| e.value.enabled && e.value.issuer == iss);
+    if ambiguous {
+        tracing::warn!(
+            target: "aisix::auth",
+            issuer = %clip(iss),
+            "two enabled OIDC providers claim this issuer; failing closed — \
+             their policies differ and neither can be chosen unambiguously",
+        );
+    }
+    found
 }
 
-/// The API key bound to `subject` **as asserted by `provider_name`**,
-/// ties broken by lowest id. A key whose `jwt_provider` names a different
-/// trust provider is never a candidate: subjects are namespaced by the
-/// provider that vouched for them, so a second trusted provider cannot
-/// mint a token impersonating the first provider's identity of the same
-/// name. The control plane enforces `(jwt_provider, jwt_subject)`
-/// uniqueness, so the tie-break only matters for a transient duplicate
-/// mid-sync.
+/// The API key bound to `subject` **as asserted by `provider_name`**. A
+/// key whose `jwt_provider` names a different trust provider is never a
+/// candidate: subjects are namespaced by the provider that vouched for
+/// them, so a second trusted provider cannot mint a token impersonating
+/// the first provider's identity of the same name. Fails closed on
+/// ambiguity for the same reason as [`provider_for_issuer`] — the CP
+/// enforces `(jwt_provider, jwt_subject)` uniqueness and the file loader
+/// rejects duplicates, so this only guards a transient race.
 fn key_for_subject(
     snapshot: &AisixSnapshot,
     provider_name: &str,
     subject: &str,
 ) -> Option<Arc<ResourceEntry<ApiKey>>> {
-    snapshot.apikeys.find_min_by_id(|e| {
+    let (found, ambiguous) = snapshot.apikeys.find_unique_by(|e| {
         e.value.jwt_subject.as_deref() == Some(subject)
             && e.value.jwt_provider.as_deref() == Some(provider_name)
-    })
+    });
+    if ambiguous {
+        tracing::warn!(
+            target: "aisix::auth",
+            provider = %clip(provider_name),
+            "two API keys share one jwt binding; failing closed — the identity \
+             is ambiguous and neither key's limits can be applied",
+        );
+    }
+    found
 }
 
 /// Authenticate a JWT-shaped bearer. Called from the auth choke point
@@ -633,6 +654,9 @@ fn http_client() -> &'static reqwest::Client {
 /// discovery document cannot relocate trust material into our network.
 async fn resolve_jwks_url(prov: &OidcProvider) -> Result<String, String> {
     if let Some(u) = &prov.jwks_uri {
+        if url_has_credentials(u) {
+            return Err("jwks_uri must not embed credentials".to_string());
+        }
         return Ok(u.clone());
     }
     let now = Instant::now();
@@ -694,6 +718,9 @@ async fn resolve_jwks_url(prov: &OidcProvider) -> Result<String, String> {
             if !same_origin(&prov.issuer, &jwks_uri) {
                 return Err("discovery jwks_uri is not on the issuer's origin".to_string());
             }
+            if url_has_credentials(&jwks_uri) {
+                return Err("discovery jwks_uri must not embed credentials".to_string());
+            }
             write_recover(discovery_cache())
                 .entry(prov.issuer.clone())
                 .or_insert(DiscoveryEntry {
@@ -716,6 +743,29 @@ async fn resolve_jwks_url(prov: &OidcProvider) -> Result<String, String> {
             }
             Err(format!("OIDC discovery failed: {e}"))
         }
+    }
+}
+
+/// True when a URL embeds credentials that must never sit in a public
+/// JWKS endpoint: userinfo (`user:pass@host`) or a credential query
+/// parameter. A defense-in-depth mirror of the control plane's ingestion
+/// check, for file-mode and discovery-returned URLs.
+fn url_has_credentials(url: &str) -> bool {
+    match reqwest::Url::parse(url) {
+        Ok(u) => {
+            if !u.username().is_empty() || u.password().is_some() {
+                return true;
+            }
+            u.query_pairs().any(|(k, _)| {
+                matches!(
+                    k.to_ascii_lowercase().as_str(),
+                    "access_token" | "token" | "client_secret" | "password" | "api_key" | "apikey"
+                )
+            })
+        }
+        // Unparseable here is caught elsewhere (fetch fails); treat as
+        // credential-free so this check doesn't double-report.
+        Err(_) => false,
     }
 }
 
@@ -1171,20 +1221,36 @@ jyxumGxNpoIV8LlzsMsaWQ==
     }
 
     #[test]
-    fn provider_and_subject_selection_tie_break_on_lowest_id() {
+    fn provider_selection_is_unique_and_fails_closed_on_duplicate_issuer() {
         let snapshot = AisixSnapshot::new();
-        let mk = |id: &str, enabled: bool| {
+        let mk = |id: &str, issuer: &str, enabled: bool| {
             let mut p = base_provider();
+            p.issuer = issuer.to_string();
             p.enabled = enabled;
             snapshot.oidc_providers.insert(ResourceEntry::new(id, p, 1));
         };
-        mk("b-provider", true);
-        mk("a-provider", true);
-        mk("0-disabled", false);
-        let picked = provider_for_issuer(&snapshot, "https://idp.test/realms/agents").unwrap();
-        assert_eq!(picked.id, "a-provider");
-        assert!(provider_for_issuer(&snapshot, "https://other.test").is_none());
+        mk("corp", "https://corp.test", true);
+        mk("partner", "https://partner.test", true);
+        mk("disabled", "https://off.test", false);
+        assert_eq!(
+            provider_for_issuer(&snapshot, "https://corp.test")
+                .unwrap()
+                .id,
+            "corp"
+        );
+        // A disabled provider is not selected even on an exact issuer match.
+        assert!(provider_for_issuer(&snapshot, "https://off.test").is_none());
+        assert!(provider_for_issuer(&snapshot, "https://unknown.test").is_none());
 
+        // Two ENABLED providers claiming one issuer -> fail closed, not a
+        // silent pick (their audience/scope policies differ).
+        mk("corp-dup", "https://corp.test", true);
+        assert!(provider_for_issuer(&snapshot, "https://corp.test").is_none());
+    }
+
+    #[test]
+    fn key_selection_namespaces_by_provider_and_fails_closed_on_duplicate() {
+        let snapshot = AisixSnapshot::new();
         let mk_key = |id: &str, subject: Option<&str>, provider: Option<&str>| {
             let mut k: ApiKey =
                 serde_json::from_str(r#"{"key_hash":"h","allowed_models":["*"]}"#).unwrap();
@@ -1194,13 +1260,11 @@ jyxumGxNpoIV8LlzsMsaWQ==
             k.key_hash = format!("hash-{id}");
             snapshot.apikeys.insert(ResourceEntry::new(id, k, 1));
         };
-        mk_key("k-2", Some("agent-1"), Some("corp"));
         mk_key("k-1", Some("agent-1"), Some("corp"));
         mk_key("k-3", Some("agent-2"), Some("corp"));
         mk_key("k-4", None, None);
-        // A key bound to the SAME subject under a DIFFERENT provider must
-        // never be selected — this is the cross-provider impersonation
-        // guard (audit H1).
+        // Same subject under a DIFFERENT provider resolves separately —
+        // the cross-provider impersonation guard (audit H1).
         mk_key("k-5", Some("agent-1"), Some("partner"));
         assert_eq!(
             key_for_subject(&snapshot, "corp", "agent-1").unwrap().id,
@@ -1214,9 +1278,13 @@ jyxumGxNpoIV8LlzsMsaWQ==
             key_for_subject(&snapshot, "partner", "agent-1").unwrap().id,
             "k-5"
         );
-        // No provider match → no key, even though the subject exists.
+        // No provider match -> no key, even though the subject exists.
         assert!(key_for_subject(&snapshot, "unknown", "agent-1").is_none());
         assert!(key_for_subject(&snapshot, "corp", "agent-9").is_none());
+
+        // A duplicate (provider, subject) pair -> fail closed.
+        mk_key("k-1-dup", Some("agent-1"), Some("corp"));
+        assert!(key_for_subject(&snapshot, "corp", "agent-1").is_none());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/jwt.rs
+++ b/crates/aisix-proxy/src/jwt.rs
@@ -1,0 +1,1050 @@
+//! Inbound OIDC/JWT authentication (AISIX-Cloud#1080, #1081).
+//!
+//! When the environment has at least one enabled [`OidcProvider`], a bearer
+//! token that is a JWT is authenticated here instead of the API-key hash
+//! lookup: the token's unverified `iss` selects the trust provider, the
+//! signature is verified against the provider's JWKS (fetched and cached,
+//! with a rate-limited refresh when an unknown `kid` appears so key
+//! rotation needs no restart), the registered claims (`exp` required,
+//! `aud` against the provider's accepted audiences, `nbf` when present)
+//! and the provider's `required_scopes` / `bound_claims` are enforced, and
+//! the value of the provider's `identity_claim` selects the API key whose
+//! `jwt_subject` equals it. The request then proceeds as that key — its
+//! `allowed_models`, rate limits, budget, and usage attribution all apply
+//! unchanged.
+//!
+//! Design invariants:
+//!
+//! - **No fallback**: once a token is JWT-shaped and JWT auth is enabled,
+//!   a validation failure is final — it is never retried as an API key.
+//! - **Issuer allow-list**: a JWT whose `iss` matches no enabled provider
+//!   is rejected; there is no catch-all validation path.
+//! - **Default deny**: `exp`, `iss`, and `aud` must be present and valid
+//!   on every token; a missing identity claim or an unmapped identity is
+//!   a rejection, never an anonymous pass.
+//! - **Asymmetric algorithms only**: HMAC family excluded, so a JWKS can
+//!   never be confused into acting as a shared secret.
+//! - Every decision (allow and deny, API-key and JWT path alike) is
+//!   recorded on the `aisix_auth_decisions_total` metric, and denials are
+//!   logged under `target: "aisix::auth"` with the detailed reason class —
+//!   the raw token is never logged.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::{Duration, Instant};
+
+use aisix_core::models::{BoundClaimExpect, OidcProvider};
+use aisix_core::resource::ResourceEntry;
+use aisix_core::{AisixSnapshot, ApiKey};
+use base64::Engine;
+use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::{Algorithm, DecodingKey, Validation};
+
+use crate::auth::AuthenticatedKey;
+use crate::error::ProxyError;
+use crate::state::ProxyState;
+
+/// How long a fetched JWKS (and a discovery-resolved JWKS URL) stays fresh.
+const JWKS_TTL: Duration = Duration::from_secs(600);
+
+/// Minimum interval between fetches for one JWKS URL outside the TTL
+/// schedule — bounds both the unknown-`kid` refresh (a token signed by a
+/// just-rotated key triggers at most one refetch per interval, so rotation
+/// is picked up within a second while a stream of garbage `kid`s cannot
+/// flood the identity provider) and retries after a failed fetch.
+const JWKS_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Per-request deadline for JWKS / discovery fetches.
+const JWKS_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cap on a JWKS / discovery response body. A real JWKS is a few KB; the
+/// cap keeps a misconfigured URL (pointing at some arbitrary endpoint)
+/// from ballooning memory.
+const JWKS_MAX_BYTES: usize = 512 * 1024;
+
+/// Verification algorithms accepted on inbound JWTs: the asymmetric
+/// families only. HMAC is deliberately excluded — accepting it would let
+/// a public JWKS double as a shared signing secret (algorithm-confusion).
+const ALLOWED_ALGS: [Algorithm; 9] = [
+    Algorithm::RS256,
+    Algorithm::RS384,
+    Algorithm::RS512,
+    Algorithm::PS256,
+    Algorithm::PS384,
+    Algorithm::PS512,
+    Algorithm::ES256,
+    Algorithm::ES384,
+    Algorithm::EdDSA,
+];
+
+/// Cap on signature attempts for a token without a `kid` against a
+/// multi-key JWKS.
+const MAX_KEYS_TRIED: usize = 8;
+
+/// True when the bearer has the structural shape of a JWT: three
+/// non-empty dot-separated segments whose first segment base64url-decodes
+/// to a JSON object carrying `alg` (a JOSE header). The header check
+/// keeps custom-imported API keys that merely contain dots on the
+/// API-key path.
+pub(crate) fn looks_like_jwt(token: &str) -> bool {
+    let parts: Vec<&str> = token.splitn(4, '.').collect();
+    if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+        return false;
+    }
+    matches!(b64url_json(parts[0]), Some(v) if v.get("alg").is_some())
+}
+
+/// True when the snapshot has at least one enabled trust provider — the
+/// gate for entering the JWT path at all.
+pub(crate) fn any_enabled_provider(snapshot: &AisixSnapshot) -> bool {
+    snapshot
+        .oidc_providers
+        .entries()
+        .iter()
+        .any(|e| e.value.enabled)
+}
+
+fn b64url_json(segment: &str) -> Option<serde_json::Value> {
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(segment)
+        .ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Unverified peek at the payload's `iss`, used only to select the trust
+/// provider. The selected provider's issuer is then pinned in the real
+/// validation, so a forged `iss` still has to survive signature and
+/// issuer verification against that provider's keys.
+fn unverified_issuer(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    b64url_json(payload)?
+        .get("iss")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// The enabled provider matching `iss`, ties broken by lowest id so
+/// duplicate rows resolve deterministically (same discipline as the MCP
+/// policy resolver).
+fn provider_for_issuer(
+    snapshot: &AisixSnapshot,
+    iss: &str,
+) -> Option<Arc<ResourceEntry<OidcProvider>>> {
+    let mut best: Option<Arc<ResourceEntry<OidcProvider>>> = None;
+    for entry in snapshot.oidc_providers.entries() {
+        if !entry.value.enabled || entry.value.issuer != iss {
+            continue;
+        }
+        match &best {
+            Some(b) if b.id <= entry.id => {}
+            _ => best = Some(entry),
+        }
+    }
+    best
+}
+
+/// The API key bound to `subject` via `jwt_subject`, ties broken by
+/// lowest id. The control plane enforces per-environment uniqueness, so
+/// the tie-break only matters for a transient duplicate mid-sync.
+fn key_for_subject(snapshot: &AisixSnapshot, subject: &str) -> Option<Arc<ResourceEntry<ApiKey>>> {
+    let mut best: Option<Arc<ResourceEntry<ApiKey>>> = None;
+    for entry in snapshot.apikeys.entries() {
+        if entry.value.jwt_subject.as_deref() != Some(subject) {
+            continue;
+        }
+        match &best {
+            Some(b) if b.id <= entry.id => {}
+            _ => best = Some(entry),
+        }
+    }
+    best
+}
+
+/// Authenticate a JWT-shaped bearer. Called from the auth choke point
+/// once [`looks_like_jwt`] and [`any_enabled_provider`] both hold.
+pub(crate) async fn authenticate_jwt(
+    state: &ProxyState,
+    token: &str,
+) -> Result<AuthenticatedKey, ProxyError> {
+    let snapshot = state.snapshot.load();
+
+    let header = match jsonwebtoken::decode_header(token) {
+        Ok(h) => h,
+        Err(_) => {
+            return Err(deny(
+                state,
+                "jwt_malformed",
+                "",
+                None,
+                ProxyError::JwtInvalid,
+            ))
+        }
+    };
+    let kid = header.kid.clone();
+
+    let Some(iss) = unverified_issuer(token) else {
+        return Err(deny(
+            state,
+            "jwt_missing_issuer",
+            "",
+            kid.as_deref(),
+            ProxyError::JwtInvalid,
+        ));
+    };
+
+    let Some(provider) = provider_for_issuer(&snapshot, &iss) else {
+        return Err(deny(
+            state,
+            "jwt_untrusted_issuer",
+            &iss,
+            kid.as_deref(),
+            ProxyError::JwtInvalid,
+        ));
+    };
+    let prov = &provider.value;
+
+    if !ALLOWED_ALGS.contains(&header.alg) {
+        return Err(deny(
+            state,
+            "jwt_alg_not_allowed",
+            &iss,
+            kid.as_deref(),
+            ProxyError::JwtInvalid,
+        ));
+    }
+
+    // ── Signing keys ─────────────────────────────────────────────────
+    let jwks_url = match resolve_jwks_url(prov).await {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::warn!(
+                target: "aisix::auth",
+                provider = %prov.name,
+                issuer = %prov.issuer,
+                error = %e,
+                "cannot resolve the trust provider's JWKS endpoint",
+            );
+            return Err(deny(
+                state,
+                "jwks_unavailable",
+                &iss,
+                kid.as_deref(),
+                ProxyError::JwksUnavailable,
+            ));
+        }
+    };
+    let jwks = match get_jwks(&jwks_url).await {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::warn!(
+                target: "aisix::auth",
+                provider = %prov.name,
+                issuer = %prov.issuer,
+                error = %e,
+                "cannot fetch the trust provider's JWKS",
+            );
+            return Err(deny(
+                state,
+                "jwks_unavailable",
+                &iss,
+                kid.as_deref(),
+                ProxyError::JwksUnavailable,
+            ));
+        }
+    };
+
+    let mut candidates = candidate_keys(&jwks, kid.as_deref());
+    if candidates.is_empty() {
+        // Unknown (or absent-yet-unmatched) kid: the identity provider may
+        // have just rotated its keys — refetch once, rate-limited.
+        if let Some(fresh) = refresh_jwks_rate_limited(&jwks_url).await {
+            candidates = candidate_keys(&fresh, kid.as_deref());
+        }
+    }
+    if candidates.is_empty() {
+        return Err(deny(
+            state,
+            "jwt_unknown_kid",
+            &iss,
+            kid.as_deref(),
+            ProxyError::JwtInvalid,
+        ));
+    }
+
+    // ── Signature + registered claims ────────────────────────────────
+    let claims = match validate_with_keys(token, header.alg, prov, &candidates) {
+        Ok(c) => c,
+        Err((reason, err)) => return Err(deny(state, reason, &iss, kid.as_deref(), err)),
+    };
+
+    // ── Provider claim requirements ──────────────────────────────────
+    if let Err(reason) = check_provider_claims(&claims, prov) {
+        return Err(deny(
+            state,
+            reason,
+            &iss,
+            kid.as_deref(),
+            ProxyError::JwtClaimsRejected,
+        ));
+    }
+
+    // ── Identity mapping ─────────────────────────────────────────────
+    let Some(subject) = nested_claim(&claims, &prov.identity_claim).and_then(|v| v.as_str()) else {
+        return Err(deny(
+            state,
+            "jwt_identity_claim_missing",
+            &iss,
+            kid.as_deref(),
+            ProxyError::JwtIdentityUnmapped,
+        ));
+    };
+
+    let Some(entry) = key_for_subject(&snapshot, subject) else {
+        tracing::warn!(
+            target: "aisix::auth",
+            method = "jwt",
+            reason = "jwt_identity_unmapped",
+            provider = %prov.name,
+            issuer = %iss,
+            subject = %subject,
+            "rejected inbound JWT: no API key carries this jwt_subject",
+        );
+        state
+            .metrics
+            .record_auth_decision("jwt", false, "jwt_identity_unmapped");
+        return Err(ProxyError::JwtIdentityUnmapped);
+    };
+
+    // Same lifecycle enforcement as the API-key path (#933).
+    if entry.value.disabled {
+        return Err(deny(
+            state,
+            "key_disabled",
+            &iss,
+            kid.as_deref(),
+            ProxyError::ApiKeyDisabled,
+        ));
+    }
+    if entry.value.is_expired_at(chrono::Utc::now()) {
+        return Err(deny(
+            state,
+            "key_expired",
+            &iss,
+            kid.as_deref(),
+            ProxyError::ApiKeyExpired,
+        ));
+    }
+
+    state.metrics.record_auth_decision("jwt", true, "");
+    tracing::debug!(
+        target: "aisix::auth",
+        method = "jwt",
+        provider = %prov.name,
+        issuer = %iss,
+        subject = %subject,
+        api_key_id = %entry.id,
+        "jwt authentication succeeded",
+    );
+    Ok(AuthenticatedKey { entry })
+}
+
+/// Record a denial on the metric + decision log and hand back the error.
+/// The raw token never appears here — only the reason class and the
+/// token's routing metadata (issuer / kid).
+fn deny(
+    state: &ProxyState,
+    reason: &'static str,
+    issuer: &str,
+    kid: Option<&str>,
+    err: ProxyError,
+) -> ProxyError {
+    state.metrics.record_auth_decision("jwt", false, reason);
+    tracing::warn!(
+        target: "aisix::auth",
+        method = "jwt",
+        reason = %reason,
+        issuer = %issuer,
+        kid = %kid.unwrap_or(""),
+        "rejected inbound JWT",
+    );
+    err
+}
+
+/// Verify signature + registered claims against each candidate key.
+/// Signature/algorithm mismatches try the next key (rotation overlap with
+/// an absent `kid`); claim-level failures are final — they read the same
+/// for every key.
+fn validate_with_keys(
+    token: &str,
+    alg: Algorithm,
+    prov: &OidcProvider,
+    keys: &[DecodingKey],
+) -> Result<serde_json::Value, (&'static str, ProxyError)> {
+    let mut validation = Validation::new(alg);
+    validation.set_issuer(&[&prov.issuer]);
+    validation.set_audience(&prov.audiences);
+    // `aud`/`iss` are only checked when present — requiring them makes
+    // absence a rejection (default deny), alongside the always-required
+    // `exp`.
+    validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+    validation.leeway = prov.leeway_secs;
+    validation.validate_nbf = true;
+
+    let mut last: Option<jsonwebtoken::errors::Error> = None;
+    for key in keys {
+        match jsonwebtoken::decode::<serde_json::Value>(token, key, &validation) {
+            Ok(data) => return Ok(data.claims),
+            Err(e) => {
+                use jsonwebtoken::errors::ErrorKind;
+                let retryable = matches!(
+                    e.kind(),
+                    ErrorKind::InvalidSignature | ErrorKind::InvalidAlgorithm
+                );
+                last = Some(e);
+                if !retryable {
+                    break;
+                }
+            }
+        }
+    }
+
+    use jsonwebtoken::errors::ErrorKind;
+    let (reason, err) = match last.as_ref().map(jsonwebtoken::errors::Error::kind) {
+        Some(ErrorKind::ExpiredSignature) => ("jwt_expired", ProxyError::JwtExpired),
+        Some(ErrorKind::ImmatureSignature) => ("jwt_not_yet_valid", ProxyError::JwtInvalid),
+        Some(ErrorKind::InvalidAudience) => ("jwt_audience_mismatch", ProxyError::JwtInvalid),
+        Some(ErrorKind::InvalidIssuer) => ("jwt_issuer_mismatch", ProxyError::JwtInvalid),
+        Some(ErrorKind::MissingRequiredClaim(_)) => ("jwt_missing_claim", ProxyError::JwtInvalid),
+        Some(ErrorKind::InvalidSignature) => ("jwt_bad_signature", ProxyError::JwtInvalid),
+        _ => ("jwt_invalid", ProxyError::JwtInvalid),
+    };
+    Err((reason, err))
+}
+
+/// Enforce the provider's `required_scopes` and `bound_claims`. Returns
+/// the denial reason class on the first unmet requirement.
+fn check_provider_claims(
+    claims: &serde_json::Value,
+    prov: &OidcProvider,
+) -> Result<(), &'static str> {
+    if !prov.required_scopes.is_empty() {
+        let scopes = token_scopes(claims);
+        if !prov
+            .required_scopes
+            .iter()
+            .all(|req| scopes.iter().any(|s| s == req))
+        {
+            return Err("jwt_scope_missing");
+        }
+    }
+    if let Some(bound) = &prov.bound_claims {
+        for (path, expect) in bound {
+            let matched = nested_claim(claims, path)
+                .is_some_and(|actual| bound_claim_matches(actual, expect));
+            if !matched {
+                return Err("jwt_bound_claim_mismatch");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The token's granted scopes: a `scope` claim as the OAuth
+/// space-delimited string, or as an array of strings.
+fn token_scopes(claims: &serde_json::Value) -> Vec<String> {
+    match claims.get("scope") {
+        Some(serde_json::Value::String(s)) => s.split_whitespace().map(str::to_string).collect(),
+        Some(serde_json::Value::Array(items)) => items
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(str::to_string)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Resolve a claim by path, dots traversing nested objects
+/// (`realm_access.roles`).
+fn nested_claim<'a>(claims: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut cur = claims;
+    for seg in path.split('.') {
+        cur = cur.get(seg)?;
+    }
+    Some(cur)
+}
+
+/// A bound-claim requirement holds when the claim equals — or, for array
+/// claims, contains — one of the expected values. Non-string claim shapes
+/// never match (deny by default).
+fn bound_claim_matches(actual: &serde_json::Value, expect: &BoundClaimExpect) -> bool {
+    match actual {
+        serde_json::Value::String(s) => expect.accepted().any(|e| e == s),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .filter_map(|v| v.as_str())
+            .any(|s| expect.accepted().any(|e| e == s)),
+        _ => false,
+    }
+}
+
+/// Decoding keys to try: an exact `kid` match when the token names one,
+/// otherwise every signature-use key in the set (bounded) — an identity
+/// provider mid-rotation may publish two keys, and some omit `kid`
+/// entirely.
+fn candidate_keys(jwks: &JwkSet, kid: Option<&str>) -> Vec<DecodingKey> {
+    match kid {
+        Some(kid) => jwks
+            .find(kid)
+            .and_then(|jwk| DecodingKey::from_jwk(jwk).ok())
+            .into_iter()
+            .collect(),
+        None => jwks
+            .keys
+            .iter()
+            .filter(|jwk| {
+                jwk.common
+                    .public_key_use
+                    .as_ref()
+                    .is_none_or(|u| matches!(u, jsonwebtoken::jwk::PublicKeyUse::Signature))
+            })
+            .filter_map(|jwk| DecodingKey::from_jwk(jwk).ok())
+            .take(MAX_KEYS_TRIED)
+            .collect(),
+    }
+}
+
+// ── JWKS fetch + cache ───────────────────────────────────────────────
+
+struct JwksEntry {
+    /// The last successfully fetched key set and when it landed.
+    jwks: Option<(Arc<JwkSet>, Instant)>,
+    /// Last fetch attempt, success or failure — the rate-limit clock.
+    last_attempt: Option<Instant>,
+}
+
+/// Process-global JWKS cache keyed by URL. Guards are held only for map
+/// lookups/inserts, never across an await; concurrent misses may fetch in
+/// parallel (each result is valid — last insert wins).
+fn jwks_cache() -> &'static RwLock<HashMap<String, JwksEntry>> {
+    static CACHE: OnceLock<RwLock<HashMap<String, JwksEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Discovery results keyed by issuer: the resolved JWKS URL.
+fn discovery_cache() -> &'static RwLock<HashMap<String, (String, Instant)>> {
+    static CACHE: OnceLock<RwLock<HashMap<String, (String, Instant)>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Shared HTTP client for JWKS / discovery fetches. Redirects are
+/// disabled — a key endpoint never legitimately redirects, and following
+/// one would fetch trust material from wherever it points.
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        aisix_gateway::client_builder()
+            .timeout(JWKS_FETCH_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap_or_default()
+    })
+}
+
+/// The JWKS URL for a provider: its configured `jwks_uri`, or the
+/// `jwks_uri` advertised by the issuer's OIDC discovery document
+/// (cached; a stale value keeps serving when a re-fetch fails).
+async fn resolve_jwks_url(prov: &OidcProvider) -> Result<String, String> {
+    if let Some(u) = &prov.jwks_uri {
+        return Ok(u.clone());
+    }
+    let now = Instant::now();
+    if let Some((url, at)) = discovery_cache().read().unwrap().get(&prov.issuer) {
+        if now.duration_since(*at) < JWKS_TTL {
+            return Ok(url.clone());
+        }
+    }
+    let discovery_url = format!(
+        "{}/.well-known/openid-configuration",
+        prov.issuer.trim_end_matches('/')
+    );
+    match fetch_json(&discovery_url).await {
+        Ok(doc) => {
+            let jwks_uri = doc
+                .get("jwks_uri")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "discovery document carries no jwks_uri".to_string())?
+                .to_string();
+            discovery_cache()
+                .write()
+                .unwrap()
+                .insert(prov.issuer.clone(), (jwks_uri.clone(), now));
+            Ok(jwks_uri)
+        }
+        Err(e) => {
+            // Serve the stale resolution rather than failing auth outright.
+            if let Some((url, _)) = discovery_cache().read().unwrap().get(&prov.issuer) {
+                tracing::warn!(
+                    target: "aisix::auth",
+                    issuer = %prov.issuer,
+                    error = %e,
+                    "OIDC discovery re-fetch failed; keeping the previously resolved JWKS URL",
+                );
+                return Ok(url.clone());
+            }
+            Err(format!("OIDC discovery failed: {e}"))
+        }
+    }
+}
+
+/// The cached key set for `url`, fetching when absent or past
+/// [`JWKS_TTL`]. A failed re-fetch keeps serving the stale set
+/// (network-partition tolerance); with nothing cached the error
+/// propagates and the request fails closed as retryable.
+async fn get_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
+    let now = Instant::now();
+    if let Some(entry) = jwks_cache().read().unwrap().get(url) {
+        if let Some((jwks, fetched_at)) = &entry.jwks {
+            if now.duration_since(*fetched_at) < JWKS_TTL {
+                return Ok(jwks.clone());
+            }
+        }
+    }
+    refresh_jwks(url).await
+}
+
+/// One fetch for an unknown `kid`, suppressed inside
+/// [`JWKS_REFRESH_MIN_INTERVAL`] of the previous attempt.
+async fn refresh_jwks_rate_limited(url: &str) -> Option<Arc<JwkSet>> {
+    let now = Instant::now();
+    if let Some(entry) = jwks_cache().read().unwrap().get(url) {
+        if let Some(at) = entry.last_attempt {
+            if now.duration_since(at) < JWKS_REFRESH_MIN_INTERVAL {
+                return None;
+            }
+        }
+    }
+    refresh_jwks(url).await.ok()
+}
+
+async fn refresh_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
+    // Stamp the attempt before awaiting so a slow endpoint is not
+    // hammered by concurrent unknown-kid refreshes.
+    {
+        let mut map = jwks_cache().write().unwrap();
+        map.entry(url.to_string())
+            .or_insert(JwksEntry {
+                jwks: None,
+                last_attempt: None,
+            })
+            .last_attempt = Some(Instant::now());
+    }
+    match fetch_json(url).await.and_then(|v| {
+        serde_json::from_value::<JwkSet>(v).map_err(|e| format!("not a JWKS document: {e}"))
+    }) {
+        Ok(set) => {
+            let arc = Arc::new(set);
+            jwks_cache()
+                .write()
+                .unwrap()
+                .entry(url.to_string())
+                .and_modify(|e| e.jwks = Some((arc.clone(), Instant::now())))
+                .or_insert(JwksEntry {
+                    jwks: Some((arc.clone(), Instant::now())),
+                    last_attempt: Some(Instant::now()),
+                });
+            Ok(arc)
+        }
+        Err(e) => {
+            if let Some(entry) = jwks_cache().read().unwrap().get(url) {
+                if let Some((stale, _)) = &entry.jwks {
+                    tracing::warn!(
+                        target: "aisix::auth",
+                        error = %e,
+                        "JWKS re-fetch failed; keeping the previously fetched key set",
+                    );
+                    return Ok(stale.clone());
+                }
+            }
+            Err(e)
+        }
+    }
+}
+
+async fn fetch_json(url: &str) -> Result<serde_json::Value, String> {
+    let resp = http_client()
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("endpoint returned status {}", resp.status()));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("reading response failed: {e}"))?;
+    if bytes.len() > JWKS_MAX_BYTES {
+        return Err(format!("response exceeds {JWKS_MAX_BYTES} bytes"));
+    }
+    serde_json::from_slice(&bytes).map_err(|e| format!("response is not JSON: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_core::resource::ResourceEntry;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+
+    /// Test-only RSA keypair. The private PEM signs fixture tokens; the
+    /// JWK below is its public half (kid `test-kid-1`).
+    const TEST_RSA_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDfARbZauGK4bRk
+UL0gWcsvGyFBMVW6eeNcAy7U0APH92H5DSImyf1WhnvfDareRkXFBhiHy6Bj0wfz
+7yE7kgPNhXB0l4r8mFd3biTklxt5fDKqvJZd473fFOkiM//DjB62lodXfDLwhr0o
+zQi0xCnPzMyzQx9EVR1v1JwW/9lS4QaEgiVGDES9mh0kfnszw7sH5IFwKz2BgtHS
+gHJ+Wykr7hB7DY103OxE69BXKA2bJ+k/0ai8dQiSzgfIEkailvy/2wZoOfVbEfWp
+wXPuP+ipqn/9c9mbbjMRtUHOjgBQvqiwjix21nh8ZoeCA8z/YuvdgXXTJgoG0h+I
+WLyQXSOxAgMBAAECggEABPxNak3uk0Ae3Cab8ScLblcBGX0vXqG5TgYk3A13JYIn
+1r1kQpFoewXlq2PEVVTP3CrvOHX6dNDeetB2oed5SJ/PlvkJBUL9+EW7ncACarxh
+QO+XaFZI7pL/7/ZRT6oIc7+OG2FuSByoX6BPLgS8BJEeZcbojOAJmPBGub2S5RHn
+x/g/a58W+AmudYZY+aqVg84SBu8FQF7J3ygvT2we6k0xu7nPp23lpF9zQdLcDRlM
+d1Dqu3JyQApKO4xtfcQFGbJzq6fIyaFX08mkQeewkek3XXf2JUmcnfCx37gOv8hy
+7k8nPT1vzzFIVJFx/f+W91KmixmrNU7mlvpuHRBlKwKBgQD+vtCwzkU6wvXr6OaL
+R3iT+QSt49aMHIi6u0SSDJnjVoQDVXivyybVRRCwYWXzng5ajt1fs9dsW2ELxco3
+mCrf5ayrsUhjytSEvCXXfpomA75518s+r3Nlu7qccHTvlRxLzLk1rQ9UilEYVT3s
+DF4xbu/91rJ9gNWiocv4xGa3PwKBgQDgGkEvTMsoiJQW0Drs+rohBThw24Bt0wvP
+wSwgz71PxwJvEIT8qeCJDBINiXeTDPe8pxpO+As+iaBdJ5YQ7ctyuGvLA6892zto
+/AcszvCL8R6sxcPt9ak4/GhY0weKT4DsjjPNOPWFY9ebZ/xD/6R9lb6Ksi+G/pXM
+CusKpfzZDwKBgAw8hjG39sNX0hA+47QU/sm80Gi55Phd9oNhs22AhXPSGA1A8ccf
+7wGXi7GtPARztyTKb//E17gwu3yhR5FcEdMnaR/mKCADAipOD1NGlYj17RRVNUIR
+k21zkwcor7VCaFWLw+m8IlxhOHv+vDa2cV/WgFilE3XL1nc1ZmLQrE5pAoGAIig+
+STxWNs5ia/u/D4HDvuaxzJnYQGULhtX1qOag/zjhCRamfnBSFfFuCvwp6pLua6W4
+n9K0vAp0E97Fw7zK5qhvXZkpK69vpbfMTCsahOnyd/kIvQtViKcILIm1u4IUr3mZ
+Ma191p/6K+i0jZS4eJ/LVA6GqffB00DSxGO6X0cCgYAA+KRVMdHHBiuL3XO0srlR
+0lY0cuVX8TTsJf1AkLH8rutn3Xa7maLVOrNoUnhE6j5UmzojlzMGUTmi1sryMipU
+MFt+Fn9pwKAtrgAFlmGhAsOBmC4fnn0jNN4aV6B5gSbQFLSGXmF3qCJHTLT2gPR3
+jyxumGxNpoIV8LlzsMsaWQ==
+-----END PRIVATE KEY-----";
+
+    const TEST_JWKS: &str = r#"{"keys":[{"kty":"RSA","kid":"test-kid-1","use":"sig","alg":"RS256","n":"3wEW2WrhiuG0ZFC9IFnLLxshQTFVunnjXAMu1NADx_dh-Q0iJsn9VoZ73w2q3kZFxQYYh8ugY9MH8-8hO5IDzYVwdJeK_JhXd24k5JcbeXwyqryWXeO93xTpIjP_w4wetpaHV3wy8Ia9KM0ItMQpz8zMs0MfRFUdb9ScFv_ZUuEGhIIlRgxEvZodJH57M8O7B-SBcCs9gYLR0oByflspK-4Qew2NdNzsROvQVygNmyfpP9GovHUIks4HyBJGopb8v9sGaDn1WxH1qcFz7j_oqap__XPZm24zEbVBzo4AUL6osI4sdtZ4fGaHggPM_2Lr3YF10yYKBtIfiFi8kF0jsQ","e":"AQAB"}]}"#;
+
+    fn test_provider(json: &str) -> OidcProvider {
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn base_provider() -> OidcProvider {
+        test_provider(
+            r#"{
+              "name": "test-idp",
+              "issuer": "https://idp.test/realms/agents",
+              "audiences": ["aisix"]
+            }"#,
+        )
+    }
+
+    fn encoding_key() -> EncodingKey {
+        EncodingKey::from_rsa_pem(TEST_RSA_PEM.as_bytes()).unwrap()
+    }
+
+    fn decoding_keys() -> Vec<DecodingKey> {
+        let jwks: JwkSet = serde_json::from_str(TEST_JWKS).unwrap();
+        candidate_keys(&jwks, Some("test-kid-1"))
+    }
+
+    fn sign(claims: &serde_json::Value) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-kid-1".to_string());
+        encode(&header, claims, &encoding_key()).unwrap()
+    }
+
+    fn future() -> i64 {
+        chrono::Utc::now().timestamp() + 3600
+    }
+
+    fn valid_claims() -> serde_json::Value {
+        serde_json::json!({
+            "iss": "https://idp.test/realms/agents",
+            "aud": "aisix",
+            "sub": "agent-1",
+            "exp": future(),
+        })
+    }
+
+    #[test]
+    fn looks_like_jwt_accepts_real_tokens_only() {
+        assert!(looks_like_jwt(&sign(&valid_claims())));
+        // Generated gateway keys.
+        assert!(!looks_like_jwt("sk-3f5a1b2c"));
+        // Custom-imported keys that merely contain dots: segments do not
+        // decode to a JOSE header.
+        assert!(!looks_like_jwt("a.b.c"));
+        assert!(!looks_like_jwt("my.custom.key"));
+        // Wrong segment counts.
+        assert!(!looks_like_jwt("a.b"));
+        assert!(!looks_like_jwt("a.b.c.d"));
+        assert!(!looks_like_jwt(""));
+        // A base64url JSON first segment without `alg` is not a JWT.
+        let not_jose = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{\"a\":1}");
+        assert!(!looks_like_jwt(&format!("{not_jose}.x.y")));
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_token() {
+        let claims = validate_with_keys(
+            &sign(&valid_claims()),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys(),
+        )
+        .unwrap();
+        assert_eq!(claims["sub"], "agent-1");
+    }
+
+    #[test]
+    fn validate_rejects_expired_token_as_jwt_expired() {
+        let mut c = valid_claims();
+        c["exp"] = serde_json::json!(chrono::Utc::now().timestamp() - 3600);
+        let (reason, err) = validate_with_keys(
+            &sign(&c),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys(),
+        )
+        .unwrap_err();
+        assert_eq!(reason, "jwt_expired");
+        assert!(matches!(err, ProxyError::JwtExpired));
+    }
+
+    #[test]
+    fn validate_requires_exp() {
+        let mut c = valid_claims();
+        c.as_object_mut().unwrap().remove("exp");
+        let (reason, _) = validate_with_keys(
+            &sign(&c),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys(),
+        )
+        .unwrap_err();
+        assert_eq!(reason, "jwt_missing_claim");
+    }
+
+    #[test]
+    fn validate_requires_audience_presence_and_match() {
+        let mut missing = valid_claims();
+        missing.as_object_mut().unwrap().remove("aud");
+        let (reason, _) = validate_with_keys(
+            &sign(&missing),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys(),
+        )
+        .unwrap_err();
+        assert_eq!(reason, "jwt_missing_claim");
+
+        let mut wrong = valid_claims();
+        wrong["aud"] = serde_json::json!("someone-else");
+        let (reason, _) = validate_with_keys(
+            &sign(&wrong),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys(),
+        )
+        .unwrap_err();
+        assert_eq!(reason, "jwt_audience_mismatch");
+
+        // Array audiences match when any element is accepted.
+        let mut array = valid_claims();
+        array["aud"] = serde_json::json!(["other", "aisix"]);
+        assert!(validate_with_keys(
+            &sign(&array),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys()
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_wrong_issuer() {
+        let mut c = valid_claims();
+        c["iss"] = serde_json::json!("https://evil.test");
+        let (reason, _) = validate_with_keys(
+            &sign(&c),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys(),
+        )
+        .unwrap_err();
+        assert_eq!(reason, "jwt_issuer_mismatch");
+    }
+
+    #[test]
+    fn validate_rejects_future_nbf_and_accepts_past_nbf() {
+        let mut c = valid_claims();
+        c["nbf"] = serde_json::json!(future());
+        let (reason, _) = validate_with_keys(
+            &sign(&c),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys(),
+        )
+        .unwrap_err();
+        assert_eq!(reason, "jwt_not_yet_valid");
+
+        let mut ok = valid_claims();
+        ok["nbf"] = serde_json::json!(chrono::Utc::now().timestamp() - 60);
+        assert!(validate_with_keys(
+            &sign(&ok),
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys()
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_tampered_signature() {
+        let token = sign(&valid_claims());
+        let mut parts: Vec<String> = token.split('.').map(str::to_string).collect();
+        // Re-encode the payload with a widened scope; the signature no
+        // longer covers it.
+        let mut payload = valid_claims();
+        payload["sub"] = serde_json::json!("agent-admin");
+        parts[1] = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&payload).unwrap());
+        let tampered = parts.join(".");
+        let (reason, _) = validate_with_keys(
+            &tampered,
+            Algorithm::RS256,
+            &base_provider(),
+            &decoding_keys(),
+        )
+        .unwrap_err();
+        assert_eq!(reason, "jwt_bad_signature");
+    }
+
+    #[test]
+    fn leeway_tolerates_recent_expiry() {
+        let mut prov = base_provider();
+        prov.leeway_secs = 120;
+        let mut c = valid_claims();
+        c["exp"] = serde_json::json!(chrono::Utc::now().timestamp() - 30);
+        assert!(validate_with_keys(&sign(&c), Algorithm::RS256, &prov, &decoding_keys()).is_ok());
+    }
+
+    #[test]
+    fn scope_and_bound_claim_checks() {
+        let prov = test_provider(
+            r#"{
+              "name": "test-idp",
+              "issuer": "https://idp.test/realms/agents",
+              "audiences": ["aisix"],
+              "required_scopes": ["ai.access"],
+              "bound_claims": {
+                "department": "ai-lab",
+                "realm_access.roles": ["agent", "batch"]
+              }
+            }"#,
+        );
+
+        let mut good = valid_claims();
+        good["scope"] = serde_json::json!("openid ai.access");
+        good["department"] = serde_json::json!("ai-lab");
+        good["realm_access"] = serde_json::json!({"roles": ["other", "agent"]});
+        assert!(check_provider_claims(&good, &prov).is_ok());
+
+        // Scope may also arrive as an array.
+        let mut array_scope = good.clone();
+        array_scope["scope"] = serde_json::json!(["ai.access"]);
+        assert!(check_provider_claims(&array_scope, &prov).is_ok());
+
+        let mut no_scope = good.clone();
+        no_scope["scope"] = serde_json::json!("openid");
+        assert_eq!(
+            check_provider_claims(&no_scope, &prov),
+            Err("jwt_scope_missing")
+        );
+
+        let mut wrong_dept = good.clone();
+        wrong_dept["department"] = serde_json::json!("finance");
+        assert_eq!(
+            check_provider_claims(&wrong_dept, &prov),
+            Err("jwt_bound_claim_mismatch")
+        );
+
+        // A missing bound claim denies — never a silent pass.
+        let mut missing = good.clone();
+        missing.as_object_mut().unwrap().remove("department");
+        assert_eq!(
+            check_provider_claims(&missing, &prov),
+            Err("jwt_bound_claim_mismatch")
+        );
+
+        // Non-string claim shapes never match.
+        let mut numeric = good.clone();
+        numeric["department"] = serde_json::json!(7);
+        assert_eq!(
+            check_provider_claims(&numeric, &prov),
+            Err("jwt_bound_claim_mismatch")
+        );
+    }
+
+    #[test]
+    fn candidate_keys_selects_by_kid_and_falls_back_to_all() {
+        let jwks: JwkSet = serde_json::from_str(TEST_JWKS).unwrap();
+        assert_eq!(candidate_keys(&jwks, Some("test-kid-1")).len(), 1);
+        assert!(candidate_keys(&jwks, Some("rotated-away")).is_empty());
+        // No kid on the token: every signature key is a candidate.
+        assert_eq!(candidate_keys(&jwks, None).len(), 1);
+    }
+
+    #[test]
+    fn provider_and_subject_selection_tie_break_on_lowest_id() {
+        let snapshot = AisixSnapshot::new();
+        let mk = |id: &str, enabled: bool| {
+            let mut p = base_provider();
+            p.enabled = enabled;
+            snapshot.oidc_providers.insert(ResourceEntry::new(id, p, 1));
+        };
+        mk("b-provider", true);
+        mk("a-provider", true);
+        mk("0-disabled", false);
+        let picked = provider_for_issuer(&snapshot, "https://idp.test/realms/agents").unwrap();
+        assert_eq!(picked.id, "a-provider");
+        assert!(provider_for_issuer(&snapshot, "https://other.test").is_none());
+
+        let mk_key = |id: &str, subject: Option<&str>| {
+            let mut k: ApiKey =
+                serde_json::from_str(r#"{"key_hash":"h","allowed_models":["*"]}"#).unwrap();
+            k.jwt_subject = subject.map(str::to_string);
+            // Distinct key_hash per row so the by-name index stays unique.
+            k.key_hash = format!("hash-{id}");
+            snapshot.apikeys.insert(ResourceEntry::new(id, k, 1));
+        };
+        mk_key("k-2", Some("agent-1"));
+        mk_key("k-1", Some("agent-1"));
+        mk_key("k-3", Some("agent-2"));
+        mk_key("k-4", None);
+        assert_eq!(key_for_subject(&snapshot, "agent-1").unwrap().id, "k-1");
+        assert_eq!(key_for_subject(&snapshot, "agent-2").unwrap().id, "k-3");
+        assert!(key_for_subject(&snapshot, "agent-9").is_none());
+    }
+
+    #[test]
+    fn nested_claim_traverses_dots() {
+        let v = serde_json::json!({"a": {"b": {"c": "x"}}, "flat": "y"});
+        assert_eq!(nested_claim(&v, "a.b.c").unwrap(), "x");
+        assert_eq!(nested_claim(&v, "flat").unwrap(), "y");
+        assert!(nested_claim(&v, "a.missing").is_none());
+    }
+
+    #[test]
+    fn unverified_issuer_reads_the_payload() {
+        assert_eq!(
+            unverified_issuer(&sign(&valid_claims())).as_deref(),
+            Some("https://idp.test/realms/agents")
+        );
+        assert!(unverified_issuer("sk-abc").is_none());
+    }
+}

--- a/crates/aisix-proxy/src/jwt.rs
+++ b/crates/aisix-proxy/src/jwt.rs
@@ -81,12 +81,21 @@ const ALLOWED_ALGS: [Algorithm; 9] = [
 /// multi-key JWKS.
 const MAX_KEYS_TRIED: usize = 8;
 
-/// True when the bearer has the structural shape of a JWT: three
-/// non-empty dot-separated segments whose first segment base64url-decodes
-/// to a JSON object carrying `alg` (a JOSE header). The header check
-/// keeps custom-imported API keys that merely contain dots on the
-/// API-key path.
+/// Upper bound on a bearer we will treat as a JWT. A real IdP token is a
+/// few KB; the cap stops a several-hundred-KB `Authorization` header from
+/// driving the base64/JSON work (done up to three times per request)
+/// before anything is verified.
+const MAX_JWT_BYTES: usize = 16 * 1024;
+
+/// True when the bearer has the structural shape of a JWT: within the
+/// size cap, three non-empty dot-separated segments whose first segment
+/// base64url-decodes to a JSON object carrying `alg` (a JOSE header). The
+/// header check keeps custom-imported API keys that merely contain dots
+/// on the API-key path.
 pub(crate) fn looks_like_jwt(token: &str) -> bool {
+    if token.len() > MAX_JWT_BYTES {
+        return false;
+    }
     let parts: Vec<&str> = token.splitn(4, '.').collect();
     if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
         return false;
@@ -97,11 +106,7 @@ pub(crate) fn looks_like_jwt(token: &str) -> bool {
 /// True when the snapshot has at least one enabled trust provider — the
 /// gate for entering the JWT path at all.
 pub(crate) fn any_enabled_provider(snapshot: &AisixSnapshot) -> bool {
-    snapshot
-        .oidc_providers
-        .entries()
-        .iter()
-        .any(|e| e.value.enabled)
+    snapshot.oidc_providers.any(|e| e.value.enabled)
 }
 
 fn b64url_json(segment: &str) -> Option<serde_json::Value> {
@@ -130,44 +135,39 @@ fn provider_for_issuer(
     snapshot: &AisixSnapshot,
     iss: &str,
 ) -> Option<Arc<ResourceEntry<OidcProvider>>> {
-    let mut best: Option<Arc<ResourceEntry<OidcProvider>>> = None;
-    for entry in snapshot.oidc_providers.entries() {
-        if !entry.value.enabled || entry.value.issuer != iss {
-            continue;
-        }
-        match &best {
-            Some(b) if b.id <= entry.id => {}
-            _ => best = Some(entry),
-        }
-    }
-    best
+    snapshot
+        .oidc_providers
+        .find_min_by_id(|e| e.value.enabled && e.value.issuer == iss)
 }
 
-/// The API key bound to `subject` via `jwt_subject`, ties broken by
-/// lowest id. The control plane enforces per-environment uniqueness, so
-/// the tie-break only matters for a transient duplicate mid-sync.
-fn key_for_subject(snapshot: &AisixSnapshot, subject: &str) -> Option<Arc<ResourceEntry<ApiKey>>> {
-    let mut best: Option<Arc<ResourceEntry<ApiKey>>> = None;
-    for entry in snapshot.apikeys.entries() {
-        if entry.value.jwt_subject.as_deref() != Some(subject) {
-            continue;
-        }
-        match &best {
-            Some(b) if b.id <= entry.id => {}
-            _ => best = Some(entry),
-        }
-    }
-    best
+/// The API key bound to `subject` **as asserted by `provider_name`**,
+/// ties broken by lowest id. A key whose `jwt_provider` names a different
+/// trust provider is never a candidate: subjects are namespaced by the
+/// provider that vouched for them, so a second trusted provider cannot
+/// mint a token impersonating the first provider's identity of the same
+/// name. The control plane enforces `(jwt_provider, jwt_subject)`
+/// uniqueness, so the tie-break only matters for a transient duplicate
+/// mid-sync.
+fn key_for_subject(
+    snapshot: &AisixSnapshot,
+    provider_name: &str,
+    subject: &str,
+) -> Option<Arc<ResourceEntry<ApiKey>>> {
+    snapshot.apikeys.find_min_by_id(|e| {
+        e.value.jwt_subject.as_deref() == Some(subject)
+            && e.value.jwt_provider.as_deref() == Some(provider_name)
+    })
 }
 
 /// Authenticate a JWT-shaped bearer. Called from the auth choke point
-/// once [`looks_like_jwt`] and [`any_enabled_provider`] both hold.
+/// once [`looks_like_jwt`] and [`any_enabled_provider`] both hold, with
+/// the snapshot the gate already loaded (avoids a second atomic load;
+/// any change between them fails closed to `jwt_untrusted_issuer`).
 pub(crate) async fn authenticate_jwt(
     state: &ProxyState,
+    snapshot: &AisixSnapshot,
     token: &str,
 ) -> Result<AuthenticatedKey, ProxyError> {
-    let snapshot = state.snapshot.load();
-
     let header = match jsonwebtoken::decode_header(token) {
         Ok(h) => h,
         Err(_) => {
@@ -192,7 +192,7 @@ pub(crate) async fn authenticate_jwt(
         ));
     };
 
-    let Some(provider) = provider_for_issuer(&snapshot, &iss) else {
+    let Some(provider) = provider_for_issuer(snapshot, &iss) else {
         return Err(deny(
             state,
             "jwt_untrusted_issuer",
@@ -253,12 +253,12 @@ pub(crate) async fn authenticate_jwt(
         }
     };
 
-    let mut candidates = candidate_keys(&jwks, kid.as_deref());
+    let mut candidates = candidate_keys(&jwks, kid.as_deref(), header.alg);
     if candidates.is_empty() {
         // Unknown (or absent-yet-unmatched) kid: the identity provider may
         // have just rotated its keys — refetch once, rate-limited.
         if let Some(fresh) = refresh_jwks_rate_limited(&jwks_url).await {
-            candidates = candidate_keys(&fresh, kid.as_deref());
+            candidates = candidate_keys(&fresh, kid.as_deref(), header.alg);
         }
     }
     if candidates.is_empty() {
@@ -299,15 +299,15 @@ pub(crate) async fn authenticate_jwt(
         ));
     };
 
-    let Some(entry) = key_for_subject(&snapshot, subject) else {
+    let Some(entry) = key_for_subject(snapshot, &prov.name, subject) else {
         tracing::warn!(
             target: "aisix::auth",
             method = "jwt",
             reason = "jwt_identity_unmapped",
-            provider = %prov.name,
-            issuer = %iss,
-            subject = %subject,
-            "rejected inbound JWT: no API key carries this jwt_subject",
+            provider = %clip(&prov.name),
+            issuer = %clip(&iss),
+            subject = ?clip(subject),
+            "rejected inbound JWT: no API key binds this identity to this provider",
         );
         state
             .metrics
@@ -348,9 +348,29 @@ pub(crate) async fn authenticate_jwt(
     Ok(AuthenticatedKey { entry })
 }
 
+/// Cap on attacker-controlled token metadata reproduced in the decision
+/// log. `kid`, and `iss` before the issuer allow-list matches, come
+/// straight from an unauthenticated token, so they are logged with
+/// `Debug` (which escapes newlines and control bytes) and truncated —
+/// a probe cannot forge log lines or inflate log volume through them.
+const LOGGED_METADATA_MAX: usize = 128;
+
+fn clip(s: &str) -> &str {
+    match s.char_indices().nth(LOGGED_METADATA_MAX) {
+        Some((i, _)) => &s[..i],
+        None => s,
+    }
+}
+
 /// Record a denial on the metric + decision log and hand back the error.
 /// The raw token never appears here — only the reason class and the
-/// token's routing metadata (issuer / kid).
+/// token's routing metadata (issuer / kid), escaped and truncated.
+///
+/// Pre-allow-list reason classes (a malformed token, an untrusted or
+/// missing issuer) are the scanner-probe shapes: they carry no operator
+/// signal beyond the metric, so they log at `debug`. Once a trust
+/// provider has matched, a denial names a real configured issuer and is
+/// worth a `warn`.
 fn deny(
     state: &ProxyState,
     reason: &'static str,
@@ -359,14 +379,29 @@ fn deny(
     err: ProxyError,
 ) -> ProxyError {
     state.metrics.record_auth_decision("jwt", false, reason);
-    tracing::warn!(
-        target: "aisix::auth",
-        method = "jwt",
-        reason = %reason,
-        issuer = %issuer,
-        kid = %kid.unwrap_or(""),
-        "rejected inbound JWT",
+    let pre_match = matches!(
+        reason,
+        "jwt_malformed" | "jwt_missing_issuer" | "jwt_untrusted_issuer" | "jwt_alg_not_allowed"
     );
+    if pre_match {
+        tracing::debug!(
+            target: "aisix::auth",
+            method = "jwt",
+            reason = %reason,
+            issuer = ?clip(issuer),
+            kid = ?clip(kid.unwrap_or("")),
+            "rejected inbound JWT (pre-verification)",
+        );
+    } else {
+        tracing::warn!(
+            target: "aisix::auth",
+            method = "jwt",
+            reason = %reason,
+            issuer = ?clip(issuer),
+            kid = ?clip(kid.unwrap_or("")),
+            "rejected inbound JWT",
+        );
+    }
     err
 }
 
@@ -491,26 +526,43 @@ fn bound_claim_matches(actual: &serde_json::Value, expect: &BoundClaimExpect) ->
 /// otherwise every signature-use key in the set (bounded) — an identity
 /// provider mid-rotation may publish two keys, and some omit `kid`
 /// entirely.
-fn candidate_keys(jwks: &JwkSet, kid: Option<&str>) -> Vec<DecodingKey> {
+fn candidate_keys(jwks: &JwkSet, kid: Option<&str>, alg: Algorithm) -> Vec<DecodingKey> {
     match kid {
         Some(kid) => jwks
             .find(kid)
+            .filter(|jwk| usable_for_verification(jwk, alg))
             .and_then(|jwk| DecodingKey::from_jwk(jwk).ok())
             .into_iter()
             .collect(),
         None => jwks
             .keys
             .iter()
-            .filter(|jwk| {
-                jwk.common
-                    .public_key_use
-                    .as_ref()
-                    .is_none_or(|u| matches!(u, jsonwebtoken::jwk::PublicKeyUse::Signature))
-            })
+            .filter(|jwk| usable_for_verification(jwk, alg))
             .filter_map(|jwk| DecodingKey::from_jwk(jwk).ok())
             .take(MAX_KEYS_TRIED)
             .collect(),
     }
+}
+
+/// True when a JWK may verify a signature at `alg`: not an
+/// encryption-only key (RFC 7517 §4.2 `use`), and — when the key names
+/// an algorithm — that algorithm (RFC 7517 §4.4 `alg`). Applied on both
+/// the `kid`-matched and the fall-through paths so a `use:enc` or
+/// wrong-`alg` key is never tried, even when its `kid` is named.
+fn usable_for_verification(jwk: &jsonwebtoken::jwk::Jwk, alg: Algorithm) -> bool {
+    let use_ok = jwk
+        .common
+        .public_key_use
+        .as_ref()
+        .is_none_or(|u| matches!(u, jsonwebtoken::jwk::PublicKeyUse::Signature));
+    // `KeyAlgorithm` (JWK `alg`) and `Algorithm` (token `alg`) are
+    // distinct enums with no cross-conversion; their variant names are
+    // identical (RS256 … EdDSA), so compare the Debug spellings.
+    let alg_ok = jwk
+        .common
+        .key_algorithm
+        .is_none_or(|k| format!("{k:?}") == format!("{alg:?}"));
+    use_ok && alg_ok
 }
 
 // ── JWKS fetch + cache ───────────────────────────────────────────────
@@ -522,6 +574,26 @@ struct JwksEntry {
     last_attempt: Option<Instant>,
 }
 
+/// One issuer's resolved discovery result plus its rate-limit clock.
+struct DiscoveryEntry {
+    /// The resolved `jwks_uri` and when discovery last succeeded.
+    resolved: Option<(String, Instant)>,
+    /// Last discovery attempt, success or failure.
+    last_attempt: Option<Instant>,
+}
+
+/// Read a poisoned-lock-tolerant guard. A panic while some other request
+/// held the lock only ever happened during a map op (never across an
+/// await), so the map is structurally intact; recovering the inner value
+/// keeps JWT auth alive instead of poisoning it process-wide.
+fn read_recover<T>(lock: &RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
+    lock.read().unwrap_or_else(|e| e.into_inner())
+}
+
+fn write_recover<T>(lock: &RwLock<T>) -> std::sync::RwLockWriteGuard<'_, T> {
+    lock.write().unwrap_or_else(|e| e.into_inner())
+}
+
 /// Process-global JWKS cache keyed by URL. Guards are held only for map
 /// lookups/inserts, never across an await; concurrent misses may fetch in
 /// parallel (each result is valid — last insert wins).
@@ -530,9 +602,9 @@ fn jwks_cache() -> &'static RwLock<HashMap<String, JwksEntry>> {
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
-/// Discovery results keyed by issuer: the resolved JWKS URL.
-fn discovery_cache() -> &'static RwLock<HashMap<String, (String, Instant)>> {
-    static CACHE: OnceLock<RwLock<HashMap<String, (String, Instant)>>> = OnceLock::new();
+/// Discovery results keyed by issuer.
+fn discovery_cache() -> &'static RwLock<HashMap<String, DiscoveryEntry>> {
+    static CACHE: OnceLock<RwLock<HashMap<String, DiscoveryEntry>>> = OnceLock::new();
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
@@ -551,63 +623,144 @@ fn http_client() -> &'static reqwest::Client {
 }
 
 /// The JWKS URL for a provider: its configured `jwks_uri`, or the
-/// `jwks_uri` advertised by the issuer's OIDC discovery document
-/// (cached; a stale value keeps serving when a re-fetch fails).
+/// `jwks_uri` advertised by the issuer's OIDC discovery document.
+///
+/// Discovery is cached (TTL) and rate-limited on failure the same way
+/// the JWKS fetch is, so an issuer whose discovery document is down does
+/// not get re-probed once per request. The advertised `jwks_uri` is
+/// verified against the issuer (OIDC Discovery 1.0 §4.3) and constrained
+/// to the issuer's own origin, so a compromised or misconfigured
+/// discovery document cannot relocate trust material into our network.
 async fn resolve_jwks_url(prov: &OidcProvider) -> Result<String, String> {
     if let Some(u) = &prov.jwks_uri {
         return Ok(u.clone());
     }
     let now = Instant::now();
-    if let Some((url, at)) = discovery_cache().read().unwrap().get(&prov.issuer) {
-        if now.duration_since(*at) < JWKS_TTL {
-            return Ok(url.clone());
+    let (stale, attempted_recently) = {
+        let map = read_recover(discovery_cache());
+        match map.get(&prov.issuer) {
+            Some(entry) => {
+                if let Some((url, at)) = &entry.resolved {
+                    if now.duration_since(*at) < JWKS_TTL {
+                        return Ok(url.clone());
+                    }
+                }
+                (
+                    entry.resolved.as_ref().map(|(u, _)| u.clone()),
+                    entry
+                        .last_attempt
+                        .is_some_and(|at| now.duration_since(at) < JWKS_REFRESH_MIN_INTERVAL),
+                )
+            }
+            None => (None, false),
         }
+    };
+    if attempted_recently {
+        // Suppressed by the refresh interval: serve the stale resolution
+        // rather than probe a down issuer once per request.
+        return stale
+            .ok_or_else(|| "OIDC discovery suppressed by the refresh interval".to_string());
     }
+
+    // Stamp the attempt before awaiting so concurrent misses don't stampede.
+    write_recover(discovery_cache())
+        .entry(prov.issuer.clone())
+        .or_insert(DiscoveryEntry {
+            resolved: None,
+            last_attempt: None,
+        })
+        .last_attempt = Some(now);
+
     let discovery_url = format!(
         "{}/.well-known/openid-configuration",
         prov.issuer.trim_end_matches('/')
     );
     match fetch_json(&discovery_url).await {
         Ok(doc) => {
+            // §4.3: the document must claim the issuer we asked about.
+            if doc.get("issuer").and_then(|v| v.as_str()) != Some(prov.issuer.as_str()) {
+                return Err(
+                    "discovery document issuer does not match the configured issuer".to_string(),
+                );
+            }
             let jwks_uri = doc
                 .get("jwks_uri")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| "discovery document carries no jwks_uri".to_string())?
                 .to_string();
-            discovery_cache()
-                .write()
-                .unwrap()
-                .insert(prov.issuer.clone(), (jwks_uri.clone(), now));
+            // The advertised endpoint decides where trust material comes
+            // from, so it must stay on the issuer's own origin — otherwise
+            // the discovery document is an open redirect into our network.
+            if !same_origin(&prov.issuer, &jwks_uri) {
+                return Err("discovery jwks_uri is not on the issuer's origin".to_string());
+            }
+            write_recover(discovery_cache())
+                .entry(prov.issuer.clone())
+                .or_insert(DiscoveryEntry {
+                    resolved: None,
+                    last_attempt: Some(now),
+                })
+                .resolved = Some((jwks_uri.clone(), now));
             Ok(jwks_uri)
         }
         Err(e) => {
             // Serve the stale resolution rather than failing auth outright.
-            if let Some((url, _)) = discovery_cache().read().unwrap().get(&prov.issuer) {
+            if let Some(url) = stale {
                 tracing::warn!(
                     target: "aisix::auth",
-                    issuer = %prov.issuer,
+                    issuer = %clip(&prov.issuer),
                     error = %e,
                     "OIDC discovery re-fetch failed; keeping the previously resolved JWKS URL",
                 );
-                return Ok(url.clone());
+                return Ok(url);
             }
             Err(format!("OIDC discovery failed: {e}"))
         }
     }
 }
 
+/// True when `candidate` shares scheme + host + port with `base`.
+fn same_origin(base: &str, candidate: &str) -> bool {
+    match (reqwest::Url::parse(base), reqwest::Url::parse(candidate)) {
+        (Ok(b), Ok(c)) => {
+            b.scheme() == c.scheme()
+                && b.host_str() == c.host_str()
+                && b.port_or_known_default() == c.port_or_known_default()
+        }
+        _ => false,
+    }
+}
+
 /// The cached key set for `url`, fetching when absent or past
-/// [`JWKS_TTL`]. A failed re-fetch keeps serving the stale set
-/// (network-partition tolerance); with nothing cached the error
-/// propagates and the request fails closed as retryable.
+/// [`JWKS_TTL`]. A fetch attempted within [`JWKS_REFRESH_MIN_INTERVAL`]
+/// suppresses another one: one inbound JWT must never become one
+/// outbound JWKS fetch, or a slow/down endpoint turns every request into
+/// a [`JWKS_FETCH_TIMEOUT`] wait and floods the identity provider. A
+/// failed re-fetch keeps serving the stale set; with nothing cached the
+/// error propagates and the request fails closed as retryable.
 async fn get_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
     let now = Instant::now();
-    if let Some(entry) = jwks_cache().read().unwrap().get(url) {
-        if let Some((jwks, fetched_at)) = &entry.jwks {
-            if now.duration_since(*fetched_at) < JWKS_TTL {
-                return Ok(jwks.clone());
+    let (stale, attempted_recently) = {
+        let map = read_recover(jwks_cache());
+        match map.get(url) {
+            Some(entry) => {
+                if let Some((jwks, fetched_at)) = &entry.jwks {
+                    if now.duration_since(*fetched_at) < JWKS_TTL {
+                        return Ok(jwks.clone());
+                    }
+                }
+                (
+                    entry.jwks.as_ref().map(|(j, _)| j.clone()),
+                    entry
+                        .last_attempt
+                        .is_some_and(|at| now.duration_since(at) < JWKS_REFRESH_MIN_INTERVAL),
+                )
             }
+            None => (None, false),
         }
+    };
+    if attempted_recently {
+        return stale.ok_or_else(|| "JWKS fetch suppressed by the refresh interval".to_string());
     }
     refresh_jwks(url).await
 }
@@ -616,7 +769,7 @@ async fn get_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
 /// [`JWKS_REFRESH_MIN_INTERVAL`] of the previous attempt.
 async fn refresh_jwks_rate_limited(url: &str) -> Option<Arc<JwkSet>> {
     let now = Instant::now();
-    if let Some(entry) = jwks_cache().read().unwrap().get(url) {
+    if let Some(entry) = read_recover(jwks_cache()).get(url) {
         if let Some(at) = entry.last_attempt {
             if now.duration_since(at) < JWKS_REFRESH_MIN_INTERVAL {
                 return None;
@@ -628,9 +781,9 @@ async fn refresh_jwks_rate_limited(url: &str) -> Option<Arc<JwkSet>> {
 
 async fn refresh_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
     // Stamp the attempt before awaiting so a slow endpoint is not
-    // hammered by concurrent unknown-kid refreshes.
+    // hammered by concurrent refreshes.
     {
-        let mut map = jwks_cache().write().unwrap();
+        let mut map = write_recover(jwks_cache());
         map.entry(url.to_string())
             .or_insert(JwksEntry {
                 jwks: None,
@@ -643,9 +796,7 @@ async fn refresh_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
     }) {
         Ok(set) => {
             let arc = Arc::new(set);
-            jwks_cache()
-                .write()
-                .unwrap()
+            write_recover(jwks_cache())
                 .entry(url.to_string())
                 .and_modify(|e| e.jwks = Some((arc.clone(), Instant::now())))
                 .or_insert(JwksEntry {
@@ -655,7 +806,7 @@ async fn refresh_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
             Ok(arc)
         }
         Err(e) => {
-            if let Some(entry) = jwks_cache().read().unwrap().get(url) {
+            if let Some(entry) = read_recover(jwks_cache()).get(url) {
                 if let Some((stale, _)) = &entry.jwks {
                     tracing::warn!(
                         target: "aisix::auth",
@@ -671,7 +822,7 @@ async fn refresh_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
 }
 
 async fn fetch_json(url: &str) -> Result<serde_json::Value, String> {
-    let resp = http_client()
+    let mut resp = http_client()
         .get(url)
         .send()
         .await
@@ -679,14 +830,27 @@ async fn fetch_json(url: &str) -> Result<serde_json::Value, String> {
     if !resp.status().is_success() {
         return Err(format!("endpoint returned status {}", resp.status()));
     }
-    let bytes = resp
-        .bytes()
-        .await
-        .map_err(|e| format!("reading response failed: {e}"))?;
-    if bytes.len() > JWKS_MAX_BYTES {
+    // Reject on the advertised length when present, then enforce the cap
+    // while streaming — `bytes()` would buffer the whole body first, so a
+    // hostile endpoint could OOM a small pod before any size check.
+    if resp
+        .content_length()
+        .is_some_and(|n| n > JWKS_MAX_BYTES as u64)
+    {
         return Err(format!("response exceeds {JWKS_MAX_BYTES} bytes"));
     }
-    serde_json::from_slice(&bytes).map_err(|e| format!("response is not JSON: {e}"))
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| format!("reading response failed: {e}"))?
+    {
+        if buf.len() + chunk.len() > JWKS_MAX_BYTES {
+            return Err(format!("response exceeds {JWKS_MAX_BYTES} bytes"));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    serde_json::from_slice(&buf).map_err(|e| format!("response is not JSON: {e}"))
 }
 
 #[cfg(test)]
@@ -748,7 +912,7 @@ jyxumGxNpoIV8LlzsMsaWQ==
 
     fn decoding_keys() -> Vec<DecodingKey> {
         let jwks: JwkSet = serde_json::from_str(TEST_JWKS).unwrap();
-        candidate_keys(&jwks, Some("test-kid-1"))
+        candidate_keys(&jwks, Some("test-kid-1"), Algorithm::RS256)
     }
 
     fn sign(claims: &serde_json::Value) -> String {
@@ -993,10 +1157,17 @@ jyxumGxNpoIV8LlzsMsaWQ==
     #[test]
     fn candidate_keys_selects_by_kid_and_falls_back_to_all() {
         let jwks: JwkSet = serde_json::from_str(TEST_JWKS).unwrap();
-        assert_eq!(candidate_keys(&jwks, Some("test-kid-1")).len(), 1);
-        assert!(candidate_keys(&jwks, Some("rotated-away")).is_empty());
+        assert_eq!(
+            candidate_keys(&jwks, Some("test-kid-1"), Algorithm::RS256).len(),
+            1
+        );
+        assert!(candidate_keys(&jwks, Some("rotated-away"), Algorithm::RS256).is_empty());
         // No kid on the token: every signature key is a candidate.
-        assert_eq!(candidate_keys(&jwks, None).len(), 1);
+        assert_eq!(candidate_keys(&jwks, None, Algorithm::RS256).len(), 1);
+        // The JWK declares alg RS256, so a token claiming a different alg
+        // finds no usable key (RFC 7517 §4.4).
+        assert!(candidate_keys(&jwks, Some("test-kid-1"), Algorithm::PS256).is_empty());
+        assert!(candidate_keys(&jwks, None, Algorithm::ES256).is_empty());
     }
 
     #[test]
@@ -1014,21 +1185,71 @@ jyxumGxNpoIV8LlzsMsaWQ==
         assert_eq!(picked.id, "a-provider");
         assert!(provider_for_issuer(&snapshot, "https://other.test").is_none());
 
-        let mk_key = |id: &str, subject: Option<&str>| {
+        let mk_key = |id: &str, subject: Option<&str>, provider: Option<&str>| {
             let mut k: ApiKey =
                 serde_json::from_str(r#"{"key_hash":"h","allowed_models":["*"]}"#).unwrap();
             k.jwt_subject = subject.map(str::to_string);
+            k.jwt_provider = provider.map(str::to_string);
             // Distinct key_hash per row so the by-name index stays unique.
             k.key_hash = format!("hash-{id}");
             snapshot.apikeys.insert(ResourceEntry::new(id, k, 1));
         };
-        mk_key("k-2", Some("agent-1"));
-        mk_key("k-1", Some("agent-1"));
-        mk_key("k-3", Some("agent-2"));
-        mk_key("k-4", None);
-        assert_eq!(key_for_subject(&snapshot, "agent-1").unwrap().id, "k-1");
-        assert_eq!(key_for_subject(&snapshot, "agent-2").unwrap().id, "k-3");
-        assert!(key_for_subject(&snapshot, "agent-9").is_none());
+        mk_key("k-2", Some("agent-1"), Some("corp"));
+        mk_key("k-1", Some("agent-1"), Some("corp"));
+        mk_key("k-3", Some("agent-2"), Some("corp"));
+        mk_key("k-4", None, None);
+        // A key bound to the SAME subject under a DIFFERENT provider must
+        // never be selected — this is the cross-provider impersonation
+        // guard (audit H1).
+        mk_key("k-5", Some("agent-1"), Some("partner"));
+        assert_eq!(
+            key_for_subject(&snapshot, "corp", "agent-1").unwrap().id,
+            "k-1"
+        );
+        assert_eq!(
+            key_for_subject(&snapshot, "corp", "agent-2").unwrap().id,
+            "k-3"
+        );
+        assert_eq!(
+            key_for_subject(&snapshot, "partner", "agent-1").unwrap().id,
+            "k-5"
+        );
+        // No provider match → no key, even though the subject exists.
+        assert!(key_for_subject(&snapshot, "unknown", "agent-1").is_none());
+        assert!(key_for_subject(&snapshot, "corp", "agent-9").is_none());
+    }
+
+    #[test]
+    fn same_origin_matches_scheme_host_port() {
+        assert!(same_origin(
+            "https://sso.example.com/realms/x",
+            "https://sso.example.com/realms/x/certs"
+        ));
+        // default port equivalence
+        assert!(same_origin(
+            "https://sso.example.com",
+            "https://sso.example.com:443/certs"
+        ));
+        // different host / scheme / port all rejected
+        assert!(!same_origin(
+            "https://sso.example.com",
+            "https://evil.example.com/certs"
+        ));
+        assert!(!same_origin(
+            "https://sso.example.com",
+            "http://sso.example.com/certs"
+        ));
+        assert!(!same_origin(
+            "https://sso.example.com",
+            "https://sso.example.com:8443/certs"
+        ));
+    }
+
+    #[test]
+    fn oversized_token_is_not_a_jwt() {
+        let big = format!("{}.{}.{}", "a".repeat(MAX_JWT_BYTES), "b", "c");
+        assert!(big.len() > MAX_JWT_BYTES);
+        assert!(!looks_like_jwt(&big));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -44,6 +44,7 @@ pub mod health;
 mod http_client;
 mod images;
 mod jobs;
+mod jwt;
 mod mcp;
 mod messages;
 mod model_resolve;

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -135,7 +135,7 @@ async fn prepare(
     headers: &HeaderMap,
     client: &ClientContext,
 ) -> Result<Prepared, ProxyError> {
-    let auth = authenticate(state, headers)?;
+    let auth = authenticate(state, headers).await?;
 
     let requested_model = params
         .get("model")
@@ -258,28 +258,31 @@ async fn prepare(
 
 /// Header bearer (`Authorization` / `x-api-key`) first, then the browser
 /// subprotocol credential.
-fn authenticate(state: &ProxyState, headers: &HeaderMap) -> Result<AuthenticatedKey, ProxyError> {
+async fn authenticate(
+    state: &ProxyState,
+    headers: &HeaderMap,
+) -> Result<AuthenticatedKey, ProxyError> {
     if let Some(auth) = headers.get(axum::http::header::AUTHORIZATION) {
         let s = auth.to_str().map_err(|_| ProxyError::MissingAuth)?;
         let token = s.strip_prefix("Bearer ").map(str::trim).unwrap_or("");
         if token.is_empty() {
             return Err(ProxyError::MissingAuth);
         }
-        return crate::auth::authenticate_token(state, token);
+        return crate::auth::authenticate_token(state, token).await;
     }
     if let Some(raw) = headers.get("x-api-key") {
         let token = raw.to_str().map_err(|_| ProxyError::MissingAuth)?.trim();
         if token.is_empty() {
             return Err(ProxyError::MissingAuth);
         }
-        return crate::auth::authenticate_token(state, token);
+        return crate::auth::authenticate_token(state, token).await;
     }
     if let Some(proto) = headers.get("sec-websocket-protocol") {
         let s = proto.to_str().map_err(|_| ProxyError::MissingAuth)?;
         for item in s.split(',') {
             if let Some(token) = item.trim().strip_prefix(SUBPROTOCOL_KEY_PREFIX) {
                 if !token.is_empty() {
-                    return crate::auth::authenticate_token(state, token);
+                    return crate::auth::authenticate_token(state, token).await;
                 }
             }
         }

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -303,6 +303,21 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
         ),
     );
 
+    // oidc_providers — identity: name; no secrets (issuer / audiences /
+    // JWKS endpoint are all public trust configuration).
+    push_kind(
+        &mut collections,
+        "oidc_providers",
+        emit_entries(
+            &snapshot.oidc_providers,
+            |p| p.name.clone(),
+            "oidc_providers",
+            &mut diag,
+            |_, _, _| {},
+            |_, _| {},
+        ),
+    );
+
     // guardrail_attachments are consumed above to decide which guardrails
     // are gateway-wide; they are not a file collection of their own.
 

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -170,6 +170,14 @@
         "null"
       ]
     },
+    "jwt_subject": {
+      "description": "External identity bound to this key for JWT authentication. When a request presents a valid JWT issued by a configured `oidc_providers` entry, the value of the provider's `identity_claim` selects the key whose `jwt_subject` equals it, and the request proceeds with this key's permissions, rate limits, and budget. Values must be unique within the environment. When omitted, the key is never selected by JWT authentication.",
+      "minLength": 1,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "key_hash": {
       "description": "SHA-256 hexadecimal hash of the plaintext bearer. The proxy hashes incoming bearer tokens before lookup.",
       "minLength": 1,

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -170,8 +170,16 @@
         "null"
       ]
     },
+    "jwt_provider": {
+      "description": "Name of the `oidc_providers` entry permitted to assert this key's `jwt_subject`. A subject is only ever resolved for the trust provider named here, so a second trusted provider cannot mint a token impersonating this provider's identity of the same name. Required whenever `jwt_subject` is set; ignored otherwise.",
+      "minLength": 1,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "jwt_subject": {
-      "description": "External identity bound to this key for JWT authentication. When a request presents a valid JWT issued by a configured `oidc_providers` entry, the value of the provider's `identity_claim` selects the key whose `jwt_subject` equals it, and the request proceeds with this key's permissions, rate limits, and budget. Values must be unique within the environment. When omitted, the key is never selected by JWT authentication.",
+      "description": "External identity bound to this key for JWT authentication. When a request presents a valid JWT issued by the `oidc_providers` entry named in `jwt_provider`, the value of that provider's `identity_claim` selects the key whose `jwt_subject` equals it, and the request proceeds with this key's permissions, rate limits, and budget. The `(jwt_provider, jwt_subject)` pair is unique within the environment. When omitted, the key is never selected by JWT authentication.",
       "minLength": 1,
       "type": [
         "string",

--- a/schemas/resources/oidc_provider.schema.json
+++ b/schemas/resources/oidc_provider.schema.json
@@ -13,6 +13,7 @@
           "items": {
             "type": "string"
           },
+          "minItems": 1,
           "type": "array"
         }
       ],

--- a/schemas/resources/oidc_provider.schema.json
+++ b/schemas/resources/oidc_provider.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "BoundClaimExpect": {
+      "anyOf": [
+        {
+          "description": "The claim must equal (or, for array claims, contain) this value.",
+          "type": "string"
+        },
+        {
+          "description": "The claim must equal (or, for array claims, contain) at least one of these values.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "Expected value(s) for one bound claim: a single string, or a list matched as any-of."
+    }
+  },
+  "properties": {
+    "audiences": {
+      "description": "Accepted `aud` values. The token's audience (a string or an array) must contain at least one of these. Every token must carry an audience claim.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "bound_claims": {
+      "additionalProperties": {
+        "$ref": "#/definitions/BoundClaimExpect"
+      },
+      "description": "Additional claim requirements, all of which must hold. Keys name claims (dots traverse nested objects, e.g. `\"realm_access.roles\"`); each requirement is satisfied when the claim equals — or, for array claims, contains — one of the expected values.",
+      "type": "object"
+    },
+    "enabled": {
+      "default": true,
+      "description": "Whether the provider participates in JWT authentication. A disabled provider is kept but ignored. Treated as `true` when omitted.",
+      "type": "boolean"
+    },
+    "identity_claim": {
+      "default": "sub",
+      "description": "Claim whose value selects the API key to act as: the request is bound to the key whose `jwt_subject` equals this claim's value. Dots traverse nested objects (e.g. `\"resource_access.account\"`). Defaults to `sub`.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "issuer": {
+      "description": "Expected `iss` claim, compared byte-for-byte against the token's issuer. A JWT whose issuer matches no enabled provider is rejected.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "jwks_uri": {
+      "description": "JWKS endpoint URL the signing keys are fetched from. When omitted, the endpoint is resolved once from the issuer's OIDC discovery document (`<issuer>/.well-known/openid-configuration`) and cached.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "leeway_secs": {
+      "description": "Clock-skew allowance in seconds applied to time-based claims (`exp`, `nbf`). Defaults to 0.",
+      "format": "uint64",
+      "maximum": 300.0,
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "name": {
+      "description": "Human-readable provider name, unique within the environment (e.g. `\"corp-keycloak\"`).",
+      "minLength": 1,
+      "type": "string"
+    },
+    "required_scopes": {
+      "description": "Scopes that must all be present in the token's `scope` claim (a space-delimited string or an array of strings). An empty list requires nothing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "audiences",
+    "issuer",
+    "name"
+  ],
+  "title": "OidcProvider",
+  "type": "object"
+}

--- a/tests/e2e/src/cases/jwt-auth-e2e.test.ts
+++ b/tests/e2e/src/cases/jwt-auth-e2e.test.ts
@@ -126,24 +126,39 @@ describe("jwt auth e2e: OIDC trust providers + jwt_subject key binding", () => {
     });
 
     // agent-1 → a key allowed MODEL only, rpm-limited to 2 so the
-    // rate-limit inheritance is observable.
+    // rate-limit inheritance is observable. Bound to the mock-idp
+    // provider: the pair (jwt_provider, jwt_subject) is what a token
+    // resolves against.
     await seed.createApiKey({
       key_hash: createHash("sha256").update("sk-jwt-agent-1").digest("hex"),
       allowed_models: [MODEL],
       jwt_subject: "agent-1",
+      jwt_provider: "mock-idp",
       rate_limit: { rpm: 2 },
     });
-    // agent-2 via the discovery provider, unrestricted models.
+    // agent-2 under mock-idp, unrestricted models.
     await seed.createApiKey({
       key_hash: createHash("sha256").update("sk-jwt-agent-2").digest("hex"),
       allowed_models: ["*"],
       jwt_subject: "agent-2",
+      jwt_provider: "mock-idp",
     });
-    // agent-disabled → a disabled key.
+    // A DISTINCT key with the SAME subject "agent-2" but bound to the
+    // discovery provider — proves subjects are namespaced by provider
+    // (audit H1): a token from mock-idp-discovery resolves here, not to
+    // the mock-idp agent-2 key above.
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update("sk-jwt-agent-2-disc").digest("hex"),
+      allowed_models: ["*"],
+      jwt_subject: "agent-2",
+      jwt_provider: "mock-idp-discovery",
+    });
+    // agent-disabled → a disabled key under mock-idp.
     await seed.createApiKey({
       key_hash: createHash("sha256").update("sk-jwt-agent-3").digest("hex"),
       allowed_models: ["*"],
       jwt_subject: "agent-disabled",
+      jwt_provider: "mock-idp",
       disabled: true,
     });
 
@@ -321,12 +336,93 @@ describe("jwt auth e2e: OIDC trust providers + jwt_subject key binding", () => {
   test("discovery-resolved provider authenticates (no jwks_uri configured)", async (ctx) => {
     if (skipUnlessUp(ctx)) return;
 
+    // Signed by idp2, issuer idp2 → resolves the mock-idp-discovery
+    // provider (no jwks_uri, endpoint found via OIDC discovery) → maps
+    // to the agent-2 key bound to that provider.
     const res = await chat(
       app!,
       idp2!.sign(agentClaims(idp2!.url, { sub: "agent-2" })),
     );
     expect(res.status).toBe(200);
     await res.text();
+  });
+
+  test("cross-provider impersonation is blocked: same subject, other provider → 401", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // A token from the discovery IdP asserting sub "agent-1" — a subject
+    // bound ONLY to the mock-idp provider. Even though the token is
+    // genuinely signed by a trusted provider, the identity must not
+    // resolve to the mock-idp agent-1 key (audit H1). agent-1 has no
+    // binding under mock-idp-discovery, so it is unmapped.
+    const res = await chat(
+      app!,
+      idp2!.sign(agentClaims(idp2!.url, { sub: "agent-1" })),
+    );
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_identity_unmapped");
+  });
+
+  test("no fallback: a JWT-shaped bearer that is also a valid API key is not retried as a key", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // Seed a key whose PLAINTEXT is a real JWT from the trusted IdP but
+    // whose claims fail (wrong audience). Presented as a bearer it would
+    // authenticate on the key path — but the JWT path owns it and its
+    // failure is final, with no fall-through to the key lookup.
+    const plaintext = idp!.sign(validClaims({ aud: "someone-else" }));
+    await seed!.createApiKey({
+      key_hash: createHash("sha256").update(plaintext).digest("hex"),
+      allowed_models: [MODEL],
+    });
+    // Give the key time to propagate, then confirm it is still rejected
+    // as a JWT (never accepted as the key it also is).
+    await sleep(2500);
+    const res = await chat(app!, plaintext);
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_invalid");
+  });
+
+  test("algorithm confusion: an HS256 token is rejected (asymmetric-only allowlist)", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // Forge the JOSE header alg to HS256 — the classic attempt to make
+    // the public JWKS modulus act as an HMAC secret. The signature is
+    // still the RS256 one, but the alg is outside ALLOWED_ALGS, so it is
+    // rejected before any key is tried.
+    const res = await chat(
+      app!,
+      idp!.sign(validClaims(), { header: { alg: "HS256" } }),
+    );
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_invalid");
+  });
+
+  test("a token with no kid verifies against a single-key JWKS", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // Omitting kid is legal; against a one-key set the sole signature
+    // key is the candidate. This exercises the no-kid fall-through path.
+    const res = await chat(app!, idp!.sign(validClaims(), { omitKid: true }));
+    expect(res.status).toBe(200);
+    await res.text();
+  });
+
+  test("the JWKS is cached: a burst of requests does not refetch per request", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // Warm the cache, record the fetch count, then burst. One inbound
+    // JWT must never be one outbound JWKS fetch (audit H2) — the count
+    // must not grow by the number of requests.
+    await waitFor200(() => chat(app!, idp!.sign(validClaims({ sub: "agent-2" }))));
+    const before = idp!.jwksFetches;
+    for (let i = 0; i < 8; i++) {
+      const res = await chat(app!, idp!.sign(validClaims({ sub: "agent-2" })));
+      await res.text();
+    }
+    // Allow a small slack for a TTL-boundary refresh, but nothing near
+    // one-per-request.
+    expect(idp!.jwksFetches - before).toBeLessThanOrEqual(1);
   });
 
   test("IdP key rotation is picked up without a restart", async (ctx) => {

--- a/tests/e2e/src/cases/jwt-auth-e2e.test.ts
+++ b/tests/e2e/src/cases/jwt-auth-e2e.test.ts
@@ -125,14 +125,22 @@ describe("jwt auth e2e: OIDC trust providers + jwt_subject key binding", () => {
       audiences: ["aisix-gateway"],
     });
 
-    // agent-1 → a key allowed MODEL only, rpm-limited to 2 so the
-    // rate-limit inheritance is observable. Bound to the mock-idp
-    // provider: the pair (jwt_provider, jwt_subject) is what a token
-    // resolves against.
+    // agent-1 → a key allowed MODEL only, bound to mock-idp. NOT
+    // rate-limited: 200-expecting tests share this identity, so its
+    // budget must not be exhaustible by earlier requests. The pair
+    // (jwt_provider, jwt_subject) is what a token resolves against.
     await seed.createApiKey({
       key_hash: createHash("sha256").update("sk-jwt-agent-1").digest("hex"),
       allowed_models: [MODEL],
       jwt_subject: "agent-1",
+      jwt_provider: "mock-idp",
+    });
+    // agent-rl → a dedicated rpm=2 key the rate-limit test can exhaust
+    // in isolation, so the coupling that flaked the shared key is gone.
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update("sk-jwt-agent-rl").digest("hex"),
+      allowed_models: ["*"],
+      jwt_subject: "agent-rl",
       jwt_provider: "mock-idp",
       rate_limit: { rpm: 2 },
     });
@@ -212,13 +220,14 @@ describe("jwt auth e2e: OIDC trust providers + jwt_subject key binding", () => {
   test("the bound key's rate_limit applies: burst past rpm → 429", async (ctx) => {
     if (skipUnlessUp(ctx)) return;
 
-    // rpm=2 on agent-1's key. Earlier tests in this file consumed the
-    // window unpredictably, so just burst until a 429 shows up — the
-    // contract is that JWT-authenticated traffic hits the bound key's
-    // limiter at all (an unbound identity would never 429).
+    // A dedicated rpm=2 identity (agent-rl) no other test shares, so the
+    // burst-to-429 is deterministic and cannot starve the 200-expecting
+    // tests. The contract is that JWT-authenticated traffic hits the
+    // bound key's limiter at all (an unbound identity would never 429).
+    const rlClaims = () => validClaims({ sub: "agent-rl" });
     let saw429 = false;
     for (let i = 0; i < 6 && !saw429; i++) {
-      const res = await chat(app!, idp!.sign(validClaims()));
+      const res = await chat(app!, idp!.sign(rlClaims()));
       saw429 = res.status === 429;
       await res.text();
     }

--- a/tests/e2e/src/cases/jwt-auth-e2e.test.ts
+++ b/tests/e2e/src/cases/jwt-auth-e2e.test.ts
@@ -1,0 +1,507 @@
+import { createHash } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  agentClaims,
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startMockIdp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type MockIdp,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: inbound OIDC/JWT authentication (AISIX-Cloud#1080, #1081).
+//
+// The environment trusts a mock identity provider (`oidc_providers`
+// row); API keys carry `jwt_subject` bindings. Pinned journeys:
+//
+//   1. A valid agent JWT authenticates and runs as its bound key —
+//      the key's allowed_models and rate_limit apply unchanged.
+//   2. Expired / tampered / wrong-audience / cross-issuer / exp-less
+//      tokens are all rejected before the upstream is touched, with
+//      stable `error.code` values.
+//   3. required_scopes and bound_claims reject entitlement gaps with
+//      403, distinct from the 401 credential failures.
+//   4. A valid token whose identity has no bound key is rejected
+//      (`jwt_identity_unmapped`) — never an anonymous pass.
+//   5. IdP key rotation is picked up without a gateway restart.
+//   6. Deleting the trust provider fails closed.
+//   7. `/v1/messages` renders the Anthropic error envelope.
+//   8. Auth decisions surface on `aisix_auth_decisions_total`.
+//   9. Without any trust provider, a JWT-shaped bearer falls through
+//      to the API-key path (and dotted custom keys keep working even
+//      with a provider configured).
+//
+// References:
+// - RFC 7519 (JWT) §4.1 registered claims
+//   <https://datatracker.ietf.org/doc/html/rfc7519#section-4.1>
+// - RFC 7517 (JWK) <https://datatracker.ietf.org/doc/html/rfc7517>
+// - OIDC Discovery 1.0 §4 <https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig>
+
+const MODEL = "jwt-auth-model";
+const OTHER_MODEL = "jwt-auth-other-model";
+
+function chatBody(model = MODEL): string {
+  return JSON.stringify({
+    model,
+    messages: [{ role: "user", content: "jwt auth probe" }],
+  });
+}
+
+async function chat(
+  app: SpawnedApp,
+  token: string,
+  model = MODEL,
+): Promise<Response> {
+  return fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: chatBody(model),
+  });
+}
+
+async function errorCode(res: Response): Promise<string | undefined> {
+  const body = (await res.json()) as { error?: { code?: string } };
+  return body.error?.code;
+}
+
+describe("jwt auth e2e: OIDC trust providers + jwt_subject key binding", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let idp: MockIdp | undefined;
+  let idp2: MockIdp | undefined;
+  let seed: SeedClient | undefined;
+  let providerId: string | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    idp = await startMockIdp();
+    idp2 = await startMockIdp();
+    app = await spawnApp({});
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "jwt-auth-pk",
+      api_key: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    for (const name of [MODEL, OTHER_MODEL]) {
+      await seed.createModel({
+        display_name: name,
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+    }
+
+    // The trusted provider, pinned to a direct jwks_uri. Requires the
+    // `ai.access` scope and a department bound claim.
+    const provider = await seed.createOidcProvider({
+      name: "mock-idp",
+      issuer: idp.url,
+      audiences: ["aisix-gateway"],
+      jwks_uri: idp.jwksUrl,
+      required_scopes: ["ai.access"],
+      bound_claims: { department: "ai-lab" },
+    });
+    providerId = provider.id;
+
+    // A second provider resolved via OIDC discovery (no jwks_uri).
+    await seed.createOidcProvider({
+      name: "mock-idp-discovery",
+      issuer: idp2.url,
+      audiences: ["aisix-gateway"],
+    });
+
+    // agent-1 → a key allowed MODEL only, rpm-limited to 2 so the
+    // rate-limit inheritance is observable.
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update("sk-jwt-agent-1").digest("hex"),
+      allowed_models: [MODEL],
+      jwt_subject: "agent-1",
+      rate_limit: { rpm: 2 },
+    });
+    // agent-2 via the discovery provider, unrestricted models.
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update("sk-jwt-agent-2").digest("hex"),
+      allowed_models: ["*"],
+      jwt_subject: "agent-2",
+    });
+    // agent-disabled → a disabled key.
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update("sk-jwt-agent-3").digest("hex"),
+      allowed_models: ["*"],
+      jwt_subject: "agent-disabled",
+      disabled: true,
+    });
+
+    await waitConfigPropagation(async () => {
+      const res = await chat(app!, idp!.sign(validClaims()));
+      await res.text();
+      return res.status === 200;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await idp?.close();
+    await idp2?.close();
+  });
+
+  function validClaims(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return agentClaims(idp!.url, {
+      scope: "openid ai.access",
+      department: "ai-lab",
+      ...overrides,
+    });
+  }
+
+  function skipUnlessUp(ctx: { skip: () => void }): boolean {
+    if (!etcdReachable || !app || !upstream || !idp || !idp2) {
+      ctx.skip();
+      return true;
+    }
+    return false;
+  }
+
+  test("valid agent JWT authenticates and runs as its bound key", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await chat(app!, idp!.sign(validClaims()));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { choices?: unknown[] };
+    expect(Array.isArray(body.choices)).toBe(true);
+  });
+
+  test("the bound key's allowed_models applies: other model → 403", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await chat(app!, idp!.sign(validClaims()), OTHER_MODEL);
+    expect(res.status).toBe(403);
+    await res.text();
+  });
+
+  test("the bound key's rate_limit applies: burst past rpm → 429", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // rpm=2 on agent-1's key. Earlier tests in this file consumed the
+    // window unpredictably, so just burst until a 429 shows up — the
+    // contract is that JWT-authenticated traffic hits the bound key's
+    // limiter at all (an unbound identity would never 429).
+    let saw429 = false;
+    for (let i = 0; i < 6 && !saw429; i++) {
+      const res = await chat(app!, idp!.sign(validClaims()));
+      saw429 = res.status === 429;
+      await res.text();
+    }
+    expect(saw429).toBe(true);
+  });
+
+  test("expired token → 401 jwt_expired, upstream untouched", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const hits = upstream!.receivedRequests.length;
+    const res = await chat(
+      app!,
+      idp!.sign(validClaims({ exp: Math.floor(Date.now() / 1000) - 3600 })),
+    );
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_expired");
+    expect(upstream!.receivedRequests.length).toBe(hits);
+  });
+
+  test("token without exp → 401 (default deny), upstream untouched", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const hits = upstream!.receivedRequests.length;
+    const claims = validClaims();
+    delete claims.exp;
+    const res = await chat(app!, idp!.sign(claims));
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_invalid");
+    expect(upstream!.receivedRequests.length).toBe(hits);
+  });
+
+  test("tampered payload → 401 jwt_invalid, upstream untouched", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const hits = upstream!.receivedRequests.length;
+    const token = idp!.sign(validClaims());
+    const parts = token.split(".");
+    parts[1] = Buffer.from(
+      JSON.stringify(validClaims({ sub: "agent-2" })),
+    ).toString("base64url");
+    const res = await chat(app!, parts.join("."));
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_invalid");
+    expect(upstream!.receivedRequests.length).toBe(hits);
+  });
+
+  test("wrong audience → 401 jwt_invalid", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await chat(app!, idp!.sign(validClaims({ aud: "someone-else" })));
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_invalid");
+  });
+
+  test("token from one issuer signed by another's key → 401", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // idp2 signs a token claiming idp1 as its issuer: the row matched
+    // is idp1's, whose JWKS cannot verify idp2's signature. Trust must
+    // never cross providers.
+    const res = await chat(app!, idp2!.sign(validClaims()));
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_invalid");
+  });
+
+  test("unknown issuer → 401 jwt_invalid (issuer allow-list)", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await chat(
+      app!,
+      idp!.sign(validClaims({ iss: "https://unregistered.example.com" })),
+    );
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_invalid");
+  });
+
+  test("missing required scope → 403 jwt_claims_rejected", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await chat(app!, idp!.sign(validClaims({ scope: "openid" })));
+    expect(res.status).toBe(403);
+    expect(await errorCode(res)).toBe("jwt_claims_rejected");
+  });
+
+  test("bound claim mismatch or absence → 403 jwt_claims_rejected", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const wrong = await chat(app!, idp!.sign(validClaims({ department: "finance" })));
+    expect(wrong.status).toBe(403);
+    expect(await errorCode(wrong)).toBe("jwt_claims_rejected");
+
+    const claims = validClaims();
+    delete claims.department;
+    const missing = await chat(app!, idp!.sign(claims));
+    expect(missing.status).toBe(403);
+    expect(await errorCode(missing)).toBe("jwt_claims_rejected");
+  });
+
+  test("valid token with unbound identity → 401 jwt_identity_unmapped", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await chat(app!, idp!.sign(validClaims({ sub: "agent-nobody" })));
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("jwt_identity_unmapped");
+  });
+
+  test("identity bound to a disabled key → 401 api_key_disabled", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await chat(app!, idp!.sign(validClaims({ sub: "agent-disabled" })));
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("api_key_disabled");
+  });
+
+  test("discovery-resolved provider authenticates (no jwks_uri configured)", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await chat(
+      app!,
+      idp2!.sign(agentClaims(idp2!.url, { sub: "agent-2" })),
+    );
+    expect(res.status).toBe(200);
+    await res.text();
+  });
+
+  test("IdP key rotation is picked up without a restart", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // Ensure the current JWKS is cached, then rotate.
+    const before = await chat(app!, idp!.sign(validClaims()));
+    // May be 200 or 429 (rate-limit test shares the key) — either way
+    // the JWKS is warm now.
+    await before.text();
+    const oldKid = idp!.currentKid;
+    idp!.rotate();
+
+    // Sit out the unknown-kid refresh rate limit, then a token under
+    // the new kid must verify — the gateway refetches the JWKS on the
+    // unknown kid instead of waiting for TTL expiry or a restart.
+    await sleep(1100);
+    const rotated = await waitFor200(() =>
+      chat(app!, idp!.sign(agentClaims(idp!.url, {
+        sub: "agent-2",
+        scope: "ai.access",
+        department: "ai-lab",
+      }))),
+    );
+    expect(rotated).toBe(true);
+
+    // A token still signed by the retired key no longer verifies.
+    await sleep(1100);
+    const stale = await chat(
+      app!,
+      idp!.sign(validClaims({ sub: "agent-2" }), { signWithKid: oldKid }),
+    );
+    expect(stale.status).toBe(401);
+    await stale.text();
+  });
+
+  test("/v1/messages renders the Anthropic error envelope on a JWT failure", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${idp!.sign(
+          validClaims({ exp: Math.floor(Date.now() / 1000) - 60 }),
+        )}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as {
+      type?: string;
+      error?: { type?: string };
+    };
+    expect(body.type).toBe("error");
+    expect(body.error?.type).toBe("authentication_error");
+  });
+
+  test("auth decisions surface on aisix_auth_decisions_total", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    const res = await fetch(`${app!.metricsUrl}/metrics`);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("aisix_auth_decisions_total");
+    expect(text).toMatch(/aisix_auth_decisions_total\{[^}]*method="jwt"[^}]*result="allowed"[^}]*\}/);
+    expect(text).toMatch(/aisix_auth_decisions_total\{[^}]*reason="jwt_expired"[^}]*\}/);
+  });
+
+  test("a custom dotted API key still authenticates while JWT auth is on", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    // Dots alone must not route a bearer down the JWT path — only a
+    // real JOSE header does. A custom-imported key shaped `a.b.c`
+    // keeps working even with trust providers configured.
+    const plaintext = "my.imported.key";
+    await seed!.createApiKey({
+      key_hash: createHash("sha256").update(plaintext).digest("hex"),
+      allowed_models: [MODEL],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await chat(app!, plaintext);
+      await res.text();
+      return res.status === 200;
+    });
+  });
+
+  test("deleting the trust provider fails closed", async (ctx) => {
+    if (skipUnlessUp(ctx)) return;
+
+    await seed!.delete("oidc_providers", providerId!);
+    // Poll until the deletion propagates: the same valid token flips
+    // from authenticating to rejected (its issuer is no longer
+    // trusted; the discovery provider still is, so JWT auth stays on
+    // and this is the allow-list shrinking, not the feature turning
+    // off).
+    await waitConfigPropagation(async () => {
+      const res = await chat(app!, idp!.sign(validClaims({ sub: "agent-2" })));
+      await res.text();
+      return res.status === 401;
+    });
+  });
+});
+
+async function waitFor200(request: () => Promise<Response>): Promise<boolean> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const res = await request();
+    await res.text();
+    if (res.status === 200) return true;
+    await sleep(300);
+  }
+  return false;
+}
+
+describe("jwt auth e2e: no trust provider configured", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let idp: MockIdp | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    idp = await startMockIdp();
+    app = await spawnApp({});
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    const pk = await seed.createProviderKey({
+      display_name: "jwt-off-pk",
+      api_key: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update("sk-plain").digest("hex"),
+      allowed_models: [MODEL],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await chat(app!, "sk-plain");
+      await res.text();
+      return res.status === 200;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await idp?.close();
+  });
+
+  test("a JWT-shaped bearer falls through to the key path and 401s without any JWKS fetch", async (ctx) => {
+    if (!etcdReachable || !app || !idp) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await chat(app!, idp!.sign(agentClaims(idp!.url)));
+    expect(res.status).toBe(401);
+    await res.text();
+    // The token never entered the JWT path: the mock IdP was never
+    // consulted. This pins "JWT auth is off unless a provider row
+    // exists" — no accidental outbound fetches on unmanaged
+    // deployments.
+    expect(idp!.jwksFetches).toBe(0);
+  });
+});

--- a/tests/e2e/src/cases/jwt-auth-e2e.test.ts
+++ b/tests/e2e/src/cases/jwt-auth-e2e.test.ts
@@ -402,8 +402,13 @@ describe("jwt auth e2e: OIDC trust providers + jwt_subject key binding", () => {
     if (skipUnlessUp(ctx)) return;
 
     // Omitting kid is legal; against a one-key set the sole signature
-    // key is the candidate. This exercises the no-kid fall-through path.
-    const res = await chat(app!, idp!.sign(validClaims(), { omitKid: true }));
+    // key is the candidate. Use the unrestricted agent-2 key so a
+    // successful auth is not masked by agent-1's rpm=2 window, which
+    // earlier successful requests may have consumed.
+    const res = await chat(
+      app!,
+      idp!.sign(validClaims({ sub: "agent-2" }), { omitKid: true }),
+    );
     expect(res.status).toBe(200);
     await res.text();
   });

--- a/tests/e2e/src/harness/index.ts
+++ b/tests/e2e/src/harness/index.ts
@@ -15,3 +15,4 @@ export {
   type MockSls,
   type CapturedPutLogs,
 } from "./sls-mock.js";
+export { startMockIdp, agentClaims, type MockIdp, type SignOpts } from "./jwks-mock.js";

--- a/tests/e2e/src/harness/jwks-mock.ts
+++ b/tests/e2e/src/harness/jwks-mock.ts
@@ -1,0 +1,170 @@
+import { createServer, type Server } from "node:http";
+import {
+  createPrivateKey,
+  createPublicKey,
+  createSign,
+  generateKeyPairSync,
+  type KeyObject,
+} from "node:crypto";
+
+import { pickFreePort } from "./ports.js";
+
+/**
+ * Mock OIDC identity provider for JWT-auth e2e: serves a JWKS document
+ * and an OIDC discovery document from a local HTTP server, and signs
+ * RS256 tokens with the matching private keys.
+ *
+ * `rotate()` replaces the published key set with a freshly generated
+ * key under a new `kid` — the mock-side half of the "key rotation
+ * without a gateway restart" scenario. Old keys are dropped from the
+ * JWKS (the strictest rotation), but their signer handles stay usable
+ * so a test can still mint a token with a retired key.
+ */
+export interface MockIdp {
+  /** Base URL, also the issuer unless a test overrides `iss`. */
+  url: string;
+  /** JWKS endpoint URL (`<url>/jwks`). */
+  jwksUrl: string;
+  /** `kid` of the currently published signing key. */
+  currentKid: string;
+  /** Number of JWKS fetches served, for cache-behavior assertions. */
+  jwksFetches: number;
+  /** Sign an RS256 JWT with the current key. */
+  sign(claims: Record<string, unknown>, opts?: SignOpts): string;
+  /** Publish a brand-new signing key under a new kid, dropping the old. */
+  rotate(): void;
+  close(): Promise<void>;
+}
+
+export interface SignOpts {
+  /** Override the `kid` placed in the JOSE header (default: current key). */
+  kid?: string;
+  /** Sign with a specific retired key instead of the current one. */
+  signWithKid?: string;
+  /** Omit the `kid` header entirely. */
+  omitKid?: boolean;
+  /** Extra JOSE header fields (e.g. a different `alg` label). */
+  header?: Record<string, unknown>;
+}
+
+interface KeyEntry {
+  kid: string;
+  privateKey: KeyObject;
+  jwk: Record<string, unknown>;
+}
+
+function b64u(data: Buffer | string): string {
+  return Buffer.from(data).toString("base64url");
+}
+
+function newKey(kid: string): KeyEntry {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+  });
+  const jwk = publicKey.export({ format: "jwk" }) as Record<string, unknown>;
+  return {
+    kid,
+    privateKey,
+    jwk: { ...jwk, kid, use: "sig", alg: "RS256" },
+  };
+}
+
+export async function startMockIdp(): Promise<MockIdp> {
+  const keys: KeyEntry[] = [newKey("kid-1")];
+  const retired: KeyEntry[] = [];
+  let generation = 1;
+
+  const state = {
+    jwksFetches: 0,
+  };
+
+  const port = await pickFreePort();
+  const url = `http://127.0.0.1:${port}`;
+
+  const server: Server = createServer((req, res) => {
+    const path = (req.url ?? "").split("?")[0];
+    if (path === "/jwks") {
+      state.jwksFetches += 1;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ keys: keys.map((k) => k.jwk) }));
+      return;
+    }
+    if (path === "/.well-known/openid-configuration") {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          issuer: url,
+          jwks_uri: `${url}/jwks`,
+        }),
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+
+  function findSigner(opts?: SignOpts): KeyEntry {
+    if (opts?.signWithKid) {
+      const k = [...keys, ...retired].find((k) => k.kid === opts.signWithKid);
+      if (!k) throw new Error(`no key ${opts.signWithKid}`);
+      return k;
+    }
+    return keys[0];
+  }
+
+  return {
+    url,
+    jwksUrl: `${url}/jwks`,
+    get currentKid() {
+      return keys[0].kid;
+    },
+    get jwksFetches() {
+      return state.jwksFetches;
+    },
+    sign(claims, opts) {
+      const signer = findSigner(opts);
+      const header: Record<string, unknown> = {
+        alg: "RS256",
+        typ: "JWT",
+        ...(opts?.omitKid ? {} : { kid: opts?.kid ?? signer.kid }),
+        ...opts?.header,
+      };
+      const signingInput = `${b64u(JSON.stringify(header))}.${b64u(
+        JSON.stringify(claims),
+      )}`;
+      const sig = createSign("RSA-SHA256")
+        .update(signingInput)
+        .sign(createPrivateKey(signer.privateKey.export({ format: "pem", type: "pkcs8" })));
+      return `${signingInput}.${sig.toString("base64url")}`;
+    },
+    rotate() {
+      generation += 1;
+      retired.push(...keys.splice(0));
+      keys.push(newKey(`kid-${generation}`));
+    },
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+/** Standard claim set for a mock agent token, expiring in one hour. */
+export function agentClaims(
+  issuer: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    iss: issuer,
+    aud: "aisix-gateway",
+    sub: "agent-1",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    ...overrides,
+  };
+}
+
+// Re-exported so tests can build unrelated public keys (e.g. a second
+// IdP whose keys must NOT verify against the first one's JWKS).
+export { createPublicKey };

--- a/tests/e2e/src/harness/seed.ts
+++ b/tests/e2e/src/harness/seed.ts
@@ -72,6 +72,12 @@ export class SeedClient {
     return this.put("rate_limit_policies", policy);
   }
 
+  async createOidcProvider(
+    provider: Record<string, unknown>,
+  ): Promise<{ id: string; value: Record<string, unknown> }> {
+    return this.put("oidc_providers", provider);
+  }
+
   /**
    * Overwrite the document at `<prefix>/<kind>/<id>` — the seed-side
    * equivalent of an Admin API PUT. Propagation is asynchronous; probe


### PR DESCRIPTION
Adds the data-plane half of AISIX-Cloud#1080 / AISIX-Cloud#1081: requests may now authenticate with an IdP-issued JWT (Keycloak or any OIDC-compliant provider) instead of a gateway API key. The paired control-plane PR (cp-admin.yaml CRUD + dashboard + CP↔DP e2e) follows in AISIX-Cloud.

## What

**New etcd kind `oidc_providers`** — env-scoped trust rows:

```jsonc
{
  "name": "corp-keycloak",
  "issuer": "https://sso.example.com/realms/agents",   // exact-match allow-list
  "audiences": ["aisix-gateway"],                      // token aud must intersect
  "jwks_uri": "https://…/certs",                       // optional; OIDC discovery fallback
  "identity_claim": "sub",                             // dot-paths supported
  "required_scopes": ["ai.access"],
  "bound_claims": { "department": "ai-lab", "realm_access.roles": ["agent"] },
  "leeway_secs": 0,
  "enabled": true
}
```

**JWT path at the single auth choke point** (`authenticate_token`): inherited by every proxy surface — chat/completions/messages/responses/embeddings/rerank/audio/images/videos/files/batches/fine-tuning, `/mcp`, `/a2a`, realtime WebSocket subprotocol auth, and passthrough — with **no fallback** to key lookup once a real JWT enters the path. A bearer is treated as a JWT only when it has three segments **and** the first decodes to a JOSE header, so dotted custom-imported keys keep working.

**Validation chain** (RFC 7519 §4.1, all default-deny):
- asymmetric algorithms only (`RS*`/`PS*`/`ES256/384`/`EdDSA`) — HMAC excluded so a public JWKS can never double as a shared signing secret
- signature against the matched provider's JWKS
- `exp` **required** and valid; `nbf` honored when present; per-provider `leeway_secs`
- `iss` pinned to the matched provider; an issuer matching no enabled row is rejected (the provider list is an allow-list, no catch-all path)
- `aud` **required**, matched against `audiences`
- `required_scopes` (space-delimited string or array `scope` claim) and `bound_claims` (dot-paths traverse nested claims) → `403 jwt_claims_rejected`

**Identity mapping — external token → internal API key**: the provider's `identity_claim` value selects the key whose new **`ApiKey.jwt_subject`** equals it. The request then proceeds as that key, so `allowed_models`, rate limits, budgets, usage attribution, and MCP/A2A ACLs all apply unchanged; an unmapped identity is `401 jwt_identity_unmapped`, never an anonymous pass. One key per agent identity gives 110+ agents per-agent budget/limit/attribution with zero changes downstream.

**JWKS lifecycle**: per-URL process cache (10 min TTL); fetches refuse redirects, carry a 5 s timeout and a 512 KB cap; a failed re-fetch serves the stale set (network-partition tolerance); an **unknown `kid` triggers a rate-limited (1/s) immediate re-fetch**, so IdP key rotation is picked up within ~1 s with no gateway restart.

**Auth decisions become observable** (the audit half of AISIX-Cloud#1081): new `aisix_auth_decisions_total{method, result, reason}` metric + `target="aisix::auth"` decision logs (denials at WARN with reason class / issuer / kid / subject — never the token; API-key path included). Previously a 401 was invisible — the extractor short-circuits before every handler, so no counter or log ever fired. New stable `error.code` values follow the existing lifecycle-code convention: `jwt_expired`, `jwt_invalid` (signature/issuer/audience collapsed to avoid an oracle), `jwt_claims_rejected` (403), `jwt_identity_unmapped`, `jwks_unavailable` (503 — IdP unreachable is retryable, not a credential judgment). `/v1/messages` renders all of them in the Anthropic envelope via the existing status mapping.

**Full config-surface wiring for the new kind**: loader, watch supervisor (apply/delete/clone/counts merge loops — the initial gap here was caught by the e2e and is now pinned by the every-kind supervisor tests), standalone `resources_file` (with a duplicate-`jwt_subject` load error mirroring the duplicate-credential rule), snapshot export, `schemas/resources/` via dump-schema. No Admin API CRUD surface for the kind in this PR (same posture as `mcp_policies`; the resources file covers standalone deployments).

## Reference-implementation comparison

Mainstream LLM proxies implement this same overall shape: an external JWT verified against a cached JWKS, then mapped to an internal virtual key that carries budget/limit/model policy (claim-value → key mapping), with structural JWT/key discrimination on the bearer and no fallback after a failed JWT validation. Upstream specs: RFC 7519 (JWT), RFC 7517 (JWK), OIDC Discovery 1.0 §4.

Deliberate divergences, all tightening:

| Area | Common behavior | Here |
|---|---|---|
| `iss`/`aud`/`exp` | global path verifies iss/aud only when configured; exp-less tokens accepted | all three mandatory |
| unlisted issuer | falls back to a catch-all verification path | rejected (allow-list) |
| unknown `kid` | waits out the JWKS cache TTL (rotation outage up to TTL) | rate-limited immediate re-fetch |
| unmapped identity | falls back to group/team-based identity | rejected (default deny) |
| JIT auto-registration | proxy writes the key row itself | out of scope — the DP is an etcd read-only consumer; fleets pre-create keys via the CP/Admin API |

## Tests

- `tests/e2e/src/cases/jwt-auth-e2e.test.ts` (20 cases, real binary + etcd + mock IdP): happy path; bound-key `allowed_models`/`rate_limit` inheritance; expired / tampered / exp-less / wrong-aud / cross-issuer / unknown-issuer rejections with stable codes and **zero upstream hits**; scope / bound-claim 403s; unmapped identity; disabled key; discovery-resolved provider; **key rotation without restart**; provider deletion failing closed; Anthropic envelope; metric exposure; dotted custom keys unaffected; and zero JWKS fetches when no provider is configured.
- Unit: validation matrix against a fixture RSA keypair (expired / missing-exp / missing-aud / wrong-iss / future-nbf / tampered / leeway), claim helpers, kid selection, provider/subject tie-breaks, schema/filesource/supervisor kind wiring.

Fixes api7/AISIX-Cloud#1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `oidc_providers` support end-to-end (schema, loading, snapshots, and exports).
  * Enabled inbound OIDC/JWT authentication with issuer discovery, JWKS validation, claim/scope checks, and key rotation.
  * Added an `aisix_auth_decisions_total` metric for authentication outcomes.
* **Bug Fixes**
  * Enforced API key JWT binding rules, including rejecting `jwt_subject` without `jwt_provider` and detecting duplicate `(jwt_provider, jwt_subject)` mappings.
* **Documentation**
  * Added JSON Schemas for `oidc_provider` and JWT subject binding fields.
* **Tests**
  * Added comprehensive JWT auth E2E coverage (including fail-closed behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->