### PR TITLE
feat(providers): surface in-band stream errors as a typed BridgeError

### DIFF
--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -240,6 +240,27 @@ pub enum BridgeError {
     },
     #[error("upstream returned an unparseable body: {0}")]
     UpstreamDecode(String),
+    /// A provider-reported error carried *inside* a 2xx streaming
+    /// response body — an OpenAI-family `data: {"error":{...}}` frame,
+    /// an Anthropic `event: error` frame, a Gemini in-stream error
+    /// object, or a Bedrock event-stream modeled exception. By the time
+    /// one arrives the upstream HTTP status was already a success, so
+    /// [`UpstreamStatus`](Self::UpstreamStatus) cannot represent it.
+    /// `status` is the numeric code embedded in (or documented for) the
+    /// error body when the provider supplies one; `None` when the
+    /// envelope carries no numeric code. Distinguishing this from
+    /// [`UpstreamDecode`](Self::UpstreamDecode) keeps the provider's
+    /// own error type/message intact instead of surfacing a serde
+    /// parse failure (AISIX-Cloud#1222 scenario 3).
+    #[error("upstream reported an in-band stream error: {message}")]
+    UpstreamInBand {
+        status: Option<u16>,
+        message: String,
+        /// Boxed for the same `result_large_err` reason as
+        /// [`UpstreamStatus`](Self::UpstreamStatus).
+        parsed: Option<Box<UpstreamErrorView>>,
+        wire: UpstreamWire,
+    },
     #[error("bridge is misconfigured: {0}")]
     Config(String),
     /// Customer-fixable upstream config — the admin's ProviderKey/Model
@@ -380,6 +401,88 @@ pub async fn capture_upstream_error_http(
     }
 }
 
+/// Probe one SSE `data:` payload for a provider in-band error envelope
+/// (`{"error": {...}}` or `{"error": "..."}`) and capture it as a
+/// [`BridgeError::UpstreamInBand`]. Returns `None` when the payload is
+/// not an error envelope — callers fall back to their decode-error
+/// path, so a genuinely malformed frame still surfaces as
+/// [`BridgeError::UpstreamDecode`].
+///
+/// Field handling is tolerant across the OpenAI-compatible family and
+/// Google's error shape:
+/// - `error.type` (OpenAI / Anthropic vocabulary) populates the view's
+///   `kind`; absent that, Google's `error.status` gRPC token
+///   (`UNAVAILABLE`, `RESOURCE_EXHAUSTED`, …) does, so the per-wire
+///   translation tables in `error_translate` apply either way.
+/// - `error.code` may be a JSON number (Google) or a string (OpenAI).
+///   A numeric value in 400..=599 — either form — becomes the embedded
+///   `status`; a non-numeric string stays in the view's `code`.
+/// - a bare-string `error` value becomes the message (LiteLLM accepts
+///   this form from OpenAI-compatible aggregators; so do we).
+///
+/// All captured strings are truncated at
+/// [`MAX_UPSTREAM_ERROR_MESSAGE_BYTES`], same as
+/// [`capture_upstream_error_http`].
+pub fn capture_in_band_error(payload: &str, wire: UpstreamWire) -> Option<BridgeError> {
+    #[derive(serde::Deserialize)]
+    struct Outer {
+        error: ErrorField,
+    }
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum ErrorField {
+        Obj(Inner),
+        Str(String),
+    }
+    #[derive(serde::Deserialize)]
+    struct Inner {
+        message: Option<String>,
+        #[serde(rename = "type")]
+        kind: Option<String>,
+        code: Option<serde_json::Value>,
+        param: Option<String>,
+        status: Option<String>,
+    }
+
+    let cap = MAX_UPSTREAM_ERROR_MESSAGE_BYTES;
+    let outer: Outer = serde_json::from_str(payload).ok()?;
+    let (status, message, parsed) = match outer.error {
+        ErrorField::Str(s) => (None, truncate_lossy(&s, cap), None),
+        ErrorField::Obj(inner) => {
+            let numeric_status = match &inner.code {
+                Some(serde_json::Value::Number(n)) => n.as_u64(),
+                Some(serde_json::Value::String(s)) => s.parse::<u64>().ok(),
+                _ => None,
+            }
+            .and_then(|n| u16::try_from(n).ok())
+            .filter(|n| (400..=599).contains(n));
+            let code_str = match &inner.code {
+                Some(serde_json::Value::String(s)) if numeric_status.is_none() => {
+                    Some(truncate_lossy(s, cap))
+                }
+                _ => None,
+            };
+            let view = UpstreamErrorView {
+                kind: inner.kind.or(inner.status).map(|k| truncate_lossy(&k, cap)),
+                message: inner.message.as_deref().map(|m| truncate_lossy(m, cap)),
+                code: code_str,
+                param: inner.param.map(|p| truncate_lossy(&p, cap)),
+            };
+            let message = view
+                .message
+                .clone()
+                .unwrap_or_else(|| truncate_lossy(payload, cap));
+            (numeric_status, message, Some(Box::new(view)))
+        }
+    };
+    Some(BridgeError::UpstreamInBand {
+        status,
+        message,
+        parsed,
+        wire,
+    })
+}
+
 /// Read the response body, stopping after `limit` bytes. Used to bound
 /// upstream-error parsing cost regardless of `Content-Length`. Errors
 /// during read surface as an empty buffer — the caller falls through
