### PR TITLE
feat(obs): split the TTFT bucket set from e2e latency and make both configurable

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -93,6 +93,24 @@ observability:
     #     client: billing-batcher
     #   - pattern: "internal-eval-harness"
     #     client: eval-harness
+    # Optional per-metric histogram bucket edges, in seconds. Each metric
+    # keeps its own default when unset — they differ on purpose, because
+    # the three distributions do: end-to-end latency starts in the
+    # milliseconds (cache hits, requests refused before dispatch) while
+    # time-to-first-token cannot be faster than the upstream, and guardrail
+    # checks run an order of magnitude below both. Edges must be finite,
+    # positive and strictly ascending; do not list `+Inf` (it is added for
+    # you). Validated at boot; changes require a restart.
+    #
+    # Every edge costs one `_bucket` series PER label combination, so
+    # lengthening a list multiplies time series. Changing a list also
+    # changes the metric contract: dashboards and recording rules that
+    # hardcode an `le` value break, and series recorded before the change
+    # are not comparable with those after it.
+    # buckets:
+    #   request_e2e_latency: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 420, 600]
+    #   request_ttft: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300]
+    #   guardrail_latency: [0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30]
   tracing:
     otlp:
       enabled: false

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -75,6 +75,13 @@ observability:
     # client_type_rules:
     #   - pattern: "^py-billing-batcher/"
     #     client: billing-batcher
+    # Optional per-metric histogram bucket edges, in seconds; each metric
+    # keeps its own default when unset. See config.example.yaml for the
+    # full annotation and the cardinality/contract caveats. Override with
+    # a comma-separated list, e.g.
+    # AISIX_OBSERVABILITY__METRICS__BUCKETS__REQUEST_TTFT=0.1,0.5,1,5,30,300
+    # buckets:
+    #   request_ttft: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300]
   tracing:
     otlp:
       enabled: false

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -541,6 +541,32 @@ pub struct MetricsConfig {
     /// owns the scrape owns the label set. Order matters (first match
     /// wins); compiled + validated at boot (fail-fast), never hot-reloaded.
     pub client_type_rules: Vec<ClientTypeRule>,
+    /// Operator overrides for the histogram bucket edges
+    /// (AISIX-Cloud#1226). Deployment-scoped for the same reason as
+    /// `client_type_rules`: the series these edges mint go to this DP's
+    /// own Prometheus scrape surface. Validated at boot (fail-fast),
+    /// never hot-reloaded.
+    pub buckets: HistogramBucketsConfig,
+}
+
+/// Per-metric bucket-edge overrides, in seconds. An unset field keeps that
+/// metric's built-in default; the defaults deliberately differ per metric
+/// because the three distributions do (see `aisix_obs::metrics`). Edges
+/// must be finite, positive and strictly ascending; the `+Inf` bucket is
+/// appended by the exporter and must not be listed.
+///
+/// Changing these changes the Prometheus metric contract: dashboards and
+/// recording rules that hardcode an `le` value break, and previously
+/// recorded series are not comparable across the change.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct HistogramBucketsConfig {
+    /// `aisix_request_e2e_latency_seconds`
+    pub request_e2e_latency: Option<Vec<f64>>,
+    /// `aisix_request_ttft_seconds`
+    pub request_ttft: Option<Vec<f64>>,
+    /// `aisix_guardrail_latency_seconds`
+    pub guardrail_latency: Option<Vec<f64>>,
 }
 
 /// One `client_type_rules` entry: a regex tried against the raw inbound
