### PR TITLE
feat(obs): record client-abandoned requests as 499

### DIFF
--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -57,6 +57,17 @@ pub const M_PROXY_IN_FLIGHT: &str = "aisix_proxy_in_flight_requests";
 pub const M_PROXY_REQUESTS_TOTAL: &str = "aisix_proxy_requests_total";
 pub const M_PROXY_FAILED_REQUESTS_TOTAL: &str = "aisix_proxy_failed_requests_total";
 pub const M_PROXY_REQUEST_DURATION: &str = "aisix_proxy_request_duration_seconds";
+/// Requests the client abandoned before the response head was written.
+/// Every other proxy series is emitted at the end of a handler, which a
+/// cancelled request never reaches — without this one those requests are
+/// absent from the metrics entirely, not counted as failures.
+///
+/// The label set is `endpoint` ONLY. A cancelled request has no resolved
+/// model / provider key / team (the body may not even be parsed yet), so
+/// the `RequestLabels` families cannot represent it; and `endpoint`
+/// arrives already collapsed to a bounded route template by the proxy
+/// layer, keeping this series low-cardinality by construction (#451).
+pub const M_PROXY_CLIENT_CANCELLED_TOTAL: &str = "aisix_proxy_client_cancelled_requests_total";
 pub const M_DEPLOYMENT_REQUESTS_TOTAL: &str = "aisix_deployment_requests_total";
 pub const M_DEPLOYMENT_SUCCESS_TOTAL: &str = "aisix_deployment_success_responses_total";
 pub const M_DEPLOYMENT_FAILURE_TOTAL: &str = "aisix_deployment_failure_responses_total";
@@ -448,6 +459,19 @@ impl Metrics {
             metrics::counter!(
                 M_RATELIMIT_REJECTIONS,
                 "scope" => scope.to_string(),
+            )
+            .increment(1);
+        });
+    }
+
+    /// Count a request the client abandoned before it produced a response
+    /// head. `endpoint` must already be a bounded route template — see
+    /// [`M_PROXY_CLIENT_CANCELLED_TOTAL`].
+    pub fn record_client_cancelled(&self, endpoint: &str) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_PROXY_CLIENT_CANCELLED_TOTAL,
+                "endpoint" => endpoint.to_string(),
             )
             .increment(1);
         });

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -4694,6 +4694,15 @@ where
             // a post-yield increment under-counts by 1 on every
             // abort path (#419, audit follow-up).
         }
+        // Upstream EOF — the response was delivered in full. Record it here,
+        // BEFORE the end-of-stream guardrail work below, which awaits remote
+        // provider calls and is a routine drop point: SDK clients close on
+        // the terminal frame, and a flag set after the scan would report a
+        // fully-delivered response as abandoned. This also keeps it ahead of
+        // the final `[DONE]` yield, since `async_stream::stream!` resumes the
+        // body only when the consumer pulls again. Same placement as the
+        // sibling streams in messages.rs and responses_bridge.rs.
+        guard.comp().reached_end = true;
         // Per #204: run the output guardrail on the accumulated
         // assistant content BEFORE emitting `[DONE]`. Buffer-then-
         // check is the right cadence for a blocking guardrail:
@@ -4935,12 +4944,6 @@ where
         // consumers can detect truncation. The `errored` flag is
         // set by the loop above whenever an error event is yielded
         // OR by the output-guardrail check above on a Block verdict.
