### PR TITLE
docs: bring the README in line with what the gateway actually ships

### DIFF
--- a/.github/release-notes-header.md
+++ b/.github/release-notes-header.md
@@ -3,7 +3,7 @@
 New to AISIX? Get the gateway running and route your first LLM request in minutes:
 
 - 📖 **Documentation** — https://docs.api7.ai/ai-gateway/
-- ⚡ **Self-hosted quickstart** (gateway + etcd via Docker Compose) — https://docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart
+- ⚡ **Gateway quickstart** (one container, declarative `resources.yaml`) — https://docs.api7.ai/ai-gateway/getting-started/gateway-quickstart
 
 ## 📦 Download
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ for a managed control plane with team governance, budgets, audit, and a dashboar
 One container. No control plane, no database, no configuration store — the gateway reads
 every dynamic resource from one declarative `resources.yaml`.
 
-```yaml title="config.yaml"
+```yaml
+# config.yaml
 resources_file: /etc/aisix/resources.yaml
 proxy:
   addr: "0.0.0.0:3000"
@@ -68,7 +69,8 @@ observability:
       addr: "0.0.0.0:9090"
 ```
 
-```yaml title="resources.yaml"
+```yaml
+# resources.yaml
 _format_version: "1"
 
 provider_keys:
@@ -93,6 +95,7 @@ export OPENAI_API_KEY="YOUR_PROVIDER_KEY"
 export CALLER_API_KEY="YOUR_CALLER_KEY"
 
 docker run -d --name aisix \
+  --platform linux/amd64 \
   -v "$(pwd)/config.yaml:/etc/aisix/config.yaml:ro" \
   -v "$(pwd)/resources.yaml:/etc/aisix/resources.yaml:ro" \
   -e OPENAI_API_KEY -e CALLER_API_KEY \
@@ -139,7 +142,7 @@ Covered by 165 end-to-end test files (426 cases) that run against real gateway p
 - **OpenAI-compatible proxy** (`:3000`) — `chat/completions`, `completions`, `responses`,
   `embeddings`, `rerank`, `images/generations`, `audio/{speech,transcriptions,translations}`,
   `videos` (submit → poll → fetch), `files`, `batches`, `fine_tuning/jobs`, `realtime`,
-  `GET /v1/models`, and a `passthrough/:provider/*` escape hatch. Native SSE streaming,
+  `GET /v1/models`, plus a root-level `/passthrough/:provider/*` escape hatch. Native SSE streaming,
   tool/function calling, JSON mode, vision/multimodal input, and reasoning-content support.
 - **Anthropic Messages API** — `POST /v1/messages` as a first-class route, working against
   **any** configured upstream: requests and responses (including streaming) are translated
@@ -165,8 +168,8 @@ Covered by 165 end-to-end test files (426 cases) that run against real gateway p
   monitor mode records what would have happened without blocking.
 - **Caching** — exact-match response cache with per-policy TTL and model/key scope matchers;
   memory and Redis backends; cost-saved telemetry on every hit. Separately, **automatic
-  prompt caching** injects Anthropic cache breakpoints so callers get provider-side prompt
-  discounts without changing their requests.
+  prompt caching** can be enabled per direct Anthropic model to inject cache breakpoints, so
+  callers get provider-side prompt discounts without changing their requests.
 - **MCP gateway** — register upstream MCP servers as first-class resources and front them
   all behind one endpoint (`/mcp`), with the gateway holding each server's upstream
   credential, namespacing tools per server, and enforcing per-caller tool access. Also
@@ -207,8 +210,7 @@ OpenAI-shaped.
 
 Plus specialized handling for vendor quirks (e.g. DeepSeek reasoning content) and dedicated
 **rerank / embeddings** vendors (Cohere, Jina). Details in
-[adapter protocol families](https://docs.api7.ai/ai-gateway/providers/adapters). More providers on the
-[roadmap](ROADMAP.md).
+[adapter protocol families](https://docs.api7.ai/ai-gateway/providers/adapters).
 
 ## ☁️ Open source vs AISIX Cloud
 
@@ -253,7 +255,7 @@ Same gateway binary, same proxy API — in every form the gateway runs in your e
 | Configuration | Declarative `resources.yaml`, or etcd for a cluster | Dashboard + Cloud Admin API, multi-environment |
 | Tenancy | Single instance / namespace | Org → Team → Member → Environment |
 | Provider keys | In the resources file as `${VAR}` env references, or in etcd | Envelope-encrypted at rest, write-only, in-place rotation |
-| Caller keys | SHA-256 hashed, model allowlists, expiry, rotation | Hashed + masked reveal, rotation, ownership, PATs |
+| Inbound auth | Caller keys (SHA-256 hashed, model allowlists, expiry), or OIDC/JWT bearers | Same, plus masked reveal, key ownership, and PATs |
 | Budgets | — (rate and token limits only) | Per key / provider / env / org / team, hard-stop & alerts |
 | RBAC | Admin key = full access | Org roles (owner / admin / member), invites |
 | Audit log | — | Full org-scoped audit with diff viewer |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ every dynamic resource from one declarative `resources.yaml`.
 resources_file: /etc/aisix/resources.yaml
 proxy:
   addr: "0.0.0.0:3000"
+admin:
+  enabled: false          # a declarative gateway needs no admin listener
 observability:
   metrics:
     prometheus:

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ static binary with low per-request overhead. Self-host for free, forever.
 
 [**Start free**](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=ai-gateway) ·
 [**Documentation**](https://docs.api7.ai/ai-gateway/) ·
-[**Quickstart**](https://docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart) ·
+[**Quickstart**](https://docs.api7.ai/ai-gateway/getting-started/gateway-quickstart) ·
 [**AISIX Cloud**](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=cloud) ·
 [**Roadmap**](ROADMAP.md)
 
 <br>
 
-<img src="assets/aisix-architecture.svg" alt="AISIX AI Gateway architecture — one OpenAI- or Anthropic-compatible API in front of OpenAI, Anthropic, Gemini/Vertex, Bedrock, Azure OpenAI, and DeepSeek, with API key auth, rate limits and budgets, guardrails, caching, routing and failover, and observability in between" width="100%">
+<img src="assets/aisix-architecture.svg" alt="AISIX AI Gateway architecture — one OpenAI- or Anthropic-compatible API in front of OpenAI, Anthropic, Gemini/Vertex, Bedrock, Azure OpenAI, and DeepSeek, with API key auth, rate and token limits, guardrails, caching, routing and failover, and observability in between" width="100%">
 
 </div>
 
@@ -36,36 +36,86 @@ DeepSeek, and any OpenAI-compatible endpoint. It gives platform teams one place 
 govern, secure, and observe LLM traffic, with first-class SSE streaming and low gateway
 overhead.
 
-It runs as a **single static binary** — low cold-start, lock-free config reads, dynamic
-configuration over etcd with no restarts. Run it **self-hosted and free**, or connect it to
+It runs as a **single static binary** — low cold-start, lock-free config reads, and hot
+configuration reloads with no restarts: declare resources in one `resources.yaml` and
+reload on `SIGHUP`, or point the gateway at etcd for a multi-replica cluster. Run it **self-hosted and free**, or connect it to
 **[AISIX Cloud](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=cloud)**
 for a managed control plane with team governance, budgets, audit, and a dashboard.
 
-> **AISIX AI Gateway (this repo)** is the open-source core — the gateway/data plane.
-> **[AISIX Cloud](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=cloud)**
-> is the managed SaaS that adds the multi-tenant control plane on top. The proxy API is
-> identical in both. **New to AISIX Cloud? [Start free →](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=cloud)**
+> **AISIX AI Gateway (this repo)** is the open-source core — the gateway, i.e. the data
+> plane. **[AISIX Cloud](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=cloud)**
+> adds a managed control plane on top, either operated by API7 (**Hybrid Cloud**) or run
+> entirely in your own infrastructure (**On-Premises**). In every form the gateway runs in
+> your environment and calls providers directly — live AI traffic never leaves your
+> infrastructure. The proxy API is identical throughout.
+> **[Talk to us about AISIX Cloud →](https://api7.ai/contact?utm_source=github&utm_medium=readme&utm_campaign=cloud)**
 
 ## ⚡ Quickstart
 
-AISIX is etcd-backed, so the fastest local run is Docker Compose (gateway + etcd). Grab the
-ready-to-run `docker-compose.yml` and example `config.yaml` from the
-[self-hosted quickstart](https://docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart), then:
+One container. No control plane, no database, no configuration store — the gateway reads
+every dynamic resource from one declarative `resources.yaml`.
 
-```bash
-docker compose up          # proxy → :3000, admin API → :3001
+```yaml title="config.yaml"
+resources_file: /etc/aisix/resources.yaml
+proxy:
+  addr: "0.0.0.0:3000"
+observability:
+  metrics:
+    prometheus:
+      enabled: true
+      addr: "0.0.0.0:9090"
 ```
 
-Configure a model and an API key through the admin API on `:3001`
-([quickstart](https://docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart)),
-then call the gateway exactly like OpenAI:
+```yaml title="resources.yaml"
+_format_version: "1"
+
+provider_keys:
+  - display_name: openai-main
+    provider: openai
+    api_key: ${OPENAI_API_KEY}        # interpolated from the environment
+
+models:
+  - display_name: my-model
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: openai-main
+
+api_keys:
+  - display_name: local-dev
+    key_env: CALLER_API_KEY           # hashed at load; the plaintext is never stored
+    allowed_models: ["my-model"]
+```
+
+```bash
+export OPENAI_API_KEY="YOUR_PROVIDER_KEY"
+export CALLER_API_KEY="YOUR_CALLER_KEY"
+
+docker run -d --name aisix \
+  -v "$(pwd)/config.yaml:/etc/aisix/config.yaml:ro" \
+  -v "$(pwd)/resources.yaml:/etc/aisix/resources.yaml:ro" \
+  -e OPENAI_API_KEY -e CALLER_API_KEY \
+  -p 3000:3000 -p 9090:9090 \
+  ghcr.io/api7/aisix:latest        # proxy → :3000, metrics + status → :9090
+```
+
+Then call the gateway exactly like OpenAI:
 
 ```bash
 curl http://localhost:3000/v1/chat/completions \
-  -H "Authorization: Bearer $AISIX_API_KEY" \
+  -H "Authorization: Bearer $CALLER_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model":"my-model","messages":[{"role":"user","content":"hello"}]}'
 ```
+
+Edit `resources.yaml` and send `SIGHUP` (`docker kill -s HUP aisix`) to apply changes with
+no restart — an invalid file is rejected whole and the last good configuration keeps
+serving. Check a file before booting with `aisix validate --resources resources.yaml`.
+
+Full walkthrough: the
+[Gateway Quickstart](https://docs.api7.ai/ai-gateway/getting-started/gateway-quickstart) ·
+every field: the [resources file reference](https://docs.api7.ai/ai-gateway/reference/resources-file).
+For a multi-replica cluster, point the gateway at etcd instead — `resources_file` and
+`etcd` are mutually exclusive.
 
 ## ✨ Why AISIX
 
@@ -76,39 +126,68 @@ curl http://localhost:3000/v1/chat/completions \
   on the hot path, native streaming.
 - **Open-source core, free forever.** Apache-2.0, self-hostable end to end. Reach for
   AISIX Cloud only when you want the managed control plane.
-- **Production controls built in.** Routing & failover, rate limits, budgets, guardrails,
-  caching, and observability ship in the box.
+- **Production controls built in.** Routing & failover, rate limits, guardrails, caching,
+  and observability ship in the box. (Budgets and spend caps are an AISIX Cloud feature —
+  the gateway enforces the control plane's decisions.)
 
 ## 🧩 Features — available today
 
-Covered by 90+ E2E tests.
+Covered by 165 end-to-end test files (426 cases) that run against real gateway processes.
 
-- **OpenAI-compatible proxy** (`:3000`) — `chat/completions`, `responses`, `embeddings`,
-  `rerank`, `images/generations`, `audio/{speech,transcriptions,translations}`,
+- **OpenAI-compatible proxy** (`:3000`) — `chat/completions`, `completions`, `responses`,
+  `embeddings`, `rerank`, `images/generations`, `audio/{speech,transcriptions,translations}`,
+  `videos` (submit → poll → fetch), `files`, `batches`, `fine_tuning/jobs`, `realtime`,
   `GET /v1/models`, and a `passthrough/:provider/*` escape hatch. Native SSE streaming,
   tool/function calling, JSON mode, vision/multimodal input, and reasoning-content support.
 - **Anthropic Messages API** — `POST /v1/messages` as a first-class route, working against
   **any** configured upstream: requests and responses (including streaming) are translated
   both ways when a model points at a non-Anthropic provider.
-- **Routing & failover** — virtual/routing models, weighted load balancing, automatic
-  failover, retry budgets, cooldowns, and per-attempt timeouts.
+- **Routing & failover** — virtual/routing models with six strategies: `round_robin`,
+  `weighted` (with sticky/canary hashing), `failover`, plus metric-based `least_cost`,
+  `least_latency`, and `least_busy`. Retry budgets, cooldowns, tag-conditional targets,
+  and per-attempt timeouts.
+- **Ensemble models** — fan one request out to a panel of models concurrently, then have a
+  judge model synthesize a single answer, with a minimum-successful-responses threshold.
 - **Semantic routing** — one virtual model that dispatches by the *meaning* of each
   request: it embeds the prompt, scores it against per-route example utterances, and routes
   to the best match (or a default). See the
   [semantic routing docs](https://docs.api7.ai/ai-gateway/routing/semantic-routing).
-- **Rate limiting & concurrency** — RPM/RPD + TPM/TPD + concurrency caps, AND-combined
-  across `ApiKey`, `Model`, and policy scopes (`api_key` / `model` / `team` / `member`).
-- **Guardrails** — content-policy enforcement on input and output: keyword/regex
-  (in-process), AWS Bedrock Guardrails, Azure AI Content Safety (Prompt Shield + text
-  moderation), and Aliyun content moderation. A block returns `422 content_filter`.
+- **Rate limiting & concurrency** — RPS/RPM/RPH/RPD + TPM/TPD + concurrency caps,
+  AND-combined across caller keys, models, and policy scopes (`api_key` / `model` / `team` /
+  `member` / `team_member`). Counters are per-process by default, or shared across replicas
+  with the Redis backend.
+- **Guardrails** — content-policy enforcement on input and output, in-process or through a
+  provider: keyword/regex, built-in PII detection and redaction, Presidio, Lakera, OpenAI
+  Moderation, AWS Bedrock Guardrails, Azure AI Content Safety (Prompt Shield + text
+  moderation), and two Alibaba Cloud services. A block returns `422 content_filter`;
+  monitor mode records what would have happened without blocking.
 - **Caching** — exact-match response cache with per-policy TTL and model/key scope matchers;
-  memory and Redis backends; cost-saved telemetry on every hit.
+  memory and Redis backends; cost-saved telemetry on every hit. Separately, **automatic
+  prompt caching** injects Anthropic cache breakpoints so callers get provider-side prompt
+  discounts without changing their requests.
+- **MCP gateway** — register upstream MCP servers as first-class resources and front them
+  all behind one endpoint (`/mcp`), with the gateway holding each server's upstream
+  credential, namespacing tools per server, and enforcing per-caller tool access. Also
+  exposes a REST API as MCP tools from its OpenAPI description.
+- **A2A agent gateway** — front A2A (Agent-to-Agent) agents at `/a2a/:agent`, serving each
+  agent's card with URLs rewritten to the gateway, over JSON-RPC 2.0.
+- **Inbound authentication** — caller API keys (SHA-256 hashed, model allowlists, expiry,
+  rotation), or OIDC/JWT bearer tokens validated against registered providers (Entra ID,
+  Okta, Google Workspace, or any OIDC issuer) with JWKS caching.
 - **Observability** — Prometheus `/metrics`, structured per-request access logs, usage
   events, OTLP/GenAI span export (Langfuse, Honeycomb, Grafana Cloud, or any OTLP receiver),
   plus dedicated Datadog and Aliyun SLS log exporters and object-storage (S3/GCS/Azure Blob)
   telemetry.
-- **Admin API** (`:3001`) — JSON-Schema-validated CRUD for every resource, OpenAPI 3 with a
-  Scalar UI at `/admin/openapi-scalar`, per-model upstream health, and a built-in playground.
+- **Declarative configuration** — one `resources.yaml` carries all ten resource collections
+  (provider keys, models, caller keys, guardrails, MCP servers, A2A agents, cache policies,
+  observability exporters, rate-limit policies, OIDC providers), validated against the same
+  JSON Schemas the gateway uses at runtime. `aisix validate` checks a file offline; `SIGHUP`
+  reloads it atomically.
+- **Operational endpoints** — `/livez` and `/readyz` on the proxy listener; `/status/config`,
+  `/status/ready`, `/status/models`, and Prometheus `/metrics` on a dedicated metrics
+  listener (`:9090`). The admin listener (`:3001`) additionally serves a resource read
+  surface, OpenAPI 3 with a Scalar UI, and a playground — its resource **write** endpoints
+  still work but are deprecated in favor of declarative configuration.
 
 ## 🔌 Supported providers
 
@@ -129,9 +208,11 @@ Plus specialized handling for vendor quirks (e.g. DeepSeek reasoning content) an
 [adapter protocol families](https://docs.api7.ai/ai-gateway/providers/adapters). More providers on the
 [roadmap](ROADMAP.md).
 
-## ☁️ Self-hosted vs AISIX Cloud
+## ☁️ Open source vs AISIX Cloud
 
-Same gateway binary, same proxy API. **AISIX Cloud** adds the managed control plane on top.
+Same gateway binary, same proxy API — in every form the gateway runs in your environment.
+**AISIX Cloud** adds a managed control plane on top, either operated by API7
+(**Hybrid Cloud**) or running entirely in your infrastructure (**On-Premises**).
 
 <table>
   <tr>
@@ -164,40 +245,44 @@ Same gateway binary, same proxy API. **AISIX Cloud** adds the managed control pl
   <a href="https://aisix-demo.api7.ai/"><b>▶ Try the live dashboard demo — aisix-demo.api7.ai</b></a>
 </p>
 
-| | Self-hosted (this repo) | [AISIX Cloud](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=cloud) (managed) |
+| | Open-source gateway (this repo) | [AISIX Cloud](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=cloud) (Hybrid Cloud or On-Premises) |
 |---|---|---|
-| Price | Free · Apache-2.0 · forever | Managed SaaS — [see pricing](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=pricing) |
-| Configuration | Admin API on `:3001` + etcd | Dashboard + API, multi-environment |
+| Price | Free · Apache-2.0 · forever | Commercial — [talk to us](https://api7.ai/contact?utm_source=github&utm_medium=readme&utm_campaign=pricing) |
+| Configuration | Declarative `resources.yaml`, or etcd for a cluster | Dashboard + Cloud Admin API, multi-environment |
 | Tenancy | Single instance / namespace | Org → Team → Member → Environment |
-| Provider keys | Stored in etcd (mTLS channel) | Envelope-encrypted at rest |
-| API keys | Hashed, shown once, rotation | Hashed + masked reveal, rotation, PATs |
-| Budgets | Per-key rate limits; budgets are Cloud-only | Per key / provider / env / org, hard-stop & alerts |
+| Provider keys | In the resources file as `${VAR}` env references, or in etcd | Envelope-encrypted at rest, write-only, in-place rotation |
+| Caller keys | SHA-256 hashed, model allowlists, expiry, rotation | Hashed + masked reveal, rotation, ownership, PATs |
+| Budgets | — (rate and token limits only) | Per key / provider / env / org / team, hard-stop & alerts |
 | RBAC | Admin key = full access | Org roles (owner / admin / member), invites |
 | Audit log | — | Full org-scoped audit with diff viewer |
-| Billing & metering | — | Plans, usage metering, Stripe portal |
-| Surface | OpenAPI + playground | Full dashboard + per-environment playground |
+| Usage & cost | Export logs, metrics, and usage events yourself | Managed usage views, model pricing catalog, spend reporting |
+| Surface | Status endpoints, OpenAPI read surface, playground | Full dashboard + per-environment playground |
 
 → **Want the managed control plane, governance, budgets, and dashboard?**
-**[Start free](https://api7.ai/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=cloud)** or
-**[book a demo](https://api7.ai/contact?utm_source=github&utm_medium=readme&utm_campaign=demo)**.
+**[Talk to API7](https://api7.ai/contact?utm_source=github&utm_medium=readme&utm_campaign=cloud)** about
+Hybrid Cloud or On-Premises, or **[book a demo](https://api7.ai/contact?utm_source=github&utm_medium=readme&utm_campaign=demo)**.
 
 ## 🏗️ Architecture
 
-A single Cargo workspace; one binary (`aisix-server`) wires the crates together.
+A single Cargo workspace; the `aisix-server` crate builds one binary named `aisix` that
+wires the crates together.
 
 ```
 crates/
-├── aisix-core           Config, snapshot, resource model, errors
+├── aisix-core           Config, snapshot, resource model, resources.yaml source, errors
 ├── aisix-etcd           Config provider + watch supervisor
 ├── aisix-gateway        Hub & bridge, SSE parser, provider trait
-├── aisix-proxy          /v1/* handlers, routing, middleware
-├── aisix-admin          CRUD + playground + OpenAPI
+├── aisix-proxy          /v1/*, /mcp, /a2a handlers, routing, middleware
+├── aisix-admin          Read surface + playground + OpenAPI (writes deprecated)
 ├── aisix-provider-*     openai · anthropic · azure-openai · bedrock · vertex
-├── aisix-ratelimit      fixed-window + token accounting + concurrency
+├── aisix-mcp            MCP gateway — server registry, tool ACL, transports
+├── aisix-a2a            A2A agent gateway — agent cards, JSON-RPC bridge
+├── aisix-ratelimit      fixed-window + token accounting + concurrency (local | redis)
 ├── aisix-cache          memory + redis backends
+├── aisix-redis          shared Redis connection for cache + rate limits
 ├── aisix-guardrails     pre/post content-policy hooks
 ├── aisix-obs            tracing, metrics, access log, exporters
-└── aisix-server         single binary — bootstrap + CLI
+└── aisix-server         the `aisix` binary — bootstrap + CLI
 ```
 
 ## 🗺️ Roadmap
@@ -205,17 +290,19 @@ crates/
 Highlights on the [roadmap](ROADMAP.md); tracked live in
 [issues](https://github.com/api7/aisix/issues):
 
-- 100+ additional provider integrations (Together, Fireworks, Replicate, …)
-- Semantic (embedding-similarity) caching + pgvector backend
-- More guardrails — Lakera, Presidio, OpenAI Moderation, Llama-Guard
+- Semantic (embedding-similarity) response caching
 - More observability sinks — Langsmith, Helicone, Slack alerts
-- JWT / OIDC auth for proxy clients (Entra ID, Okta, Google Workspace)
-- Distributed (Redis-backed) rate limiting
-- MCP gateway — registration, transports, auth, cost tracking
+- Prompt templates managed as gateway resources
+- Llama-Guard as a guardrail provider
+
+Shipped since this list was last written: the MCP gateway, the A2A agent gateway,
+OIDC/JWT inbound auth, Redis-backed distributed rate limiting, and the Lakera, Presidio,
+PII, and OpenAI Moderation guardrails — see **Features** above.
 
 ## 🛠️ Development
 
-Prerequisites: the Rust toolchain pinned in `rust-toolchain.toml`, plus Docker (for etcd).
+Prerequisites: the Rust toolchain pinned in `rust-toolchain.toml`. Docker is only needed
+for the tests that exercise etcd, Redis, or provider emulators.
 
 ```bash
 cargo check --workspace
@@ -226,8 +313,11 @@ cargo test --workspace
 # Coverage (matches the CI gate)
 cargo llvm-cov --workspace --lcov --output-path lcov.info
 
-# Run locally (needs a reachable etcd + a config.yaml — see the docs quickstart)
+# Run locally against a resources.yaml (no etcd needed — see the Quickstart above)
 cargo run -p aisix-server --bin aisix -- --config config.yaml
+
+# Check a resources file without starting a listener
+cargo run -p aisix-server --bin aisix -- validate --resources resources.yaml
 ```
 
 ## 💬 Community

--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ docker run -d --name aisix \
   -v "$(pwd)/config.yaml:/etc/aisix/config.yaml:ro" \
   -v "$(pwd)/resources.yaml:/etc/aisix/resources.yaml:ro" \
   -e OPENAI_API_KEY -e CALLER_API_KEY \
-  -p 3000:3000 -p 9090:9090 \
+  -p 3000:3000 -p 127.0.0.1:9090:9090 \
   ghcr.io/api7/aisix:latest        # proxy → :3000, metrics + status → :9090
+#                                  ^ the metrics/status listener is unauthenticated;
+#                                    keep it on loopback or a private network
 ```
 
 Then call the gateway exactly like OpenAI:
@@ -191,8 +193,10 @@ Covered by 165 end-to-end test files (426 cases) that run against real gateway p
 - **Operational endpoints** — `/livez` and `/readyz` on the proxy listener; `/status/config`,
   `/status/ready`, `/status/models`, and Prometheus `/metrics` on a dedicated metrics
   listener (`:9090`). The admin listener (`:3001`) additionally serves a resource read
-  surface, OpenAPI 3 with a Scalar UI, and a playground — its resource **write** endpoints
-  still work but are deprecated in favor of declarative configuration.
+  surface, OpenAPI 3 with a Scalar UI, and a playground. Its resource **write** endpoints
+  are deprecated in favor of declarative configuration: on a `resources_file` gateway they
+  are rejected with `409`, and on a store-backed gateway they still work but every mutating
+  response carries an RFC 9745 `Deprecation` header.
 
 ## 🔌 Supported providers
 
@@ -271,7 +275,7 @@ Hybrid Cloud or On-Premises, or **[book a demo](https://api7.ai/contact?utm_sour
 A single Cargo workspace; the `aisix-server` crate builds one binary named `aisix` that
 wires the crates together.
 
-```
+```text
 crates/
 ├── aisix-core           Config, snapshot, resource model, resources.yaml source, errors
 ├── aisix-etcd           Config provider + watch supervisor
@@ -317,8 +321,9 @@ cargo test --workspace
 # Coverage (matches the CI gate)
 cargo llvm-cov --workspace --lcov --output-path lcov.info
 
-# Run locally against a resources.yaml (no etcd needed — see the Quickstart above)
-cargo run -p aisix-server --bin aisix -- --config config.yaml
+# Run locally against a resources.yaml (no etcd needed). Copy the Quickstart's two files
+# and change resources_file to the local path, e.g. resources_file: ./resources.yaml
+cargo run -p aisix-server --bin aisix -- --config config.local.yaml
 
 # Check a resources file without starting a listener
 cargo run -p aisix-server --bin aisix -- validate --resources resources.yaml

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This page lists capabilities that are planned or in progress but not yet generally available. It shows direction, not dates, and is not a delivery commitment.
 
-For what the gateway does today — including [semantic routing](https://docs.api7.ai/ai-gateway/routing-and-resilience/semantic-routing), [ensemble models](https://docs.api7.ai/ai-gateway/routing-and-resilience/ensemble-models), [caching](https://docs.api7.ai/ai-gateway/add-traffic-controls/response-caching), and [guardrails](https://docs.api7.ai/ai-gateway/add-traffic-controls/guardrails) — see the [AISIX AI Gateway documentation](https://docs.api7.ai/ai-gateway/).
+For what the gateway does today — including [semantic routing](https://docs.api7.ai/ai-gateway/routing/semantic-routing), [ensemble models](https://docs.api7.ai/ai-gateway/routing/ensemble-models), [caching](https://docs.api7.ai/ai-gateway/traffic-controls/caching), and [guardrails](https://docs.api7.ai/ai-gateway/traffic-controls/guardrails/overview) — see the [AISIX AI Gateway documentation](https://docs.api7.ai/ai-gateway/).
 
 ## How to read this page
 
@@ -16,13 +16,11 @@ The **Surface** column shows where a capability lands: **Gateway** is the AISIX 
 
 | Capability | What's planned | Surface |
 | --- | --- | --- |
-| MCP gateway | Register MCP servers as first-class resources and govern them with the same caller keys, teams, and policies as model traffic, including transport, authentication, per-tool access control, and per-server usage. | Gateway · Cloud |
+| MCP governance in Cloud | Manage registered MCP servers, per-tool access, and per-server usage from the dashboard and Cloud Admin API. The gateway-side MCP surface already ships. | Cloud |
 | Enterprise SSO | Single sign-on through SAML and generic OIDC, beyond today's social logins. | Cloud |
 | Directory sync (SCIM) | Provision and deprovision users and groups from your identity provider. | Cloud |
 | Service accounts | Login-less, first-class principals for automated callers. | Cloud |
-| Smart routing strategies | Cost-aware, latency-aware, and least-connections target selection, alongside today's ordered, weighted, failover, and semantic routing. | Gateway |
 | Semantic caching | Serve responses for prompts close in meaning, on top of today's exact-match cache. | Gateway |
-| PII guardrails | Detect and redact personally identifiable information in requests and responses. | Gateway |
 
 ## Next
 
@@ -41,7 +39,6 @@ The **Surface** column shows where a capability lands: **Gateway** is the AISIX 
 | --- | --- | --- |
 | External secret management | Manage provider and API credentials through external KMS and secret stores such as Vault. | Gateway · Cloud |
 | Expanded observability export | OTLP export for metrics and logs, alerting integrations such as Slack and PagerDuty, and first-party data-warehouse sinks. | Gateway · Cloud |
-| More proxy endpoints | Passthrough for Batch, Files, and Fine-tuning, plus Realtime endpoints. | Gateway |
 | Metered usage billing | Usage-based billing in addition to subscription plans. | Cloud |
 | SDKs and agent-framework integrations | First-party SDKs and integrations with common agent frameworks. | Gateway · Cloud |
 

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -114,7 +114,7 @@ const ADMIN_WRITE_DEPRECATION: &str = "@1783929480";
 /// RFC 9745 — human-readable documentation covering the declarative
 /// configuration paths that replace Admin API writes.
 const ADMIN_WRITE_DEPRECATION_LINK: &str =
-    "<https://docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart>; rel=\"deprecation\"";
+    "<https://docs.api7.ai/ai-gateway/reference/resources-file>; rel=\"deprecation\"";
 
 pub fn build_router(state: AdminState) -> Router {
     // Eagerly build the merged OpenAPI doc so any panic in schema


### PR DESCRIPTION
The README had drifted far enough to misinform someone evaluating the project. I verified every factual claim against the code at `main` — findings and fixes below.

## Broken links (one of them in the shipped binary)

Three README quickstart links, the release-notes template, and **the `Link: rel="deprecation"` header the gateway emits on every deprecated Admin API write** all pointed at `docs.api7.ai/ai-gateway/getting-started/self-hosted-quickstart`, which now returns **404**. The header one is the worst of the four: it is an in-band signal we hand to API clients at runtime. It now points at the resources-file reference — the thing that actually replaces Admin API writes.

## Claims that were wrong

| README said | Reality |
|---|---|
| "AISIX is etcd-backed, so the fastest local run is Docker Compose" + "grab the ready-to-run `docker-compose.yml`" | etcd is one of **two mutually exclusive** sources; a single container runs fully declaratively from `resources.yaml`. And this repo ships no compose file, so there was nothing to grab. |
| "Configure a model and an API key through the admin API on `:3001`" | That write path is deprecated (RFC 9745 headers on every mutating response) and returns `409` on a file-managed gateway. Also `config.example.yaml` binds admin to `127.0.0.1`, so the instruction was not even runnable as written. |
| "Production controls built in … **budgets** … ship in the box" | Budgets are an AISIX Cloud feature. `crates/aisix-proxy/src/budget.rs` asks cp-api per request over mTLS; the gateway has no budget resource of its own. This one advertised a commercial capability as open-source. |
| "JSON-Schema-validated CRUD for **every resource**" | Eight kinds. |
| Roadmap: MCP gateway · OIDC/JWT auth · Redis-backed rate limiting · Lakera / Presidio / OpenAI Moderation guardrails | **All shipped.** Listing them as future work tells an evaluator they are missing. |

## Capabilities the README never mentioned

MCP gateway, A2A agent gateway, ensemble models, video generation, automatic prompt caching, OIDC/JWT inbound auth, and declarative `resources.yaml` configuration — none appeared anywhere.

Understated: guardrails listed 4 families (**ten** kinds ship), routing listed 3 strategies (**six** ship, including `least_cost` / `least_latency` / `least_busy`), rate limits omitted the per-second and per-hour windows plus the Redis backend, the proxy surface omitted six route families, and "90+ E2E tests" understated a **165-file, 426-case** suite. The crate tree omitted `aisix-mcp`, `aisix-a2a`, and `aisix-redis`, and said the binary is `aisix-server` when it is `aisix`.

## Also

- Quickstart is now the real one-container declarative path, with `SIGHUP` reload and `aisix validate`.
- Naming follows the current product model: the commercial side is AISIX Cloud in a **Hybrid Cloud** or **On-Premises** deployment, and the gateway always runs in the user's environment — live traffic never leaves it.
- Roadmap now lists only genuinely open work, with a line naming what shipped.

## Verification

`cargo check -p aisix-admin` and `cargo test -p aisix-admin` pass (the deprecation-header test asserts `rel="deprecation"` is present, not the URL). Repo-wide grep for the dead URL returns nothing. Every replacement docs URL was checked live for a 200.

## Not in this PR

The Admin API write path is still present in the code — removal was planned for v0.5.0 and we are now past v0.6.0. This PR describes the deprecation accurately; scheduling the actual removal is a separate decision. `ROADMAP.md` also lists four shipped items (MCP gateway, PII guardrails, smart routing strategies, more proxy endpoints) and needs the same pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated navigation and quickstart guidance for running AISIX as a single binary with declarative resource configuration.
  - Added instructions for validating `resources.yaml` without starting a listener.
  - Expanded documentation covering routing, security, observability, caching, MCP and agent gateways, and other production capabilities.
  - Added an updated comparison of open-source AISIX and AISIX Cloud features.
  - Updated administrative API deprecation guidance to reference the resource-file documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->