### PR TITLE
ci(e2e): run the harness on Node 22, which pnpm 11 requires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,13 @@ jobs:
       - run: chmod +x target/debug/aisix
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          # pnpm 11 requires Node 22.13 or newer — it imports `node:sqlite`
+          # for its store index. The job only passes on Node 20 because it
+          # happens not to reach that code path; any pnpm command that
+          # touches the store (a cache step, `pnpm store path`) fails with
+          # ERR_UNKNOWN_BUILTIN_MODULE. GitHub is also deprecating Node 20
+          # on its runners.
+          node-version: 22
       - uses: pnpm/action-setup@v6
         with:
           # Matches the pnpm developers run locally. The harness's


### PR DESCRIPTION
#836 moved the e2e job to pnpm 11 but left `actions/setup-node` on Node 20. **pnpm 11 requires Node 22.13 or newer** — it imports `node:sqlite` for its store index — so that combination is only working by accident: this job never reaches the store code path, so the install succeeds. Any pnpm command that does touch the store (`pnpm store path`, a `cache: pnpm` step, a future harness change) fails with `ERR_UNKNOWN_BUILTIN_MODULE`.

That is not hypothetical — it is exactly how the same pnpm bump broke the control plane's dashboard and UI-image jobs, which do run `pnpm store path` via `setup-node`'s cache: api7/AISIX-Cloud#1172.

GitHub is deprecating Node 20 on its runners anyway; the job logs already warn about it.