-        // Mark BEFORE the final yield, not after: `async_stream::stream!`
-        // resumes the body only when the consumer pulls again, and plenty
-        // of SSE clients stop reading the moment they see `[DONE]`. A flag
-        // set after the yield would therefore stay unset for a perfectly
-        // normal request and report it as abandoned.
-        guard.comp().reached_end = true;
         if !errored {
             yield Ok::<_, Infallible>(Event::default().data("[DONE]"));
         }

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1660,7 +1660,15 @@ async fn dispatch(
                     &model_id_for_telem,
                     &model_for_metrics,
                     &api_key_id_for_telem,
-                    /* status_code */ 200,
+                    // A stream the consumer abandoned mid-flight is reported
+                    // as 499, matching what LiteLLM records for the same
+                    // event. The upstream work still happened, so the event
+                    // is emitted either way — only its outcome differs.
+                    if comp.reached_end {
+                        200
+                    } else {
+                        crate::CLIENT_CLOSED_REQUEST
+                    },
                     // Scoped to the winning attempt, not the request: the
                     // failed attempts before it emit their own events and
                     // `started` would double-count them (plus the pre-dispatch
@@ -4091,6 +4099,18 @@ struct StreamCompletion {
     /// output checks (AISIX-Cloud#562). Merged with the input-side hits
     /// by the on_complete telemetry closure.
     monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
+    /// `true` once the generator reached its own end — upstream EOF, an
+    /// error frame, or an output-guardrail block. It stays `false` only
+    /// when the consumer went away first, because `async_stream::stream!`
+    /// then simply stops resuming the body and the tail never runs. That
+    /// makes it the one signal at the Drop site that distinguishes a
+    /// delivered response from an abandoned one, which the telemetry
+    /// closure turns into `499` (see `CLIENT_CLOSED_REQUEST`).
+    ///
+    /// Distinct from `chunks_delivered`: a stream can deliver chunks and
+    /// still be abandoned midway, and a zero-chunk stream can still
+    /// legitimately reach its end (an immediate error frame).
+    reached_end: bool,
 }
 
 /// Parameters needed to run output-guardrail evaluation at
@@ -4915,13 +4935,19 @@ where
         // consumers can detect truncation. The `errored` flag is
         // set by the loop above whenever an error event is yielded
         // OR by the output-guardrail check above on a Block verdict.
+        // Mark BEFORE the final yield, not after: `async_stream::stream!`
+        // resumes the body only when the consumer pulls again, and plenty
+        // of SSE clients stop reading the moment they see `[DONE]`. A flag
+        // set after the yield would therefore stay unset for a perfectly
+        // normal request and report it as abandoned.
+        guard.comp().reached_end = true;
         if !errored {
             yield Ok::<_, Infallible>(Event::default().data("[DONE]"));
         }
         // `guard` drops here. On client disconnect, the generator
         // drops at the suspension point inside the loop; Drop fires
         // there with whatever StreamCompletion has been captured up
-        // to that point.
+        // to that point — `reached_end` still false.
     };
     // Hyper polls this generator after the request-id middleware has
     // returned, so re-attach the request span here — while we're still

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -75,6 +75,7 @@ pub use health::{
 };
 pub use state::{CacheBackends, ProxyState};
 
+use aisix_obs::AccessLog;
 use axum::extract::State;
 use axum::http::{header, HeaderValue, Request};
 use axum::middleware::{self, Next};
@@ -185,6 +186,16 @@ pub fn build_router(state: ProxyState) -> Router {
         .layer(middleware::from_fn_with_state(
             state.clone(),
             record_in_flight_request,
+        ))
+        // Record requests the caller abandoned before any response head
+        // existed. Sits outside `record_in_flight_request` so a hang-up
+        // during body upload (which the body-limit layers above are
+        // awaiting) is captured too, and inside `ensure_request_id` so
+        // the emitted line carries the same request id the caller was
+        // handed. See `record_client_cancel`.
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            record_client_cancel,
         ))
         // Identify the data plane on every response, including error
         // envelopes and short-circuited responses from the layers
