### PR TITLE
build: keep the symbol table in release binaries for field profiling

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -192,6 +192,24 @@ jobs:
           docker logs smoke-aisix
           test -n "$ok"
 
+      # The profiling contract from #847: the shipped binary must stay
+      # profileable in the field, meaning the symbol table and the DWARF
+      # line tables survive into the image. A future strip step,
+      # RUSTFLAGS change, or base-image swap would break flame graphs
+      # silently, so pin it here — and print the size so every PR
+      # records the real Linux artifact cost.
+      - name: Verify shipped binary keeps symbols + line tables (#847)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -eux
+          IMAGE="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)"
+          cid="$(docker create "$IMAGE")"
+          docker cp "$cid:/usr/local/bin/aisix" /tmp/aisix-shipped
+          docker rm "$cid"
+          ls -l /tmp/aisix-shipped
+          test "$(nm /tmp/aisix-shipped | grep -c ' [tT] ')" -gt 1000
+          readelf -S /tmp/aisix-shipped | grep -E '\.debug_line|\.debug_info|\.symtab'
+
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -193,12 +193,12 @@ jobs:
           test -n "$ok"
 
       # The profiling contract from #847: the shipped binary must stay
-      # profileable in the field, meaning the symbol table and the DWARF
-      # line tables survive into the image. A future strip step,
+      # profileable in the field, meaning the symbol table survives into
+      # the image (function-level flame graphs). A future strip step,
       # RUSTFLAGS change, or base-image swap would break flame graphs
       # silently, so pin it here — and print the size so every PR
       # records the real Linux artifact cost.
-      - name: Verify shipped binary keeps symbols + line tables (#847)
+      - name: Verify shipped binary keeps its symbol table (#847)
         if: github.event_name == 'pull_request'
         run: |
           set -eux
@@ -208,7 +208,7 @@ jobs:
           docker rm "$cid"
           ls -l /tmp/aisix-shipped
           test "$(nm /tmp/aisix-shipped | grep -c ' [tT] ')" -gt 1000
-          readelf -S /tmp/aisix-shipped | grep -E '\.debug_line|\.debug_info|\.symtab'
+          readelf -S /tmp/aisix-shipped | grep -E '\.symtab|\.eh_frame'
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,8 +150,9 @@ lto = "thin"
 codegen-units = 1
 strip = "symbols"
 
-# Release-equivalent codegen with readable stacks, for on-CPU flame graphs
+# Release-equivalent codegen with readable stacks, for sampling profilers
 # (cargo flamegraph --profile profiling). Never use for release artifacts.
+# See issue #847.
 [profile.profiling]
 inherits = "release"
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,13 @@ lto = "thin"
 codegen-units = 1
 strip = "symbols"
 
+# Release-equivalent codegen with readable stacks, for on-CPU flame graphs
+# (cargo flamegraph --profile profiling). Never use for release artifacts.
+[profile.profiling]
+inherits = "release"
+debug = "line-tables-only"
+strip = "none"
+
 [profile.coverage]
 inherits = "dev"
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,12 +147,17 @@ tempfile = "3.13"
 
 # Shipped binaries must stay profileable in the field (perf / cargo
 # flamegraph against the very build a user runs), so keep the symbol
-# table and DWARF line tables in release artifacts. See issue #847.
+# table: function-level flame graphs cost ~10 MiB over stripped. DWARF
+# stays out — line tables alone measured ~142 MB here (cgu=1 + thin
+# LTO explode inlined-instance records). For an ad-hoc line-level
+# build when a deep dive needs file:line attribution:
+#   CARGO_PROFILE_RELEASE_DEBUG=line-tables-only \
+#   CARGO_PROFILE_RELEASE_STRIP=none cargo build --release
+# See issue #847.
 [profile.release]
 lto = "thin"
 codegen-units = 1
-debug = "line-tables-only"
-strip = "none"
+strip = "debuginfo"
 
 [profile.coverage]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,16 +145,12 @@ wiremock = "0.6"
 testcontainers = "0.23"
 tempfile = "3.13"
 
+# Shipped binaries must stay profileable in the field (perf / cargo
+# flamegraph against the very build a user runs), so keep the symbol
+# table and DWARF line tables in release artifacts. See issue #847.
 [profile.release]
 lto = "thin"
 codegen-units = 1
-strip = "symbols"
-
-# Release-equivalent codegen with readable stacks, for sampling profilers
-# (cargo flamegraph --profile profiling). Never use for release artifacts.
-# See issue #847.
-[profile.profiling]
-inherits = "release"
 debug = "line-tables-only"
 strip = "none"
 


### PR DESCRIPTION
## What

Keeps the symbol table in release binaries (`strip = "symbols"` → `strip = "debuginfo"`), so sampling profilers (cargo-flamegraph, samply, perf) produce readable function-level on-CPU flame graphs against the exact build users run. All DWARF stays out of the shipped artifact. The docker PR job now guards this contract.

Part of #847.

## Why

aisix ships as a single binary, and performance problems surface on the build users actually run — asking a user to reproduce on a special diagnostic build is not a workable support model. With `strip = "symbols"`, shipped binaries carried no symbol table at all, so a flame graph taken against a deployment degraded to bare-address towers.

Two earlier revisions of this PR were rejected in review:

1. A separate opt-in `[profile.profiling]` — rejected because the shipped artifact itself must be the profileable one.
2. `debug = "line-tables-only"` + `strip = "none"` on release — rejected on measured cost: with `codegen-units = 1` + thin LTO, the line tables alone measure ~142 MB (~200k inlined-instance records), roughly quadrupling the shipped binary for file:line attribution that hotspot work rarely needs.

Final shape: symbol table only. Function-level frames cover field hotspot profiling, and `.eh_frame` (always present — panic unwinding needs it) keeps DWARF-based stack walking in perf working. When a deep dive needs file:line and inline attribution, an ad-hoc build is one override away (documented in the manifest comment):

```bash
CARGO_PROFILE_RELEASE_DEBUG=line-tables-only CARGO_PROFILE_RELEASE_STRIP=none cargo build --release
```

`strip = "debuginfo"` is the modern cargo default for this situation, pinned explicitly so the contract survives toolchain-default drift; it also drops the DWARF that the precompiled std would otherwise leak into the binary.

## Cost / impact

- Binary size: shipped Linux binary goes 46.7 MiB (pre-PR `:dev` image baseline, fully stripped) → 53.8 MiB — **+7.1 MiB / +15.2%**, CI-measured by this PR's docker job. The macOS local build agrees (+6.0 MiB / +14.9%). For contrast, the rejected line-tables revision measured roughly 4x.
- Runtime: none — the symbol table lives in non-loadable sections; codegen flags are untouched (`lto = "thin"`, `codegen-units = 1`)
- Shipped binaries now expose internal function names; accepted as the support-model tradeoff. Build-path strings in `rodata` (panic/tracing metadata) ship today already and are unaffected either way; `--remap-path-prefix` is tracked in #847 as a follow-up for both.

## CI guard

`docker-image.yml`'s PR path now extracts `/usr/local/bin/aisix` from the built image, asserts the text-symbol count, and prints the artifact size — a future Dockerfile strip step, RUSTFLAGS change, or base-image swap cannot silently break field profiling again, and every PR records the real Linux artifact cost.

## Usage

```bash
cargo flamegraph --bin aisix -- <args>   # release is cargo flamegraph's default profile
flamegraph --pid <aisix-pid>             # attach to a running deployment
```

## Verification

- CI: the new "Verify shipped binary keeps its symbol table (#847)" step passed on this head — Linux artifact 56,424,392 bytes, 42,290 text symbols, `.eh_frame`/`.eh_frame_hdr` present (perf's DWARF unwinding needs them)
- Local: full release build (46.4 MiB, 42,029 text symbols on macOS), then an end-to-end profiling session against this exact build — mock upstream, 32-connection load, 380k requests at 12.7k req/s, `cargo flamegraph` produced a fully symbolized graph: 2,747 unique frames, zero address-only frames, 269 aisix-crate frames (`aisix_proxy::chat::*`, `aisix_obs::metrics::*`, provider bridge frames all readable)

The remaining #847 checklist items (a Linux perf session, rust-lld `--no-rosegment` verification, the internal guide) stay tracked in the issue.
