### PR TITLE
ci(e2e): install with pnpm 11, matching the version developers run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,11 @@ jobs:
           node-version: 20
       - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          # Matches the pnpm developers run locally. The harness's
+          # `tests/e2e/pnpm-workspace.yaml` uses the `allowBuilds` key this
+          # line unlocks — pnpm 9 rejects that file outright, so the two
+          # must move together.
+          version: 11
       - name: check harness exists
         id: harness
         run: |

--- a/tests/e2e/pnpm-workspace.yaml
+++ b/tests/e2e/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+# pnpm 10+ does not run a dependency's install scripts unless it is named
+# here. esbuild (via vitest) links its platform binary in that script, and
+# pnpm 9 ran it by default — so keeping it enabled preserves the behavior
+# this harness has always had. Without the entry `pnpm install` fails with
+# ERR_PNPM_IGNORED_BUILDS.
+#
+# This file MUST NOT be committed while CI still installs with pnpm 9: a
+# workspace manifest without a `packages:` key fails that version outright
+# ("packages field missing or empty").
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
CI pinned pnpm 9 while local installs are on 11. The gap is not cosmetic — pnpm 10 changed install-script handling, and the two versions now disagree about a file:

- Under pnpm 10+, a dependency's install scripts do not run unless the package is named in `pnpm-workspace.yaml`. A local `pnpm install` in `tests/e2e` fails with `ERR_PNPM_IGNORED_BUILDS: esbuild@0.28.1` and writes a placeholder workspace file.
- Committing that placeholder breaks CI, because pnpm 9 reads any `pnpm-workspace.yaml` as a workspace manifest and exits with `ERROR packages field missing or empty` before running a test. That is what happened on #835.

So the harness is currently unbuildable locally without producing a file that breaks CI. Pinning CI to the version developers actually run closes it.

The workflow bump and the workspace file have to land in the same commit — pnpm 9 rejects the file, pnpm 11 requires it. esbuild keeps its install script enabled, which is what pnpm 9 did by default, so nothing about the harness's behavior changes.

`version: 11` follows the existing major-line style of `version: 9`, so patch releases still flow.

**Verification:** full e2e suite under pnpm 11.17.0 — 163 files, 422 passed, 3 skipped, 0 failed.

Supersedes the narrower "ignore the stray file" approach this PR originally carried: with CI on pnpm 11 the file is real configuration, not an artifact.