### PR TITLE
fix(metrics): prevent unbounded histogram memory growth

### DIFF
--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -275,6 +275,15 @@ impl Metrics {
         self.inner.handle.render()
     }
 
+    /// Drain pending histogram samples into their distributions.
+    ///
+    /// `PrometheusBuilder::build_recorder` does not start the exporter's
+    /// background upkeep task, so the server must call this periodically
+    /// even when no Prometheus server is scraping the metrics endpoint.
+    pub fn run_upkeep(&self) {
+        self.inner.handle.run_upkeep();
+    }
+
     /// Reflect the config load-observability state into the recorder. Called
     /// at scrape time by the metrics/status listener so `aisix_config_*`
     /// series always mirror the live [`aisix_core::ConfigStatus`]. Idempotent
@@ -1419,6 +1428,27 @@ mod tests {
         assert!(rendered.contains("provider=\"openai\""));
         assert!(rendered.contains("outcome=\"success\""));
         assert!(rendered.contains(M_REQUEST_DURATION));
+    }
+
+    #[test]
+    fn upkeep_preserves_recorded_histogram_samples() {
+        let m = Metrics::new(false);
+        for _ in 0..1_000 {
+            m.record_request(
+                "openai",
+                "my-gpt4",
+                200,
+                RequestOutcome::Success,
+                Duration::from_millis(120),
+            );
+        }
+
+        m.run_upkeep();
+
+        let rendered = m.render();
+        assert!(rendered.lines().any(|line| line
+            .starts_with("aisix_request_duration_seconds_count")
+            && line.ends_with(" 1000")));
     }
 
     /// AISIX-Cloud#1076: the per-execution guardrail histogram renders with

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -1430,27 +1430,6 @@ mod tests {
         assert!(rendered.contains(M_REQUEST_DURATION));
     }
 
-    #[test]
-    fn upkeep_preserves_recorded_histogram_samples() {
-        let m = Metrics::new(false);
-        for _ in 0..1_000 {
-            m.record_request(
-                "openai",
-                "my-gpt4",
-                200,
-                RequestOutcome::Success,
-                Duration::from_millis(120),
-            );
-        }
-
-        m.run_upkeep();
-
-        let rendered = m.render();
-        assert!(rendered.lines().any(|line| line
-            .starts_with("aisix_request_duration_seconds_count")
-            && line.ends_with(" 1000")));
-    }
-
     /// AISIX-Cloud#1076: the per-execution guardrail histogram renders with
     /// real `_bucket{le=…}` series (quantile-aggregatable, not a summary)
     /// and the full bounded label set; `error_type` defaults to `none`.

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -54,3 +54,4 @@ hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
 [dev-dependencies]
 tempfile = "3"
 wiremock = "0.6"
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -662,6 +662,24 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // above); it becomes the constant `env_id` label on the SLO latency
     // histograms. Standalone DPs leave it empty → "unknown".
     let metrics = Arc::new(Metrics::new_with_env_id(&cfg.etcd.env_id));
+    let metrics_upkeep_task = {
+        let metrics = metrics.clone();
+        let mut cancel = cancel_rx.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(5));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => metrics.run_upkeep(),
+                    changed = cancel.changed() => {
+                        if changed.is_err() || *cancel.borrow() {
+                            break;
+                        }
+                    }
+                }
+            }
+        })
+    };
     // Cache backends (#519 B.8). The memory cache is always built
     // (in-process, cheap); the redis cache is built iff `cache.redis`
     // is configured. Which instance serves a request is selected by
@@ -984,6 +1002,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     if let Some(task) = telemetry_task {
         let _ = task.await;
     }
+    let _ = metrics_upkeep_task.await;
     let _ = background_check_task.await;
     tracing::info!("aisix shut down cleanly");
     Ok(())

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -307,6 +307,27 @@ fn select_managed_boot_path(bundle_on_disk: bool, bundle_provided: bool) -> Mana
     }
 }
 