@@ -300,6 +311,106 @@ impl Drop for InFlightGuard {
     fn drop(&mut self) {
         self.metrics
             .decrement_proxy_in_flight(&self.endpoint, &self.inbound_protocol);
+    }
+}
+
+/// nginx's non-standard "client closed request" status, used here purely
+/// as a recorded outcome — nothing is ever sent to a caller that already
+/// hung up. LiteLLM reports the same event as 499, so an operator running
+/// both reads one number.
+const CLIENT_CLOSED_REQUEST: u16 = 499;
+
+/// `error_kind` for an abandoned request, mirroring LiteLLM's
+/// `ClientDisconnected` error class.
+const CLIENT_DISCONNECTED_KIND: &str = "client_disconnected";
+
+/// Record a request whose caller hung up before the response head was
+/// written.
+///
+/// Every endpoint logs and meters itself at the end of its own handler —
+/// 29 `emit_access_log` call sites across 12 modules. When the client
+/// disconnects first, axum drops the handler future and *none* of that
+/// code runs: the request leaves no access-log line, no usage event and
+/// no metric. It is invisible exactly where an operator most needs it,
+/// because the usual reason a caller gives up is a long
+/// time-to-first-token.
+///
+/// A cancelled future is only observable from `Drop`, so arm a guard,
+/// disarm it once the inner service yields a response, and emit from
+/// `Drop` when it is still armed. Doing it in one layer rather than in
+/// each handler also keeps the endpoint family from drifting the way the
+/// request-id header did before `ensure_request_id` (see request_id.rs).
+///
+/// This is NOT the streaming-disconnect path: once SSE bytes flow the
+/// response head is already committed, so the handler has logged and the
+/// per-stream `Drop` guard emits the usage event (see
+/// `chat::build_sse_stream`). Response bodies are polled after this
+/// middleware has returned, so a mid-stream hang-up leaves the guard
+/// disarmed and is not double-counted here.
+async fn record_client_cancel(
+    State(state): State<ProxyState>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let mut guard = ClientCancelGuard {
+        armed: true,
+        metrics: state.metrics.clone(),
+        endpoint: normalize_endpoint_label(request.uri().path()),
+        method: request.method().clone(),
+        uri: request.uri().clone(),
+        request_id: request
+            .extensions()
+            .get::<request_id::RequestId>()
+            .map(|id| id.0.clone())
+            .unwrap_or_default(),
+        started: std::time::Instant::now(),
+    };
+    let response = next.run(request).await;
+    guard.armed = false;
+    response
+}
+
+struct ClientCancelGuard {
+    /// Cleared when the inner service returns. Still set at drop time
+    /// means the future was cancelled rather than completed.
+    armed: bool,
+    metrics: std::sync::Arc<aisix_obs::Metrics>,
+    /// Bounded route template — safe as a metric label (#451).
+    endpoint: &'static str,
+    method: axum::http::Method,
+    /// `Uri` clones are reference-counted internally; the path is only
+    /// read on the cancel path, so the happy path pays no formatting.
+    uri: axum::http::Uri,
+    request_id: String,
+    started: std::time::Instant,
+}
+
+impl Drop for ClientCancelGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let latency = self.started.elapsed();
+        AccessLog {
+            method: self.method.as_str(),
+            path: self.uri.path(),
+            status: CLIENT_CLOSED_REQUEST,
+            latency,
+            provider: None,
+            model: None,
+            api_key_id: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            total_tokens: None,
+            request_id: &self.request_id,
+            served_by_model: None,
+            routing_attempt_count: None,
+            routing_fallback_count: None,
+            error_kind: Some(CLIENT_DISCONNECTED_KIND),
+            error: Some("client closed the request before the response head was written"),
+        }
+        .emit();
+        self.metrics.record_client_cancelled(self.endpoint);
     }
 }
 
@@ -5929,6 +6040,183 @@ data: [DONE]\n\n";
         // unrelated event.
         assert_eq!(event.status_code, 200);
         assert!(!event.guardrail_blocked);
