### PR TITLE
feat(tls): configurable trust for every outbound connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,16 +139,25 @@ version = "0.3.0"
 dependencies = [
  "aisix-core",
  "async-trait",
+ "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
  "bytes",
  "dashmap",
  "futures",
  "http 1.4.0",
+ "rcgen",
  "reqwest 0.12.28",
+ "rustls 0.23.38",
+ "rustls-native-certs 0.8.3",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -902,7 +911,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.38",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1233,7 +1242,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "rustls 0.23.38",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -1489,6 +1498,16 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2414,7 +2433,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.38",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -3209,6 +3228,12 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -3721,12 +3746,18 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
+ "rustls 0.23.38",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "ryu",
  "sha1_smol",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3849,7 +3880,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.38",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4021,14 +4052,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -4056,16 +4100,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls 0.23.38",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.12",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4210,12 +4254,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,24 @@ aliyun-log-sdk-protobuf = "0.1"
 aliyun-log-sdk-sign = "0.2"
 lz4_flex = "0.11"
 
-# HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "gzip", "multipart"] }
+# HTTP client.
+#
+# `rustls-tls-native-roots` is load-bearing and must stay declared here:
+# it is what makes `SSL_CERT_FILE` / `SSL_CERT_DIR` work at all, and what
+# makes the platform trust store additive to the compiled-in Mozilla set.
+# It used to arrive only by feature unification from `object_store`'s
+# `aws` feature, so dropping the log-export sink would have silently
+# stopped the gateway trusting anything the operating system trusts
+# (api7/aisix#860).
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "rustls-tls-native-roots", "gzip", "multipart"] }
 
-# TLS
+# TLS. The root-store crates are direct dependencies because the
+# outbound paths that are not reqwest — the Realtime WebSocket — have to
+# assemble the same trust store by hand (aisix-gateway::upstream_tls).
 rustls = "0.23"
+rustls-native-certs = "0.8"
+rustls-pemfile = "2"
+webpki-roots = "0.26"
 
 # Serialization / validation
 serde = { version = "1", features = ["derive"] }
@@ -118,7 +131,13 @@ hex = "0.4"
 
 # Caching / storage backends
 moka = { version = "0.12", features = ["future"] }
-redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "cluster-async", "sentinel"] }
+# The TLS features are what make a `rediss://` URL connect at all: without
+# them redis-rs rejects the scheme at parse time with "can't connect with
+# TLS, the feature is not enabled", so every TLS Redis deployment failed at
+# boot (api7/aisix#860). `webpki-roots` gives the same built-in root set the
+# HTTP clients trust, and `insecure` is what `redis.tls.verify: false`
+# lowers to.
+redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager", "cluster-async", "sentinel", "tls-rustls-webpki-roots", "tls-rustls-insecure"] }
 
 # Object-storage observability sink (aisix-obs): ONE crate covering S3 / GCS /
 # Azure Blob (+ S3-compatible MinIO/R2) behind a single `ObjectStore` trait, so
@@ -139,6 +158,11 @@ aws-credential-types = "1"
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 aws-smithy-runtime-api = "1"
 aws-smithy-types = "1"
+# Lets the Bedrock clients be built on an HTTP stack that carries
+# `upstream.tls.ca_file`, instead of the SDK's own default trust store
+# (api7/aisix#860). aws-lc matches the process-wide rustls provider
+# installed in main().
+aws-smithy-http-client = { version = "1", default-features = false, features = ["rustls-aws-lc"] }
 
 # Test-only
 wiremock = "0.6"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,8 +119,9 @@ cache:
   # `redis` block below (validated at boot).
   backend: "memory"   # memory | redis
   # redis:
-  #   # mode picks the topology. Credentials and TLS (rediss://) travel
-  #   # inside the URLs, as in single mode.
+  #   # mode picks the topology. Credentials travel inside the URLs, as
+  #   # in single mode; a `rediss://` URL turns TLS on and the `tls` block
+  #   # below configures what it trusts.
   #   mode: "single"   # single | cluster | sentinel
   #   # mode: single  → one endpoint:
   #   url: "redis://127.0.0.1:6379"
@@ -136,6 +137,19 @@ cache:
   #   # username: "default"      # Redis ACL user (cluster nodes / sentinel master)
   #   # password: "s3cret"
   #   # database: 0              # DB index for the sentinel master (not used by cluster)
+  #   # Trust settings for a `rediss://` URL, ignored on plaintext
+  #   # `redis://`. Separate from `upstream.tls` because an in-cluster
+  #   # Redis is normally issued by a different authority than the model
+  #   # endpoints. Same fields and same meanings.
+  #   # tls:
+  #   #   ca_file: "/etc/aisix/tls/redis-ca.pem"
+  #   #   client_cert_file: "/etc/aisix/tls/redis-client.crt"
+  #   #   client_key_file:  "/etc/aisix/tls/redis-client.key"
+  #   #   verify: true
+  #   # NOTE: in sentinel mode the client library accepts no custom trust
+  #   # roots for the master it discovers, so ca_file does not apply there
+  #   # (it is logged at startup). Use SSL_CERT_FILE or the system trust
+  #   # store for that one case; `verify` does apply.
 
 # Rate-limit counter backend (api7/AISIX-Cloud#798).
 #
@@ -155,6 +169,7 @@ ratelimit:
   #   # nodes: ["redis://10.0.0.1:6379"]        # mode: cluster
   #   # sentinels: ["redis://10.0.0.1:26379"]   # mode: sentinel
   #   # master_name: "mymaster"                  # mode: sentinel
+  #   # tls: { ca_file: "/etc/aisix/tls/redis-ca.pem" }   # for rediss://
   # Seconds before an unreleased concurrency slot (crashed replica /
   # hung upstream) is reclaimed. Redis backend only.
   # concurrency_ttl_secs: 300
@@ -214,6 +229,38 @@ upstream:
   # the provider's own edge performs, so raising this multiplies the load a
   # struggling upstream sees.
   # retries: 2
+
+  # Trust settings for the TLS handshake with every upstream: the provider
+  # bridges, guardrail services, MCP and A2A upstreams, OIDC/JWKS fetches,
+  # the Realtime WebSocket, Bedrock, and the log-export object stores.
+  #
+  # Unset, the trust store is the platform's — the built-in root set plus
+  # whatever SSL_CERT_FILE / SSL_CERT_DIR point at. Those environment
+  # variables keep working and stay additive; ca_file is the same idea
+  # expressed in config instead of in the process environment.
+  # tls:
+  #   # PEM file of one or more certificates to trust as issuers, for an
+  #   # upstream whose certificate is signed by a private or enterprise CA.
+  #   # ADDITIVE: public providers stay reachable. A full chain in one
+  #   # bundle works — every certificate in the file is loaded.
+  #   ca_file: "/etc/aisix/tls/private-ca.pem"
+  #
+  #   # Client certificate for upstreams that require mutual TLS. Both
+  #   # fields are required together.
+  #   # client_cert_file: "/etc/aisix/tls/client.crt"
+  #   # client_key_file:  "/etc/aisix/tls/client.key"
+  #
+  #   # false accepts ANY certificate — expired, issued for another host,
+  #   # or presented by an interceptor — which removes the only thing
+  #   # stopping a machine-in-the-middle from reading and rewriting every
+  #   # prompt, response, and upstream API key on the connection. For a
+  #   # test environment where the alternative is not running at all;
+  #   # prefer ca_file everywhere else.
+  #   #
+  #   # Two paths cannot honour it and log so at startup: Bedrock (the AWS
+  #   # SDK's HTTP stack cannot disable verification, and cannot present a
+  #   # client certificate either), and Redis in sentinel mode.
+  #   # verify: true
 
 # Connection-layer settings for the inbound side — the clients, or the
 # gateway in front of this one, talking to the listeners above. The

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -117,6 +117,15 @@ upstream:
   # tcp_keepalive_retries: 5
   pool_idle_timeout_secs: 30
   # pool_max_idle_per_host: 32
+  # Trust settings for every upstream TLS handshake — model endpoints,
+  # guardrail services, MCP / A2A upstreams, OIDC discovery, Realtime,
+  # Bedrock, log-export object stores. `ca_file` is additive to the
+  # platform trust store, so trusting a private CA leaves the public
+  # providers reachable. See config.example.yaml for the full block.
+  # tls:
+  #   ca_file: "/etc/aisix/tls/private-ca.pem"
+  #   # client_cert_file / client_key_file for mutual TLS
+  #   # verify: true   # false accepts ANY certificate — test use only
 
 # Connection-layer settings for the inbound side. `idle_timeout_secs: 0`
 # (the default) never closes an idle client connection, leaving that to

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -699,6 +699,14 @@ pub struct RedisConnConfig {
     /// Database index for the Sentinel-discovered master (default 0).
     /// Not applicable to `cluster` (Redis Cluster only has DB 0).
     pub database: Option<i64>,
+    /// Trust settings for a `rediss://` connection. Independent of
+    /// `upstream.tls` because the cache/rate-limit backend sits inside
+    /// the deployment and is usually issued by a different authority
+    /// than the model endpoints.
+    ///
+    /// Only consulted for `rediss://` URLs; a plaintext `redis://`
+    /// connection never negotiates TLS regardless of what is set here.
+    pub tls: OutboundTlsConfig,
 }
 
 impl RedisConnConfig {
@@ -731,6 +739,19 @@ impl RedisConnConfig {
                     ));
                 }
             }
