### PR TITLE
feat(mcp): per-(API key × MCP server) rate limiting

### DIFF
--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -46,10 +46,10 @@ pub use models::{
     validate_rate_limit_policy, A2aAgent, A2aAuthType, A2aProtocolVersion, Adapter, AisixSnapshot,
     ApiKey, AppliedGuardrail, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
     GuardrailExecution, GuardrailHookPoint, GuardrailKind, GuardrailMetricsSink,
-    GuardrailMonitorHit, KeywordConfig, KeywordPattern, McpAuthType, McpServer, McpTransport,
-    Model, ObservabilityExporter, ParamConstraints, PolicyScope, PolicyWindow, ProviderKey,
-    RateLimit, RateLimitPolicy, RequestOverrides, ResponseOverrides, Routing, RoutingStrategy,
-    RoutingTarget, SchemaError, StreamDoneMarker, TelemetryKind, TelemetryTags,
+    GuardrailMonitorHit, KeywordConfig, KeywordPattern, McpAuthType, McpRateLimit, McpServer,
+    McpTransport, Model, ObservabilityExporter, ParamConstraints, PolicyScope, PolicyWindow,
+    ProviderKey, RateLimit, RateLimitPolicy, RequestOverrides, ResponseOverrides, Routing,
+    RoutingStrategy, RoutingTarget, SchemaError, StreamDoneMarker, TelemetryKind, TelemetryTags,
     WhenAllUnavailablePolicy, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use resource::{Resource, ResourceEntry};

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -9,11 +9,13 @@
 //! looks up by the hash. Net security win: no plaintext API key
 //! ever sits in the DB or KV.
 
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::mcp_policy::McpAccess;
-use super::rate_limit::RateLimit;
+use super::rate_limit::{McpRateLimit, RateLimit};
 use crate::resource::Resource;
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -96,6 +98,16 @@ pub struct ApiKey {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_access: Option<McpAccess>,
 
+    /// Per-MCP-server limits for this key, keyed by the registered MCP server
+    /// name — the `<server>` half of the `<server>__<tool>` names the gateway
+    /// exposes. A `tools/call` is metered against the entry for the server it
+    /// targets **and** the key's own `rate_limit`, each in its own counter, so
+    /// a burst against one server never consumes another's budget. A server
+    /// with no entry here is bounded by `rate_limit` alone. Only tool calls
+    /// are metered; the `initialize` / `tools/list` handshake is not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_rate_limits: Option<BTreeMap<String, McpRateLimit>>,
+
     /// A2A agents this key may reach, named by their registered names. Entries
     /// are matched as single-`*` globs, mirroring `allowed_tools`: `"*"` grants
     /// every agent and an entry without a `*` matches one agent exactly. When
@@ -177,6 +189,13 @@ impl ApiKey {
                 .iter()
                 .any(|t| crate::wildcard::wildcard_matches(t, tool)),
         }
+    }
+
+    /// The limits this key carries for one MCP server, named as it is
+    /// registered (the `<server>` namespace of a `<server>__<tool>` call).
+    /// `None` when the key sets no limit for that server.
+    pub fn mcp_rate_limit(&self, server: &str) -> Option<&McpRateLimit> {
+        self.mcp_rate_limits.as_ref()?.get(server)
     }
 
     /// True if this key may reach the given A2A agent, named by its registered
@@ -281,6 +300,7 @@ mod tests {
             jwt_provider: None,
             allowed_tools: None,
             mcp_access: None,
+            mcp_rate_limits: None,
             allowed_agents: None,
             expires_at: None,
             disabled: false,

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -61,7 +61,7 @@ pub use provider_key::{
     ParamConstraints, ProviderKey, RequestOverrides, ResponseOverrides, StreamDoneMarker,
     TelemetryKind, TelemetryTags,
 };
-pub use rate_limit::RateLimit;
+pub use rate_limit::{McpRateLimit, RateLimit};
 pub use rate_limit_policy::{PolicyScope, PolicyWindow, RateLimitPolicy};
 pub use routing::{Routing, RoutingStrategy, RoutingTarget, WhenAllUnavailablePolicy};
 pub use schema::{

--- a/crates/aisix-core/src/models/rate_limit.rs
+++ b/crates/aisix-core/src/models/rate_limit.rs
@@ -57,6 +57,61 @@ impl RateLimit {
     }
 }
 
+/// Limits for one API key's calls to one MCP server
+/// (`ApiKey::mcp_rate_limits`).
+///
+/// Carries only the request-count dimensions of [`RateLimit`]: an MCP
+/// `tools/call` commits no tokens, so a token-rate cap here would never be
+/// consumed — the shape leaves `tpm`/`tpd` out rather than accepting a knob
+/// that is silently inert.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct McpRateLimit {
+    /// Tool calls per 1-second window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rps: Option<u64>,
+
+    /// Tool calls per 60-second window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpm: Option<u64>,
+
+    /// Tool calls per 3,600-second window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rph: Option<u64>,
+
+    /// Tool calls per 86,400-second window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpd: Option<u64>,
+
+    /// Max concurrent in-flight tool calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<u32>,
+}
+
+impl McpRateLimit {
+    pub const fn is_unrestricted(&self) -> bool {
+        self.rps.is_none()
+            && self.rpm.is_none()
+            && self.rph.is_none()
+            && self.rpd.is_none()
+            && self.concurrency.is_none()
+    }
+}
+
+impl From<&McpRateLimit> for RateLimit {
+    fn from(mcp: &McpRateLimit) -> Self {
+        Self {
+            tpm: None,
+            tpd: None,
+            rps: mcp.rps,
+            rpm: mcp.rpm,
+            rph: mcp.rph,
+            rpd: mcp.rpd,
+            concurrency: mcp.concurrency,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -10,9 +10,9 @@
 //!
 //! A `tools/call` is governed by the SAME pipeline as an LLM request, keyed on
 //! the caller's API key: per-tool access control (the key's `allowed_tools`),
-//! rate-limit + budget (`quota::enforce`), guardrails on both the tool
-//! arguments (input) and the tool result (output), and a usage event into the
-//! shared sink.
+//! rate-limit + budget (`quota::enforce_mcp`, which adds the key's per-MCP-server
+//! limit to the shared layers), guardrails on both the tool arguments (input)
+//! and the tool result (output), and a usage event into the shared sink.
 
 use std::time::{Duration, Instant};
 
@@ -142,13 +142,15 @@ async fn dispatch(
         (String::new(), String::new())
     };
 
-    // Reuse the LLM path's rate-limit + budget gate on the unit of work. The
-    // reservation is held for the duration of the call and dropped after (no
-    // tokens to commit — a tool call carries no token cost), which releases the
-    // concurrency slot. On 429 / budget-exceeded this returns before any
-    // upstream is contacted — and the rejected call is still recorded.
+    // Reuse the LLM path's rate-limit + budget gate on the unit of work, plus
+    // the key's own limit for the MCP server this tool belongs to
+    // (AISIX-Cloud#1079). The reservation is held for the duration of the call
+    // and dropped after (no tokens to commit — a tool call carries no token
+    // cost), which releases the concurrency slot. On 429 / budget-exceeded this
+    // returns before any upstream is contacted — and the rejected call is still
+    // recorded.
     let _reservation = if is_tool_call {
-        match crate::quota::enforce(state, &auth, None).await {
+        match crate::quota::enforce_mcp(state, &auth, &mcp_server).await {
             Ok(reservation) => Some(reservation),
             Err(err) => {
                 let response = err.into_response();
@@ -544,6 +546,128 @@ mod tests {
             "tools/call",
             serde_json::json!({ "name": "ghost__tool", "arguments": {} }),
         )
+    }
+
+    /// A `tools/call` for `<server>__tool`, authenticated with `token`.
+    fn tools_call_on(token: &str, server: &str) -> HttpRequest<Body> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": format!("{server}__tool"), "arguments": {} }
+        });
+        HttpRequest::post("/mcp")
+            .header("host", "mcp.aisix.example.com")
+            .header("content-type", "application/json")
+            .header("accept", "application/json, text/event-stream")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    /// A snapshot carrying one key per `(id, token, mcp_rate_limits)` triple.
+    /// No key-level `rate_limit`, so any 429 can only come from the
+    /// per-MCP-server layer.
+    fn snapshot_with_mcp_server_limits(keys: &[(&str, &str, serde_json::Value)]) -> AisixSnapshot {
+        let snapshot = AisixSnapshot::new();
+        for (id, token, limits) in keys {
+            let apikey: ApiKey = serde_json::from_value(serde_json::json!({
+                "key_hash": ApiKey::hash_bearer(token),
+                "allowed_models": ["*"],
+                "allowed_tools": ["*"],
+                "mcp_rate_limits": limits,
+            }))
+            .expect("valid apikey");
+            snapshot.apikeys.insert(ResourceEntry::new(*id, apikey, 1));
+        }
+        snapshot
+    }
+
+    #[tokio::test]
+    async fn mcp_server_rate_limit_counts_per_server() {
+        // The key may call `alpha` once a minute; `beta` is uncapped.
+        let router = router_with(snapshot_with_mcp_server_limits(&[(
+            "ak-1",
+            TOKEN,
+            serde_json::json!({ "alpha": { "rpm": 1 } }),
+        )]));
+
+        let first = router
+            .clone()
+            .oneshot(tools_call_on(TOKEN, "alpha"))
+            .await
+            .expect("router responds");
+        assert_ne!(
+            first.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "first alpha tool call should pass the gate"
+        );
+
+        let second = router
+            .clone()
+            .oneshot(tools_call_on(TOKEN, "alpha"))
+            .await
+            .expect("router responds");
+        assert_eq!(
+            second.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "second alpha tool call in the window should be rate-limited"
+        );
+
+        // A server the key sets no limit for keeps its own (unlimited)
+        // counter — alpha's burst must not spend beta's budget.
+        for _ in 0..3 {
+            let other = router
+                .clone()
+                .oneshot(tools_call_on(TOKEN, "beta"))
+                .await
+                .expect("router responds");
+            assert_ne!(
+                other.status(),
+                StatusCode::TOO_MANY_REQUESTS,
+                "an unlimited server must not be limited by another server's burst"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_server_rate_limit_counts_per_key() {
+        // Two keys, each capped at one `alpha` call per minute. Exhausting
+        // one must leave the other's quota intact.
+        const OTHER_TOKEN: &str = "sk-mcp-endpoint-test-2";
+        let limits = serde_json::json!({ "alpha": { "rpm": 1 } });
+        let router = router_with(snapshot_with_mcp_server_limits(&[
+            ("ak-1", TOKEN, limits.clone()),
+            ("ak-2", OTHER_TOKEN, limits),
+        ]));
+
+        for _ in 0..2 {
+            router
+                .clone()
+                .oneshot(tools_call_on(TOKEN, "alpha"))
+                .await
+                .expect("router responds");
+        }
+        let exhausted = router
+            .clone()
+            .oneshot(tools_call_on(TOKEN, "alpha"))
+            .await
+            .expect("router responds");
+        assert_eq!(
+            exhausted.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "the first key should be at its alpha limit"
+        );
+
+        let other_key = router
+            .oneshot(tools_call_on(OTHER_TOKEN, "alpha"))
+            .await
+            .expect("router responds");
+        assert_ne!(
+            other_key.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "a second key must not be limited by the first key's burst"
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -4,7 +4,10 @@
 //! 1. Budget pre-check (cp-api cached decision)
 //! 2. API-key inline rate limit (`auth.entry.id`)
 //! 3. Model inline rate limit (`model:<name>`) — when the resolved Model has one
-//! 4. Policy-based rate limits — looked up from the snapshot's
+//! 4. MCP-server rate limit (`mcp:<api_key_id>:<server>`) — on an MCP
+//!    `tools/call`, the key's `mcp_rate_limits` entry for the server the
+//!    call targets
+//! 5. Policy-based rate limits — looked up from the snapshot's
 //!    `rate_limit_policies` table, matched by scope
 //!    (api_key/model/team/member/team_member). `team_member` is a
 //!    per-member default for a team: it matches every key in the team
@@ -119,11 +122,14 @@ fn policy_bucket_key(policy: &RateLimitPolicy, entry_id: &str, auth: &Authentica
     base
 }
 
-/// Reserve across all applicable rate-limit layers (api_key, model, policies).
+/// Reserve across all applicable rate-limit layers (api_key, model,
+/// mcp_server, policies). `mcp_server` is the MCP server an in-flight
+/// `tools/call` targets; `None` for every non-MCP endpoint.
 async fn reserve_layers(
     state: &ProxyState,
     auth: &AuthenticatedKey,
     model_rl: Option<&ModelRateLimit>,
+    mcp_server: Option<&str>,
 ) -> Result<MultiReservation, ProxyError> {
     let mut reservations = Vec::with_capacity(8);
 
@@ -151,7 +157,25 @@ async fn reserve_layers(
         }
     }
 
-    // Layer 3+: Rate limit policies from snapshot.
+    // Layer 3: per-MCP-server limit carried by this key. Bucketed on
+    // `mcp:<api_key_id>:<server>` so each server the key reaches counts
+    // independently — of the other servers, and of every other key.
+    if let Some(server) = mcp_server {
+        if let Some(limits) = auth.key().mcp_rate_limit(server) {
+            let rl = RateLimit::from(limits);
+            if !rl.is_unrestricted() {
+                let key = format!("mcp:{}:{}", auth.entry.id, server);
+                let r = state
+                    .limiter
+                    .pre_commit(&key, &rl)
+                    .await
+                    .map_err(ProxyError::from)?;
+                reservations.push(r);
+            }
+        }
+    }
+
+    // Layer 4+: Rate limit policies from snapshot.
     let snap = state.snapshot.load();
     for entry in snap.rate_limit_policies.entries() {
         let policy = &entry.value;
@@ -196,6 +220,27 @@ pub(crate) async fn enforce(
     auth: &AuthenticatedKey,
     model_rl: Option<&ModelRateLimit>,
 ) -> Result<MultiReservation, ProxyError> {
+    check_budget(state, auth).await?;
+    reserve_layers(state, auth, model_rl, None).await
+}
+
+/// Apply budget + multi-layer rate-limit checks for one MCP `tools/call`
+/// against `mcp_server`, the server the called tool belongs to. Same gate
+/// as [`enforce`] plus the key's per-server layer; MCP resolves no model,
+/// so the model layers are never engaged.
+pub(crate) async fn enforce_mcp(
+    state: &ProxyState,
+    auth: &AuthenticatedKey,
+    mcp_server: &str,
+) -> Result<MultiReservation, ProxyError> {
+    check_budget(state, auth).await?;
+    reserve_layers(state, auth, None, Some(mcp_server)).await
+}
+
+/// Budget pre-check shared by the enforce entry points: refreshes the
+/// budget gauges from the cached cp-api decision and rejects the request
+/// when the key is over budget.
+async fn check_budget(state: &ProxyState, auth: &AuthenticatedKey) -> Result<(), ProxyError> {
     let decision = state.budgets.check(&auth.entry.id).await;
     let budget_labels = aisix_obs::BudgetLabels {
         api_key_id: &auth.entry.id,
@@ -222,8 +267,7 @@ pub(crate) async fn enforce(
             }),
         )));
     }
-
-    reserve_layers(state, auth, model_rl).await
+    Ok(())
 }
 
 /// Rate-limit-only enforcement (no budget check). Used by `chat.rs`
@@ -233,7 +277,7 @@ pub(crate) async fn enforce_rate_limit(
     auth: &AuthenticatedKey,
     model_rl: Option<&ModelRateLimit>,
 ) -> Result<MultiReservation, ProxyError> {
-    reserve_layers(state, auth, model_rl).await
+    reserve_layers(state, auth, model_rl, None).await
 }
 
 /// Reserve ONLY the model-scoped layers (a model's inline `rate_limit` plus

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -60,6 +60,58 @@
         }
       ]
     },
+    "McpRateLimit": {
+      "additionalProperties": false,
+      "description": "Limits for one API key's calls to one MCP server (`ApiKey::mcp_rate_limits`).\n\nCarries only the request-count dimensions of [`RateLimit`]: an MCP `tools/call` commits no tokens, so a token-rate cap here would never be consumed — the shape leaves `tpm`/`tpd` out rather than accepting a knob that is silently inert.",
+      "properties": {
+        "concurrency": {
+          "description": "Max concurrent in-flight tool calls.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "rpd": {
+          "description": "Tool calls per 86,400-second window.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "rph": {
+          "description": "Tool calls per 3,600-second window.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "rpm": {
+          "description": "Tool calls per 60-second window.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "rps": {
+          "description": "Tool calls per 1-second window.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "RateLimit": {
       "additionalProperties": false,
       "properties": {
@@ -208,6 +260,16 @@
         }
       ],
       "description": "Policy-driven MCP access for this key. When present, it supersedes `allowed_tools`: the key's grant is computed from the environment's and its team's MCP access policies according to `mode` (`inherit`, `restrict`, or `deny`), and `allowed_tools` is not consulted. When omitted, the key keeps the explicit `allowed_tools` behavior — with policy `deny` patterns still subtracted, since deny applies to every key the policy covers."
+    },
+    "mcp_rate_limits": {
+      "additionalProperties": {
+        "$ref": "#/definitions/McpRateLimit"
+      },
+      "description": "Per-MCP-server limits for this key, keyed by the registered MCP server name — the `<server>` half of the `<server>__<tool>` names the gateway exposes. A `tools/call` is metered against the entry for the server it targets **and** the key's own `rate_limit`, each in its own counter, so a burst against one server never consumes another's budget. A server with no entry here is bounded by `rate_limit` alone. Only tool calls are metered; the `initialize` / `tools/list` handshake is not.",
+      "type": [
+        "object",
+        "null"
+      ]
     },
     "rate_limit": {
       "anyOf": [

--- a/tests/e2e/src/cases/mcp-server-ratelimit-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-server-ratelimit-e2e.test.ts
@@ -1,0 +1,240 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  awaitWindowHeadroom,
+  spawnApp,
+  startMcpUpstream,
+  waitConfigPropagation,
+  type McpUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: per-(API key × MCP server) rate limiting against a real gateway +
+// etcd + two real MCP upstreams (official TypeScript SDK servers).
+//
+// The key's `mcp_rate_limits` maps an MCP server name to that key's limits
+// for it, so a runaway agent hammering one server cannot exhaust another's
+// budget — nor another key's budget for the same server.
+//
+// Pinned contract:
+//   - a key capped at rpm=2 on `alpha` gets 429 on its third alpha call
+//     inside the window;
+//   - `beta`, which the key sets no limit for, keeps serving;
+//   - a second key with the identical alpha cap is unaffected by the first
+//     key's burst (the counter is per key, not per server);
+//   - a key with no `mcp_rate_limits` at all is never capped;
+//   - `initialize` / `tools/list` keep answering while the cap is spent —
+//     a client can always connect and enumerate.
+
+const ALPHA_RPM = 2;
+
+const KEY_CAPPED = "sk-mcp-rl-capped";
+const KEY_CAPPED_TWIN = "sk-mcp-rl-capped-twin";
+const KEY_UNCAPPED = "sk-mcp-rl-uncapped";
+
+const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
+
+interface RpcReply {
+  status: number;
+  json?: {
+    result?: {
+      tools?: Array<{ name: string }>;
+      content?: Array<{ type: string; text?: string }>;
+      isError?: boolean;
+    };
+    error?: { code: number; message: string };
+  };
+}
+
+describe("mcp server rate limit e2e: per api key × mcp server", () => {
+  let app: SpawnedApp | undefined;
+  let alpha: McpUpstream | undefined;
+  let beta: McpUpstream | undefined;
+  let etcdReachable = false;
+  let seed: SeedClient;
+
+  const post = async (token: string, body: unknown): Promise<RpcReply> => {
+    const res = await fetch(`${app!.proxyUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let json: RpcReply["json"];
+    try {
+      json = text ? JSON.parse(text) : undefined;
+    } catch {
+      json = undefined;
+    }
+    return { status: res.status, json };
+  };
+
+  /** Spec-faithful per-operation handshake (the endpoint is stateless). */
+  const initialize = async (token: string): Promise<number> => {
+    const init = await post(token, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "mcp-rl-e2e", version: "0.1" },
+      },
+    });
+    await post(token, { jsonrpc: "2.0", method: "notifications/initialized" });
+    return init.status;
+  };
+
+  const listToolNames = async (
+    token: string,
+  ): Promise<{ status: number; names?: string[] }> => {
+    const status = await initialize(token);
+    if (status !== 200) return { status };
+    const r = await post(token, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+    const tools = r.json?.result?.tools;
+    if (r.status !== 200 || !tools) return { status: r.status };
+    return { status: r.status, names: tools.map((t) => t.name).sort() };
+  };
+
+  /**
+   * One `tools/call`, reported as the HTTP status plus the tool's text on
+   * success. A rate-limited call never reaches the tool, so the caller
+   * asserts on `status` alone.
+   */
+  const callTool = async (
+    token: string,
+    name: string,
+  ): Promise<{ status: number; text?: string }> => {
+    const r = await post(token, {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name, arguments: { text: "hi" } },
+    });
+    return { status: r.status, text: r.json?.result?.content?.[0]?.text };
+  };
+
+  const ALL_TOOLS = [
+    "alpha__echo",
+    "alpha__reverse",
+    "beta__echo",
+    "beta__reverse",
+  ];
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    alpha = await startMcpUpstream("alpha");
+    beta = await startMcpUpstream("beta");
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    await seed.update("mcp_servers", randomUUID(), {
+      display_name: "alpha",
+      url: alpha.url,
+      enabled: true,
+    });
+    await seed.update("mcp_servers", randomUUID(), {
+      display_name: "beta",
+      url: beta.url,
+      enabled: true,
+    });
+
+    const keyDoc = (
+      plaintext: string,
+      extra: Record<string, unknown>,
+    ): Record<string, unknown> => ({
+      key_hash: sha256(plaintext),
+      allowed_models: [],
+      allowed_tools: ["*"],
+      ...extra,
+    });
+    // Both capped keys carry the SAME alpha cap, so a shared counter would
+    // show up as the twin inheriting the first key's exhaustion.
+    await seed.createApiKey(
+      keyDoc(KEY_CAPPED, { mcp_rate_limits: { alpha: { rpm: ALPHA_RPM } } }),
+    );
+    await seed.createApiKey(
+      keyDoc(KEY_CAPPED_TWIN, {
+        mcp_rate_limits: { alpha: { rpm: ALPHA_RPM } },
+      }),
+    );
+    await seed.createApiKey(keyDoc(KEY_UNCAPPED, {}));
+
+    // Probe every key to its steady state — `tools/list` is unmetered, so
+    // the probe cannot spend any key's tool-call budget.
+    await waitConfigPropagation(async () => {
+      for (const token of [KEY_CAPPED, KEY_CAPPED_TWIN, KEY_UNCAPPED]) {
+        const listed = await listToolNames(token);
+        if (
+          listed.status !== 200 ||
+          JSON.stringify(listed.names) !== JSON.stringify(ALL_TOOLS)
+        ) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await alpha?.close();
+    await beta?.close();
+  });
+
+  test("the cap binds on its own server and leaves every other bucket alone", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    // The limiter buckets on fixed wall-clock minutes; keep the burst
+    // inside one window so the 429 assertion can't straddle a roll-over.
+    await awaitWindowHeadroom();
+
+    for (let i = 0; i < ALPHA_RPM; i++) {
+      const call = await callTool(KEY_CAPPED, "alpha__echo");
+      expect(call.status).toBe(200);
+      expect(call.text).toBe("alpha:hi");
+    }
+
+    const overLimit = await callTool(KEY_CAPPED, "alpha__echo");
+    expect(overLimit.status).toBe(429);
+
+    // A second tool on the SAME capped server shares that server's counter.
+    const sameServerOtherTool = await callTool(KEY_CAPPED, "alpha__reverse");
+    expect(sameServerOtherTool.status).toBe(429);
+
+    // `beta` carries no entry for this key — its own counter is untouched.
+    const otherServer = await callTool(KEY_CAPPED, "beta__echo");
+    expect(otherServer.status).toBe(200);
+    expect(otherServer.text).toBe("beta:hi");
+
+    // The same cap on another key is a separate bucket.
+    const twin = await callTool(KEY_CAPPED_TWIN, "alpha__echo");
+    expect(twin.status).toBe(200);
+    expect(twin.text).toBe("alpha:hi");
+
+    // A key that sets no per-server limits is never capped.
+    for (let i = 0; i < ALPHA_RPM + 2; i++) {
+      const uncapped = await callTool(KEY_UNCAPPED, "alpha__echo");
+      expect(uncapped.status).toBe(200);
+    }
+
+    // Handshake + discovery keep answering with the cap fully spent.
+    const listed = await listToolNames(KEY_CAPPED);
+    expect(listed.status).toBe(200);
+    expect(listed.names).toEqual(ALL_TOOLS);
+  }, 60_000);
+});


### PR DESCRIPTION
## What

An API key can now carry **per-MCP-server limits**: `mcp_rate_limits`, a map from registered MCP server name to that key's limits for it. A `tools/call` is metered against the entry for the server the called tool belongs to, in its own counter, on top of the key's existing `rate_limit`.

```yaml
api_keys:
  - display_name: agent-bot
    mcp_rate_limits:
      github: { rpm: 100, concurrency: 5 }
      slack:  { rpm: 200 }
```

Without this, a key's only MCP ceiling was its global `rate_limit`: one agent looping on one MCP server burned the same budget every other server (and every other kind of call) drew from, and there was no way to cap "this key may call the payments server 10×/min but the docs server 1000×/min".

## How

- **`ApiKey.mcp_rate_limits: Option<BTreeMap<String, McpRateLimit>>`** — keyed by the registered server name, i.e. the `<server>` half of the `<server>__<tool>` names the gateway exposes. The `/mcp` handler already split the called tool into `(server, tool)`, so nothing new has to be parsed.
- **`McpRateLimit` carries only the request-count dimensions** — `rps` / `rpm` / `rph` / `rpd` / `concurrency`. An MCP tool call commits no tokens, so `tpm`/`tpd` would be a knob that is accepted and then never consumed; the shape leaves them out rather than shipping a silently inert limit.
- **`quota::enforce_mcp`** — the budget pre-check was extracted out of `enforce` and is now shared; `reserve_layers` gained an optional MCP-server dimension that reserves on `mcp:<api_key_id>:<server>`. All layers stay AND-ed, so the key's own `rate_limit` still binds. The bucket key carries the api-key id, so two keys with the same cap on the same server never share a counter.
- **Scope unchanged elsewhere** — only `tools/call` is metered; `initialize` / `tools/list` still pass through, so a client can connect and enumerate with its tool-call budget spent. A server with no entry is bounded by `rate_limit` alone. On rejection the endpoint returns the same 429 (with `Retry-After`) it already returned for the key-level limit.

## Prior art

- The one gateway with a dedicated field for this models it the same way: a map on the caller's key from MCP server name → RPM, enforced only on tool calls, bucketed `{key}:{server}`, 429 on exceed. This change matches that contract and widens it to the request-count dimensions this gateway already supports everywhere else (the map value is an object, not a bare integer, so `concurrency` and the sub-minute/longer windows come along).
- Two other gateways express the same thing generically instead: each MCP server is an ordinary route/service, and a multi-dimensional limiter buckets on `consumer × service` (or on limiter descriptors). Same effective granularity, no MCP-specific field — but it requires the operator to model every MCP server as a separate route, which does not fit a gateway that aggregates all MCP servers behind one `/mcp` endpoint.
- Nobody researched enforces limits at **individual-tool** granularity, which is why this stops at the server level.

## Test plan

- [x] `tests/e2e/src/cases/mcp-server-ratelimit-e2e.test.ts` — real gateway + etcd + two real MCP upstreams. A key capped `rpm=2` on `alpha` gets 200/200/429; a second tool on the same server shares that counter; `beta` (no entry) keeps serving; a twin key with the identical cap is unaffected; a key with no `mcp_rate_limits` is never capped; `initialize`/`tools/list` still answer with the cap spent. Verified non-vacuous — reverting the handler to the pre-change gate fails it with `expected 200 to be 429`.
- [x] Unit: per-server independence and per-key independence in `crates/aisix-proxy/src/mcp.rs`.
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all green.

Concurrency is not separately re-tested here: the value goes into the same limiter reservation the key-level `concurrency` already uses, which `concurrency-e2e.test.ts` covers.

## Follow-up

- Control plane: `mcp_rate_limits` needs the cp-admin schema, projection, and dashboard control before a managed user can set it — paired PR follows in AISIX-Cloud, and user documentation ships in api7/docs.
- A2A has the same shape (`/a2a` meters per key only), and could take a per-agent limit the same way. Deliberately out of scope here.

Fixes api7/AISIX-Cloud#1079
