### PR TITLE
revert(mcp): drop policy expiry (expires_at) from mcp_policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "aisix-gateway",
  "async-trait",
  "axum",
- "chrono",
  "futures",
  "hex",
  "http 1.4.0",

--- a/crates/aisix-core/src/models/mcp_policy.rs
+++ b/crates/aisix-core/src/models/mcp_policy.rs
@@ -24,7 +24,7 @@ use crate::resource::Resource;
 #[serde(rename_all = "snake_case")]
 pub enum McpPolicyScope {
     /// The environment-wide default, applied to keys whose team has no
-    /// active policy of its own.
+    /// enabled policy of its own.
     Env,
     /// A team-level policy, applied to the keys that belong to the team
     /// named by `scope_ref`. It replaces the environment default for those
@@ -98,7 +98,7 @@ fn default_enabled() -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum McpAccessMode {
-    /// The key uses the inherited grant unchanged: its team's active policy
+    /// The key uses the inherited grant unchanged: its team's enabled policy
     /// when one exists, otherwise the environment-default policy.
     Inherit,
     /// The key uses the intersection of the inherited grant and its own

--- a/crates/aisix-core/src/models/mcp_policy.rs
+++ b/crates/aisix-core/src/models/mcp_policy.rs
@@ -15,7 +15,6 @@
 //! policy `deny` patterns still subtracted. The effective-ACL computation
 //! lives with the MCP gateway endpoint, which resolves it per request.
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::resource::Resource;
@@ -79,14 +78,8 @@ pub struct McpPolicy {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deny: Vec<String>,
 
-    /// RFC 3339 timestamp after which the policy stops applying — it then
-    /// neither grants nor denies anything. When omitted or set to `null`,
-    /// the policy never expires.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<DateTime<Utc>>,
-
-    /// Whether the policy is applied. A disabled policy is kept but ignored,
-    /// exactly like an expired one. Treated as `true` when omitted.
+    /// Whether the policy is applied. A disabled policy is kept but
+    /// ignored. Treated as `true` when omitted.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
@@ -98,16 +91,6 @@ pub struct McpPolicy {
 
 fn default_enabled() -> bool {
     true
-}
-
-impl McpPolicy {
-    /// True if the policy participates in effective-ACL resolution at `now`:
-    /// enabled and not past its `expires_at` deadline. The expiry comparison
-    /// is strict (`<`), matching API-key expiry: the policy still applies at
-    /// the deadline instant itself.
-    pub fn is_active_at(&self, now: DateTime<Utc>) -> bool {
-        self.enabled && self.expires_at.is_none_or(|deadline| deadline >= now)
-    }
 }
 
 /// How an API key combines with the applicable MCP access policies:
@@ -188,7 +171,6 @@ mod tests {
         assert_eq!(p.mode, McpPolicyMode::Selected);
         assert_eq!(p.allow, vec!["github__*", "postgres__query"]);
         assert_eq!(p.deny, vec!["github__delete_repository"]);
-        assert!(p.expires_at.is_none());
         assert!(p.enabled);
     }
 
@@ -223,37 +205,13 @@ mod tests {
     }
 
     #[test]
-    fn is_active_honors_enabled_and_expiry() {
+    fn enabled_defaults_true_and_roundtrips_false() {
         let active: McpPolicy = serde_json::from_str(r#"{"scope":"env","mode":"all"}"#).unwrap();
-        let now = chrono::Utc::now();
-        assert!(active.is_active_at(now));
+        assert!(active.enabled);
 
         let disabled: McpPolicy =
             serde_json::from_str(r#"{"scope":"env","mode":"all","enabled":false}"#).unwrap();
-        assert!(!disabled.is_active_at(now));
-
-        let expiring: McpPolicy = serde_json::from_str(
-            r#"{"scope":"env","mode":"all","expires_at":"2030-01-01T00:00:00Z"}"#,
-        )
-        .unwrap();
-        let before = "2029-12-31T23:59:59Z".parse().unwrap();
-        let at = "2030-01-01T00:00:00Z".parse().unwrap();
-        let after = "2030-01-01T00:00:01Z".parse().unwrap();
-        assert!(expiring.is_active_at(before));
-        // Strict comparison: still applies at the deadline instant itself,
-        // inactive strictly after it (same boundary as API-key expiry).
-        assert!(expiring.is_active_at(at));
-        assert!(!expiring.is_active_at(after));
-    }
-
-    #[test]
-    fn rejects_malformed_expires_at() {
-        // A non-RFC3339 string must fail deserialization so the loader
-        // rejects the row instead of silently treating the policy as
-        // never-expiring.
-        let r: Result<McpPolicy, _> =
-            serde_json::from_str(r#"{"scope":"env","mode":"all","expires_at":"tomorrow"}"#);
-        assert!(r.is_err());
+        assert!(!disabled.enabled);
     }
 
     #[test]
@@ -304,7 +262,6 @@ mod tests {
         assert!(v.get("allow").is_none());
         assert!(v.get("deny").is_none());
         assert!(v.get("scope_ref").is_none());
-        assert!(v.get("expires_at").is_none());
 
         let a: McpAccess = serde_json::from_str(r#"{"mode":"inherit"}"#).unwrap();
         let v = serde_json::to_value(&a).unwrap();

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -409,8 +409,8 @@ pub fn oidc_provider_root_schema() -> Value {
 
 /// Canonical JSON Schema for the `mcp_policy` resource, derived from the
 /// [`McpPolicy`](crate::models::McpPolicy) struct. Uses the nullable `Option`
-/// representation (`true`) so `scope_ref`/`expires_at` accept an explicit
-/// `null` as well as being absent. The `scope`/`mode` closed sets come from
+/// representation (`true`) so `scope_ref` accepts an explicit `null` as
+/// well as being absent. The `scope`/`mode` closed sets come from
 /// the [`McpPolicyScope`](crate::models::McpPolicyScope) /
 /// [`McpPolicyMode`](crate::models::McpPolicyMode) enums, plus the one
 /// cross-field invariant `schemars` cannot express: a `team`-scoped policy
@@ -1531,7 +1531,6 @@ mod tests {
             "scope": "team",
             "scope_ref": "team-uuid-1",
             "mode": "all",
-            "expires_at": "2030-01-01T00:00:00Z",
             "enabled": true
         }))
         .unwrap();

--- a/crates/aisix-mcp/Cargo.toml
+++ b/crates/aisix-mcp/Cargo.toml
@@ -16,8 +16,6 @@ aisix-core = { path = "../aisix-core" }
 aisix-gateway = { path = "../aisix-gateway" }
 tokio.workspace = true
 async-trait.workspace = true
-# Effective-ACL resolution timestamps policy expiry checks (`ToolAcl::resolve`).
-chrono.workspace = true
 futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -26,7 +26,6 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, Content, ErrorData, ListToolsResult,
     PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
@@ -127,34 +126,34 @@ impl ToolAcl {
     }
 
     /// Resolve the effective ACL for `key` from the `mcp_policies` in
-    /// `snapshot` at time `now`.
+    /// `snapshot`.
     ///
     /// - A key without an `mcp_access` block keeps its legacy allow side
-    ///   (`allowed_tools`, no inheritance) — with active policy `deny`
+    ///   (`allowed_tools`, no inheritance) — with enabled policies' `deny`
     ///   patterns still subtracted, since deny applies to every key a policy
     ///   covers.
     /// - `deny` mode grants nothing.
     /// - `inherit` / `restrict` take the base grant from the key's team
-    ///   policy when one is active, else the environment-default policy,
+    ///   policy when one is enabled, else the environment-default policy,
     ///   else nothing; `restrict` intersects the key's own `allow` patterns
     ///   on top.
     /// - Deny patterns are unioned across the environment policy, the team
     ///   policy, and the key — an environment-level deny holds even when a
     ///   team policy replaces the environment's grant.
     ///
-    /// Inactive policies (disabled or expired) neither grant nor deny.
-    pub fn resolve(snapshot: &AisixSnapshot, key: &ApiKey, now: DateTime<Utc>) -> Self {
+    /// Disabled policies neither grant nor deny.
+    pub fn resolve(snapshot: &AisixSnapshot, key: &ApiKey) -> Self {
         // Grant side: pick the governing row per scope deterministically
         // (lowest id wins) so a duplicated row — the writer enforces
         // uniqueness — can only ever produce a stable outcome. Deny side:
-        // union across EVERY active row that applies to this key, so a
+        // union across EVERY enabled row that applies to this key, so a
         // deny pattern can never disappear by losing a duplicate-row
         // tie-break.
         let mut env_policy: Option<Arc<ResourceEntry<McpPolicy>>> = None;
         let mut team_policy: Option<Arc<ResourceEntry<McpPolicy>>> = None;
         let mut deny: Vec<String> = Vec::new();
         for entry in snapshot.mcp_policies.entries() {
-            if !entry.value.is_active_at(now) {
+            if !entry.value.enabled {
                 continue;
             }
             let slot = match entry.value.scope {

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -894,7 +894,7 @@ async fn tool_acl_per_server_wildcard_scopes_to_one_server() {
 #[test]
 fn resolve_duplicate_scope_rows_deny_union_survives_tie_break() {
     // Grant side: lowest id governs. Deny side: the union of every
-    // active applicable row — a deny must never vanish because its row
+    // enabled applicable row — a deny must never vanish because its row
     // lost the duplicate tie-break.
     let snapshot = policy_snapshot(&[
         (

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -524,7 +524,7 @@ fn policy_snapshot(rows: &[(&str, serde_json::Value)]) -> AisixSnapshot {
 }
 
 fn resolve_now(snapshot: &AisixSnapshot, key: &aisix_core::models::ApiKey) -> ToolAcl {
-    ToolAcl::resolve(snapshot, key, chrono::Utc::now())
+    ToolAcl::resolve(snapshot, key)
 }
 
 #[test]
@@ -732,7 +732,7 @@ fn resolve_inherit_ignores_key_allow_patterns() {
 }
 
 #[test]
-fn resolve_ignores_disabled_and_expired_policies() {
+fn resolve_ignores_disabled_policies() {
     let key = acl_key(serde_json::json!({
         "key_hash":"h","allowed_models":[],"team_id":"team-1",
         "mcp_access":{"mode":"inherit"}
@@ -755,12 +755,13 @@ fn resolve_ignores_disabled_and_expired_policies() {
     assert!(acl.permits("slack__post_message"));
     assert!(!acl.permits("github__create_issue"));
 
-    // Expired env policy → no grant at all (and its deny stops applying).
+    // Disabled env policy → no grant at all, and its deny stops
+    // applying (a disabled policy neither grants nor denies).
     let snapshot = policy_snapshot(&[(
         "p-env",
         serde_json::json!({
             "scope":"env","mode":"all","deny":["slack__*"],
-            "expires_at":"2000-01-01T00:00:00Z"
+            "enabled":false
         }),
     )]);
     let legacy = acl_key(serde_json::json!({
@@ -769,7 +770,7 @@ fn resolve_ignores_disabled_and_expired_policies() {
     assert!(!resolve_now(&snapshot, &key).permits("anything__at_all"));
     assert!(
         resolve_now(&snapshot, &legacy).permits("slack__post_message"),
-        "an expired policy's deny must stop applying"
+        "a disabled policy's deny must stop applying"
     );
 }
 

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -231,7 +231,7 @@ async fn dispatch(
     // Scope the gateway to the tools this caller's key permits — resolved
     // from the key together with the environment/team MCP access policies —
     // so MCP tool access is governed by the same key object as LLM access.
-    let acl = aisix_mcp::ToolAcl::resolve(&snapshot, auth.key(), chrono::Utc::now());
+    let acl = aisix_mcp::ToolAcl::resolve(&snapshot, auth.key());
     let gateway = aisix_mcp::McpGateway::from_snapshot(&snapshot).with_tool_acl(acl);
     let service = aisix_mcp::streamable_http_service(gateway);
     let request = Request::from_parts(parts, Body::from(bytes));

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -38,7 +38,7 @@
       "description": "How an API key combines with the applicable MCP access policies: `inherit`, `restrict`, or `deny`.",
       "oneOf": [
         {
-          "description": "The key uses the inherited grant unchanged: its team's active policy when one exists, otherwise the environment-default policy.",
+          "description": "The key uses the inherited grant unchanged: its team's enabled policy when one exists, otherwise the environment-default policy.",
           "enum": [
             "inherit"
           ],

--- a/schemas/resources/mcp_policy.schema.json
+++ b/schemas/resources/mcp_policy.schema.json
@@ -54,7 +54,7 @@
       "description": "Which API keys an MCP access policy applies to.",
       "oneOf": [
         {
-          "description": "The environment-wide default, applied to keys whose team has no active policy of its own.",
+          "description": "The environment-wide default, applied to keys whose team has no enabled policy of its own.",
           "enum": [
             "env"
           ],

--- a/schemas/resources/mcp_policy.schema.json
+++ b/schemas/resources/mcp_policy.schema.json
@@ -87,16 +87,8 @@
     },
     "enabled": {
       "default": true,
-      "description": "Whether the policy is applied. A disabled policy is kept but ignored, exactly like an expired one. Treated as `true` when omitted.",
+      "description": "Whether the policy is applied. A disabled policy is kept but ignored. Treated as `true` when omitted.",
       "type": "boolean"
-    },
-    "expires_at": {
-      "description": "RFC 3339 timestamp after which the policy stops applying — it then neither grants nor denies anything. When omitted or set to `null`, the policy never expires.",
-      "format": "date-time",
-      "type": [
-        "string",
-        "null"
-      ]
     },
     "mode": {
       "allOf": [


### PR DESCRIPTION
Scope trim for the layered MCP access policy (#822, Ref api7/AISIX-Cloud#1034): policy expiry turned out not to be a customer requirement, so the surface is reverted to its minimal shape before any release carries it. A policy's activity is now the `enabled` flag alone — a disabled policy neither grants nor denies.

- `McpPolicy` loses `expires_at` (schema regenerated); `ToolAcl::resolve` drops its timestamp parameter and the `/mcp` mount no longer threads a clock into ACL resolution; the chrono dependency added for this leaves `aisix-mcp`.
- Tests: the expiry cases collapse into enabled-only equivalents (12 model + 28 gateway + 16 proxy tests pass); the TS e2e suite never used the field (8/8 pass against a rebuilt binary).
- Compatibility: the document schema is closed (`deny_unknown_fields`), so a stored row carrying `expires_at` would be rejected after this lands. No released version ever wrote the field (0.5.0 predates #822); only a policy saved with an expiry on a dev/main deployment inside the feature's two-day window would need one re-save. The paired control-plane revert (field off the API/UI/projection, and the never-released DB column dropped outright — the additive-only rule protects released shapes only) follows once this is on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * MCP policies no longer expire based on time.
  * Disabled policies remain excluded from tool authorization decisions.
  * Omitted policy settings continue to default to enabled.
* **Schema Updates**
  * Updated policy documentation to reflect current nullability and enabled-policy behavior.
  * Removed expiration-related fields and guidance from policy schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Transition detail for that window: the loader skips a schema-rejected row and serves the rest, so a stored policy row still carrying `expires_at` is dropped whole until re-saved — its grant fails closed (visible immediately), and its `deny` overlay stops applying until the re-save. Both resolve with one save of the policy.