+        }
+        match (&self.tls.client_cert_file, &self.tls.client_key_file) {
+            (Some(_), None) => {
+                return Err(format!(
+                    "{ctx}.tls.client_cert_file requires {ctx}.tls.client_key_file"
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(format!(
+                    "{ctx}.tls.client_key_file requires {ctx}.tls.client_cert_file"
+                ));
+            }
+            _ => {}
         }
         Ok(())
     }
@@ -789,7 +810,7 @@ pub enum RateLimitBackend {
 /// here, and the request fails with an opaque transport error.
 ///
 /// Every duration accepts `0` to disable that individual knob.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct UpstreamConfig {
     /// Deployment-wide default for `Model.timeout`: the end-to-end deadline
@@ -839,6 +860,9 @@ pub struct UpstreamConfig {
     /// each retry re-sends the full request body, and stacks on top of any
     /// retry the provider's own edge performs.
     pub retries: u32,
+    /// Trust settings for the TLS handshake with every upstream peer —
+    /// see [`OutboundTlsConfig`].
+    pub tls: OutboundTlsConfig,
 }
 
 impl Default for UpstreamConfig {
@@ -853,7 +877,78 @@ impl Default for UpstreamConfig {
             pool_idle_timeout_secs: 30,
             pool_max_idle_per_host: None,
             retries: DEFAULT_UPSTREAM_RETRIES,
+            tls: OutboundTlsConfig::default(),
         }
+    }
+}
+
+/// Trust settings for a class of TLS connections the gateway *opens*.
+///
+/// Used twice, because the two peer classes are issued certificates by
+/// different authorities and must be configurable apart: `upstream.tls`
+/// covers everything the gateway calls out to on a request path — the
+/// provider bridges, guardrail services, MCP and A2A upstreams, the
+/// OIDC/JWKS fetches, the Realtime WebSocket, Bedrock, and the
+/// log-export object stores — while a `redis.tls` block covers the
+/// shared cache / rate-limit backend.
+///
+/// Scope note: this is the connection the gateway makes as a *client*.
+/// The certificate the gateway *presents* on its own listeners is
+/// `proxy.tls` / `admin.tls`, and the etcd channel keeps its own
+/// [`EtcdTlsConfig`] because it is a control-plane link whose bundle is
+/// issued by the control plane rather than configured by the operator.
+///
+/// Without any of this set, the trust store is the platform's: the
+/// built-in root set plus whatever `SSL_CERT_FILE` / `SSL_CERT_DIR`
+/// point at. Those environment variables keep working and stay
+/// additive, but they are process-wide and cannot be expressed per
+/// peer class, which is what `ca_file` is for.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct OutboundTlsConfig {
+    /// Path to a PEM file holding one or more certificates to trust as
+    /// issuers, for upstreams whose certificate is signed by a private
+    /// or enterprise CA.
+    ///
+    /// **Additive**: these are trusted *in addition to* the built-in
+    /// roots, so adding a private CA never stops a public provider from
+    /// being reachable. Every certificate in the file is loaded, so a
+    /// full chain in one bundle works.
+    pub ca_file: Option<String>,
+    /// Path to a PEM client certificate presented to upstreams that
+    /// require mutual TLS. Must be set together with `client_key_file`.
+    pub client_cert_file: Option<String>,
+    /// Path to the PEM private key for `client_cert_file`.
+    pub client_key_file: Option<String>,
+    /// Whether the upstream's certificate is verified at all.
+    ///
+    /// Setting this to `false` accepts any certificate, including an
+    /// expired one, one issued for a different host, and one presented
+    /// by an interceptor — which removes the only protection against a
+    /// machine-in-the-middle reading and rewriting every prompt,
+    /// response, and upstream API key that crosses the connection.
+    /// Intended for a test environment where the alternative is not
+    /// running at all; prefer `ca_file` everywhere else.
+    pub verify: bool,
+}
+
+impl Default for OutboundTlsConfig {
+    fn default() -> Self {
+        Self {
+            ca_file: None,
+            client_cert_file: None,
+            client_key_file: None,
+            verify: true,
+        }
+    }
+}
+
+impl OutboundTlsConfig {
+    /// Whether anything here departs from the platform default trust
+    /// behaviour. Used to keep the "no TLS config" path building exactly
+    /// the client it built before this block existed.
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
     }
 }
 
@@ -1058,6 +1153,25 @@ impl Config {
             redis
                 .validate("cache.redis")
                 .map_err(BootstrapError::Config)?;
+        }
+        // A half-configured client identity would otherwise be silently
+        // dropped and surface much later as an upstream 4xx from a peer
+        // that wanted mutual TLS.
+        match (
+            &self.upstream.tls.client_cert_file,
+            &self.upstream.tls.client_key_file,
+        ) {
+            (Some(_), None) => {
+                return Err(BootstrapError::Config(
+                    "upstream.tls.client_cert_file requires upstream.tls.client_key_file".into(),
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(BootstrapError::Config(
+                    "upstream.tls.client_key_file requires upstream.tls.client_cert_file".into(),
+                ));
+            }
+            _ => {}
         }
         Ok(())
     }

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -1853,6 +1853,112 @@ observability:
         assert_eq!(cfg.observability.metrics.prometheus.addr, "0.0.0.0:9090");
     }
 
