### PR TITLE
feat(config): deployment-wide default for upstream request/stream timeouts

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -160,6 +160,21 @@ ratelimit:
 # The values below are the defaults; uncomment to override. Every
 # duration accepts 0 to switch that knob off.
 upstream:
+  # Deployment-wide default for `Model.timeout`: the end-to-end deadline
+  # for non-streaming calls, and the fallback streaming budget (below),
+  # for every model that does not set its own. A backstop against an
+  # upstream that accepted the connection and then goes silent forever —
+  # not a responsiveness target (set per-model `timeout` for that), so it
+  # is deliberately generous: deep-reasoning calls can run past 10
+  # minutes. A model opts out with `timeout: 0`; setting 0 here restores
+  # the old "no deadline unless configured" behaviour.
+  # timeout_ms: 6000000
+
+  # Deployment-wide default for `Model.stream_timeout`: the maximum gap
+  # between streaming chunks. 0 falls back to `timeout_ms`, mirroring how
+  # an unset `Model.stream_timeout` falls back to `Model.timeout`.
+  # stream_timeout_ms: 0
+
   # Max time for DNS + TCP + TLS before an attempt fails. Without it a
   # black-holed upstream is bounded only by the model's own timeout.
   # connect_timeout_ms: 5000

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -107,6 +107,8 @@ cache:
 # the gateway expires them — the symptom is intermittent transport
 # errors against an otherwise healthy upstream.
 upstream:
