### PR TITLE
fix(bedrock): enforce the model deadline and connect timeout on the SDK client

### DIFF
--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -355,17 +355,21 @@ fn build_client(
     );
     // The SDK enforces the deadlines the other bridges get from
     // `tokio::time::timeout` wrappers: the shared `upstream.connect_timeout`
-    // bounds the dial, and the resolved per-request deadline cancels the
-    // whole operation (SdkError::TimeoutError → BridgeError::Timeout in
-    // `map_sdk_error`). Without these the SDK client has NO timeouts and a
-    // silent upstream holds the request open past the model's `timeout` —
-    // the deadline used to matter only for post-hoc error relabelling.
-    // `operation_timeout` covers send + response headers; a converse_stream
-    // body is bounded per-chunk by the proxy's read-timeout wrapper, same
-    // as every other bridge.
+    // bounds the dial (explicitly disabled when the operator set `0`, or
+    // the SDK's default plugins would quietly restore their own 3.1 s),
+    // and the resolved per-request deadline cancels the whole operation
+    // (SdkError::TimeoutError → BridgeError::Timeout in `map_sdk_error`).
+    // Without an operation timeout nothing bounds the call after connect —
+    // a silent upstream holds the request open past the model's `timeout`,
+    // which used to matter only for post-hoc error relabelling.
+    // `operation_timeout` covers send + response headers for
+    // converse_stream (the event-stream body is bounded per-chunk by the
+    // proxy's read-timeout wrapper, same as every other bridge) and the
+    // full body read for non-streaming operations.
     let mut timeouts = aws_smithy_types::timeout::TimeoutConfig::builder();