+    /// The block the issue reports as missing. `AISIX_UPSTREAM_SSL_VERIFY`
+    /// used to be rejected at boot with "unknown field", and the error
+    /// listed every section *except* a place to put a CA.
+    #[test]
+    fn loads_the_upstream_tls_block() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+upstream:
+  tls:
+    ca_file: "/etc/aisix/tls/private-ca.pem"
+    client_cert_file: "/etc/aisix/tls/client.crt"
+    client_key_file: "/etc/aisix/tls/client.key"
+    verify: false
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(
+            cfg.upstream.tls.ca_file.as_deref(),
+            Some("/etc/aisix/tls/private-ca.pem")
+        );
+        assert!(!cfg.upstream.tls.verify);
+    }
+
+    /// Verification must stay on for a deployment that never mentions
+    /// TLS — the block is `#[serde(default)]`, and a derived `Default`
+    /// would have made `verify` false.
+    #[test]
+    fn omitting_the_tls_block_keeps_verification_on() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert!(cfg.upstream.tls.verify);
+        assert!(cfg.upstream.tls.is_default());
+    }
+
+    /// Half an identity is silently dropped by every TLS stack and then
+    /// surfaces much later as a 4xx from a peer that wanted mutual TLS.
+    #[test]
+    fn a_client_certificate_without_its_key_is_rejected_at_boot() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+upstream:
+  tls:
+    client_cert_file: "/etc/aisix/tls/client.crt"
+"#,
+        );
+        let err = Config::load_from_path(Some(f.path()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("client_key_file"), "{err}");
+    }
+
+    #[test]
+    fn redis_carries_its_own_tls_block() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+ratelimit:
+  backend: redis
+  redis:
+    mode: single
+    url: "rediss://redis.internal:6379"
+    tls:
+      ca_file: "/etc/aisix/tls/redis-ca.pem"
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        let redis = cfg.ratelimit.redis.as_ref().unwrap();
+        assert_eq!(
+            redis.tls.ca_file.as_deref(),
+            Some("/etc/aisix/tls/redis-ca.pem")
+        );
+        // Independent of the upstream block: the two peers are issued by
+        // different authorities in every real deployment.
+        assert!(cfg.upstream.tls.is_default());
+    }
+
     #[test]
     fn rejects_unknown_fields() {
         let f = write_yaml(

--- a/crates/aisix-gateway/Cargo.toml
+++ b/crates/aisix-gateway/Cargo.toml
@@ -21,6 +21,26 @@ sha2.workspace = true
 thiserror.workspace = true
 http.workspace = true
 dashmap.workspace = true
+tracing.workspace = true
+# Outbound TLS trust (upstream_tls): the non-reqwest outbound stacks need
+# the root store assembled directly, so the rustls side is a direct dep.
+rustls.workspace = true
+rustls-native-certs.workspace = true
+rustls-pemfile.workspace = true
+webpki-roots.workspace = true
+# Only for the Bedrock HTTP stack, behind the `aws` feature so a build
+# that excludes Bedrock does not pull the AWS crates in through here.
+aws-smithy-http-client = { workspace = true, optional = true }
+aws-smithy-runtime-api = { workspace = true, optional = true }
+
+[features]
+default = []
+# Enables `upstream_tls::aws_http_client`, so Bedrock clients share the
+# deployment's outbound trust roots. Turned on by the crates that build
+# AWS SDK clients (aisix-provider-bedrock, aisix-guardrails/bedrock).
+aws = ["dep:aws-smithy-http-client", "dep:aws-smithy-runtime-api"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+rcgen.workspace = true
+tempfile.workspace = true

--- a/crates/aisix-gateway/src/lib.rs
+++ b/crates/aisix-gateway/src/lib.rs
@@ -30,6 +30,7 @@ pub mod hub;
 pub mod sse;
 pub mod upstream_headers;
 pub mod upstream_http;
+pub mod upstream_tls;
 
 pub use bridge::{
     capture_upstream_error_http, content_type_is_json, parse_retry_after, read_body_capped,
@@ -50,3 +51,4 @@ pub use upstream_headers::{
 pub use upstream_http::{
     client_builder, error_with_causes, transport_error_message, UpstreamHttpConfig,
 };
+pub use upstream_tls::TlsSettings;

--- a/crates/aisix-gateway/src/upstream_http.rs
+++ b/crates/aisix-gateway/src/upstream_http.rs
@@ -18,6 +18,8 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use crate::upstream_tls::TlsSettings;
+
 /// Suffixes marking a query parameter whose value is a credential and must
 /// be redacted out of logged URLs. Vertex/Gemini accept `?key=` and
 /// `?access_token=`, and an operator can put either directly in a
@@ -85,6 +87,11 @@ pub struct UpstreamHttpConfig {
     /// Cap on idle connections kept per upstream host. `None` leaves
     /// reqwest's default (unbounded).
     pub pool_max_idle_per_host: Option<usize>,
+    /// Trust material for the TLS handshake — see [`TlsSettings`]. Lives
+    /// here rather than beside each client so the private-CA / mTLS /
+    /// verification decision is made once and reaches every outbound
+    /// stack, not just the ones someone remembered to wire.
+    pub tls: TlsSettings,
 }
 
 impl Default for UpstreamHttpConfig {
@@ -96,6 +103,7 @@ impl Default for UpstreamHttpConfig {
             tcp_keepalive_retries: Some(5),
             pool_idle_timeout: Some(Duration::from_secs(30)),
             pool_max_idle_per_host: None,
+            tls: TlsSettings::default(),
         }
     }
 }
@@ -106,8 +114,14 @@ static CONFIG: OnceLock<UpstreamHttpConfig> = OnceLock::new();
 /// during boot, before any bridge builds its client. Later calls are
 /// ignored — the pools are already built, so a second set would silently
 /// not apply.
-pub fn init(cfg: UpstreamHttpConfig) {
+///
+/// Fails when the configured TLS material does not parse, which is the
+/// point at which a wrong `upstream.tls.ca_file` should stop the boot
+/// rather than become a transport error on the first upstream call.
+pub fn init(cfg: UpstreamHttpConfig) -> Result<(), String> {
+    crate::upstream_tls::init_reqwest_material(&cfg.tls)?;
     let _ = CONFIG.set(cfg);
+    Ok(())
 }
 
 /// The active settings, defaulting when [`init`] was never called (tests,
@@ -116,8 +130,9 @@ pub fn config() -> &'static UpstreamHttpConfig {
     CONFIG.get_or_init(UpstreamHttpConfig::default)
 }
 
-/// A `reqwest::ClientBuilder` with the connection settings applied. Callers
-/// add their own `user_agent` / TLS options and `build()`.
+/// A `reqwest::ClientBuilder` with the connection settings **and the
+/// deployment's outbound TLS trust** applied. Callers add their own
+/// `user_agent` and `build()`.
 pub fn client_builder() -> reqwest::ClientBuilder {
     let cfg = config();
     let mut b = reqwest::Client::builder()
@@ -134,6 +149,26 @@ pub fn client_builder() -> reqwest::ClientBuilder {
     }
     if let Some(n) = cfg.pool_max_idle_per_host {
         b = b.pool_max_idle_per_host(n);
+    }
+    apply_tls(b, &cfg.tls)
+}
+
+/// Layer the outbound trust decision onto a builder. Split out so the
+/// per-ProviderKey clients get byte-for-byte the same treatment as the
+/// shared one.
+pub(crate) fn apply_tls(
+    mut b: reqwest::ClientBuilder,
+    tls: &TlsSettings,
+) -> reqwest::ClientBuilder {
+    let material = crate::upstream_tls::reqwest_material();
+    for root in &material.roots {
+        b = b.add_root_certificate(root.clone());
+    }
+    if let Some(identity) = &material.identity {
+        b = b.identity(identity.clone());
+    }
+    if !tls.verify {
+        b = b.danger_accept_invalid_certs(true);
     }
     b
 }

--- a/crates/aisix-gateway/src/upstream_http.rs
+++ b/crates/aisix-gateway/src/upstream_http.rs
@@ -290,10 +290,7 @@ mod tests {
             let src = std::fs::read_to_string(&file).expect("read source");
             // Tests build throwaway clients on purpose; only the
             // production half of each file is in scope.
-            let production = match src.find("#[cfg(test)]") {
-                Some(i) => &src[..i],
-                None => &src[..],
-            };
+            let production = production_half(&src);
             // `shared_http_client()` in aisix-mcp is the sanctioned
             // counterpart of `client_builder()` for rmcp's own reqwest
             // line (rmcp pins 0.13; it gets the same
@@ -320,6 +317,105 @@ mod tests {
              `aisix_gateway::client_builder()`:\n{}",
             offenders.join("\n"),
         );
+    }
+
+    /// The outbound stacks that are *not* reqwest each have exactly one
+    /// sanctioned construction site, and each of those sites is the only
+    /// thing standing between `upstream.tls` and a client that quietly
+    /// trusts the wrong set of roots.
+    ///
+    /// Nothing else catches a regression here: a client built without the
+    /// shared trust material works perfectly against every public
+    /// provider and fails only against the private CA the setting exists
+    /// for — which is to say, only in the customer's environment.
+    ///
+    /// Each entry is (probe, what the file must also mention, why).
+    #[test]
+    fn every_non_reqwest_outbound_stack_applies_the_shared_tls_settings() {
+        const RULES: &[(&str, &str, &str)] = &[
+            (
+                // Catches a *new* WebSocket call site: `connect_async`
+                // builds its own connector over webpki roots only.
+                "tokio_tungstenite::connect_async(",
+                "rustls_client_config",
+                "the Realtime WebSocket must dial through the shared rustls config \
+                 (`connect_async` builds its own connector over webpki roots only)",
+            ),
+            (
+                // Catches the existing call site being weakened — passing
+                // `Connector::Plain` or `None` still compiles and still
+                // connects, just to a different set of roots.
+                "connect_async_tls_with_config",
+                "rustls_client_config",
+                "the Realtime WebSocket connector must come from \
+                 `upstream_tls::rustls_client_config()`",
+            ),
+            (
+                "aws_config::SdkConfig::builder()",
+                "aws_http_client",
+                "Bedrock SDK clients must be built on `upstream_tls::aws_http_client()`",
+            ),
+            (
+                "AmazonS3Builder::",
+                "tls_client_options",
+                "object-store exporters must pass `tls_client_options()` as client options",
+            ),
+            (
+                "MicrosoftAzureBuilder::",
+                "tls_client_options",
+                "object-store exporters must pass `tls_client_options()` as client options",
+            ),
+            (
+                "GoogleCloudStorageBuilder::",
+                "tls_client_options",
+                "object-store exporters must pass `tls_client_options()` as client options",
+            ),
+        ];
+
+        let crates_dir = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/.."));
+        let mut offenders = Vec::new();
+        for file in rust_sources(crates_dir) {
+            let src = std::fs::read_to_string(&file).expect("read source");
+            let production = production_half(&src);
+            for (probe, required, why) in RULES {
+                if production.contains(probe) && !production.contains(required) {
+                    offenders.push(format!("{}: {}", file.display(), why));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "these reach an external service without the deployment's outbound TLS \
+             trust:\n{}",
+            offenders.join("\n"),
+        );
+    }
+
+    /// The part of a source file that is not the test module.
+    ///
+    /// Cuts at the top-level `#[cfg(test)] mod …` specifically, not at
+    /// the first `#[cfg(test)]` anywhere: that attribute is also used on
+    /// struct fields and match arms, several of which appear near the
+    /// top of a file, and cutting there silently excused everything
+    /// below from every scan in this module.
+    fn production_half(src: &str) -> &str {
+        const MARKER: &str = "\n#[cfg(test)]\nmod ";
+        match src.find(MARKER) {
+            Some(i) => &src[..i],
+            None => src,
+        }
+    }
+
+    /// The scans above are only worth their runtime if they actually see
+    /// the whole file — an early `#[cfg(test)]` field attribute used to
+    /// hide every call site under it.
+    #[test]
+    fn production_half_cuts_at_the_test_module_not_a_field_attribute() {
+        let src = "struct S {\n    #[cfg(test)]\n    probe: bool,\n}\nfn f() {}\n\
+                   #[cfg(test)]\nmod tests {\n    fn t() {}\n}\n";
+        let production = production_half(src);
+        assert!(production.contains("fn f()"), "{production}");
+        assert!(!production.contains("fn t()"), "{production}");
     }
 
     fn rust_sources(dir: &std::path::Path) -> Vec<std::path::PathBuf> {

--- a/crates/aisix-gateway/src/upstream_tls.rs
+++ b/crates/aisix-gateway/src/upstream_tls.rs
@@ -1,0 +1,529 @@
+//! Trust material for every TLS connection the gateway *opens*.
+//!
+//! One module, because the same operator setting has to reach clients
+//! built on four different stacks, and a setting that reaches only some
+//! of them fails silently — the request just keeps working against the
+//! public providers and keeps failing against the private one:
+//!
+//! - the workspace `reqwest` (provider bridges, guardrails, MCP
+//!   OpenAPI/OAuth, A2A, passthrough, JWKS/OIDC discovery, OTLP export)
+//!   via [`reqwest_material`], applied inside
+//!   [`crate::upstream_http::client_builder`];
+//! - rmcp's own `reqwest` line (MCP streamable-http), which is a
+//!   different crate version and so needs the raw PEM, not our parsed
+//!   `reqwest::Certificate`;
+//! - raw rustls (the Realtime WebSocket) via [`rustls_client_config`];
+//! - the AWS SDK (Bedrock) via [`extra_ca_pem`] — see the note on
+//!   [`TlsSettings::verify`] for the one knob that stack cannot express.
+//!
+//! Everything here is *additive to* the platform trust store, which
+//! stays whatever `SSL_CERT_FILE` / `SSL_CERT_DIR` and the system bundle
+//! make it. Trusting a private CA never removes trust in a public one.
+
+use std::sync::{Arc, OnceLock};
+
+use aisix_core::config::OutboundTlsConfig;
+
+/// PEM material and verification policy shared by every outbound client.
+///
+/// Holds PEM *bytes* rather than parsed certificates because the four
+/// consumers above parse into three incompatible types. The bytes are
+/// validated once at load time so a malformed bundle fails the boot
+/// rather than the first request that needs it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsSettings {
+    /// Extra trust roots, PEM-encoded, added to the built-in root set.
+    pub extra_ca_pem: Option<Arc<Vec<u8>>>,
+    /// Client certificate and private key presented to peers that
+    /// require mutual TLS.
+    pub client_identity: Option<Arc<ClientIdentityPem>>,
+    /// Whether the peer's certificate is verified.
+    ///
+    /// `false` accepts any certificate from any peer, which is the
+    /// whole of what TLS was protecting on a link that carries prompts,
+    /// responses, and upstream API keys. Not expressible on the AWS SDK
+    /// stack (Bedrock), whose public configuration surface covers trust
+    /// roots only; [`aws_http_client`] logs that rather than letting the
+    /// setting look applied.
+    pub verify: bool,
+}
+
+impl Default for TlsSettings {
+    fn default() -> Self {
+        Self {
+            extra_ca_pem: None,
+            client_identity: None,
+            verify: true,
+        }
+    }
+}
+
+impl TlsSettings {
+    /// Whether this leaves every client exactly as it was built before
+    /// the `upstream.tls` block existed.
+    pub fn is_default(&self) -> bool {
+        self.extra_ca_pem.is_none() && self.client_identity.is_none() && self.verify
+    }
+
+    /// Read the configured PEM files off disk and validate them.
+    ///
+    /// Reading here rather than at first use means an unreadable or
+    /// malformed bundle stops the boot with the path in the message,
+    /// instead of surfacing later as a generic upstream transport error.
+    ///
+    /// `block` labels the config section in every error, so an operator
+    /// reading the failure knows whether to look at `upstream.tls` or at
+    /// one of the `redis` blocks.
+    pub fn load(block: &str, cfg: &OutboundTlsConfig) -> Result<Self, String> {
+        let extra_ca_pem = match &cfg.ca_file {
+            None => None,
+            Some(path) => {
+                let pem = std::fs::read(path)
+                    .map_err(|e| format!("{block}.ca_file: read {path}: {e}"))?;
+                let count = rustls_pemfile::certs(&mut pem.as_slice())
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| format!("{block}.ca_file: parse {path}: {e}"))?
+                    .len();
+                // An empty-but-readable file is the shape a bad
+                // ConfigMap key or a failed `kubectl cp` leaves behind,
+                // and it would otherwise look like a configured CA.
+                if count == 0 {
+                    return Err(format!(
+                        "{block}.ca_file: {path} contains no CERTIFICATE block"
+                    ));
+                }
+                Some(Arc::new(pem))
+            }
+        };
+
+        let client_identity = match (&cfg.client_cert_file, &cfg.client_key_file) {
+            (Some(cert_path), Some(key_path)) => {
+                let cert = std::fs::read(cert_path)
+                    .map_err(|e| format!("{block}.client_cert_file: read {cert_path}: {e}"))?;
+                let key = std::fs::read(key_path)
+                    .map_err(|e| format!("{block}.client_key_file: read {key_path}: {e}"))?;
+                Some(Arc::new(ClientIdentityPem { key, cert }))
+            }
+            // The mismatched pairs are rejected by `Config::validate`.
+            _ => None,
+        };
+
+        Ok(Self {
+            extra_ca_pem,
+            client_identity,
+            verify: cfg.verify,
+        })
+    }
+}
+
+/// A client certificate and the private key that goes with it, both PEM.
+///
+/// Kept as two halves because the consumers disagree about the shape:
+/// reqwest wants one concatenated blob ([`ClientIdentityPem::joined`]),
+/// redis-rs wants the two fields separately.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientIdentityPem {
+    pub key: Vec<u8>,
+    pub cert: Vec<u8>,
+}
+
+impl ClientIdentityPem {
+    /// Key then certificate in one PEM blob, the form
+    /// `reqwest::Identity::from_pem` expects.
+    ///
+    /// The separator matters: PEM written by a deploy script or dumped
+    /// out of an env var often has no trailing newline, which would glue
+    /// the key's END line onto the certificate's BEGIN line and make the
+    /// whole blob unparseable.
+    pub fn joined(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.key.len() + self.cert.len() + 1);
+        out.extend_from_slice(&self.key);
+        if !self.key.ends_with(b"\n") {
+            out.push(b'\n');
+        }
+        out.extend_from_slice(&self.cert);
+        out
+    }
+}
+
+/// The extra trust roots as raw PEM, for the stacks that parse PEM
+/// themselves (rmcp's reqwest line, the AWS SDK's `TrustStore`).
+pub fn extra_ca_pem() -> Option<Arc<Vec<u8>>> {
+    crate::upstream_http::config().tls.extra_ca_pem.clone()
+}
+
+// ─── reqwest (workspace line) ────────────────────────────────────────
+
+/// Parsed-once reqwest trust material. `reqwest::Certificate` and
+/// `Identity` are both `Clone`, so parsing at boot and cloning per
+/// client keeps PEM parsing off every client construction.
+#[derive(Default)]
+pub struct ReqwestTlsMaterial {
+    pub roots: Vec<reqwest::Certificate>,
+    pub identity: Option<reqwest::Identity>,
+}
+
+static REQWEST_TLS: OnceLock<ReqwestTlsMaterial> = OnceLock::new();
+
+/// Parse `settings` into reqwest's types and install them process-wide.
+/// Called from [`crate::upstream_http::init`] during boot; the error is
+/// what turns a malformed bundle into a failed boot.
+pub(crate) fn init_reqwest_material(settings: &TlsSettings) -> Result<(), String> {
+    let roots = match &settings.extra_ca_pem {
+        Some(pem) => reqwest::Certificate::from_pem_bundle(pem)
+            .map_err(|e| format!("upstream.tls.ca_file: {e}"))?,
+        None => Vec::new(),
+    };
+    let identity = match &settings.client_identity {
+        Some(id) => Some(
+            reqwest::Identity::from_pem(&id.joined())
+                .map_err(|e| format!("upstream.tls.client_cert_file/client_key_file: {e}"))?,
+        ),
+        None => None,
+    };
+    let _ = REQWEST_TLS.set(ReqwestTlsMaterial { roots, identity });
+    Ok(())
+}
+
+/// The installed reqwest trust material, empty when nothing was
+/// configured (or in tests, which never call `init`).
+pub fn reqwest_material() -> &'static ReqwestTlsMaterial {
+    REQWEST_TLS.get_or_init(ReqwestTlsMaterial::default)
+}
+
+// ─── raw rustls (Realtime WebSocket) ─────────────────────────────────
+
+/// A `rustls::ClientConfig` carrying the same trust decision the reqwest
+/// clients get, for the outbound paths that speak rustls directly.
+///
+/// Built once: assembling the root store re-reads the system trust
+/// store, which costs hundreds of milliseconds on some platforms.
+pub fn rustls_client_config() -> Arc<rustls::ClientConfig> {
+    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    CONFIG
+        .get_or_init(|| {
+            Arc::new(build_rustls_client_config(
+                &crate::upstream_http::config().tls,
+            ))
+        })
+        .clone()
+}
+
+fn build_rustls_client_config(tls: &TlsSettings) -> rustls::ClientConfig {
+    // `ClientConfig::builder()` picks the crypto provider implicitly and
+    // **panics** when it cannot: more than one provider is compiled into
+    // the workspace (redis-rs's rustls feature pulls in ring alongside
+    // the aws-lc-rs everything else uses). `main` installs a default
+    // before anything touches TLS, but this module must not depend on
+    // having been reached after that — a panic here would take down a
+    // request path over a configuration detail.
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
+    let builder = rustls::ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()
+        .expect("the crypto provider supports the default protocol versions");
+    let mut config = if tls.verify {
+        builder
+            .with_root_certificates(root_store(tls))
+            .with_no_client_auth()
+    } else {
+        builder
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(danger::AcceptAnyServerCert(provider)))
+            .with_no_client_auth()
+    };
+    // The WebSocket upstream is HTTP/1.1; advertising anything else
+    // would let a peer negotiate a protocol the transport can't speak.
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    config
+}
+
+/// Built-in roots (platform store + the compiled-in Mozilla set, which
+/// is what reqwest trusts) plus whatever `ca_file` added.
+fn root_store(tls: &TlsSettings) -> rustls::RootCertStore {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let native = rustls_native_certs::load_native_certs();
+    if !native.errors.is_empty() {
+        tracing::warn!(errors = ?native.errors, "some native root certificates failed to load");
+    }
+    let (_added, _ignored) = roots.add_parsable_certificates(native.certs);
+    if let Some(pem) = &tls.extra_ca_pem {
+        // Validated in `TlsSettings::load`, so a parse failure here is
+        // not reachable from a booted process.
+        match rustls_pemfile::certs(&mut pem.as_slice()).collect::<Result<Vec<_>, _>>() {
+            Ok(certs) => {
+                let (_added, ignored) = roots.add_parsable_certificates(certs);
+                if ignored > 0 {
+                    tracing::warn!(
+                        ignored,
+                        "upstream.tls.ca_file: some certificates were not usable as trust anchors"
+                    );
+                }
+            }
+            Err(e) => tracing::error!(error = %e, "upstream.tls.ca_file: parse failed"),
+        }
+    }
+    roots
+}
+
+// ─── AWS SDK (Bedrock) ───────────────────────────────────────────────
+
+/// The HTTP client every Bedrock SDK client is built on, carrying the
+/// deployment's extra trust roots.
+///
+/// Built once and shared: the AWS SDK otherwise constructs a connector
+/// per client, and each construction re-reads the platform trust store.
+///
+/// Two of the four `upstream.tls` knobs stop here, because the SDK's
+/// HTTP stack exposes trust roots and nothing else on its stable
+/// surface: a client certificate cannot be presented, and verification
+/// cannot be switched off. Both are announced by
+/// [`warn_unsupported_for_aws`] rather than silently ignored. The
+/// private-CA case this feature exists for — a Bedrock-compatible
+/// endpoint behind an enterprise CA, or an intercepting corporate proxy
+/// — is fully served by `ca_file`.
+#[cfg(feature = "aws")]
+pub fn aws_http_client() -> aws_smithy_runtime_api::client::http::SharedHttpClient {
+    use aws_smithy_http_client::tls;
+    static CLIENT: OnceLock<aws_smithy_runtime_api::client::http::SharedHttpClient> =
+        OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            let tls_cfg = &crate::upstream_http::config().tls;
+            warn_unsupported_for_aws(tls_cfg);
+
+            let mut trust_store = tls::TrustStore::default();
+            if let Some(pem) = &tls_cfg.extra_ca_pem {
+                trust_store = trust_store.with_pem_certificate(pem.as_slice());
+            }
+            let context = tls::TlsContext::builder()
+                .with_trust_store(trust_store)
+                .build()
+                .expect("TLS context from a bundle validated at boot");
+
+            aws_smithy_http_client::Builder::new()
+                .tls_provider(tls::Provider::rustls(
+                    tls::rustls_provider::CryptoMode::AwsLc,
+                ))
+                .tls_context(context)
+                .build_https()
+        })
+        .clone()
+}
+
+/// Say out loud which `upstream.tls` knobs the AWS SDK stack cannot
+/// honour. An operator who set one and then sees a Bedrock TLS failure
+/// should read the reason in the log rather than conclude the setting is
+/// broken.
+#[cfg(feature = "aws")]
+fn warn_unsupported_for_aws(tls: &TlsSettings) {
+    if !tls.verify {
+        tracing::warn!(
+            "upstream.tls.verify=false does not apply to Bedrock: the AWS SDK's HTTP stack \
+             has no way to disable certificate verification, so Bedrock certificates are \
+             still checked. Use upstream.tls.ca_file to trust the endpoint's issuer."
+        );
+    }
+    if tls.client_identity.is_some() {
+        tracing::warn!(
+            "upstream.tls client certificate does not apply to Bedrock: the AWS SDK's HTTP \
+             stack has no way to present one, so Bedrock connections are not mutually \
+             authenticated."
+        );
+    }
+}
+
+mod danger {
+    use std::sync::Arc;
+
+    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
+    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+    use rustls::{DigitallySignedStruct, Error, SignatureScheme};
+
+    /// Accepts every server certificate. Installed only when the
+    /// operator set `upstream.tls.verify: false`.
+    ///
+    /// Signature *validation* is still delegated to the crypto provider:
+    /// the handshake must still be internally consistent, we just stop
+    /// asking who signed the certificate. That keeps the failure mode to
+    /// "we cannot tell who the peer is" rather than "the transport is
+    /// arbitrary".
+    #[derive(Debug)]
+    pub struct AcceptAnyServerCert(pub Arc<CryptoProvider>);
+
+    impl ServerCertVerifier for AcceptAnyServerCert {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp: &[u8],
+            _now: UnixTime,
+        ) -> Result<ServerCertVerified, Error> {
+            Ok(ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            verify_tls12_signature(
+                message,
+                cert,
+                dss,
+                &self.0.signature_verification_algorithms,
+            )
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &self.0.signature_verification_algorithms,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            self.0.signature_verification_algorithms.supported_schemes()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ca_pem() -> Vec<u8> {
+        let mut params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let kp = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+        params.self_signed(&kp).unwrap().pem().into_bytes()
+    }
+
+    #[test]
+    fn default_settings_leave_every_client_untouched() {
+        let settings = TlsSettings::load("upstream.tls", &OutboundTlsConfig::default()).unwrap();
+        assert!(settings.is_default());
+        assert!(settings.verify);
+    }
+
+    #[test]
+    fn ca_file_is_read_and_validated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ca.pem");
+        std::fs::write(&path, ca_pem()).unwrap();
+
+        let settings = TlsSettings::load(
+            "upstream.tls",
+            &OutboundTlsConfig {
+                ca_file: Some(path.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(settings.extra_ca_pem.is_some());
+        assert!(!settings.is_default());
+    }
+
+    /// A readable-but-not-a-certificate file is the shape a mis-keyed
+    /// ConfigMap mount leaves behind. It must fail the boot rather than
+    /// look like a configured CA that silently trusts nothing extra.
+    #[test]
+    fn ca_file_that_holds_no_certificate_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ca.pem");
+        std::fs::write(&path, b"not a certificate\n").unwrap();
+
+        let err = TlsSettings::load(
+            "upstream.tls",
+            &OutboundTlsConfig {
+                ca_file: Some(path.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("no CERTIFICATE block"), "{err}");
+    }
+
+    #[test]
+    fn missing_ca_file_names_the_path() {
+        let err = TlsSettings::load(
+            "upstream.tls",
+            &OutboundTlsConfig {
+                ca_file: Some("/nonexistent/private-ca.pem".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("/nonexistent/private-ca.pem"), "{err}");
+    }
+
+    /// PEM emitted by a deploy script often lacks the trailing newline;
+    /// concatenating naively would fuse the key's END line onto the
+    /// cert's BEGIN line and make the identity unparseable.
+    #[test]
+    fn identity_pem_separates_blocks_without_a_trailing_newline() {
+        let identity = ClientIdentityPem {
+            key: b"-----END PRIVATE KEY-----".to_vec(),
+            cert: b"-----BEGIN CERTIFICATE-----".to_vec(),
+        };
+        assert_eq!(
+            String::from_utf8(identity.joined()).unwrap(),
+            "-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----"
+        );
+    }
+
+    #[test]
+    fn reqwest_material_parses_a_real_ca_bundle() {
+        let settings = TlsSettings {
+            extra_ca_pem: Some(Arc::new(ca_pem())),
+            ..Default::default()
+        };
+        let roots =
+            reqwest::Certificate::from_pem_bundle(settings.extra_ca_pem.as_ref().unwrap()).unwrap();
+        assert_eq!(roots.len(), 1);
+    }
+
+    /// Two certificates in one file is the ordinary shape of an
+    /// enterprise bundle (root + intermediate); loading only the first
+    /// would leave a chain unverifiable.
+    #[test]
+    fn a_multi_certificate_bundle_loads_every_entry() {
+        let mut bundle = ca_pem();
+        bundle.extend_from_slice(&ca_pem());
+        let roots = reqwest::Certificate::from_pem_bundle(&bundle).unwrap();
+        assert_eq!(roots.len(), 2);
+    }
+
+    /// More than one crypto provider is compiled in (redis-rs's rustls
+    /// feature adds ring next to the aws-lc-rs everything else uses), so
+    /// `ClientConfig::builder()` cannot pick one and panics. These two
+    /// deliberately do NOT install a default first: the module has to
+    /// stand on its own, or the Realtime WebSocket path panics whenever
+    /// it is reached before `main` gets to `install_default`.
+    #[test]
+    fn verify_false_builds_a_config_that_accepts_any_certificate() {
+        let cfg = build_rustls_client_config(&TlsSettings {
+            verify: false,
+            ..Default::default()
+        });
+        assert_eq!(cfg.alpn_protocols, vec![b"http/1.1".to_vec()]);
+    }
+
+    #[test]
+    fn verify_true_builds_a_config_over_the_built_in_roots() {
+        let cfg = build_rustls_client_config(&TlsSettings::default());
+        assert_eq!(cfg.alpn_protocols, vec![b"http/1.1".to_vec()]);
+    }
+}

--- a/crates/aisix-guardrails/Cargo.toml
+++ b/crates/aisix-guardrails/Cargo.toml
@@ -59,6 +59,9 @@ bedrock = [
     "dep:aws-credential-types",
     "dep:aws-smithy-async",
     "dep:aws-smithy-runtime-api",
+    # So the guardrail's Bedrock client trusts the same roots the
+    # provider bridge's does.
+    "aisix-gateway/aws",
 ]
 azure-content-safety = ["dep:reqwest"]
 aliyun-text-moderation = [

--- a/crates/aisix-guardrails/src/bedrock.rs
+++ b/crates/aisix-guardrails/src/bedrock.rs
@@ -144,6 +144,9 @@ impl BedrockGuardrail {
             .behavior_version(BehaviorVersion::latest())
             .region(Region::new(cfg.region.clone()))
             .credentials_provider(SharedCredentialsProvider::new(creds))
+            // Same shared HTTP stack as the Bedrock provider bridge, so
+            // `upstream.tls.ca_file` covers the guardrail call too.
+            .http_client(aisix_gateway::upstream_tls::aws_http_client())
             // The retry sleep_impl is needed for the SDK's built-in
             // retries; aws-config's default features set this when
             // the rt-tokio feature is on (see workspace Cargo.toml).

--- a/crates/aisix-mcp/src/bridge.rs
+++ b/crates/aisix-mcp/src/bridge.rs
@@ -53,7 +53,12 @@ pub const DEFAULT_UPSTREAM_TIMEOUT: Duration = Duration::from_secs(30);
 ///   stall rmcp avoids. An operator can restore rmcp's behaviour with
 ///   `upstream.pool_max_idle_per_host: 0`;
 /// - the TCP keepalive triple moves from reqwest's default 15 s/15 s/3
-///   to the deployment's 60 s/30 s/5.
+///   to the deployment's 60 s/30 s/5;
+/// - the deployment's `upstream.tls` trust decision applies here too. An
+///   MCP server behind an enterprise CA is exactly as common as a model
+///   endpoint behind one, and the PEM has to be re-parsed rather than
+///   reused because rmcp's `Certificate` is a different crate version's
+///   type than the one `upstream_tls` caches for the workspace line.
 ///
 /// One client for all MCP upstreams = one shared pool, matching how the
 /// provider bridges share theirs (auth is injected per-request by the
@@ -77,6 +82,35 @@ fn shared_http_client() -> rmcp_reqwest::Client {
             }
             if let Some(n) = cfg.pool_max_idle_per_host {
                 b = b.pool_max_idle_per_host(n);
+            }
+            if let Some(pem) = &cfg.tls.extra_ca_pem {
+                // Already validated at boot by `TlsSettings::load`; a
+                // failure here would mean rmcp's reqwest disagrees with
+                // ours about the same bytes, which is worth a loud line
+                // rather than a silently untrusting client.
+                match rmcp_reqwest::Certificate::from_pem_bundle(pem) {
+                    Ok(roots) => {
+                        for root in roots {
+                            b = b.add_root_certificate(root);
+                        }
+                    }
+                    Err(e) => tracing::error!(
+                        error = %e,
+                        "upstream.tls.ca_file not applied to MCP upstream connections"
+                    ),
+                }
+            }
+            if let Some(configured) = &cfg.tls.client_identity {
+                match rmcp_reqwest::Identity::from_pem(&configured.joined()) {
+                    Ok(identity) => b = b.identity(identity),
+                    Err(e) => tracing::error!(
+                        error = %e,
+                        "upstream.tls client identity not applied to MCP upstream connections"
+                    ),
+                }
+            }
+            if !cfg.tls.verify {
+                b = b.danger_accept_invalid_certs(true);
             }
             b.build().unwrap_or_else(|_| rmcp_reqwest::Client::new())
         })

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -184,6 +184,37 @@ pub enum ObjectStoreCredentials {
     },
 }
 
+/// HTTP client options carrying the deployment's outbound TLS trust, so
+/// an on-prem object store — a MinIO or an internal S3-compatible host
+/// behind an enterprise CA — is reachable on the same `upstream.tls`
+/// setting the provider bridges use.
+///
+/// Applied first in every builder chain: `with_client_options` replaces
+/// the whole options value, so a later `with_allow_http` layers onto
+/// this rather than the other way round.
+fn tls_client_options() -> object_store::ClientOptions {
+    let tls = &aisix_gateway::upstream_http::config().tls;
+    let mut options = object_store::ClientOptions::new();
+    if let Some(pem) = &tls.extra_ca_pem {
+        // Validated at boot by `TlsSettings::load`.
+        match object_store::Certificate::from_pem_bundle(pem) {
+            Ok(roots) => {
+                for root in roots {
+                    options = options.with_root_certificate(root);
+                }
+            }
+            Err(e) => tracing::error!(
+                error = %e,
+                "upstream.tls.ca_file not applied to object-store exports"
+            ),
+        }
+    }
+    if !tls.verify {
+        options = options.with_allow_invalid_certificates(true);
+    }
+    options
+}
+
 /// Build the provider-agnostic [`ObjectStore`] handle for a configured
 /// exporter. **This is the only provider-specific code** — each arm picks the
 /// matching `object_store` builder, which owns that cloud's signing. An
@@ -206,6 +237,7 @@ pub fn build_object_store(
             },
         ) => {
             let mut b = object_store::aws::AmazonS3Builder::new()
+                .with_client_options(tls_client_options())
                 .with_bucket_name(bucket)
                 .with_access_key_id(access_key_id)
                 .with_secret_access_key(secret_access_key);
@@ -241,6 +273,7 @@ pub fn build_object_store(
             // the service-account JSON's `gcs_base_url` field instead, so the
             // `endpoint` config is intentionally not applied for GCS.
             let b = object_store::gcp::GoogleCloudStorageBuilder::new()
+                .with_client_options(tls_client_options())
                 .with_bucket_name(bucket)
                 .with_service_account_key(service_account_key);
             let store = b
@@ -256,6 +289,7 @@ pub fn build_object_store(
             },
         ) => {
             let mut b = object_store::azure::MicrosoftAzureBuilder::new()
+                .with_client_options(tls_client_options())
                 .with_container_name(bucket)
                 .with_account(account)
                 .with_access_key(access_key);
@@ -310,7 +344,9 @@ pub fn build_object_store_ambient(
                         .to_string(),
                 ));
             }
-            let mut b = object_store::aws::AmazonS3Builder::from_env().with_bucket_name(bucket);
+            let mut b = object_store::aws::AmazonS3Builder::from_env()
+                .with_client_options(tls_client_options())
+                .with_bucket_name(bucket);
             if let Some(r) = region {
                 b = b.with_region(r);
             }
@@ -323,6 +359,7 @@ pub fn build_object_store_ambient(
             // No service-account key set → `object_store` sources Application
             // Default Credentials (GKE Workload Identity / GCE metadata).
             let store = object_store::gcp::GoogleCloudStorageBuilder::new()
+                .with_client_options(tls_client_options())
                 .with_bucket_name(bucket)
                 .build()
                 .map_err(|e| {

--- a/crates/aisix-provider-bedrock/Cargo.toml
+++ b/crates/aisix-provider-bedrock/Cargo.toml
@@ -10,7 +10,7 @@ description = "aisix: AWS Bedrock runtime provider bridge (skeleton — multi-pu
 
 [dependencies]
 aisix-core = { path = "../aisix-core" }
-aisix-gateway = { path = "../aisix-gateway" }
+aisix-gateway = { path = "../aisix-gateway", features = ["aws"] }
 # Reuse Anthropic Messages request/response wire types for the
 # `anthropic.*` Bedrock publisher (Claude on Bedrock) non-stream
 # /invoke path. The body shape is the Anthropic Messages API minus

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -379,6 +379,10 @@ fn build_client(
         .region(Region::new(creds.region.clone()))
         .credentials_provider(SharedCredentialsProvider::new(aws_creds))
         .timeout_config(timeouts.build())
+        // Shared HTTP stack carrying `upstream.tls.ca_file`, so a
+        // Bedrock-compatible endpoint behind a private CA is reachable
+        // on the same setting every other upstream uses.
+        .http_client(aisix_gateway::upstream_tls::aws_http_client())
         // Retries belong to the gateway's own budget
         // (`routing::effective_retries`), which emits per-attempt telemetry
         // and honours per-model config. Left at its default the SDK would

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -65,6 +65,30 @@ const AZURE_REALTIME_API_VERSION: &str = "2024-10-01-preview";
 /// Subprotocol item carrying the caller's API key in the browser flow.
 const SUBPROTOCOL_KEY_PREFIX: &str = "openai-insecure-api-key.";
 
+/// Dial the upstream Realtime endpoint under the deployment's outbound
+/// TLS trust.
+///
+/// `connect_async` would build its own connector over the compiled-in
+/// root set only, which leaves this the one upstream path that ignores
+/// `upstream.tls` *and* `SSL_CERT_FILE` — a self-hosted Realtime
+/// endpoint behind an enterprise CA would fail here while the same
+/// provider's `/v1/chat/completions` worked.
+async fn connect_upstream(
+    request: tokio_tungstenite::tungstenite::handshake::client::Request,
+) -> Result<
+    (
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        tokio_tungstenite::tungstenite::handshake::client::Response,
+    ),
+    tokio_tungstenite::tungstenite::Error,
+> {
+    let connector =
+        tokio_tungstenite::Connector::Rustls(aisix_gateway::upstream_tls::rustls_client_config());
+    tokio_tungstenite::connect_async_tls_with_config(request, None, false, Some(connector)).await
+}
+
 pub(crate) async fn realtime(
     State(state): State<ProxyState>,
     Query(params): Query<HashMap<String, String>>,
@@ -390,7 +414,7 @@ async fn run_session(
 
     let (mut client_tx, mut client_rx) = client_ws.split();
 
-    let upstream = match tokio_tungstenite::connect_async(upstream_request).await {
+    let upstream = match connect_upstream(upstream_request).await {
         Ok((ws, _resp)) => ws,
         Err(e) => {
             tracing::warn!(error = %e, model = %requested_model, "realtime upstream connect failed");

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -143,20 +143,25 @@ impl ConnectionLike for RedisConnHandle {
 /// rather than per request. Assumes [`RedisConnConfig::validate`] already
 /// passed (the boot path validates before calling this).
 pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
+    let tls = load_tls(cfg)?;
     match cfg.mode {
         RedisMode::Single => {
-            let url = cfg.url.as_deref().unwrap_or_default();
-            let client = redis::Client::open(url)?;
+            let url = insecure_url(cfg.url.as_deref().unwrap_or_default(), cfg);
+            let client = match &tls {
+                Some(certs) => redis::Client::build_with_tls(url.as_str(), certs.clone())?,
+                None => redis::Client::open(url.as_str())?,
+            };
             let conn = ConnectionManager::new(client).await?;
             tracing::info!(target: "aisix::redis", mode = "single", "connected");
             Ok(RedisConn::Single(conn))
         }
         RedisMode::Cluster => {
-            let nodes: Vec<&str> = cfg
+            let nodes: Vec<String> = cfg
                 .nodes
                 .iter()
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty())
+                .map(|s| insecure_url(s, cfg))
                 .collect();
             // ACL creds for the nodes can travel in the node URLs, or be
             // set explicitly here (applied to every node). Cluster has no
@@ -167,6 +172,9 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
             }
             if let Some(p) = &cfg.password {
                 builder = builder.password(p.clone());
+            }
+            if let Some(certs) = &tls {
+                builder = builder.certs(certs.clone());
             }
             let client = builder.build()?;
             let conn = client.get_async_connection().await?;
@@ -182,8 +190,9 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
             let sentinels: Vec<String> = cfg
                 .sentinels
                 .iter()
-                .map(|s| s.trim().to_string())
+                .map(|s| s.trim())
                 .filter(|s| !s.is_empty())
+                .map(|s| insecure_url(s, cfg))
                 .collect();
             let master_name = cfg.master_name.clone().unwrap_or_default();
             // The master/data node may need its own auth and TLS; the
@@ -193,7 +202,26 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
             let tls_mode = sentinels
                 .first()
                 .filter(|u| u.starts_with("rediss://"))
-                .map(|_| redis::TlsMode::Secure);
+                .map(|_| {
+                    if cfg.tls.verify {
+                        redis::TlsMode::Secure
+                    } else {
+                        redis::TlsMode::Insecure
+                    }
+                });
+            // `SentinelClient::build` takes no `TlsCertificates`, so the
+            // master connection redis-rs opens after discovery can only
+            // use the built-in trust store. Say so rather than let a
+            // configured CA look applied — `SSL_CERT_FILE` is the working
+            // alternative in this one mode.
+            if tls_mode.is_some() && cfg.tls.ca_file.is_some() {
+                tracing::warn!(
+                    target: "aisix::redis",
+                    "redis.tls.ca_file is not applied in sentinel mode: the client library \
+                     accepts no custom trust roots for the sentinel-discovered master. Put \
+                     the CA in the system trust store, or point SSL_CERT_FILE at it."
+                );
+            }
             // Auth/DB for the discovered master. It has no URL of its own,
             // so ACL username/password and the DB index are configured
             // here; this is independent of the sentinels' own auth.
@@ -235,9 +263,146 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
     }
 }
 
+/// Read the `redis.tls` PEM files into the shape redis-rs wants, or
+/// `None` when the operator configured no custom trust material (the
+/// built-in root set, plus `SSL_CERT_FILE`, then applies).
+fn load_tls(cfg: &RedisConnConfig) -> RedisResult<Option<redis::TlsCertificates>> {
+    let read = |path: &str, field: &str| -> RedisResult<Vec<u8>> {
+        std::fs::read(path).map_err(|e| {
+            redis::RedisError::from((
+                redis::ErrorKind::InvalidClientConfig,
+                "redis TLS material could not be read",
+                format!("redis.tls.{field}: read {path}: {e}"),
+            ))
+        })
+    };
+
+    let root_cert = match &cfg.tls.ca_file {
+        Some(path) => Some(read(path, "ca_file")?),
+        None => None,
+    };
+    let client_tls = match (&cfg.tls.client_cert_file, &cfg.tls.client_key_file) {
+        // The mismatched pairs are rejected by `RedisConnConfig::validate`.
+        (Some(cert), Some(key)) => Some(redis::ClientTlsConfig {
+            client_cert: read(cert, "client_cert_file")?,
+            client_key: read(key, "client_key_file")?,
+        }),
+        _ => None,
+    };
+
+    if root_cert.is_none() && client_tls.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(redis::TlsCertificates {
+        client_tls,
+        root_cert,
+    }))
+}
+
+/// redis-rs carries "do not verify the server certificate" in the URL
+/// rather than in a builder option, as the `#insecure` fragment on a
+/// `rediss://` URL. Translate `redis.tls.verify: false` into that.
+///
+/// Left alone for a plaintext `redis://` URL, where the fragment is
+/// rejected outright, and for a URL that already carries a fragment,
+/// which the operator set deliberately.
+fn insecure_url(url: &str, cfg: &RedisConnConfig) -> String {
+    if cfg.tls.verify || !url.starts_with("rediss://") || url.contains('#') {
+        return url.to_string();
+    }
+    // The fragment must follow a path segment: redis-rs parses the URL
+    // with the `url` crate, and `rediss://host:6379#insecure` leaves the
+    // fragment attached to an empty path, which it then reads as a
+    // database index.
+    if url.rsplit('/').next().is_some_and(|s| s.contains(':')) {
+        format!("{url}/#insecure")
+    } else {
+        format!("{url}#insecure")
+    }
+}
+
 /// Re-export so dependents don't need a direct `redis` dependency just to
 /// name the connect error.
 pub use redis::RedisError as ConnectError;
+
+#[cfg(test)]
+mod tls_tests {
+    use super::*;
+    use aisix_core::config::OutboundTlsConfig;
+
+    fn cfg_with(url: &str, verify: bool) -> RedisConnConfig {
+        RedisConnConfig {
+            mode: RedisMode::Single,
+            url: Some(url.to_string()),
+            tls: OutboundTlsConfig {
+                verify,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn verify_true_leaves_the_url_alone() {
+        let cfg = cfg_with("rediss://redis.internal:6379", true);
+        assert_eq!(
+            insecure_url("rediss://redis.internal:6379", &cfg),
+            "rediss://redis.internal:6379"
+        );
+    }
+
+    /// redis-rs reads the fragment only after a path separator; without
+    /// the trailing slash it parses `6379#insecure` as the database
+    /// index and the connection fails to open at all.
+    #[test]
+    fn verify_false_appends_the_insecure_fragment_after_a_path_separator() {
+        let cfg = cfg_with("rediss://redis.internal:6379", false);
+        assert_eq!(
+            insecure_url("rediss://redis.internal:6379", &cfg),
+            "rediss://redis.internal:6379/#insecure"
+        );
+    }
+
+    #[test]
+    fn verify_false_keeps_an_existing_path() {
+        let cfg = cfg_with("rediss://redis.internal:6379/2", false);
+        assert_eq!(
+            insecure_url("rediss://redis.internal:6379/2", &cfg),
+            "rediss://redis.internal:6379/2#insecure"
+        );
+    }
+
+    /// A plaintext connection never negotiates TLS, and redis-rs rejects
+    /// any fragment on a `redis://` URL — adding one would turn "verify
+    /// is off" into "the backend does not connect".
+    #[test]
+    fn verify_false_does_not_touch_a_plaintext_url() {
+        let cfg = cfg_with("redis://redis.internal:6379", false);
+        assert_eq!(
+            insecure_url("redis://redis.internal:6379", &cfg),
+            "redis://redis.internal:6379"
+        );
+    }
+
+    #[test]
+    fn no_tls_material_configured_leaves_the_default_trust_store() {
+        let cfg = cfg_with("rediss://redis.internal:6379", true);
+        assert!(load_tls(&cfg).unwrap().is_none());
+    }
+
+    #[test]
+    fn an_unreadable_ca_file_names_the_field_and_the_path() {
+        let mut cfg = cfg_with("rediss://redis.internal:6379", true);
+        cfg.tls.ca_file = Some("/nonexistent/redis-ca.pem".into());
+        // `TlsCertificates` is not `Debug`, so `unwrap_err` is out.
+        let Err(err) = load_tls(&cfg) else {
+            panic!("an unreadable ca_file must fail the connect")
+        };
+        let err = err.to_string();
+        assert!(err.contains("redis.tls.ca_file"), "{err}");
+        assert!(err.contains("/nonexistent/redis-ca.pem"), "{err}");
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -153,7 +153,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Before any bridge builds its `reqwest::Client` — the connection
     // pools are constructed once and can't be reconfigured afterwards.
-    aisix_gateway::upstream_http::init(upstream_http_config(&cfg.upstream));
+    aisix_gateway::upstream_http::init(upstream_http_config(&cfg.upstream)?)
+        .map_err(|e| anyhow::anyhow!("upstream TLS init failed: {e}"))?;
 
     run(cfg).await
 }
@@ -1275,21 +1276,39 @@ fn load_heartbeat_config_from_disk(
 /// `crates/aisix-proxy/src/rerank.rs` and bypasses the Bridge.
 /// Translate the `upstream:` config block into the gateway's client
 /// settings. Every duration treats `0` as "leave this knob off".
-fn upstream_http_config(cfg: &aisix_core::config::UpstreamConfig) -> UpstreamHttpConfig {
+///
+/// Fails when `upstream.tls` names a file that cannot be read or does
+/// not hold the PEM it claims to — the boot is where an operator can
+/// still act on that, and it is a far better signal than the generic
+/// `UnknownIssuer` transport error the misconfiguration otherwise
+/// produces on every upstream call.
+fn upstream_http_config(
+    cfg: &aisix_core::config::UpstreamConfig,
+) -> anyhow::Result<UpstreamHttpConfig> {
     fn ms(v: u64) -> Option<Duration> {
         (v > 0).then(|| Duration::from_millis(v))
     }
     fn secs(v: u64) -> Option<Duration> {
         (v > 0).then(|| Duration::from_secs(v))
     }
-    UpstreamHttpConfig {
+    let tls = aisix_gateway::TlsSettings::load("upstream.tls", &cfg.tls)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if !tls.verify {
+        tracing::warn!(
+            "upstream.tls.verify is false: upstream certificates are NOT checked, so any \
+             peer able to intercept the connection can read and rewrite prompts, responses, \
+             and upstream API keys"
+        );
+    }
+    Ok(UpstreamHttpConfig {
         connect_timeout: ms(cfg.connect_timeout_ms),
         tcp_keepalive: secs(cfg.tcp_keepalive_secs),
         tcp_keepalive_interval: secs(cfg.tcp_keepalive_interval_secs),
         tcp_keepalive_retries: (cfg.tcp_keepalive_retries > 0).then_some(cfg.tcp_keepalive_retries),
         pool_idle_timeout: secs(cfg.pool_idle_timeout_secs),
         pool_max_idle_per_host: cfg.pool_max_idle_per_host,
-    }
+        tls,
+    })
 }
 
 fn build_hub() -> Hub {

--- a/tests/e2e/src/cases/upstream-tls-trust-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-tls-trust-e2e.test.ts
@@ -1,0 +1,274 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: outbound TLS trust is configurable (#860).
+//
+// An upstream whose certificate is signed by a private CA is the ordinary
+// on-prem shape, and before this the gateway had no way to be told about
+// one: no `ca_file`, no verification override, and the only working
+// mechanism (`SSL_CERT_FILE`) was undocumented and process-wide. What an
+// operator saw was a generic 502.
+//
+// Each scenario runs a fresh gateway against an HTTPS mock upstream whose
+// leaf is signed by a throwaway CA:
+//
+//   1. no TLS config      → 502, and the error names the certificate as
+//                           the cause rather than something generic;
+//   2. upstream.tls.ca_file → 200;
+//   3. upstream.tls.verify: false → 200 without any CA configured;
+//   4. SSL_CERT_FILE      → 200, and public roots stay trusted (the
+//                           pre-existing mechanism the issue asks to have
+//                           documented, pinned so it cannot regress).
+
+const CALLER_PLAINTEXT = "sk-upstream-tls-e2e";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const MODEL = "private-ca-model";
+
+const REPLY = {
+  id: "cmpl-private-ca",
+  object: "chat.completion",
+  created: 1,
+  model: "gpt-4o-mini",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "trusted" },
+      finish_reason: "stop",
+    },
+  ],
+  usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+};
+
+interface Pki {
+  dir: string;
+  caCertPath: string;
+  serverKey: string;
+  serverCert: string;
+}
+
+/**
+ * A throwaway CA and a leaf it signs for 127.0.0.1. Deliberately NOT
+ * self-signed at the leaf: the gateway must be shown to trust the *issuer*
+ * from `ca_file`, which a self-signed leaf would not distinguish from
+ * "trusts anything it was handed".
+ */
+function makePki(): Pki {
+  const dir = mkdtempSync(join(tmpdir(), "aisix-upstream-tls-"));
+  const p = (name: string) => join(dir, name);
+  const openssl = (args: string[]) =>
+    execFileSync("openssl", args, { stdio: ["ignore", "pipe", "pipe"] });
+
+  openssl(["genrsa", "-out", p("ca.key"), "2048"]);
+  openssl([
+    "req", "-x509", "-new", "-key", p("ca.key"),
+    "-out", p("ca.crt"), "-days", "1", "-sha256",
+    "-subj", "/CN=aisix-e2e-private-ca",
+  ]);
+
+  openssl(["genrsa", "-out", p("server.key"), "2048"]);
+  openssl([
+    "req", "-new", "-key", p("server.key"), "-out", p("server.csr"),
+    "-subj", "/CN=127.0.0.1",
+  ]);
+  writeFileSync(p("ext.cnf"), "subjectAltName=IP:127.0.0.1\n", "utf8");
+  openssl([
+    "x509", "-req", "-in", p("server.csr"),
+    "-CA", p("ca.crt"), "-CAkey", p("ca.key"), "-CAcreateserial",
+    "-out", p("server.crt"), "-days", "1", "-sha256",
+    "-extfile", p("ext.cnf"),
+  ]);
+
+  const read = (name: string) =>
+    execFileSync("cat", [p(name)]).toString("utf8");
+  return {
+    dir,
+    caCertPath: p("ca.crt"),
+    serverKey: read("server.key"),
+    serverCert: read("server.crt"),
+  };
+}
+
+function opensslAvailable(): boolean {
+  try {
+    execFileSync("openssl", ["version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("outbound TLS trust (#860)", () => {
+  let pki: Pki | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+  let haveOpenssl = false;
+  const apps: SpawnedApp[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+    haveOpenssl = opensslAvailable();
+    if (!etcdReachable || !haveOpenssl) return;
+
+    pki = makePki();
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: REPLY,
+      tls: { key: pki.serverKey, cert: pki.serverCert },
+    });
+  });
+
+  afterAll(async () => {
+    await Promise.all(apps.map((a) => a.exit()));
+    await upstream?.close();
+  });
+
+  /** Boot a gateway with the given `upstream.tls` block, seeded to route to the mock. */
+  async function gatewayFor(
+    tls: Record<string, unknown> | undefined,
+    extraEnv?: Record<string, string>,
+  ): Promise<SpawnedApp> {
+    const app = await spawnApp({
+      ...(tls ? { extra: { upstream: { tls } } } : {}),
+      ...(extraEnv ? { extraEnv } : {}),
+    });
+    apps.push(app);
+    const seed = new SeedClient(new EtcdClient(), app.etcdPrefix);
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [MODEL],
+    });
+    const pk = await seed.createProviderKey({
+      display_name: `private-ca-pk-${app.etcdPrefix}`,
+      secret: "sk-mock",
+      api_base: upstream!.baseUrl,
+    });
+    await seed.createModel({
+      display_name: MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    return app;
+  }
+
+  async function chat(app: SpawnedApp): Promise<{ status: number; body: string }> {
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    return { status: res.status, body: await res.text() };
+  }
+
+  /**
+   * Poll until the seeded key and model have propagated far enough that
+   * the request reaches upstream dispatch — which is the only point
+   * where a TLS decision is observable. 401/403/404 all mean the
+   * snapshot is still catching up; 200 and 502 are both "dispatch ran",
+   * and which one it is is exactly what each test asserts.
+   */
+  async function settle(app: SpawnedApp): Promise<void> {
+    await waitConfigPropagation(async () => {
+      try {
+        const { status } = await chat(app);
+        return status === 200 || status === 502;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  test("without any TLS config the private CA is rejected, and the error says so", async (ctx) => {
+    if (!etcdReachable || !haveOpenssl) {
+      ctx.skip();
+      return;
+    }
+    const app = await gatewayFor(undefined);
+    await settle(app);
+
+    const { status, body } = await chat(app);
+    expect(status).toBe(502);
+    // The whole complaint in the issue is that the operator cannot tell
+    // a trust problem from any other transport failure.
+    expect(body.toLowerCase()).toContain("certificate");
+  });
+
+  test("upstream.tls.ca_file makes the private CA trusted", async (ctx) => {
+    if (!etcdReachable || !haveOpenssl) {
+      ctx.skip();
+      return;
+    }
+    const app = await gatewayFor({ ca_file: pki!.caCertPath });
+    await settle(app);
+
+    const { status, body } = await chat(app);
+    expect(status).toBe(200);
+    expect(JSON.parse(body).choices[0].message.content).toBe("trusted");
+  });
+
+  test("upstream.tls.verify false accepts the certificate with no CA configured", async (ctx) => {
+    if (!etcdReachable || !haveOpenssl) {
+      ctx.skip();
+      return;
+    }
+    const app = await gatewayFor({ verify: false });
+    await settle(app);
+
+    expect((await chat(app)).status).toBe(200);
+  });
+
+  test("SSL_CERT_FILE is still honoured", async (ctx) => {
+    if (!etcdReachable || !haveOpenssl) {
+      ctx.skip();
+      return;
+    }
+    // The mechanism the issue asks to have documented. It worked only
+    // because reqwest's native-roots feature arrived transitively from
+    // `object_store`'s cloud features; that feature is now declared
+    // outright, and this pins the behaviour so removing an unrelated
+    // dependency cannot silently take it away again.
+    //
+    // The additive half — that a private CA here does not displace the
+    // built-in roots — is not asserted: it needs a real public host, and
+    // these specs stay offline. It follows from reqwest loading the
+    // webpki set alongside the native one.
+    const app = await gatewayFor(undefined, { SSL_CERT_FILE: pki!.caCertPath });
+    await settle(app);
+
+    expect((await chat(app)).status).toBe(200);
+  });
+
+  test("a ca_file that is not a certificate fails the boot instead of trusting nothing", async (ctx) => {
+    if (!etcdReachable || !haveOpenssl) {
+      ctx.skip();
+      return;
+    }
+    const bogus = join(pki!.dir, "not-a-cert.pem");
+    writeFileSync(bogus, "this is not a certificate\n", "utf8");
+
+    await expect(
+      spawnApp({ extra: { upstream: { tls: { ca_file: bogus } } } }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/e2e/src/harness/upstream-openai.ts
+++ b/tests/e2e/src/harness/upstream-openai.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from "node:http";
+import { createServer as createTlsServer } from "node:https";
 import { pickFreePort } from "./ports.js";
 
 export interface OpenAiUpstreamOptions {
@@ -49,6 +50,13 @@ export interface OpenAiUpstreamOptions {
    * from the upstream when computing the cooldown TTL.
    */
   responseHeaders?: Record<string, string>;
+  /**
+   * Serve HTTPS with this key/cert pair (PEM) instead of plain HTTP, so
+   * `baseUrl` is `https://…`. Used by the outbound-TLS specs to stand up
+   * an upstream whose certificate is signed by a private CA the gateway
+   * does not trust out of the box.
+   */
+  tls?: { key: string | Buffer; cert: string | Buffer };
 }
 
 export interface OpenAiUpstreamStep {
@@ -97,7 +105,10 @@ export async function startOpenAiUpstream(
   const received: ReceivedRequest[] = [];
   let requestIndex = 0;
 
-  const server: Server = createServer((req, res) => {
+  const handler = (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => {
     // When the gateway abandons a slow upstream (e.g. a #554 request/stream
     // timeout fires and the client connection is dropped), a later
     // `res.write`/`res.end` here would emit an error on a closed socket.
@@ -208,13 +219,17 @@ export async function startOpenAiUpstream(
         ),
       );
     });
-  });
+  };
+
+  const server: Server = opts.tls
+    ? createTlsServer({ key: opts.tls.key, cert: opts.tls.cert }, handler)
+    : createServer(handler);
 
   const port = await pickFreePort();
   await new Promise<void>((resolve) =>
     server.listen(port, "127.0.0.1", resolve),
   );
-  const baseUrl = `http://127.0.0.1:${port}`;
+  const baseUrl = `${opts.tls ? "https" : "http"}://127.0.0.1:${port}`;
 
   return {
     baseUrl,


### PR DESCRIPTION
Outbound TLS trust had no configuration surface. There was no `ca_file`, no
client certificate, and no verification override anywhere in the config file
or the resource schemas, so an upstream behind a private or enterprise CA
answered with a generic 502:

```
transport error: error sending request for url (https://...):
client error (Connect): invalid peer certificate: UnknownIssuer
```

The only way out was `SSL_CERT_FILE` — process-wide, undocumented, and not
honoured by several of the outbound paths at all.

## What this adds

`upstream.tls` with `ca_file`, `client_cert_file`, `client_key_file` and
`verify`, applied to every stack the gateway dials out on:

| stack | reaches |
|---|---|
| workspace reqwest, via `client_builder()` | provider bridges, all seven guardrails, MCP OpenAPI + OAuth, A2A, passthrough, JWKS/OIDC discovery, OTLP export |
| rmcp's own reqwest line | MCP streamable-http upstreams |
| raw rustls | the Realtime WebSocket |
| AWS SDK | Bedrock provider bridge + Bedrock guardrail |
| object_store | S3 / GCS / Azure log export |

`ca_file` is **additive** to the platform trust store, so trusting a private
CA never makes a public provider unreachable. `SSL_CERT_FILE` / `SSL_CERT_DIR`
keep working unchanged.

Redis gets its own `tls` block on the `redis` config rather than sharing
`upstream.tls`: the cache / rate-limit backend sits inside the deployment and
is normally issued by a different authority than the model endpoints, so the
two have to be configurable apart.

## Defects found while wiring this up

- **`SSL_CERT_FILE` worked only by accident.** reqwest's
  `rustls-tls-native-roots` was never declared — it arrived through
  `object_store`'s `aws` feature. Dropping the log-export sink would have
  silently stopped the gateway trusting anything the operating system trusts.
  Now declared on the workspace dependency.
- **`rediss://` could not connect at all.** The `redis` dependency enabled no
  TLS feature, so the URL was rejected at parse time with `can't connect with
  TLS, the feature is not enabled`; the `TlsMode` handling in sentinel mode was
  unreachable code.
- **`rustls::ClientConfig::builder()` panics** when several crypto providers are
  compiled in, which enabling the redis TLS feature makes true. The shared
  config now selects the provider explicitly instead of depending on having
  been reached after `main` installs a default.
- **The bare-reqwest-client guard test had a hole.** It cut each file at the
  first `#[cfg(test)]`, which is commonly a struct-field attribute near the top
  — in `aisix-provider-bedrock/src/bridge.rs` that is line 84, so the whole file
  was excused from the scan. It now cuts at the top-level test module.

## Limits, stated rather than silent

Two knobs stop at the AWS SDK, whose stable HTTP surface exposes trust roots
only: a client certificate cannot be presented, and verification cannot be
disabled. Redis in sentinel mode likewise takes no custom trust roots, because
the client library offers no way to pass them for the discovered master. All
three log a warning when the setting is present, rather than looking applied.

## Behaviour changes

None by default. With no `tls` block the clients are built exactly as before.
Bad TLS material fails the boot with the file path in the message instead of
becoming a transport error on every upstream call.

## Tests

E2E (`upstream-tls-trust-e2e.test.ts`) runs an HTTPS mock upstream whose leaf
is signed by a throwaway CA — not self-signed, so trusting the *issuer* is what
has to work. No config → 502 naming the certificate; `ca_file` → 200;
`verify: false` → 200 with no CA; `SSL_CERT_FILE` → 200; a `ca_file` holding no
certificate fails the boot.

The source-level guard grows one rule per non-reqwest stack. Each was
mutation-checked: removing the wiring at any of the five sites fails the test.

Fixes #860
