### PR TITLE
fix(audio): bill the usage a streamed transcription reports

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -744,10 +744,16 @@ async fn multipart_dispatch(
     // `text`/`srt`/`vtt` response_formats aren't JSON at all). Parse
     // failure or absence → None → zero-token emit. Done before the
     // bytes move into the Body.
+    //
+    // A `stream=true` transcription answers with SSE instead of a JSON
+    // object, so the parse above finds nothing — the counts ride the
+    // terminal `transcript.text.done` event. Without the second read the
+    // whole streaming surface bills zero and never moves TPM/TPD.
     let usage = serde_json::from_slice::<Value>(&body_bytes)
         .ok()
         .as_ref()
-        .and_then(extract_token_usage);
+        .and_then(extract_token_usage)
+        .or_else(|| extract_sse_token_usage(&upstream_headers, &body_bytes));
 
     // #911 [21]: commit the actual token cost so TPM/TPD is enforced for the
     // audio transcription/translation endpoints like chat + embeddings.
@@ -1151,6 +1157,38 @@ async fn speech_dispatch(
 /// whisper-1 (and the `text`/`srt`/`vtt` response formats) return no
 /// token block → `None`. Spec:
 /// <https://platform.openai.com/docs/api-reference/audio/json-object>
+/// `(prompt, completion)` from a *streamed* transcription body.
+///
+/// `stream=true` on the transcribe models answers `text/event-stream`:
+/// a run of `transcript.text.delta` events and a terminal
+/// `transcript.text.done` that carries the same `usage` block the
+/// non-streaming response would have returned. The body is already
+/// buffered here, so decode it and take the last event that carries
+/// usage — the shape stays the same whether the provider puts it on
+/// `transcript.text.done` or on a later event.
+///
+/// Gated on the upstream content type so a `text`/`srt`/`vtt` transcript
+/// that happens to contain a `data:` line is never mistaken for a stream.
+fn extract_sse_token_usage(headers: &HeaderMap, body: &[u8]) -> Option<(u32, u32)> {
+    let is_sse = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("text/event-stream"));
+    if !is_sse {
+        return None;
+    }
+    let mut decoder = aisix_gateway::SseDecoder::new();
+    let mut events = decoder.feed(body);
+    events.extend(decoder.finish());
+    events.iter().rev().find_map(|event| match event {
+        aisix_gateway::SseEvent::Data(payload) => serde_json::from_str::<Value>(payload)
+            .ok()
+            .as_ref()
+            .and_then(extract_token_usage),
+        aisix_gateway::SseEvent::Done => None,
+    })
+}
+
 fn extract_token_usage(body: &Value) -> Option<(u32, u32)> {
     let usage = body.get("usage")?;
     let input = usage.get("input_tokens").and_then(Value::as_u64)? as u32;
@@ -1727,6 +1765,79 @@ mod tests {
         assert_eq!(event.api_key_id, "k-1");
         assert_eq!(event.model_id, "m-1");
         assert_eq!(event.inbound_protocol, "openai");
+    }
+
+    /// AISIX-Cloud#1138: a `stream=true` transcription answers
+    /// `text/event-stream`, so the usage block rides the terminal
+    /// `transcript.text.done` event instead of a JSON body. Pre-fix the
+    /// JSON parse found nothing and the whole streaming surface emitted
+    /// zero tokens — unbilled spend that also never moved TPM/TPD, while
+    /// the identical non-streaming request billed normally.
+    /// <https://platform.openai.com/docs/api-reference/audio/create-transcription>
+    #[tokio::test]
+    async fn streamed_transcription_bills_the_terminal_event_usage() {
+        let upstream = MockServer::start().await;
+        let sse = concat!(
+            "data: {\"type\":\"transcript.text.delta\",\"delta\":\"hello\"}\n\n",
+            "data: {\"type\":\"transcript.text.delta\",\"delta\":\" world\"}\n\n",
+            "data: {\"type\":\"transcript.text.done\",\"text\":\"hello world\",",
+            "\"usage\":{\"type\":\"tokens\",\"total_tokens\":38,\"input_tokens\":26,",
+            "\"input_token_details\":{\"text_tokens\":0,\"audio_tokens\":26},",
+            "\"output_tokens\":12}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse, "text/event-stream"))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-transcribe"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = transcription_multipart("my-transcribe");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted for a streamed transcription")
+            .expect("usage_sink sender dropped");
+        assert_eq!(
+            (event.prompt_tokens, event.completion_tokens),
+            (26, 12),
+            "the terminal transcript.text.done usage must be billed"
+        );
+    }
+
+    /// The SSE read is content-type gated: a `srt`/`vtt` transcript is
+    /// `text/plain` and may legitimately contain a line starting with
+    /// `data:`, which must never be decoded as a usage-bearing event.
+    #[test]
+    fn plain_text_transcript_is_not_read_as_a_stream() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static("text/plain; charset=utf-8"),
+        );
+        let body = concat!(
+            "1\n00:00:00,000 --> 00:00:02,000\n",
+            "data: {\"usage\":{\"input_tokens\":999,\"output_tokens\":999}}\n\n",
+        );
+        assert_eq!(
+            super::extract_sse_token_usage(&headers, body.as_bytes()),
+            None
+        );
     }
 
     /// AISIX-Cloud#867 parity: a successful audio request must carry the

--- a/tests/e2e/src/cases/audio-streaming-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/audio-streaming-usage-e2e.test.ts
@@ -1,0 +1,221 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E regression for AISIX-Cloud#1138: a `stream=true` transcription must
+// be billed for the tokens the upstream reports.
+//
+// The transcribe models answer a streaming transcription with
+// `text/event-stream`: `transcript.text.delta` events and a terminal
+// `transcript.text.done` carrying the same `usage` block the
+// non-streaming response would have returned. Pre-fix the audio handler
+// only looked for a JSON object, so the whole streaming surface emitted
+// zero tokens — unbilled spend that also never moved TPM/TPD, while the
+// identical non-streaming request billed normally.
+//
+// Usage telemetry has no cp-api receiver in DP e2e, so — like the
+// /v1/responses streaming test (#808) — the emitted values are observed
+// through the per-env OTLP/HTTP fan-out.
+
+const CALLER_PLAINTEXT = "sk-issue-1138-audio-stream";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const INPUT_TOKENS = 26;
+const OUTPUT_TOKENS = 12;
+
+// Real streaming-transcription wire shape.
+const TRANSCRIPT_SSE = [
+  `data: ${JSON.stringify({ type: "transcript.text.delta", delta: "hello" })}`,
+  `data: ${JSON.stringify({ type: "transcript.text.delta", delta: " world" })}`,
+  `data: ${JSON.stringify({
+    type: "transcript.text.done",
+    text: "hello world",
+    usage: {
+      type: "tokens",
+      input_tokens: INPUT_TOKENS,
+      output_tokens: OUTPUT_TOKENS,
+      total_tokens: INPUT_TOKENS + OUTPUT_TOKENS,
+      input_token_details: { text_tokens: 0, audio_tokens: INPUT_TOKENS },
+    },
+  })}`,
+  "data: [DONE]",
+].join("\n\n").concat("\n\n");
+
+interface OtlpReceiver {
+  url: string;
+  spanAttrs: Array<Record<string, string>>;
+  close(): Promise<void>;
+}
+
+async function startOtlpReceiver(): Promise<OtlpReceiver> {
+  const spanAttrs: Array<Record<string, string>> = [];
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(raw);
+        for (const rs of body.resourceSpans ?? []) {
+          for (const ss of rs.scopeSpans ?? []) {
+            for (const span of ss.spans ?? []) {
+              const attrs: Record<string, string> = {};
+              for (const a of span.attributes ?? []) {
+                const v = a.value ?? {};
+                attrs[a.key] =
+                  v.stringValue ?? String(v.intValue ?? v.boolValue ?? "");
+              }
+              spanAttrs.push(attrs);
+            }
+          }
+        }
+      } catch {
+        // ignore malformed bodies — assertions fail on missing spans
+      }
+      res.statusCode = 200;
+      res.end("{}");
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${port}/v1/traces`,
+    spanAttrs,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+async function waitUsageSpan(
+  recv: OtlpReceiver,
+  requestId: string,
+  timeoutMs = 10_000,
+): Promise<Record<string, string>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hit = recv.spanAttrs.find(
+      (a) =>
+        a["aisix.request_id"] === requestId &&
+        a["gen_ai.usage.input_tokens"] !== undefined,
+    );
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`no usage span for request_id=${requestId}`);
+}
+
+describe("streaming transcription usage emission (#1138)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let otlp: OtlpReceiver | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // The upload is multipart, so the upstream can't be asked to stream
+    // off a `stream: true` JSON field — serve the SSE bytes as the raw
+    // 200 body with the streaming content type instead.
+    upstream = await startOpenAiUpstream({
+      rawBody: TRANSCRIPT_SSE,
+      rawContentType: "text/event-stream",
+    });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    otlp = await startOtlpReceiver();
+    await seed.createObservabilityExporter({
+      name: "issue1138-otlp",
+      enabled: true,
+      kind: "otlp_http",
+      endpoint: otlp.url,
+    });
+
+    const pk = await seed.createProviderKey({
+      display_name: "issue1138-pk",
+      secret: "sk-openai-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "stream-transcribe",
+      provider: "openai",
+      model_name: "gpt-4o-transcribe",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["stream-transcribe"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await otlp?.close();
+  });
+
+  test("a streamed transcription bills the terminal event's tokens", async (ctx) => {
+    if (!etcdReachable || !app || !upstream || !otlp) {
+      ctx.skip();
+      return;
+    }
+    const proxyUrl = app.proxyUrl;
+
+    const call = () => {
+      const form = new FormData();
+      form.set("model", "stream-transcribe");
+      form.set("stream", "true");
+      form.set(
+        "file",
+        new Blob([new Uint8Array([0x49, 0x44, 0x33])], { type: "audio/mpeg" }),
+        "a.mp3",
+      );
+      return fetch(`${proxyUrl}/v1/audio/transcriptions`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+        body: form,
+      });
+    };
+
+    await waitConfigPropagation(async () => {
+      try {
+        return (await call()).ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const resp = await call();
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toContain("text/event-stream");
+    const requestId = resp.headers.get("x-aisix-request-id") ?? "";
+    expect(requestId, "the DP must stamp a request id").not.toBe("");
+
+    // The caller still gets the upstream's stream verbatim.
+    const body = await resp.text();
+    expect(body).toContain("transcript.text.delta");
+    expect(body).toContain("transcript.text.done");
+
+    const span = await waitUsageSpan(otlp, requestId);
+    expect(
+      Number(span["gen_ai.usage.input_tokens"]),
+      "the terminal transcript.text.done usage must be billed",
+    ).toBe(INPUT_TOKENS);
+    expect(Number(span["gen_ai.usage.output_tokens"])).toBe(OUTPUT_TOKENS);
+  });
+});


### PR DESCRIPTION
## Problem

`stream=true` on `/v1/audio/transcriptions` is answered with `text/event-stream` instead of a JSON object — a run of `transcript.text.delta` events and a terminal `transcript.text.done` that carries the same `usage` block the non-streaming response would have returned:

```
data: {"type":"transcript.text.delta","delta":"And"}
...
data: {"type":"transcript.text.done","text":"…","usage":{"type":"tokens","input_tokens":110,"output_tokens":28,"total_tokens":138}}
data: [DONE]
```

`multipart_dispatch` only ran `serde_json::from_slice` over the body, so that parse found nothing and the request emitted a **zero-token** UsageEvent. The reservation was also committed as zero, so TPM/TPD never moved.

The same request without `stream=true` bills normally. Measured against real OpenAI through a real DP: non-streamed `gpt-4o-transcribe` recorded `prompt=26 completion=12`; the identical audio with `stream=true` recorded `0/0`. A caller therefore chooses whether to be metered, which makes this a quota/billing bypass rather than a missing-feature gap.

## Fix

The body is already fully buffered before the response is built, so `extract_sse_token_usage` decodes it with the existing `aisix_gateway::SseDecoder` and takes the last event carrying a usage block — the shape holds whether the provider puts it on `transcript.text.done` or a later event.

It is gated on the upstream response's content type, so a `text`/`srt`/`vtt` transcript containing a line that starts with `data:` is never mistaken for a stream.

Scope is deliberately the accounting only. Delivery is unchanged: the stream is still relayed intact, event for event, and still arrives in one write at the end. Incremental passthrough is a separate question (LiteLLM does not list `stream` among its supported transcription params at all), tracked outside this PR.

## Tests

Both fail before the fix and pass after:

- `audio::tests::streamed_transcription_bills_the_terminal_event_usage` — mock upstream returns the SSE shape above; the emitted UsageEvent must carry `(26, 12)`.
- `audio::tests::plain_text_transcript_is_not_read_as_a_stream` — a `text/plain` srt body whose cue text starts with `data:` must not be decoded as usage.
- `tests/e2e/src/cases/audio-streaming-usage-e2e.test.ts` — real `aisix` binary + etcd + mock upstream; asserts the caller still receives the verbatim stream and that the OTLP fan-out reports the terminal event's token counts.

Verified end-to-end against real OpenAI via api7/AISIX-Cloud#1220.

Ref api7/AISIX-Cloud#1138