-    if let Some(d) = aisix_gateway::upstream_http::config().connect_timeout {
-        timeouts = timeouts.connect_timeout(d);
+    match aisix_gateway::upstream_http::config().connect_timeout {
+        Some(d) => timeouts = timeouts.connect_timeout(d),
+        None => timeouts = timeouts.disable_connect_timeout(),
     }
     if let Some(d) = deadline {
         timeouts = timeouts.operation_timeout(d);
@@ -2285,6 +2289,43 @@ mod tests {
             started.elapsed() < std::time::Duration::from_secs(4),
             "deadline did not cancel the call: took {:?}",
             started.elapsed()
+        );
+    }
+
+    /// A retryable upstream failure must reach the gateway's routing
+    /// budget after exactly ONE wire attempt. Before
+    /// `RetryConfig::disabled()` the SDK's standard mode re-hit the
+    /// upstream up to 3 times transparently — invisible to per-attempt
+    /// telemetry and stacked under the gateway's own retry budget.
+    #[tokio::test]
+    async fn sdk_does_not_retry_on_its_own() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/model/.+/invoke$"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(serde_json::json!({"message": "internal failure"})),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = BedrockBridge::new().with_endpoint_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-retry",
+            sample_model_with("anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
+
+        let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        assert!(
+            matches!(err, BridgeError::UpstreamStatus { status: 500, .. }),
+            "expected UpstreamStatus 500, got {err:?}"
+        );
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "the SDK must not retry on its own",
         );
     }
 

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -337,6 +337,7 @@ fn build_client(
     creds: &BedrockSecret,
     endpoint_url: Option<&str>,
     hdr: &UpstreamHeaderContext<'_>,
+    deadline: Option<std::time::Duration>,
 ) -> Result<BedrockClient, BridgeError> {
     if creds.region.trim().is_empty() {
         return Err(BridgeError::InvalidUpstreamConfig(
@@ -352,10 +353,35 @@ fn build_client(
         None,
         "aisix-provider-bedrock",
     );
+    // The SDK enforces the deadlines the other bridges get from
+    // `tokio::time::timeout` wrappers: the shared `upstream.connect_timeout`
+    // bounds the dial, and the resolved per-request deadline cancels the
+    // whole operation (SdkError::TimeoutError → BridgeError::Timeout in
+    // `map_sdk_error`). Without these the SDK client has NO timeouts and a
+    // silent upstream holds the request open past the model's `timeout` —
+    // the deadline used to matter only for post-hoc error relabelling.
+    // `operation_timeout` covers send + response headers; a converse_stream
+    // body is bounded per-chunk by the proxy's read-timeout wrapper, same
+    // as every other bridge.
+    let mut timeouts = aws_smithy_types::timeout::TimeoutConfig::builder();
+    if let Some(d) = aisix_gateway::upstream_http::config().connect_timeout {
+        timeouts = timeouts.connect_timeout(d);
+    }
+    if let Some(d) = deadline {
+        timeouts = timeouts.operation_timeout(d);
+    }
     let mut builder = aws_config::SdkConfig::builder()
         .behavior_version(BehaviorVersion::latest())
         .region(Region::new(creds.region.clone()))
         .credentials_provider(SharedCredentialsProvider::new(aws_creds))
+        .timeout_config(timeouts.build())
+        // Retries belong to the gateway's own budget
+        // (`routing::effective_retries`), which emits per-attempt telemetry
+        // and honours per-model config. Left at its default the SDK would
+        // add a hidden standard-mode retry layer (3 attempts) underneath,
+        // grinding the upstream invisibly — no other bridge's HTTP client
+        // retries on its own.
+        .retry_config(aws_smithy_types::retry::RetryConfig::disabled())
         .sleep_impl(aws_smithy_async::rt::sleep::SharedAsyncSleep::new(
             aws_smithy_async::rt::sleep::TokioSleep::new(),
         ));
@@ -856,7 +882,7 @@ impl BedrockBridge {
         };
         // Converse paths carry no JSON body, but default_headers still apply
         // (header-level, publisher-agnostic) via the signing interceptor.
-        build_client(&creds, endpoint_url, &ctx.header_ctx())
+        build_client(&creds, endpoint_url, &ctx.header_ctx(), ctx.deadline)
     }
 
     /// Dispatch Bedrock chat via the unified Converse API.
@@ -2220,6 +2246,46 @@ mod tests {
         let chat = bridge.chat(&req, &ctx).await.unwrap();
         assert_eq!(chat.message.content_str(), "hello from bedrock");
         assert_eq!(chat.usage.total_tokens, 9);
+    }
+
+    /// The model's deadline must CANCEL a silent Bedrock call, not just
+    /// relabel an error after the fact. Before the SDK `timeout_config`
+    /// wiring, this call sat through the upstream's full 8 s delay and
+    /// came back `Ok` — the deadline was consulted only inside
+    /// `map_sdk_error`, which never ran on success.
+    #[tokio::test]
+    async fn chat_deadline_cancels_a_silent_upstream() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/model/.+/invoke$"))
+            .respond_with(
+                default_anthropic_response_template().set_delay(std::time::Duration::from_secs(8)),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = BedrockBridge::new().with_endpoint_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-deadline",
+            sample_model_with("anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            sample_pk_with_secret(valid_secret_json()),
+        )
+        .with_deadline(std::time::Duration::from_millis(300));
+        let req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
+
+        let started = std::time::Instant::now();
+        let err = bridge.chat(&req, &ctx).await.unwrap_err();
+        assert!(
+            matches!(err, BridgeError::Timeout { .. }),
+            "expected Timeout, got {err:?}"
+        );
+        // Generous CI margin, but far below the 8 s the upstream stalls:
+        // proves cancellation, not post-hoc relabelling.
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(4),
+            "deadline did not cancel the call: took {:?}",
+            started.elapsed()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The Bedrock bridge was the only dispatch path where a model's `timeout` did not actually bound the call. The SDK client is built with **no `timeout_config` at all**, and `ctx.deadline` was consulted only inside `map_sdk_error` — i.e. after a call had already failed for some other reason, purely to relabel the error as `Timeout`. A Bedrock upstream that accepted the connection and then went silent held the request open indefinitely, while every other bridge cancels at the deadline via its `with_deadline` / `tokio::time::timeout` wrapper. (The connect phase itself was bounded only by the SDK default plugins' own 3.1 s — `upstream.connect_timeout_ms`, which reaches every reqwest-based bridge through the shared client builder, never reached the AWS SDK client, including its documented `0` = disabled convention.)

## Change

`build_client` now installs a `TimeoutConfig` on the SDK client:

- `connect_timeout` ← the shared `upstream.connect_timeout_ms` (same knob every other bridge honors);
- `operation_timeout` ← the per-request `ctx.deadline` (the model/group/deployment-resolved timeout). An elapsed deadline surfaces as `SdkError::TimeoutError`, which `map_sdk_error` already maps to `BridgeError::Timeout`, so retry / fallback / cooldown classification is untouched. The per-request client construction the bridge already does (stateless by design) is what makes a per-request `operation_timeout` possible.

`converse_stream` bodies stay bounded per-chunk by the proxy-side read-timeout wrapper, exactly like every other bridge's streams; `operation_timeout` covers send + response headers only.

SDK-internal retries are disabled (`RetryConfig::disabled()`): retries belong to the gateway's `routing::effective_retries` budget, which emits per-attempt telemetry and honors per-model config. Left at its default, the SDK adds a hidden standard-mode retry layer (up to 3 attempts) underneath the gateway's own budget, grinding the upstream invisibly — no other bridge's HTTP client retries on its own.

Not in scope: the Bedrock **guardrail** client builds its own SDK client but wraps every call in `tokio::time::timeout(guardrail.timeout_ms)` (default 5 s), so it is already bounded end-to-end.

## Behaviour changes

1. Bedrock models now time out at their resolved deadline like every other provider (previously: unbounded on a silent upstream).
2. Hidden SDK-level retries (up to 3 transparent attempts on retryable failures) no longer happen; retry behaviour is governed solely by `Model.retries` / `routing.retries` / `upstream.retries`.

## Tests

`chat_deadline_cancels_a_silent_upstream` drives the real `bridge.chat()` through wiremock with an 8 s response delay and a 300 ms deadline, asserting `BridgeError::Timeout` **and** an elapsed time far below the delay (cancellation, not relabelling). Verified to fail without the fix: the call sits through the full 8 s and returns `Ok`.

`sdk_does_not_retry_on_its_own` pins the single-attempt semantics with a wiremock hit counter: a 500 reaches the gateway after exactly one wire attempt. Verified to fail without `RetryConfig::disabled()` — the SDK hits the upstream 3 times.