+  # timeout_ms: 6000000
+  # stream_timeout_ms: 0
   # connect_timeout_ms: 5000
   # tcp_keepalive_secs: 60
   # tcp_keepalive_interval_secs: 30

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -784,6 +784,24 @@ pub enum RateLimitBackend {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct UpstreamConfig {
+    /// Deployment-wide default for `Model.timeout`: the end-to-end deadline
+    /// in milliseconds for non-streaming upstream calls (and the fallback
+    /// budget for streaming ones, below). Applies to every model that sets
+    /// neither its own `timeout` nor a group-level one. `0` restores the
+    /// pre-default behaviour: no deadline at all.
+    ///
+    /// The default matches the LiteLLM proxy's `request_timeout` (6000 s).
+    /// It is a backstop against an upstream that accepted the connection
+    /// and then goes silent forever — not a responsiveness target, which
+    /// is what per-model `timeout` is for. Deliberately generous so it can
+    /// never cut down a legitimate long request (deep-reasoning calls run
+    /// past 10 minutes).
+    pub timeout_ms: u64,
+    /// Deployment-wide default for `Model.stream_timeout`: the maximum gap
+    /// in milliseconds between upstream streaming chunks. `0` (the
+    /// default) falls back to `timeout_ms`, mirroring how an unset
+    /// `Model.stream_timeout` falls back to `Model.timeout`.
+    pub stream_timeout_ms: u64,
     /// Max time for DNS + TCP + TLS before an attempt fails. Without it a
     /// black-holed upstream is bounded only by the model's overall timeout.
     pub connect_timeout_ms: u64,
@@ -818,6 +836,8 @@ pub struct UpstreamConfig {
 impl Default for UpstreamConfig {
     fn default() -> Self {
         Self {
+            timeout_ms: DEFAULT_UPSTREAM_TIMEOUT_MS,
+            stream_timeout_ms: 0,
             connect_timeout_ms: 5_000,
             tcp_keepalive_secs: 60,
             tcp_keepalive_interval_secs: 30,
@@ -833,6 +853,10 @@ impl Default for UpstreamConfig {
 /// which is also what the LiteLLM router falls back to when neither
 /// `router_settings.num_retries` nor `litellm_settings.num_retries` is set.
 pub const DEFAULT_UPSTREAM_RETRIES: u32 = 2;
+
+/// Deployment-wide request-timeout default: 6000 s, matching the LiteLLM
+/// proxy's `request_timeout`. See [`UpstreamConfig::timeout_ms`].
+pub const DEFAULT_UPSTREAM_TIMEOUT_MS: u64 = 6_000_000;
 
 /// Connection-layer settings for the inbound side — the client (or the
 /// gateway in front of this one) talking to the proxy and admin listeners.
@@ -1372,6 +1396,8 @@ admin:
 "#,
         );
         let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.upstream.timeout_ms, 6_000_000);
+        assert_eq!(cfg.upstream.stream_timeout_ms, 0);
         assert_eq!(cfg.upstream.connect_timeout_ms, 5_000);
         assert_eq!(cfg.upstream.tcp_keepalive_secs, 60);
         assert_eq!(cfg.upstream.tcp_keepalive_interval_secs, 30);
@@ -1395,6 +1421,8 @@ admin:
   addr: "127.0.0.1:3001"
   admin_keys: ["k1"]
 upstream:
+  timeout_ms: 0
+  stream_timeout_ms: 30000
   connect_timeout_ms: 2000
   pool_idle_timeout_secs: 10
   tcp_keepalive_secs: 0
@@ -1402,6 +1430,8 @@ upstream:
 "#,
         );
         let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.upstream.timeout_ms, 0);
+        assert_eq!(cfg.upstream.stream_timeout_ms, 30_000);
         assert_eq!(cfg.upstream.connect_timeout_ms, 2_000);
         assert_eq!(cfg.upstream.pool_idle_timeout_secs, 10);
         assert_eq!(cfg.upstream.tcp_keepalive_secs, 0);

--- a/crates/aisix-core/src/models/ensemble.rs
+++ b/crates/aisix-core/src/models/ensemble.rs
@@ -103,8 +103,7 @@ impl EnsembleConfig {
     }
 
     /// Per-call upstream deadline applied to each panel member and the
-    /// judge call. Folds the `0`/absent sentinel into `None` like
-    /// [`Model::request_timeout`](super::Model::request_timeout) so callers
+    /// judge call. Folds the `0`/absent sentinel into `None` so callers
     /// can apply it unconditionally.
     pub fn timeout(&self) -> Option<std::time::Duration> {
         self.timeout_ms

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -232,7 +232,7 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
 
-    /// Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to the group's `stream_timeout`, then to the deployment-wide `upstream.stream_timeout_ms` default, then to the resolved `timeout`.
+    /// Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to the group's `stream_timeout`, then to the model's (or group's) `timeout`, then to the deployment-wide `upstream.stream_timeout_ms` / `timeout_ms` defaults.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_timeout: Option<u64>,
 

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -228,11 +228,11 @@ pub struct Model {
     #[schemars(length(min = 1))]
     pub provider_key_id: Option<String>,
 
-    /// End-to-end timeout in milliseconds for non-streaming upstream calls. `0` or absent disables the non-streaming timeout.
+    /// End-to-end timeout in milliseconds for non-streaming upstream calls. Absent falls back to the group's `timeout`, then to the deployment-wide `upstream.timeout_ms` default. `0` disables the non-streaming timeout for this model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
 
-    /// Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to `timeout`.
+    /// Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to the group's `stream_timeout`, then to the deployment-wide `upstream.stream_timeout_ms` default, then to the resolved `timeout`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_timeout: Option<u64>,
 
@@ -325,35 +325,25 @@ impl Model {
         self.model_name.as_deref()
     }
 
-    /// Non-streaming request deadline derived from `timeout`. Folds the
-    /// `0`/absent "no timeout" sentinel into `None` so callers can apply
-    /// it unconditionally with `if let Some(d) = ...`.
-    pub fn request_timeout(&self) -> Option<std::time::Duration> {
+    /// This resource's own non-streaming deadline, as one level of the
+    /// model → group → `upstream.timeout_ms` resolution performed by the
+    /// proxy's `effective_timeouts`. Tri-state: `None` defers to the next
+    /// level, `Some(None)` is an explicit `0` ("no deadline, stop
+    /// resolving"), `Some(Some(d))` is a configured deadline.
+    pub fn request_timeout_level(&self) -> Option<Option<std::time::Duration>> {
         self.timeout
-            .filter(|&ms| ms > 0)
-            .map(std::time::Duration::from_millis)
+            .map(|ms| (ms > 0).then(|| std::time::Duration::from_millis(ms)))
     }
 
-    /// Streaming per-chunk read deadline derived from `stream_timeout`.
-    /// Same `0`/absent → `None` folding as [`Model::request_timeout`].
+    /// This resource's own streaming per-chunk deadline, as one level of
+    /// the model → group → `upstream.stream_timeout_ms` → resolved
+    /// `timeout` chain. Unlike [`Model::request_timeout_level`], `0` and
+    /// absent both defer — `stream_timeout` has always used `0` as "fall
+    /// back", not "disable".
     pub fn stream_read_timeout(&self) -> Option<std::time::Duration> {
         self.stream_timeout
             .filter(|&ms| ms > 0)
             .map(std::time::Duration::from_millis)
-    }
-
-    /// Effective deadline for a streaming request: a positive
-    /// `stream_timeout`, otherwise the non-streaming `timeout`. Applied to the
-    /// connect phase, the per-chunk read timeout, and the first-chunk
-    /// failover gate. Because `stream_read_timeout()` folds `0` to `None`,
-    /// `stream_timeout: 0` is treated the same as absent — it falls back to
-    /// `timeout` rather than disabling the streaming timeout. `None` (both
-    /// unset or `0`) = no streaming timeout. Note: a model that sets only a
-    /// small `timeout` therefore also gets that value as its streaming
-    /// budget.
-    pub fn stream_timeout_effective(&self) -> Option<std::time::Duration> {
-        self.stream_read_timeout()
-            .or_else(|| self.request_timeout())
     }
 
     /// Whether a client at `source_ip` may access this model (#557).
@@ -500,59 +490,30 @@ mod tests {
         .unwrap();
         assert_eq!(m.stream_timeout, Some(2_500));
         assert_eq!(
-            m.request_timeout(),
-            Some(std::time::Duration::from_millis(30_000))
+            m.request_timeout_level(),
+            Some(Some(std::time::Duration::from_millis(30_000)))
         );
         assert_eq!(
             m.stream_read_timeout(),
             Some(std::time::Duration::from_millis(2_500))
         );
 
-        // Absent → None.
+        // Absent → defer to the next resolution level.
         let none: Model = serde_json::from_str(
             r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1"}"#,
         )
         .unwrap();
-        assert_eq!(none.request_timeout(), None);
+        assert_eq!(none.request_timeout_level(), None);
         assert_eq!(none.stream_read_timeout(), None);
 
-        // Explicit 0 is the "no timeout" sentinel → None.
+        // Explicit `timeout: 0` resolves to "no deadline" and stops the
+        // chain; explicit `stream_timeout: 0` defers like absent.
         let zero: Model = serde_json::from_str(
             r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","timeout":0,"stream_timeout":0}"#,
         )
         .unwrap();
-        assert_eq!(zero.request_timeout(), None);
+        assert_eq!(zero.request_timeout_level(), Some(None));
         assert_eq!(zero.stream_read_timeout(), None);
-
-        // stream_timeout_effective cascade: prefer stream_timeout when set.
-        assert_eq!(
-            m.stream_timeout_effective(),
-            Some(std::time::Duration::from_millis(2_500))
-        );
-        // Falls back to `timeout` when stream_timeout is absent.
-        let timeout_only: Model = serde_json::from_str(
-            r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","timeout":5000}"#,
-        )
-        .unwrap();
-        assert_eq!(
-            timeout_only.stream_timeout_effective(),
-            Some(std::time::Duration::from_millis(5_000))
-        );
-        // None when neither is set, and when both are the 0 sentinel.
-        assert_eq!(none.stream_timeout_effective(), None);
-        assert_eq!(zero.stream_timeout_effective(), None);
-
-        // Explicit `stream_timeout: 0` folds to absent → falls back to
-        // `timeout`, not "disable streaming".
-        let stream_zero_timeout_set: Model = serde_json::from_str(
-            r#"{"display_name":"x","provider":"openai","model_name":"g","provider_key_id":"pk-1","timeout":5000,"stream_timeout":0}"#,
-        )
-        .unwrap();
-        assert_eq!(stream_zero_timeout_set.stream_read_timeout(), None);
-        assert_eq!(
-            stream_zero_timeout_set.stream_timeout_effective(),
-            Some(std::time::Duration::from_millis(5_000))
-        );
     }
 
     #[test]

--- a/crates/aisix-core/src/models/semantic.rs
+++ b/crates/aisix-core/src/models/semantic.rs
@@ -167,8 +167,7 @@ impl Semantic {
     }
 
     /// Per-call embedding deadline. Folds the `0`/absent sentinel into
-    /// `None` like [`Model::request_timeout`](super::Model::request_timeout)
-    /// so callers can apply it unconditionally.
+    /// `None` so callers can apply it unconditionally.
     pub fn embedding_timeout(&self) -> Option<std::time::Duration> {
         self.embedding_timeout_ms
             .filter(|&ms| ms > 0)

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -654,7 +654,9 @@ async fn multipart_dispatch(
             // the per-model E2E request timeout like the other direct-upstream
             // paths (count_tokens/rerank/responses) so a slow/blackholed audio
             // provider fails over and the model's timeout cooldown can engage.
-            if let Some(d) = model.request_timeout() {
+            if let Some(d) =
+                crate::routing::effective_timeouts(model, None, state.default_timeouts).request
+            {
                 req = req.timeout(d);
             }
             async move {
@@ -1039,7 +1041,9 @@ async fn speech_dispatch(
                 .json(&body);
             // #554/#911: speech synthesis is non-streaming; apply the per-model
             // E2E request timeout (same as count_tokens/rerank/responses).
-            if let Some(d) = model.request_timeout() {
+            if let Some(d) =
+                crate::routing::effective_timeouts(model, None, state.default_timeouts).request
+            {
                 req = req.timeout(d);
             }
             async move {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1277,14 +1277,20 @@ async fn dispatch(
                 Arc::new(pk_entry.value.clone()),
                 Some(client),
             );
-            if let Some(d) = model.stream_timeout_effective() {
+            // Effective streaming budget, resolved target → group →
+            // `upstream.stream_timeout_ms`/`timeout_ms`. Used for the
+            // connect deadline (above) AND the per-chunk read timeout +
+            // first-chunk peek below, so the budget is applied
+            // consistently.
+            let timeouts = crate::routing::effective_timeouts(
+                model,
+                Some(&virtual_entry.value),
+                state.default_timeouts,
+            );
+            let stream_budget = timeouts.stream;
+            if let Some(d) = stream_budget {
                 ctx = ctx.with_deadline(d);
             }
-            // Effective streaming budget: `stream_timeout`, falling back to
-            // `timeout`. Used for the connect deadline (above) AND the
-            // per-chunk read timeout + first-chunk peek below, so the budget
-            // is applied consistently.
-            let stream_budget = model.stream_timeout_effective();
 
             // How many times to re-hit the SAME target (with backoff) on a
             // retryable failure before failing over to the next one.
@@ -1351,19 +1357,20 @@ async fn dispatch(
                     }
                 };
                 let attempt_started = Instant::now();
-                // Connect, then — only when a streaming budget is configured —
-                // peek the first chunk so a slow or erroring first token fails
-                // over before the 200 is committed. Without a budget there is
-                // nothing to gate on, so the stream is committed directly (a
-                // first-chunk error then surfaces in-band, exactly like the
-                // pre-#554 behavior). The read-timeout wrapper is a no-op when
-                // the budget is None.
+                // Connect, then — only when a streaming budget is configured
+                // ON THE RESOURCES — peek the first chunk so a slow or
+                // erroring first token fails over before the 200 is
+                // committed. The deployment-default budget does not peek
+                // (see `TimeoutBudget::stream_configured`): it stays a read
+                // timeout, so the 200 commits directly and the SSE
+                // heartbeats cover the wait for the first token. The
+                // read-timeout wrapper is a no-op when the budget is None.
                 let attempt_stream: Result<aisix_gateway::ChatChunkStream, BridgeError> =
                     match bridge.chat_stream(req, &ctx).await {
                         Err(e) => Err(e),
                         Ok(up) => {
                             let up = crate::stream_timeout::with_read_timeout(up, stream_budget);
-                            if stream_budget.is_some() {
+                            if timeouts.stream_configured {
                                 let mut up = up;
                                 match up.next().await {
                                     // Re-prepend the peeked chunk so the SSE pump
@@ -2175,7 +2182,13 @@ async fn dispatch(
             Arc::new(pk_entry.value.clone()),
             Some(client),
         );
-        if let Some(d) = model.request_timeout() {
+        if let Some(d) = crate::routing::effective_timeouts(
+            model,
+            Some(&virtual_entry.value),
+            state.default_timeouts,
+        )
+        .request
+        {
             ctx = ctx.with_deadline(d);
         }
         // Per-target retry budget — see the streaming loop above.
@@ -2870,7 +2883,9 @@ async fn dispatch_ensemble(
             Arc::new(judge_pk.value.clone()),
             Some(client),
         );
-        if let Some(deadline) = judge_model.request_timeout() {
+        if let Some(deadline) =
+            crate::routing::effective_timeouts(judge_model, None, state.default_timeouts).request
+        {
             judge_ctx = judge_ctx.with_deadline(deadline);
         }
 

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -323,7 +323,8 @@ async fn dispatch(
         Arc::new(pk_entry.value.clone()),
         Some(client_ctx),
     );
-    if let Some(d) = model.request_timeout() {
+    if let Some(d) = crate::routing::effective_timeouts(model, None, state.default_timeouts).request
+    {
         ctx = ctx.with_deadline(d);
     }
 

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -267,6 +267,11 @@ async fn dispatch(
                 body,
                 &target.model,
                 &target.id,
+                crate::routing::effective_timeouts(
+                    &target.model,
+                    Some(&model_entry.value),
+                    state.default_timeouts,
+                ),
                 request_id,
                 client,
             )
@@ -319,6 +324,9 @@ async fn count_tokens_to_target(
     body: &Value,
     model: &aisix_core::Model,
     model_id: &str,
+    // Deadlines resolved by the caller across target → group → deployment
+    // default (`routing::effective_timeouts`); this fn only applies them.
+    timeouts: crate::routing::TimeoutBudget,
     request_id: &str,
     client: &ClientContext,
 ) -> Result<Response, ProxyError> {
@@ -402,7 +410,7 @@ async fn count_tokens_to_target(
     let client = crate::http_client::client();
     let mut req = client.post(&url).headers(headers).json(&body);
     // #554: count_tokens is non-streaming; apply the E2E request timeout.
-    if let Some(d) = model.request_timeout() {
+    if let Some(d) = timeouts.request {
         req = req.timeout(d);
     }
     let send_started = Instant::now();

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -402,7 +402,8 @@ async fn dispatch(
         Arc::new(pk_entry.value.clone()),
         Some(client_ctx),
     );
-    if let Some(d) = model.request_timeout() {
+    if let Some(d) = crate::routing::effective_timeouts(model, None, state.default_timeouts).request
+    {
         ctx = ctx.with_deadline(d);
     }
 

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -136,7 +136,9 @@ impl ModelCaller for ProxyModelCaller<'_> {
             Arc::new(pk_entry.value.clone()),
             Some(self.client),
         );
-        if let Some(deadline) = model.request_timeout() {
+        if let Some(deadline) =
+            crate::routing::effective_timeouts(model, None, self.state.default_timeouts).request
+        {
             ctx = ctx.with_deadline(deadline);
         }
 

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -302,7 +302,8 @@ async fn dispatch(
         Arc::new(pk_entry.value.clone()),
         Some(client_ctx),
     );
-    if let Some(d) = model.request_timeout() {
+    if let Some(d) = crate::routing::effective_timeouts(model, None, state.default_timeouts).request
+    {
         ctx = ctx.with_deadline(d);
     }
 

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -393,7 +393,10 @@ async fn send_upstream(
         UpstreamBody::Multipart(form) => builder.multipart(form),
     };
 
-    if let Some(d) = target.model_entry.value.request_timeout() {
+    if let Some(d) =
+        crate::routing::effective_timeouts(&target.model_entry.value, None, state.default_timeouts)
+            .request
+    {
         builder = builder.timeout(d);
     }
 

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -700,6 +700,13 @@ async fn dispatch(
             state.default_retries,
             i + 1 < n,
         );
+        // Deadlines resolved target → group → deployment default, next to
+        // the retry budget so the two knobs stay in lockstep.
+        let timeouts = crate::routing::effective_timeouts(
+            &target.model,
+            Some(&model_entry.value),
+            state.default_timeouts,
+        );
         for attempt_idx in 0..=budget.attempts {
             // Upstream `Retry-After` when the last failure carried one, else
             // exponential backoff + jitter, before re-hitting the SAME target
@@ -755,6 +762,7 @@ async fn dispatch(
                 &snapshot,
                 body,
                 target,
+                timeouts,
                 &model_name,
                 request_id,
                 started,
@@ -879,6 +887,9 @@ async fn dispatch_to_target(
     snapshot: &aisix_core::AisixSnapshot,
     body: &Value,
     target: &crate::routing::AttemptModel,
+    // Deadlines resolved by the caller across target → group → deployment
+    // default (`routing::effective_timeouts`); this fn only applies them.
+    timeouts: crate::routing::TimeoutBudget,
     model_name: &str,
     request_id: &str,
     started: Instant,
@@ -924,6 +935,7 @@ async fn dispatch_to_target(
             body,
             model,
             &target.id,
+            timeouts,
             &pk_entry.value,
             &pk_entry.id,
             model_name,
@@ -950,6 +962,7 @@ async fn dispatch_to_target(
         body,
         model,
         &target.id,
+        timeouts,
         &pk_entry.value,
         &pk_entry.id,
         model_name,
@@ -981,6 +994,7 @@ async fn anthropic_passthrough_dispatch(
     body: &Value,
     model: &aisix_core::Model,
     model_id: &str,
+    timeouts: crate::routing::TimeoutBudget,
     pk_value: &aisix_core::ProviderKey,
     pk_id: &str,
     model_name: &str,
@@ -1090,7 +1104,7 @@ async fn anthropic_passthrough_dispatch(
     // whole stream); the streaming branch below enforces the per-chunk
     // read timeout instead.
     if !is_stream {
-        if let Some(d) = model.request_timeout() {
+        if let Some(d) = timeouts.request {
             req_builder = req_builder.timeout(d);
         }
     }
@@ -1104,11 +1118,7 @@ async fn anthropic_passthrough_dispatch(
     // Streaming bounds the connect by the stream deadline (reqwest's
     // request-level timeout can't be used — it would cap the whole stream);
     // non-streaming relies on the request-level timeout set above.
-    let connect_deadline = if is_stream {
-        model.stream_timeout_effective()
-    } else {
-        None
-    };
+    let connect_deadline = if is_stream { timeouts.stream } else { None };
     let upstream_resp =
         crate::stream_timeout::send_with_deadline(req_builder, connect_deadline, send_started)
             .await
@@ -1167,14 +1177,14 @@ async fn anthropic_passthrough_dispatch(
         // target) before the 200 is committed; without one, forward directly
         // (pre-#554 behavior). A mid-stream stall truncates the forwarded
         // stream — there is no in-band error frame for an opaque passthrough.
-        let stream_budget = model.stream_timeout_effective();
+        let stream_budget = timeouts.stream;
         let wrapped: std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>> =
             Box::pin(crate::stream_timeout::with_read_timeout_bytes(
                 upstream_resp.bytes_stream(),
                 stream_budget,
             ));
         let body_stream: std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>> =
-            if stream_budget.is_some() {
+            if timeouts.stream_configured {
                 let mut wrapped = wrapped;
                 let first_bytes = match wrapped.next().await {
                     Some(Ok(b)) => b,
@@ -1717,6 +1727,7 @@ async fn cross_provider_dispatch(
     body: &Value,
     model: &aisix_core::Model,
     model_id: &str,
+    timeouts: crate::routing::TimeoutBudget,
     provider_key: &aisix_core::ProviderKey,
     provider_key_id: &str,
     model_name: &str,
@@ -1789,9 +1800,9 @@ async fn cross_provider_dispatch(
         Some(client),
     );
     let connect_deadline = if is_stream {
-        model.stream_timeout_effective()
+        timeouts.stream
     } else {
-        model.request_timeout()
+        timeouts.request
     };
     if let Some(d) = connect_deadline {
         ctx = ctx.with_deadline(d);
@@ -1823,9 +1834,9 @@ async fn cross_provider_dispatch(
         // (pre-#554 behavior; a first-chunk error then surfaces in-band). The
         // wrapper keeps enforcing the read timeout on the remaining chunks
         // either way (no-op when unset).
-        let stream_budget = model.stream_timeout_effective();
+        let stream_budget = timeouts.stream;
         let upstream = crate::stream_timeout::with_read_timeout(upstream, stream_budget);
-        let upstream: aisix_gateway::ChatChunkStream = if stream_budget.is_some() {
+        let upstream: aisix_gateway::ChatChunkStream = if timeouts.stream_configured {
             let mut upstream = upstream;
             let first_chunk = match upstream.next().await {
                 Some(Ok(chunk)) => chunk,

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -527,7 +527,9 @@ async fn dispatch(
             // request timeout, matching the first-class non-streaming paths.
             // Without it a slow/blackholed upstream could pin a passthrough
             // connection open indefinitely regardless of the model's timeout.
-            if let Some(d) = model.request_timeout() {
+            if let Some(d) =
+                crate::routing::effective_timeouts(model, None, state.default_timeouts).request
+            {
                 builder = builder.timeout(d);
             }
 

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -461,10 +461,12 @@ async fn run_session(
     // (`downstream_remote_disconnect` and friends) the issue asks for
     // separately, which needs its own status decision.
     let mut session_error: Option<ProxyError> = None;
-    // Operator-configured stream idle deadline (stream_timeout on the
-    // Model). Absent → no idle cap; realtime sessions are long-lived by
-    // design.
-    let idle_cap = model_entry.value.stream_timeout_effective();
+    // Stream idle deadline, resolved model → `upstream.stream_timeout_ms`
+    // / `timeout_ms`. Realtime sessions are long-lived by design, so the
+    // deployment default (6000 s) only reaps sessions with no traffic in
+    // either direction for that long; `timeout: 0` on the model lifts it.
+    let idle_cap =
+        crate::routing::effective_timeouts(&model_entry.value, None, state.default_timeouts).stream;
 
     loop {
         let next = async {

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -411,7 +411,9 @@ async fn dispatch(
         match crate::routing::retrying_dispatch(state, model, "/v1/rerank", || {
             let mut req = client.post(&url).headers(headers.clone()).json(body);
             // #554: rerank is non-streaming; apply the E2E request timeout.
-            if let Some(d) = model.request_timeout() {
+            if let Some(d) =
+                crate::routing::effective_timeouts(model, None, state.default_timeouts).request
+            {
                 req = req.timeout(d);
             }
             async move {

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -577,6 +577,13 @@ async fn dispatch(
             state.default_retries,
             target_idx + 1 < attempt_models.len(),
         );
+        // Deadlines resolved target → group → deployment default, next to
+        // the retry budget so the two knobs stay in lockstep.
+        let timeouts = crate::routing::effective_timeouts(
+            &target.model,
+            Some(&model_entry.value),
+            state.default_timeouts,
+        );
         for attempt_idx in 0..=budget.attempts {
             // Upstream `Retry-After` when the last failure carried one, else
             // exponential backoff + jitter, before re-hitting the SAME target
@@ -643,6 +650,7 @@ async fn dispatch(
                     body,
                     &target.model,
                     &target.id,
+                    timeouts,
                     request_id,
                     resolved_chain.clone(),
                     started,
@@ -664,6 +672,7 @@ async fn dispatch(
                     body,
                     &target.model,
                     &target.id,
+                    timeouts,
                     request_id,
                     resolved_chain.clone(),
                     started,
@@ -883,6 +892,9 @@ async fn responses_to_target(
     body: &Value,
     model: &aisix_core::Model,
     model_id: &str,
+    // Deadlines resolved by the caller across target → group → deployment
+    // default (`routing::effective_timeouts`); this fn only applies them.
+    timeouts: crate::routing::TimeoutBudget,
     request_id: &str,
     // Arc so the live-forward streaming path can carry the chain into its
     // end-of-stream observation (AISIX-Cloud#1010).
@@ -1010,7 +1022,7 @@ async fn responses_to_target(
     // whole stream); the streaming branch below enforces the per-chunk
     // read timeout instead.
     if !is_stream {
-        if let Some(d) = model.request_timeout() {
+        if let Some(d) = timeouts.request {
             req = req.timeout(d);
         }
     }
@@ -1024,11 +1036,7 @@ async fn responses_to_target(
     // Streaming bounds the connect by the stream deadline (reqwest's
     // request-level timeout can't be used — it would cap the whole stream);
     // non-streaming relies on the request-level timeout set above.
-    let connect_deadline = if is_stream {
-        model.stream_timeout_effective()
-    } else {
-        None
-    };
+    let connect_deadline = if is_stream { timeouts.stream } else { None };
     let upstream_resp =
         crate::stream_timeout::send_with_deadline(req, connect_deadline, send_started)
             .await
@@ -1098,10 +1106,9 @@ async fn responses_to_target(
             };
             let stream = upstream_resp.bytes_stream();
             futures::pin_mut!(stream);
-            // Effective streaming budget: `stream_timeout`, falling back to
-            // `timeout` — applied to every buffered read, consistent with the
-            // verbatim branch and the connect deadline.
-            let read_to = model.stream_timeout_effective();
+            // Effective streaming budget — applied to every buffered read,
+            // consistent with the verbatim branch and the connect deadline.
+            let read_to = timeouts.stream;
             let mut buf: Vec<u8> = Vec::new();
             let mut saw_chunk = false;
             loop {
@@ -1283,7 +1290,7 @@ async fn responses_to_target(
         // without one, forward directly (pre-#554 behavior). A mid-stream
         // stall truncates the forwarded stream (no in-band error frame for
         // an opaque byte passthrough).
-        let stream_budget = model.stream_timeout_effective();
+        let stream_budget = timeouts.stream;
         let wrapped: std::pin::Pin<
             Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>,
         > = Box::pin(crate::stream_timeout::with_read_timeout_bytes(
@@ -1292,7 +1299,7 @@ async fn responses_to_target(
         ));
         let body_stream: std::pin::Pin<
             Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>,
-        > = if stream_budget.is_some() {
+        > = if timeouts.stream_configured {
             let mut wrapped = wrapped;
             let first_bytes = match wrapped.next().await {
                 Some(Ok(b)) => b,
@@ -1644,6 +1651,9 @@ async fn responses_cross_provider_to_target(
     body: &Value,
     model: &aisix_core::Model,
     model_id: &str,
+    // Deadlines resolved by the caller across target → group → deployment
+    // default (`routing::effective_timeouts`); this fn only applies them.
+    timeouts: crate::routing::TimeoutBudget,
     request_id: &str,
     chain: Arc<aisix_guardrails::GuardrailChain>,
     started: Instant,
@@ -1709,9 +1719,9 @@ async fn responses_cross_provider_to_target(
         Some(client_ctx),
     );
     let connect_deadline = if is_stream {
-        model.stream_timeout_effective()
+        timeouts.stream
     } else {
-        model.request_timeout()
+        timeouts.request
     };
     if let Some(d) = connect_deadline {
         ctx = ctx.with_deadline(d);
@@ -1737,9 +1747,9 @@ async fn responses_cross_provider_to_target(
         // #554: peek the first chunk so a slow/erroring first token fails
         // over before the 200 is committed (when a stream budget is set);
         // the wrapper keeps enforcing the per-chunk read timeout either way.
-        let stream_budget = model.stream_timeout_effective();
+        let stream_budget = timeouts.stream;
         let upstream = crate::stream_timeout::with_read_timeout(upstream, stream_budget);
-        let upstream: aisix_gateway::ChatChunkStream = if stream_budget.is_some() {
+        let upstream: aisix_gateway::ChatChunkStream = if timeouts.stream_configured {
             let mut upstream = upstream;
             let first_chunk = match upstream.next().await {
                 Some(Ok(chunk)) => chunk,

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -223,6 +223,95 @@ impl RetryBudget {
     }
 }
 
+/// Request/stream deadlines for one dispatch target, resolved across the
+/// same levels as [`effective_retries`]: the target model, then its group,
+/// then the deployment-wide `upstream.timeout_ms` /
+/// `upstream.stream_timeout_ms` defaults from the DP config.
+#[derive(Debug, Clone, Copy)]
+pub struct TimeoutBudget {
+    /// End-to-end deadline for a non-streaming call. `None` = unbounded.
+    pub request: Option<std::time::Duration>,
+    /// Streaming budget: bounds the connect phase and the gap between
+    /// chunks. `None` = unbounded.
+    pub stream: Option<std::time::Duration>,
+    /// True when `stream` came from the target/group resources rather than
+    /// the deployment defaults. Gates the pre-200 first-chunk peek: an
+    /// operator who configured a streaming budget on the resource asked
+    /// for slow-first-token FAILOVER (#554), which requires withholding
+    /// the 200 until the first chunk arrives. The deployment default must
+    /// NOT do that — it is a backstop, and withholding headers for its
+    /// (long) duration would also silence the SSE heartbeats that exist
+    /// precisely to cover a slow first token (AISIX-Cloud#1126). With the
+    /// default budget, a first-chunk stall surfaces as an in-band timeout
+    /// after the 200 instead of failing over. Same shape as
+    /// [`RetryBudget::covers`]: explicit config opts into the sharper
+    /// behaviour, the deployment default stays conservative.
+    pub stream_configured: bool,
+}
+
+/// Deployment-wide timeout defaults (`upstream.timeout_ms` /
+/// `upstream.stream_timeout_ms`) with the `0` = "no default" sentinel
+/// already folded to `None`.
+#[derive(Debug, Clone, Copy)]
+pub struct TimeoutDefaults {
+    pub request: Option<std::time::Duration>,
+    pub stream: Option<std::time::Duration>,
+}
+
+impl Default for TimeoutDefaults {
+    /// Mirrors `UpstreamConfig::default()` so an embedded ProxyState built
+    /// without config wiring behaves like a default deployment.
+    fn default() -> Self {
+        Self {
+            request: Some(std::time::Duration::from_millis(
+                aisix_core::config::DEFAULT_UPSTREAM_TIMEOUT_MS,
+            )),
+            stream: None,
+        }
+    }
+}
+
+/// Resolve the request/stream deadlines for one dispatch target.
+///
+/// `timeout` resolves model → group → deployment default, first level that
+/// says anything wins. An explicit `0` at model or group level resolves to
+/// "no deadline" and STOPS the chain — that is how an operator opts a
+/// long-running model out of the deployment backstop.
+///
+/// The streaming budget resolves the RESOURCE levels first — the model /
+/// group `stream_timeout` (`0` defers, its historical semantics), then the
+/// resource-resolved `timeout` (so a model with only `timeout` gets that
+/// value as its streaming budget too, and `timeout: 0` opts the stream out
+/// as well) — and only then the deployment defaults, `stream_timeout_ms`
+/// falling back to `timeout_ms`. Resource config always beats deployment
+/// config, mirroring how the LiteLLM router resolves `stream_timeout`
+/// before ever consulting the global `request_timeout`.
+pub fn effective_timeouts(
+    target: &Model,
+    group: Option<&Model>,
+    defaults: TimeoutDefaults,
+) -> TimeoutBudget {
+    let request_level = target
+        .request_timeout_level()
+        .or_else(|| group.and_then(|g| g.request_timeout_level()));
+    let request = request_level.unwrap_or(defaults.request);
+    let resource_stream = target
+        .stream_read_timeout()
+        .or_else(|| group.and_then(|g| g.stream_read_timeout()));
+    let (stream, stream_configured) = if let Some(d) = resource_stream {
+        (Some(d), true)
+    } else if let Some(r) = request_level {
+        (r, r.is_some())
+    } else {
+        (defaults.stream.or(defaults.request), false)
+    };
+    TimeoutBudget {
+        request,
+        stream,
+        stream_configured,
+    }
+}
+
 /// Drive one single-model upstream call under that model's retry budget.
 ///
 /// The group-capable endpoints (chat, messages, responses, count_tokens)
@@ -1496,6 +1585,172 @@ mod tests {
         // same-target retries gets them even with fallbacks queued up.
         assert_eq!(budget(Some(3), None, 2, true).attempts, 3);
         assert_eq!(budget(None, Some(Some(3)), 2, true).attempts, 3);
+    }
+
+    // ── effective_timeouts ────────────────────────────────────────
+    fn model_with_timeouts(timeout: Option<u64>, stream_timeout: Option<u64>) -> Model {
+        let mut m: Model = serde_json::from_str(
+            r#"{"display_name":"m","provider":"openai","model_name":"gpt-4o","provider_key_id":"pk"}"#,
+        )
+        .unwrap();
+        m.timeout = timeout;
+        m.stream_timeout = stream_timeout;
+        m
+    }
+
+    fn defaults_ms(request: Option<u64>, stream: Option<u64>) -> TimeoutDefaults {
+        TimeoutDefaults {
+            request: request.map(std::time::Duration::from_millis),
+            stream: stream.map(std::time::Duration::from_millis),
+        }
+    }
+
+    fn ms(v: u64) -> Option<std::time::Duration> {
+        Some(std::time::Duration::from_millis(v))
+    }
+
+    #[test]
+    fn effective_timeouts_prefers_the_target_then_the_group_then_the_default() {
+        let group = model_with_timeouts(Some(2_000), Some(1_500));
+        // Target wins over group and default.
+        let t = effective_timeouts(
+            &model_with_timeouts(Some(1_000), Some(500)),
+            Some(&group),
+            defaults_ms(Some(9_000), Some(8_000)),
+        );
+        assert_eq!(t.request, ms(1_000));
+        assert_eq!(t.stream, ms(500));
+        // Group applies when the target is silent.
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            Some(&group),
+            defaults_ms(Some(9_000), Some(8_000)),
+        );
+        assert_eq!(t.request, ms(2_000));
+        assert_eq!(t.stream, ms(1_500));
+        // Deployment default applies when both are silent — the case that
+        // used to mean "no deadline at all".
+        let silent_group = model_with_timeouts(None, None);
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            Some(&silent_group),
+            defaults_ms(Some(9_000), Some(8_000)),
+        );
+        assert_eq!(t.request, ms(9_000));
+        assert_eq!(t.stream, ms(8_000));
+        // A direct model has no group at all.
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            None,
+            defaults_ms(Some(9_000), None),
+        );
+        assert_eq!(t.request, ms(9_000));
+    }
+
+    #[test]
+    fn effective_timeouts_explicit_zero_disables_and_stops_the_chain() {
+        // `timeout: 0` on the model is an opt-out of the deployment
+        // backstop, not "unset" — a long-running model must be able to
+        // escape the default.
+        let t = effective_timeouts(
+            &model_with_timeouts(Some(0), None),
+            None,
+            defaults_ms(Some(9_000), None),
+        );
+        assert_eq!(t.request, None);
+        assert_eq!(t.stream, None);
+        // Same at group level.
+        let group_zero = model_with_timeouts(Some(0), None);
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            Some(&group_zero),
+            defaults_ms(Some(9_000), None),
+        );
+        assert_eq!(t.request, None);
+        // `upstream.timeout_ms: 0` restores the pre-default behaviour.
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            None,
+            defaults_ms(None, None),
+        );
+        assert_eq!(t.request, None);
+        assert_eq!(t.stream, None);
+    }
+
+    #[test]
+    fn effective_timeouts_stream_zero_defers_and_falls_back_to_request() {
+        // `stream_timeout: 0`/absent defers (its historical semantics),
+        // ending at the resource-resolved request timeout.
+        let t = effective_timeouts(
+            &model_with_timeouts(Some(5_000), Some(0)),
+            None,
+            defaults_ms(Some(9_000), None),
+        );
+        assert_eq!(t.stream, ms(5_000));
+        // Resource config beats deployment config: a model `timeout` wins
+        // over the deployment stream default.
+        let t = effective_timeouts(
+            &model_with_timeouts(Some(5_000), None),
+            None,
+            defaults_ms(Some(9_000), Some(700)),
+        );
+        assert_eq!(t.stream, ms(5_000));
+        // With no resource-level timeouts, the deployment stream default
+        // applies, falling back to the deployment request default.
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            None,
+            defaults_ms(Some(9_000), Some(700)),
+        );
+        assert_eq!(t.stream, ms(700));
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            None,
+            defaults_ms(Some(9_000), None),
+        );
+        assert_eq!(t.stream, ms(9_000));
+    }
+
+    #[test]
+    fn effective_timeouts_only_resource_config_arms_the_first_chunk_peek() {
+        // Deployment-default budgets must not withhold the 200 waiting for
+        // the first chunk — that would silence the SSE heartbeats that
+        // cover a slow first token (AISIX-Cloud#1126).
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            None,
+            defaults_ms(Some(9_000), Some(700)),
+        );
+        assert!(!t.stream_configured);
+        // A model/group streaming budget — or a model `timeout` acting as
+        // one — is an explicit ask for slow-first-token failover (#554).
+        let t = effective_timeouts(
+            &model_with_timeouts(None, Some(700)),
+            None,
+            defaults_ms(Some(9_000), None),
+        );
+        assert!(t.stream_configured);
+        let t = effective_timeouts(
+            &model_with_timeouts(Some(5_000), None),
+            None,
+            defaults_ms(None, None),
+        );
+        assert!(t.stream_configured);
+        let group = model_with_timeouts(None, Some(700));
+        let t = effective_timeouts(
+            &model_with_timeouts(None, None),
+            Some(&group),
+            defaults_ms(Some(9_000), None),
+        );
+        assert!(t.stream_configured);
+        // `timeout: 0` disarms everything.
+        let t = effective_timeouts(
+            &model_with_timeouts(Some(0), None),
+            None,
+            defaults_ms(Some(9_000), None),
+        );
+        assert!(!t.stream_configured);
+        assert_eq!(t.stream, None);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -280,12 +280,16 @@ impl Default for TimeoutDefaults {
 ///
 /// The streaming budget resolves the RESOURCE levels first — the model /
 /// group `stream_timeout` (`0` defers, its historical semantics), then the
-/// resource-resolved `timeout` (so a model with only `timeout` gets that
-/// value as its streaming budget too, and `timeout: 0` opts the stream out
-/// as well) — and only then the deployment defaults, `stream_timeout_ms`
-/// falling back to `timeout_ms`. Resource config always beats deployment
-/// config, mirroring how the LiteLLM router resolves `stream_timeout`
-/// before ever consulting the global `request_timeout`.
+/// resource-resolved `timeout` — and only then the deployment defaults,
+/// `stream_timeout_ms` falling back to `timeout_ms`. Within that, the
+/// dedicated stream knob outranks the generic one at EVERY level: a
+/// group's `stream_timeout` beats a member's `timeout` for streams, and
+/// supplies a budget even to a member whose `timeout: 0` opted out of the
+/// request deadline. (A model with only `timeout` still gets that value
+/// as its streaming budget, and its `timeout: 0` still opts the stream
+/// out, whenever no resource-level `stream_timeout` exists.) This is the
+/// LiteLLM router's shape: the `stream_timeout` chain is exhausted before
+/// the non-stream `timeout` chain is consulted at all.
 pub fn effective_timeouts(
     target: &Model,
     group: Option<&Model>,
@@ -1751,6 +1755,35 @@ mod tests {
         );
         assert!(!t.stream_configured);
         assert_eq!(t.stream, None);
+    }
+
+    #[test]
+    fn effective_timeouts_stream_knob_outranks_the_timeout_knob_across_levels() {
+        // The dedicated stream knob wins at every level: a group
+        // `stream_timeout` beats a member's own `timeout` for the
+        // streaming budget (the member's `timeout` still governs its
+        // non-streaming deadline). LiteLLM resolves the same way — the
+        // stream chain is exhausted before the non-stream chain starts.
+        let group = model_with_timeouts(None, Some(700));
+        let t = effective_timeouts(
+            &model_with_timeouts(Some(5_000), None),
+            Some(&group),
+            defaults_ms(Some(9_000), None),
+        );
+        assert_eq!(t.request, ms(5_000));
+        assert_eq!(t.stream, ms(700));
+        assert!(t.stream_configured);
+        // ...including a member that opted OUT of the request deadline:
+        // `timeout: 0` cannot cancel a group's explicit stream budget —
+        // only the dedicated knob governs the dedicated budget.
+        let t = effective_timeouts(
+            &model_with_timeouts(Some(0), None),
+            Some(&group),
+            defaults_ms(Some(9_000), None),
+        );
+        assert_eq!(t.request, None);
+        assert_eq!(t.stream, ms(700));
+        assert!(t.stream_configured);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -157,6 +157,11 @@ pub struct ProxyState {
     /// dispatch falls back to when neither the target Model nor its model
     /// group sets one. See `routing::effective_retries`.
     pub default_retries: u32,
+    /// Deployment-wide timeout defaults (`upstream.timeout_ms` /
+    /// `upstream.stream_timeout_ms`) — the floor every dispatch falls back
+    /// to when neither the target Model nor its model group sets one. See
+    /// `routing::effective_timeouts`.
+    pub default_timeouts: crate::routing::TimeoutDefaults,
 }
 
 impl ProxyState {
@@ -185,6 +190,7 @@ impl ProxyState {
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
             default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
+            default_timeouts: crate::routing::TimeoutDefaults::default(),
         }
     }
 
@@ -220,6 +226,7 @@ impl ProxyState {
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
             default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
+            default_timeouts: crate::routing::TimeoutDefaults::default(),
         }
     }
 
@@ -265,6 +272,7 @@ impl ProxyState {
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
             default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
+            default_timeouts: crate::routing::TimeoutDefaults::default(),
         }
     }
 
@@ -295,6 +303,18 @@ impl ProxyState {
     /// [`aisix_core::config::DEFAULT_UPSTREAM_RETRIES`].
     pub fn with_default_retries(mut self, retries: u32) -> Self {
         self.default_retries = retries;
+        self
+    }
+
+    /// Apply the deployment-wide `upstream.timeout_ms` /
+    /// `upstream.stream_timeout_ms` defaults, with `0` meaning "no
+    /// default at that slot".
+    pub fn with_default_timeouts(mut self, timeout_ms: u64, stream_timeout_ms: u64) -> Self {
+        self.default_timeouts = crate::routing::TimeoutDefaults {
+            request: (timeout_ms > 0).then(|| std::time::Duration::from_millis(timeout_ms)),
+            stream: (stream_timeout_ms > 0)
+                .then(|| std::time::Duration::from_millis(stream_timeout_ms)),
+        };
         self
     }
 

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1194,7 +1194,13 @@ async fn provider_call(
                     .header(header::CONTENT_TYPE, "application/json")
                     .json(b);
             }
-            if let Some(d) = target.model_entry.value.request_timeout() {
+            if let Some(d) = crate::routing::effective_timeouts(
+                &target.model_entry.value,
+                None,
+                state.default_timeouts,
+            )
+            .request
+            {
                 builder = builder.timeout(d);
             }
             async move {
@@ -1296,7 +1302,9 @@ async fn proxy_content(
     }
     let builder = client.get(url).headers(headers);
 
-    let stream_budget = target.model_entry.value.stream_timeout_effective();
+    let stream_budget =
+        crate::routing::effective_timeouts(&target.model_entry.value, None, state.default_timeouts)
+            .stream;
     let started = Instant::now();
     let note = |e: aisix_gateway::BridgeError| {
         crate::cooldown::note_failure(

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -713,6 +713,8 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             .map_err(|e| anyhow::anyhow!(e))?;
     proxy_state = proxy_state.with_client_classifier(Arc::new(client_classifier));
     proxy_state = proxy_state.with_default_retries(cfg.upstream.retries);
+    proxy_state =
+        proxy_state.with_default_timeouts(cfg.upstream.timeout_ms, cfg.upstream.stream_timeout_ms);
     if let Some(client) = budget_client {
         proxy_state = proxy_state.with_budget_client(client);
     }

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -962,13 +962,13 @@
       "description": "Semantic-routing configuration. When set, the gateway embeds the request and dispatches to the route whose examples it matches best, using that route's target Model for upstream dispatch."
     },
     "stream_timeout": {
-      "description": "Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to `timeout`.",
+      "description": "Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to the group's `stream_timeout`, then to the deployment-wide `upstream.stream_timeout_ms` default, then to the resolved `timeout`.",
       "format": "uint64",
       "minimum": 0.0,
       "type": "integer"
     },
     "timeout": {
-      "description": "End-to-end timeout in milliseconds for non-streaming upstream calls. `0` or absent disables the non-streaming timeout.",
+      "description": "End-to-end timeout in milliseconds for non-streaming upstream calls. Absent falls back to the group's `timeout`, then to the deployment-wide `upstream.timeout_ms` default. `0` disables the non-streaming timeout for this model.",
       "format": "uint64",
       "minimum": 0.0,
       "type": "integer"

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -962,7 +962,7 @@
       "description": "Semantic-routing configuration. When set, the gateway embeds the request and dispatches to the route whose examples it matches best, using that route's target Model for upstream dispatch."
     },
     "stream_timeout": {
-      "description": "Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to the group's `stream_timeout`, then to the deployment-wide `upstream.stream_timeout_ms` default, then to the resolved `timeout`.",
+      "description": "Maximum gap in milliseconds between upstream streaming chunks. `0` or absent falls back to the group's `stream_timeout`, then to the model's (or group's) `timeout`, then to the deployment-wide `upstream.stream_timeout_ms` / `timeout_ms` defaults.",
       "format": "uint64",
       "minimum": 0.0,
       "type": "integer"

--- a/tests/e2e/src/cases/upstream-timeout-defaults-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-timeout-defaults-e2e.test.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for the deployment-wide request-timeout default
+// (`upstream.timeout_ms` / `upstream.stream_timeout_ms`).
+//
+// Before this knob, a Model without `timeout` had NO deadline at all: an
+// upstream that accepted the connection and then went silent forever held
+// the request open indefinitely. Now every model inherits a deployment
+// backstop, resolved model → group → `upstream.timeout_ms`:
+//   - a model with neither its own `timeout` nor a group one times out at
+//     the deployment default (non-streaming AND the streaming budget);
+//   - `timeout: 0` on the model opts it out of the backstop entirely;
+//   - an explicit model `timeout` beats the deployment default in both
+//     directions;
+//   - a group's `timeout` applies to members that don't set their own.
+//
+// The gateway surfaces an elapsed upstream deadline as 504.
+
+const CALLER_PLAINTEXT = "sk-timeout-defaults-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// Deployment default under test; upstream stalls are comfortably longer.
+const DEFAULT_MS = 1500;
+const STALL_MS = 8000;
+const SLOW_OK_MS = 3000;
+
+function reply(content: string): unknown {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: 0,
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+function chunk(content: string): string {
+  return JSON.stringify({
+    id: "evt",
+    object: "chat.completion.chunk",
+    model: "gpt-4o-mini",
+    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+  });
+}
+
+async function callChat(
+  app: SpawnedApp,
+  model: string,
+  stream = false,
+): Promise<Response> {
+  return fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hi" }],
+      ...(stream ? { stream: true } : {}),
+    }),
+  });
+}
+
+describe("deployment-wide upstream timeout default", () => {
+  // App with a short deployment default — the subject under test.
+  let app: SpawnedApp | undefined;
+  // App with a long deployment default — proves the group-level fallback
+  // (its 1.5s cut can only come from the group's own `timeout`).
+  let grouped: SpawnedApp | undefined;
+  let etcdReachable = false;
+
+  let stalling: OpenAiUpstream | undefined;
+  let slowOk: OpenAiUpstream | undefined;
+  let streamStall: OpenAiUpstream | undefined;
+  let groupStalling: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    stalling = await startOpenAiUpstream({
+      responseDelayMs: STALL_MS,
+      nonStreamBody: reply("stalled"),
+    });
+    slowOk = await startOpenAiUpstream({
+      responseDelayMs: SLOW_OK_MS,
+      nonStreamBody: reply("slow-ok"),
+    });
+    streamStall = await startOpenAiUpstream({
+      // First chunk immediately, then a stall far past the default.
+      eventDelayMs: STALL_MS,
+      streamEvents: [chunk("first "), chunk("never "), "[DONE]"],
+    });
+    groupStalling = await startOpenAiUpstream({
+      responseDelayMs: STALL_MS,
+      nonStreamBody: reply("group-stalled"),
+    });
+
+    app = await spawnApp({ extra: { upstream: { timeout_ms: DEFAULT_MS } } });
+    grouped = await spawnApp({ extra: { upstream: { timeout_ms: 60_000 } } });
+
+    {
+      const seed = new SeedClient(etcd, app.etcdPrefix);
+      const pk = async (name: string, u: OpenAiUpstream) =>
+        (
+          await seed.createProviderKey({
+            display_name: name,
+            secret: "sk-mock",
+            api_base: `${u.baseUrl}/v1`,
+          })
+        ).id;
+      const stallingPk = await pk("td-stalling-pk", stalling);
+      const slowOkPk = await pk("td-slow-ok-pk", slowOk);
+      const streamStallPk = await pk("td-stream-stall-pk", streamStall);
+      // No `timeout` anywhere → inherits the deployment default.
+      await seed.createModel({
+        display_name: "td-defaulted",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: stallingPk,
+        cooldown: { enabled: false },
+      });
+      // Same silent upstream, `timeout: 0` → opted out of the backstop.
+      await seed.createModel({
+        display_name: "td-opted-out",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: slowOkPk,
+        timeout: 0,
+        cooldown: { enabled: false },
+      });
+      // Explicit model `timeout` above the deployment default wins.
+      await seed.createModel({
+        display_name: "td-explicit",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: slowOkPk,
+        timeout: SLOW_OK_MS + 2000,
+        cooldown: { enabled: false },
+      });
+      // Streaming: no `stream_timeout`/`timeout` → the deployment default
+      // is the streaming budget too.
+      await seed.createModel({
+        display_name: "td-stream-defaulted",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: streamStallPk,
+        cooldown: { enabled: false },
+      });
+      await seed.createApiKey({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: [
+          "td-defaulted",
+          "td-opted-out",
+          "td-explicit",
+          "td-stream-defaulted",
+        ],
+      });
+      await waitConfigPropagation(async () => {
+        const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+          headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+        });
+        if (!res.ok) return false;
+        const body = (await res.json()) as { data?: Array<{ id: string }> };
+        return !!body.data?.some((m) => m.id === "td-stream-defaulted");
+      });
+    }
+
+    {
+      const seed = new SeedClient(etcd, grouped.etcdPrefix);
+      const pkId = (
+        await seed.createProviderKey({
+          display_name: "td-group-pk",
+          secret: "sk-mock",
+          api_base: `${groupStalling.baseUrl}/v1`,
+        })
+      ).id;
+      await seed.createModel({
+        display_name: "td-member",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pkId,
+        cooldown: { enabled: false },
+      });
+      // The group's own `timeout` — the member sets none, and the
+      // deployment default here is 60s, so a fast 504 can only come from
+      // this level.
+      await seed.createModel({
+        display_name: "td-group",
+        timeout: DEFAULT_MS,
+        routing: { strategy: "failover", targets: [{ model: "td-member" }] },
+      });
+      await seed.createApiKey({
+        key_hash: CALLER_KEY_HASH,
+        allowed_models: ["td-group"],
+      });
+      // Routing models are not listed on /v1/models — gate on a probe call
+      // instead (the pattern timeout-fallback-e2e uses). A 504 means the
+      // virtual model and its member are both loaded; before that the
+      // gateway answers 404.
+      await waitConfigPropagation(async () => {
+        const res = await callChat(grouped!, "td-group");
+        if (res.status !== 504) {
+          await res.text();
+          return false;
+        }
+        await res.text();
+        return true;
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all([app?.exit(), grouped?.exit()]);
+    await Promise.all([
+      stalling?.close(),
+      slowOk?.close(),
+      streamStall?.close(),
+      groupStalling?.close(),
+    ]);
+  });
+
+  test("a model with no timeout inherits the deployment default", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const started = Date.now();
+    const res = await callChat(app, "td-defaulted");
+    const elapsed = Date.now() - started;
+    expect(res.status).toBe(504);
+    // Cut by the 1.5s default, well before the 8s upstream stall.
+    expect(elapsed).toBeGreaterThanOrEqual(DEFAULT_MS - 200);
+    expect(elapsed).toBeLessThan(STALL_MS - 1500);
+    const body = (await res.json()) as { error?: { message?: string } };
+    expect(body.error?.message ?? "").toContain("timed out");
+  }, 30_000);
+
+  test("timeout: 0 opts a model out of the deployment default", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const res = await callChat(app, "td-opted-out");
+    // 3s upstream, 1.5s deployment default: only the opt-out lets this
+    // complete.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    expect(body.choices[0]?.message.content).toBe("slow-ok");
+  }, 30_000);
+
+  test("an explicit model timeout beats the deployment default", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const res = await callChat(app, "td-explicit");
+    expect(res.status).toBe(200);
+  }, 30_000);
+
+  test("streaming inherits the deployment default as its chunk budget", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const started = Date.now();
+    const res = await callChat(app, "td-stream-defaulted", true);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const elapsed = Date.now() - started;
+    // The first chunk arrived; the 8s mid-stream stall was cut by the
+    // 1.5s default rather than waiting out the upstream.
+    expect(text).toContain("first");
+    expect(text).not.toContain("never");
+    expect(elapsed).toBeLessThan(STALL_MS - 1500);
+  }, 30_000);
+
+  test("a group's timeout applies to members without their own", async (ctx) => {
+    if (!etcdReachable || !grouped) return ctx.skip();
+    const started = Date.now();
+    const res = await callChat(grouped, "td-group");
+    const elapsed = Date.now() - started;
+    expect(res.status).toBe(504);
+    // The deployment default in this app is 60s; only the group's own
+    // 1.5s `timeout` can cut the call this early.
+    expect(elapsed).toBeGreaterThanOrEqual(DEFAULT_MS - 200);
+    expect(elapsed).toBeLessThan(STALL_MS - 1500);
+  }, 30_000);
+});


### PR DESCRIPTION
## Problem

A Model that sets neither `timeout` nor `stream_timeout` has **no upstream deadline at all**: an upstream that accepts the connection and then goes silent forever holds the request open indefinitely. TCP keepalive (already on by default) only detects a dead peer — it cannot detect a live-but-silent one, so the only bound left is the client's own patience. The mainstream LLM-proxy baseline never runs unbounded: its router falls back to a global `request_timeout` of **6000 s** when no deployment-level timeout is set, and its per-deployment `stream_timeout` falls back to the non-stream timeout the same way.

Two smaller gaps in the same area:

- The `timeout`/`stream_timeout` fields on a model group (a Model carrying `routing`) were **dead fields** — members only ever used their own values, unlike `retries`, which already resolves member → group → deployment default.
- There was no config-file surface to set a deployment-wide timeout at all.

## Change

- New `upstream.timeout_ms` (default `6_000_000` = 6000 s, matching the reference proxy's `request_timeout`) and `upstream.stream_timeout_ms` (default `0` = fall back to `timeout_ms`). Env overrides work like every other `upstream.*` knob (`AISIX_UPSTREAM__TIMEOUT_MS`, `AISIX_UPSTREAM__STREAM_TIMEOUT_MS`).
- New `routing::effective_timeouts` resolves deadlines **target → group → deployment default**, mirroring `effective_retries`, and is applied uniformly across every dispatch family: chat, messages (passthrough + cross-provider), responses (both), count_tokens, completions, embeddings, rerank, images, audio (transcription + speech), videos, jobs, passthrough, ensemble (panel + judge), and the realtime idle cap.
- `timeout: 0` at model or group level opts that resource out of the backstop (unchanged for existing users of `0`); `upstream.timeout_ms: 0` restores the old unbounded behaviour deployment-wide. `stream_timeout: 0` keeps its historical "defer" semantics at every level.
- Streaming precedence follows the baseline: resource levels first (`stream_timeout`, then the resource-resolved `timeout`), deployment defaults last. Within that, the dedicated stream knob outranks the generic one at every level — a group's `stream_timeout` beats a member's own `timeout` for the streaming budget, and supplies one even to a member whose `timeout: 0` opted out of the request deadline (unit-tested; same shape as the reference router, whose stream chain is exhausted before its non-stream chain starts).
- **The deployment-default streaming budget does not arm the pre-200 first-chunk peek** (`TimeoutBudget::stream_configured`). Peeking withholds the 200 until the first token — that is the #554 slow-first-token failover contract and stays exactly as-is for resource-configured budgets — but doing it for the deployment default would withhold headers for every model and silence the #818 SSE heartbeats whose whole purpose is covering a slow first token. With only the default budget, a first-chunk stall surfaces as an in-band timeout after the 200 instead of failing over. Same shape as `RetryBudget::covers`: explicit config opts into the sharper behaviour.

## Behaviour changes

1. Models with no `timeout` configured anywhere are now bounded at 6000 s end-to-end (non-streaming) / 6000 s inter-chunk (streaming). This is a backstop against infinite hangs, deliberately generous so it can never cut a legitimate long request.
2. Group-level `timeout`/`stream_timeout` now apply to members that don't set their own. A pre-existing group-level `stream_timeout` (previously a dead field) therefore also arms the pre-200 first-chunk peek for members without their own streaming config.
3. For CP-managed deployments, the control plane currently normalizes an explicit `timeout: 0` to unset — after this change those models pick up the 6000 s backstop instead of staying unbounded. A companion CP PR (preserve explicit `0`, expose the group-level fields) is queued to restore the opt-out there; standalone/file-based deployments are unaffected.

## Tests

- `routing::effective_timeouts` unit tests: three-level precedence, explicit-zero opt-out at each level, stream fallback order, peek arming.
- New E2E `upstream-timeout-defaults-e2e.test.ts` (real binary + etcd + mock upstream): default applies (504 at the deadline), `timeout: 0` opt-out, explicit model timeout beats the default, streaming inherits the default as its chunk budget without suppressing the 200/heartbeats, group timeout applies to members.
- `timeout-fallback-e2e` (the #554 contract) and `downstream-connection-e2e` (the #818 heartbeat contract) pass unchanged.
- CP contract-check pre-run against the regenerated schemas: clean (the `timeout`/`stream_timeout` schema delta is description-only).
