### PR TITLE
feat(headers): request-context variables in default_headers + client-header forwarding allowlist

### DIFF
--- a/crates/aisix-core/src/header_template.rs
+++ b/crates/aisix-core/src/header_template.rs
@@ -1,0 +1,233 @@
+//! `${...}` variable substitution for `ProviderKey.request.default_headers`
+//! values (AISIX-Cloud#1112).
+//!
+//! An operator writes `"x-tenant-id": "${request.api_key.team_id}"` on the
+//! ProviderKey and the data plane renders it per request, just before the
+//! upstream call, so internal model services can attribute traffic to the
+//! calling tenant/team/key without the customer minting a provider
+//! credential per tenant.
+//!
+//! Three rules make this safe to expose to operator-supplied config:
+//!
+//! 1. **Closed vocabulary.** Only the names in [`HEADER_TEMPLATE_VARS`]
+//!    resolve. Anything else makes the whole template unresolvable — cp-api
+//!    rejects unknown names at write time and the renderer refuses them
+//!    again at runtime, so a typo can never fall through as a literal
+//!    `${...}` on the wire.
+//! 2. **No secret is reachable.** The vocabulary carries identifiers and
+//!    display names only. The caller's plaintext bearer, the ProviderKey
+//!    secret and every credential field are simply not in [`HeaderVars`],
+//!    so no template can name them.
+//! 3. **Empty means skip, never blank.** A variable that has no value for
+//!    this request (a key with no team, say) renders the whole header
+//!    unresolvable and the header is dropped. Emitting `x-tenant-id: ""`
+//!    would read to the upstream as "tenant is the empty string", which is
+//!    a different and misleading claim.
+
+use std::fmt::Write as _;
+
+/// The closed set of variable names a `default_headers` value may
+/// reference. Kept in the same order the docs list them.
+///
+/// cp-api mirrors this list in
+/// `internal/cpapi/resources/provider_key_overrides.go` so a bad template
+/// is a 400 at write time rather than a silently-dropped header at
+/// dispatch time. **The two lists must stay in sync**; this one is
+/// canonical.
+pub const HEADER_TEMPLATE_VARS: &[&str] = &[
+    "request.id",
+    "request.api_key.id",
+    "request.api_key.name",
+    "request.api_key.team_id",
+    "request.api_key.user_id",
+    "model.id",
+    "model.name",
+    "provider_key.id",
+    "provider_key.name",
+];
+
+/// Per-request values the [`HEADER_TEMPLATE_VARS`] resolve against.
+///
+/// Every field is optional because the underlying resource field is
+/// optional (`team_id` on a personal key) or because the call site has no
+/// such resource in scope. An absent field makes any template naming it
+/// unresolvable — see the module docs.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HeaderVars<'a> {
+    pub request_id: Option<&'a str>,
+    pub api_key_id: Option<&'a str>,
+    pub api_key_name: Option<&'a str>,
+    pub api_key_team_id: Option<&'a str>,
+    pub api_key_user_id: Option<&'a str>,
+    pub model_id: Option<&'a str>,
+    pub model_name: Option<&'a str>,
+    pub provider_key_id: Option<&'a str>,
+    pub provider_key_name: Option<&'a str>,
+}
+
+impl<'a> HeaderVars<'a> {
+    /// Resolve one variable name. `None` for both an unknown name and a
+    /// known-but-absent value — the caller treats them identically
+    /// (the header is dropped), and cp-api has already rejected the
+    /// unknown-name case at write time.
+    fn resolve(&self, name: &str) -> Option<&'a str> {
+        let v = match name {
+            "request.id" => self.request_id,
+            "request.api_key.id" => self.api_key_id,
+            "request.api_key.name" => self.api_key_name,
+            "request.api_key.team_id" => self.api_key_team_id,
+            "request.api_key.user_id" => self.api_key_user_id,
+            "model.id" => self.model_id,
+            "model.name" => self.model_name,
+            "provider_key.id" => self.provider_key_id,
+            "provider_key.name" => self.provider_key_name,
+            _ => None,
+        }?;
+        // An empty string is the same "no value for this request" state as
+        // an absent field — see the module docs on why a blank header is
+        // worse than no header.
+        (!v.is_empty()).then_some(v)
+    }
+}
+
+/// True when `value` contains at least one `${...}` reference.
+///
+/// Lets the apply path skip rendering entirely for the overwhelmingly
+/// common static-header case.
+pub fn is_template(value: &str) -> bool {
+    value.contains("${")
+}
+
+/// Render a `default_headers` value, substituting every `${name}` for its
+/// per-request value.
+///
+/// Returns `None` when the template cannot be fully resolved — an unknown
+/// variable name, a variable with no value for this request, or an
+/// unterminated `${`. The caller drops that header rather than sending a
+/// partially-substituted value. A value with no `${` renders to itself.
+///
+/// A resolved value that would inject CR/LF/NUL is rejected the same way
+/// (`None`): the substituted-in data is a display name an operator typed
+/// into the dashboard, so it is not trusted to be header-safe even though
+/// cp-api validates the template's own literal text.
+pub fn render_header_template(value: &str, vars: &HeaderVars<'_>) -> Option<String> {
+    if !is_template(value) {
+        return Some(value.to_string());
+    }
+    let mut out = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let end = after.find('}')?;
+        let resolved = vars.resolve(after[..end].trim())?;
+        // `write!` into a String is infallible.
+        let _ = out.write_str(resolved);
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    if out.contains(['\r', '\n', '\0']) {
+        return None;
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars() -> HeaderVars<'static> {
+        HeaderVars {
+            request_id: Some("req-1"),
+            api_key_id: Some("ak-uuid"),
+            api_key_name: Some("acme-prod"),
+            api_key_team_id: Some("team-7"),
+            api_key_user_id: Some("user-9"),
+            model_id: Some("m-uuid"),
+            model_name: Some("gpt-4o"),
+            provider_key_id: Some("pk-uuid"),
+            provider_key_name: Some("openai-main"),
+        }
+    }
+
+    #[test]
+    fn static_value_renders_to_itself() {
+        assert_eq!(
+            render_header_template("plain", &vars()).as_deref(),
+            Some("plain")
+        );
+        assert!(!is_template("plain"));
+    }
+
+    #[test]
+    fn every_documented_variable_resolves() {
+        for name in HEADER_TEMPLATE_VARS {
+            let rendered = render_header_template(&format!("${{{name}}}"), &vars());
+            assert!(
+                rendered.is_some_and(|v| !v.is_empty()),
+                "documented variable {name} must resolve"
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_literal_and_multiple_variables() {
+        assert_eq!(
+            render_header_template("k=${request.api_key.name}/${model.name}!", &vars()).as_deref(),
+            Some("k=acme-prod/gpt-4o!")
+        );
+    }
+
+    #[test]
+    fn unknown_variable_is_unresolvable() {
+        assert_eq!(render_header_template("${request.secret}", &vars()), None);
+        // cp-api rejects these at write time; belt-and-braces at runtime.
+        assert_eq!(render_header_template("${api_key.secret}", &vars()), None);
+    }
+
+    #[test]
+    fn absent_or_empty_variable_drops_the_header() {
+        let no_team = HeaderVars {
+            api_key_team_id: None,
+            ..vars()
+        };
+        assert_eq!(
+            render_header_template("${request.api_key.team_id}", &no_team),
+            None
+        );
+        let blank_team = HeaderVars {
+            api_key_team_id: Some(""),
+            ..vars()
+        };
+        assert_eq!(
+            render_header_template("t=${request.api_key.team_id}", &blank_team),
+            None,
+            "a blank value must drop the header, not send `t=`"
+        );
+    }
+
+    #[test]
+    fn unterminated_reference_is_unresolvable() {
+        assert_eq!(render_header_template("${request.id", &vars()), None);
+    }
+
+    #[test]
+    fn resolved_value_carrying_crlf_is_rejected() {
+        let injected = HeaderVars {
+            api_key_name: Some("evil\r\nx-admin: 1"),
+            ..vars()
+        };
+        assert_eq!(
+            render_header_template("${request.api_key.name}", &injected),
+            None
+        );
+    }
+
+    #[test]
+    fn whitespace_inside_the_reference_is_tolerated() {
+        assert_eq!(
+            render_header_template("${ request.id }", &vars()).as_deref(),
+            Some("req-1")
+        );
+    }
+}

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod config;
 pub mod config_status;
 pub mod error;
 pub mod filesource;
+pub mod header_template;
 pub mod models;
 pub mod resource;
 pub mod snapshot;
@@ -38,6 +39,7 @@ pub use config_status::{
 pub use error::{
     AdminError, AdminErrorEnvelope, BootstrapError, ProxyError, ProxyErrorEnvelope, RateLimitScope,
 };
+pub use header_template::{render_header_template, HeaderVars, HEADER_TEMPLATE_VARS};
 pub use models::{
     validate_a2a_agent, validate_apikey, validate_cache_policy, validate_guardrail,
     validate_mcp_server, validate_model, validate_observability_exporter, validate_provider_key,

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -24,6 +24,12 @@ pub struct ApiKey {
     #[schemars(length(min = 1))]
     pub key_hash: String,
 
+    /// Operator-facing label for this key, as shown in the dashboard.
+    /// Read only by the `${request.api_key.name}` header template
+    /// (AISIX-Cloud#1112); never used for authentication or routing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+
     /// Model identifiers this key may use. An empty array denies access to every model.
     pub allowed_models: Vec<String>,
 
@@ -265,6 +271,7 @@ mod tests {
     fn empty_allowed_models_denies_everything() {
         let k = ApiKey {
             key_hash: "abc".into(),
+            display_name: None,
             allowed_models: vec![],
             rate_limit: None,
             team_id: None,

--- a/crates/aisix-core/src/models/provider_key.rs
+++ b/crates/aisix-core/src/models/provider_key.rs
@@ -195,12 +195,24 @@ pub struct RequestOverrides {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub param_constraints: Option<ParamConstraints>,
 
-    /// `apply_default_headers` input. Top-level headers added to the
-    /// outbound request when the caller did not set them. Reserved
-    /// auth headers are dropped by `apply_default_headers` as
-    /// defense-in-depth.
+    /// Top-level headers added to the outbound request when the caller did
+    /// not set them. Values may reference the request context with `${...}`
+    /// variables, such as `"${request.api_key.team_id}"`; a header whose
+    /// variables do not all resolve is dropped rather than sent blank. See
+    /// [`crate::header_template`] for the closed variable vocabulary.
+    /// Reserved auth headers are dropped as defense-in-depth.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub default_headers: HashMap<String, String>,
+
+    /// Inbound client headers forwarded to the upstream provider, as
+    /// single-`*` glob patterns matched case-insensitively against the
+    /// header name (`"anthropic-beta"`, `"x-trace-*"`). Empty — the
+    /// default — forwards nothing, which is the behavior of every
+    /// standard-protocol endpoint before AISIX-Cloud#1167. Auth,
+    /// transport, and gateway-owned headers are never forwarded whatever
+    /// the patterns say.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub forward_client_headers: Vec<String>,
 
     /// `apply_default_body_fields` input. Top-level body fields added
     /// when the caller did not set them. `serde_json::Map` preserves

--- a/crates/aisix-core/src/resource.rs
+++ b/crates/aisix-core/src/resource.rs
@@ -17,6 +17,13 @@ use std::ops::Deref;
 /// can build a secondary name-index without knowing the concrete type.
 pub trait Resource: Send + Sync + 'static {
     /// Stable UUID v4 identifying this resource (etcd key suffix).
+    ///
+    /// **Read the id from the enclosing [`ResourceEntry::id`], not from
+    /// here.** Implementations return a `runtime_id` field that the
+    /// snapshot loader does not populate, so at runtime this is the empty
+    /// string for every entity loaded from etcd — only tests set it. The
+    /// trait keeps the method because the snapshot's index construction is
+    /// generic over it.
     fn id(&self) -> &str;
 
     /// Human-readable unique name within the resource kind. Used for

--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -16,12 +16,14 @@
 //! The trait is deliberately `async_trait` rather than GATs — ergonomic
 //! wins outweigh the boxing cost on the provider path.
 
-use aisix_core::{Model, ProviderKey};
+use aisix_core::{HeaderVars, Model, ProviderKey, Resource};
 use async_trait::async_trait;
 use futures::stream::BoxStream;
+use http::HeaderMap;
 use std::time::Duration;
 
 use crate::chat::{ChatChunk, ChatFormat, ChatResponse, EmbeddingRequest, EmbeddingResponse};
+use crate::upstream_headers::{CallerIdentity, UpstreamHeaderContext};
 
 /// Maximum number of bytes read from an upstream error response body
 /// before attempting JSON envelope parse. Bounds memory and parser cost
@@ -99,6 +101,14 @@ pub struct BridgeContext {
     /// Deadline for the entire upstream call. Bridges are expected to
     /// honour this by cancelling any in-flight HTTP request.
     pub deadline: Option<Duration>,
+    /// The authenticated caller, for `${request.api_key.*}` header
+    /// templates. Default (all-empty) on calls with no caller behind
+    /// them — a background job poll, an internal embedding lookup.
+    pub caller: CallerIdentity,
+    /// The inbound request's headers, source for the ProviderKey's
+    /// `request.forward_client_headers` allowlist. `None` on the same
+    /// caller-less paths as above.
+    pub client_headers: Option<std::sync::Arc<HeaderMap>>,
 }
 
 impl BridgeContext {
@@ -112,12 +122,48 @@ impl BridgeContext {
             model,
             provider_key,
             deadline: None,
+            caller: CallerIdentity::default(),
+            client_headers: None,
         }
     }
 
     pub fn with_deadline(mut self, deadline: Duration) -> Self {
         self.deadline = Some(deadline);
         self
+    }
+
+    /// Attach the caller identity and inbound headers the outbound-header
+    /// pipeline reads. Dispatch paths with a real client request call this;
+    /// leaving it off means no client header is ever forwarded and
+    /// `${request.api_key.*}` templates do not resolve.
+    pub fn with_client(
+        mut self,
+        caller: CallerIdentity,
+        client_headers: Option<std::sync::Arc<HeaderMap>>,
+    ) -> Self {
+        self.caller = caller;
+        self.client_headers = client_headers;
+        self
+    }
+
+    /// The context [`crate::upstream_headers::apply_request_headers`] needs
+    /// to render `default_headers` templates and forward client headers.
+    pub fn header_ctx(&self) -> UpstreamHeaderContext<'_> {
+        UpstreamHeaderContext {
+            overrides: self.provider_key.request.as_ref(),
+            vars: HeaderVars {
+                request_id: Some(&self.request_id),
+                api_key_id: Some(&self.caller.api_key_id),
+                api_key_name: self.caller.api_key_name.as_deref(),
+                api_key_team_id: self.caller.team_id.as_deref(),
+                api_key_user_id: self.caller.user_id.as_deref(),
+                model_id: Some(self.model.id()),
+                model_name: Some(&self.model.display_name),
+                provider_key_id: Some(self.provider_key.id()),
+                provider_key_name: Some(&self.provider_key.display_name),
+            },
+            client_headers: self.client_headers.as_deref(),
+        }
     }
 }
 

--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -16,7 +16,7 @@
 //! The trait is deliberately `async_trait` rather than GATs — ergonomic
 //! wins outweigh the boxing cost on the provider path.
 
-use aisix_core::{HeaderVars, Model, ProviderKey, Resource};
+use aisix_core::{HeaderVars, Model, ProviderKey};
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use http::HeaderMap;
@@ -109,6 +109,14 @@ pub struct BridgeContext {
     /// `request.forward_client_headers` allowlist. `None` on the same
     /// caller-less paths as above.
     pub client_headers: Option<std::sync::Arc<HeaderMap>>,
+    /// Snapshot ids of the resolved Model and ProviderKey, for the
+    /// `${model.id}` / `${provider_key.id}` header templates. They are
+    /// carried separately because a `Model` / `ProviderKey` value does not
+    /// know its own etcd id at runtime — the id lives on the enclosing
+    /// `ResourceEntry`, and `Resource::id()` on the value reads an
+    /// unpopulated field outside tests.
+    pub model_id: String,
+    pub provider_key_id: String,
 }
 
 impl BridgeContext {
@@ -124,6 +132,8 @@ impl BridgeContext {
             deadline: None,
             caller: CallerIdentity::default(),
             client_headers: None,
+            model_id: String::new(),
+            provider_key_id: String::new(),
         }
     }
 
@@ -146,6 +156,18 @@ impl BridgeContext {
         self
     }
 
+    /// Attach the snapshot ids of the resolved Model / ProviderKey. See
+    /// the field docs for why they cannot be read off the values.
+    pub fn with_resource_ids(
+        mut self,
+        model_id: impl Into<String>,
+        provider_key_id: impl Into<String>,
+    ) -> Self {
+        self.model_id = model_id.into();
+        self.provider_key_id = provider_key_id.into();
+        self
+    }
+
     /// The context [`crate::upstream_headers::apply_request_headers`] needs
     /// to render `default_headers` templates and forward client headers.
     pub fn header_ctx(&self) -> UpstreamHeaderContext<'_> {
@@ -157,9 +179,9 @@ impl BridgeContext {
                 api_key_name: self.caller.api_key_name.as_deref(),
                 api_key_team_id: self.caller.team_id.as_deref(),
                 api_key_user_id: self.caller.user_id.as_deref(),
-                model_id: Some(self.model.id()),
+                model_id: Some(&self.model_id),
                 model_name: Some(&self.model.display_name),
-                provider_key_id: Some(self.provider_key.id()),
+                provider_key_id: Some(&self.provider_key_id),
                 provider_key_name: Some(&self.provider_key.display_name),
             },
             client_headers: self.client_headers.as_deref(),

--- a/crates/aisix-gateway/src/lib.rs
+++ b/crates/aisix-gateway/src/lib.rs
@@ -28,6 +28,7 @@ pub mod chat;
 pub mod credential;
 pub mod hub;
 pub mod sse;
+pub mod upstream_headers;
 pub mod upstream_http;
 
 pub use bridge::{
@@ -42,6 +43,10 @@ pub use chat::{
 pub use credential::credential_fingerprint;
 pub use hub::Hub;
 pub use sse::{SseDecoder, SseEvent};
+pub use upstream_headers::{
+    apply_request_headers, resolve_extra_headers, CallerIdentity, UpstreamHeaderContext,
+    RESERVED_UPSTREAM_HEADERS,
+};
 pub use upstream_http::{
     client_builder, error_with_causes, transport_error_message, UpstreamHttpConfig,
 };

--- a/crates/aisix-gateway/src/upstream_headers.rs
+++ b/crates/aisix-gateway/src/upstream_headers.rs
@@ -1,0 +1,454 @@
+//! The one place outbound headers that are **not** owned by the gateway get
+//! added to a standard-protocol upstream request.
+//!
+//! Two operator-facing features share this pipeline, in this order:
+//!
+//! 1. `request.default_headers` — static headers the ProviderKey injects,
+//!    with `${...}` request-context variables rendered per request
+//!    (AISIX-Cloud#1112).
+//! 2. `request.forward_client_headers` — inbound client headers matching an
+//!    operator-configured allowlist, forwarded verbatim
+//!    (AISIX-Cloud#1167).
+//!
+//! **Precedence is gateway > operator > client, and it is structural.** Every
+//! caller inserts its own bridge-owned headers (auth, `content-type`,
+//! `x-aisix-request-id`, streaming `accept`) into the `HeaderMap` *first*, and
+//! nothing here overwrites a name that is already present. Within this module
+//! `default_headers` is resolved before the client allowlist, so an operator
+//! header wins over a client header of the same name. On top of that, the
+//! [`RESERVED_UPSTREAM_HEADERS`] / [`NEVER_FORWARD_HEADERS`] guards drop the
+//! auth and transport families outright, so neither an operator typo nor a
+//! `"*"`-happy allowlist can reach them.
+//!
+//! Before #1167 the standard endpoints rebuilt the outbound header set from
+//! scratch and dropped every client header — the default this module
+//! preserves. `/passthrough/*` is the opposite policy (forward everything
+//! except `pk.strip_headers`) and does not use this pipeline.
+
+use std::collections::HashSet;
+
+use aisix_core::{wildcard::wildcard_matches, HeaderVars, RequestOverrides};
+use http::{
+    header::{HeaderName, HeaderValue},
+    HeaderMap,
+};
+
+/// Headers an operator's `default_headers` block may never set, and that are
+/// never forwarded from a client.
+///
+/// The auth entries are the credentials each bridge mints for itself: letting
+/// config override them would swap the gateway's upstream identity for an
+/// attacker-supplied one. The last three are host-routing / session /
+/// proxy-auth headers that no provider auth scheme uses but that are still
+/// dangerous to hand to config.
+///
+/// cp-api rejects these at write time
+/// (`internal/cpapi/resources/provider_key_overrides.go`); this list is the
+/// runtime half of that pair, and the two must stay in sync.
+pub const RESERVED_UPSTREAM_HEADERS: &[&str] = &[
+    "authorization",        // OpenAI / Anthropic / Vertex Bearer
+    "x-api-key",            // Anthropic raw, also OpenAI legacy proxies
+    "x-goog-api-key",       // Gemini API key
+    "api-key",              // Azure OpenAI key
+    "x-amz-security-token", // AWS SigV4 session header (Bedrock)
+    "x-amz-date",           // AWS SigV4 timestamp (Bedrock)
+    "x-amz-content-sha256", // AWS SigV4 body hash (Bedrock)
+    "proxy-authorization",  // proxy auth — never operator-controllable
+    "cookie",               // session bleed between caller and upstream
+    "host",                 // URL hijack via Host header
+];
+
+/// Client headers never forwarded, on top of [`RESERVED_UPSTREAM_HEADERS`].
+///
+/// Hop-by-hop headers (RFC 9110 §7.6.1) describe *this* connection, not the
+/// one the gateway opens to the upstream. The content/accept entries describe
+/// a body this gateway re-serializes and a response shape it parses, so
+/// relaying the caller's copies would describe the wrong message.
+const NEVER_FORWARD_HEADERS: &[&str] = &[
+    "accept",
+    "accept-encoding",
+    "connection",
+    "content-encoding",
+    "content-length",
+    "content-type",
+    "expect",
+    "keep-alive",
+    "proxy-authenticate",
+    "set-cookie",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+];
+
+/// Client header prefixes never forwarded whatever the allowlist says.
+///
+/// `x-aisix-*` is the gateway's own namespace (`x-aisix-request-id`,
+/// `x-aisix-routing-tags`, …) — forwarding a client's copy would let a caller
+/// spoof gateway-asserted context upstream. `x-stainless-*` is the client
+/// SDK's self-description; LiteLLM excludes it from its own forwarding for
+/// the same reason we do — relaying one SDK's version headers to a provider
+/// that reads them for its own SDK breaks the call.
+const NEVER_FORWARD_PREFIXES: &[&str] = &["x-aisix-", "x-stainless-"];
+
+/// The authenticated caller's non-secret identity, resolved once per
+/// request so `${request.api_key.*}` templates can name it.
+///
+/// Deliberately holds identifiers and the operator-typed key label only.
+/// The plaintext bearer and its hash are not here and must not be added:
+/// this struct is the whole reachable surface of the caller from a
+/// header template.
+#[derive(Debug, Clone, Default)]
+pub struct CallerIdentity {
+    pub api_key_id: String,
+    pub api_key_name: Option<String>,
+    pub team_id: Option<String>,
+    pub user_id: Option<String>,
+}
+
+impl CallerIdentity {
+    /// Read the identity off the authenticated key's snapshot entry.
+    pub fn from_entry(entry: &aisix_core::ResourceEntry<aisix_core::ApiKey>) -> Self {
+        Self {
+            api_key_id: entry.id.clone(),
+            api_key_name: entry.value.display_name.clone(),
+            team_id: entry.value.team_id.clone(),
+            user_id: entry.value.user_id.clone(),
+        }
+    }
+}
+
+/// Everything the header pipeline reads for one upstream call.
+///
+/// A default-constructed context adds nothing, which is what the paths
+/// with no operator config and no client request behind them want.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UpstreamHeaderContext<'a> {
+    /// The ProviderKey's `request` block, source of both `default_headers`
+    /// and `forward_client_headers`.
+    pub overrides: Option<&'a RequestOverrides>,
+    /// Values for `${...}` references in `default_headers`.
+    pub vars: HeaderVars<'a>,
+    /// The inbound request's headers, source for `forward_client_headers`.
+    /// `None` where a call has no client request behind it (a background
+    /// poll of an async job, a semantic-routing embedding lookup) — those
+    /// requests forward nothing.
+    pub client_headers: Option<&'a HeaderMap>,
+}
+
+impl<'a> UpstreamHeaderContext<'a> {
+    /// Context for a call with no request-context variables and no client
+    /// headers to forward — only static `default_headers` apply.
+    pub fn from_overrides(overrides: Option<&'a RequestOverrides>) -> Self {
+        Self {
+            overrides,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_vars(mut self, vars: HeaderVars<'a>) -> Self {
+        self.vars = vars;
+        self
+    }
+
+    pub fn with_client_headers(mut self, headers: &'a HeaderMap) -> Self {
+        self.client_headers = Some(headers);
+        self
+    }
+}
+
+fn is_reserved(name: &str) -> bool {
+    RESERVED_UPSTREAM_HEADERS.contains(&name)
+}
+
+fn is_forwardable_name(name: &str) -> bool {
+    !is_reserved(name)
+        && !NEVER_FORWARD_HEADERS.contains(&name)
+        && !NEVER_FORWARD_PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
+/// Whether an allowlist pattern admits a header name. Patterns are matched
+/// case-insensitively against the lowercase name, and a single `*` glob is
+/// supported (`"x-trace-*"`), matching how `allowed_models` / `allowed_tools`
+/// patterns behave elsewhere in the snapshot.
+fn allowlist_admits(patterns: &[String], name: &str) -> bool {
+    patterns
+        .iter()
+        .any(|p| wildcard_matches(&p.to_ascii_lowercase(), name))
+}
+
+/// Resolve the operator-configured headers for one upstream call: rendered
+/// `default_headers` first, then the client headers the allowlist admits.
+///
+/// Names are returned lowercase and de-duplicated (first wins, so a
+/// `default_headers` entry shadows a client header of the same name).
+/// Entries whose name or value will not parse as HTTP are skipped rather
+/// than failing the request — an unparseable entry is a config error one
+/// layer up, which cp-api rejects at write time.
+///
+/// Callers that build a [`HeaderMap`] should use [`apply_request_headers`];
+/// this lower-level form exists for the Bedrock path, whose headers have to
+/// be handed to the AWS SDK's pre-signing interceptor instead.
+pub fn resolve_extra_headers(ctx: &UpstreamHeaderContext<'_>) -> Vec<(HeaderName, HeaderValue)> {
+    let Some(r) = ctx.overrides else {
+        return Vec::new();
+    };
+    let mut out: Vec<(HeaderName, HeaderValue)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for (name, value) in &r.default_headers {
+        let Ok(parsed_name) = name.parse::<HeaderName>() else {
+            continue;
+        };
+        if is_reserved(parsed_name.as_str()) || !seen.insert(parsed_name.as_str().to_string()) {
+            continue;
+        }
+        // An unresolvable template drops just this header — see
+        // `aisix_core::header_template`.
+        let Some(rendered) = aisix_core::render_header_template(value, &ctx.vars) else {
+            continue;
+        };
+        let Ok(parsed_value) = HeaderValue::from_str(&rendered) else {
+            continue;
+        };
+        out.push((parsed_name, parsed_value));
+    }
+
+    if r.forward_client_headers.is_empty() {
+        return out;
+    }
+    let Some(client) = ctx.client_headers else {
+        return out;
+    };
+    for name in client.keys() {
+        // `HeaderName` is already lowercase on the wire-parsed side.
+        let lower = name.as_str();
+        if !is_forwardable_name(lower)
+            || !allowlist_admits(&r.forward_client_headers, lower)
+            || seen.contains(lower)
+        {
+            continue;
+        }
+        // A repeated header (`anthropic-beta: a` twice) forwards its first
+        // value only; the upstream sees one well-formed header rather than
+        // a list this gateway never interpreted.
+        let Some(value) = client.get(name) else {
+            continue;
+        };
+        seen.insert(lower.to_string());
+        out.push((name.clone(), value.clone()));
+    }
+    out
+}
+
+/// Merge the operator-configured headers into an outbound request's
+/// `HeaderMap`, leaving every name the caller already set untouched.
+///
+/// Callers MUST insert their bridge-owned headers (auth, `content-type`,
+/// `x-aisix-request-id`) before calling this — that ordering is what makes
+/// gateway-owned headers un-overridable.
+pub fn apply_request_headers(headers: &mut HeaderMap, ctx: &UpstreamHeaderContext<'_>) {
+    for (name, value) in resolve_extra_headers(ctx) {
+        if headers.contains_key(&name) {
+            continue;
+        }
+        headers.insert(name, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn overrides(defaults: &[(&str, &str)], forward: &[&str]) -> RequestOverrides {
+        RequestOverrides {
+            default_headers: defaults
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect::<HashMap<_, _>>(),
+            forward_client_headers: forward.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    fn client(headers: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (k, v) in headers {
+            map.insert(
+                k.parse::<HeaderName>().unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn default_headers_are_added_and_templates_rendered() {
+        let r = overrides(
+            &[
+                ("x-corp-trace", "static"),
+                ("x-tenant-id", "${request.api_key.team_id}"),
+            ],
+            &[],
+        );
+        let vars = HeaderVars {
+            api_key_team_id: Some("team-7"),
+            ..Default::default()
+        };
+        let mut headers = HeaderMap::new();
+        let ctx = UpstreamHeaderContext::from_overrides(Some(&r)).with_vars(vars);
+        apply_request_headers(&mut headers, &ctx);
+        assert_eq!(headers["x-corp-trace"], "static");
+        assert_eq!(headers["x-tenant-id"], "team-7");
+    }
+
+    #[test]
+    fn unresolvable_template_drops_only_its_own_header() {
+        let r = overrides(
+            &[
+                ("x-tenant-id", "${request.api_key.team_id}"),
+                ("x-key", "${request.api_key.name}"),
+            ],
+            &[],
+        );
+        let vars = HeaderVars {
+            api_key_name: Some("acme"),
+            api_key_team_id: None,
+            ..Default::default()
+        };
+        let mut headers = HeaderMap::new();
+        let ctx = UpstreamHeaderContext::from_overrides(Some(&r)).with_vars(vars);
+        apply_request_headers(&mut headers, &ctx);
+        assert!(
+            !headers.contains_key("x-tenant-id"),
+            "a key with no team must not send a blank tenant header"
+        );
+        assert_eq!(headers["x-key"], "acme");
+    }
+
+    #[test]
+    fn caller_owned_headers_are_never_overwritten() {
+        let r = overrides(&[("x-corp-trace", "operator")], &["x-corp-trace"]);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-corp-trace", HeaderValue::from_static("gateway"));
+        let inbound = client(&[("x-corp-trace", "client")]);
+        let ctx = UpstreamHeaderContext::from_overrides(Some(&r)).with_client_headers(&inbound);
+        apply_request_headers(&mut headers, &ctx);
+        assert_eq!(headers["x-corp-trace"], "gateway");
+    }
+
+    #[test]
+    fn default_headers_win_over_a_forwarded_client_header() {
+        let r = overrides(&[("x-tenant-id", "operator")], &["x-tenant-id"]);
+        let mut headers = HeaderMap::new();
+        let inbound = client(&[("x-tenant-id", "client-claimed")]);
+        let ctx = UpstreamHeaderContext::from_overrides(Some(&r)).with_client_headers(&inbound);
+        apply_request_headers(&mut headers, &ctx);
+        assert_eq!(headers["x-tenant-id"], "operator");
+    }
+
+    #[test]
+    fn reserved_auth_headers_are_dropped_from_both_sources() {
+        let r = overrides(
+            &[
+                ("authorization", "Bearer attacker"),
+                ("api-key", "attacker"),
+            ],
+            &["authorization", "x-api-key", "cookie", "*"],
+        );
+        let mut headers = HeaderMap::new();
+        let inbound = client(&[
+            ("authorization", "Bearer caller"),
+            ("x-api-key", "caller"),
+            ("cookie", "session=1"),
+        ]);
+        let ctx = UpstreamHeaderContext::from_overrides(Some(&r)).with_client_headers(&inbound);
+        apply_request_headers(&mut headers, &ctx);
+        assert!(headers.is_empty(), "leaked: {headers:?}");
+    }
+
+    #[test]
+    fn transport_and_gateway_namespaces_are_never_forwarded() {
+        let r = overrides(&[], &["*"]);
+        let mut headers = HeaderMap::new();
+        let inbound = client(&[
+            ("content-length", "12"),
+            ("connection", "keep-alive"),
+            ("x-aisix-request-id", "spoofed"),
+            ("x-stainless-lang", "js"),
+            ("x-keep", "yes"),
+        ]);
+        let ctx = UpstreamHeaderContext::from_overrides(Some(&r)).with_client_headers(&inbound);
+        apply_request_headers(&mut headers, &ctx);
+        assert_eq!(headers.len(), 1, "leaked: {headers:?}");
+        assert_eq!(headers["x-keep"], "yes");
+    }
+
+    #[test]
+    fn allowlist_matches_exact_names_and_a_single_glob() {
+        let r = overrides(&[], &["Anthropic-Beta", "x-trace-*"]);
+        let mut headers = HeaderMap::new();
+        let inbound = client(&[
+            ("anthropic-beta", "tools-2024-05-16"),
+            ("x-trace-id", "t-1"),
+            ("x-trace-parent", "p-1"),
+            ("x-tenant-id", "not-allowlisted"),
+        ]);
+        let ctx = UpstreamHeaderContext::from_overrides(Some(&r)).with_client_headers(&inbound);
+        apply_request_headers(&mut headers, &ctx);
+        assert_eq!(headers["anthropic-beta"], "tools-2024-05-16");
+        assert_eq!(headers["x-trace-id"], "t-1");
+        assert_eq!(headers["x-trace-parent"], "p-1");
+        assert!(!headers.contains_key("x-tenant-id"));
+    }
+
+    #[test]
+    fn a_default_header_the_caller_did_not_set_is_added_case_insensitively() {
+        // The caller's mixed-case header must still block a lowercase-keyed
+        // default — `http::HeaderName` canonicalizes both sides.
+        let r = overrides(
+            &[("anthropic-version", "2023-06-01"), ("x-foo", "default")],
+            &[],
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Foo", HeaderValue::from_static("caller-value"));
+        apply_request_headers(
+            &mut headers,
+            &UpstreamHeaderContext::from_overrides(Some(&r)),
+        );
+        assert_eq!(headers["anthropic-version"], "2023-06-01");
+        assert_eq!(headers["x-foo"], "caller-value");
+    }
+
+    #[test]
+    fn an_unparseable_header_name_skips_only_that_entry() {
+        let r = overrides(&[("not a valid name", "v"), ("x-foo", "ok")], &[]);
+        let mut headers = HeaderMap::new();
+        apply_request_headers(
+            &mut headers,
+            &UpstreamHeaderContext::from_overrides(Some(&r)),
+        );
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers["x-foo"], "ok");
+    }
+
+    #[test]
+    fn empty_allowlist_forwards_nothing() {
+        let r = overrides(&[], &[]);
+        let inbound = client(&[("x-trace-id", "t-1")]);
+        let mut headers = HeaderMap::new();
+        let ctx = UpstreamHeaderContext::from_overrides(Some(&r)).with_client_headers(&inbound);
+        apply_request_headers(&mut headers, &ctx);
+        assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn no_overrides_block_is_a_no_op() {
+        let inbound = client(&[("x-trace-id", "t-1")]);
+        let mut headers = HeaderMap::new();
+        let ctx = UpstreamHeaderContext::default().with_client_headers(&inbound);
+        apply_request_headers(&mut headers, &ctx);
+        assert!(headers.is_empty());
+    }
+}

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -16,8 +16,8 @@
 
 use aisix_core::{RequestOverrides, ResponseOverrides, StreamDoneMarker};
 use aisix_gateway::{
-    Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream, ChatFormat, ChatResponse,
-    SseDecoder, SseEvent,
+    apply_request_headers, Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream,
+    ChatFormat, ChatResponse, SseDecoder, SseEvent, UpstreamHeaderContext,
 };
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -30,9 +30,9 @@ use serde_json::Value;
 use std::time::{Duration, Instant};
 
 use aisix_provider_openai::overrides::{
-    apply_content_list_to_string, apply_default_body_fields, apply_default_headers,
-    apply_param_constraints, apply_param_renames, apply_stream_done_marker_policy,
-    extract_reasoning_field, StreamDoneOutcome,
+    apply_content_list_to_string, apply_default_body_fields, apply_param_constraints,
+    apply_param_renames, apply_stream_done_marker_policy, extract_reasoning_field,
+    StreamDoneOutcome,
 };
 use aisix_provider_openai::wire::{
     build_request, messages_from, response_into_chat_response, stream_chunk_into_chat_chunk,
@@ -587,17 +587,17 @@ fn prepare_outbound_body<T: serde::Serialize>(
 /// In both branches the bridge also sets `Content-Type: application/json`,
 /// `x-aisix-request-id: <ctx.request_id>`, and (for streaming)
 /// `Accept: text/event-stream`. Bridge-owned headers are inserted
-/// before `apply_default_headers` so the reserved-headers list in
-/// `aisix-provider-openai::overrides` (which already covers
-/// `api-key`, `authorization`, `x-api-key`, plus hop-by-hop /
-/// proxy-auth headers) cannot overwrite them. Defense in depth: the
-/// reserved-list blocks even before the `headers.contains_key` guard
-/// inside `apply_default_headers`.
+/// before `apply_request_headers` so the reserved-headers list in
+/// `aisix-gateway::upstream_headers` (which already covers `api-key`,
+/// `authorization`, `x-api-key`, plus proxy-auth / session headers)
+/// cannot overwrite them. Defense in depth: the reserved-list blocks
+/// even before the skip-if-present guard inside
+/// `apply_request_headers`.
 fn build_request_headers(
     auth: &AzureAuth,
     request_id: &str,
     sse: bool,
-    request: Option<&RequestOverrides>,
+    hdr: &UpstreamHeaderContext<'_>,
 ) -> Result<HeaderMap, BridgeError> {
     let mut headers = HeaderMap::new();
     match (&auth.api_key, &auth.bearer_token) {
@@ -644,9 +644,7 @@ fn build_request_headers(
             HeaderValue::from_static("text/event-stream"),
         );
     }
-    if let Some(r) = request {
-        apply_default_headers(&mut headers, &r.default_headers);
-    }
+    apply_request_headers(&mut headers, hdr);
     Ok(headers)
 }
 
@@ -684,12 +682,7 @@ impl Bridge for AzureOpenAiBridge {
             ctx.provider_key.request.as_ref(),
             ctx.provider_key.response.as_ref(),
         )?;
-        let headers = build_request_headers(
-            &auth,
-            &ctx.request_id,
-            false,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&auth, &ctx.request_id, false, &ctx.header_ctx())?;
         let url = self.resolve_url(&upstream);
         let client = self.client.clone();
         let started = Instant::now();
@@ -741,12 +734,7 @@ impl Bridge for AzureOpenAiBridge {
             ctx.provider_key.request.as_ref(),
             ctx.provider_key.response.as_ref(),
         )?;
-        let headers = build_request_headers(
-            &auth,
-            &ctx.request_id,
-            true,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&auth, &ctx.request_id, true, &ctx.header_ctx())?;
         let url = self.resolve_url(&upstream);
         let client = self.client.clone();
         let started = Instant::now();
@@ -1256,8 +1244,13 @@ mod tests {
     fn build_request_headers_uses_api_key_not_bearer() {
         // Critical Azure-vs-OpenAI distinction: the auth header is
         // literally `api-key`, NOT `Authorization: Bearer`.
-        let headers =
-            build_request_headers(&api_key_auth("az-secret-key"), "req-1", false, None).unwrap();
+        let headers = build_request_headers(
+            &api_key_auth("az-secret-key"),
+            "req-1",
+            false,
+            &UpstreamHeaderContext::default(),
+        )
+        .unwrap();
         assert_eq!(headers.get("api-key").unwrap(), "az-secret-key");
         assert!(
             !headers.contains_key("authorization"),
@@ -1273,7 +1266,13 @@ mod tests {
 
     #[test]
     fn build_request_headers_sets_sse_accept_when_streaming() {
-        let headers = build_request_headers(&api_key_auth("az-key"), "req-1", true, None).unwrap();
+        let headers = build_request_headers(
+            &api_key_auth("az-key"),
+            "req-1",
+            true,
+            &UpstreamHeaderContext::default(),
+        )
+        .unwrap();
         assert_eq!(headers.get("accept").unwrap(), "text/event-stream");
     }
 
@@ -1289,16 +1288,14 @@ mod tests {
         default_headers.insert("api-key".to_string(), "ATTACKER-KEY".to_string());
         default_headers.insert("authorization".to_string(), "Bearer ATTACKER".to_string());
         let request_overrides = RequestOverrides {
-            param_renames: HashMap::new(),
-            param_constraints: None,
-            default_body_fields: Default::default(),
             default_headers,
+            ..Default::default()
         };
         let headers = build_request_headers(
             &api_key_auth("legit-key"),
             "req-1",
             false,
-            Some(&request_overrides),
+            &UpstreamHeaderContext::from_overrides(Some(&request_overrides)),
         )
         .unwrap();
         assert_eq!(
@@ -1318,14 +1315,16 @@ mod tests {
         let mut default_headers = HashMap::new();
         default_headers.insert("x-custom-trace".to_string(), "trace-123".to_string());
         let request_overrides = RequestOverrides {
-            param_renames: HashMap::new(),
-            param_constraints: None,
-            default_body_fields: Default::default(),
             default_headers,
+            ..Default::default()
         };
-        let headers =
-            build_request_headers(&api_key_auth("k"), "req-1", false, Some(&request_overrides))
-                .unwrap();
+        let headers = build_request_headers(
+            &api_key_auth("k"),
+            "req-1",
+            false,
+            &UpstreamHeaderContext::from_overrides(Some(&request_overrides)),
+        )
+        .unwrap();
         assert_eq!(headers.get("x-custom-trace").unwrap(), "trace-123");
     }
 
@@ -1333,16 +1332,26 @@ mod tests {
     fn build_request_headers_rejects_invalid_api_key_chars() {
         // A secret with a newline would let an operator inject extra
         // headers via the api-key value.
-        let err = build_request_headers(&api_key_auth("legit\nx-evil: 1"), "req-1", false, None)
-            .unwrap_err();
+        let err = build_request_headers(
+            &api_key_auth("legit\nx-evil: 1"),
+            "req-1",
+            false,
+            &UpstreamHeaderContext::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, BridgeError::InvalidUpstreamCredentials(_)));
         assert_eq!(err.http_status(), 401);
     }
 
     #[test]
     fn build_request_headers_rejects_invalid_request_id_chars() {
-        let err =
-            build_request_headers(&api_key_auth("legit"), "req\nbad", false, None).unwrap_err();
+        let err = build_request_headers(
+            &api_key_auth("legit"),
+            "req\nbad",
+            false,
+            &UpstreamHeaderContext::default(),
+        )
+        .unwrap_err();
         assert!(matches!(err, BridgeError::Config(_)));
     }
 

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -19,7 +19,7 @@
 use aisix_gateway::{
     Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream, ChatDelta, ChatFormat,
     ChatMessage, ChatResponse, EmbeddingObject, EmbeddingRequest, EmbeddingResponse,
-    EmbeddingUsage, EmbeddingVector, FinishReason, Role, UsageStats,
+    EmbeddingUsage, EmbeddingVector, FinishReason, Role, UpstreamHeaderContext, UsageStats,
 };
 use async_trait::async_trait;
 use aws_credential_types::provider::SharedCredentialsProvider;
@@ -48,10 +48,11 @@ use aisix_provider_anthropic::wire::{
 
 // Per-`ProviderKey` request override pipeline (#302 §5 / #340). The JSON-body
 // transforms reuse the shared primitives the OpenAI / Vertex bridges call;
-// `default_headers` ride a pre-signing interceptor (see
-// [`DefaultHeadersInterceptor`]) so they land inside the SigV4-signed
-// canonical request rather than being appended after the signature is computed.
-use aisix_core::{ParamConstraints, RequestOverrides};
+// `default_headers` and forwarded client headers ride a pre-signing
+// interceptor (see [`DefaultHeadersInterceptor`]) so they land inside the
+// SigV4-signed canonical request rather than being appended after the
+// signature is computed.
+use aisix_core::ParamConstraints;
 use aisix_provider_openai::overrides::{
     apply_content_list_to_string, apply_default_body_fields, apply_param_constraints,
     apply_param_renames,
@@ -335,7 +336,7 @@ impl BedrockSecret {
 fn build_client(
     creds: &BedrockSecret,
     endpoint_url: Option<&str>,
-    request: Option<&RequestOverrides>,
+    hdr: &UpstreamHeaderContext<'_>,
 ) -> Result<BedrockClient, BridgeError> {
     if creds.region.trim().is_empty() {
         return Err(BridgeError::InvalidUpstreamConfig(
@@ -363,38 +364,37 @@ fn build_client(
     }
     let sdk_cfg = builder.build();
 
-    // Register the default-headers interceptor only when the PK actually
-    // carries (non-reserved) default_headers, so the common no-override path
+    // Register the extra-headers interceptor only when the PK actually
+    // contributes (non-SigV4-owned) headers, so the common no-override path
     // builds the client byte-for-byte as before. The interceptor injects at
     // `modify_before_signing`, so the headers are covered by the SigV4
     // signature (#340).
     let mut conf = aws_sdk_bedrockruntime::config::Builder::from(&sdk_cfg);
-    if let Some(r) = request {
-        let headers = filtered_default_headers(&r.default_headers);
-        if !headers.is_empty() {
-            conf = conf.interceptor(DefaultHeadersInterceptor { headers });
-        }
+    let headers = filtered_extra_headers(hdr);
+    if !headers.is_empty() {
+        conf = conf.interceptor(DefaultHeadersInterceptor { headers });
     }
     Ok(BedrockClient::from_conf(conf.build()))
 }
 
-/// Drop SigV4-owned headers ([`wire::reserved_sigv4_headers`]) from an
-/// operator-supplied `default_headers` block before they reach the signing
-/// interceptor. cp-api SHOULD reject these at write time (#302 §5), but the DP
+/// Resolve the ProviderKey's extra headers (rendered `default_headers` plus
+/// allowlisted client headers) and drop the SigV4-owned names
+/// ([`wire::reserved_sigv4_headers`]) before they reach the signing
+/// interceptor. cp-api SHOULD reject those at write time (#302 §5), but the DP
 /// enforces it again here as defense-in-depth — an override naming e.g.
 /// `x-amz-date` or `authorization` must never perturb the signature. Matching
 /// is case-insensitive (HTTP header names are).
-fn filtered_default_headers(
-    defaults: &std::collections::HashMap<String, String>,
-) -> Vec<(String, String)> {
+fn filtered_extra_headers(hdr: &UpstreamHeaderContext<'_>) -> Vec<(String, String)> {
     let reserved = wire::reserved_sigv4_headers();
-    defaults
-        .iter()
-        .filter(|(name, _)| {
-            let lower = name.to_ascii_lowercase();
-            !reserved.contains(&lower.as_str())
+    aisix_gateway::resolve_extra_headers(hdr)
+        .into_iter()
+        .filter(|(name, _)| !reserved.contains(&name.as_str()))
+        .map(|(name, value)| {
+            (
+                name.as_str().to_string(),
+                String::from_utf8_lossy(value.as_bytes()).into_owned(),
+            )
         })
-        .map(|(name, value)| (name.clone(), value.clone()))
         .collect()
 }
 
@@ -856,7 +856,7 @@ impl BedrockBridge {
         };
         // Converse paths carry no JSON body, but default_headers still apply
         // (header-level, publisher-agnostic) via the signing interceptor.
-        build_client(&creds, endpoint_url, ctx.provider_key.request.as_ref())
+        build_client(&creds, endpoint_url, &ctx.header_ctx())
     }
 
     /// Dispatch Bedrock chat via the unified Converse API.

--- a/crates/aisix-provider-bedrock/src/wire.rs
+++ b/crates/aisix-provider-bedrock/src/wire.rs
@@ -12,7 +12,7 @@
 /// operator-supplied override would invalidate the signature.
 ///
 /// Same defense-in-depth pattern as OpenAiBridge's
-/// `RESERVED_DEFAULT_HEADERS` — cp-api should reject these at write
+/// `RESERVED_UPSTREAM_HEADERS` — cp-api should reject these at write
 /// time, but the DP enforces it again at apply time.
 pub(crate) fn reserved_sigv4_headers() -> &'static [&'static str] {
     &[

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -21,8 +21,9 @@
 
 use aisix_core::{RequestOverrides, ResponseOverrides, StreamDoneMarker};
 use aisix_gateway::{
-    Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream, ChatFormat, ChatResponse,
-    EmbeddingRequest, EmbeddingResponse, SseDecoder, SseEvent,
+    apply_request_headers, Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream,
+    ChatFormat, ChatResponse, EmbeddingRequest, EmbeddingResponse, SseDecoder, SseEvent,
+    UpstreamHeaderContext,
 };
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -35,9 +36,9 @@ use serde_json::Value;
 use std::time::{Duration, Instant};
 
 use crate::overrides::{
-    apply_content_list_to_string, apply_default_body_fields, apply_default_headers,
-    apply_param_constraints, apply_param_renames, apply_stream_done_marker_policy,
-    extract_reasoning_field, StreamDoneOutcome,
+    apply_content_list_to_string, apply_default_body_fields, apply_param_constraints,
+    apply_param_renames, apply_stream_done_marker_policy, extract_reasoning_field,
+    StreamDoneOutcome,
 };
 use crate::wire::{
     build_request, embed_request_body, embed_response_into, messages_from,
@@ -320,11 +321,10 @@ fn prepare_outbound_body<T: serde::Serialize>(
 /// x-aisix-request-id, and optionally Accept: text/event-stream
 /// for streaming calls), then merge any `default_headers` the PK carries.
 /// Bridge-owned headers are inserted before the merge so
-/// [`apply_default_headers`] cannot overwrite them — the
-/// `if headers.contains_key(&parsed_name)` guard inside
-/// `apply_default_headers` plus the [`RESERVED_DEFAULT_HEADERS`] list
-/// gives two layers of defense against an operator-supplied
-/// `default_headers` accidentally clobbering auth.
+/// [`apply_request_headers`] cannot overwrite them — its skip-if-present
+/// rule plus `RESERVED_UPSTREAM_HEADERS` gives two layers of defense
+/// against an operator-supplied `default_headers` entry (or a forwarded
+/// client header) clobbering auth.
 ///
 /// The previous `bridge_name` parameter + `X-Aisix-Bridge` outbound
 /// header was removed in AISIX-Cloud#468: after the Phase A clean
@@ -340,7 +340,7 @@ fn build_request_headers(
     api_key_str: &str,
     request_id: &str,
     sse: bool,
-    request: Option<&RequestOverrides>,
+    hdr: &UpstreamHeaderContext<'_>,
 ) -> Result<HeaderMap, BridgeError> {
     let mut headers = HeaderMap::new();
     let auth = HeaderValue::from_str(&format!("Bearer {api_key_str}")).map_err(|e| {
@@ -363,9 +363,7 @@ fn build_request_headers(
             HeaderValue::from_static("text/event-stream"),
         );
     }
-    if let Some(r) = request {
-        apply_default_headers(&mut headers, &r.default_headers);
-    }
+    apply_request_headers(&mut headers, hdr);
     Ok(headers)
 }
 
@@ -391,12 +389,7 @@ impl Bridge for OpenAiBridge {
             ctx.provider_key.request.as_ref(),
             ctx.provider_key.response.as_ref(),
         )?;
-        let headers = build_request_headers(
-            key,
-            &ctx.request_id,
-            false,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(key, &ctx.request_id, false, &ctx.header_ctx())?;
         let url = format!("{base}/chat/completions");
         let client = self.client.clone();
         let started = Instant::now();
@@ -442,12 +435,7 @@ impl Bridge for OpenAiBridge {
             ctx.provider_key.request.as_ref(),
             ctx.provider_key.response.as_ref(),
         )?;
-        let headers = build_request_headers(
-            key,
-            &ctx.request_id,
-            false,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(key, &ctx.request_id, false, &ctx.header_ctx())?;
         let url = format!("{base}/embeddings");
         let client = self.client.clone();
         let started = Instant::now();
@@ -498,12 +486,7 @@ impl Bridge for OpenAiBridge {
             ctx.provider_key.request.as_ref(),
             ctx.provider_key.response.as_ref(),
         )?;
-        let headers = build_request_headers(
-            key,
-            &ctx.request_id,
-            false,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(key, &ctx.request_id, false, &ctx.header_ctx())?;
 
         let url = format!("{base}/completions");
         let client = self.client.clone();
@@ -553,12 +536,7 @@ impl Bridge for OpenAiBridge {
             ctx.provider_key.request.as_ref(),
             ctx.provider_key.response.as_ref(),
         )?;
-        let headers = build_request_headers(
-            key,
-            &ctx.request_id,
-            false,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(key, &ctx.request_id, false, &ctx.header_ctx())?;
 
         let url = format!("{base}/images/generations");
         let client = self.client.clone();
@@ -600,12 +578,7 @@ impl Bridge for OpenAiBridge {
             ctx.provider_key.request.as_ref(),
             ctx.provider_key.response.as_ref(),
         )?;
-        let headers = build_request_headers(
-            key,
-            &ctx.request_id,
-            true,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(key, &ctx.request_id, true, &ctx.header_ctx())?;
         let url = format!("{base}/chat/completions");
         let client = self.client.clone();
         let started = Instant::now();

--- a/crates/aisix-provider-openai/src/overrides.rs
+++ b/crates/aisix-provider-openai/src/overrides.rs
@@ -34,10 +34,6 @@
 use std::collections::HashMap;
 
 use aisix_core::{ParamConstraints, StreamDoneMarker};
-use http::{
-    header::{HeaderName, HeaderValue},
-    HeaderMap,
-};
 use serde_json::{Map, Value};
 
 /// Outcome of evaluating an SSE stream against a
@@ -119,56 +115,6 @@ pub fn apply_param_constraints(body: &mut Value, constraints: &ParamConstraints)
         if let Some(num) = serde_json::Number::from_f64(next) {
             *temp = Value::Number(num);
         }
-    }
-}
-
-/// Authentication-related headers that `apply_default_headers` will
-/// never set, even if cp-api validation slips and allows them through.
-/// Defense-in-depth: a misconfigured `default_headers` block must never
-/// override the auth header the OpenAiBridge sets itself. cp-api SHOULD
-/// reject these at write time (issue #302 §5 validation rules), but
-/// the DP enforces it again at apply time.
-///
-/// `HeaderName` is case-insensitive so the lowercase form is the
-/// canonical comparison key.
-const RESERVED_DEFAULT_HEADERS: &[&str] = &[
-    "authorization",        // OpenAI / Anthropic / Vertex Bearer
-    "x-api-key",            // Anthropic raw, also OpenAI legacy proxies
-    "x-goog-api-key",       // Gemini API key
-    "api-key",              // Azure OpenAI key
-    "x-amz-security-token", // AWS SigV4 session header (Bedrock)
-    "x-amz-date",           // AWS SigV4 timestamp (Bedrock)
-];
-
-/// Apply `request.default_headers` to an outbound `HeaderMap`.
-///
-/// Headers already present on `headers` (case-insensitive, since
-/// [`http::HeaderName`] is case-insensitive) are left alone — the
-/// caller's explicit value always wins over a default. Names or
-/// values that fail [`HeaderName`] / [`HeaderValue`] parsing are
-/// silently skipped; the default block came from cp-api validation
-/// and any unparseable entry is a config error one layer up, not a
-/// runtime failure the dispatch should hard-fail on.
-///
-/// **Auth-header guard:** keys in [`RESERVED_DEFAULT_HEADERS`] are
-/// dropped before insertion as defense-in-depth — a misconfigured
-/// default_headers block must never inject `Authorization` or vendor
-/// API-key headers that would override the Bridge's own auth.
-pub fn apply_default_headers(headers: &mut HeaderMap, defaults: &HashMap<String, String>) {
-    for (name, value) in defaults {
-        let Ok(parsed_name) = name.parse::<HeaderName>() else {
-            continue;
-        };
-        if RESERVED_DEFAULT_HEADERS.contains(&parsed_name.as_str()) {
-            continue;
-        }
-        if headers.contains_key(&parsed_name) {
-            continue;
-        }
-        let Ok(parsed_value) = HeaderValue::from_str(value) else {
-            continue;
-        };
-        headers.insert(parsed_name, parsed_value);
     }
 }
 
@@ -499,85 +445,6 @@ mod tests {
         let constraints = ParamConstraints::default();
         apply_param_constraints(&mut body, &constraints);
         assert_eq!(body["temperature"].as_f64(), Some(2.0));
-    }
-
-    // --- apply_default_headers ------------------------------------
-
-    #[test]
-    fn adds_missing_default_header() {
-        let mut headers = HeaderMap::new();
-        let defaults = HashMap::from([("anthropic-version".to_string(), "2023-06-01".to_string())]);
-        apply_default_headers(&mut headers, &defaults);
-        assert_eq!(headers.get("anthropic-version").unwrap(), "2023-06-01");
-    }
-
-    #[test]
-    fn does_not_overwrite_existing_header() {
-        let mut headers = HeaderMap::new();
-        headers.insert("x-foo", HeaderValue::from_static("caller-value"));
-        let defaults = HashMap::from([("x-foo".to_string(), "default-value".to_string())]);
-        apply_default_headers(&mut headers, &defaults);
-        assert_eq!(headers.get("x-foo").unwrap(), "caller-value");
-    }
-
-    #[test]
-    fn header_match_is_case_insensitive() {
-        // Caller-set header in mixed case must still block a default
-        // header keyed in lowercase — http::HeaderName is canonicalized.
-        let mut headers = HeaderMap::new();
-        headers.insert("X-Foo", HeaderValue::from_static("caller-value"));
-        let defaults = HashMap::from([("x-foo".to_string(), "default-value".to_string())]);
-        apply_default_headers(&mut headers, &defaults);
-        assert_eq!(headers.get("x-foo").unwrap(), "caller-value");
-    }
-
-    #[test]
-    fn skips_unparseable_header_name() {
-        let mut headers = HeaderMap::new();
-        let defaults = HashMap::from([
-            ("not a valid name".to_string(), "v".to_string()),
-            ("x-foo".to_string(), "ok".to_string()),
-        ]);
-        apply_default_headers(&mut headers, &defaults);
-        assert!(headers.get("x-foo").is_some());
-        assert_eq!(headers.len(), 1);
-    }
-
-    #[test]
-    fn rejects_reserved_auth_headers() {
-        // Defense-in-depth: even if cp-api validation slipped and shipped
-        // a default_headers block containing Authorization / X-Api-Key /
-        // X-Goog-Api-Key, DP must not inject them. Case-insensitive via
-        // HeaderName canonicalization.
-        let mut headers = HeaderMap::new();
-        let defaults = HashMap::from([
-            (
-                "Authorization".to_string(),
-                "Bearer attacker-token".to_string(),
-            ),
-            ("X-Api-Key".to_string(), "attacker-key".to_string()),
-            ("X-API-KEY".to_string(), "attacker-key-2".to_string()),
-            (
-                "x-goog-api-key".to_string(),
-                "attacker-google-key".to_string(),
-            ),
-            ("x-foo".to_string(), "ok-default".to_string()),
-        ]);
-        apply_default_headers(&mut headers, &defaults);
-        assert!(
-            headers.get("authorization").is_none(),
-            "auth must be blocked"
-        );
-        assert!(
-            headers.get("x-api-key").is_none(),
-            "x-api-key must be blocked"
-        );
-        assert!(
-            headers.get("x-goog-api-key").is_none(),
-            "x-goog-api-key must be blocked"
-        );
-        assert_eq!(headers.get("x-foo").unwrap(), "ok-default");
-        assert_eq!(headers.len(), 1, "only x-foo should have been inserted");
     }
 
     // --- apply_default_body_fields --------------------------------

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -72,10 +72,10 @@ use aisix_provider_openai::wire::{
 // targeted keys are absent, so they are safe to call uniformly across the
 // five publisher rails (the Gemini `contents` shape simply does not match the
 // OpenAI-style top-level keys the request transforms look for).
-use aisix_core::RequestOverrides;
+use aisix_gateway::{apply_request_headers, UpstreamHeaderContext};
 use aisix_provider_openai::overrides::{
-    apply_content_list_to_string, apply_default_body_fields, apply_default_headers,
-    apply_param_constraints, apply_param_renames,
+    apply_content_list_to_string, apply_default_body_fields, apply_param_constraints,
+    apply_param_renames,
 };
 
 /// `anthropic_version` value Vertex's Claude `:rawPredict` endpoint
@@ -684,11 +684,7 @@ impl Bridge for VertexBridge {
         apply_body_overrides(&mut body, ctx);
 
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
         let model_echo = req.model.clone();
@@ -813,11 +809,7 @@ impl VertexBridge {
         // via the in-process token minter from SA JSON. Failure
         // surfaces as a Config error (operator-actionable).
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
 
@@ -909,11 +901,7 @@ impl VertexBridge {
         }
 
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
 
@@ -997,11 +985,7 @@ impl VertexBridge {
         // Resolve bearer BEFORE entering the stream future so a
         // token-mint error surfaces as a direct Err, not mid-stream.
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
 
@@ -1109,11 +1093,7 @@ impl VertexBridge {
         apply_body_overrides(&mut body, ctx);
 
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
 
@@ -1166,11 +1146,7 @@ impl VertexBridge {
         // Resolve bearer BEFORE entering the stream future so a
         // token-mint error surfaces as a direct Err, not mid-stream.
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
 
@@ -1303,11 +1279,7 @@ impl VertexBridge {
         apply_body_overrides(&mut body, ctx);
 
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
 
@@ -1373,11 +1345,7 @@ impl VertexBridge {
         // Resolve bearer BEFORE entering the stream future so a
         // token-mint error surfaces as a direct Err, not mid-stream.
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
 
@@ -1488,11 +1456,7 @@ impl VertexBridge {
         // entering the stream future so token-mint errors surface
         // as a direct Err return rather than being yielded mid-stream.
         let access_token = creds.resolve_access_token(&self.token_minter).await?;
-        let headers = build_request_headers(
-            &access_token,
-            &ctx.request_id,
-            ctx.provider_key.request.as_ref(),
-        )?;
+        let headers = build_request_headers(&access_token, &ctx.request_id, &ctx.header_ctx())?;
         let client = self.client.clone();
         let started = Instant::now();
 
@@ -1676,14 +1640,14 @@ fn gemini_chunk_into_chat_chunks(
 /// reproduce locally without us echoing them back.
 ///
 /// When the `ProviderKey` carries `request.default_headers`, they are
-/// applied last via [`apply_default_headers`], which refuses to overwrite
+/// applied last via [`apply_request_headers`], which refuses to overwrite
 /// any header already set here (the Bearer auth, content-type, and request
 /// id) and additionally drops reserved auth headers — so a misconfigured
 /// `default_headers` block can never clobber the Vertex OAuth Bearer.
 fn build_request_headers(
     access_token: &str,
     request_id: &str,
-    request: Option<&RequestOverrides>,
+    hdr: &UpstreamHeaderContext<'_>,
 ) -> Result<HeaderMap, BridgeError> {
     if access_token.is_empty() {
         return Err(BridgeError::Config(
@@ -1702,9 +1666,7 @@ fn build_request_headers(
     let rid = HeaderValue::from_str(request_id)
         .map_err(|_| BridgeError::Config("request_id contains invalid header characters".into()))?;
     headers.insert(HeaderName::from_static("x-aisix-request-id"), rid);
-    if let Some(r) = request {
-        apply_default_headers(&mut headers, &r.default_headers);
-    }
+    apply_request_headers(&mut headers, hdr);
     Ok(headers)
 }
 
@@ -3904,8 +3866,12 @@ mod tests {
         // Newline in the access token would let it inject an extra
         // header — header builder must reject AND must not echo the
         // bad bytes back to the customer.
-        let err = build_request_headers("ya29.X-DISTINCTIVE-LEAK-Y\nX-Evil: 1", "req-1", None)
-            .unwrap_err();
+        let err = build_request_headers(
+            "ya29.X-DISTINCTIVE-LEAK-Y\nX-Evil: 1",
+            "req-1",
+            &UpstreamHeaderContext::default(),
+        )
+        .unwrap_err();
         match err {
             BridgeError::Config(msg) => {
                 assert!(
@@ -3925,8 +3891,12 @@ mod tests {
 
     #[test]
     fn header_invalid_request_id_error_does_not_leak_bytes() {
-        let err = build_request_headers("ya29.legit", "req-X-DISTINCTIVE-RID-LEAK-Y\nfoo", None)
-            .unwrap_err();
+        let err = build_request_headers(
+            "ya29.legit",
+            "req-X-DISTINCTIVE-RID-LEAK-Y\nfoo",
+            &UpstreamHeaderContext::default(),
+        )
+        .unwrap_err();
         match err {
             BridgeError::Config(msg) => {
                 assert!(

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -97,7 +97,7 @@ pub async fn transcriptions(
         // (build_v1_url) owns the `/v1` prefix.
         "/audio/transcriptions",
         &request_id,
-        &client.source_ip,
+        &client,
     )
     .await
     {
@@ -197,7 +197,7 @@ pub async fn translations(
         // (build_v1_url) owns the `/v1` prefix.
         "/audio/translations",
         &request_id,
-        &client.source_ip,
+        &client,
     )
     .await
     {
@@ -293,7 +293,7 @@ pub async fn speech(
         .unwrap_or("unknown")
         .to_string();
 
-    match speech_dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
+    match speech_dispatch(&state, &auth, body, &request_id, &client).await {
         Ok((
             resp,
             provider,
@@ -401,7 +401,7 @@ async fn multipart_dispatch(
     mut multipart: Multipart,
     upstream_path: &str,
     request_id: &str,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<AudioDispatchSuccess, ProxyError> {
     // Collect all fields first so we can find `model` before building the
     // outgoing reqwest multipart.
@@ -439,7 +439,7 @@ async fn multipart_dispatch(
     }
 
     // Client-IP allowlist gate (#557): reject before quota / upstream.
-    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+    crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
     // #696: transcriptions/translations run the guardrail chain too. The
     // audio bytes aren't scannable text, but the optional `prompt` form
@@ -605,11 +605,12 @@ async fn multipart_dispatch(
         form
     };
 
-    // Build headers explicitly so the PK's `request.default_headers` can inject
-    // operator headers (AISIX-Cloud#867 follow-up). The body is a multipart
-    // form, so the JSON body-field overrides don't apply here — only headers do.
-    // Content-Type is left to `.multipart()` (it sets the boundary). Reserved
-    // auth headers are protected by `apply_default_headers`.
+    // Build headers explicitly so the PK's `request.default_headers` and
+    // `request.forward_client_headers` can inject operator/client headers
+    // (AISIX-Cloud#867 follow-up). The body is a multipart form, so the JSON
+    // body-field overrides don't apply here — only headers do. Content-Type
+    // is left to `.multipart()` (it sets the boundary). Reserved auth
+    // headers are protected by `apply_request_headers`.
     let mut headers = axum::http::HeaderMap::new();
     let auth_hv = header::HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
         ProxyError::Bridge(aisix_gateway::BridgeError::Config(format!(
@@ -626,9 +627,16 @@ async fn multipart_dispatch(
         header::HeaderName::from_static("x-aisix-request-id"),
         rid_hv,
     );
-    if let Some(r) = pk_entry.value.request.as_ref() {
-        aisix_provider_openai::overrides::apply_default_headers(&mut headers, &r.default_headers);
-    }
+    aisix_gateway::apply_request_headers(
+        &mut headers,
+        &crate::dispatch::upstream_header_ctx(
+            &pk_entry.value,
+            &pk_entry.id,
+            model,
+            &model_entry.id,
+            client_ctx,
+        ),
+    );
 
     let client = crate::http_client::client();
     let tracker = &state.runtime_status;
@@ -860,7 +868,7 @@ async fn speech_dispatch(
     auth: &AuthenticatedKey,
     mut body: Value,
     request_id: &str,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<
     (
         Response,
@@ -889,7 +897,7 @@ async fn speech_dispatch(
     }
 
     // Client-IP allowlist gate (#557): reject before guardrails / upstream.
-    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+    crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
     // #545: /v1/audio/speech must run input guardrails. Before this it
     // forwarded the user `input` text (synthesized to audio) with no
@@ -1005,9 +1013,16 @@ async fn speech_dispatch(
         header::HeaderName::from_static("x-aisix-request-id"),
         rid_hv,
     );
-    if let Some(r) = pk_entry.value.request.as_ref() {
-        aisix_provider_openai::overrides::apply_default_headers(&mut headers, &r.default_headers);
-    }
+    aisix_gateway::apply_request_headers(
+        &mut headers,
+        &crate::dispatch::upstream_header_ctx(
+            &pk_entry.value,
+            &pk_entry.id,
+            model,
+            &model_entry.id,
+            client_ctx,
+        ),
+    );
 
     let client = crate::http_client::client();
     let speech_url = crate::dispatch::build_v1_url(&base, "/audio/speech");

--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -48,7 +48,14 @@ where
                 return Err(e);
             }
         };
-        authenticate_token(&proxy_state, &token).await
+        let authed = authenticate_token(&proxy_state, &token).await?;
+        // Publish the resolved key so extractors that run after this one can
+        // see who is calling without re-authenticating. `ClientContext` reads
+        // it for the `${request.api_key.*}` header templates
+        // (AISIX-Cloud#1112) — which is why every handler declares
+        // `auth: AuthenticatedKey` before `client: ClientContext`.
+        parts.extensions.insert(authed.entry.clone());
+        Ok(authed)
     }
 }
 

--- a/crates/aisix-proxy/src/background.rs
+++ b/crates/aisix-proxy/src/background.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use aisix_core::models::BackgroundModelCheck;
 use aisix_core::{AisixSnapshot, Model};
-use aisix_gateway::{BridgeContext, BridgeError, ChatFormat, ChatMessage, Hub};
+use aisix_gateway::{BridgeError, ChatFormat, ChatMessage, Hub};
 use tokio::sync::Semaphore;
 
 use crate::dispatch;
@@ -119,9 +119,15 @@ async fn check_direct_model(
         max_tokens: Some(cfg.max_tokens),
         ..ChatFormat::new(model.display_name.clone(), vec![])
     };
-    let model_arc = Arc::new(model.clone());
-    let pk_arc = Arc::new(pk_entry.value.clone());
-    let ctx = BridgeContext::new(request_id, model_arc, pk_arc).with_deadline(timeout(cfg));
+    let ctx = dispatch::bridge_ctx(
+        request_id,
+        model_id,
+        Arc::new(model.clone()),
+        &pk_entry.id,
+        Arc::new(pk_entry.value.clone()),
+        None,
+    )
+    .with_deadline(timeout(cfg));
 
     let _ = bridge.chat(&req, &ctx).await?;
     let _ = model_id;

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1255,7 +1255,8 @@ async fn dispatch(
             // stream timeout; the read-timeout wrapper below enforces the
             // same budget on the first and subsequent chunks.
             let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-                .with_client(client.caller.clone(), Some(client.headers.clone()));
+                .with_client(client.caller.clone(), Some(client.headers.clone()))
+                .with_resource_ids(&attempt.id, &pk_entry.id);
             if let Some(d) = model.stream_timeout_effective() {
                 ctx = ctx.with_deadline(d);
             }
@@ -2139,7 +2140,8 @@ async fn dispatch(
         // surfaces as a retryable `BridgeError::Timeout`, so a slow target
         // fails over to the next one via the loop below.
         let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-            .with_client(client.caller.clone(), Some(client.headers.clone()));
+            .with_client(client.caller.clone(), Some(client.headers.clone()))
+            .with_resource_ids(&attempt.id, &pk_entry.id);
         if let Some(d) = model.request_timeout() {
             ctx = ctx.with_deadline(d);
         }
@@ -2832,7 +2834,8 @@ async fn dispatch_ensemble(
             Arc::new(judge_model.clone()),
             Arc::new(judge_pk.value.clone()),
         )
-        .with_client(client.caller.clone(), Some(client.headers.clone()));
+        .with_client(client.caller.clone(), Some(client.headers.clone()))
+        .with_resource_ids(&judge_entry.id, &judge_pk.id);
         if let Some(deadline) = judge_model.request_timeout() {
             judge_ctx = judge_ctx.with_deadline(deadline);
         }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1254,7 +1254,8 @@ async fn dispatch(
             // Streaming deadline (#554): bound the connect by the effective
             // stream timeout; the read-timeout wrapper below enforces the
             // same budget on the first and subsequent chunks.
-            let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+            let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
+                .with_client(client.caller.clone(), Some(client.headers.clone()));
             if let Some(d) = model.stream_timeout_effective() {
                 ctx = ctx.with_deadline(d);
             }
@@ -2137,7 +2138,8 @@ async fn dispatch(
         // Per-attempt non-streaming deadline (#554): an elapsed `timeout`
         // surfaces as a retryable `BridgeError::Timeout`, so a slow target
         // fails over to the next one via the loop below.
-        let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+        let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
+            .with_client(client.caller.clone(), Some(client.headers.clone()));
         if let Some(d) = model.request_timeout() {
             ctx = ctx.with_deadline(d);
         }
@@ -2719,6 +2721,7 @@ async fn dispatch_ensemble(
         state,
         snapshot,
         request_id,
+        client,
     };
 
     // Streaming ensemble (OPTION A): the panel must be buffered to synthesize,
@@ -2828,7 +2831,8 @@ async fn dispatch_ensemble(
             request_id,
             Arc::new(judge_model.clone()),
             Arc::new(judge_pk.value.clone()),
-        );
+        )
+        .with_client(client.caller.clone(), Some(client.headers.clone()));
         if let Some(deadline) = judge_model.request_timeout() {
             judge_ctx = judge_ctx.with_deadline(deadline);
         }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -18,7 +18,7 @@
 
 use aisix_cache::{Cache, CacheKey};
 use aisix_core::AppliedGuardrail;
-use aisix_gateway::{BridgeContext, BridgeError, ChatFormat};
+use aisix_gateway::{BridgeError, ChatFormat};
 use aisix_guardrails::GuardrailVerdict;
 use aisix_obs::{
     content_capture_cap, AccessLog, CapturedContent, LatencyLabels, LlmUsage, Metrics,
@@ -1249,14 +1249,18 @@ async fn dispatch(
                 ));
                 continue 'targets;
             };
-            let model_arc = Arc::new(model.clone());
-            let pk_arc = Arc::new(pk_entry.value.clone());
+
             // Streaming deadline (#554): bound the connect by the effective
             // stream timeout; the read-timeout wrapper below enforces the
             // same budget on the first and subsequent chunks.
-            let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-                .with_client(client.caller.clone(), Some(client.headers.clone()))
-                .with_resource_ids(&attempt.id, &pk_entry.id);
+            let mut ctx = crate::dispatch::bridge_ctx(
+                request_id,
+                &attempt.id,
+                Arc::new(model.clone()),
+                &pk_entry.id,
+                Arc::new(pk_entry.value.clone()),
+                Some(client),
+            );
             if let Some(d) = model.stream_timeout_effective() {
                 ctx = ctx.with_deadline(d);
             }
@@ -2134,14 +2138,18 @@ async fn dispatch(
             )));
             continue;
         };
-        let model_arc = Arc::new(model.clone());
-        let pk_arc = Arc::new(pk_entry.value.clone());
+
         // Per-attempt non-streaming deadline (#554): an elapsed `timeout`
         // surfaces as a retryable `BridgeError::Timeout`, so a slow target
         // fails over to the next one via the loop below.
-        let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-            .with_client(client.caller.clone(), Some(client.headers.clone()))
-            .with_resource_ids(&attempt.id, &pk_entry.id);
+        let mut ctx = crate::dispatch::bridge_ctx(
+            request_id,
+            &attempt.id,
+            Arc::new(model.clone()),
+            &pk_entry.id,
+            Arc::new(pk_entry.value.clone()),
+            Some(client),
+        );
         if let Some(d) = model.request_timeout() {
             ctx = ctx.with_deadline(d);
         }
@@ -2829,13 +2837,14 @@ async fn dispatch_ensemble(
                 )),
             ));
         };
-        let mut judge_ctx = BridgeContext::new(
+        let mut judge_ctx = crate::dispatch::bridge_ctx(
             request_id,
+            &judge_entry.id,
             Arc::new(judge_model.clone()),
+            &judge_pk.id,
             Arc::new(judge_pk.value.clone()),
-        )
-        .with_client(client.caller.clone(), Some(client.headers.clone()))
-        .with_resource_ids(&judge_entry.id, &judge_pk.id);
+            Some(client),
+        );
         if let Some(deadline) = judge_model.request_timeout() {
             judge_ctx = judge_ctx.with_deadline(deadline);
         }

--- a/crates/aisix-proxy/src/client_ip.rs
+++ b/crates/aisix-proxy/src/client_ip.rs
@@ -11,10 +11,12 @@
 //! trusted proxies configured (the default) the peer is always logged.
 
 use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 
 use aisix_core::config::RealIpConfig;
 use axum::extract::{ConnectInfo, FromRef, FromRequestParts};
 use axum::http::request::Parts;
+use axum::http::HeaderMap;
 use ipnet::IpNet;
 
 use crate::state::ProxyState;
@@ -142,6 +144,19 @@ pub struct ClientContext {
     /// the two always match. Falls back to a fresh id when the middleware
     /// isn't in the chain (e.g. a handler unit test with a bare router).
     pub request_id: String,
+    /// The request's inbound headers, kept so dispatch can honour a
+    /// ProviderKey's `request.forward_client_headers` allowlist
+    /// (AISIX-Cloud#1167). Held behind an `Arc` because every dispatch
+    /// path clones the context; nothing here is forwarded unless an
+    /// operator names the header.
+    pub headers: Arc<HeaderMap>,
+    /// The authenticated caller, for `${request.api_key.*}` header
+    /// templates (AISIX-Cloud#1112). Read from the request extension the
+    /// [`crate::auth::AuthenticatedKey`] extractor publishes, so it is
+    /// filled only when that extractor ran first — which every handler
+    /// arranges by declaring `auth` before `client`. Default (empty) on
+    /// the unauthenticated paths; those resolve no `api_key` variable.
+    pub caller: aisix_gateway::CallerIdentity,
 }
 
 #[axum::async_trait]
@@ -203,6 +218,12 @@ where
             routing_tags,
             routing_key,
             request_id,
+            headers: Arc::new(parts.headers.clone()),
+            caller: parts
+                .extensions
+                .get::<Arc<aisix_core::ResourceEntry<aisix_core::ApiKey>>>()
+                .map(|e| aisix_gateway::CallerIdentity::from_entry(e))
+                .unwrap_or_default(),
         })
     }
 }

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -320,7 +320,8 @@ async fn dispatch(
     let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
     let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()));
+        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()))
+        .with_resource_ids(&model_entry.id, &pk_entry.id);
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -14,9 +14,7 @@
 //! 7. Call `bridge.complete(body, ctx)` → JSON response.
 //! 8. Providers that don't support completions return 501.
 
-use aisix_gateway::{
-    BridgeContext, BridgeError, ChatMessage, ChatResponse, FinishReason, UsageStats,
-};
+use aisix_gateway::{BridgeError, ChatMessage, ChatResponse, FinishReason, UsageStats};
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -316,12 +314,15 @@ async fn dispatch(
     let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
-    let model_arc = Arc::new(model.clone());
-    let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()))
-        .with_resource_ids(&model_entry.id, &pk_entry.id);
+    let mut ctx = crate::dispatch::bridge_ctx(
+        request_id,
+        &model_entry.id,
+        Arc::new(model.clone()),
+        &pk_entry.id,
+        Arc::new(pk_entry.value.clone()),
+        Some(client_ctx),
+    );
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -99,7 +99,7 @@ pub async fn completions(
         .unwrap_or("unknown")
         .to_string();
 
-    match dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
+    match dispatch(&state, &auth, body, &request_id, &client).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             // Audit MEDIUM-2 on PR #426: use the actual response
@@ -217,7 +217,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     mut body: Value,
     request_id: &str,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<CompletionDispatchSuccess, ProxyError> {
     let model_name = body
         .get("model")
@@ -236,7 +236,7 @@ async fn dispatch(
     }
 
     // Client-IP allowlist gate (#557): reject before guardrails / upstream.
-    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+    crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
     // #545: /v1/completions must run input guardrails. Before this it
     // forwarded the user `prompt` to the upstream with no configured
@@ -319,7 +319,8 @@ async fn dispatch(
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
+        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()));
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -268,6 +268,7 @@ async fn dispatch(
                 &target.model,
                 &target.id,
                 request_id,
+                client,
             )
             .await
             {
@@ -311,6 +312,7 @@ async fn dispatch(
 /// Dispatch one concrete Anthropic target's count_tokens passthrough to
 /// `{api_base}/v1/messages/count_tokens`. The caller has already
 /// confirmed `model.provider == anthropic`.
+#[allow(clippy::too_many_arguments)]
 async fn count_tokens_to_target(
     state: &ProxyState,
     snapshot: &aisix_core::AisixSnapshot,
@@ -318,6 +320,7 @@ async fn count_tokens_to_target(
     model: &aisix_core::Model,
     model_id: &str,
     request_id: &str,
+    client: &ClientContext,
 ) -> Result<Response, ProxyError> {
     let mut body = body.clone();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
@@ -355,13 +358,14 @@ async fn count_tokens_to_target(
     let url = crate::dispatch::build_v1_url(&base, "/messages/count_tokens");
 
     // Build the outbound HeaderMap explicitly so the PK's
-    // `request.default_headers` block can inject operator-supplied
-    // headers (e.g. `anthropic-beta`) via the shared apply pipeline.
-    // The bridge-owned headers (x-api-key, anthropic-version,
-    // content-type, x-aisix-request-id) are inserted FIRST;
-    // `apply_default_headers` skips keys already present + the reserved
-    // auth-header blacklist (`x-api-key`), so operator headers can never
-    // clobber auth here (ai-gateway#337). Anthropic auth shape:
+    // `request.default_headers` / `request.forward_client_headers` can
+    // inject operator-supplied and allowlisted client headers (e.g.
+    // `anthropic-beta`) via the shared apply pipeline. The bridge-owned
+    // headers (x-api-key, anthropic-version, content-type,
+    // x-aisix-request-id) are inserted FIRST; `apply_request_headers`
+    // skips keys already present + the reserved auth-header blacklist
+    // (`x-api-key`), so neither source can clobber auth here
+    // (ai-gateway#337). Anthropic auth shape:
     // `x-api-key` + `anthropic-version`, NOT `Authorization: Bearer`.
     let mut headers = axum::http::HeaderMap::new();
     let api_key_hv = HeaderValue::from_str(api_key).map_err(|e| {
@@ -384,9 +388,16 @@ async fn count_tokens_to_target(
         )))
     })?;
     headers.insert(HeaderName::from_static("x-aisix-request-id"), rid_hv);
-    if let Some(r) = pk_entry.value.request.as_ref() {
-        aisix_provider_openai::overrides::apply_default_headers(&mut headers, &r.default_headers);
-    }
+    aisix_gateway::apply_request_headers(
+        &mut headers,
+        &crate::dispatch::upstream_header_ctx(
+            &pk_entry.value,
+            &pk_entry.id,
+            model,
+            model_id,
+            client,
+        ),
+    );
 
     let client = crate::http_client::client();
     let mut req = client.post(&url).headers(headers).json(&body);
@@ -927,7 +938,7 @@ mod tests {
 
     /// Operator `default_headers` must NOT be able to overwrite the
     /// gateway-owned `x-api-key` auth header (ai-gateway#337) — the
-    /// reserved blacklist in `apply_default_headers` protects it.
+    /// reserved blacklist in `apply_request_headers` protects it.
     #[tokio::test]
     async fn default_headers_cannot_overwrite_x_api_key() {
         let upstream = MockServer::start().await;

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -269,6 +269,37 @@ pub(crate) fn require_api_key<'a>(
     Ok(provider_key.api_key.as_str())
 }
 
+/// Build the outbound-header context for a dispatch path that constructs
+/// its upstream request directly instead of going through a `Bridge`
+/// (`/v1/messages`, `/v1/responses`, `/v1/messages/count_tokens`, audio,
+/// rerank, videos, jobs).
+///
+/// The Bridge paths get the same thing from
+/// [`aisix_gateway::BridgeContext::header_ctx`]; both must resolve the
+/// same variables from the same sources, so keep them in step.
+pub(crate) fn upstream_header_ctx<'a>(
+    pk: &'a ProviderKey,
+    pk_id: &'a str,
+    model: &'a Model,
+    model_id: &'a str,
+    client: &'a crate::client_ip::ClientContext,
+) -> aisix_gateway::UpstreamHeaderContext<'a> {
+    let caller = &client.caller;
+    aisix_gateway::UpstreamHeaderContext::from_overrides(pk.request.as_ref())
+        .with_vars(aisix_core::HeaderVars {
+            request_id: Some(&client.request_id),
+            api_key_id: Some(&caller.api_key_id),
+            api_key_name: caller.api_key_name.as_deref(),
+            api_key_team_id: caller.team_id.as_deref(),
+            api_key_user_id: caller.user_id.as_deref(),
+            model_id: Some(model_id),
+            model_name: Some(&model.display_name),
+            provider_key_id: Some(pk_id),
+            provider_key_name: Some(&pk.display_name),
+        })
+        .with_client_headers(&client.headers)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -269,6 +269,37 @@ pub(crate) fn require_api_key<'a>(
     Ok(provider_key.api_key.as_str())
 }
 
+/// Build the [`BridgeContext`] for one upstream call.
+///
+/// The single chokepoint for wiring a Bridge dispatch: it carries the
+/// snapshot ids (which a `Model` / `ProviderKey` value does not know about
+/// itself) and, for a call made on behalf of a caller, that caller's
+/// identity and inbound headers. Both feed
+/// [`aisix_gateway::BridgeContext::header_ctx`], so a site that skipped
+/// either would silently stop rendering `${...}` header templates or
+/// forwarding allowlisted client headers, with no compiler signal —
+/// hence one constructor rather than a chain every caller must remember.
+///
+/// `client` is `None` for calls with no client request behind them: the
+/// semantic-router's embedding lookup and the background health prober.
+/// Those forward no client header and resolve no `${request.api_key.*}`
+/// variable, but still resolve the model / provider-key ones.
+pub(crate) fn bridge_ctx(
+    request_id: &str,
+    model_id: &str,
+    model: Arc<Model>,
+    provider_key_id: &str,
+    provider_key: Arc<ProviderKey>,
+    client: Option<&crate::client_ip::ClientContext>,
+) -> aisix_gateway::BridgeContext {
+    let ctx = aisix_gateway::BridgeContext::new(request_id, model, provider_key)
+        .with_resource_ids(model_id, provider_key_id);
+    match client {
+        Some(c) => ctx.with_client(c.caller.clone(), Some(c.headers.clone())),
+        None => ctx,
+    }
+}
+
 /// Build the outbound-header context for a dispatch path that constructs
 /// its upstream request directly instead of going through a `Bridge`
 /// (`/v1/messages`, `/v1/responses`, `/v1/messages/count_tokens`, audio,

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -397,7 +397,8 @@ async fn dispatch(
     let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
     let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()));
+        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()))
+        .with_resource_ids(&model_entry.id, &pk_entry.id);
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -125,7 +125,7 @@ pub async fn embeddings(
     };
     let model_name = body.model.clone();
 
-    match dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
+    match dispatch(&state, &auth, body, &request_id, &client).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             let status = 200u16;
@@ -265,7 +265,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     mut body: EmbeddingRequestBody,
     request_id: &str,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<EmbedDispatchSuccess, ProxyError> {
     let snapshot = state.snapshot.load();
 
@@ -277,7 +277,7 @@ async fn dispatch(
     }
 
     // Client-IP allowlist gate (#557): reject before guardrails / upstream.
-    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+    crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
     let model = &model_entry.value;
     let provider = crate::dispatch::require_provider(model)?;
@@ -396,7 +396,8 @@ async fn dispatch(
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
+        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()));
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -15,7 +15,7 @@
 //! `"type": "not_implemented"`.
 
 use aisix_core::AppliedGuardrail;
-use aisix_gateway::{BridgeContext, BridgeError, ChatFormat, ChatMessage, EmbeddingRequest};
+use aisix_gateway::{BridgeError, ChatFormat, ChatMessage, EmbeddingRequest};
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -393,12 +393,15 @@ async fn dispatch(
         dimensions: body.dimensions,
     };
 
-    let model_arc = Arc::new(model.clone());
-    let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()))
-        .with_resource_ids(&model_entry.id, &pk_entry.id);
+    let mut ctx = crate::dispatch::bridge_ctx(
+        request_id,
+        &model_entry.id,
+        Arc::new(model.clone()),
+        &pk_entry.id,
+        Arc::new(pk_entry.value.clone()),
+        Some(client_ctx),
+    );
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -28,7 +28,7 @@ use futures::future::join_all;
 
 use aisix_core::models::{EnsembleConfig, Judge, PanelMember};
 use aisix_core::AisixSnapshot;
-use aisix_gateway::bridge::{BridgeContext, BridgeError};
+use aisix_gateway::bridge::BridgeError;
 use aisix_gateway::chat::{ChatFormat, ChatMessage, ChatResponse, Role, UsageStats};
 
 use crate::state::ProxyState;
@@ -128,16 +128,14 @@ impl ModelCaller for ProxyModelCaller<'_> {
             })?;
 
         // Per-member request deadline from the member Model's own `timeout`.
-        let mut ctx = BridgeContext::new(
+        let mut ctx = crate::dispatch::bridge_ctx(
             self.request_id,
+            &entry.id,
             Arc::new(model.clone()),
+            &pk_entry.id,
             Arc::new(pk_entry.value.clone()),
-        )
-        .with_client(
-            self.client.caller.clone(),
-            Some(self.client.headers.clone()),
-        )
-        .with_resource_ids(&entry.id, &pk_entry.id);
+            Some(self.client),
+        );
         if let Some(deadline) = model.request_timeout() {
             ctx = ctx.with_deadline(deadline);
         }

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -86,6 +86,10 @@ pub(crate) struct ProxyModelCaller<'a> {
     pub state: &'a ProxyState,
     pub snapshot: &'a AisixSnapshot,
     pub request_id: &'a str,
+    /// The originating request's context. Member calls are dispatched on
+    /// the caller's behalf, so they carry the same caller identity and
+    /// forwardable client headers as a single-upstream dispatch would.
+    pub client: &'a crate::client_ip::ClientContext,
 }
 
 #[async_trait]
@@ -128,6 +132,10 @@ impl ModelCaller for ProxyModelCaller<'_> {
             self.request_id,
             Arc::new(model.clone()),
             Arc::new(pk_entry.value.clone()),
+        )
+        .with_client(
+            self.client.caller.clone(),
+            Some(self.client.headers.clone()),
         );
         if let Some(deadline) = model.request_timeout() {
             ctx = ctx.with_deadline(deadline);

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -136,7 +136,8 @@ impl ModelCaller for ProxyModelCaller<'_> {
         .with_client(
             self.client.caller.clone(),
             Some(self.client.headers.clone()),
-        );
+        )
+        .with_resource_ids(&entry.id, &pk_entry.id);
         if let Some(deadline) = model.request_timeout() {
             ctx = ctx.with_deadline(deadline);
         }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -297,7 +297,8 @@ async fn dispatch(
     let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
     let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()));
+        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()))
+        .with_resource_ids(&model_entry.id, &pk_entry.id);
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -77,7 +77,7 @@ pub async fn image_generations(
         .unwrap_or("unknown")
         .to_string();
 
-    match dispatch(&state, &auth, body, &request_id, &client.source_ip).await {
+    match dispatch(&state, &auth, body, &request_id, &client).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             emit_access_log(
@@ -182,7 +182,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     mut body: Value,
     request_id: &str,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<ImageDispatchSuccess, ProxyError> {
     // Owned so the #696 in-place prompt masking below can borrow `body`
     // mutably.
@@ -203,7 +203,7 @@ async fn dispatch(
     }
 
     // Client-IP allowlist gate (#557): reject before guardrails / upstream.
-    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+    crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
     // #545: /v1/images/generations must run input guardrails. Before this it
     // forwarded the user `prompt` with no configured content/DLP check, so a
@@ -296,7 +296,8 @@ async fn dispatch(
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
+        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()));
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -11,7 +11,7 @@
 //! 8. Providers that don't support image generation return 501.
 
 use aisix_core::AppliedGuardrail;
-use aisix_gateway::{BridgeContext, BridgeError};
+use aisix_gateway::BridgeError;
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, RequestOutcome, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -293,12 +293,15 @@ async fn dispatch(
     let bridge = crate::dispatch::resolve_bridge(&state.hub, &pk_entry.value)
         .ok_or(ProxyError::ProviderUnavailable)?;
 
-    let model_arc = Arc::new(model.clone());
-    let pk_arc = Arc::new(pk_entry.value.clone());
     // #554: apply the configured request `timeout` as the upstream deadline.
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()))
-        .with_resource_ids(&model_entry.id, &pk_entry.id);
+    let mut ctx = crate::dispatch::bridge_ctx(
+        request_id,
+        &model_entry.id,
+        Arc::new(model.clone()),
+        &pk_entry.id,
+        Arc::new(pk_entry.value.clone()),
+        Some(client_ctx),
+    );
     if let Some(d) = model.request_timeout() {
         ctx = ctx.with_deadline(d);
     }

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -359,17 +359,31 @@ async fn send_upstream(
         url,
     );
 
-    builder = match target.adapter {
-        Adapter::AzureOpenai => builder.header("api-key", &target.secret),
-        _ => builder.header(header::AUTHORIZATION, format!("Bearer {}", target.secret)),
+    // Gateway-owned headers go into the map first; the operator / client set
+    // is merged on top and skips any name already there.
+    // `RequestBuilder::header` APPENDS on a repeat name, so building the map
+    // is what keeps a colliding operator header from putting two values of
+    // e.g. `x-aisix-request-id` on the wire.
+    let mut headers = HeaderMap::new();
+    let (auth_name, auth_value) = match target.adapter {
+        Adapter::AzureOpenai => (
+            axum::http::HeaderName::from_static("api-key"),
+            target.secret.clone(),
+        ),
+        _ => (header::AUTHORIZATION, format!("Bearer {}", target.secret)),
     };
-    builder = builder.header("x-aisix-request-id", request_id);
-    // Operator/client headers ride every round-trip. `reqwest` appends on
-    // repeat names, so the gateway-owned names above are filtered out of
-    // `extra_headers` at resolve time by the shared pipeline.
-    for (name, value) in &target.extra_headers {
-        builder = builder.header(name, value);
+    if let Ok(v) = axum::http::HeaderValue::from_str(&auth_value) {
+        headers.insert(auth_name, v);
     }
+    if let Ok(v) = axum::http::HeaderValue::from_str(request_id) {
+        headers.insert(axum::http::HeaderName::from_static("x-aisix-request-id"), v);
+    }
+    for (name, value) in &target.extra_headers {
+        if !headers.contains_key(name) {
+            headers.insert(name.clone(), value.clone());
+        }
+    }
+    builder = builder.headers(headers);
 
     builder = match body {
         UpstreamBody::Empty => builder,

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -143,6 +143,11 @@ pub(crate) struct JobTarget {
     pub pk_entry: Arc<ResourceEntry<ProviderKey>>,
     pub secret: String,
     pub adapter: Adapter,
+    /// The ProviderKey's rendered `default_headers` plus the client headers
+    /// its `forward_client_headers` allowlist admits, resolved once when the
+    /// target is resolved so every round-trip on this surface (upload, poll,
+    /// download) sends the same set (AISIX-Cloud#1112 / #1167).
+    pub extra_headers: Vec<(axum::http::HeaderName, axum::http::HeaderValue)>,
 }
 
 impl JobTarget {
@@ -185,7 +190,7 @@ pub(crate) fn resolve_target(
     state: &ProxyState,
     auth: &AuthenticatedKey,
     wanted: Option<&str>,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<JobTarget, ProxyError> {
     let snapshot = state.snapshot.load();
 
@@ -233,7 +238,7 @@ pub(crate) fn resolve_target(
     };
 
     let model = &model_entry.value;
-    crate::dispatch::check_ip_access(model, source_ip)?;
+    crate::dispatch::check_ip_access(model, &client_ctx.source_ip)?;
 
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
     let adapter = supported_adapter(&pk_entry.value).ok_or_else(|| {
@@ -246,11 +251,20 @@ pub(crate) fn resolve_target(
     })?;
     let secret = crate::dispatch::require_api_key(&pk_entry.value, model)?.to_string();
 
+    let extra_headers =
+        aisix_gateway::resolve_extra_headers(&crate::dispatch::upstream_header_ctx(
+            &pk_entry.value,
+            &pk_entry.id,
+            model,
+            &model_entry.id,
+            client_ctx,
+        ));
     Ok(JobTarget {
         model_entry,
         pk_entry,
         secret,
         adapter,
+        extra_headers,
     })
 }
 
@@ -350,6 +364,12 @@ async fn send_upstream(
         _ => builder.header(header::AUTHORIZATION, format!("Bearer {}", target.secret)),
     };
     builder = builder.header("x-aisix-request-id", request_id);
+    // Operator/client headers ride every round-trip. `reqwest` appends on
+    // repeat names, so the gateway-owned names above are filtered out of
+    // `extra_headers` at resolve time by the shared pipeline.
+    for (name, value) in &target.extra_headers {
+        builder = builder.header(name, value);
+    }
 
     builder = match body {
         UpstreamBody::Empty => builder,
@@ -792,7 +812,7 @@ pub(crate) async fn create_file(
         })?;
 
         let wanted = form_model.or_else(|| explicit_model(&params, &headers));
-        let target = resolve_target(&state, &auth, wanted.as_deref(), &client.source_ip)?;
+        let target = resolve_target(&state, &auth, wanted.as_deref(), &client)?;
 
         // Batch/fine-tune input files carry end-user content — scan them
         // like any other inbound payload.
@@ -1002,7 +1022,7 @@ pub(crate) async fn create_batch(
         let wanted = embedded
             .or(body_model)
             .or_else(|| explicit_model(&params, &headers));
-        let target = resolve_target(&state, &auth, wanted.as_deref(), &client.source_ip)?;
+        let target = resolve_target(&state, &auth, wanted.as_deref(), &client)?;
 
         // Forward the provider wire shape: raw file id, no gateway-only
         // routing fields.
@@ -1074,7 +1094,7 @@ pub(crate) async fn get_batch(
     let result = async {
         require_safe_upstream_id(&raw)?;
         let wanted = embedded.or_else(|| explicit_model(&params, &headers));
-        let target = resolve_target(&state, &auth, wanted.as_deref(), &client.source_ip)?;
+        let target = resolve_target(&state, &auth, wanted.as_deref(), &client)?;
         let _reservation = crate::quota::enforce(
             &state,
             &auth,
@@ -1223,7 +1243,7 @@ pub(crate) async fn create_ft_job(
             .unwrap_or((training_file.clone(), None));
         require_safe_upstream_id(&raw_training)?;
         let wanted = embedded.or_else(|| explicit_model(&params, &headers));
-        let target = resolve_target(&state, &auth, wanted.as_deref(), &client.source_ip)?;
+        let target = resolve_target(&state, &auth, wanted.as_deref(), &client)?;
 
         if let Some(obj) = req_json.as_object_mut() {
             obj.insert("training_file".into(), Value::String(raw_training));
@@ -1413,7 +1433,7 @@ async fn forward_simple(
             None => None,
         };
         let wanted = embedded.or_else(|| explicit_model(&params, &headers));
-        let target = resolve_target(&state, &auth, wanted.as_deref(), &client.source_ip)?;
+        let target = resolve_target(&state, &auth, wanted.as_deref(), &client)?;
 
         if let Some(body) = &spec.body {
             scan_input_blob(&state, &auth, &target, body, &mut monitor_hits).await?;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1026,13 +1026,14 @@ async fn anthropic_passthrough_dispatch(
         .unwrap_or(false);
 
     // Build the outbound HeaderMap explicitly so the PK's
-    // `request.default_headers` block can inject operator-supplied
-    // headers via the shared apply pipeline. The bridge-owned
-    // headers (x-api-key, anthropic-version, content-type,
-    // x-aisix-request-id) are inserted FIRST — `apply_default_headers`
-    // skips keys already present + the reserved auth-header blacklist
-    // (`x-api-key` is in `RESERVED_DEFAULT_HEADERS`), so operator
-    // headers can never clobber auth here (ai-gateway#337).
+    // `request.default_headers` / `request.forward_client_headers` can
+    // inject operator-supplied and allowlisted client headers via the
+    // shared apply pipeline. The bridge-owned headers (x-api-key,
+    // anthropic-version, content-type, x-aisix-request-id) are inserted
+    // FIRST — `apply_request_headers` skips keys already present + the
+    // reserved auth-header blacklist (`x-api-key` is in
+    // `RESERVED_UPSTREAM_HEADERS`), so neither source can clobber auth
+    // here (ai-gateway#337).
     let mut headers = axum::http::HeaderMap::new();
     let api_key_hv = HeaderValue::from_str(api_key).map_err(|e| {
         ProxyError::Bridge(aisix_gateway::BridgeError::Config(format!(
@@ -1054,9 +1055,10 @@ async fn anthropic_passthrough_dispatch(
         )))
     })?;
     headers.insert(HeaderName::from_static("x-aisix-request-id"), rid_hv);
-    if let Some(r) = pk_value.request.as_ref() {
-        aisix_provider_openai::overrides::apply_default_headers(&mut headers, &r.default_headers);
-    }
+    aisix_gateway::apply_request_headers(
+        &mut headers,
+        &crate::dispatch::upstream_header_ctx(pk_value, pk_id, model, model_id, client_ctx),
+    );
 
     let client = crate::http_client::client();
     let mut req_builder = client.post(&url).headers(headers).json(&body);
@@ -1747,7 +1749,8 @@ async fn cross_provider_dispatch(
     // the streaming read budget for stream calls, the E2E request timeout
     // otherwise. The streaming path additionally enforces the per-chunk
     // read timeout below.
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
+        .with_client(client.caller.clone(), Some(client.headers.clone()));
     let connect_deadline = if is_stream {
         model.stream_timeout_effective()
     } else {
@@ -3626,7 +3629,7 @@ mod tests {
     //
     // Issue refs: ai-gateway#335 (`apply_param_constraints` not wired
     // on /v1/messages), ai-gateway#337 (same gap for
-    // `apply_default_headers`). Same site / same fix covers
+    // `apply_request_headers`). Same site / same fix covers
     // `param_renames` and `default_body_fields`.
 
     /// Build an Anthropic ProviderKey JSON with the given request
@@ -3814,7 +3817,7 @@ mod tests {
     #[tokio::test]
     async fn anthropic_passthrough_default_headers_cannot_overwrite_x_api_key() {
         // Defense-in-depth: `x-api-key` is in
-        // `aisix_provider_openai::overrides::RESERVED_DEFAULT_HEADERS`
+        // `aisix_gateway::upstream_headers::RESERVED_UPSTREAM_HEADERS`
         // — even if cp-api validation slips and lets the operator
         // register a default_headers entry with `x-api-key`, the apply
         // function MUST drop it so the PK's secret remains the auth

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -907,6 +907,7 @@ async fn dispatch_to_target(
             model,
             &target.id,
             &pk_entry.value,
+            &pk_entry.id,
             model_name,
             request_id,
             started,
@@ -1689,6 +1690,7 @@ async fn cross_provider_dispatch(
     model: &aisix_core::Model,
     model_id: &str,
     provider_key: &aisix_core::ProviderKey,
+    provider_key_id: &str,
     model_name: &str,
     request_id: &str,
     started: Instant,
@@ -1750,7 +1752,8 @@ async fn cross_provider_dispatch(
     // otherwise. The streaming path additionally enforces the per-chunk
     // read timeout below.
     let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client.caller.clone(), Some(client.headers.clone()));
+        .with_client(client.caller.clone(), Some(client.headers.clone()))
+        .with_resource_ids(model_id, provider_key_id);
     let connect_deadline = if is_stream {
         model.stream_timeout_effective()
     } else {

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1709,7 +1709,7 @@ async fn cross_provider_dispatch(
     input_redactions: crate::redact::RedactionCounts,
     input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<DispatchOutcome, ProxyError> {
-    use aisix_gateway::{Bridge, BridgeContext};
+    use aisix_gateway::Bridge;
     use aisix_provider_anthropic::{
         chat_response_into_anthropic_json, parse_inbound_request, translate_extras_to_openai_shape,
         AnthropicSseEncoder,
@@ -1745,15 +1745,19 @@ async fn cross_provider_dispatch(
     translate_extras_to_openai_shape(&mut chat.extra);
 
     let is_stream = chat.is_streaming();
-    let model_arc = Arc::new(model.clone());
-    let pk_arc = Arc::new(provider_key.clone());
+
     // #554: bound the upstream connect with the appropriate deadline —
     // the streaming read budget for stream calls, the E2E request timeout
     // otherwise. The streaming path additionally enforces the per-chunk
     // read timeout below.
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client.caller.clone(), Some(client.headers.clone()))
-        .with_resource_ids(model_id, provider_key_id);
+    let mut ctx = crate::dispatch::bridge_ctx(
+        request_id,
+        model_id,
+        Arc::new(model.clone()),
+        provider_key_id,
+        Arc::new(provider_key.clone()),
+        Some(client),
+    );
     let connect_deadline = if is_stream {
         model.stream_timeout_effective()
     } else {

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -84,7 +84,7 @@ pub async fn rerank(
         .unwrap_or("")
         .to_string();
 
-    match dispatch(&state, &auth, &mut body, &request_id, &client.source_ip).await {
+    match dispatch(&state, &auth, &mut body, &request_id, &client).await {
         Ok(success) => {
             let elapsed = started.elapsed();
             let status = success.response.status().as_u16();
@@ -199,7 +199,7 @@ async fn dispatch(
     auth: &AuthenticatedKey,
     body: &mut Value,
     request_id: &str,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<RerankDispatchSuccess, ProxyError> {
     let snapshot = state.snapshot.load();
 
@@ -217,7 +217,7 @@ async fn dispatch(
     }
 
     // Client-IP allowlist gate (#557): reject before guardrails / upstream.
-    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+    crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
     // #545: /v1/rerank must run input guardrails. Before this it forwarded
     // the user `query` + `documents` with no configured content/DLP check,
@@ -363,8 +363,9 @@ async fn dispatch(
     };
     let url = crate::dispatch::build_v1_url(&base, "/rerank");
 
-    // Build headers explicitly so the PK's `request.default_headers` can inject
-    // operator headers (reserved auth headers are protected by the apply step).
+    // Build headers explicitly so the PK's `request.default_headers` and
+    // `request.forward_client_headers` can inject operator/client headers
+    // (reserved auth headers are protected by the apply step).
     let mut headers = axum::http::HeaderMap::new();
     let auth_hv = HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
         ProxyError::Bridge(aisix_gateway::BridgeError::Config(format!(
@@ -385,9 +386,16 @@ async fn dispatch(
         axum::http::header::HeaderName::from_static("x-aisix-request-id"),
         rid_hv,
     );
-    if let Some(r) = pk_entry.value.request.as_ref() {
-        aisix_provider_openai::overrides::apply_default_headers(&mut headers, &r.default_headers);
-    }
+    aisix_gateway::apply_request_headers(
+        &mut headers,
+        &crate::dispatch::upstream_header_ctx(
+            &pk_entry.value,
+            &pk_entry.id,
+            model,
+            &model_entry.id,
+            client_ctx,
+        ),
+    );
 
     let client = crate::http_client::client();
     // Send, check the status, and read the body as one retryable unit, so a

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1674,7 +1674,8 @@ async fn responses_cross_provider_to_target(
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
     let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()));
+        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()))
+        .with_resource_ids(model_id, &provider_key_id);
     let connect_deadline = if is_stream {
         model.stream_timeout_effective()
     } else {

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -947,10 +947,11 @@ async fn responses_to_target(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Build headers explicitly so the PK's `request.default_headers` can inject
-    // operator headers. Bridge-owned headers go in FIRST; `apply_default_headers`
-    // skips already-present keys + the reserved auth blacklist, so an operator
-    // header can never clobber auth.
+    // Build headers explicitly so the PK's `request.default_headers` and
+    // `request.forward_client_headers` can inject operator/client headers.
+    // Bridge-owned headers go in FIRST; `apply_request_headers` skips
+    // already-present keys + the reserved auth blacklist, so neither can
+    // clobber auth.
     let mut headers = axum::http::HeaderMap::new();
     let auth_hv = HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
         ProxyError::Bridge(aisix_gateway::BridgeError::Config(format!(
@@ -968,9 +969,16 @@ async fn responses_to_target(
         )))
     })?;
     headers.insert(HeaderName::from_static("x-aisix-request-id"), rid_hv);
-    if let Some(r) = pk_entry.value.request.as_ref() {
-        aisix_provider_openai::overrides::apply_default_headers(&mut headers, &r.default_headers);
-    }
+    aisix_gateway::apply_request_headers(
+        &mut headers,
+        &crate::dispatch::upstream_header_ctx(
+            &pk_entry.value,
+            &pk_entry.id,
+            model,
+            model_id,
+            client_ctx,
+        ),
+    );
 
     let client = crate::http_client::client();
     let mut req = client.post(&url).headers(headers).json(&body);
@@ -1665,7 +1673,8 @@ async fn responses_cross_provider_to_target(
     let is_stream = chat.is_streaming();
     let model_arc = Arc::new(model.clone());
     let pk_arc = Arc::new(pk_entry.value.clone());
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc);
+    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
+        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()));
     let connect_deadline = if is_stream {
         model.stream_timeout_effective()
     } else {

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1637,7 +1637,7 @@ async fn responses_cross_provider_to_target(
     // `input_redactions`.
     input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<ResponseDispatchSuccess, ProxyError> {
-    use aisix_gateway::{Bridge, BridgeContext};
+    use aisix_gateway::Bridge;
 
     // Content capture (AISIX-Cloud#947), same contract as the verbatim
     // target: prompt = the client-facing Responses request body
@@ -1671,11 +1671,14 @@ async fn responses_cross_provider_to_target(
     let chat = crate::responses_bridge::responses_request_to_chat(requested_model, body);
 
     let is_stream = chat.is_streaming();
-    let model_arc = Arc::new(model.clone());
-    let pk_arc = Arc::new(pk_entry.value.clone());
-    let mut ctx = BridgeContext::new(request_id, model_arc, pk_arc)
-        .with_client(client_ctx.caller.clone(), Some(client_ctx.headers.clone()))
-        .with_resource_ids(model_id, &provider_key_id);
+    let mut ctx = crate::dispatch::bridge_ctx(
+        request_id,
+        model_id,
+        Arc::new(model.clone()),
+        &provider_key_id,
+        Arc::new(pk_entry.value.clone()),
+        Some(client_ctx),
+    );
     let connect_deadline = if is_stream {
         model.stream_timeout_effective()
     } else {

--- a/crates/aisix-proxy/src/semantic.rs
+++ b/crates/aisix-proxy/src/semantic.rs
@@ -19,7 +19,7 @@ use dashmap::DashMap;
 use aisix_core::models::{EmbeddingFailureMode, OnEmbeddingFailure, Semantic};
 use aisix_core::resource::ResourceEntry;
 use aisix_core::{AisixSnapshot, Model};
-use aisix_gateway::{BridgeContext, EmbeddingRequest, EmbeddingVector};
+use aisix_gateway::{EmbeddingRequest, EmbeddingVector};
 
 use crate::error::ProxyError;
 use crate::routing::AttemptModel;
@@ -314,10 +314,13 @@ async fn embed_texts(
         dimensions,
     };
     let ctx = {
-        let base = BridgeContext::new(
+        let base = crate::dispatch::bridge_ctx(
             request_id,
+            &embed_entry.id,
             Arc::new(model.clone()),
+            &pk_entry.id,
             Arc::new(pk_entry.value.clone()),
+            None,
         );
         match semantic.embedding_timeout() {
             Some(d) => base.with_deadline(d),

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1152,28 +1152,44 @@ async fn provider_call(
         "/v1/videos",
         retry_permit,
         || {
-            let mut builder = client
-                .request(method.clone(), url)
-                .header(header::AUTHORIZATION, format!("Bearer {}", target.secret))
-                .header("x-aisix-request-id", request_id);
+            // Gateway-owned headers go into the map first; the operator /
+            // client set is merged on top and skips any name already there.
+            // `RequestBuilder::header` APPENDS on a repeat name, so building
+            // the map is what keeps a colliding operator header from putting
+            // two values of e.g. `x-aisix-request-id` on the wire.
+            let mut headers = axum::http::HeaderMap::new();
+            if let Ok(v) = header::HeaderValue::from_str(&format!("Bearer {}", target.secret)) {
+                headers.insert(header::AUTHORIZATION, v);
+            }
+            if let Ok(v) = header::HeaderValue::from_str(request_id) {
+                headers.insert(header::HeaderName::from_static("x-aisix-request-id"), v);
+            }
             // A provider header required on every call (submit and poll) — e.g.
             // Runway's mandatory `X-Runway-Version`. Applied unconditionally,
             // before the submit-only body/header block below.
             if let Some((name, value)) = target.provider.all_request_header() {
-                builder = builder.header(name, value);
-            }
-            // Operator/client headers ride every round-trip. `reqwest` appends
-            // on repeat names, so the gateway-owned names above are filtered
-            // out of `extra_headers` at resolve time by the shared pipeline.
-            for (name, value) in &target.extra_headers {
-                builder = builder.header(name, value);
-            }
-            if let Some(b) = body {
-                if target.provider.submit_headers_async() {
-                    // DashScope requires the async-mode header — it rejects
-                    // synchronous video-synthesis calls outright.
-                    builder = builder.header("X-DashScope-Async", "enable");
+                if let (Ok(n), Ok(v)) = (
+                    name.parse::<header::HeaderName>(),
+                    header::HeaderValue::from_str(value),
+                ) {
+                    headers.insert(n, v);
                 }
+            }
+            if target.provider.submit_headers_async() && body.is_some() {
+                // DashScope requires the async-mode header — it rejects
+                // synchronous video-synthesis calls outright.
+                headers.insert(
+                    header::HeaderName::from_static("x-dashscope-async"),
+                    header::HeaderValue::from_static("enable"),
+                );
+            }
+            for (name, value) in &target.extra_headers {
+                if !headers.contains_key(name) {
+                    headers.insert(name.clone(), value.clone());
+                }
+            }
+            let mut builder = client.request(method.clone(), url).headers(headers);
+            if let Some(b) = body {
                 builder = builder
                     .header(header::CONTENT_TYPE, "application/json")
                     .json(b);
@@ -1254,18 +1270,31 @@ async fn proxy_content(
     request_id: &str,
 ) -> Result<Response, ProxyError> {
     let client = crate::http_client::client();
-    let mut builder = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", target.secret))
-        .header("x-aisix-request-id", request_id);
+    // Same map-then-merge shape as `provider_call` — see the comment there
+    // on why the gateway-owned names cannot be appended to.
+    let mut headers = axum::http::HeaderMap::new();
+    if let Ok(v) = header::HeaderValue::from_str(&format!("Bearer {}", target.secret)) {
+        headers.insert(header::AUTHORIZATION, v);
+    }
+    if let Ok(v) = header::HeaderValue::from_str(request_id) {
+        headers.insert(header::HeaderName::from_static("x-aisix-request-id"), v);
+    }
     // A provider header required on every call (e.g. Runway's version header) —
     // future-proofs Proxy mode for such vendors; a no-op for OpenAI.
     if let Some((name, value)) = target.provider.all_request_header() {
-        builder = builder.header(name, value);
+        if let (Ok(n), Ok(v)) = (
+            name.parse::<header::HeaderName>(),
+            header::HeaderValue::from_str(value),
+        ) {
+            headers.insert(n, v);
+        }
     }
     for (name, value) in &target.extra_headers {
-        builder = builder.header(name, value);
+        if !headers.contains_key(name) {
+            headers.insert(name.clone(), value.clone());
+        }
     }
+    let builder = client.get(url).headers(headers);
 
     let stream_budget = target.model_entry.value.stream_timeout_effective();
     let started = Instant::now();

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1025,6 +1025,11 @@ struct VideoTarget {
     provider_label: String,
     base_url: String,
     secret: String,
+    /// The ProviderKey's rendered `default_headers` plus the client headers
+    /// its `forward_client_headers` allowlist admits, resolved once when the
+    /// target is resolved so every round-trip on this surface (submit, poll,
+    /// content fetch) sends the same set (AISIX-Cloud#1112 / #1167).
+    extra_headers: Vec<(axum::http::HeaderName, axum::http::HeaderValue)>,
 }
 
 impl VideoTarget {
@@ -1042,14 +1047,14 @@ fn resolve_video_target(
     auth: &AuthenticatedKey,
     model_entry: std::sync::Arc<aisix_core::ResourceEntry<aisix_core::Model>>,
     acl_name: &str,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<Result<VideoTarget, Response>, ProxyError> {
     let snapshot = state.snapshot.load();
 
     if !auth.key().can_access(acl_name) {
         return Err(ProxyError::ModelForbidden(acl_name.to_string()));
     }
-    crate::dispatch::check_ip_access(&model_entry.value, source_ip)?;
+    crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
     let provider = crate::dispatch::require_provider(&model_entry.value)?.to_string();
     // Providers outside the mapped set get a typed 501 so callers can
@@ -1079,6 +1084,14 @@ fn resolve_video_target(
     };
     let secret = crate::dispatch::require_api_key(&pk_entry.value, &model_entry.value)?.to_string();
 
+    let extra_headers =
+        aisix_gateway::resolve_extra_headers(&crate::dispatch::upstream_header_ctx(
+            &pk_entry.value,
+            &pk_entry.id,
+            &model_entry.value,
+            &model_entry.id,
+            client_ctx,
+        ));
     Ok(Ok(VideoTarget {
         pk_id: pk_entry.id.to_string(),
         provider: video_provider,
@@ -1086,6 +1099,7 @@ fn resolve_video_target(
         base_url,
         secret,
         model_entry,
+        extra_headers,
     }))
 }
 
@@ -1146,6 +1160,12 @@ async fn provider_call(
             // Runway's mandatory `X-Runway-Version`. Applied unconditionally,
             // before the submit-only body/header block below.
             if let Some((name, value)) = target.provider.all_request_header() {
+                builder = builder.header(name, value);
+            }
+            // Operator/client headers ride every round-trip. `reqwest` appends
+            // on repeat names, so the gateway-owned names above are filtered
+            // out of `extra_headers` at resolve time by the shared pipeline.
+            for (name, value) in &target.extra_headers {
                 builder = builder.header(name, value);
             }
             if let Some(b) = body {
@@ -1241,6 +1261,9 @@ async fn proxy_content(
     // A provider header required on every call (e.g. Runway's version header) —
     // future-proofs Proxy mode for such vendors; a no-op for OpenAI.
     if let Some((name, value)) = target.provider.all_request_header() {
+        builder = builder.header(name, value);
+    }
+    for (name, value) in &target.extra_headers {
         builder = builder.header(name, value);
     }
 
@@ -1534,21 +1557,20 @@ async fn dispatch_create(
         ));
     }
 
-    let target =
-        match resolve_video_target(state, auth, model_entry, &body.model, &client.source_ip)? {
-            Ok(t) => t,
-            Err(resp) => {
-                return Ok(CreateSuccess {
-                    response: resp,
-                    provider: "unknown".into(),
-                    model_id,
-                    provider_key_id: String::new(),
-                    applied_guardrails: Vec::new(),
-                    monitor_hits: Vec::new(),
-                    upstream_called: false,
-                })
-            }
-        };
+    let target = match resolve_video_target(state, auth, model_entry, &body.model, client)? {
+        Ok(t) => t,
+        Err(resp) => {
+            return Ok(CreateSuccess {
+                response: resp,
+                provider: "unknown".into(),
+                model_id,
+                provider_key_id: String::new(),
+                applied_guardrails: Vec::new(),
+                monitor_hits: Vec::new(),
+                upstream_called: false,
+            })
+        }
+    };
 
     // Input guardrail chain over the prompt — same resolution as chat /
     // embeddings, run BEFORE the rate-limit reservation so a policy
@@ -1675,7 +1697,7 @@ fn resolve_get_target(
     state: &ProxyState,
     auth: &AuthenticatedKey,
     video_id: &str,
-    source_ip: &str,
+    client_ctx: &ClientContext,
 ) -> Result<(VideoTarget, String), ProxyError> {
     let (entry_id, alias, task_id) =
         decode_video_id(video_id).ok_or_else(|| ProxyError::VideoNotFound(video_id.to_string()))?;
@@ -1684,7 +1706,7 @@ fn resolve_get_target(
         .models
         .get_by_id(&entry_id)
         .ok_or_else(|| ProxyError::VideoNotFound(video_id.to_string()))?;
-    match resolve_video_target(state, auth, model_entry, &alias, source_ip) {
+    match resolve_video_target(state, auth, model_entry, &alias, client_ctx) {
         Ok(Ok(target)) => Ok((target, task_id)),
         // Unsupported provider → uniform 404 (oracle fold, see above).
         Ok(Err(_)) => Err(ProxyError::VideoNotFound(video_id.to_string())),
@@ -1710,7 +1732,7 @@ pub async fn get_video(
     };
 
     let result: Result<(Response, String, String), ProxyError> = async {
-        let (target, task_id) = resolve_get_target(&state, &auth, &video_id, &client.source_ip)?;
+        let (target, task_id) = resolve_get_target(&state, &auth, &video_id, &client)?;
         // Poll traffic is exempt from model-level limits BY DESIGN
         // (AISIX-Cloud#1118 decision 3): a client polling a task it
         // already paid an RPM slot to submit must not starve itself.
@@ -1761,7 +1783,7 @@ pub async fn video_content(
     };
 
     let result: Result<(Response, String, String), ProxyError> = async {
-        let (target, task_id) = resolve_get_target(&state, &auth, &video_id, &client.source_ip)?;
+        let (target, task_id) = resolve_get_target(&state, &auth, &video_id, &client)?;
         // Same model-layer exemption as the poll route (see get_video).
         let reservation = crate::quota::enforce(&state, &auth, None).await?;
         let result = poll_task(&state, &target, &task_id, &client.request_id).await;

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -162,6 +162,13 @@
       "description": "Administratively disabled. A disabled key is rejected with `401` until it is enabled again; the key itself is preserved. Treated as `false` when omitted.",
       "type": "boolean"
     },
+    "display_name": {
+      "description": "Operator-facing label for this key, as shown in the dashboard. Read only by the `${request.api_key.name}` header template (AISIX-Cloud#1112); never used for authentication or routing.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "expires_at": {
       "description": "RFC 3339 timestamp after which the key stops authenticating. Requests presenting an expired key are rejected with `401`. When omitted or set to `null`, the key never expires.",
       "format": "date-time",

--- a/schemas/resources/provider_key.schema.json
+++ b/schemas/resources/provider_key.schema.json
@@ -63,8 +63,15 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "`apply_default_headers` input. Top-level headers added to the outbound request when the caller did not set them. Reserved auth headers are dropped by `apply_default_headers` as defense-in-depth.",
+          "description": "Top-level headers added to the outbound request when the caller did not set them. Values may reference the request context with `${...}` variables, such as `\"${request.api_key.team_id}\"`; a header whose variables do not all resolve is dropped rather than sent blank. See [`crate::header_template`] for the closed variable vocabulary. Reserved auth headers are dropped as defense-in-depth.",
           "type": "object"
+        },
+        "forward_client_headers": {
+          "description": "Inbound client headers forwarded to the upstream provider, as single-`*` glob patterns matched case-insensitively against the header name (`\"anthropic-beta\"`, `\"x-trace-*\"`). Empty — the default — forwards nothing, which is the behavior of every standard-protocol endpoint before AISIX-Cloud#1167. Auth, transport, and gateway-owned headers are never forwarded whatever the patterns say.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "param_constraints": {
           "anyOf": [

--- a/tests/e2e/src/cases/batch-files-finetuning-e2e.test.ts
+++ b/tests/e2e/src/cases/batch-files-finetuning-e2e.test.ts
@@ -202,6 +202,26 @@ describe("jobs e2e: /v1/files + /v1/batches + /v1/fine_tuning/jobs (#720)", () =
       provider_key_id: pk.id,
     });
 
+    // A second key carrying operator headers, including one that collides
+    // with a gateway-owned name — see the header test below.
+    const hdrPk = await seed.createProviderKey({
+      display_name: "jobs-e2e-hdr-pk",
+      secret: "sk-upstream-jobs",
+      api_base: `${upstream.baseUrl}/v1`,
+      request: {
+        default_headers: {
+          "x-corp-trace": "jobs-operator-value",
+          "x-aisix-request-id": "operator-should-not-win",
+        },
+      },
+    });
+    await seed.createModel({
+      display_name: "jobs-e2e-hdr-model",
+      provider: "openai",
+      model_name: "gpt-4o",
+      provider_key_id: hdrPk.id,
+    });
+
     // Gate on the DP snapshot, not the store: /v1/models only lists the
     // model once the snapshot has it, and only authenticates once the
     // caller key has propagated too. Touches no upstream.
@@ -357,6 +377,48 @@ describe("jobs e2e: /v1/files + /v1/batches + /v1/fine_tuning/jobs (#720)", () =
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as { id: string };
     expect(body.id.startsWith("aisix-")).toBe(true);
+  });
+
+  // The jobs surface applied no `default_headers` at all before #1167 — it
+  // built its upstream request with `RequestBuilder::header`, which APPENDS
+  // on a repeated name. So this pins both halves: the operator's header now
+  // reaches the upstream, and one that collides with a gateway-owned name
+  // neither wins nor doubles the value on the wire.
+  test("provider-key headers reach the jobs upstream without doubling gateway headers", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const baseline = upstream.received.length;
+    const form = new FormData();
+    form.set("purpose", "batch");
+    form.set("model", "jobs-e2e-hdr-model");
+    form.set(
+      "file",
+      new Blob(['{"custom_id":"hdr"}\n'], { type: "application/jsonl" }),
+      "hdr.jsonl",
+    );
+    const resp = await fetch(`${app.proxyUrl}/v1/files`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+      body: form,
+    });
+    expect(resp.status).toBe(200);
+
+    const sent = upstream.received
+      .slice(baseline)
+      .filter((r) => r.method === "POST" && r.path === "/v1/files");
+    expect(sent).toHaveLength(1);
+    const headers = sent[0]!.headers;
+
+    expect(headers["x-corp-trace"]).toBe("jobs-operator-value");
+    // node joins repeated header values with a comma, so an appended
+    // duplicate shows up here as `<gateway>,operator-should-not-win`.
+    const rid = headers["x-aisix-request-id"] ?? "";
+    expect(rid).not.toContain(",");
+    expect(rid).not.toBe("operator-should-not-win");
+    expect(rid).not.toBe("");
+    expect(headers.authorization).toBe("Bearer sk-upstream-jobs");
   });
 
   test("auth is mandatory on the jobs surface", async (ctx) => {

--- a/tests/e2e/src/cases/upstream-header-context-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-header-context-e2e.test.ts
@@ -1,0 +1,402 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the two operator-facing outbound-header features on
+// `ProviderKey.request`, exercised through a real gateway against a real
+// upstream (AISIX-Cloud#1112 + #1167).
+//
+//   1. `default_headers` values carrying `${...}` request-context
+//      variables — rendered per request, and DROPPED (not blanked) when a
+//      variable has no value for that request.
+//   2. `forward_client_headers` — the operator's allowlist of inbound
+//      client headers to relay upstream, exact names and `x-*` globs.
+//
+// The security contracts are pinned alongside the happy paths, because
+// they are the reason the default is "forward nothing": the caller's own
+// `Authorization` / `x-api-key`, the gateway's `x-aisix-*` namespace, and
+// the transport headers must never reach the provider — not even when the
+// operator writes `"*"` in the allowlist. Precedence is asserted in the
+// same direction the pipeline enforces it: gateway > operator > client.
+//
+// Coverage spans three dispatch families that build their upstream headers
+// in different code: the OpenAI Bridge (`/v1/chat/completions`, streaming
+// and not) and the Anthropic native passthrough (`/v1/messages`), which
+// the issue calls out as the pair most likely to drift.
+//
+// Reference:
+//   - LiteLLM's equivalent: `forward_client_headers_to_llm_api`
+//     <https://docs.litellm.ai/docs/proxy/forward_client_headers>
+//   - Anthropic beta headers (the canonical forwarding case)
+//     <https://docs.anthropic.com/en/api/beta-headers>
+
+const CALLER_PLAINTEXT = "sk-hdrctx-caller-PLAINTEXT-MARKER";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// A second caller on the same ProviderKey, with no team — proves an
+// unresolvable `${request.api_key.team_id}` drops just that header.
+const TEAMLESS_PLAINTEXT = "sk-hdrctx-teamless-PLAINTEXT-MARKER";
+const TEAMLESS_KEY_HASH = createHash("sha256")
+  .update(TEAMLESS_PLAINTEXT)
+  .digest("hex");
+
+const PROVIDER_SECRET = "sk-mock-provider-secret";
+const TEAM_ID = "team-acme-42";
+const USER_ID = "user-7";
+const KEY_NAME = "acme-prod-key";
+
+const ANTHROPIC_BODY = {
+  id: "msg_01",
+  type: "message",
+  role: "assistant",
+  content: [{ type: "text", text: "hi" }],
+  model: "claude-3-5-haiku-20241022",
+  stop_reason: "end_turn",
+  usage: { input_tokens: 5, output_tokens: 4 },
+};
+
+describe("upstream header context e2e: ${...} variables + client-header allowlist", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let anthropicUpstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+  let openaiModelId = "";
+  let openaiPkId = "";
+  let anthropicModelId = "";
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // Two mocks: the OpenAI-shaped one answers the Bridge path, the
+    // Anthropic-shaped one answers the native `/v1/messages` passthrough.
+    // A single mock cannot serve both — its canned body is path-agnostic,
+    // so an Anthropic body on the chat route decodes as a 502.
+    upstream = await startOpenAiUpstream();
+    anthropicUpstream = await startOpenAiUpstream({
+      nonStreamBody: ANTHROPIC_BODY,
+    });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    // One ProviderKey carrying both features: templated static headers
+    // plus a client-header allowlist mixing an exact name and a glob.
+    const request = {
+      default_headers: {
+        "x-tenant-id": "${request.api_key.team_id}",
+        "x-caller-key": "${request.api_key.name}",
+        "x-corp-model": "${model.name}",
+        "x-provider-key": "${provider_key.name}",
+        "x-model-id": "${model.id}",
+        "x-pk-id": "${provider_key.id}",
+        "x-corp-request-id": "${request.id}",
+        "x-corp-static": "static-value",
+        // Same name as a header the client also sends — operator wins.
+        "x-overlap": "from-operator",
+      },
+      forward_client_headers: [
+        "anthropic-beta",
+        "x-trace-*",
+        "x-overlap",
+      ],
+    };
+
+    const openaiPk = await seed.createProviderKey({
+      display_name: "hdrctx-openai-pk",
+      secret: PROVIDER_SECRET,
+      api_base: `${upstream.baseUrl}/v1`,
+      request,
+    });
+    const openaiModel = await seed.createModel({
+      display_name: "hdrctx-openai-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: openaiPk.id,
+    });
+    openaiModelId = openaiModel.id;
+    openaiPkId = openaiPk.id;
+
+    const anthropicPk = await seed.createProviderKey({
+      display_name: "hdrctx-anthropic-pk",
+      provider: "anthropic",
+      adapter: "anthropic",
+      secret: PROVIDER_SECRET,
+      api_base: anthropicUpstream.baseUrl,
+      request,
+    });
+    const anthropicModel = await seed.createModel({
+      display_name: "hdrctx-anthropic-model",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: anthropicPk.id,
+    });
+    anthropicModelId = anthropicModel.id;
+
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      display_name: KEY_NAME,
+      team_id: TEAM_ID,
+      user_id: USER_ID,
+      allowed_models: ["hdrctx-openai-model", "hdrctx-anthropic-model"],
+    });
+    await seed.createApiKey({
+      key_hash: TEAMLESS_KEY_HASH,
+      display_name: "teamless-key",
+      allowed_models: ["hdrctx-openai-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await anthropicUpstream?.close();
+  });
+
+  /** POST a chat request as `plaintext`, returning the upstream's view of it. */
+  async function chat(
+    plaintext: string,
+    headers: Record<string, string>,
+    extraBody: Record<string, unknown> = {},
+  ) {
+    const baseline = upstream!.receivedRequests.length;
+    const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${plaintext}`,
+        "content-type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify({
+        model: "hdrctx-openai-model",
+        messages: [{ role: "user", content: "hello" }],
+        ...extraBody,
+      }),
+    });
+    await res.text();
+    const sent = upstream!.receivedRequests.slice(baseline);
+    return { status: res.status, sent };
+  }
+
+  test(
+    "default_headers render request-context variables; unresolved ones are dropped",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      await waitConfigPropagation(async () => {
+        const { status } = await chat(CALLER_PLAINTEXT, {});
+        return status === 200;
+      });
+
+      const { status, sent } = await chat(CALLER_PLAINTEXT, {});
+      expect(status).toBe(200);
+      expect(sent).toHaveLength(1);
+      const h = sent[0]!.headers;
+
+      expect(h["x-tenant-id"]).toBe(TEAM_ID);
+      expect(h["x-caller-key"]).toBe(KEY_NAME);
+      expect(h["x-provider-key"]).toBe("hdrctx-openai-pk");
+      expect(h["x-corp-static"]).toBe("static-value");
+      // `${model.name}` is the gateway-facing display name, not the
+      // upstream model id — the operator configured the former.
+      expect(h["x-corp-model"]).toBe("hdrctx-openai-model");
+
+      // A key with no team must not send `x-tenant-id: ""` — a blank
+      // header reads to the upstream as "the tenant is the empty
+      // string", which is a different and wrong claim.
+      const teamless = await chat(TEAMLESS_PLAINTEXT, {});
+      expect(teamless.status).toBe(200);
+      const th = teamless.sent[0]!.headers;
+      expect(th["x-tenant-id"]).toBeUndefined();
+      expect(th["x-caller-key"]).toBe("teamless-key");
+    },
+    30_000,
+  );
+
+  test(
+    "allowlisted client headers reach upstream; unlisted ones do not",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const { status, sent } = await chat(CALLER_PLAINTEXT, {
+        "anthropic-beta": "tools-2024-05-16",
+        "x-trace-id": "trace-abc",
+        "x-trace-parent": "parent-def",
+        // Not named by any allowlist entry.
+        "x-not-allowlisted": "nope",
+      });
+      expect(status).toBe(200);
+      const h = sent[0]!.headers;
+
+      expect(h["anthropic-beta"]).toBe("tools-2024-05-16");
+      expect(h["x-trace-id"]).toBe("trace-abc");
+      expect(h["x-trace-parent"]).toBe("parent-def");
+      expect(h["x-not-allowlisted"]).toBeUndefined();
+    },
+    30_000,
+  );
+
+  test(
+    "operator default_headers win over a forwarded client header of the same name",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const { status, sent } = await chat(CALLER_PLAINTEXT, {
+        "x-overlap": "from-client",
+      });
+      expect(status).toBe(200);
+      // Single-valued, and the operator's value — not a two-valued
+      // `from-operator, from-client` list.
+      expect(sent[0]!.headers["x-overlap"]).toBe("from-operator");
+    },
+    30_000,
+  );
+
+  test(
+    "auth, gateway-owned and transport headers are never forwarded",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const { status, sent } = await chat(CALLER_PLAINTEXT, {
+        "x-api-key": CALLER_PLAINTEXT,
+        cookie: "session=secret",
+        "x-aisix-request-id": "spoofed-by-caller",
+        "x-stainless-lang": "js",
+      });
+      expect(status).toBe(200);
+      const req = sent[0]!;
+
+      // The upstream sees the ProviderKey's credential, and the caller's
+      // plaintext appears nowhere in the request.
+      expect(req.headers.authorization).toBe(`Bearer ${PROVIDER_SECRET}`);
+      for (const [name, value] of Object.entries(req.headers)) {
+        expect(value, `caller plaintext leaked in "${name}"`).not.toContain(
+          CALLER_PLAINTEXT,
+        );
+      }
+      expect(req.body).not.toContain(CALLER_PLAINTEXT);
+      expect(req.headers.cookie).toBeUndefined();
+      expect(req.headers["x-stainless-lang"]).toBeUndefined();
+      // The gateway stamps its own correlation id; the caller's forged
+      // value must not be what the upstream sees.
+      expect(req.headers["x-aisix-request-id"]).not.toBe("spoofed-by-caller");
+    },
+    30_000,
+  );
+
+  test(
+    "streaming dispatch sends the same headers as non-streaming",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const { status, sent } = await chat(
+        CALLER_PLAINTEXT,
+        { "x-trace-id": "trace-stream" },
+        { stream: true },
+      );
+      expect(status).toBe(200);
+      const h = sent[0]!.headers;
+      expect(h["x-tenant-id"]).toBe(TEAM_ID);
+      expect(h["x-caller-key"]).toBe(KEY_NAME);
+      expect(h["x-trace-id"]).toBe("trace-stream");
+      expect(h.authorization).toBe(`Bearer ${PROVIDER_SECRET}`);
+    },
+    30_000,
+  );
+
+  test(
+    "the Anthropic native passthrough applies the same pipeline",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const baseline = anthropicUpstream!.receivedRequests.length;
+      const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "application/json",
+          "anthropic-beta": "prompt-caching-2024-07-31",
+          "x-not-allowlisted": "nope",
+        },
+        body: JSON.stringify({
+          model: "hdrctx-anthropic-model",
+          max_tokens: 16,
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+      await res.text();
+      expect(res.status).toBe(200);
+
+      const sent = anthropicUpstream!.receivedRequests.slice(baseline);
+      expect(sent).toHaveLength(1);
+      const h = sent[0]!.headers;
+      expect(h["anthropic-beta"]).toBe("prompt-caching-2024-07-31");
+      expect(h["x-tenant-id"]).toBe(TEAM_ID);
+      expect(h["x-provider-key"]).toBe("hdrctx-anthropic-pk");
+      expect(h["x-model-id"]).toBe(anthropicModelId);
+      expect(h["x-not-allowlisted"]).toBeUndefined();
+      // Anthropic auth shape stays the gateway's own.
+      expect(h["x-api-key"]).toBe(PROVIDER_SECRET);
+    },
+    30_000,
+  );
+
+  test(
+    "id variables resolve to the resource ids, and request.id to this request",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      // `${model.id}` / `${provider_key.id}` are the etcd resource ids;
+      // assert against the ids the seed returned, so a regression that
+      // resolved them off the wrong entry is caught rather than merely
+      // producing some non-empty string.
+      const baseline = upstream.receivedRequests.length;
+      const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "hdrctx-openai-model",
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+      await res.text();
+      expect(res.status).toBe(200);
+      const h = upstream.receivedRequests.slice(baseline)[0]!.headers;
+
+      expect(h["x-model-id"]).toBe(openaiModelId);
+      expect(h["x-pk-id"]).toBe(openaiPkId);
+      // `${request.id}` is this request's correlation id — the same one
+      // the gateway echoes to the caller and stamps upstream.
+      expect(h["x-corp-request-id"]).toBe(h["x-aisix-request-id"]);
+      expect(h["x-corp-request-id"]).toBeTruthy();
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
Two operator-facing header capabilities on `ProviderKey.request`, sharing one outbound-header pipeline.

**`default_headers` values can reference the request context.** An operator writes `"x-tenant-id": "${request.api_key.team_id}"` and the data plane renders it per request, so an internal model service can attribute traffic to the calling team/key without the customer minting a provider credential per tenant. The vocabulary is closed: `request.id`, `request.api_key.{id,name,team_id,user_id}`, `model.{id,name}`, `provider_key.{id,name}`. No secret is reachable — the plaintext bearer and the ProviderKey credential are simply not in the variable context. A header whose variables do not all resolve (a key with no team, an unknown name, a value carrying CR/LF) is **dropped**, never sent blank: `x-tenant-id: ""` would read upstream as "the tenant is the empty string".

**`forward_client_headers` relays inbound client headers.** An operator-configured allowlist of exact header names or single-`*` globs (`anthropic-beta`, `x-trace-*`), matched case-insensitively. Empty by default, so every standard endpoint keeps its current behavior of dropping all client headers. This is what lets a caller use `anthropic-beta` or propagate a trace context through the gateway without dropping to `/passthrough/*`.

Precedence is gateway > operator > client, and it is structural: each caller inserts its own headers (auth, `content-type`, `x-aisix-request-id`, streaming `accept`) first, and nothing in the pipeline overwrites a name already present. On top of that, auth headers (`authorization`, `x-api-key`, `api-key`, `x-goog-api-key`, SigV4 names, `proxy-authorization`, `cookie`, `host`) are refused from both sources, and the transport family plus the `x-aisix-*` and `x-stainless-*` prefixes are never forwarded from a client — a `"*"` allowlist cannot reach any of them.

## Implementation

The pipeline moves to `aisix_gateway::upstream_headers`, replacing `aisix_provider_openai::overrides::apply_default_headers`. All four bridges (OpenAI, Azure, Vertex, Bedrock — the last via its pre-signing SigV4 interceptor, so forwarded headers stay inside the signature) and every direct-dispatch handler (`/v1/messages`, `/v1/responses`, `/v1/messages/count_tokens`, audio, rerank) now resolve outbound headers through the single choke point.

`/v1/videos` and the files/batches/fine-tuning surface applied **no** `default_headers` at all — a pre-existing gap in the handler family. Both now carry the resolved set on every round-trip.

`BridgeContext` gains the caller identity, the inbound headers, and the Model/ProviderKey snapshot ids. The ids are carried explicitly because `Resource::id()` reads `runtime_id`, which nothing populates outside tests — reading it would have silently resolved `${model.id}` to empty on every Bridge path.

The caller identity reaches the pipeline via a request extension published by the `AuthenticatedKey` extractor and read back by `ClientContext`, so no handler has to remember to stamp it.

`api_key` documents gain an optional `display_name` for `${request.api_key.name}`; the control plane starts projecting it in the paired CP PR.

## Compatibility

Both fields default to empty/absent, so a ProviderKey written before this change produces byte-identical upstream requests. Adding `display_name` to the `api_key` document requires this DP release before the CP starts writing it (the document is `deny_unknown_fields`).

## Behavior comparison

LiteLLM forwards by pattern behind a boolean (`forward_client_headers_to_llm_api` → every `x-*` except `x-stainless-*`, plus `anthropic-beta`). This takes an explicit operator allowlist instead, which is stricter by default; an operator who wants LiteLLM's behavior writes `x-*`. The `x-stainless-*` exclusion is kept for the same reason LiteLLM has it — relaying one SDK's version headers to a provider that reads them for its own SDK breaks the call.

## Testing

`tests/e2e/src/cases/upstream-header-context-e2e.test.ts` — 7 cases against a real gateway and mock upstreams covering variable rendering, the drop-when-unresolved rule, exact/glob allowlist matching, operator-beats-client precedence, the credential/namespace guards, streaming vs non-streaming parity, and the Anthropic native passthrough. Unit coverage for the renderer and the merge rules lives with each.

Fixes api7/AISIX-Cloud#1112
Fixes api7/AISIX-Cloud#1167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-context variables for dynamic provider headers, including request, caller, model, and provider details.
  * Added configurable forwarding of allowlisted client headers to upstream providers.
  * Added optional API key display names for dashboard-oriented header templates.
  * Applied consistent header handling across chat, media, embeddings, jobs, videos, and other provider requests.

* **Bug Fixes**
  * Prevented unresolved or unsafe header values from being sent.
  * Protected authentication, transport, and gateway-managed headers from being overridden or forwarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->