### PR TITLE
fix(telemetry): scope the winning attempt's latency_ms to that attempt

### DIFF
--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -253,11 +253,21 @@ pub struct UsageEvent {
     // Each UsageEvent now represents ONE upstream attempt. A request
     // that fails over emits multiple events sharing `request_id` (the
     // grouping/trace key); they are ordered by `attempt_index`. This
-    // mirrors a per-call logging model — `status_code`,
-    // `latency_ms`, and `ttft_ms` are scoped to THIS attempt, so the
-    // user-perceived total is reconstructed by summing the attempts of
-    // one `request_id`. Direct (non-routing) requests emit a single
-    // event with attempt_index=0, attempt_kind="initial".
+    // mirrors a per-call logging model — `status_code`, `latency_ms`,
+    // and `ttft_ms` are scoped to THIS attempt. Direct (non-routing)
+    // requests emit a single event with attempt_index=0,
+    // attempt_kind="initial".
+    //
+    // `latency_ms` measures that attempt alone: from the moment the
+    // attempt begins to the moment it settles — for a streamed attempt
+    // that is end-of-stream, not first-chunk (`ttft_ms` carries the
+    // first-token figure). It therefore excludes everything outside the
+    // attempt: request parsing, guardrail scans, routing, and the
+    // inter-attempt retry backoff. Summing a request's attempts yields
+    // upstream time, NOT the user-perceived total — that lives in the
+    // access log's `latency_ms`, which spans the whole request (and, on
+    // a streamed request, stops when the response head is handed to the
+    // client rather than when the body finishes).
     /// 0-based index of this attempt within the request. Together with
     /// `request_id` it uniquely identifies one attempt.
     #[serde(default)]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -496,6 +496,12 @@ pub async fn chat_completions(
                     let event_model_id = winner
                         .map(|w| w.target_model_id.as_str())
                         .unwrap_or(model_id_str);
+                    // ...and its own latency, for the same reason the success
+                    // path uses `winner_latency`: the preceding failed attempts
+                    // already emitted theirs.
+                    let winner_latency = winner
+                        .map(|w| Duration::from_millis(u64::from(w.latency_ms)))
+                        .unwrap_or(elapsed);
                     emit_usage_event(
                         &state,
                         &request_id,
@@ -503,7 +509,7 @@ pub async fn chat_completions(
                         &model_name,
                         &api_key_id,
                         status,
-                        elapsed,
+                        winner_latency,
                         c.prompt_tokens,
                         c.completion_tokens,
                         UsageExtras {
@@ -1223,6 +1229,11 @@ async fn dispatch(
             upstream: aisix_gateway::ChatChunkStream,
             idx: u32,
             kind: &'static str,
+            /// When this attempt began. The end-of-stream UsageEvent
+            /// reports `attempt_started.elapsed()` so `latency_ms` covers
+            /// this attempt alone, matching the failed-attempt events and
+            /// the non-streaming winner (#655 contract in `usage.rs`).
+            attempt_started: Instant,
         }
         let mut won: Option<StreamWin> = None;
         // The winning target's own model-layer reservation (routing dispatch
@@ -1401,6 +1412,7 @@ async fn dispatch(
                             upstream,
                             idx,
                             kind,
+                            attempt_started,
                         });
                         won_member_reservation = member_reservation;
                         break 'targets;
@@ -1478,6 +1490,7 @@ async fn dispatch(
             upstream,
             idx: winner_idx,
             kind: winner_kind,
+            attempt_started: winner_attempt_started,
         } = won;
         let model = &model;
         // Hold concurrency for the stream's full lifetime instead of
@@ -1635,7 +1648,12 @@ async fn dispatch(
                     &model_for_metrics,
                     &api_key_id_for_telem,
                     /* status_code */ 200,
-                    started.elapsed(),
+                    // Scoped to the winning attempt, not the request: the
+                    // failed attempts before it emit their own events and
+                    // `started` would double-count them (plus the pre-dispatch
+                    // work and the retry backoff). The access log keeps the
+                    // request-level figure.
+                    winner_attempt_started.elapsed(),
                     comp.prompt_tokens,
                     comp.completion_tokens,
                     UsageExtras {

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -251,6 +251,13 @@ pub async fn messages(
                     .map(|w| w.target_model_id.as_str())
                     .unwrap_or(&model_id);
                 let attempt = winner.map(AttemptInfo::from_record).unwrap_or_default();
+                // `latency_ms` is scoped to the winning attempt: the failed
+                // attempts before it emitted their own events above, so
+                // `elapsed` (whole request) would double-count them. The
+                // access log carries the user-perceived total.
+                let winner_latency = winner
+                    .map(|w| Duration::from_millis(u64::from(w.latency_ms)))
+                    .unwrap_or(elapsed);
                 emit_anthropic_usage_event(
                     &state,
                     &request_id,
@@ -264,7 +271,7 @@ pub async fn messages(
                     auth.key().user_id.as_deref(),
                     auth.key().user_name.as_deref(),
                     status,
-                    elapsed,
+                    winner_latency,
                     metrics,
                     &client,
                     attempt,
@@ -746,6 +753,7 @@ async fn dispatch(
                 &model_name,
                 request_id,
                 started,
+                attempt_started,
                 &auth.entry.id,
                 auth.key().team_id.clone(),
                 auth.key().user_id.clone(),
@@ -869,6 +877,11 @@ async fn dispatch_to_target(
     model_name: &str,
     request_id: &str,
     started: Instant,
+    // When THIS attempt began. The streaming paths' end-of-stream
+    // UsageEvent reports `attempt_started.elapsed()` so `latency_ms` stays
+    // scoped to the attempt, matching the failed-attempt events and the
+    // non-streaming winner (`usage.rs` #655 contract).
+    attempt_started: Instant,
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
@@ -911,6 +924,7 @@ async fn dispatch_to_target(
             model_name,
             request_id,
             started,
+            attempt_started,
             api_key_id,
             team_id,
             user_id,
@@ -936,6 +950,7 @@ async fn dispatch_to_target(
         model_name,
         request_id,
         started,
+        attempt_started,
         api_key_id,
         team_id,
         user_id,
@@ -966,6 +981,8 @@ async fn anthropic_passthrough_dispatch(
     model_name: &str,
     request_id: &str,
     started: Instant,
+    // When THIS attempt began — see `dispatch_to_target`.
+    attempt_started: Instant,
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
@@ -1328,7 +1345,9 @@ async fn anthropic_passthrough_dispatch(
                     user_id_c.as_deref(),
                     user_name_c.as_deref(),
                     200,
-                    started.elapsed(),
+                    // Attempt-scoped, unlike the e2e histogram above: any
+                    // failed attempt before this one emitted its own event.
+                    attempt_started.elapsed(),
                     metrics,
                     &client_ctx_c,
                     attempt_c.clone(),
@@ -1694,6 +1713,8 @@ async fn cross_provider_dispatch(
     model_name: &str,
     request_id: &str,
     started: Instant,
+    // When THIS attempt began — see `dispatch_to_target`.
+    attempt_started: Instant,
     api_key_id: &str,
     team_id: Option<String>,
     user_id: Option<String>,
@@ -1845,6 +1866,7 @@ async fn cross_provider_dispatch(
         let user_id_for_telem = user_id;
         let user_name_for_telem = user_name;
         let started_for_telem = started;
+        let attempt_started_for_telem = attempt_started;
         // #492: log the same client IP/UA on streamed responses.
         let client_for_telem = client.clone();
         // Winning-attempt classification (#655) for the stream-end emit.
@@ -1955,7 +1977,8 @@ async fn cross_provider_dispatch(
                     user_id_for_telem.as_deref(),
                     user_name_for_telem.as_deref(),
                     200,
-                    started_for_telem.elapsed(),
+                    // Attempt-scoped — see the sibling passthrough path.
+                    attempt_started_for_telem.elapsed(),
                     metrics,
                     &client_for_telem,
                     attempt_for_telem.clone(),

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -242,11 +242,15 @@ pub async fn responses(
                 if let Some(usage) = success.usage {
                     // Winning-attempt classification (#655). Direct models
                     // have no recorded attempt → AttemptInfo defaults.
-                    let attempt = success
-                        .routing
-                        .winner()
-                        .map(AttemptInfo::from_record)
-                        .unwrap_or_default();
+                    let winner = success.routing.winner();
+                    let attempt = winner.map(AttemptInfo::from_record).unwrap_or_default();
+                    // `latency_ms` is scoped to the winning attempt — the
+                    // failed ones before it emitted their own events, so
+                    // `elapsed` would double-count them. Access log keeps the
+                    // request-level total.
+                    let winner_latency = winner
+                        .map(|w| Duration::from_millis(u64::from(w.latency_ms)))
+                        .unwrap_or(elapsed);
                     emit_usage_event(
                         &state,
                         &request_id,
@@ -255,7 +259,7 @@ pub async fn responses(
                         &api_key_id,
                         &success.provider_key_id,
                         status,
-                        elapsed,
+                        winner_latency,
                         &usage,
                         &client,
                         attempt,
@@ -629,6 +633,7 @@ async fn dispatch(
                     request_id,
                     resolved_chain.clone(),
                     started,
+                    attempt_started,
                     &model_name,
                     &auth.entry.id,
                     client,
@@ -649,6 +654,7 @@ async fn dispatch(
                     request_id,
                     resolved_chain.clone(),
                     started,
+                    attempt_started,
                     &model_name,
                     &auth.entry.id,
                     client,
@@ -872,6 +878,10 @@ async fn responses_to_target(
     // path's Drop guard. Unused by the non-streaming / buffered paths,
     // which emit from the handler.
     started: Instant,
+    // When THIS attempt began. The end-of-stream UsageEvent reports
+    // `attempt_started.elapsed()` so `latency_ms` stays scoped to the
+    // attempt (`started` spans the whole request — see `usage.rs`).
+    attempt_started: Instant,
     requested_model: &str,
     api_key_id: &str,
     client_ctx: &ClientContext,
@@ -1426,7 +1436,9 @@ async fn responses_to_target(
                     &api_key_id_c,
                     &provider_key_id_c,
                     200,
-                    started.elapsed(),
+                    // Attempt-scoped, unlike the e2e histogram above: any
+                    // failed attempt before this one emitted its own event.
+                    attempt_started.elapsed(),
                     &usage,
                     &client_c,
                     attempt,
@@ -1620,6 +1632,8 @@ async fn responses_cross_provider_to_target(
     request_id: &str,
     chain: Arc<aisix_guardrails::GuardrailChain>,
     started: Instant,
+    // When THIS attempt began — see `responses_to_target`.
+    attempt_started: Instant,
     requested_model: &str,
     api_key_id: &str,
     client_ctx: &ClientContext,
@@ -1878,7 +1892,8 @@ async fn responses_cross_provider_to_target(
                     &api_key_id_c,
                     &provider_key_id_c,
                     status,
-                    started.elapsed(),
+                    // Attempt-scoped — see the sibling verbatim path.
+                    attempt_started.elapsed(),
                     &usage,
                     &client_c,
                     attempt_c,

--- a/tests/e2e/src/cases/per-attempt-telemetry-e2e.test.ts
+++ b/tests/e2e/src/cases/per-attempt-telemetry-e2e.test.ts
@@ -35,11 +35,19 @@ interface OtlpReceiver {
   url: string;
   /** All span attribute maps recorded across every posted batch. */
   spanAttrs: Array<Record<string, string>>;
+  /**
+   * Same spans, plus the emitted `latency_ms`. The sink derives a span's
+   * start from `occurred_at - latency_ms`, so `end - start` recovers the
+   * UsageEvent's `latency_ms` exactly (`occurred_at`'s second-level
+   * precision cancels out in the subtraction).
+   */
+  spans: Array<{ attrs: Record<string, string>; latencyMs: number }>;
   close(): Promise<void>;
 }
 
 async function startOtlpReceiver(): Promise<OtlpReceiver> {
   const spanAttrs: Array<Record<string, string>> = [];
+  const spans: Array<{ attrs: Record<string, string>; latencyMs: number }> = [];
   const server: Server = createServer((req, res) => {
     let raw = "";
     req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
@@ -56,6 +64,12 @@ async function startOtlpReceiver(): Promise<OtlpReceiver> {
                   v.stringValue ?? String(v.intValue ?? v.boolValue ?? "");
               }
               spanAttrs.push(attrs);
+              const latencyMs = Number(
+                (BigInt(span.endTimeUnixNano ?? 0) -
+                  BigInt(span.startTimeUnixNano ?? 0)) /
+                  1_000_000n,
+              );
+              spans.push({ attrs, latencyMs });
             }
           }
         }
@@ -71,6 +85,7 @@ async function startOtlpReceiver(): Promise<OtlpReceiver> {
   return {
     url: `http://127.0.0.1:${port}/v1/traces`,
     spanAttrs,
+    spans,
     async close() {
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
@@ -96,6 +111,33 @@ async function waitForAttempts(
   throw new Error(
     `expected ${count} attempt spans for request_id=${requestId}, ` +
       `saw ${recv.spanAttrs.filter((a) => a["aisix.request_id"] === requestId).length}`,
+  );
+}
+
+/** Like `waitForAttempts`, but keeps each span's recovered `latency_ms`. */
+async function waitForAttemptSpans(
+  recv: OtlpReceiver,
+  requestId: string,
+  count: number,
+  timeoutMs = 10_000,
+): Promise<Array<{ attrs: Record<string, string>; latencyMs: number }>> {
+  const deadline = Date.now() + timeoutMs;
+  const matching = () =>
+    recv.spans.filter((s) => s.attrs["aisix.request_id"] === requestId);
+  while (Date.now() < deadline) {
+    const hits = matching();
+    if (hits.length >= count) {
+      return hits.sort(
+        (a, b) =>
+          Number(a.attrs["aisix.attempt_index"]) -
+          Number(b.attrs["aisix.attempt_index"]),
+      );
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(
+    `expected ${count} attempt spans for request_id=${requestId}, ` +
+      `saw ${matching().length}`,
   );
 }
 
@@ -249,5 +291,194 @@ describe("per-attempt telemetry e2e (#655): one UsageEvent per upstream attempt"
     expect(attempts[1]["http.response.status_code"]).toBe("200");
     expect(attempts[1]["gen_ai.usage.input_tokens"]).toBe("3");
     expect(attempts[1]["gen_ai.usage.output_tokens"]).toBe("4");
+  });
+
+  // `latency_ms` is documented (usage.rs) as scoped to ONE attempt, which
+  // is what makes the events summable. The winning attempt used to report
+  // the whole request instead — it measured from request entry, so it
+  // swallowed every preceding failed attempt (plus parsing, guardrails and
+  // the retry backoff) and double-counted them against the failed events'
+  // own latency.
+  //
+  // Both tests make the FAILING attempt the slow one: a correctly scoped
+  // winner is then far faster than the loser, while a request-scoped
+  // winner is necessarily slower (it contains the loser).
+  const SLOW_PRIMARY_MS = 700;
+
+  // Non-streaming coverage runs against /v1/responses: the /v1/chat/completions
+  // handler already scoped its winner correctly, while the `/v1/responses` and
+  // `/v1/messages` handlers passed the request-level elapsed through.
+  test("the winning attempt's latency_ms covers that attempt only, not the whole request", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    const primary = await startOpenAiUpstream({
+      status: 502,
+      responseDelayMs: SLOW_PRIMARY_MS,
+      errorBody: { error: { message: "slow then down", type: "server_error" } },
+    });
+    const secondary = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "resp_latency_scope",
+        object: "response",
+        status: "completed",
+        model: "gpt-4o-mini",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "fast winner" }],
+          },
+        ],
+        usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
+      },
+    });
+    upstreams.push(primary, secondary);
+
+    await createOpenAiModel("latency-scope-primary", primary);
+    await createOpenAiModel("latency-scope-secondary", secondary);
+    await seed.createModel({
+      display_name: "latency-scope-virtual",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "latency-scope-primary" },
+          { model: "latency-scope-secondary" },
+        ],
+        retries: 0,
+        max_fallbacks: 1,
+      },
+    });
+
+    const canary = `sk-canary-latency-${Date.now()}`;
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(canary).digest("hex"),
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${canary}` },
+      });
+      return res.status === 200;
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "latency-scope-virtual",
+        input: "measure me",
+      }),
+    });
+    expect(res.status).toBe(200);
+    // The Responses passthrough labels the response `x-aisix-request-id`.
+    const requestId = res.headers.get("x-aisix-request-id");
+    expect(requestId).toBeTruthy();
+    await res.text();
+
+    const spans = await waitForAttemptSpans(otlp, requestId!, 2);
+    expect(spans[0].attrs["aisix.attempt_kind"]).toBe("initial");
+    expect(spans[1].attrs["aisix.attempt_kind"]).toBe("fallback");
+
+    // The failed initial paid the upstream's delay.
+    expect(spans[0].latencyMs).toBeGreaterThanOrEqual(SLOW_PRIMARY_MS - 100);
+    // The winner talked to a fast upstream, so its own latency is small.
+    // Request-scoped it would be >= the primary's delay instead.
+    expect(spans[1].latencyMs).toBeLessThan(SLOW_PRIMARY_MS / 2);
+    expect(spans[1].latencyMs).toBeLessThan(spans[0].latencyMs);
+  });
+
+  test("a streamed winner's latency_ms is attempt-scoped too (end-of-stream emit)", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    const primary = await startOpenAiUpstream({
+      status: 502,
+      responseDelayMs: SLOW_PRIMARY_MS,
+      errorBody: { error: { message: "slow then down", type: "server_error" } },
+    });
+    const secondary = await startOpenAiUpstream({
+      streamEvents: [
+        JSON.stringify({
+          id: "chatcmpl-latency-stream",
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: "gpt-4o-mini",
+          choices: [{ index: 0, delta: { content: "hi" }, finish_reason: null }],
+        }),
+        JSON.stringify({
+          id: "chatcmpl-latency-stream",
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: "gpt-4o-mini",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+        }),
+        "[DONE]",
+      ],
+    });
+    upstreams.push(primary, secondary);
+
+    await createOpenAiModel("latency-stream-primary", primary);
+    await createOpenAiModel("latency-stream-secondary", secondary);
+    await seed.createModel({
+      display_name: "latency-stream-virtual",
+      routing: {
+        strategy: "failover",
+        targets: [
+          { model: "latency-stream-primary" },
+          { model: "latency-stream-secondary" },
+        ],
+        retries: 0,
+        max_fallbacks: 1,
+      },
+    });
+
+    const canary = `sk-canary-latency-stream-${Date.now()}`;
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(canary).digest("hex"),
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${canary}` },
+      });
+      return res.status === 200;
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "latency-stream-virtual",
+        messages: [{ role: "user", content: "stream me" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const requestId = res.headers.get("x-aisix-call-id");
+    expect(requestId).toBeTruthy();
+    // Drain: the winner's UsageEvent is emitted at end-of-stream.
+    await res.text();
+
+    const spans = await waitForAttemptSpans(otlp, requestId!, 2);
+    expect(spans[0].attrs["aisix.attempt_kind"]).toBe("initial");
+    expect(spans[0].attrs["http.response.status_code"]).toBe("502");
+    expect(spans[1].attrs["aisix.attempt_kind"]).toBe("fallback");
+    expect(spans[1].attrs["http.response.status_code"]).toBe("200");
+
+    expect(spans[0].latencyMs).toBeGreaterThanOrEqual(SLOW_PRIMARY_MS - 100);
+    expect(spans[1].latencyMs).toBeLessThan(SLOW_PRIMARY_MS / 2);
+    expect(spans[1].latencyMs).toBeLessThan(spans[0].latencyMs);
   });
 });


### PR DESCRIPTION
## Problem

`UsageEvent.latency_ms` is documented as scoped to ONE upstream attempt — that is what makes a request's per-attempt events summable:

```rust
// `status_code`, `latency_ms`, and `ttft_ms` are scoped to THIS attempt
```

Failed attempts honored it (`ms_since(attempt_started)`), but most **winning** attempts reported `started.elapsed()` — the whole request, measured from handler entry. A winner's latency therefore swallowed every failed attempt that preceded it, plus request parsing, guardrail scans and the retry backoff.

Observed on a real failover request: an initial attempt that burned 430ms, then a streamed winner on the same target. The two events read 430ms and 13578ms, so summing them gave 14008ms — the winner's figure already contained the loser's 430ms and ~4.6s of pre-dispatch work.

## What changed

Only `/v1/chat/completions`' non-streaming path was already correct (it used the winner's `AttemptRecord.latency_ms`). The rest of the handler family now matches:

| site | before | after |
|---|---|---|
| `chat.rs` streaming end-of-stream | `started.elapsed()` | winner's `attempt_started.elapsed()` (carried on `StreamWin`) |
| `chat.rs` billed-then-blocked terminal | `elapsed` | winner's `AttemptRecord.latency_ms` |
| `messages.rs` non-streaming winner | `elapsed` | winner's `AttemptRecord.latency_ms` |
| `messages.rs` native-Anthropic + cross-provider streaming | `started.elapsed()` | `attempt_started.elapsed()` |
| `responses.rs` non-streaming winner | `elapsed` | winner's `AttemptRecord.latency_ms` |
| `responses.rs` verbatim + cross-provider streaming | `started.elapsed()` | `attempt_started.elapsed()` |

`attempt_started` is threaded through `dispatch_to_target` / `responses_to_target` / `responses_cross_provider_to_target`.

Untouched by design:

- `record_request_e2e_latency` (SLO histograms) and the access log's `latency_ms` stay request-scoped — that is what they are for.
- Endpoints emitting a single event with no per-attempt failure rows (embeddings, rerank, completions, audio, images, passthrough) have no second event to double-count against.
- Ensemble panel/judge sub-call events (`attempt_kind="panel"`) are sub-calls rather than attempts of one target; left as-is.

The `UsageEvent` contract now also states the measurement boundaries: what an attempt's latency does and does not include, that a streamed attempt is measured to end-of-stream (`ttft_ms` carries the first-token figure), and that summing attempts yields upstream time rather than the user-perceived total.

## Behavior change worth flagging

cp-api's `MetricsByEnv` computes request latency percentiles as `SUM(latency_ms) GROUP BY request_id`. Before this change that sum double-counted failed attempts, so **p50/p99 for requests that retried or failed over were inflated**; they will drop to the real upstream time. Requests that succeeded first try are unaffected (single event, and the winner's own latency is what it always was minus pre-dispatch work).

The sum is not the user-perceived total either way — that figure lives in the access log and has no `UsageEvent` field today. cp-api's comment on `MetricsByEnv` calls the sum "user-perceived total"; that wording is now the inaccurate part, and whether to add a request-scoped field or restate the metric is a separate call.

## Tests

Two E2E regressions in `per-attempt-telemetry-e2e.test.ts`, one non-streaming (`/v1/responses`) and one streaming, each failing over from a deliberately slow 502 primary (700ms) to a fast secondary. A correctly scoped winner is far faster than the loser it followed; a request-scoped one is necessarily slower because it contains it.

Both assertions fail before this change (734ms and 705ms observed against a 350ms bound) and pass after. The OTLP receiver recovers each event's `latency_ms` from its span duration, since the sink derives span start as `occurred_at - latency_ms`.

Also run: `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --check`, and the 17 usage/streaming/latency/retry E2E files (26 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
