### PR TITLE
fix(obs): count reasoning tokens toward upstream TTFT

### DIFF
--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -490,6 +490,31 @@ pub struct ChatDelta {
     pub reasoning_content: Option<String>,
 }
 
+impl ChatDelta {
+    /// Whether this delta carries generated output — the only frames a
+    /// time-to-first-token measurement may stop on. Every streaming
+    /// handler that records `upstream_ttft_ms` off a [`ChatChunk`] shares
+    /// this predicate so the family can't drift apart again.
+    ///
+    /// Reasoning text counts. A reasoning model streams its chain of
+    /// thought first and only emits `content` once it has stopped
+    /// thinking, so a predicate that ignores `reasoning_content` reports
+    /// the end of the thinking phase as the first token — 183.5s against
+    /// a real 1.2s on the request in AISIX-Cloud#1225.
+    ///
+    /// Empty strings do not count: OpenAI opens a stream with a role-only
+    /// `{"role":"assistant","content":""}` frame, which marks the stream
+    /// starting rather than a token arriving.
+    pub fn carries_generated_output(&self) -> bool {
+        self.content.as_deref().is_some_and(|s| !s.is_empty())
+            || self
+                .reasoning_content
+                .as_deref()
+                .is_some_and(|s| !s.is_empty())
+            || self.tool_calls.as_ref().is_some_and(|t| !t.is_empty())
+    }
+}
+
 // ─── Embeddings ──────────────────────────────────────────────────────────────
 
 /// The vector returned on one embedding object. Untagged enum so JSON

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -4373,11 +4373,9 @@ where
             let maybe_chunk = match item {
                 Ok(mut chunk) => {
                     // Record TTFT on the first chunk carrying generated
-                    // output (content or tool calls). Skip role-only
-                    // chunks that OpenAI emits before actual tokens.
-                    if !first_chunk_seen
-                        && (chunk.delta.content.is_some() || chunk.delta.tool_calls.is_some())
-                    {
+                    // output — reasoning text included, role-only frames
+                    // excluded. See `ChatDelta::carries_generated_output`.
+                    if !first_chunk_seen && chunk.delta.carries_generated_output() {
                         first_chunk_seen = true;
                         guard.comp().upstream_ttft_ms =
                             attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -2269,9 +2269,7 @@ fn build_anthropic_sse_stream(
         while let Some(item) = upstream.next().await {
             match item {
                 Ok(chunk) => {
-                    if !first_chunk_seen
-                        && (chunk.delta.content.is_some() || chunk.delta.tool_calls.is_some())
-                    {
+                    if !first_chunk_seen && chunk.delta.carries_generated_output() {
                         first_chunk_seen = true;
                         guard.comp().upstream_ttft_ms =
                             attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -2265,6 +2265,14 @@ fn responses_sse_usage(bytes: &[u8]) -> Option<ResponseUsage> {
 /// Whether this SSE event carries generated output. Mirrors the set
 /// `SseTextCapture::observe` accumulates, so TTFT lands on the same frame
 /// the capture considers the first real token.
+/// Frames that carry generated output, and so may stop the TTFT clock.
+///
+/// The reasoning arms are the Responses-API counterpart of
+/// [`ChatDelta::carries_generated_output`](aisix_gateway::ChatDelta::carries_generated_output):
+/// a reasoning model streams its summary (or, for models that expose it,
+/// its raw reasoning text) well before the first `output_text` frame, so
+/// leaving them out reports the end of the thinking phase as the first
+/// token — AISIX-Cloud#1225.
 fn is_responses_content_delta(json: &Value) -> bool {
     matches!(
         json.get("type").and_then(Value::as_str),
@@ -2273,6 +2281,8 @@ fn is_responses_content_delta(json: &Value) -> bool {
                 | "response.function_call_arguments.delta"
                 | "response.mcp_call_arguments.delta"
                 | "response.custom_tool_call_input.delta"
+                | "response.reasoning_summary_text.delta"
+                | "response.reasoning_text.delta"
         )
     )
 }

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1037,9 +1037,7 @@ pub fn build_responses_bridge_stream(
         while let Some(item) = upstream.next().await {
             match item {
                 Ok(chunk) => {
-                    if !first_chunk_seen
-                        && (chunk.delta.content.is_some() || chunk.delta.tool_calls.is_some())
-                    {
+                    if !first_chunk_seen && chunk.delta.carries_generated_output() {
                         first_chunk_seen = true;
                         guard.comp().upstream_ttft_ms =
                             attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;

--- a/tests/e2e/src/cases/ttft-reasoning-e2e.test.ts
+++ b/tests/e2e/src/cases/ttft-reasoning-e2e.test.ts
@@ -242,6 +242,7 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
 
     const span = await waitForSpan(otlp, requestId!);
     const ttft = Number(span["aisix.upstream_ttft_ms"]);
+    const downstream = Number(span["aisix.downstream_latency_ms"]);
 
     // The first reasoning frame is a token arriving, so the clock stops
     // near LEAD_MS — not at CONTENT_STARTS_MS, which is what a
@@ -249,6 +250,12 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
     expect(Number.isFinite(ttft)).toBe(true);
     expect(ttft).toBeGreaterThan(0);
     expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2);
+
+    // The caller-facing figure can never precede the upstream TTFT it
+    // waited on. Skipping reasoning frames broke exactly that: the
+    // gateway forwarded them (so downstream marked the first one) while
+    // TTFT held out for content a whole thinking phase later.
+    expect(downstream).toBeGreaterThanOrEqual(ttft);
   });
 
   test("an empty role-only frame does not stop the clock", async (ctx) => {

--- a/tests/e2e/src/cases/ttft-reasoning-e2e.test.ts
+++ b/tests/e2e/src/cases/ttft-reasoning-e2e.test.ts
@@ -175,9 +175,17 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
     await otlp?.close();
   });
 
+  /**
+   * `provider` selects the dispatch path under test. `openai` takes the
+   * native routes; any other OpenAI-compatible provider (here `deepseek`)
+   * routes `/v1/messages` through the cross-provider translation and
+   * `/v1/responses` through the chat-completions bridge — the two sites
+   * that share the predicate but never see the native code paths.
+   */
   async function createModel(
     displayName: string,
     upstream: OpenAiUpstream,
+    provider: "openai" | "deepseek" = "openai",
   ): Promise<void> {
     if (!seed) throw new Error("seed client not initialized");
     const pk = await seed.createProviderKey({
@@ -187,8 +195,8 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
     });
     await seed.createModel({
       display_name: displayName,
-      provider: "openai",
-      model_name: "gpt-4o-mini",
+      provider,
+      model_name: provider === "openai" ? "gpt-4o-mini" : "deepseek-reasoner",
       provider_key_id: pk.id,
     });
   }
@@ -303,6 +311,91 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
     // wait for the frame one gap later. Reading the opener put this at ~0.
     expect(Number.isFinite(ttft)).toBe(true);
     expect(ttft).toBeGreaterThan(GAP_MS);
+  });
+
+  test("reasoning text stops the clock on the /v1/messages bridge", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    // Anthropic-shaped request, OpenAI-compatible upstream: the
+    // cross-provider translation, not the byte-for-byte passthrough.
+    const upstream = await startOpenAiUpstream({
+      streamEvents: reasoningThenContent(),
+      firstEventDelayMs: LEAD_MS,
+      eventDelayMs: GAP_MS,
+    });
+    upstreams.push(upstream);
+    await createModel("ttft-reasoning-messages", upstream, "deepseek");
+    await awaitPropagation("reasoning-messages");
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "ttft-reasoning-messages",
+        max_tokens: 128,
+        messages: [{ role: "user", content: "think then answer" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const requestId = res.headers.get("x-aisix-request-id");
+    expect(requestId).toBeTruthy();
+    await res.text();
+
+    const span = await waitForSpan(otlp, requestId!);
+    const ttft = Number(span["aisix.upstream_ttft_ms"]);
+
+    expect(Number.isFinite(ttft)).toBe(true);
+    expect(ttft).toBeGreaterThan(0);
+    expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2);
+  });
+
+  test("reasoning text stops the clock on the /v1/responses bridge", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    // A non-OpenAI provider serves /v1/responses through the
+    // chat-completions bridge, so the upstream speaks chat SSE.
+    const upstream = await startOpenAiUpstream({
+      streamEvents: reasoningThenContent(),
+      firstEventDelayMs: LEAD_MS,
+      eventDelayMs: GAP_MS,
+    });
+    upstreams.push(upstream);
+    await createModel("ttft-reasoning-resp-bridge", upstream, "deepseek");
+    await awaitPropagation("reasoning-resp-bridge");
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "ttft-reasoning-resp-bridge",
+        input: "think then answer",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const requestId = res.headers.get("x-aisix-request-id");
+    expect(requestId).toBeTruthy();
+    await res.text();
+
+    const span = await waitForSpan(otlp, requestId!);
+    const ttft = Number(span["aisix.upstream_ttft_ms"]);
+
+    expect(Number.isFinite(ttft)).toBe(true);
+    expect(ttft).toBeGreaterThan(0);
+    expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2);
   });
 
   test("reasoning summaries stop the clock on /v1/responses", async (ctx) => {

--- a/tests/e2e/src/cases/ttft-reasoning-e2e.test.ts
+++ b/tests/e2e/src/cases/ttft-reasoning-e2e.test.ts
@@ -1,0 +1,361 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: what `upstream_ttft_ms` is allowed to stop on (AISIX-Cloud#1225).
+//
+// A reasoning model streams its chain of thought first and only emits
+// `content` once it has stopped thinking. The reported request spent
+// ~182s reasoning, so a TTFT that only recognises `content` frames read
+// 183,581 ms while the gateway in front of it measured the first token at
+// 1,175 ms. The clock must stop on the first frame carrying generated
+// output of ANY kind — reasoning text included.
+//
+// The mirror-image defect: OpenAI opens every stream with a role-only
+// `{"role":"assistant","content":""}` frame. Testing `content.is_some()`
+// accepted that empty string, so the clock stopped when the stream
+// opened rather than when a token arrived.
+//
+// Both are asserted per inbound protocol, since the predicate lives at
+// four sites across the handler family.
+
+const CALLER_PLAINTEXT = "sk-ttft-reasoning-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+/** Inter-chunk gap. */
+const GAP_MS = 250;
+/** Delay before the first SSE event, so a correct TTFT is measurably > 0. */
+const LEAD_MS = 250;
+/** Reasoning frames streamed before the first content frame. */
+const REASONING_FRAMES = 6;
+/**
+ * When the first content frame lands — what a `content`-only predicate
+ * reports. A correct TTFT sits at the first reasoning frame instead, so
+ * the midpoint separates the two by a wide margin either way.
+ */
+const CONTENT_STARTS_MS = LEAD_MS + REASONING_FRAMES * GAP_MS;
+
+interface OtlpReceiver {
+  url: string;
+  spans: Array<Record<string, string>>;
+  close(): Promise<void>;
+}
+
+async function startOtlpReceiver(): Promise<OtlpReceiver> {
+  const spans: Array<Record<string, string>> = [];
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(raw);
+        for (const rs of body.resourceSpans ?? []) {
+          for (const ss of rs.scopeSpans ?? []) {
+            for (const span of ss.spans ?? []) {
+              const attrs: Record<string, string> = {};
+              for (const a of span.attributes ?? []) {
+                const v = a.value ?? {};
+                attrs[a.key] =
+                  v.stringValue ?? String(v.intValue ?? v.boolValue ?? "");
+              }
+              spans.push(attrs);
+            }
+          }
+        }
+      } catch {
+        // ignore malformed bodies — assertions fail on missing spans
+      }
+      res.statusCode = 200;
+      res.end("{}");
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${port}/v1/traces`,
+    spans,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+async function waitForSpan(
+  recv: OtlpReceiver,
+  requestId: string,
+  timeoutMs = 10_000,
+): Promise<Record<string, string>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hit = recv.spans.find((a) => a["aisix.request_id"] === requestId);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`no usage span for request_id=${requestId}`);
+}
+
+function chatChunk(delta: unknown): string {
+  return JSON.stringify({
+    id: "chatcmpl-ttft-reasoning",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-4o-mini",
+    choices: [{ index: 0, delta, finish_reason: null }],
+  });
+}
+
+const CHAT_TERMINAL = JSON.stringify({
+  id: "chatcmpl-ttft-reasoning",
+  object: "chat.completion.chunk",
+  created: 1,
+  model: "gpt-4o-mini",
+  choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+  usage: { prompt_tokens: 5, completion_tokens: 8, total_tokens: 13 },
+});
+
+/**
+ * The customer's shape: DeepSeek-class reasoning frames carry the text at
+ * `reasoning_content` and leave `content` null, then real content follows.
+ */
+function reasoningThenContent(): string[] {
+  return [
+    ...Array.from({ length: REASONING_FRAMES }, (_, i) =>
+      chatChunk({ content: null, reasoning_content: `think${i} ` }),
+    ),
+    chatChunk({ content: "answer " }),
+    chatChunk({ content: "here" }),
+    CHAT_TERMINAL,
+    "[DONE]",
+  ];
+}
+
+describe("upstream TTFT stops on the first generated-output frame", () => {
+  let etcdReachable = false;
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let otlp: OtlpReceiver | undefined;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+    otlp = await startOtlpReceiver();
+    await seed.createObservabilityExporter({
+      name: "ttft-reasoning-otlp",
+      enabled: true,
+      kind: "otlp_http",
+      endpoint: otlp.url,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+    await otlp?.close();
+  });
+
+  async function createModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!seed) throw new Error("seed client not initialized");
+    const pk = await seed.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+  }
+
+  /** Seed a throwaway key AFTER the config under test, then poll until it authenticates. */
+  async function awaitPropagation(tag: string): Promise<void> {
+    const canary = `sk-canary-${tag}-${Date.now()}`;
+    await seed!.createApiKey({
+      key_hash: createHash("sha256").update(canary).digest("hex"),
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${canary}` },
+      });
+      return res.status === 200;
+    });
+  }
+
+  test("reasoning text stops the clock on /v1/chat/completions", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startOpenAiUpstream({
+      streamEvents: reasoningThenContent(),
+      firstEventDelayMs: LEAD_MS,
+      eventDelayMs: GAP_MS,
+    });
+    upstreams.push(upstream);
+    await createModel("ttft-reasoning-chat", upstream);
+    await awaitPropagation("reasoning-chat");
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "ttft-reasoning-chat",
+        messages: [{ role: "user", content: "think then answer" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const requestId = res.headers.get("x-aisix-call-id");
+    expect(requestId).toBeTruthy();
+    await res.text();
+
+    const span = await waitForSpan(otlp, requestId!);
+    const ttft = Number(span["aisix.upstream_ttft_ms"]);
+
+    // The first reasoning frame is a token arriving, so the clock stops
+    // near LEAD_MS — not at CONTENT_STARTS_MS, which is what a
+    // content-only predicate reported.
+    expect(Number.isFinite(ttft)).toBe(true);
+    expect(ttft).toBeGreaterThan(0);
+    expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2);
+  });
+
+  test("an empty role-only frame does not stop the clock", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    // OpenAI's stream opener, then a long wait for the first real token.
+    const upstream = await startOpenAiUpstream({
+      streamEvents: [
+        chatChunk({ role: "assistant", content: "" }),
+        chatChunk({ content: "answer " }),
+        chatChunk({ content: "here" }),
+        CHAT_TERMINAL,
+        "[DONE]",
+      ],
+      eventDelayMs: GAP_MS * 2,
+    });
+    upstreams.push(upstream);
+    await createModel("ttft-role-only-chat", upstream);
+    await awaitPropagation("role-only-chat");
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "ttft-role-only-chat",
+        messages: [{ role: "user", content: "answer" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const requestId = res.headers.get("x-aisix-call-id");
+    expect(requestId).toBeTruthy();
+    await res.text();
+
+    const span = await waitForSpan(otlp, requestId!);
+    const ttft = Number(span["aisix.upstream_ttft_ms"]);
+
+    // `content: ""` is the stream opening, not a token; the clock has to
+    // wait for the frame one gap later. Reading the opener put this at ~0.
+    expect(Number.isFinite(ttft)).toBe(true);
+    expect(ttft).toBeGreaterThan(GAP_MS);
+  });
+
+  test("reasoning summaries stop the clock on /v1/responses", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startOpenAiUpstream({
+      streamEvents: [
+        JSON.stringify({ type: "response.created", response: { id: "resp_ttft" } }),
+        ...Array.from({ length: REASONING_FRAMES }, (_, i) =>
+          JSON.stringify({
+            type: "response.reasoning_summary_text.delta",
+            delta: `think${i} `,
+          }),
+        ),
+        JSON.stringify({ type: "response.output_text.delta", delta: "answer" }),
+        JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "resp_ttft",
+            status: "completed",
+            usage: { input_tokens: 6, output_tokens: 9 },
+          },
+        }),
+        "[DONE]",
+      ],
+      firstEventDelayMs: LEAD_MS,
+      eventDelayMs: GAP_MS,
+    });
+    upstreams.push(upstream);
+    await createModel("ttft-reasoning-responses", upstream);
+    await awaitPropagation("reasoning-responses");
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "ttft-reasoning-responses",
+        input: "think then answer",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const requestId = res.headers.get("x-aisix-request-id");
+    expect(requestId).toBeTruthy();
+    await res.text();
+
+    const span = await waitForSpan(otlp, requestId!);
+    const ttft = Number(span["aisix.upstream_ttft_ms"]);
+
+    // `response.created` is not generated output, so the clock runs past
+    // it; the first reasoning-summary delta stops it — one frame later,
+    // not REASONING_FRAMES later.
+    expect(Number.isFinite(ttft)).toBe(true);
+    expect(ttft).toBeGreaterThan(0);
+    expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2 + GAP_MS);
+  });
+});


### PR DESCRIPTION
## Problem

Streaming TTFT only stopped on a chunk carrying `content` or `tool_calls`. A reasoning model streams its chain of thought first and emits `content` only once it has stopped thinking, so the recorded figure was the end of the thinking phase rather than the first token.

On the reported request (`a6b2143f-2c0f-465a-8adb-dea0b1ddf5d9`, DeepSeek-R1 class, 44,214 in / 13,228 out of which 12,560 reasoning) the gateway logged **183,581 ms** while the AI gateway sitting in front of it measured the first token at **1,175 ms**. Both agreed on the total (192,851 ms vs 192,985 ms). The numbers reconcile once reasoning is counted — 12,560 reasoning tokens over 182.4 s is 68.9 tok/s and the 668 remaining content tokens over 9.27 s is 72.1 tok/s, the same model at the same rate. Read the other way round, a real 183.5 s TTFT would require all 13,228 tokens in the remaining 9.27 s.

The predicate was wrong in a second, opposite way. It tested `content.is_some()`, and OpenAI opens every stream with a role-only `{"role":"assistant","content":""}` frame; `Some("")` passed it, so the clock stopped when the stream *opened*. That is also why the size of the error depended on whether an upstream writes `content: null` or `content: ""` during reasoning — the same model behind two providers could report 1 ms or 183 s.

## Fix

Record TTFT on the first chunk carrying non-empty generated output — `content`, `reasoning_content`, or `tool_calls`. Reasoning text is generated output and is streamed to the caller as it arrives, so it stops the clock; an empty opener does not.

Three of the four sites recording `upstream_ttft_ms` off a `ChatChunk` carried the defect — `/v1/chat/completions`, the `/v1/messages` bridged path, and the `/v1/responses` bridge. They now share `ChatDelta::carries_generated_output` so the family cannot drift apart again. The fourth, `/v1/responses` native passthrough, keys off an event whitelist that omitted `response.reasoning_summary_text.delta` and `response.reasoning_text.delta`. The Anthropic native passthrough was already correct: `thinking_delta` arrives as a `content_block_delta`.

`downstream_latency_ms` is unchanged — it marks the first bytes handed to the caller, and a reasoning chunk is such a byte. The defect actually broke the documented relationship between the two: the gateway forwarded reasoning chunks (marking downstream) while TTFT held out for content a whole thinking phase later, so caller latency read *below* upstream TTFT.

LiteLLM sets `completion_start_time` on the first parsed chunk of any kind (`litellm_core_utils/streaming_handler.py`, `responses/streaming_iterator.py`), so this moves toward that baseline rather than away from it.

## Behavior change

TTFT on reasoning models drops from "time until the model stopped thinking" to the real first token. On non-reasoning models it moves from the stream opener to the first content frame — a few ms later, and what the field always claimed to measure. Historical rows are not rewritten.

## Tests

`tests/e2e/src/cases/ttft-reasoning-e2e.test.ts` — five cases against a real gateway, mock upstream and OTLP receiver, covering every changed site. Each verified to fail before the fix and pass after:

| case | path exercised | before | after |
|---|---|---|---|
| reasoning stream on `/v1/chat/completions` | chat.rs | 1756 ms (first content frame) | ~250 ms (first reasoning frame) |
| role-only `content: ""` opener | shared predicate | 1 ms | ~500 ms |
| reasoning on `/v1/messages`, non-Anthropic upstream | messages.rs cross-provider | 1757 ms | ~250 ms |
| reasoning on `/v1/responses`, non-OpenAI upstream | responses_bridge.rs | 1753 ms | ~250 ms |
| reasoning summaries on `/v1/responses` | responses.rs native | 2036 ms | ~500 ms |

Full DP e2e suite: 173 files / 455 tests pass.

Docs paired in api7/docs#2015.

Fixes api7/AISIX-Cloud#1225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-to-first-token measurement for streaming responses.
  * Reasoning output is now recognized as the first generated output, alongside content and tool calls, across supported streaming formats.
  * Empty role-only frames and non-output response events no longer start the TTFT timer.
* **Tests**
  * Added end-to-end coverage for chat completion and response streams, including reasoning-first output scenarios and cross-format bridges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
