### PR TITLE
ci(docker): add the MCP Registry ownership-verification label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # --- Stage 2: runtime --------------------------------------------------------
 FROM debian:bookworm-slim AS runtime
 
+# Ownership-verification label for the MCP Registry: when this image is
+# published as an MCP server entry, the registry requires this label to
+# match the server name in server.json.
+LABEL io.modelcontextprotocol.server.name="io.github.api7/aisix"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates tini \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
One-line enabler for listing AISIX in the official MCP Registry (registry.modelcontextprotocol.io).

The registry's OCI ownership verification requires the image to carry `LABEL io.modelcontextprotocol.server.name` matching the `server.json` name ([package-types docs](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/package-types.mdx), Docker/OCI section). Namespace `io.github.api7/aisix` uses GitHub-org authentication (no DNS setup needed); it can be republished under a DNS-verified `ai.api7/*` name later without breaking anything — the label just has to match whatever name we publish under.

No behavior change — a static image label. The registry entry itself will be published after the next release ships with this label.