### PR TITLE
perf(proxy): make request state clones constant-cost

### DIFF
--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -3796,10 +3796,8 @@ data: [DONE]\n\n";
 
         let memory: Arc<dyn Cache> = Arc::new(MemoryCache::with_defaults());
         let redis_standin: Arc<dyn Cache> = Arc::new(MemoryCache::with_defaults());
-        let mut state = build_state_with_cache(snap, hub);
-        state.cache = Some(CacheBackends::new(
-            memory.clone(),
-            Some(redis_standin.clone()),
+        let state = build_state_with_cache(snap, hub).with_cache_backends(Some(
+            CacheBackends::new(memory.clone(), Some(redis_standin.clone())),
         ));
 
         let body = serde_json::json!({

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -3796,8 +3796,10 @@ data: [DONE]\n\n";
 
         let memory: Arc<dyn Cache> = Arc::new(MemoryCache::with_defaults());
         let redis_standin: Arc<dyn Cache> = Arc::new(MemoryCache::with_defaults());
-        let state = build_state_with_cache(snap, hub).with_cache_backends(Some(
-            CacheBackends::new(memory.clone(), Some(redis_standin.clone())),
+        let mut state = build_state_with_cache(snap, hub);
+        state.cache = Some(CacheBackends::new(
+            memory.clone(),
+            Some(redis_standin.clone()),
         ));
 
         let body = serde_json::json!({

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -179,6 +179,12 @@ impl std::ops::Deref for ProxyState {
     }
 }
 
+impl std::ops::DerefMut for ProxyState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Arc::make_mut(&mut self.inner)
+    }
+}
+
 impl ProxyState {
     pub fn new(snapshot: SnapshotHandle<AisixSnapshot>, hub: Arc<Hub>, cfg: &ProxyConfig) -> Self {
         let metrics = Arc::new(Metrics::new(false));
@@ -304,12 +310,6 @@ impl ProxyState {
         self
     }
 
-    #[cfg(test)]
-    pub(crate) fn with_cache_backends(mut self, cache: Option<CacheBackends>) -> Self {
-        Arc::make_mut(&mut self.inner).cache = cache;
-        self
-    }
-
     /// Replace the guardrail index. Used by the server bootstrap to
     /// wire a live snapshot-backed index; tests can substitute a
     /// deterministic one via `LiveGuardrailIndex::new(stub_handle, None)`.
@@ -374,13 +374,46 @@ impl ProxyState {
 #[cfg(test)]
 mod tests {
     use super::ProxyState;
+    use aisix_core::snapshot::SnapshotHandle;
+    use aisix_core::{AisixSnapshot, ProxyConfig};
+    use aisix_gateway::Hub;
     use std::sync::Arc;
 
+    fn test_state() -> ProxyState {
+        ProxyState::new(
+            SnapshotHandle::new(AisixSnapshot::new()),
+            Arc::new(Hub::new()),
+            &ProxyConfig {
+                addr: "127.0.0.1:0".into(),
+                request_body_limit_bytes: 1_048_576,
+                tls: None,
+                real_ip: Default::default(),
+            },
+        )
+    }
+
     #[test]
-    fn proxy_state_clone_is_one_shared_pointer() {
+    fn proxy_state_clone_shares_one_inner_and_mutation_is_copy_on_write() {
         assert_eq!(
             std::mem::size_of::<ProxyState>(),
             std::mem::size_of::<Arc<()>>()
         );
+
+        let original = test_state();
+        assert_eq!(Arc::strong_count(&original.inner), 1);
+
+        let mut cloned = original.clone();
+        assert!(Arc::ptr_eq(&original.inner, &cloned.inner));
+        assert_eq!(Arc::strong_count(&original.inner), 2);
+
+        cloned.cache = None;
+        assert!(!Arc::ptr_eq(&original.inner, &cloned.inner));
+        assert!(original.cache.is_some());
+        assert!(cloned.cache.is_none());
+
+        let configured = original.clone().with_default_retries(99);
+        assert!(!Arc::ptr_eq(&original.inner, &configured.inner));
+        assert_ne!(original.default_retries, 99);
+        assert_eq!(configured.default_retries, 99);
     }
 }

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -95,6 +95,13 @@ impl CacheBackends {
 
 #[derive(Clone)]
 pub struct ProxyState {
+    // Axum clones state for several layers on every request. Keep the many
+    // shared handles behind one refcount so each clone/drop uses one atomic.
+    inner: Arc<ProxyStateInner>,
+}
+
+#[derive(Clone)]
+pub struct ProxyStateInner {
     pub snapshot: SnapshotHandle<AisixSnapshot>,
     pub hub: Arc<Hub>,
     pub limiter: Arc<Limiter>,
@@ -164,12 +171,20 @@ pub struct ProxyState {
     pub default_timeouts: crate::routing::TimeoutDefaults,
 }
 
+impl std::ops::Deref for ProxyState {
+    type Target = ProxyStateInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 impl ProxyState {
     pub fn new(snapshot: SnapshotHandle<AisixSnapshot>, hub: Arc<Hub>, cfg: &ProxyConfig) -> Self {
         let metrics = Arc::new(Metrics::new(false));
         let guardrail_index =
             LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
-        Self {
+        Self::from_inner(ProxyStateInner {
             snapshot,
             hub,
             limiter: Arc::new(Limiter::new()),
@@ -191,7 +206,7 @@ impl ProxyState {
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
             default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
             default_timeouts: crate::routing::TimeoutDefaults::default(),
-        }
+        })
     }
 
     /// Alternative constructor for callers that want to share a preexisting
@@ -205,7 +220,7 @@ impl ProxyState {
         let metrics = Arc::new(Metrics::new(false));
         let guardrail_index =
             LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
-        Self {
+        Self::from_inner(ProxyStateInner {
             snapshot,
             hub,
             limiter,
@@ -227,7 +242,7 @@ impl ProxyState {
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
             default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
             default_timeouts: crate::routing::TimeoutDefaults::default(),
-        }
+        })
     }
 
     /// Full constructor used by the server bootstrap — lets the same
@@ -251,7 +266,7 @@ impl ProxyState {
             metrics.clone(),
             snapshot.clone(),
         ));
-        Self {
+        Self::from_inner(ProxyStateInner {
             snapshot,
             hub,
             limiter,
@@ -273,13 +288,25 @@ impl ProxyState {
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
             default_retries: aisix_core::config::DEFAULT_UPSTREAM_RETRIES,
             default_timeouts: crate::routing::TimeoutDefaults::default(),
+        })
+    }
+
+    fn from_inner(inner: ProxyStateInner) -> Self {
+        Self {
+            inner: Arc::new(inner),
         }
     }
 
     /// Disable caching on an existing state. Used by tests that need
     /// every request to reach wiremock.
     pub fn without_cache(mut self) -> Self {
-        self.cache = None;
+        Arc::make_mut(&mut self.inner).cache = None;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_cache_backends(mut self, cache: Option<CacheBackends>) -> Self {
+        Arc::make_mut(&mut self.inner).cache = cache;
         self
     }
 
@@ -287,7 +314,7 @@ impl ProxyState {
     /// wire a live snapshot-backed index; tests can substitute a
     /// deterministic one via `LiveGuardrailIndex::new(stub_handle, None)`.
     pub fn with_guardrail_index(mut self, index: Arc<LiveGuardrailIndex>) -> Self {
-        self.guardrail_index = index;
+        Arc::make_mut(&mut self.inner).guardrail_index = index;
         self
     }
 
@@ -295,14 +322,14 @@ impl ProxyState {
     /// `observability.metrics.client_type_rules` (AISIX-Cloud#1045).
     /// Default is built-ins only.
     pub fn with_client_classifier(mut self, classifier: Arc<ClientTypeClassifier>) -> Self {
-        self.client_classifier = classifier;
+        Arc::make_mut(&mut self.inner).client_classifier = classifier;
         self
     }
 
     /// Apply the deployment-wide `upstream.retries` budget. Default is
     /// [`aisix_core::config::DEFAULT_UPSTREAM_RETRIES`].
     pub fn with_default_retries(mut self, retries: u32) -> Self {
-        self.default_retries = retries;
+        Arc::make_mut(&mut self.inner).default_retries = retries;
         self
     }
 
@@ -310,7 +337,7 @@ impl ProxyState {
     /// `upstream.stream_timeout_ms` defaults, with `0` meaning "no
     /// default at that slot".
     pub fn with_default_timeouts(mut self, timeout_ms: u64, stream_timeout_ms: u64) -> Self {
-        self.default_timeouts = crate::routing::TimeoutDefaults {
+        Arc::make_mut(&mut self.inner).default_timeouts = crate::routing::TimeoutDefaults {
             request: (timeout_ms > 0).then(|| std::time::Duration::from_millis(timeout_ms)),
             stream: (stream_timeout_ms > 0)
                 .then(|| std::time::Duration::from_millis(stream_timeout_ms)),
@@ -322,14 +349,14 @@ impl ProxyState {
     /// the server bootstrap calls this in managed mode after spawning
     /// the sender worker.
     pub fn with_usage_sink(mut self, sink: UsageSink) -> Self {
-        self.usage_sink = sink;
+        Arc::make_mut(&mut self.inner).usage_sink = sink;
         self
     }
 
     /// Swap in a live `BudgetClient` that talks to cp-api. Default is
     /// the disabled (allow-all) client used in self-hosted dev.
     pub fn with_budget_client(mut self, client: Arc<BudgetClient>) -> Self {
-        self.budgets = client;
+        Arc::make_mut(&mut self.inner).budgets = client;
         self
     }
 
@@ -339,7 +366,21 @@ impl ProxyState {
         mut self,
         probe: Arc<dyn Fn() -> Option<std::time::Duration> + Send + Sync>,
     ) -> Self {
-        self.config_apply_age = Some(probe);
+        Arc::make_mut(&mut self.inner).config_apply_age = Some(probe);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProxyState;
+    use std::sync::Arc;
+
+    #[test]
+    fn proxy_state_clone_is_one_shared_pointer() {
+        assert_eq!(
+            std::mem::size_of::<ProxyState>(),
+            std::mem::size_of::<Arc<()>>()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- store the many shared proxy handles behind one `Arc<ProxyStateInner>`
- reduce every Axum `ProxyState` clone/drop from roughly twenty refcount operations to one
- preserve consuming builder behavior with copy-on-write mutation
- add a regression test that pins `ProxyState` to one shared pointer

## Root cause

Linux `perf` and the supplied macOS flame graph both show request-path time in `ProxyState::clone`, drops, and Arc atomic operations. Axum clones state across routing, middleware, and extractors, while the old `ProxyState` cloned each Arc-backed field separately.

## Benchmark

GetBusbar OTB OpenAI-only adaptive frontier, same host/core allocation, AISIX main `22b8353`, 6-second rungs, zero failed requests:

| p99 SLO | Before | After | Change |
| --- | ---: | ---: | ---: |
| 1 ms | 30,954 RPS | 34,522 RPS | +11.53% |
| 5 ms | 31,002 RPS | 34,522 RPS | +11.35% |
| 10 ms | 31,002 RPS | 34,522 RPS | +11.35% |
| Unbounded | 31,002 RPS | 34,522 RPS | +11.35% |

The benchmark used locally saved binary names, so the OTB runner reported a final process-stop cleanup error after writing both valid artifacts. All measured rungs completed and reported zero workload failures.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p aisix-proxy -p aisix-server --all-targets -- -D warnings`
- `cargo test -p aisix-proxy` (764 passed)
- `cargo test -p aisix-server` (86 passed)
- GetBusbar network E2E against its real mock upstream and load generator

Part of api7/AISIX-Cloud#1199.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved proxy state cloning efficiency by enabling shared state ownership.
  * Preserved existing proxy configuration and cache behavior while updating internal state construction.
* **Tests**
  * Added coverage confirming efficient state sharing.
  * Updated cache routing verification to ensure entries continue reaching the configured Redis backend correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->