### PR TITLE
feat(audio): report transcription audio length as a cost basis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "http-body-util",
  "ipnet",
  "jsonwebtoken",
+ "lofty",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "serde",
@@ -2862,6 +2863,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "lofty"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca"
+dependencies = [
+ "byteorder",
+ "data-encoding",
+ "lofty_attr",
+ "log",
+ "ogg_pager",
+ "paste",
+]
+
+[[package]]
+name = "lofty_attr"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,6 +3232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ogg_pager"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d36b1d6964c3ac92b7aea701057e02b6b91143d70d83b20abf75a231a3c0216"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,6 +3332,12 @@ dependencies = [
  "structmeta",
  "syn",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,11 @@ http-body-util = "0.1"
 # Trusted-proxy CIDR matching for real-ip resolution (#492)
 ipnet = "2"
 
+# Audio properties (duration) for the transcription cost basis. Reads
+# container/codec headers only — no decoding, no C dependency — and
+# default-features-off drops the id3v2 zlib support we never exercise.
+lofty = { version = "0.24", default-features = false }
+
 # Aliyun SLS sink (aisix-obs): the official protobuf + signature sub-crates
 # ONLY — not the full `aliyun-log-rust-sdk`, which forces reqwest native-tls
 # (OpenSSL) + ~13 C/TLS crates. Transport is our own rustls reqwest, so these

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -654,6 +654,14 @@ fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
     if !event.model_id.is_empty() {
         attributes.push(attr_string("aisix.model_id", &event.model_id));
     }
+    // Duration cost basis (#457): only the duration-billed audio models
+    // carry it, so it stays off every other span.
+    if event.audio_duration_seconds > 0.0 {
+        attributes.push(attr_double(
+            "aisix.audio.duration_seconds",
+            event.audio_duration_seconds,
+        ));
+    }
     attributes.push(attr_string("aisix.exporter_name", exporter_name));
     attributes.push(attr_string("aisix.request_id", &event.request_id));
     if event.upstream_ttft_ms > 0 {
@@ -766,6 +774,13 @@ fn attr_int(key: &str, value: i64) -> Value {
         "key": key,
         // OTLP/JSON encodes int as a string to avoid JS Number precision loss.
         "value": { "intValue": value.to_string() },
+    })
+}
+
+fn attr_double(key: &str, value: f64) -> Value {
+    json!({
+        "key": key,
+        "value": { "doubleValue": value },
     })
 }
 

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -112,6 +112,17 @@ pub struct UsageEvent {
     #[serde(default, skip_serializing_if = "is_false")]
     pub usage_estimated: bool,
 
+    /// Audio length in seconds — the cost basis for models billed by
+    /// duration rather than tokens (AISIX-Cloud#1138, api7/aisix#457).
+    /// `whisper-1` reports `usage: {type: "duration", seconds: N}` and no
+    /// token counts at all, so without this field its spend is
+    /// unpriceable; cp-api multiplies it by the model's per-second rate.
+    /// Populated on `/v1/audio/transcriptions` + `/translations`; 0
+    /// elsewhere and omitted from the wire, so token-only events are
+    /// unchanged and older cp-api builds ignore it.
+    #[serde(default, skip_serializing_if = "is_zero_f64")]
+    pub audio_duration_seconds: f64,
+
     /// How long THIS attempt spent on the upstream, in milliseconds:
     /// from the moment the attempt began to the moment it settled —
     /// end-of-stream for a streamed attempt, not first-chunk.
@@ -436,6 +447,11 @@ fn is_zero_u32(n: &u32) -> bool {
 #[inline]
 fn is_false(b: &bool) -> bool {
     !*b
+}
+
+#[inline]
+fn is_zero_f64(n: &f64) -> bool {
+    *n == 0.0
 }
 
 /// Cheap clonable handle the proxy hands to request handlers. Backed

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -69,6 +69,11 @@ tracing.workspace = true
 uuid.workspace = true
 # Real-ip resolver: trusted-proxy CIDR matching for x-forwarded-for (#492)
 ipnet.workspace = true
+# Audio duration for the transcription cost basis: an upstream that
+# answers `text`/`srt`/`vtt` reports no `usage`, so the duration is read
+# off the uploaded file instead. Metadata-only (no decoding), and
+# default-features-off drops the id3v2 zlib path we never need.
+lofty.workspace = true
 
 [dev-dependencies]
 # `test-util` drives the SSE-heartbeat tests on a paused clock.

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -51,6 +51,9 @@ struct AudioDispatchSuccess {
     /// whisper-1 (no usage block) — those still emit a zero-token event
     /// so the request is visible + attributed.
     usage: Option<(u32, u32)>,
+    /// Audio length in seconds — the cost basis for the duration-billed
+    /// models (whisper-1), which report no tokens at all (#457).
+    duration_seconds: f64,
     /// The `{kind, hook}` set of guardrails that governed this request
     /// (#379 parity, wired with #696) — surfaced on the emitted UsageEvent.
     applied_guardrails: Vec<AppliedGuardrail>,
@@ -358,6 +361,9 @@ pub async fn speech(
                 elapsed,
                 0,
                 0,
+                // TTS is billed per input character, not by the length of
+                // the audio it produced — no duration cost basis here.
+                0.0,
                 &client,
                 redactions,
                 monitor_hits,
@@ -749,6 +755,18 @@ async fn multipart_dispatch(
         .as_ref()
         .and_then(extract_token_usage);
 
+    // Duration cost basis (#457): what the upstream reported, else what
+    // the uploaded file says. The probe runs only when the response
+    // carried nothing, so the common `json` path never pays for it.
+    let duration_seconds = upstream_duration_seconds(&body_bytes)
+        .or_else(|| {
+            fields
+                .iter()
+                .find(|(name, ..)| name == "file")
+                .and_then(|(.., data)| probe_audio_duration_seconds(data))
+        })
+        .unwrap_or(0.0);
+
     // #911 [21]: commit the actual token cost so TPM/TPD is enforced for the
     // audio transcription/translation endpoints like chat + embeddings.
     // Pre-fix the reservation dropped uncommitted and the counter never moved.
@@ -799,6 +817,7 @@ async fn multipart_dispatch(
                     model_id: model_entry.id.to_string(),
                     provider_key_id: pk_entry.id.to_string(),
                     usage,
+                    duration_seconds,
                     applied_guardrails,
                     redactions,
                     monitor_hits: monitor_hits.clone(),
@@ -843,6 +862,7 @@ async fn multipart_dispatch(
         model_id: model_entry.id.to_string(),
         provider_key_id: pk_entry.id.to_string(),
         usage,
+        duration_seconds,
         applied_guardrails,
         redactions,
         monitor_hits,
@@ -1161,6 +1181,49 @@ fn extract_token_usage(body: &Value) -> Option<(u32, u32)> {
     Some((input, output))
 }
 
+/// Audio length in seconds as the upstream reported it.
+///
+/// Two shapes, both from OpenAI's transcription object: the default
+/// `json` format carries `usage: {type: "duration", seconds: N}`, and
+/// `verbose_json` carries a top-level `duration`. Neither is present on
+/// the `text` / `srt` / `vtt` formats — those response bodies are not
+/// JSON at all — which is what `probe_audio_duration_seconds` covers.
+/// <https://platform.openai.com/docs/api-reference/audio/json-object>
+fn upstream_duration_seconds(body: &[u8]) -> Option<f64> {
+    let json = serde_json::from_slice::<Value>(body).ok()?;
+    let from_usage = json
+        .get("usage")
+        .and_then(|u| u.get("seconds"))
+        .and_then(Value::as_f64);
+    let seconds = from_usage.or_else(|| json.get("duration").and_then(Value::as_f64))?;
+    (seconds.is_finite() && seconds > 0.0).then_some(seconds)
+}
+
+/// Audio length in seconds read off the uploaded file.
+///
+/// The fallback for every response format that carries no duration. Cost
+/// basis must not depend on which `response_format` the caller picked —
+/// otherwise `response_format=text` is an unmetered channel, the same
+/// shape of bypass as an unbilled stream.
+///
+/// Header/metadata parse only: `lofty` reads container and codec
+/// properties without decoding audio, so an arbitrary caller upload
+/// costs microseconds and cannot pull in a decode path. Anything it
+/// cannot identify yields `None` → a zero cost basis, never an error:
+/// the transcript already succeeded and the upstream already billed.
+fn probe_audio_duration_seconds(audio: &[u8]) -> Option<f64> {
+    use lofty::file::AudioFile;
+    use lofty::probe::Probe;
+
+    let probed = Probe::new(std::io::Cursor::new(audio))
+        .guess_file_type()
+        .ok()?
+        .read()
+        .ok()?;
+    let seconds = probed.properties().duration().as_secs_f64();
+    (seconds > 0.0).then_some(seconds)
+}
+
 /// Emit a UsageEvent for a successful transcription/translation. Tokens
 /// come from the upstream `usage` block when present (gpt-4o-transcribe);
 /// zero otherwise (whisper-1) — the request is still visible/attributed.
@@ -1186,6 +1249,7 @@ fn emit_audio_usage(
         elapsed,
         prompt_tokens,
         completion_tokens,
+        success.duration_seconds,
         client,
         success.redactions.clone(),
         success.monitor_hits.clone(),
@@ -1214,6 +1278,9 @@ fn emit_usage_event(
     elapsed: Duration,
     prompt_tokens: u32,
     completion_tokens: u32,
+    // Cost basis for the duration-billed models (#457); 0 when neither
+    // the upstream nor the uploaded file yielded a length.
+    audio_duration_seconds: f64,
     client: &ClientContext,
     // Per-detector PII mask counts (#932/#696). Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
@@ -1234,6 +1301,7 @@ fn emit_usage_event(
         requested_model: requested_model.to_string(),
         prompt_tokens,
         completion_tokens,
+        audio_duration_seconds,
         // Single-attempt endpoint: the attempt spans the whole request, so
         // the upstream figure and what the caller waited for coincide.
         upstream_latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
@@ -1727,6 +1795,200 @@ mod tests {
         assert_eq!(event.api_key_id, "k-1");
         assert_eq!(event.model_id, "m-1");
         assert_eq!(event.inbound_protocol, "openai");
+    }
+
+    /// A minimal RIFF/WAVE container holding `seconds` of 8 kHz 16-bit
+    /// mono PCM — a real audio file for the probe path, small enough to
+    /// build inline.
+    fn wav_bytes(seconds: u32) -> Vec<u8> {
+        let samples = 8000usize * 2 * seconds as usize;
+        let mut wav = Vec::with_capacity(44 + samples);
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&((36 + samples) as u32).to_le_bytes());
+        wav.extend_from_slice(b"WAVEfmt ");
+        wav.extend_from_slice(&16u32.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes());
+        wav.extend_from_slice(&8000u32.to_le_bytes());
+        wav.extend_from_slice(&16000u32.to_le_bytes());
+        wav.extend_from_slice(&2u16.to_le_bytes());
+        wav.extend_from_slice(&16u16.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&(samples as u32).to_le_bytes());
+        wav.resize(44 + samples, 0);
+        wav
+    }
+
+    /// A multipart body whose `file` part is a real WAV, so the handler's
+    /// fallback probe has something to read.
+    fn transcription_multipart_wav(model: &str, seconds: u32) -> (String, axum::body::Body) {
+        let mut body = Vec::new();
+        body.extend_from_slice(
+            format!(
+                "--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n{model}\r\n\
+                 --b\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.wav\"\r\n\
+                 Content-Type: audio/wav\r\n\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend_from_slice(&wav_bytes(seconds));
+        body.extend_from_slice(b"\r\n--b--\r\n");
+        (
+            "multipart/form-data; boundary=b".to_string(),
+            axum::body::Body::from(body),
+        )
+    }
+
+    /// AISIX-Cloud#1138: whisper-1 bills by audio length and reports no
+    /// tokens, so the emitted event must carry the duration or cp-api has
+    /// nothing to price the request with.
+    #[tokio::test]
+    async fn whisper_response_emits_the_duration_cost_basis() {
+        let upstream = MockServer::start().await;
+        let body = serde_json::json!({
+            "text": "hello world",
+            "usage": {"type": "duration", "seconds": 11.0}
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-transcribe"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = transcription_multipart("my-transcribe");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.audio_duration_seconds, 11.0);
+        assert_eq!(
+            (event.prompt_tokens, event.completion_tokens),
+            (0, 0),
+            "whisper-1 reports no tokens — duration is the whole cost basis"
+        );
+    }
+
+    /// AISIX-Cloud#1138: `response_format=text` answers with a body that
+    /// carries no usage at all. The cost basis must not depend on which
+    /// response format the caller asked for, so the handler falls back to
+    /// the uploaded file's own length.
+    #[tokio::test]
+    async fn text_format_falls_back_to_the_uploaded_file_duration() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw("hello world", "text/plain"))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-transcribe"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = transcription_multipart_wav("my-transcribe", 3);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert!(
+            (event.audio_duration_seconds - 3.0).abs() < 0.05,
+            "3s of uploaded audio must be the cost basis, got {}",
+            event.audio_duration_seconds
+        );
+    }
+
+    /// The default `json` transcription reports its length under
+    /// `usage.seconds` (the duration variant of OpenAI's usage oneOf),
+    /// which is the cost basis for whisper-1 — a model that reports no
+    /// tokens at all.
+    #[test]
+    fn duration_reads_the_usage_seconds_variant() {
+        let body = br#"{"text":"hi","usage":{"type":"duration","seconds":11.0}}"#;
+        assert_eq!(super::upstream_duration_seconds(body), Some(11.0));
+    }
+
+    /// `verbose_json` puts the same figure at the top level instead.
+    #[test]
+    fn duration_reads_the_verbose_json_field() {
+        let body = br#"{"task":"transcribe","duration":2.66,"text":"hi"}"#;
+        assert_eq!(super::upstream_duration_seconds(body), Some(2.66));
+    }
+
+    /// A token-usage response carries no duration — the caller must fall
+    /// back to the file probe rather than read a zero off `usage`.
+    #[test]
+    fn duration_absent_from_a_token_usage_response() {
+        let body =
+            br#"{"text":"hi","usage":{"type":"tokens","input_tokens":26,"output_tokens":12}}"#;
+        assert_eq!(super::upstream_duration_seconds(body), None);
+    }
+
+    /// AISIX-Cloud#1138: `response_format=text` (and `srt`/`vtt`) answers
+    /// with a body that is not JSON at all, so the cost basis has to come
+    /// off the uploaded audio — otherwise the caller picks whether the
+    /// request is metered by picking a response format.
+    #[test]
+    fn duration_falls_back_to_probing_the_uploaded_file() {
+        // 1 second of 8 kHz 16-bit mono PCM in a minimal RIFF/WAVE container.
+        let samples = 8000usize * 2;
+        let mut wav = Vec::with_capacity(44 + samples);
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&((36 + samples) as u32).to_le_bytes());
+        wav.extend_from_slice(b"WAVEfmt ");
+        wav.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk size
+        wav.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        wav.extend_from_slice(&1u16.to_le_bytes()); // mono
+        wav.extend_from_slice(&8000u32.to_le_bytes()); // sample rate
+        wav.extend_from_slice(&16000u32.to_le_bytes()); // byte rate
+        wav.extend_from_slice(&2u16.to_le_bytes()); // block align
+        wav.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&(samples as u32).to_le_bytes());
+        wav.resize(44 + samples, 0);
+
+        let probed = super::probe_audio_duration_seconds(&wav)
+            .expect("a well-formed WAV must yield a duration");
+        assert!(
+            (probed - 1.0).abs() < 0.05,
+            "1s of 8kHz mono PCM should probe as ~1s, got {probed}"
+        );
+    }
+
+    /// Caller uploads are arbitrary bytes. An unrecognised file must
+    /// degrade to "no cost basis", never to an error — the transcript
+    /// already succeeded and the upstream already billed for it.
+    #[test]
+    fn probing_unrecognised_bytes_yields_no_duration() {
+        assert_eq!(super::probe_audio_duration_seconds(b"ID3fakeaudio"), None);
+        assert_eq!(super::probe_audio_duration_seconds(&[]), None);
     }
 
     /// AISIX-Cloud#867 parity: a successful audio request must carry the

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -1253,6 +1253,13 @@ fn probe_audio_duration_seconds(audio: &[u8]) -> Option<f64> {
     use lofty::file::AudioFile;
     use lofty::probe::Probe;
 
+    // WebM/Matroska first: `lofty` does not read EBML, and WebM is what
+    // a browser's MediaRecorder uploads by default — leaving it out
+    // would keep the most common web-app upload unbilled.
+    if audio.starts_with(&crate::ebml::EBML_MAGIC) {
+        return crate::ebml::duration_seconds(audio);
+    }
+
     let probed = Probe::new(std::io::Cursor::new(audio))
         .guess_file_type()
         .ok()?
@@ -1960,6 +1967,23 @@ mod tests {
             (event.audio_duration_seconds - 3.0).abs() < 0.05,
             "3s of uploaded audio must be the cost basis, got {}",
             event.audio_duration_seconds
+        );
+    }
+
+    /// AISIX-Cloud#1138: `MediaRecorder` uploads `audio/webm`, which
+    /// `lofty` cannot read — so a WebM transcription asked for as `text`
+    /// would have reported no length and billed nothing, which is the
+    /// exact bypass the file probe exists to close. Uses the header of a
+    /// file ffmpeg produced (see `ebml::tests`), whose declared length is
+    /// 7.008s.
+    #[test]
+    fn probing_reads_a_webm_upload() {
+        let webm = crate::ebml::tests::REAL_FFMPEG_WEBM_HEADER;
+        let probed =
+            super::probe_audio_duration_seconds(webm).expect("a webm upload must be measurable");
+        assert!(
+            (probed - 7.008).abs() < 0.01,
+            "webm should probe as ~7.008s, got {probed}"
         );
     }
 

--- a/crates/aisix-proxy/src/ebml.rs
+++ b/crates/aisix-proxy/src/ebml.rs
@@ -1,0 +1,343 @@
+//! Audio length from a WebM / Matroska container.
+//!
+//! `lofty` covers every audio container the transcription endpoints
+//! accept except this one, and WebM is not a corner: `MediaRecorder`
+//! produces `audio/webm;codecs=opus` by default, so it is what a browser
+//! uploads. Without it a WebM transcription asked for as `text` / `srt` /
+//! `vtt` would report no length and bill nothing (#1138).
+//!
+//! Only the header path is walked — EBML root → `Segment` → `Info` — to
+//! read `Duration` (a float in `TimecodeScale` units) and `TimecodeScale`
+//! (nanoseconds, default 1,000,000). Clusters are never entered and no
+//! audio is decoded.
+//!
+//! The input is a caller upload, so the walk is total: every read is
+//! bounds-checked, element sizes are clamped to the enclosing element,
+//! and the number of elements visited is capped. Anything malformed,
+//! truncated, or simply not Matroska yields `None`.
+//!
+//! <https://www.rfc-editor.org/rfc/rfc8794> (EBML),
+//! <https://www.matroska.org/technical/elements.html>
+
+/// EBML magic — the `EBML` root element every Matroska/WebM file opens
+/// with. Checked by the caller to pick this reader over `lofty`.
+pub(crate) const EBML_MAGIC: [u8; 4] = [0x1A, 0x45, 0xDF, 0xA3];
+
+const ID_SEGMENT: u64 = 0x1853_8067;
+const ID_INFO: u64 = 0x1549_A966;
+const ID_DURATION: u64 = 0x4489;
+const ID_TIMECODE_SCALE: u64 = 0x002A_D7B1;
+
+/// Matroska's default when `Info` omits `TimecodeScale`: one millisecond
+/// expressed in nanoseconds.
+const DEFAULT_TIMECODE_SCALE: u64 = 1_000_000;
+
+/// Total elements the walk may visit before giving up. A well-formed
+/// header reaches `Info` in a few dozen; the cap bounds the work a
+/// crafted file can cause, since sizes come from the file itself.
+const MAX_ELEMENTS: usize = 8_192;
+
+/// One decoded EBML variable-length integer: its value and its width.
+struct VInt {
+    value: u64,
+    width: usize,
+}
+
+/// Decode an EBML variable-length integer at `pos`.
+///
+/// `keep_marker` distinguishes the two uses: element IDs keep the length
+/// marker (that is what makes `0x1A45DFA3` the literal id), while sizes
+/// strip it to recover the magnitude.
+fn read_vint(data: &[u8], pos: usize, keep_marker: bool) -> Option<VInt> {
+    let first = *data.get(pos)?;
+    if first == 0 {
+        // A zero lead byte would mean a width above 8 bytes, which no
+        // real element uses and which the loop below cannot describe.
+        return None;
+    }
+    let width = first.leading_zeros() as usize + 1;
+    if width > 8 || pos + width > data.len() {
+        return None;
+    }
+    let mut value: u64 = if keep_marker {
+        u64::from(first)
+    } else {
+        // Strip the width marker to recover the magnitude. At width 8 the
+        // lead byte is all marker (0x01) and carries no value bits, and
+        // `0xFF >> 8` would overflow the shift.
+        let value_bits = if width >= 8 { 0 } else { 0xFFu8 >> width };
+        u64::from(first & value_bits)
+    };
+    for byte in &data[pos + 1..pos + width] {
+        value = (value << 8) | u64::from(*byte);
+    }
+    Some(VInt { value, width })
+}
+
+/// True when a size vint carries the all-ones "unknown size" pattern —
+/// live-muxed WebM leaves `Segment` open this way, which is exactly what
+/// a browser upload looks like.
+fn is_unknown_size(size: &VInt) -> bool {
+    let bits = 7 * size.width as u32;
+    size.value == (1u64 << bits) - 1
+}
+
+/// Audio length in seconds, or `None` if this is not a readable
+/// Matroska/WebM header.
+pub(crate) fn duration_seconds(data: &[u8]) -> Option<f64> {
+    if !data.starts_with(&EBML_MAGIC) {
+        return None;
+    }
+    let mut budget = MAX_ELEMENTS;
+    let segment = find_child(data, 0, data.len(), ID_SEGMENT, &mut budget)?;
+    let info = find_child(data, segment.0, segment.1, ID_INFO, &mut budget)?;
+
+    let mut duration: Option<f64> = None;
+    let mut scale = DEFAULT_TIMECODE_SCALE;
+    let mut pos = info.0;
+    while pos < info.1 {
+        if budget == 0 {
+            return None;
+        }
+        budget -= 1;
+        let (id, body_start, body_end, next) = read_element(data, pos, info.1)?;
+        match id {
+            ID_DURATION => duration = read_float(&data[body_start..body_end]),
+            ID_TIMECODE_SCALE => scale = read_uint(&data[body_start..body_end]),
+            _ => {}
+        }
+        pos = next?;
+    }
+
+    let ticks = duration?;
+    if !ticks.is_finite() || ticks <= 0.0 || scale == 0 {
+        return None;
+    }
+    let seconds = ticks * (scale as f64) / 1_000_000_000.0;
+    (seconds.is_finite() && seconds > 0.0).then_some(seconds)
+}
+
+/// Scan the children of one master element for `wanted`, returning the
+/// body range of the match.
+fn find_child(
+    data: &[u8],
+    start: usize,
+    end: usize,
+    wanted: u64,
+    budget: &mut usize,
+) -> Option<(usize, usize)> {
+    let mut pos = start;
+    while pos < end {
+        if *budget == 0 {
+            return None;
+        }
+        *budget -= 1;
+        let (id, body_start, body_end, next) = read_element(data, pos, end)?;
+        if id == wanted {
+            return Some((body_start, body_end));
+        }
+        // An unknown-size element that is not the one we want ends the
+        // scan: its extent is undefined, so nothing after it can be
+        // located without descending into it.
+        pos = next?;
+    }
+    None
+}
+
+/// Read one element header at `pos`.
+///
+/// Returns its id, the bounds of its body, and where the next sibling
+/// starts — `None` for the sibling when the element declared an unknown
+/// size, since there is no defined end to skip to.
+fn read_element(
+    data: &[u8],
+    pos: usize,
+    parent_end: usize,
+) -> Option<(u64, usize, usize, Option<usize>)> {
+    let id = read_vint(data, pos, true)?;
+    let size_pos = pos.checked_add(id.width)?;
+    let size = read_vint(data, size_pos, false)?;
+    let body_start = size_pos.checked_add(size.width)?;
+    if body_start > parent_end {
+        return None;
+    }
+    if is_unknown_size(&size) {
+        // Body runs to the end of the enclosing element.
+        return Some((id.value, body_start, parent_end, None));
+    }
+    // Clamp rather than reject: a truncated upload still has a readable
+    // prefix, and the caller only needs `Info`, which precedes the media
+    // data in every muxer's output.
+    let body_end = body_start
+        .checked_add(usize::try_from(size.value).ok()?)?
+        .min(parent_end);
+    Some((id.value, body_start, body_end, Some(body_end)))
+}
+
+/// EBML floats are 4 or 8 bytes, big-endian. Any other width is invalid.
+fn read_float(body: &[u8]) -> Option<f64> {
+    match body.len() {
+        4 => Some(f64::from(f32::from_be_bytes(body.try_into().ok()?))),
+        8 => Some(f64::from_be_bytes(body.try_into().ok()?)),
+        _ => None,
+    }
+}
+
+/// EBML unsigned ints are big-endian and up to 8 bytes wide.
+fn read_uint(body: &[u8]) -> u64 {
+    if body.is_empty() || body.len() > 8 {
+        return DEFAULT_TIMECODE_SCALE;
+    }
+    body.iter().fold(0u64, |acc, b| (acc << 8) | u64::from(*b))
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    /// The header of a real `ffmpeg -c:a libopus -f webm` file: an EBML
+    /// header, then a `Segment` left at unknown size (how a live muxer —
+    /// and a browser's MediaRecorder — writes it), a SeekHead whose
+    /// SeekID payloads repeat the `Info` id, and finally the real `Info`
+    /// carrying TimecodeScale 1,000,000 and Duration 7008.0.
+    ///
+    /// The SeekHead is the point of the fixture: a byte scan for the
+    /// `Info` id finds those payloads first and reads garbage. Only a
+    /// structural walk lands on the real element.
+    fn webm_header(duration_ticks: f64) -> Vec<u8> {
+        let mut out = Vec::new();
+        // EBML header (id 1A45DFA3), one child: DocType "webm".
+        let doctype = [0x42u8, 0x82, 0x84, b'w', b'e', b'b', b'm'];
+        out.extend_from_slice(&[0x1A, 0x45, 0xDF, 0xA3]);
+        out.push(0x80 | doctype.len() as u8);
+        out.extend_from_slice(&doctype);
+
+        // Segment (id 18538067) with the unknown-size marker.
+        out.extend_from_slice(&[0x18, 0x53, 0x80, 0x67]);
+        out.extend_from_slice(&[0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+
+        // SeekHead (id 114D9B74) holding one Seek → SeekID = Info id.
+        let seek_id_payload = [0x53u8, 0xAB, 0x84, 0x15, 0x49, 0xA9, 0x66];
+        let mut seek = Vec::new();
+        seek.extend_from_slice(&[0x4D, 0xBB]); // Seek
+        seek.push(0x80 | seek_id_payload.len() as u8);
+        seek.extend_from_slice(&seek_id_payload);
+        out.extend_from_slice(&[0x11, 0x4D, 0x9B, 0x74]);
+        out.push(0x80 | seek.len() as u8);
+        out.extend_from_slice(&seek);
+
+        // Info (id 1549A966): TimecodeScale + Duration.
+        let mut info = Vec::new();
+        info.extend_from_slice(&[0x2A, 0xD7, 0xB1, 0x83, 0x0F, 0x42, 0x40]); // 1_000_000
+        info.extend_from_slice(&[0x44, 0x89, 0x88]); // Duration, 8-byte float
+        info.extend_from_slice(&duration_ticks.to_be_bytes());
+        out.extend_from_slice(&[0x15, 0x49, 0xA9, 0x66]);
+        out.push(0x80 | info.len() as u8);
+        out.extend_from_slice(&info);
+        out
+    }
+
+    /// The fixture above is hand-built; this one is the first 264 bytes
+    /// of a file `ffmpeg -c:a libopus -f webm` actually produced — EBML
+    /// header, unknown-size Segment, SeekHead, and the real Info — cut
+    /// immediately after Info so no audio data rides along. ffprobe
+    /// reports 7.008s for the full file.
+    #[rustfmt::skip]
+    pub(crate) const REAL_FFMPEG_WEBM_HEADER: &[u8] = &[
+        0x1A, 0x45, 0xDF, 0xA3, 0x9F, 0x42, 0x86, 0x81, 0x01, 0x42, 0xF7, 0x81, 0x01, 0x42, 0xF2, 0x81,
+        0x04, 0x42, 0xF3, 0x81, 0x08, 0x42, 0x82, 0x84, 0x77, 0x65, 0x62, 0x6D, 0x42, 0x87, 0x81, 0x04,
+        0x42, 0x85, 0x81, 0x02, 0x18, 0x53, 0x80, 0x67, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x14, 0x6A,
+        0x11, 0x4D, 0x9B, 0x74, 0xBB, 0x4D, 0xBB, 0x8B, 0x53, 0xAB, 0x84, 0x15, 0x49, 0xA9, 0x66, 0x53,
+        0xAC, 0x81, 0xA1, 0x4D, 0xBB, 0x8B, 0x53, 0xAB, 0x84, 0x16, 0x54, 0xAE, 0x6B, 0x53, 0xAC, 0x81,
+        0xD8, 0x4D, 0xBB, 0x8C, 0x53, 0xAB, 0x84, 0x12, 0x54, 0xC3, 0x67, 0x53, 0xAC, 0x82, 0x01, 0x42,
+        0x4D, 0xBB, 0x8D, 0x53, 0xAB, 0x84, 0x1C, 0x53, 0xBB, 0x6B, 0x53, 0xAC, 0x83, 0x01, 0x14, 0x42,
+        0xEC, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x15, 0x49, 0xA9, 0x66, 0xB2, 0x2A, 0xD7, 0xB1, 0x83, 0x0F, 0x42, 0x40, 0x4D, 0x80, 0x8D,
+        0x4C, 0x61, 0x76, 0x66, 0x36, 0x32, 0x2E, 0x31, 0x32, 0x2E, 0x31, 0x30, 0x32, 0x57, 0x41, 0x8D,
+        0x4C, 0x61, 0x76, 0x66, 0x36, 0x32, 0x2E, 0x31, 0x32, 0x2E, 0x31, 0x30, 0x32, 0x44, 0x89, 0x88,
+        0x40, 0xBB, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn reads_a_header_a_real_muxer_produced() {
+        let got = super::duration_seconds(REAL_FFMPEG_WEBM_HEADER)
+            .expect("a real webm header must yield a duration");
+        assert!(
+            (got - 7.008).abs() < 0.01,
+            "ffprobe reports 7.008s for this file, reader said {got}"
+        );
+    }
+
+    #[test]
+    fn reads_duration_past_a_seekhead_and_unknown_size_segment() {
+        let webm = webm_header(7008.0);
+        let got = super::duration_seconds(&webm).expect("a webm header must yield a duration");
+        assert!(
+            (got - 7.008).abs() < 0.001,
+            "7008 ticks × 1e6 ns should be 7.008s, got {got}"
+        );
+    }
+
+    /// A 4-byte float is equally valid per the spec.
+    #[test]
+    fn reads_a_32_bit_duration() {
+        let mut info = Vec::new();
+        info.extend_from_slice(&[0x44, 0x89, 0x84]);
+        info.extend_from_slice(&2500.0f32.to_be_bytes());
+        let mut out = Vec::new();
+        out.extend_from_slice(&[0x1A, 0x45, 0xDF, 0xA3, 0x80]);
+        out.extend_from_slice(&[0x18, 0x53, 0x80, 0x67]);
+        out.extend_from_slice(&[0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+        out.extend_from_slice(&[0x15, 0x49, 0xA9, 0x66]);
+        out.push(0x80 | info.len() as u8);
+        out.extend_from_slice(&info);
+        assert_eq!(super::duration_seconds(&out), Some(2.5));
+    }
+
+    /// Not Matroska at all — the caller falls through to `lofty`.
+    #[test]
+    fn non_ebml_input_is_declined() {
+        assert_eq!(super::duration_seconds(b"RIFF....WAVEfmt "), None);
+        assert_eq!(super::duration_seconds(&[]), None);
+    }
+
+    /// Uploads are caller-controlled: truncation anywhere in the header
+    /// must yield `None` rather than panic on a slice.
+    #[test]
+    fn every_truncation_of_a_valid_header_is_survivable() {
+        let webm = webm_header(7008.0);
+        for cut in 0..webm.len() {
+            let _ = super::duration_seconds(&webm[..cut]);
+        }
+    }
+
+    /// A declared size far past the end of the buffer must not read out
+    /// of bounds — it is clamped to the parent, and the walk simply
+    /// finds nothing.
+    #[test]
+    fn oversized_declarations_are_clamped_not_trusted() {
+        let mut out = Vec::new();
+        out.extend_from_slice(&[0x1A, 0x45, 0xDF, 0xA3, 0x80]);
+        out.extend_from_slice(&[0x18, 0x53, 0x80, 0x67]);
+        // Segment claims ~4 GiB of body in a 20-byte file.
+        out.extend_from_slice(&[0x10, 0xFF, 0xFF, 0xFF]);
+        out.extend_from_slice(&[0x15, 0x49, 0xA9, 0x66, 0x80]);
+        assert_eq!(super::duration_seconds(&out), None);
+    }
+
+    /// A zero or absent duration is not a cost basis.
+    #[test]
+    fn zero_and_missing_durations_are_declined() {
+        assert_eq!(super::duration_seconds(&webm_header(0.0)), None);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(&[0x1A, 0x45, 0xDF, 0xA3, 0x80]);
+        out.extend_from_slice(&[0x18, 0x53, 0x80, 0x67]);
+        out.extend_from_slice(&[0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+        out.extend_from_slice(&[0x15, 0x49, 0xA9, 0x66, 0x80]); // empty Info
+        assert_eq!(super::duration_seconds(&out), None);
+    }
+}

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -36,6 +36,7 @@ mod completions;
 pub(crate) mod cooldown;
 mod count_tokens;
 mod dispatch;
+mod ebml;
 mod embeddings;
 mod ensemble;
 mod error;

--- a/tests/e2e/src/cases/audio-duration-cost-basis-e2e.test.ts
+++ b/tests/e2e/src/cases/audio-duration-cost-basis-e2e.test.ts
@@ -1,0 +1,252 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for AISIX-Cloud#1138 / api7/aisix#457: a transcription billed by
+// audio length must carry that length off the gateway.
+//
+// whisper-class models report `usage: {type: "duration", seconds: N}` and
+// no token counts at all, so a token-only usage event leaves cp-api with
+// nothing to price the request with. And because `response_format=text`
+// answers with a body that carries no usage whatsoever, the cost basis
+// cannot come from the response alone — otherwise the caller decides
+// whether the request is metered by choosing a response format.
+//
+// Usage telemetry has no cp-api receiver in DP e2e, so the emitted value
+// is observed through the per-env OTLP/HTTP fan-out.
+
+const CALLER_PLAINTEXT = "sk-issue-1138-duration";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const REPORTED_SECONDS = 11;
+const UPLOADED_SECONDS = 3;
+
+/** `seconds` of 8 kHz 16-bit mono PCM in a minimal RIFF/WAVE container. */
+function wavBytes(seconds: number): Uint8Array {
+  const sampleRate = 8000;
+  const dataLen = sampleRate * 2 * seconds;
+  const buf = Buffer.alloc(44 + dataLen);
+  buf.write("RIFF", 0, "ascii");
+  buf.writeUInt32LE(36 + dataLen, 4);
+  buf.write("WAVE", 8, "ascii");
+  buf.write("fmt ", 12, "ascii");
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 2, 28);
+  buf.writeUInt16LE(2, 32);
+  buf.writeUInt16LE(16, 34);
+  buf.write("data", 36, "ascii");
+  buf.writeUInt32LE(dataLen, 40);
+  return new Uint8Array(buf);
+}
+
+interface OtlpReceiver {
+  url: string;
+  spanAttrs: Array<Record<string, string>>;
+  close(): Promise<void>;
+}
+
+async function startOtlpReceiver(): Promise<OtlpReceiver> {
+  const spanAttrs: Array<Record<string, string>> = [];
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(raw);
+        for (const rs of body.resourceSpans ?? []) {
+          for (const ss of rs.scopeSpans ?? []) {
+            for (const span of ss.spans ?? []) {
+              const attrs: Record<string, string> = {};
+              for (const a of span.attributes ?? []) {
+                const v = a.value ?? {};
+                attrs[a.key] =
+                  v.stringValue ??
+                  String(v.intValue ?? v.doubleValue ?? v.boolValue ?? "");
+              }
+              spanAttrs.push(attrs);
+            }
+          }
+        }
+      } catch {
+        // ignore malformed bodies — assertions fail on missing spans
+      }
+      res.statusCode = 200;
+      res.end("{}");
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${port}/v1/traces`,
+    spanAttrs,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+async function waitSpan(
+  recv: OtlpReceiver,
+  requestId: string,
+  timeoutMs = 10_000,
+): Promise<Record<string, string>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hit = recv.spanAttrs.find((a) => a["aisix.request_id"] === requestId);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`no usage span for request_id=${requestId}`);
+}
+
+describe("audio duration cost basis (#1138)", () => {
+  let app: SpawnedApp | undefined;
+  let jsonUpstream: OpenAiUpstream | undefined;
+  let textUpstream: OpenAiUpstream | undefined;
+  let otlp: OtlpReceiver | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // One upstream per response shape rather than a scripted sequence:
+    // the readiness probe would otherwise consume the first scripted
+    // reply and shift every later assertion onto the wrong one.
+    jsonUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        text: "hello world",
+        usage: { type: "duration", seconds: REPORTED_SECONDS },
+      },
+    });
+    textUpstream = await startOpenAiUpstream({
+      rawBody: "hello world",
+      rawContentType: "text/plain",
+    });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    otlp = await startOtlpReceiver();
+    await seed.createObservabilityExporter({
+      name: "issue1138-duration-otlp",
+      enabled: true,
+      kind: "otlp_http",
+      endpoint: otlp.url,
+    });
+
+    const jsonPK = await seed.createProviderKey({
+      display_name: "issue1138-duration-pk",
+      secret: "sk-openai-mock",
+      api_base: `${jsonUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "duration-transcribe",
+      provider: "openai",
+      model_name: "whisper-1",
+      provider_key_id: jsonPK.id,
+    });
+    const textPK = await seed.createProviderKey({
+      display_name: "issue1138-text-pk",
+      secret: "sk-openai-mock",
+      api_base: `${textUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "text-transcribe",
+      provider: "openai",
+      model_name: "whisper-1",
+      provider_key_id: textPK.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["duration-transcribe", "text-transcribe"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await jsonUpstream?.close();
+    await textUpstream?.close();
+    await otlp?.close();
+  });
+
+  test("a duration-billed transcription reports its audio length", async (ctx) => {
+    if (!etcdReachable || !app || !otlp) {
+      ctx.skip();
+      return;
+    }
+    const proxyUrl = app.proxyUrl;
+
+    const call = (
+      model: string,
+      audio: Uint8Array,
+      extra: Record<string, string> = {},
+    ) => {
+      const form = new FormData();
+      form.set("model", model);
+      for (const [k, v] of Object.entries(extra)) form.set(k, v);
+      form.set("file", new Blob([audio], { type: "audio/wav" }), "a.wav");
+      return fetch(`${proxyUrl}/v1/audio/transcriptions`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+        body: form,
+      });
+    };
+
+    const probe = wavBytes(UPLOADED_SECONDS);
+    await waitConfigPropagation(async () => {
+      try {
+        const [a, b] = await Promise.all([
+          call("duration-transcribe", probe),
+          call("text-transcribe", probe),
+        ]);
+        return a.ok && b.ok;
+      } catch {
+        return false;
+      }
+    });
+
+    // 1. The upstream reported a duration — that figure wins.
+    const reported = await call("duration-transcribe", probe);
+    expect(reported.status).toBe(200);
+    const reportedSpan = await waitSpan(
+      otlp,
+      reported.headers.get("x-aisix-request-id") ?? "",
+    );
+    expect(
+      Number(reportedSpan["aisix.audio.duration_seconds"]),
+      "the upstream-reported duration is the cost basis",
+    ).toBe(REPORTED_SECONDS);
+
+    // 2. `response_format=text` carries no usage at all, so the cost
+    //    basis comes off the uploaded audio instead of vanishing.
+    const plain = await call("text-transcribe", probe, {
+      response_format: "text",
+    });
+    expect(plain.status).toBe(200);
+    const plainSpan = await waitSpan(
+      otlp,
+      plain.headers.get("x-aisix-request-id") ?? "",
+    );
+    expect(
+      Number(plainSpan["aisix.audio.duration_seconds"]),
+      "a response carrying no usage must still be priceable",
+    ).toBeCloseTo(UPLOADED_SECONDS, 1);
+  });
+});


### PR DESCRIPTION
## Problem

Models in the whisper family bill by **audio length**, not tokens. Their response reports

```json
{"text": "...", "usage": {"type": "duration", "seconds": 11}}
```

and no token counts at all. The emitted `UsageEvent` carried tokens only, so cp-api received a row with nothing to price it with — every whisper-class request settles at $0. Verified against real OpenAI through a real DP in api7/AISIX-Cloud#1138: `whisper-1` recorded `prompt=0 completion=0` while `gpt-4o-transcribe` (which does report tokens) recorded `26/12` on the same audio.

## Change

`UsageEvent` gains `audio_duration_seconds`, populated on `/v1/audio/transcriptions` and `/v1/audio/translations`. Skipped on the wire when zero, so token-only events are byte-identical to before and an older cp-api ignores the field.

Two sources, in order:

| Response format | Duration source |
| --- | --- |
| `json` | `usage.seconds` |
| `verbose_json` | top-level `duration` |
| `text` / `srt` / `vtt` | the uploaded file's own properties |

The file fallback is not an optimisation. Those three formats answer with a body that is not JSON and carries no usage whatsoever, so without it **the caller decides whether a request is metered by choosing a response format** — the same shape of bypass as an unbilled stream.

Reading the file is metadata-only: `lofty` (MIT OR Apache-2.0, `default-features = false`, 4 new crates, no C dependency) parses container/codec headers without decoding, so an arbitrary caller upload costs microseconds and anything unrecognised yields no duration rather than an error. The probe runs only when the response carried no duration, so the common `json` path never pays for it.

This is the DP half of api7/aisix#457. cp-api pricing the field is the paired CP change.

**Unchanged:** `/v1/audio/speech` — TTS bills per input character, not by the length of the audio it produced.

## Baseline

LiteLLM prices transcription as `cost_per_second × duration`, taking the duration from the response and falling back to computing it from the file with `soundfile` when absent (`calculate_request_duration`). Same two sources, same order; ours differs only in that the fallback is always available rather than an optional dependency.

## Tests

- Unit: both response shapes, the token-usage response yielding no duration, a real WAV probing to its true length, and unrecognised bytes degrading to `None`.
- Handler: a whisper-shaped response emits `audio_duration_seconds = 11` with zero tokens; a `text` response with no usage falls back to the uploaded file's 3s.
- `tests/e2e/src/cases/audio-duration-cost-basis-e2e.test.ts` — real `aisix` binary + etcd + mock upstreams, asserting both paths through the OTLP fan-out. Fails before this change (the attribute does not exist → `NaN`).

Refs api7/AISIX-Cloud#1138, #457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio transcription and translation usage can now be calculated from audio duration when token usage is unavailable.
  * Reported upstream duration is used when available; otherwise, duration is detected from the uploaded audio.
  * Speech synthesis continues to use character-based billing.
* **Observability**
  * Audio duration is now included in usage events and telemetry when applicable.
* **Tests**
  * Added coverage for duration-based billing across supported response formats and audio inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->