@@ -438,8 +541,10 @@ pub fn response_is_json(resp: &reqwest::Response) -> bool {
 
 /// Truncate a string to at most `max` bytes, splitting only on a UTF-8
 /// boundary. Appends an ellipsis when truncation occurred so log
-/// readers can tell the message was cut.
-fn truncate_lossy(s: &str, max: usize) -> String {
+/// readers can tell the message was cut. Public so bridges building
+/// [`BridgeError::UpstreamInBand`] from typed (non-JSON-probe) sources
+/// apply the same cap as [`capture_upstream_error_http`].
+pub fn truncate_lossy(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_string();
     }
@@ -466,6 +571,13 @@ impl BridgeError {
                 }
             }
             BridgeError::UpstreamDecode(_) => 502,
+            // Same forwarding rule as UpstreamStatus: an embedded 4xx is
+            // the provider's judgment of the request and passes through;
+            // 5xx / unknown collapse to 502.
+            BridgeError::UpstreamInBand { status, .. } => match status {
+                Some(s) if (400..500).contains(s) => *s,
+                _ => 502,
+            },
             BridgeError::Config(_) => 500,
             BridgeError::InvalidUpstreamConfig(_) => 400,
             BridgeError::InvalidUpstreamCredentials(_) => 401,
@@ -480,6 +592,7 @@ impl BridgeError {
             BridgeError::Timeout { .. } => "timeout",
             BridgeError::UpstreamStatus { .. } => "upstream_error",
             BridgeError::UpstreamDecode(_) => "upstream_decode_error",
+            BridgeError::UpstreamInBand { .. } => "upstream_in_band_error",
             BridgeError::Config(_) => "config_error",
             BridgeError::InvalidUpstreamConfig(_) => "invalid_request_error",
             BridgeError::InvalidUpstreamCredentials(_) => "authentication_error",
@@ -569,6 +682,136 @@ pub trait Bridge: Send + Sync + 'static {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn in_band_probe_parses_openai_string_code_envelope() {
+        let e = capture_in_band_error(
+            r#"{"error":{"message":"The server is overloaded","type":"server_error","code":"overloaded"}}"#,
+            UpstreamWire::OpenAI,
+        )
+        .expect("error envelope must be captured");
+        match e {
+            BridgeError::UpstreamInBand {
+                status,
+                message,
+                parsed,
+                wire,
+            } => {
+                assert_eq!(status, None, "non-numeric code carries no status");
+                assert_eq!(message, "The server is overloaded");
+                let view = parsed.expect("view");
+                assert_eq!(view.kind.as_deref(), Some("server_error"));
+                assert_eq!(view.code.as_deref(), Some("overloaded"));
+                assert!(matches!(wire, UpstreamWire::OpenAI));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn in_band_probe_parses_google_numeric_code_and_grpc_status() {
+        let e = capture_in_band_error(
+            r#"{"error":{"code":503,"message":"The service is currently unavailable.","status":"UNAVAILABLE"}}"#,
+            UpstreamWire::Vertex,
+        )
+        .expect("google error shape must be captured");
+        match e {
+            BridgeError::UpstreamInBand { status, parsed, .. } => {
+                assert_eq!(status, Some(503));
+                // The gRPC token lands in `kind` so the Vertex
+                // translation table applies.
+                assert_eq!(parsed.expect("view").kind.as_deref(), Some("UNAVAILABLE"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn in_band_probe_parses_numeric_string_code_as_status() {
+        let e = capture_in_band_error(
+            r#"{"error":{"code":"429","message":"rate limited"}}"#,
+            UpstreamWire::OpenAI,
+        )
+        .expect("captured");
+        match e {
+            BridgeError::UpstreamInBand { status, parsed, .. } => {
+                assert_eq!(status, Some(429));
+                // A numeric code became the status; it is not repeated
+                // in the view's string `code`.
+                assert_eq!(parsed.expect("view").code, None);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn in_band_probe_accepts_bare_string_error() {
+        let e = capture_in_band_error(r#"{"error":"boom"}"#, UpstreamWire::OpenAI)
+            .expect("bare-string error form must be captured");
+        match e {
+            BridgeError::UpstreamInBand {
+                status,
+                message,
+                parsed,
+                ..
+            } => {
+                assert_eq!(status, None);
+                assert_eq!(message, "boom");
+                assert!(parsed.is_none());
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn in_band_probe_rejects_non_error_payloads() {
+        assert!(capture_in_band_error(r#"{"id":"chunk-1"}"#, UpstreamWire::OpenAI).is_none());
+        assert!(capture_in_band_error("not json at all", UpstreamWire::OpenAI).is_none());
+        // An out-of-HTTP-range numeric code is not a status…
+        let e = capture_in_band_error(
+            r#"{"error":{"code":200,"message":"odd"}}"#,
+            UpstreamWire::OpenAI,
+        )
+        .expect("still an error envelope");
+        assert!(matches!(
+            e,
+            BridgeError::UpstreamInBand { status: None, .. }
+        ));
+    }
+
+    #[test]
+    fn in_band_probe_caps_oversized_fields() {
+        let long = "x".repeat(4 * MAX_UPSTREAM_ERROR_MESSAGE_BYTES);
+        let payload = format!(r#"{{"error":{{"message":"{long}","type":"{long}"}}}}"#);
+        let e = capture_in_band_error(&payload, UpstreamWire::OpenAI).expect("captured");
+        match e {
+            BridgeError::UpstreamInBand {
+                message, parsed, ..
+            } => {
+                assert!(message.len() <= MAX_UPSTREAM_ERROR_MESSAGE_BYTES + '…'.len_utf8());
+                let view = parsed.expect("view");
+                assert!(
+                    view.kind.unwrap().len() <= MAX_UPSTREAM_ERROR_MESSAGE_BYTES + '…'.len_utf8()
+                );
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn in_band_error_status_forwarding_matches_upstream_status_rule() {
+        let mk = |status: Option<u16>| BridgeError::UpstreamInBand {
+            status,
+            message: "m".into(),
+            parsed: None,
+            wire: UpstreamWire::OpenAI,
+        };
+        assert_eq!(mk(Some(429)).http_status(), 429, "embedded 4xx forwards");
+        assert_eq!(mk(Some(500)).http_status(), 502, "5xx collapses to 502");
+        assert_eq!(mk(Some(529)).http_status(), 502);
+        assert_eq!(mk(None).http_status(), 502);
+        assert_eq!(mk(None).error_type(), "upstream_in_band_error");
+    }
 
     #[test]
     fn timeout_maps_to_504() {

--- a/crates/aisix-gateway/src/lib.rs
+++ b/crates/aisix-gateway/src/lib.rs
@@ -33,9 +33,10 @@ pub mod upstream_http;
 pub mod upstream_tls;
 
 pub use bridge::{
-    capture_upstream_error_http, content_type_is_json, parse_retry_after, read_body_capped,
-    response_is_json, Bridge, BridgeContext, BridgeError, ChatChunkStream, UpstreamErrorView,
-    UpstreamWire, MAX_UPSTREAM_ERROR_BODY_BYTES, MAX_UPSTREAM_ERROR_MESSAGE_BYTES,
+    capture_in_band_error, capture_upstream_error_http, content_type_is_json, parse_retry_after,
+    read_body_capped, response_is_json, truncate_lossy, Bridge, BridgeContext, BridgeError,
+    ChatChunkStream, UpstreamErrorView, UpstreamWire, MAX_UPSTREAM_ERROR_BODY_BYTES,
+    MAX_UPSTREAM_ERROR_MESSAGE_BYTES,
 };
 pub use chat::{
     ChatChunk, ChatDelta, ChatFormat, ChatMessage, ChatResponse, EmbeddingObject, EmbeddingRequest,

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -373,6 +373,9 @@ where
                 let SseEvent::Data(payload) = event else { continue };
                 let parsed: AnthropicStreamEvent = serde_json::from_str(&payload)
                     .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
+                if let AnthropicStreamEvent::Error { error } = &parsed {
+                    Err(crate::wire::stream_error_into_bridge_error(error))?;
+                }
                 state.update(&parsed);
                 if let Some(c) = state.to_chunk(&parsed) {
                     yield c;
@@ -868,6 +871,63 @@ data: {\"type\":\"message_stop\"}\n\n";
             Err(BridgeError::UpstreamStatus { status: 500, .. }) => {}
             Err(other) => panic!("unexpected: {other:?}"),
         }
+    }
+
+    /// AISIX-Cloud#1222 scenario 3: Anthropic reports mid-stream
+    /// failures as an in-band `event: error` frame inside the 200
+    /// stream. Pre-fix the frame deserialized into the `Other`
+    /// catch-all and was silently swallowed — the truncated stream
+    /// then looked like a clean completion.
+    #[tokio::test]
+    async fn streaming_in_band_error_event_surfaces_as_typed_error() {
+        let server = MockServer::start().await;
+        let sse = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream\",\"model\":\"claude-sonnet-4-5\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":1}}}\n\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hel\"}}\n\n\
+event: error\n\
+data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = AnthropicBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
+
+        let first = stream.next().await.expect("delta before the error");
+        assert_eq!(first.unwrap().delta.content.as_deref(), Some("hel"));
+        let err = stream
+            .next()
+            .await
+            .expect("error event must surface, not be swallowed")
+            .unwrap_err();
+        match err {
+            BridgeError::UpstreamInBand {
+                status,
+                message,
+                parsed,
+                wire,
+            } => {
+                // 529 is the documented HTTP status for overloaded_error.
+                assert_eq!(status, Some(529));
+                assert_eq!(message, "Overloaded");
+                assert_eq!(
+                    parsed.expect("view").kind.as_deref(),
+                    Some("overloaded_error")
+                );
+                assert!(matches!(wire, aisix_gateway::UpstreamWire::Anthropic));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(stream.next().await.is_none(), "stream ends after the error");
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -22,7 +22,8 @@
 //!   stop reason — other events just advance internal state.
 
 use aisix_gateway::{
-    ChatChunk, ChatDelta, ChatFormat, ChatMessage, ChatResponse, FinishReason, Role, UsageStats,
+    BridgeError, ChatChunk, ChatDelta, ChatFormat, ChatMessage, ChatResponse, FinishReason, Role,
+    UsageStats,
 };
 use serde::{Deserialize, Serialize};
 
@@ -972,10 +973,79 @@ pub enum AnthropicStreamEvent {
     },
     #[serde(rename = "message_stop")]
     MessageStop,
+    /// In-band error event — Anthropic reports mid-stream failures
+    /// (`overloaded_error`, `api_error`, …) as an `event: error` frame
+    /// inside the committed 200 stream instead of an HTTP status.
+    /// Without this variant the frame fell into [`Self::Other`] and was
+    /// silently swallowed: the connection then closed and the truncated
+    /// stream looked like a clean completion (AISIX-Cloud#1222).
+    #[serde(rename = "error")]
+    Error { error: AnthropicStreamErrorBody },
     /// Catch-all for content_block_start / content_block_stop / ping /
     /// unknown event types — we don't need their state for chunk emission.
     #[serde(other)]
     Other,
+}
+
+/// Body of an in-band `event: error` frame:
+/// `{"type":"error","error":{"type":"overloaded_error","message":"…"}}`.
+#[derive(Debug, Deserialize)]
+pub struct AnthropicStreamErrorBody {
+    #[serde(rename = "type")]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+/// The HTTP status Anthropic documents for each error type — in-band
+/// stream errors carry only the type token, and this is the same
+/// mapping the HTTP (non-2xx) surface uses for those errors.
+/// Reference: <https://docs.anthropic.com/en/api/errors>.
+/// Unknown / absent types return `None`; the proxy treats a
+/// status-less in-band error as a transient upstream fault.
+pub fn anthropic_error_kind_status(kind: Option<&str>) -> Option<u16> {
+    match kind? {
+        "invalid_request_error" => Some(400),
+        "authentication_error" => Some(401),
+        "permission_error" => Some(403),
+        "not_found_error" => Some(404),
+        "request_too_large" => Some(413),
+        "rate_limit_error" => Some(429),
+        "api_error" => Some(500),
+        "overloaded_error" => Some(529),
+        _ => None,
+    }
+}
+
+/// Convert an in-band `event: error` body into the typed
+/// [`BridgeError::UpstreamInBand`]. Shared by the Anthropic bridge and
+/// the Vertex Claude (`:streamRawPredict`) path — both speak the
+/// Anthropic Messages wire, so the Anthropic taxonomy applies to the
+/// envelope translation either way.
+pub fn stream_error_into_bridge_error(err: &AnthropicStreamErrorBody) -> BridgeError {
+    let cap = aisix_gateway::MAX_UPSTREAM_ERROR_MESSAGE_BYTES;
+    let status = anthropic_error_kind_status(err.kind.as_deref());
+    let kind = err
+        .kind
+        .as_deref()
+        .map(|k| aisix_gateway::truncate_lossy(k, cap));
+    let message = err
+        .message
+        .as_deref()
+        .map(|m| aisix_gateway::truncate_lossy(m, cap));
+    BridgeError::UpstreamInBand {
+        status,
+        message: message
+            .clone()
+            .unwrap_or_else(|| "upstream reported a stream error".to_string()),
+        parsed: Some(Box::new(aisix_gateway::UpstreamErrorView {
+            kind,
+            message,
+            code: None,
+            param: None,
+        })),
+        wire: aisix_gateway::UpstreamWire::Anthropic,
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -890,22 +890,61 @@ fn parse_stream_chunk(
     payload: &str,
     reasoning_path: Option<&str>,
 ) -> Result<OpenAiStreamChunk, BridgeError> {
-    match reasoning_path {
-        Some(path) => {
-            let mut value: Value = serde_json::from_str(payload)
-                .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
-            extract_reasoning_field(&mut value, path);
-            serde_json::from_value(value).map_err(|e| BridgeError::UpstreamDecode(e.to_string()))
-        }
-        None => {
-            serde_json::from_str(payload).map_err(|e| BridgeError::UpstreamDecode(e.to_string()))
-        }
-    }
+    let parsed = match reasoning_path {
+        Some(path) => serde_json::from_str::<Value>(payload)
+            .map_err(|e| e.to_string())
+            .and_then(|mut value| {
+                extract_reasoning_field(&mut value, path);
+                serde_json::from_value(value).map_err(|e| e.to_string())
+            }),
+        None => serde_json::from_str(payload).map_err(|e| e.to_string()),
+    };
+    parsed.map_err(|serde_err| {
+        // A frame that isn't a chunk may be Azure reporting an error
+        // inside the 200 stream (`{"error":{...}}`) — surface the
+        // provider's own error instead of the serde failure.
+        aisix_gateway::capture_in_band_error(payload, aisix_gateway::UpstreamWire::AzureOpenAI)
+            .unwrap_or(BridgeError::UpstreamDecode(serde_err))
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// AISIX-Cloud#1222 scenario 3: an in-band `data: {"error":{...}}`
+    /// frame inside the committed 200 stream surfaces as the typed
+    /// in-band error, not a serde decode failure.
+    #[test]
+    fn parse_stream_chunk_captures_in_band_error_frame() {
+        let err = parse_stream_chunk(
+            r#"{"error":{"message":"stream failed","type":"server_error","code":"InternalServerError"}}"#,
+            None,
+        )
+        .unwrap_err();
+        match err {
+            BridgeError::UpstreamInBand {
+                status,
+                message,
+                parsed,
+                wire,
+            } => {
+                assert_eq!(status, None);
+                assert_eq!(message, "stream failed");
+                assert_eq!(
+                    parsed.expect("view").code.as_deref(),
+                    Some("InternalServerError")
+                );
+                assert!(matches!(wire, aisix_gateway::UpstreamWire::AzureOpenAI));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        // Garbage keeps the historical decode classification.
+        assert!(matches!(
+            parse_stream_chunk("{not-json", None).unwrap_err(),
+            BridgeError::UpstreamDecode(_)
+        ));
+    }
 
     #[test]
     fn resolve_accepts_canonical_https_resource() {

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -30,6 +30,7 @@ use aws_sdk_bedrockruntime::operation::converse::ConverseError;
 use aws_sdk_bedrockruntime::operation::converse_stream::ConverseStreamError;
 use aws_sdk_bedrockruntime::operation::invoke_model::InvokeModelError;
 use aws_sdk_bedrockruntime::primitives::Blob;
+use aws_sdk_bedrockruntime::types::error::ConverseStreamOutputError;
 use aws_sdk_bedrockruntime::types::{
     AnyToolChoice, ContentBlock, ContentBlockDelta, ContentBlockStart, ConversationRole,
     ConverseStreamOutput, InferenceConfiguration, Message as BedrockMessage, SpecificToolChoice,
@@ -1049,13 +1050,7 @@ impl BedrockBridge {
                     }
                     Ok(None) => break,
                     Err(e) => {
-                        // SDK already maps eventstream-decode and
-                        // transport failures into its error type.
-                        // Surface as Transport to flow through the
-                        // existing customer-visible error envelope.
-                        Err(BridgeError::Transport(format!(
-                            "bedrock converse-stream: {e}"
-                        )))?;
+                        Err(map_converse_stream_event_error(e))?;
                     }
                 }
             }
@@ -1500,6 +1495,60 @@ fn map_converse_stream_sdk_error(
     map_aws_sdk_error_generic(e, started, deadline)
 }
 
+/// Map a mid-stream `ConverseStream` receiver failure. The AWS event
+/// stream carries modeled exceptions *inside* the committed 200
+/// response — throttling, internal failures, and model stream errors
+/// arrive as event-stream messages, not HTTP statuses — so surface
+/// them as [`BridgeError::UpstreamInBand`] with the AWS exception code
+/// in the view for `error_translate` (AISIX-Cloud#1222 scenario 3).
+/// Same redaction rule as [`map_service_error`]: canned message keyed
+/// on the derived status, code-only view, no raw AWS text (which
+/// embeds ARNs / account ids). Non-service failures (transport,
+/// event-stream decode) keep the previous Transport mapping.
+fn map_converse_stream_event_error(
+    e: SdkError<ConverseStreamOutputError, aws_smithy_types::event_stream::RawMessage>,
+) -> BridgeError {
+    let Some(svc) = e.as_service_error() else {
+        // SDK already maps eventstream-decode and transport failures
+        // into its error type. Surface as Transport to flow through
+        // the existing customer-visible error envelope.
+        return BridgeError::Transport(format!("bedrock converse-stream: {e}"));
+    };
+    let status: Option<u16> = match svc {
+        ConverseStreamOutputError::InternalServerException(_) => Some(500),
+        // The exception relays the model backend's own status when it
+        // has one; 502 otherwise (an unspecified upstream fault).
+        ConverseStreamOutputError::ModelStreamErrorException(inner) => inner
+            .original_status_code()
+            .and_then(|c| u16::try_from(c).ok())
+            .or(Some(502)),
+        ConverseStreamOutputError::ThrottlingException(_) => Some(429),
+        ConverseStreamOutputError::ValidationException(_) => Some(400),
+        ConverseStreamOutputError::ServiceUnavailableException(_) => Some(503),
+        _ => None,
+    };
+    let message = match status {
+        Some(429) => "upstream rate limited".to_string(),
+        Some(400) => "upstream rejected the streaming request".to_string(),
+        Some(s) => format!("upstream reported stream error {s}"),
+        None => "upstream reported a stream error".to_string(),
+    };
+    let parsed = svc.meta().code().map(|k| {
+        Box::new(aisix_gateway::UpstreamErrorView {
+            kind: Some(k.to_string()),
+            message: None,
+            code: None,
+            param: None,
+        })
+    });
+    BridgeError::UpstreamInBand {
+        status,
+        message,
+        parsed,
+        wire: aisix_gateway::UpstreamWire::Bedrock,
+    }
+}
+
 /// Common AWS SDK error classifier. Routes through the same
 /// UpstreamStatus / Transport / Timeout taxonomy the legacy
 /// `map_service_error` uses for `/invoke`, preserving:
@@ -1775,6 +1824,100 @@ fn map_tool_choice(choice: &serde_json::Value) -> Option<ToolChoice> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── Mid-stream event errors (AISIX-Cloud#1222) ──────────────────
+
+    /// The Converse event stream carries modeled exceptions inside the
+    /// committed 200 response. They must surface as typed in-band
+    /// errors (status derived per exception family, AWS code in the
+    /// view, canned message — never the raw AWS text), not as a
+    /// generic Transport failure.
+    #[test]
+    fn converse_stream_modeled_exceptions_map_to_in_band_errors() {
+        use aws_smithy_types::error::metadata::ErrorMetadata;
+
+        let meta = |code: &str| ErrorMetadata::builder().code(code).build();
+        let cases: Vec<(ConverseStreamOutputError, Option<u16>)> = vec![
+            (
+                ConverseStreamOutputError::ThrottlingException(
+                    aws_sdk_bedrockruntime::types::error::ThrottlingException::builder()
+                        .message("Too many requests for arn:aws:secret")
+                        .meta(meta("ThrottlingException"))
+                        .build(),
+                ),
+                Some(429),
+            ),
+            (
+                ConverseStreamOutputError::InternalServerException(
+                    aws_sdk_bedrockruntime::types::error::InternalServerException::builder()
+                        .meta(meta("InternalServerException"))
+                        .build(),
+                ),
+                Some(500),
+            ),
+            (
+                ConverseStreamOutputError::ServiceUnavailableException(
+                    aws_sdk_bedrockruntime::types::error::ServiceUnavailableException::builder()
+                        .meta(meta("ServiceUnavailableException"))
+                        .build(),
+                ),
+                Some(503),
+            ),
+            (
+                ConverseStreamOutputError::ModelStreamErrorException(
+                    aws_sdk_bedrockruntime::types::error::ModelStreamErrorException::builder()
+                        .original_status_code(529)
+                        .meta(meta("ModelStreamErrorException"))
+                        .build(),
+                ),
+                Some(529),
+            ),
+            (
+                ConverseStreamOutputError::ModelStreamErrorException(
+                    aws_sdk_bedrockruntime::types::error::ModelStreamErrorException::builder()
+                        .meta(meta("ModelStreamErrorException"))
+                        .build(),
+                ),
+                Some(502),
+            ),
+        ];
+        for (svc, want_status) in cases {
+            let want_kind = svc.meta().code().map(str::to_string);
+            let e = SdkError::service_error(
+                svc,
+                aws_smithy_types::event_stream::RawMessage::invalid(None),
+            );
+            match map_converse_stream_event_error(e) {
+                BridgeError::UpstreamInBand {
+                    status,
+                    message,
+                    parsed,
+                    wire,
+                } => {
+                    assert_eq!(status, want_status);
+                    assert_eq!(parsed.expect("view").kind, want_kind);
+                    assert!(matches!(wire, aisix_gateway::UpstreamWire::Bedrock));
+                    assert!(
+                        !message.contains("arn:"),
+                        "raw AWS text must not leak: {message}"
+                    );
+                }
+                other => panic!("unexpected: {other:?}"),
+            }
+        }
+    }
+
+    /// Non-service receiver failures (event-stream decode, transport)
+    /// keep the historical Transport classification.
+    #[test]
+    fn converse_stream_non_service_error_stays_transport() {
+        let e: SdkError<ConverseStreamOutputError, aws_smithy_types::event_stream::RawMessage> =
+            SdkError::construction_failure("boom");
+        assert!(matches!(
+            map_converse_stream_event_error(e),
+            BridgeError::Transport(_)
+        ));
+    }
 
     // ─── Publisher resolution (preserved from skeleton) ───────────────
 

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -719,17 +719,22 @@ fn parse_stream_chunk(
     payload: &str,
     reasoning_path: Option<&str>,
 ) -> Result<OpenAiStreamChunk, BridgeError> {
-    match reasoning_path {
-        Some(path) => {
-            let mut value: Value = serde_json::from_str(payload)
-                .map_err(|e| BridgeError::UpstreamDecode(e.to_string()))?;
-            extract_reasoning_field(&mut value, path);
-            serde_json::from_value(value).map_err(|e| BridgeError::UpstreamDecode(e.to_string()))
-        }
-        None => {
-            serde_json::from_str(payload).map_err(|e| BridgeError::UpstreamDecode(e.to_string()))
-        }
-    }
+    let parsed = match reasoning_path {
+        Some(path) => serde_json::from_str::<Value>(payload)
+            .map_err(|e| e.to_string())
+            .and_then(|mut value| {
+                extract_reasoning_field(&mut value, path);
+                serde_json::from_value(value).map_err(|e| e.to_string())
+            }),
+        None => serde_json::from_str(payload).map_err(|e| e.to_string()),
+    };
+    parsed.map_err(|serde_err| {
+        // A frame that isn't a chunk may be the provider reporting an
+        // error inside the 200 stream (`{"error":{...}}`) — surface the
+        // provider's own error instead of the serde failure.
+        aisix_gateway::capture_in_band_error(payload, aisix_gateway::UpstreamWire::OpenAI)
+            .unwrap_or(BridgeError::UpstreamDecode(serde_err))
+    })
 }
 
 #[cfg(test)]
@@ -1155,6 +1160,61 @@ data: [DONE]\n\n";
             Err(BridgeError::UpstreamStatus { status: 500, .. }) => {}
             Err(other) => panic!("unexpected: {other:?}"),
         }
+    }
+
+    /// AISIX-Cloud#1222 scenario 3: an OpenAI-compatible upstream that
+    /// commits a 200 stream and then reports failure as a
+    /// `data: {"error":{...}}` frame. Pre-fix the frame surfaced as an
+    /// `UpstreamDecode` serde failure and the provider's own error
+    /// type/message were lost.
+    #[tokio::test]
+    async fn streaming_in_band_error_frame_surfaces_as_typed_error() {
+        let server = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"cmpl-s\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\n\n\
+data: {\"error\":{\"message\":\"The server had an error processing your request\",\"type\":\"server_error\",\"code\":\"server_error\"}}\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        let mut stream = bridge.chat_stream(&req(), &ctx).await.unwrap();
+
+        let first = stream.next().await.expect("delta before the error");
+        assert_eq!(first.unwrap().delta.content.as_deref(), Some("hel"));
+        let err = stream.next().await.expect("error frame").unwrap_err();
+        match err {
+            BridgeError::UpstreamInBand {
+                status,
+                message,
+                parsed,
+                wire,
+            } => {
+                assert_eq!(status, None);
+                assert_eq!(message, "The server had an error processing your request");
+                assert_eq!(parsed.expect("view").kind.as_deref(), Some("server_error"));
+                assert!(matches!(wire, aisix_gateway::UpstreamWire::OpenAI));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(stream.next().await.is_none());
+    }
+
+    /// Garbage that is not an error envelope keeps the historical
+    /// `UpstreamDecode` classification.
+    #[test]
+    fn parse_stream_chunk_garbage_still_decodes_error() {
+        let err = parse_stream_chunk("{not-json", None).unwrap_err();
+        assert!(matches!(err, BridgeError::UpstreamDecode(_)));
+        let err = parse_stream_chunk(r#"{"unexpected":"shape"}"#, None).unwrap_err();
+        assert!(matches!(err, BridgeError::UpstreamDecode(_)));
     }
 
     #[test]

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -601,6 +601,43 @@ fn parse_vertex_error_status(body: &[u8]) -> Option<String> {
     outer.error.status
 }
 
+/// Parse one OpenAI-shaped SSE `data:` payload from a Vertex shim /
+/// partner stream, surfacing an in-band `{"error":...}` frame as the
+/// typed [`BridgeError::UpstreamInBand`] instead of a decode failure.
+/// `context` prefixes the decode-error message exactly as before.
+fn parse_vertex_openai_stream_payload(
+    data: &str,
+    context: &str,
+) -> Result<OpenAiStreamChunk, BridgeError> {
+    serde_json::from_str(data).map_err(|e| {
+        aisix_gateway::capture_in_band_error(data, aisix_gateway::UpstreamWire::Vertex)
+            .unwrap_or_else(|| BridgeError::UpstreamDecode(format!("{context}: {e}")))
+    })
+}
+
+/// Same probe for a Gemini `streamGenerateContent?alt=sse` payload —
+/// Google reports mid-stream failures as a `{"error":{code,message,
+/// status}}` frame inside the committed 200 stream.
+///
+/// Unlike the OpenAI chunk shape, [`GeminiGenerateContentResponse`] is
+/// fully defaultable, so an error frame would *successfully* parse as
+/// an empty response and be silently swallowed — the probe must run
+/// before the chunk parse, not on its failure. The `contains` guard
+/// keeps the extra parse off the hot path.
+fn parse_vertex_gemini_stream_payload(
+    data: &str,
+    context: &str,
+) -> Result<GeminiGenerateContentResponse, BridgeError> {
+    if data.contains("\"error\"") {
+        if let Some(e) =
+            aisix_gateway::capture_in_band_error(data, aisix_gateway::UpstreamWire::Vertex)
+        {
+            return Err(e);
+        }
+    }
+    serde_json::from_str(data).map_err(|e| BridgeError::UpstreamDecode(format!("{context}: {e}")))
+}
+
 #[async_trait]
 impl Bridge for VertexBridge {
     fn name(&self) -> &'static str {
@@ -1039,6 +1076,9 @@ impl VertexBridge {
                                 "vertex anthropic stream chunk parse: {e}"
                             ))
                         })?;
+                    if let AnthropicStreamEvent::Error { error } = &parsed {
+                        Err(aisix_provider_anthropic::wire::stream_error_into_bridge_error(error))?;
+                    }
                     state.update(&parsed);
                     if let Some(chunk) = state.to_chunk(&parsed) {
                         yield chunk;
@@ -1188,12 +1228,10 @@ impl VertexBridge {
                 for event in decoder.feed(bytes.as_ref()) {
                     match event {
                         SseEvent::Data(data) => {
-                            let parsed: OpenAiStreamChunk =
-                                serde_json::from_str(&data).map_err(|e| {
-                                    BridgeError::UpstreamDecode(format!(
-                                        "vertex openai-shim stream chunk parse: {e}"
-                                    ))
-                                })?;
+                            let parsed = parse_vertex_openai_stream_payload(
+                                &data,
+                                "vertex openai-shim stream chunk parse",
+                            )?;
                             yield openai_stream_chunk_into_chat_chunk(parsed);
                         }
                         // OpenAI shim terminates with `data: [DONE]`;
@@ -1205,11 +1243,10 @@ impl VertexBridge {
             // Flush a partial trailing chunk if the connection drops
             // without a final blank line.
             if let Some(SseEvent::Data(data)) = decoder.finish() {
-                let parsed: OpenAiStreamChunk = serde_json::from_str(&data).map_err(|e| {
-                    BridgeError::UpstreamDecode(format!(
-                        "vertex openai-shim stream tail parse: {e}"
-                    ))
-                })?;
+                let parsed = parse_vertex_openai_stream_payload(
+                    &data,
+                    "vertex openai-shim stream tail parse",
+                )?;
                 yield openai_stream_chunk_into_chat_chunk(parsed);
             }
         };
@@ -1387,12 +1424,10 @@ impl VertexBridge {
                 for event in decoder.feed(bytes.as_ref()) {
                     match event {
                         SseEvent::Data(data) => {
-                            let parsed: OpenAiStreamChunk =
-                                serde_json::from_str(&data).map_err(|e| {
-                                    BridgeError::UpstreamDecode(format!(
-                                        "vertex partner :streamRawPredict chunk parse: {e}"
-                                    ))
-                                })?;
+                            let parsed = parse_vertex_openai_stream_payload(
+                                &data,
+                                "vertex partner :streamRawPredict chunk parse",
+                            )?;
                             yield openai_stream_chunk_into_chat_chunk(parsed);
                         }
                         // OpenAI-compatible upstreams (Mistral / AI21)
@@ -1402,11 +1437,10 @@ impl VertexBridge {
                 }
             }
             if let Some(SseEvent::Data(data)) = decoder.finish() {
-                let parsed: OpenAiStreamChunk = serde_json::from_str(&data).map_err(|e| {
-                    BridgeError::UpstreamDecode(format!(
-                        "vertex partner :streamRawPredict tail parse: {e}"
-                    ))
-                })?;
+                let parsed = parse_vertex_openai_stream_payload(
+                    &data,
+                    "vertex partner :streamRawPredict tail parse",
+                )?;
                 yield openai_stream_chunk_into_chat_chunk(parsed);
             }
         };
@@ -1504,12 +1538,10 @@ impl VertexBridge {
                 let bytes: Bytes = item.map_err(|e| BridgeError::Transport(aisix_gateway::transport_error_message(&e)))?;
                 for event in decoder.feed(bytes.as_ref()) {
                     if let SseEvent::Data(data) = event {
-                        let parsed: GeminiGenerateContentResponse =
-                            serde_json::from_str(&data).map_err(|e| {
-                                BridgeError::UpstreamDecode(format!(
-                                    "vertex stream chunk parse: {e}"
-                                ))
-                            })?;
+                        let parsed = parse_vertex_gemini_stream_payload(
+                            &data,
+                            "vertex stream chunk parse",
+                        )?;
                         for chunk in
                             gemini_chunk_into_chat_chunks(parsed, &upstream_id_owned, &mut emitted_role)
                         {
@@ -1527,12 +1559,10 @@ impl VertexBridge {
             // last chunk if the upstream connection drops without a
             // final `\n\n`.
             if let Some(SseEvent::Data(data)) = decoder.finish() {
-                let parsed: GeminiGenerateContentResponse =
-                    serde_json::from_str(&data).map_err(|e| {
-                        BridgeError::UpstreamDecode(format!(
-                            "vertex stream tail parse: {e}"
-                        ))
-                    })?;
+                let parsed = parse_vertex_gemini_stream_payload(
+                    &data,
+                    "vertex stream tail parse",
+                )?;
                 for chunk in
                     gemini_chunk_into_chat_chunks(parsed, &upstream_id_owned, &mut emitted_role)
                 {
@@ -4326,6 +4356,125 @@ mod tests {
             saw_decode_err,
             "expected UpstreamDecode error on invalid JSON chunk"
         );
+    }
+
+    /// AISIX-Cloud#1222 scenario 3: Google reports a mid-stream failure
+    /// as a `{"error":{code,message,status}}` frame inside the
+    /// committed 200 stream. Pre-fix it surfaced as UpstreamDecode and
+    /// the numeric code / gRPC status were lost.
+    #[tokio::test]
+    async fn chat_gemini_stream_in_band_error_frame_surfaces_typed() {
+        let body = "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"hel\"}]}}]}\n\n\
+data: {\"error\":{\"code\":503,\"message\":\"The service is currently unavailable.\",\"status\":\"UNAVAILABLE\"}}\n\n"
+            .to_string();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(body),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = VertexBridge::new().with_api_base_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("gemini-1.5-pro"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hi")]);
+        let mut stream = bridge.chat_stream(&req, &ctx).await.unwrap();
+        let mut saw_in_band = false;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(_) => continue,
+                Err(BridgeError::UpstreamInBand {
+                    status,
+                    parsed,
+                    wire,
+                    ..
+                }) => {
+                    assert_eq!(status, Some(503));
+                    assert_eq!(parsed.expect("view").kind.as_deref(), Some("UNAVAILABLE"));
+                    assert!(matches!(wire, aisix_gateway::UpstreamWire::Vertex));
+                    saw_in_band = true;
+                    break;
+                }
+                Err(other) => panic!("unexpected: {other:?}"),
+            }
+        }
+        assert!(saw_in_band, "expected typed in-band error");
+    }
+
+    /// Claude-on-Vertex speaks the Anthropic Messages wire — an
+    /// in-band `event: error` frame must surface typed instead of
+    /// being swallowed by the `Other` catch-all (same fix as the
+    /// native Anthropic bridge, AISIX-Cloud#1222).
+    #[tokio::test]
+    async fn chat_anthropic_stream_in_band_error_event_surfaces_typed() {
+        let body = "event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hel\"}}\n\n\
+event: error\n\
+data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n"
+            .to_string();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(body),
+            )
+            .mount(&server)
+            .await;
+
+        let bridge = VertexBridge::new().with_api_base_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-1",
+            sample_model_with("claude-3-5-sonnet-v2@20241022"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
+        let mut stream = bridge.chat_stream(&req, &ctx).await.unwrap();
+        let mut saw_in_band = false;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(_) => continue,
+                Err(BridgeError::UpstreamInBand { status, wire, .. }) => {
+                    assert_eq!(status, Some(529), "documented overloaded_error status");
+                    assert!(
+                        matches!(wire, aisix_gateway::UpstreamWire::Anthropic),
+                        "Anthropic taxonomy applies to Claude-on-Vertex in-band errors"
+                    );
+                    saw_in_band = true;
+                    break;
+                }
+                Err(other) => panic!("unexpected: {other:?}"),
+            }
+        }
+        assert!(saw_in_band, "expected typed in-band error");
+    }
+
+    /// The OpenAI-shim rail probes the same envelope shape.
+    #[test]
+    fn parse_vertex_openai_stream_payload_captures_error_frame() {
+        let err = parse_vertex_openai_stream_payload(
+            r#"{"error":{"message":"upstream broke","code":"500"}}"#,
+            "vertex openai-shim stream chunk parse",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            BridgeError::UpstreamInBand {
+                status: Some(500),
+                ..
+            }
+        ));
+        // Garbage keeps the decode classification + context prefix.
+        match parse_vertex_openai_stream_payload("{not-json", "ctx-prefix").unwrap_err() {
+            BridgeError::UpstreamDecode(msg) => assert!(msg.starts_with("ctx-prefix")),
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -137,6 +137,7 @@ pub(crate) fn routing_error_class(err: &BridgeError) -> &'static str {
         BridgeError::Timeout { .. } => "timeout",
         BridgeError::UpstreamStatus { .. } => "upstream_status",
         BridgeError::UpstreamDecode(_) => "upstream_decode",
+        BridgeError::UpstreamInBand { .. } => "upstream_in_band",
         BridgeError::Config(_) => "config",
         BridgeError::InvalidUpstreamConfig(_) => "invalid_config",
         BridgeError::InvalidUpstreamCredentials(_) => "invalid_credentials",

--- a/crates/aisix-proxy/src/cooldown.rs
+++ b/crates/aisix-proxy/src/cooldown.rs
@@ -86,6 +86,26 @@ pub fn decide_cooldown(
             };
             Some((ttl, reason_for_status(*status)))
         }
+        // In-band stream errors with an embedded status get the same
+        // status-list gate as HTTP status errors (no Retry-After header
+        // exists inside a stream, so the default TTL applies); a
+        // status-less one is an unspecified provider fault and follows
+        // the transport-error gate.
+        BridgeError::UpstreamInBand {
+            status: Some(status),
+            ..
+        } => {
+            let triggers = cfg.effective_trigger_statuses();
+            if !triggers.contains(status) {
+                return None;
+            }
+            Some((default_ttl, reason_for_status(*status)))
+        }
+        BridgeError::UpstreamInBand { status: None, .. }
+            if cfg.trigger_on_transport_or_default() =>
+        {
+            Some((default_ttl, "upstream_in_band_error"))
+        }
         BridgeError::Timeout { .. } if cfg.trigger_on_timeout_or_default() => {
             Some((default_ttl, "request_timeout"))
         }
@@ -148,6 +168,30 @@ mod tests {
 
     fn upstream(status: u16) -> BridgeError {
         BridgeError::upstream_status(status, "boom")
+    }
+
+    #[test]
+    fn in_band_errors_cool_down_by_embedded_status_or_transport_gate() {
+        let in_band = |status: Option<u16>| BridgeError::UpstreamInBand {
+            status,
+            message: "m".into(),
+            parsed: None,
+            wire: aisix_gateway::UpstreamWire::Anthropic,
+        };
+        // Embedded status follows the trigger-status list: 503 is in
+        // the default list, 400 is not.
+        let (ttl, reason) = decide_cooldown(&in_band(Some(503)), None).expect("cooldown");
+        assert_eq!(reason, "upstream_server_error");
+        assert!(ttl > Duration::ZERO);
+        assert!(decide_cooldown(&in_band(Some(400)), None).is_none());
+        // Status-less in-band errors follow the transport gate.
+        let (_, reason) = decide_cooldown(&in_band(None), None).expect("cooldown");
+        assert_eq!(reason, "upstream_in_band_error");
+        let cfg = CooldownConfig {
+            trigger_on_transport: Some(false),
+            ..Default::default()
+        };
+        assert!(decide_cooldown(&in_band(None), Some(&cfg)).is_none());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -374,6 +374,25 @@ impl ProxyError {
         {
             return render_bridge_upstream_envelope(*status, message, parsed.as_deref(), *wire);
         }
+        // An in-band stream error (provider error inside a 2xx stream,
+        // caught pre-first-chunk) carries the same parsed view — render
+        // it with the embedded status so a provider's in-band 429 /
+        // overloaded gets the same translated envelope its HTTP twin
+        // would. No embedded status → the generic 502 family.
+        if let ProxyError::Bridge(aisix_gateway::BridgeError::UpstreamInBand {
+            status,
+            message,
+            parsed,
+            wire,
+        }) = self
+        {
+            return render_bridge_upstream_envelope(
+                status.unwrap_or(502),
+                message,
+                parsed.as_deref(),
+                *wire,
+            );
+        }
         // A timeout's transport cause names the upstream host and the
         // connection-layer fault it hit. Same rule as the 5xx body below:
         // that is operator diagnostics, so it reaches the logs and the

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -64,6 +64,23 @@ pub fn is_retryable(err: &BridgeError, retry_on_429: bool, fallback_on_statuses:
             }
             !(400..500).contains(status)
         }
+        // An in-band stream error with an embedded status follows the
+        // same status rules as an HTTP status error (LiteLLM applies
+        // its non-429-4xx filter to in-body stream errors identically).
+        // Without a status the provider reported an unspecified stream
+        // fault — transient by assumption, like Transport.
+        BridgeError::UpstreamInBand { status, .. } => match status {
+            Some(s) => {
+                if fallback_on_statuses.contains(s) {
+                    return true;
+                }
+                if *s == 429 {
+                    return retry_on_429;
+                }
+                !(400..500).contains(s)
+            }
+            None => true,
+        },
         // Customer-fixable config / credentials (#367) is the caller's
         // mistake — retrying or failing over won't help, same as a
         // non-429 4xx.
@@ -1402,6 +1419,28 @@ mod tests {
             false,
             &[]
         ));
+    }
+
+    /// AISIX-Cloud#1222: in-band stream errors follow the same status
+    /// rules as HTTP status errors; a status-less one is treated as a
+    /// transient fault (retryable).
+    #[test]
+    fn is_retryable_classifies_in_band_errors_by_embedded_status() {
+        let in_band = |status: Option<u16>| BridgeError::UpstreamInBand {
+            status,
+            message: "m".into(),
+            parsed: None,
+            wire: aisix_gateway::UpstreamWire::OpenAI,
+        };
+        assert!(is_retryable(&in_band(Some(500)), false, &[]));
+        assert!(is_retryable(&in_band(Some(529)), false, &[]));
+        assert!(!is_retryable(&in_band(Some(400)), false, &[]));
+        assert!(!is_retryable(&in_band(Some(429)), false, &[]));
+        assert!(is_retryable(&in_band(Some(429)), true, &[]));
+        // fallback_on_statuses admits listed in-band codes too.
+        assert!(is_retryable(&in_band(Some(408)), false, &[408]));
+        assert!(!is_retryable(&in_band(Some(408)), false, &[]));
+        assert!(is_retryable(&in_band(None), false, &[]));
     }
 
     /// AISIX-Cloud#1012: `fallback_on_statuses` opts specific upstream


### PR DESCRIPTION
## Problem

Several providers report failures **inside** a committed HTTP 200 stream — an OpenAI-family `data: {"error":{...}}` frame, an Anthropic `event: error` frame, a Gemini in-stream error object, a Bedrock event-stream modeled exception. None of them survive normalization today:

- **OpenAI / Azure / Vertex shim+partner** frames fail the chunk parse and surface as `UpstreamDecode` — the provider's own `type`/`message`/`code` are replaced by a serde error string.
- **Anthropic** error events deserialize into the `#[serde(other)]` catch-all and are **silently swallowed**; the connection then closes and the truncated stream ends looking like a clean completion (the chat pump even emits `[DONE]`).
- **Gemini** error frames *successfully* parse as an empty fully-defaultable response and are swallowed the same way.
- **Bedrock** `ConverseStream` modeled exceptions (Throttling / InternalServer / ModelStreamError / ServiceUnavailable / Validation) collapse into a generic `Transport`.

This is scenario 3 of the mid-stream fallback feature (`Ref` below): before the router can *react* to in-band errors, they need to exist as a first-class error type.

## Change

New `BridgeError::UpstreamInBand { status, message, parsed, wire }`, captured at every provider stream-parse site:

| provider | detection | embedded status |
|---|---|---|
| openai / azure / vertex(shim, partner) | chunk-parse failure → `capture_in_band_error` probe | numeric `error.code` (number or numeric string) in 400..=599 |
| vertex (gemini) | probe **before** parse (error frames parse as an empty response otherwise) | numeric `error.code`; gRPC token → view `kind` |
| anthropic + claude-on-vertex | typed `AnthropicStreamEvent::Error` variant | documented kind→status table (`overloaded_error`→529, …) |
| bedrock | `recv()` service-error match | exception family (429/500/503/400); `ModelStreamErrorException.original_status_code`, else 502 |

Downstream wiring:

- `is_retryable`: embedded status follows the same rules as an HTTP status (non-429 4xx not retryable, `retry_on_429` / `fallback_on_statuses` apply — same filter LiteLLM applies to in-body stream errors); status-less in-band errors classify as transient (retryable).
- `decide_cooldown`: embedded status gates on the trigger-status list; status-less follows the transport gate (`reason: upstream_in_band_error`).
- Pre-first-chunk (the peek window of #554): the client envelope renders through the same per-wire translation tables as the equivalent HTTP error — an in-band 429/4xx forwards translated, 5xx/unknown collapses to the canned 502 family.
- Mid-stream: the SSE `event: error` frame now carries `type: upstream_in_band_error` and the provider's message instead of a serde failure.
- Bedrock keeps its redaction rule: canned message, AWS exception code in the view, never raw AWS text (ARNs/account ids).

## Behavior changes

- Anthropic (native + on-Vertex) mid-stream error events: silently-swallowed → surfaced as an in-band error frame with no `[DONE]` (truncation is now detectable).
- Pre-first-chunk in-band errors: were `UpstreamDecode` (retryable, 502) → now status-aware; an in-band 4xx≠429 no longer burns retries/failover, an in-band 429 honours `retry_on_429`.
- Everything else keeps its classification (garbage frames stay `UpstreamDecode`, non-service Bedrock receiver failures stay `Transport`).

## Tests

Per-provider: openai + anthropic + vertex(gemini/claude/shim) wiremock streams asserting the typed error (kind/status/wire) and that garbage keeps `UpstreamDecode`; azure parse unit; bedrock exception-family matrix incl. `original_status_code` passthrough and the no-ARN-leak assertion. Proxy: `is_retryable` and cooldown matrices for the new variant. Gateway: `capture_in_band_error` envelope-shape matrix (string/numeric codes, gRPC token, bare-string error, caps, non-error rejection).

Fixes api7/AISIX-Cloud#1222