+    }
+
+    const CANCEL_METRIC: &str = "aisix_proxy_client_cancelled_requests_total";
+
+    /// A caller that hangs up before the response head exists must still
+    /// leave a trace. Every endpoint logs and meters from the tail of its
+    /// own handler, which a cancelled future never reaches — so such a
+    /// request used to be absent from the access log, the usage events
+    /// AND the metrics simultaneously. That made "the client says it sent
+    /// N requests but the gateway only logged M" unaccountable, and it
+    /// hid exactly the case operators care about: a caller giving up
+    /// during a long time-to-first-token.
+    #[tokio::test]
+    async fn client_cancel_before_response_head_is_recorded() {
+        let upstream = MockServer::start().await;
+        // Outlives the patience window below, so the handler is still
+        // awaiting the upstream when its future is dropped.
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_secs(30))
+                    .set_body_json(serde_json::json!({
+                        "id": "cmpl-never",
+                        "model": "gpt-4o",
+                        "choices": []
+                    })),
+            )
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub);
+        let metrics = state.metrics.clone();
+        let app = build_router(state);
+
+        assert!(!metrics.render().contains(CANCEL_METRIC));
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        // Dropping the in-flight future is precisely what axum does when
+        // the client's connection goes away before the handler produced a
+        // response head.
+        let outcome =
+            tokio::time::timeout(std::time::Duration::from_millis(300), app.oneshot(req)).await;
+        assert!(
+            outcome.is_err(),
+            "upstream answered too fast to model a cancel"
+        );
+
+        let rendered = metrics.render();
+        assert!(
+            rendered.contains(CANCEL_METRIC),
+            "cancelled request left no metric: {rendered}"
+        );
+        assert!(
+            rendered.contains("endpoint=\"/v1/chat/completions\""),
+            "cancel metric lost its endpoint label: {rendered}"
+        );
+    }
+
+    /// The guard must stay silent on the happy path. A completed request
+    /// is already logged and metered by its own handler; counting it as a
+    /// client cancel too would make the new series useless for alerting.
+    #[tokio::test]
+    async fn completed_request_is_not_counted_as_client_cancel() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-ok",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub);
+        let metrics = state.metrics.clone();
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rendered = metrics.render();
+        assert!(
+            !rendered.contains(CANCEL_METRIC),
+            "a completed request was miscounted as a client cancel: {rendered}"
+        );
+    }
+
+    /// A mid-stream hang-up is NOT a head-phase cancel. By the time SSE
+    /// bytes flow the response head is committed, the handler has already
+    /// written its access log, and the per-stream Drop guard emits the
+    /// usage event (see `streaming_chat_telemetry_fires_on_client_disconnect`).
+    /// Counting it here as well would report one disconnect twice under
+    /// two different outcomes.
+    #[tokio::test]
+    async fn mid_stream_disconnect_is_not_counted_as_head_phase_cancel() {
+        let upstream = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"cmpl-mid\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-mid\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub);
+        let metrics = state.metrics.clone();
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Read one chunk, then hang up mid-stream.
+        let mut body_stream = resp.into_body().into_data_stream();
+        let _first = body_stream.next().await;
+        drop(body_stream);
+
+        let rendered = metrics.render();
+        assert!(
+            !rendered.contains(CANCEL_METRIC),
+            "mid-stream disconnect was double-counted as a head-phase cancel: {rendered}"
+        );
     }
 
     /// Regression for #225: streaming chat must read the terminal SSE

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -387,7 +387,15 @@ struct ClientCancelGuard {
 
 impl Drop for ClientCancelGuard {
     fn drop(&mut self) {
-        if !self.armed {
+        // A panicking handler also leaves the guard armed — its future is
+        // dropped mid-unwind exactly like a cancelled one. Attributing that
+        // to the caller would be wrong twice over: it fabricates a client
+        // disconnect that never happened, and it buries the panic under a
+        // benign-looking 499. A panic has its own signal (tokio surfaces the
+        // task failure and hyper drops the connection), so stay silent and
+        // let that stand. Emitting here would also risk a double panic,
+        // which aborts the process.
+        if !self.armed || std::thread::panicking() {
             return;
         }
         let latency = self.started.elapsed();
@@ -6159,6 +6167,37 @@ data: [DONE]\n\n";
         assert!(
             !rendered.contains(CANCEL_METRIC),
             "a completed request was miscounted as a client cancel: {rendered}"
+        );
+    }
+
+    /// A panicking handler drops the guard mid-unwind with `armed` still
+    /// set, which looks identical to a cancel from `Drop`'s point of view.
+    /// Recording it would invent a client disconnect that never happened and
+    /// bury the panic under a benign 499, so the guard must stay silent and
+    /// let the panic's own signal stand.
+    #[test]
+    fn cancel_guard_stays_silent_during_unwind() {
+        let metrics = std::sync::Arc::new(aisix_obs::Metrics::new(false));
+        let probe = metrics.clone();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = ClientCancelGuard {
+                armed: true,
+                metrics: metrics.clone(),
+                endpoint: "/v1/chat/completions",
+                method: axum::http::Method::POST,
+                uri: "/v1/chat/completions".parse().unwrap(),
+                request_id: "req-unwind".to_string(),
+                started: std::time::Instant::now(),
+            };
+            panic!("handler blew up");
+        }));
+
+        assert!(result.is_err(), "the test's own panic must have unwound");
+        assert!(
+            !probe.render().contains(CANCEL_METRIC),
+            "a panicking handler was miscounted as a client cancel: {}",
+            probe.render()
         );
     }
 

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -6113,6 +6113,78 @@ data: [DONE]\n\n";
         );
     }
 