@@ -1043,6 +1069,12 @@ impl Config {
                 .list_separator(",")
                 .with_list_parse_key("etcd.endpoints")
                 .with_list_parse_key("admin.admin_keys")
+                // The deployed chart injects gateway config purely through
+                // AISIX_* env vars, so the bucket overrides are unreachable
+                // in Kubernetes without opting their keys into list parsing.
+                .with_list_parse_key("observability.metrics.buckets.request_e2e_latency")
+                .with_list_parse_key("observability.metrics.buckets.request_ttft")
+                .with_list_parse_key("observability.metrics.buckets.guardrail_latency")
                 .try_parsing(true),
         );
 

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -1065,13 +1065,16 @@ impl Config {
                 // which blows up secrets that happen to contain a
                 // comma with a serde "invalid type: sequence, expected
                 // a string" error. Opt in only for fields that are
-                // actually Vec<String>.
+                // actually sequences.
+                //
+                // EVERY sequence field belongs on this list: the deployed
+                // chart injects gateway config purely through AISIX_* env
+                // vars, so an unregistered key is not merely awkward from
+                // the environment — it fails to deserialize, leaving the
+                // field unreachable in Kubernetes.
                 .list_separator(",")
                 .with_list_parse_key("etcd.endpoints")
                 .with_list_parse_key("admin.admin_keys")
-                // The deployed chart injects gateway config purely through
-                // AISIX_* env vars, so the bucket overrides are unreachable
-                // in Kubernetes without opting their keys into list parsing.
                 .with_list_parse_key("observability.metrics.buckets.request_e2e_latency")
                 .with_list_parse_key("observability.metrics.buckets.request_ttft")
                 .with_list_parse_key("observability.metrics.buckets.guardrail_latency")

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -29,8 +29,8 @@ pub mod wildcard;
 
 pub use config::{
     AdminConfig, CacheBackend, CacheConfig, ClientTypeRule, Config, EtcdConfig, EtcdTlsConfig,
-    ManagedConfig, ObservabilityConfig, ProxyConfig, RateLimitBackend, RateLimitConfig,
-    RealIpConfig, RedisConnConfig, RedisMode, TlsConfig,
+    HistogramBucketsConfig, ManagedConfig, ObservabilityConfig, ProxyConfig, RateLimitBackend,
+    RateLimitConfig, RealIpConfig, RedisConnConfig, RedisMode, TlsConfig,
 };
 pub use config_status::{
     hash_bytes, hash_entries, AppliedSnapshot, ConfigMetricsView, ConfigState, ConfigStatus,

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -30,8 +30,8 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 pub use access_log::AccessLog;
 pub use metrics::{
     client_type_from_user_agent, BudgetGauges, BudgetLabels, ClientTypeClassifier,
-    DeploymentLabels, DeploymentState, LatencyLabels, LlmUsage, Metrics, RequestLabels,
-    RequestOutcome, UsageLabels,
+    DeploymentLabels, DeploymentState, HistogramBuckets, LatencyLabels, LlmUsage, Metrics,
+    RequestLabels, RequestOutcome, UsageLabels,
 };
 pub use otlp::{install_otlp_tracer, shutdown_otlp, OtlpError, OtlpHandle};
 pub use otlp_http_sink::{content_capture_cap, OtlpHttpFanOut, OtlpSink};

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -183,22 +183,135 @@ pub const M_CONFIG_APPLIED_REVISION: &str = "aisix_config_applied_revision";
 pub const M_CONFIG_HASH_INFO: &str = "aisix_config_hash_info";
 pub const M_CONFIG_SOURCE_CONNECTED: &str = "aisix_config_source_connected";
 
-/// Bucket edges for the two SLO histograms, spanning LLM latency ranges:
-/// sub-100ms cache hits / TTFT through multi-minute long generations.
-/// 14 edges → 15 `_bucket` series per label combination; keep
+/// Default bucket edges for [`M_REQUEST_E2E_LATENCY_SECONDS`], spanning the
+/// full client-perceived range: a millisecond-scale rejection or cache hit
+/// through a multi-minute generation. The low edges earn their keep here —
+/// requests refused before dispatch and cache hits really do return in
+/// single-digit milliseconds — and the 420/600 s edges keep
+/// `histogram_quantile()` interpolating instead of pinning P99 at the top
+/// edge, since `upstream.timeout_ms` allows far longer requests.
+/// 17 edges → 18 `_bucket` series per label combination; keep
 /// [`LatencyLabels`] lean before adding edges.
-pub const LATENCY_HISTOGRAM_BUCKETS: &[f64] = &[
-    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+pub const DEFAULT_E2E_LATENCY_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 420.0,
+    600.0,
 ];
 
-/// Bucket edges for [`M_GUARDRAIL_LATENCY_SECONDS`] — shifted an order of
-/// magnitude below the SLO buckets: local (keyword/pii) checks run in
-/// microseconds, the added-latency budget under scrutiny is ~50 ms
-/// (AISIX-Cloud#1076), and remote guardrail timeouts default to 5 s. The
-/// 30 s top edge outlives any configurable guardrail timeout.
-pub const GUARDRAIL_LATENCY_BUCKETS: &[f64] = &[
+/// Default bucket edges for [`M_REQUEST_TTFT_SECONDS`] (AISIX-Cloud#1226).
+/// Deliberately NOT the same set as [`DEFAULT_E2E_LATENCY_BUCKETS`]: this
+/// histogram observes the *upstream* time-to-first-token, so a request the
+/// gateway answers itself (cache hit, pre-dispatch rejection) never lands
+/// here at all and the millisecond edges stay empty forever against a
+/// hosted provider — one dead series per label combination each. The floor
+/// stays at 50 ms rather than higher so a co-located self-hosted upstream
+/// (vLLM / Ollama) remains distinguishable; deployments that only ever call
+/// hosted providers can raise it via `observability.metrics.buckets`.
+/// The top edge stays at 300 s where the e2e set continues to 600 s:
+/// time-to-*first*-token beyond five minutes is not a range worth two more
+/// permanently-empty series.
+pub const DEFAULT_TTFT_BUCKETS: &[f64] = &[
+    0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+];
+
+/// Default bucket edges for [`M_GUARDRAIL_LATENCY_SECONDS`] — shifted an
+/// order of magnitude below the request-latency sets: local (keyword/pii)
+/// checks run in microseconds, the added-latency budget under scrutiny is
+/// ~50 ms (AISIX-Cloud#1076), and remote guardrail timeouts default to 5 s.
+/// The 30 s top edge outlives any configurable guardrail timeout.
+pub const DEFAULT_GUARDRAIL_LATENCY_BUCKETS: &[f64] = &[
     0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
 ];
+
+/// Resolved bucket edges for the three real (non-summary) histograms,
+/// each either the default above or an operator override from
+/// `observability.metrics.buckets` (AISIX-Cloud#1226).
+///
+/// Every edge here costs one `_bucket` time series **per label
+/// combination** on a metric labelled by endpoint × model × provider ×
+/// status_class × streaming, so an override is a cardinality decision as
+/// much as a resolution one.
+#[derive(Debug, Clone)]
+pub struct HistogramBuckets {
+    pub request_e2e_latency: Vec<f64>,
+    pub request_ttft: Vec<f64>,
+    pub guardrail_latency: Vec<f64>,
+}
+
+impl Default for HistogramBuckets {
+    fn default() -> Self {
+        Self {
+            request_e2e_latency: DEFAULT_E2E_LATENCY_BUCKETS.to_vec(),
+            request_ttft: DEFAULT_TTFT_BUCKETS.to_vec(),
+            guardrail_latency: DEFAULT_GUARDRAIL_LATENCY_BUCKETS.to_vec(),
+        }
+    }
+}
+
+impl HistogramBuckets {
+    /// Upper bound on operator-supplied edges. Prometheus wants a bucket
+    /// count in the tens, not the hundreds; the built-in sets use 12–17.
+    pub const MAX_EDGES: usize = 64;
+
+    /// Resolve `observability.metrics.buckets`, falling back to the
+    /// defaults per metric. Errors are boot-fatal by design: a silently
+    /// ignored override would leave the deployment reading quantiles off
+    /// bucket edges it did not choose.
+    pub fn from_config(cfg: &aisix_core::HistogramBucketsConfig) -> Result<Self, String> {
+        Ok(Self {
+            request_e2e_latency: resolve_edges(
+                "request_e2e_latency",
+                cfg.request_e2e_latency.as_deref(),
+                DEFAULT_E2E_LATENCY_BUCKETS,
+            )?,
+            request_ttft: resolve_edges(
+                "request_ttft",
+                cfg.request_ttft.as_deref(),
+                DEFAULT_TTFT_BUCKETS,
+            )?,
+            guardrail_latency: resolve_edges(
+                "guardrail_latency",
+                cfg.guardrail_latency.as_deref(),
+                DEFAULT_GUARDRAIL_LATENCY_BUCKETS,
+            )?,
+        })
+    }
+}
+
+/// Validate one override list, or hand back the default when unset.
+/// `+Inf` is rejected rather than tolerated: the exporter appends it
+/// itself, so accepting one here would emit a duplicate `le="+Inf"`.
+fn resolve_edges(field: &str, edges: Option<&[f64]>, default: &[f64]) -> Result<Vec<f64>, String> {
+    let Some(edges) = edges else {
+        return Ok(default.to_vec());
+    };
+    let ctx = format!("observability.metrics.buckets.{field}");
+    if edges.is_empty() {
+        return Err(format!("{ctx}: must list at least one bucket edge"));
+    }
+    if edges.len() > HistogramBuckets::MAX_EDGES {
+        return Err(format!(
+            "{ctx}: {} edges exceed the limit of {}",
+            edges.len(),
+            HistogramBuckets::MAX_EDGES
+        ));
+    }
+    for (i, &edge) in edges.iter().enumerate() {
+        if !edge.is_finite() || edge <= 0.0 {
+            return Err(format!(
+                "{ctx}[{i}]: {edge} must be a finite positive number of seconds \
+                 (the +Inf bucket is added automatically)"
+            ));
+        }
+        if i > 0 && edge <= edges[i - 1] {
+            return Err(format!(
+                "{ctx}[{i}]: {edge} must be greater than the preceding edge {} \
+                 — bucket edges are cumulative and must strictly ascend",
+                edges[i - 1]
+            ));
+        }
+    }
+    Ok(edges.to_vec())
+}
 
 /// Holds an isolated `PrometheusRecorder` plus its render handle.
 /// `metrics::*` macros talk to whatever recorder is in scope; we use
@@ -447,6 +560,12 @@ impl Metrics {
     /// histograms. Empty ids (standalone DP) collapse to `"unknown"`,
     /// matching the missing-dimension convention used elsewhere.
     pub fn new_with_env_id(env_id: &str) -> Self {
+        Self::new_with_buckets(env_id, &HistogramBuckets::default())
+    }
+
+    /// Like [`Metrics::new_with_env_id`], with operator-supplied histogram
+    /// bucket edges (`observability.metrics.buckets`, AISIX-Cloud#1226).
+    pub fn new_with_buckets(env_id: &str, buckets: &HistogramBuckets) -> Self {
         // Buckets ONLY for the SLO histograms and the guardrail latency
         // histogram: with `metrics-exporter-prometheus`, a distribution
         // without configured buckets renders as a summary — which is what
@@ -454,19 +573,19 @@ impl Metrics {
         let recorder = PrometheusBuilder::new()
             .set_buckets_for_metric(
                 Matcher::Full(M_REQUEST_E2E_LATENCY_SECONDS.to_string()),
-                LATENCY_HISTOGRAM_BUCKETS,
+                &buckets.request_e2e_latency,
             )
-            .expect("static bucket list is non-empty")
+            .expect("bucket lists are validated non-empty")
             .set_buckets_for_metric(
                 Matcher::Full(M_REQUEST_TTFT_SECONDS.to_string()),
-                LATENCY_HISTOGRAM_BUCKETS,
+                &buckets.request_ttft,
             )
-            .expect("static bucket list is non-empty")
+            .expect("bucket lists are validated non-empty")
             .set_buckets_for_metric(
                 Matcher::Full(M_GUARDRAIL_LATENCY_SECONDS.to_string()),
-                GUARDRAIL_LATENCY_BUCKETS,
+                &buckets.guardrail_latency,
             )
-            .expect("static bucket list is non-empty")
+            .expect("bucket lists are validated non-empty")
             .build_recorder();
         let handle = recorder.handle();
         Self {
@@ -2641,10 +2760,7 @@ mod tests {
         assert!(out.contains("aisix_request_e2e_latency_seconds_sum"));
         assert!(out.contains("aisix_request_e2e_latency_seconds_count"));
         assert!(out.contains("aisix_request_ttft_seconds_bucket"));
-        assert!(
-            out.contains("le=\"2.5\""),
-            "configured bucket edges present"
-        );
+        assert!(out.contains("le=\"2\""), "configured bucket edges present");
 
         // The label contract: constant env_id, bucketed status, bounded
         // dims — and none of the per-key/per-user dimensions.
@@ -2662,7 +2778,7 @@ mod tests {
         }
     }
 
-    /// A 1.5s observation lands in the 2.5 bucket but not the 1.0 bucket —
+    /// A 1.5s observation lands in the 2.0 bucket but not the 1.0 bucket —
     /// pins that the configured edges actually apply (a default-bucket
     /// fallback would place them differently or render a summary).
     #[test]
@@ -2690,7 +2806,7 @@ mod tests {
                 .unwrap_or_else(|| panic!("no bucket le={le} in:\n{out}"))
         };
         assert_eq!(bucket_val("1"), 0, "1.5s must not land in le=1");
-        assert_eq!(bucket_val("2.5"), 1, "1.5s must land in le=2.5");
+        assert_eq!(bucket_val("2"), 1, "1.5s must land in le=2");
         // Empty env_id collapses to the missing-dimension convention.
         assert!(out.contains("env_id=\"unknown\""));
         assert!(out.contains("status_class=\"5xx\""));
@@ -2728,6 +2844,179 @@ mod tests {
             "legacy duration series must stay a summary (quantiles), got:\n{out}"
         );
         assert!(out.contains("aisix_request_duration_seconds"));
+    }
+
+    /// Every `le` value exposed for `metric`, in exposition order.
+    fn rendered_edges(out: &str, metric: &str) -> Vec<String> {
+        let prefix = format!("{metric}_bucket");
+        out.lines()
+            .filter(|l| l.starts_with(&prefix))
+            .filter_map(|l| l.split("le=\"").nth(1))
+            .filter_map(|rest| rest.split('"').next())
+            .map(str::to_owned)
+            .collect()
+    }
+
+    /// AISIX-Cloud#1226: TTFT no longer borrows the end-to-end latency
+    /// edges. The two sets are pinned here because they are a public
+    /// metric contract — a dashboard that hardcodes an `le` breaks when
+    /// they move, so moving them must be a deliberate edit to this list.
+    #[test]
+    fn ttft_and_e2e_expose_their_own_default_bucket_edges() {
+        let m = Metrics::new_with_env_id("env-1");
+        let labels = LatencyLabels {
+            endpoint: "/v1/chat/completions",
+            model: "gpt-4o",
+            provider: "openai",
+            status: 200,
+            streaming: true,
+        };
+        m.record_request_e2e_latency(labels, Duration::from_millis(1500));
+        m.record_request_ttft(labels, Duration::from_millis(1500));
+        let out = m.render();
+
+        assert_eq!(
+            rendered_edges(&out, "aisix_request_e2e_latency_seconds"),
+            [
+                "0.005", "0.01", "0.025", "0.05", "0.1", "0.25", "0.5", "1", "2", "5", "10", "30",
+                "60", "120", "300", "420", "600", "+Inf",
+            ],
+        );
+        assert_eq!(
+            rendered_edges(&out, "aisix_request_ttft_seconds"),
+            [
+                "0.05", "0.1", "0.25", "0.5", "1", "2", "5", "10", "30", "60", "120", "300",
+                "+Inf",
+            ],
+        );
+    }
+
+    /// The observation-placement contract for TTFT, the metric #1226 is
+    /// about: 1.5s lands in `le=2` and not in the edge below it.
+    #[test]
+    fn ttft_observation_lands_in_the_right_bucket() {
+        let m = Metrics::new_with_env_id("env-1");
+        m.record_request_ttft(
+            LatencyLabels {
+                endpoint: "/v1/messages",
+                model: "claude",
+                provider: "anthropic",
+                status: 200,
+                streaming: true,
+            },
+            Duration::from_millis(1500),
+        );
+        let out = m.render();
+        let bucket_val = |le: &str| -> u64 {
+            out.lines()
+                .find(|l| {
+                    l.starts_with("aisix_request_ttft_seconds_bucket")
+                        && l.contains(&format!("le=\"{le}\""))
+                })
+                .and_then(|l| l.rsplit(' ').next())
+                .and_then(|v| v.parse().ok())
+                .unwrap_or_else(|| panic!("no bucket le={le} in:\n{out}"))
+        };
+        assert_eq!(bucket_val("1"), 0, "1.5s must not land in le=1");
+        assert_eq!(bucket_val("2"), 1, "1.5s must land in le=2");
+        assert_eq!(bucket_val("+Inf"), 1);
+    }
+
+    /// An override replaces only the metric it names; the other two keep
+    /// their defaults. This is the whole point of the per-metric shape —
+    /// tuning TTFT must not silently re-cut the e2e or guardrail series.
+    #[test]
+    fn bucket_override_applies_to_only_the_named_metric() {
+        let buckets = HistogramBuckets::from_config(&aisix_core::HistogramBucketsConfig {
+            request_ttft: Some(vec![0.5, 3.0]),
+            ..Default::default()
+        })
+        .expect("valid override");
+        let m = Metrics::new_with_buckets("env-1", &buckets);
+        let labels = LatencyLabels {
+            endpoint: "/v1/chat/completions",
+            model: "gpt-4o",
+            provider: "openai",
+            status: 200,
+            streaming: true,
+        };
+        m.record_request_e2e_latency(labels, Duration::from_millis(1500));
+        m.record_request_ttft(labels, Duration::from_millis(1500));
+        m.record_guardrail_execution(&aisix_core::GuardrailExecution {
+            guardrail_name: "g",
+            kind: "keyword",
+            phase: "input",
+            result: "passed",
+            error_type: None,
+            elapsed: Duration::from_millis(3),
+        });
+        let out = m.render();
+
+        assert_eq!(
+            rendered_edges(&out, "aisix_request_ttft_seconds"),
+            ["0.5", "3", "+Inf"],
+        );
+        assert_eq!(
+            rendered_edges(&out, "aisix_request_e2e_latency_seconds").first(),
+            Some(&"0.005".to_string()),
+            "e2e keeps its default edges",
+        );
+        assert_eq!(
+            rendered_edges(&out, "aisix_guardrail_latency_seconds").first(),
+            Some(&"0.001".to_string()),
+            "guardrail keeps its default edges",
+        );
+    }
+
+    /// Unset fields fall back to the built-in defaults rather than to an
+    /// empty (summary-rendering) list.
+    #[test]
+    fn empty_bucket_config_resolves_to_the_defaults() {
+        let resolved =
+            HistogramBuckets::from_config(&aisix_core::HistogramBucketsConfig::default())
+                .expect("empty config is valid");
+        assert_eq!(resolved.request_e2e_latency, DEFAULT_E2E_LATENCY_BUCKETS);
+        assert_eq!(resolved.request_ttft, DEFAULT_TTFT_BUCKETS);
+        assert_eq!(
+            resolved.guardrail_latency,
+            DEFAULT_GUARDRAIL_LATENCY_BUCKETS
+        );
+    }
+
+    /// Boot-fatal validation: every shape Prometheus cannot express, or
+    /// that would silently produce a broken exposition, is rejected with
+    /// the offending field named.
+    #[test]
+    fn invalid_bucket_overrides_are_rejected() {
+        let cases: [(Vec<f64>, &str); 6] = [
+            (vec![], "at least one"),
+            (vec![0.1, 0.1], "strictly ascend"),
+            (vec![1.0, 0.5], "strictly ascend"),
+            (vec![0.0, 1.0], "finite positive"),
+            (vec![-1.0, 1.0], "finite positive"),
+            (vec![0.1, f64::INFINITY], "finite positive"),
+        ];
+        for (edges, needle) in cases {
+            let err = HistogramBuckets::from_config(&aisix_core::HistogramBucketsConfig {
+                request_ttft: Some(edges.clone()),
+                ..Default::default()
+            })
+            .expect_err(&format!("{edges:?} must be rejected"));
+            assert!(
+                err.contains(needle) && err.contains("buckets.request_ttft"),
+                "{edges:?} → {err:?} must name the field and mention {needle:?}",
+            );
+        }
+
+        let too_many: Vec<f64> = (1..=HistogramBuckets::MAX_EDGES + 1)
+            .map(|i| i as f64)
+            .collect();
+        let err = HistogramBuckets::from_config(&aisix_core::HistogramBucketsConfig {
+            guardrail_latency: Some(too_many),
+            ..Default::default()
+        })
+        .expect_err("over-long list must be rejected");
+        assert!(err.contains("exceed the limit of 64"), "{err}");
     }
 
     fn config_metrics_view(source_kind: aisix_core::SourceKind) -> aisix_core::ConfigMetricsView {

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -683,7 +683,16 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // env_id is resolved by now (managed provisioning / sidecar restore
     // above); it becomes the constant `env_id` label on the SLO latency
     // histograms. Standalone DPs leave it empty → "unknown".
-    let metrics = Arc::new(Metrics::new_with_env_id(&cfg.etcd.env_id));
+    // AISIX-Cloud#1226: operator bucket overrides. Validation errors are
+    // boot-fatal — a silently ignored override would leave the deployment
+    // reading quantiles off bucket edges it did not choose.
+    let histogram_buckets =
+        aisix_obs::HistogramBuckets::from_config(&cfg.observability.metrics.buckets)
+            .map_err(|e| anyhow::anyhow!(e))?;
+    let metrics = Arc::new(Metrics::new_with_buckets(
+        &cfg.etcd.env_id,
+        &histogram_buckets,
+    ));
     let metrics_upkeep_task = {
         let metrics = metrics.clone();
         tokio::spawn(run_metrics_upkeep(

--- a/tests/e2e/src/cases/metrics-histogram-buckets-e2e.test.ts
+++ b/tests/e2e/src/cases/metrics-histogram-buckets-e2e.test.ts
@@ -1,0 +1,208 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  spawnApp,
+  startOpenAiUpstream,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// AISIX-Cloud#1226: the two request-latency histograms no longer share one
+// bucket set, and every set is operator-overridable.
+//
+// Both halves are observable contracts, so both are pinned here against a
+// real scrape rather than against the Rust constants: a dashboard reads
+// `le` values off this exposition, and the override half is the only way a
+// deployment can move them. The override is delivered through an `AISIX_*`
+// environment variable because that is the channel the Kubernetes chart
+// uses — config there is injected as env vars on top of an image-baked
+// config file, so a knob that only works from YAML is unreachable in the
+// deployment that needs it most.
+
+const CALLER_PLAINTEXT = "sk-histogram-buckets-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const E2E_SERIES = "aisix_request_e2e_latency_seconds";
+const TTFT_SERIES = "aisix_request_ttft_seconds";
+
+function resources(upstreamBase: string): string {
+  return `
+_format_version: "1"
+provider_keys:
+  - display_name: buckets-pk
+    provider: openai
+    api_key: sk-mock
+    api_base: ${upstreamBase}/v1
+models:
+  - display_name: buckets-model
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: buckets-pk
+api_keys:
+  - display_name: buckets-caller
+    key_hash: ${CALLER_KEY_HASH}
+    allowed_models: ["buckets-model"]
+`;
+}
+
+/** Every `le` value the scrape exposes for `series`, in exposition order. */
+function edgesOf(body: string, series: string): string[] {
+  return body
+    .split("\n")
+    .filter((l) => l.startsWith(`${series}_bucket{`))
+    .map((l) => l.match(/le="([^"]+)"/)?.[1])
+    .filter((le): le is string => le !== undefined);
+}
+
+async function streamOnce(app: SpawnedApp): Promise<void> {
+  const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "buckets-model",
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+    }),
+  });
+  await res.text();
+  expect(res.status).toBe(200);
+}
+
+/**
+ * Scrape until both histograms have appeared. A streaming request records
+ * its TTFT at stream completion, so the first scrape after the response
+ * body is drained can still race ahead of the observation.
+ */
+async function scrapeBothSeries(app: SpawnedApp): Promise<string> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const res = await fetch(`${app.metricsUrl}/metrics`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    const ready = edgesOf(body, E2E_SERIES).length > 0 && edgesOf(body, TTFT_SERIES).length > 0;
+    if (ready || Date.now() > deadline) return body;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
+
+function startStreamingUpstream(): Promise<OpenAiUpstream> {
+  return startOpenAiUpstream({
+    streamEvents: [
+      '{"id":"buckets","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+      '{"id":"buckets","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}',
+      '{"id":"buckets","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+      "[DONE]",
+    ],
+    eventDelayMs: 20,
+  });
+}
+
+describe("histogram buckets e2e: TTFT and e2e latency expose distinct default edges", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    upstream = await startStreamingUpstream();
+    app = await spawnApp({ resourcesFile: resources(upstream.baseUrl) });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("the two series carry their own edges, and TTFT is not a copy of e2e", async () => {
+    await streamOnce(app!);
+    const body = await scrapeBothSeries(app!);
+
+    // The published default sets. Pinned literally: moving an edge breaks
+    // every dashboard that selects on it, so it must be a deliberate edit.
+    expect(edgesOf(body, E2E_SERIES)).toEqual([
+      "0.005",
+      "0.01",
+      "0.025",
+      "0.05",
+      "0.1",
+      "0.25",
+      "0.5",
+      "1",
+      "2",
+      "5",
+      "10",
+      "30",
+      "60",
+      "120",
+      "300",
+      "420",
+      "600",
+      "+Inf",
+    ]);
+    expect(edgesOf(body, TTFT_SERIES)).toEqual([
+      "0.05",
+      "0.1",
+      "0.25",
+      "0.5",
+      "1",
+      "2",
+      "5",
+      "10",
+      "30",
+      "60",
+      "120",
+      "300",
+      "+Inf",
+    ]);
+
+    // The property behind those two lists, stated directly: TTFT drops the
+    // millisecond edges it can never reach through a hosted provider, and
+    // e2e keeps the headroom above 300s that a long generation needs.
+    for (const le of ["0.005", "0.01", "0.025"]) {
+      expect(edgesOf(body, TTFT_SERIES), `TTFT must not carry le=${le}`).not.toContain(le);
+      expect(edgesOf(body, E2E_SERIES), `e2e must keep le=${le}`).toContain(le);
+    }
+    expect(edgesOf(body, E2E_SERIES)).toContain("600");
+    expect(edgesOf(body, TTFT_SERIES)).not.toContain("600");
+
+    // Still a well-formed histogram: +Inf last, and the sum/count pair
+    // histogram_quantile() needs.
+    for (const series of [E2E_SERIES, TTFT_SERIES]) {
+      expect(edgesOf(body, series).at(-1)).toBe("+Inf");
+      expect(body).toContain(`${series}_sum`);
+      expect(body).toContain(`${series}_count`);
+    }
+  });
+});
+
+describe("histogram buckets e2e: an operator override replaces only the named metric", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    upstream = await startStreamingUpstream();
+    app = await spawnApp({
+      resourcesFile: resources(upstream.baseUrl),
+      extraEnv: {
+        AISIX_OBSERVABILITY__METRICS__BUCKETS__REQUEST_TTFT: "0.5,3",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("the overridden series uses the supplied edges; the others keep defaults", async () => {
+    await streamOnce(app!);
+    const body = await scrapeBothSeries(app!);
+
+    expect(edgesOf(body, TTFT_SERIES)).toEqual(["0.5", "3", "+Inf"]);
+    // Overriding one metric must not re-cut the others — the reason the
+    // knob is per-metric rather than one list for every histogram.
+    expect(edgesOf(body, E2E_SERIES).at(0)).toBe("0.005");
+    expect(edgesOf(body, E2E_SERIES).at(-2)).toBe("600");
+  });
+});


### PR DESCRIPTION
`aisix_request_ttft_seconds` borrowed `aisix_request_e2e_latency_seconds`'s bucket edges, and the two do not describe the same distribution.

TTFT observes the **upstream** time-to-first-token, so a request the gateway answers itself (cache hit, request refused before dispatch) never lands on it at all — `record_request_ttft` skips a zero duration. Against a hosted provider the millisecond edges are therefore unreachable, and each one costs a `_bucket` time series per label combination that is permanently zero. Sampling real traffic (`dpmgr_usage_events`, 2026-07-03…07-28) puts the two distributions three orders of magnitude apart:

| | min | p50 | p90 | p99 | max |
|---|---|---|---|---|---|
| TTFT (n=50) | 1.05s | 5.29s | 14.5s | 47.3s | 47.3s |
| e2e latency (n=180) | 1ms | 1.18s | 9.6s | 57.9s | 186.9s |

The low edges are dead weight on one series and load-bearing on the other — end-to-end latency really does start in the milliseconds, because a fast rejection or a cache hit returns there. A single shared set cannot serve both.

Separately, both sets stopped at a 300s top edge while `upstream.timeout_ms` permits far longer requests, so `histogram_quantile()` pins P99 at 300s instead of interpolating — and the sample above already reaches 187s.

## Changes

**`aisix_request_ttft_seconds`** — drops the two sub-50ms edges, keeps a 300s top:

```
0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300
```

The floor stays at 50ms rather than moving higher so a co-located self-hosted upstream (where TTFT really can be tens of milliseconds) stays distinguishable. The top stays at 300s where the e2e set continues: time-to-*first*-token beyond five minutes is not a range worth two more permanently-empty series.

**`aisix_request_e2e_latency_seconds`** — keeps its low edges, gains headroom above 300s:

```
0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 420, 600
```

### What this does not fully achieve

The issue asks that the low end stop showing several consecutive long-empty buckets. Against a hosted-provider-only deployment this change reduces that run rather than eliminating it: with a 1.05s measured floor, `le=0.05` through `le=1` still record nothing, so the run goes from about six buckets to about four.

That is a deliberate trade, not an oversight. Cutting the floor to 0.25s would zero the run for hosted providers, but it would also collapse every co-located self-hosted upstream — vLLM or Ollama on the same node, where time to first token genuinely is tens of milliseconds — into a single first bucket with no resolution at all, and that deployment has no way to get it back except by reconfiguring. The reverse is not true: a deployment that only ever calls hosted providers can now raise its own floor with the override this PR adds. Choosing the default that stays useful for the case that cannot self-correct seemed the better side to err on, but I am happy to move it if you would rather the shipped default be tuned for hosted traffic.

**New `observability.metrics.buckets`** — overrides the edges per metric:

```yaml
observability:
  metrics:
    buckets:
      request_e2e_latency: [0.005, 0.01, 0.1, 1, 10, 60, 600]
      request_ttft: [0.1, 0.5, 1, 5, 30, 300]
      guardrail_latency: [0.001, 0.01, 0.1, 1, 5]
```

An unset field keeps that metric's default. Edges must be finite, positive and strictly ascending, at most 64 of them, and must not list `+Inf` (the exporter appends it). Validation is boot-fatal, matching `client_type_rules` — a silently ignored override would leave the deployment reading quantiles off edges it did not choose.

The knob is per-metric rather than one list for every histogram because the defaults are now deliberately different: collapsing them back into one list on the first override would undo the split this PR is making.

## Reachable from the environment, not just YAML

The deployed chart injects gateway configuration purely as `AISIX_*` environment variables on top of an image-baked config file, so a YAML-only knob would be unreachable in Kubernetes — the deployment that most needs to tune cardinality. The three keys are registered for comma-separated list parsing:

```
AISIX_OBSERVABILITY__METRICS__BUCKETS__REQUEST_TTFT=0.1,0.5,1,5,30,300
```

`config-rs` opts into list parsing per key, so without that registration the variable fails to deserialize (`invalid type: string "0.1,0.5", expected a sequence`). The E2E case below drives this exact path and does fail without the registration.

## Behavior change

This is a Prometheus metric contract change:

- `le="2.5"` no longer exists on either series (it is `2` now, matching the wider ecosystem).
- `aisix_request_ttft_seconds` no longer exposes `le="0.01"` / `le="0.025"`.
- `aisix_request_e2e_latency_seconds` gains `le="0.005"`, `le="420"`, `le="600"`.

Dashboards and recording rules that select on a removed `le` need updating, and series recorded before the change are not comparable with those after it. Bucket counts move from 15/15 to 18 (e2e) and 13 (TTFT).

Blast radius inside our own repos is nil: the only references to these series anywhere in the gateway, control plane, chart or docs are the documented PromQL examples, and every one of them groups with `sum by (le)` rather than selecting a specific boundary, so none of them change meaning. The impact is limited to user-authored dashboards, which the paired docs change calls out explicitly.

## Comparison with other gateways

The reference implementation nearest to us keeps **one** latency bucket set shared across total latency, provider-call latency and time-to-first-token, overridable through a single global list. This PR deliberately diverges on both points, and the divergence was raised and agreed before implementation:

- **Separate defaults**, because the shared set is exactly what produces the dead low buckets this issue reports — that project's set starts even lower (0.005) and so carries the problem one bucket further.
- **Per-metric override**, because a single global list cannot express the split.

Where it does not conflict, this PR follows that baseline: the e2e set is its bucket list verbatim, including the 420/600 edges and `2` in place of `2.5`. Another surveyed gateway exposes no TTFT histogram at all (it is derived from the difference of two duration metrics) but does use per-metric bucket sets tuned to each distribution, which is the shape adopted here.

## Tests

DP standalone E2E (`tests/e2e/src/cases/metrics-histogram-buckets-e2e.test.ts`), against a real `aisix` binary and mock upstream, scraping the real metrics listener:

- the default edges of both series, pinned literally, plus the property behind them (TTFT carries no sub-50ms edge and no 600s edge; e2e carries both);
- an operator override applied through the environment variable replaces only the named series while the other two keep their defaults.

Unit coverage in `aisix-obs`: default resolution, per-metric override isolation, observation placement (1.5s lands in `le=2`, not `le=1`), and rejection of every invalid shape (empty, duplicate, descending, zero, negative, `+Inf`, over-long) with the offending field named.

## Control plane

None needed. This is deployment-scoped gateway configuration — the same class as `observability.metrics.client_type_rules` and `prometheus.addr` — not an etcd-projected resource field, so it does not pass through `cp-admin.yaml`. The series it shapes go to the operator's own scrape surface.

Fixes api7/AISIX-Cloud#1226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable histogram bucket boundaries for request latency, time to first token, and guardrail latency metrics.
  * Added environment-variable configuration support with documented examples and defaults.
  * Invalid bucket settings are rejected during startup with validation for ordering, values, and size.

* **Bug Fixes**
  * Improved metric accuracy by using distinct default boundaries for end-to-end latency and time to first token measurements.

* **Tests**
  * Added coverage for default buckets, custom overrides, boundary placement, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