+async fn run_metrics_upkeep<F>(mut cancel: watch::Receiver<bool>, period: Duration, upkeep: F)
+where
+    F: Fn(),
+{
+    let mut interval = tokio::time::interval(period);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        if *cancel.borrow() {
+            break;
+        }
+        tokio::select! {
+            _ = interval.tick() => upkeep(),
+            changed = cancel.changed() => {
+                if changed.is_err() || *cancel.borrow() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
 /// Factored out of `main` so the integration tests can drive the full
 /// startup with a real config struct and still use `#[tokio::test]`.
 async fn run(mut cfg: Config) -> anyhow::Result<()> {
@@ -664,21 +685,11 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let metrics = Arc::new(Metrics::new_with_env_id(&cfg.etcd.env_id));
     let metrics_upkeep_task = {
         let metrics = metrics.clone();
-        let mut cancel = cancel_rx.clone();
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(5));
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => metrics.run_upkeep(),
-                    changed = cancel.changed() => {
-                        if changed.is_err() || *cancel.borrow() {
-                            break;
-                        }
-                    }
-                }
-            }
-        })
+        tokio::spawn(run_metrics_upkeep(
+            cancel_rx.clone(),
+            Duration::from_secs(5),
+            move || metrics.run_upkeep(),
+        ))
     };
     // Cache backends (#519 B.8). The memory cache is always built
     // (in-process, cheap); the redis cache is built iff `cache.redis`
@@ -1478,6 +1489,33 @@ async fn wait_for_signal(
 mod tests {
     use super::*;
     use clap::Parser;
+
+    #[tokio::test(start_paused = true)]
+    async fn metrics_upkeep_runs_periodically_and_stops_on_cancel() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = calls.clone();
+        let task = tokio::spawn(run_metrics_upkeep(
+            cancel_rx,
+            Duration::from_secs(5),
+            move || {
+                observed.fetch_add(1, Ordering::SeqCst);
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        tokio::time::advance(Duration::from_secs(5)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        cancel_tx.send(true).unwrap();
+        task.await.unwrap();
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
 
     #[test]
     fn supplied_certs_take_precedence_over_persisted_bundle() {


### PR DESCRIPTION
## Summary

- periodically drain pending Prometheus histogram samples when AISIX owns a low-level recorder
- stop the upkeep task through the existing shared shutdown channel
- verify periodic upkeep scheduling and shutdown cancellation with paused Tokio time

## Root cause

AISIX builds `metrics-exporter-prometheus` with `PrometheusBuilder::build_recorder()`. That low-level API does not spawn the exporter's upkeep task. Without Prometheus scrapes, each request leaves pending histogram samples in the recorder, so RSS grows approximately linearly with request count.

This is the memory issue tracked from api7/AISIX-Cloud#1199. It is independent of the allocator: local glibc and jemalloc runs both showed roughly constant retained bytes per request, and an unchanged binary stopped growing when `/metrics` was scraped periodically.

## Benchmark

GetBusbar/benchmarking, OpenAI-to-OpenAI cell, ARM64 Colima VM, 8 vCPU / 6.8 GiB, gateway pinned to 4 cores, 300-second memory load:

| Metric | Before | After |
| --- | ---: | ---: |
| Idle RSS | 67.20 MiB | 67.26 MiB |
| Load-window RSS | 553.04 MiB | 90.81 MiB |
| Peak RSS | 701.76 MiB | 91.64 MiB |
| Recovered RSS | 701.76 MiB | 89.77 MiB |
| Growth | +118.42 MiB/min | -1.45 MiB/min |
| Plateau | false | true |
| Added latency p99 | 225 us | 197 us |
| RPS under 10 ms p99 | 33,527 | 35,922 |

A second post-fix run measured 89.67 MiB peak, 87.34 MiB recovered, and -1.66 MiB/min growth.

## Independent audit

- MEDIUM: the original histogram test could pass because `render()` also drains pending samples, so it did not prove the scheduler lifecycle. Resolved by factoring the upkeep loop and testing periodic execution plus cancellation with paused Tokio time.

## Validation

- `cargo test -p aisix-obs` — 147 passed, 5 ignored real-cloud smoke tests
- `cargo test -p aisix-server` — 87 passed
- `cargo clippy -p aisix-obs -p aisix-server --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- GetBusbar OpenAI-to-OpenAI full memory protocol, two post-fix runs