+    /// Same contract, but with an output guardrail attached — the shape that
+    /// puts an awaiting end-of-stream scan between the upstream's last chunk
+    /// and `[DONE]`. `reached_end` must be set before that scan, so pin the
+    /// outcome with one configured.
+    ///
+    /// This fixes the placement contract; it cannot reproduce the race
+    /// itself. A keyword guardrail scans locally, so its await completes
+    /// immediately and a consumer cannot realistically be dropped inside it.
+    /// The actual protection is that all five stream paths mark the flag at
+    /// upstream EOF, ahead of any scan.
+    #[tokio::test]
+    async fn streaming_chat_with_output_guardrail_reports_200_when_fully_consumed() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"cmpl-guard\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-guard\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"all clear\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-guard\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
+        // The literal never appears in the response above, so the scan runs
+        // to completion and allows — the stream is delivered in full.
+        seed_guardrail(
+            &state.snapshot,
+            "g-eos-scan",
+            r#"{"name":"eos-scan-guard","kind":"keyword","hook_point":"output","patterns":[{"kind":"literal","value":"never-present-literal"}]}"#,
+        );
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut body_stream = resp.into_body().into_data_stream();
+        while body_stream.next().await.is_some() {}
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("usage event was never emitted")
+            .expect("sender dropped without sending");
+        assert_eq!(
+            event.status_code, 200,
+            "a fully consumed stream with an output guardrail must not be reported as a cancel"
+        );
+    }
+
     const CANCEL_METRIC: &str = "aisix_proxy_client_cancelled_requests_total";
 
     /// A caller that hangs up before the response head exists must still

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -318,7 +318,7 @@ impl Drop for InFlightGuard {
 /// as a recorded outcome — nothing is ever sent to a caller that already
 /// hung up. LiteLLM reports the same event as 499, so an operator running
 /// both reads one number.
-const CLIENT_CLOSED_REQUEST: u16 = 499;
+pub(crate) const CLIENT_CLOSED_REQUEST: u16 = 499;
 
 /// `error_kind` for an abandoned request, mirroring LiteLLM's
 /// `ClientDisconnected` error class.
@@ -6046,8 +6046,71 @@ data: [DONE]\n\n";
         // simply that an event fires; counts are best-effort. Pin
         // the structural fields to confirm we didn't grab some
         // unrelated event.
-        assert_eq!(event.status_code, 200);
+        assert_eq!(
+            event.status_code, CLIENT_CLOSED_REQUEST,
+            "an abandoned stream must be recorded as a client cancel, not as a success"
+        );
         assert!(!event.guardrail_blocked);
+    }
+
+    /// The counterpart to the test above: a stream the consumer reads to
+    /// completion must stay `200`. Without this, the `reached_end` flag
+    /// could be wired to something that is never set and every streamed
+    /// request would silently be reported as abandoned.
+    #[tokio::test]
+    async fn streaming_chat_telemetry_reports_200_when_fully_consumed() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"cmpl-full\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-full\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"cmpl-full\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
+        let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "my-gpt4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = run(app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Drain to the end, the way a client that wants the whole answer does.
+        let mut body_stream = resp.into_body().into_data_stream();
+        while body_stream.next().await.is_some() {}
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("usage event was never emitted")
+            .expect("sender dropped without sending");
+        assert_eq!(
+            event.status_code, 200,
+            "a fully consumed stream must not be reported as a client cancel"
+        );
     }
 
     const CANCEL_METRIC: &str = "aisix_proxy_client_cancelled_requests_total";

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1361,7 +1361,15 @@ async fn anthropic_passthrough_dispatch(
                     team_id_c.as_deref(),
                     user_id_c.as_deref(),
                     user_name_c.as_deref(),
-                    200,
+                    // A stream the consumer abandoned mid-flight is reported
+                    // as 499, matching LiteLLM. The upstream work still
+                    // happened, so the event is emitted either way — only
+                    // its outcome differs.
+                    if usage.reached_end {
+                        200
+                    } else {
+                        crate::CLIENT_CLOSED_REQUEST
+                    },
                     // Attempt-scoped, unlike the e2e histogram above: any
                     // failed attempt before this one emitted its own event.
                     attempt_started.elapsed(),
@@ -1998,7 +2006,13 @@ async fn cross_provider_dispatch(
                     team_id_for_telem.as_deref(),
                     user_id_for_telem.as_deref(),
                     user_name_for_telem.as_deref(),
-                    200,
+                    // See the sibling passthrough path: an abandoned stream
+                    // is reported as 499, matching LiteLLM.
+                    if comp.reached_end {
+                        200
+                    } else {
+                        crate::CLIENT_CLOSED_REQUEST
+                    },
                     // Attempt-scoped — see the sibling passthrough path.
                     attempt_started_for_telem.elapsed(),
                     metrics,
@@ -2353,6 +2367,10 @@ fn build_anthropic_sse_stream(
                 }
             }
         }
+        // Upstream stream over — the response was received in full. Record
+        // it before the scan below, which awaits a remote provider and is a
+        // routine drop point for clients that close on the terminal event.
+        guard.comp().reached_end = true;
         // End-of-stream output guardrail (#448): scan the accumulated
         // assistant text and, on a block, emit a terminal Anthropic
         // `error` event instead of completing the stream cleanly.
@@ -2511,6 +2529,11 @@ fn finish_reason_label(reason: &aisix_gateway::FinishReason) -> String {
 
 #[derive(Default)]
 struct AnthropicStreamCompletion {
+    /// `true` once the upstream stream reached its end, i.e. the response
+    /// was received in full. Stays `false` when the consumer went away
+    /// first — the generator is dropped at a suspension point and the tail
+    /// never runs — which the telemetry closure reports as `499`.
+    reached_end: bool,
     prompt_tokens: u32,
     completion_tokens: u32,
     cache_creation_tokens: u32,
@@ -2862,6 +2885,11 @@ pub(crate) const MAX_SSE_FRAME_BUF_BYTES: usize = 1 << 20; // 1 MiB
 /// corresponding frame.
 #[derive(Default)]
 struct AnthropicStreamUsage {
+    /// `true` once the upstream stream reached its end, i.e. the response
+    /// was forwarded in full. Stays `false` when the consumer went away
+    /// first — the generator is dropped at a suspension point and the tail
+    /// never runs — which the telemetry closure reports as `499`.
+    reached_end: bool,
     prompt_tokens: u32,
     completion_tokens: u32,
     cache_creation_tokens: u32,
@@ -3327,6 +3355,10 @@ where
                 return;
             }
         }
+        // Upstream stream over — the response was forwarded in full. Record
+        // it before the scan below, which awaits a remote provider and is a
+        // routine drop point for clients that close on the terminal event.
+        guard.usage().reached_end = true;
         // End-of-stream output guardrail (#448): scan the accumulated
         // assistant text. On a block, emit a terminal Anthropic `error`
         // event. On the hold-back path (BufferFull) nothing has been

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -114,6 +114,15 @@ impl From<ProxyError> for ResponsesDispatchError {
 /// the ones below.
 #[derive(Default, Clone)]
 struct ResponseUsage {
+    /// `true` once the upstream stream reached EOF, i.e. the response was
+    /// delivered in full. Stays `false` when the consumer went away first,
+    /// which is what the telemetry closure turns into `499`.
+    ///
+    /// Set at upstream EOF rather than after the end-of-stream guardrail
+    /// scan: SDK clients routinely close right after the terminal frame and
+    /// drop this generator at that await, and such a request was delivered
+    /// in full — marking it later would report it as abandoned.
+    reached_end: bool,
     prompt_tokens: u32,
     completion_tokens: u32,
     /// True when any token counter was filled by the local estimator
@@ -1457,7 +1466,15 @@ async fn responses_to_target(
                     &requested_model_c,
                     &api_key_id_c,
                     &provider_key_id_c,
-                    200,
+                    // A stream the consumer abandoned mid-flight is reported
+                    // as 499, matching LiteLLM. The upstream work still
+                    // happened, so the event is emitted either way — only
+                    // its outcome differs.
+                    if usage.reached_end {
+                        200
+                    } else {
+                        crate::CLIENT_CLOSED_REQUEST
+                    },
                     // Attempt-scoped, unlike the e2e histogram above: any
                     // failed attempt before this one emitted its own event.
                     attempt_started.elapsed(),
@@ -1875,6 +1892,7 @@ async fn responses_cross_provider_to_target(
                 // in-flight.
                 drop(in_flight);
                 let usage = ResponseUsage {
+                    reached_end: comp.reached_end,
                     prompt_tokens: comp.prompt_tokens,
                     completion_tokens: comp.completion_tokens,
                     reasoning_tokens: comp.reasoning_tokens,
@@ -1986,6 +2004,9 @@ async fn responses_cross_provider_to_target(
 
     let usage = {
         let mut u = ResponseUsage {
+            // Non-streaming: the response was received in full or this code
+            // would not run.
+            reached_end: true,
             prompt_tokens: resp.usage.prompt_tokens,
             completion_tokens: resp.usage.completion_tokens,
             reasoning_tokens: resp.usage.reasoning_tokens,
@@ -2157,6 +2178,9 @@ fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
         .and_then(|v| v.as_u64())
         .unwrap_or(0) as u32;
     Some(ResponseUsage {
+        // Parsed from a fully buffered response body, so by definition the
+        // response was delivered in full.
+        reached_end: true,
         prompt_tokens,
         completion_tokens,
         usage_estimated: false,
@@ -2540,6 +2564,13 @@ where
                 }
             }
             yield item;
+        }
+        // Upstream EOF — the response was delivered in full. Record that
+        // before the scan below, which awaits a remote provider and is a
+        // routine drop point for clients that close on the terminal frame.
+        {
+            let (usage_acc, _) = guard.parts();
+            usage_acc.get_or_insert_with(Default::default).reached_end = true;
         }
         // Clean end-of-stream: run the monitor observation (needs async, so
         // it can't live in the Drop guard), then complete explicitly. The

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -884,6 +884,11 @@ impl ResponsesSseEncoder {
 /// End-of-stream telemetry captured by [`build_responses_bridge_stream`].
 #[derive(Default, Debug)]
 pub struct ResponsesStreamCompletion {
+    /// `true` once the upstream stream reached EOF, i.e. the response was
+    /// received in full. Stays `false` when the consumer went away first —
+    /// the generator is then dropped at a suspension point and the tail
+    /// never runs — which the telemetry closure reports as `499`.
+    pub reached_end: bool,
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub reasoning_tokens: u32,
@@ -1139,6 +1144,11 @@ pub fn build_responses_bridge_stream(
                 }
             }
         }
+
+        // Upstream EOF — the response was received in full. Record it before
+        // the guardrail work below, which awaits a remote provider and is a
+        // routine drop point for clients that close on the terminal frame.
+        guard.comp().reached_end = true;
 
         // No output-hook guardrail: nothing to scan.
         let Some(chain) = output_guardrail.as_ref() else { return; };


### PR DESCRIPTION
## Problem

A caller that gives up on a request left the gateway reporting it two different ways depending on *when* it went away, and one of those ways was nothing at all.

**Before the response head** — axum drops the handler future, so none of the per-endpoint tail code runs (29 `emit_access_log` call sites across 12 modules). The request was absent from the access log, the usage events *and* the metrics simultaneously. That made "the client says it sent N requests but the gateway logged M" unaccountable, and it hid exactly the case operators care about: a caller giving up during a long time-to-first-token.

**Mid-stream** — the per-stream `Drop` guard did emit a usage event, but marked it `200`, claiming a delivery that never finished.

## What changed

Both are now recorded as `499`, nginx's client-closed-request convention. LiteLLM reports the same event the same way (`ClientDisconnected`), so an operator running both products reads one number.

**Head-phase cancel** — a cancelled future is only observable from `Drop`, so one layer arms a guard, disarms it when the inner service yields a response, and emits from `Drop` when it is still armed:

- an access-log line with `status=499` and `error_kind="client_disconnected"`
- a new counter `aisix_proxy_client_cancelled_requests_total{endpoint}`

Doing it in a single layer rather than at 29 call sites also keeps the endpoint family from drifting the way the request-id header did before `ensure_request_id`. It sits outside `record_in_flight_request` so a hang-up during body upload is captured too, and inside `ensure_request_id` so the line carries the request id the caller was handed.

A **panicking** handler drops the guard mid-unwind with `armed` still set, which is indistinguishable from a cancel at the `Drop` site. Guarded with `std::thread::panicking()`: recording it would invent a disconnect that never happened and bury the panic under a benign 499, and emitting from a `Drop` during an unwind risks a double panic. A panic already has its own signal.

**Mid-stream abandon** — each streaming path carries `reached_end` on its completion payload, set when the upstream stream ends and read by the telemetry closure to pick 200 or 499. All five guards are covered so the family cannot drift: chat's `CompleteOnDrop`, both Anthropic guards, `ResponsesUsageGuard`, and the cross-provider `CompleteOnDrop`.

The marker is set at upstream EOF rather than after the end-of-stream guardrail scan, and on the chat path before the final `[DONE]` yield. `async_stream::stream!` resumes the body only when the consumer pulls again, and SDK clients routinely stop reading at the terminal frame — marking later would report those perfectly normal requests as abandoned. Non-streaming constructions of `ResponseUsage` set it `true`: reaching that code means the response was received in full.

## Behaviour change

- New access-log line and new metric family where there was previously nothing. Nothing is sent to the client — it has already hung up; 499 is a recorded outcome, not a transmitted status.
- **A mid-stream abandon now reports `499` instead of `200`.** The event is still emitted either way — the upstream work happened and may have been billed — only the outcome differs. Dashboards that count streamed successes by `status_code == 200` will see these move out of the success bucket, which is the point.

## Tests

- `client_cancel_before_response_head_is_recorded` — counter and `endpoint` label exist after a cancel. Verified to fail when the layer is unmounted.
- `cancel_guard_stays_silent_during_unwind` — a panicking handler is not miscounted. Verified to fail when the `panicking()` check is removed.
- `completed_request_is_not_counted_as_client_cancel` / `mid_stream_disconnect_is_not_counted_as_head_phase_cancel` — no false positives, no double counting.
- `streaming_chat_telemetry_fires_on_client_disconnect` now pins 499; a new `streaming_chat_telemetry_reports_200_when_fully_consumed` pins the other direction. Verified to fail when the marker is removed — without it every streamed request would silently be reported as abandoned.

768 tests pass.

## Follow-up

A usage event for a *head-phase* cancel is not emitted yet. The agreed rule is to emit one when the request already reached the upstream (it may have incurred cost there) and to rely on the access log otherwise. That needs the dispatch context threaded to the guard and is left to its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability for requests cancelled by clients before a response begins.
  * Added endpoint-level metrics for client-cancelled requests.
  * Cancelled requests now appear with a dedicated cancellation status and error classification.

* **Bug Fixes**
  * Streaming usage telemetry now distinguishes fully completed responses from client-abandoned streams.
  * Completed requests and mid-response disconnects are no longer incorrectly classified as early cancellations.
  * Cancellation metrics are suppressed during panic unwinding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->