### PR TITLE
feat(mcp): warn once when a credentialed upstream is reached over cleartext http

### DIFF
--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -149,8 +149,43 @@ impl std::fmt::Debug for A2aUpstream {
     }
 }
 
+/// Warn — once per (agent, url) per process — when a credentialed agent is
+/// reached over cleartext HTTP: the gateway-held secret travels unencrypted
+/// on every call. Same posture as the MCP registry's warning (#879): a
+/// warning, never a rejection, and no request-behavior change. Deduped
+/// because the upstream is rebuilt per request. The scheme check mirrors
+/// the URL parser (lowercased scheme, leading whitespace stripped).
+fn warn_cleartext_credential(agent: &A2aAgent) {
+    use std::sync::{Mutex, OnceLock};
+    static WARNED: OnceLock<Mutex<std::collections::HashSet<(String, String)>>> = OnceLock::new();
+    if agent.auth_type == A2aAuthType::None {
+        return;
+    }
+    let cleartext = agent
+        .url
+        .trim_start()
+        .get(..7)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("http://"));
+    if !cleartext {
+        return;
+    }
+    let mut warned = WARNED
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if warned.insert((agent.name.clone(), agent.url.clone())) {
+        tracing::warn!(
+            agent = %agent.name,
+            url = %agent.url,
+            "the gateway-held A2A agent credential is sent over cleartext http; anyone \
+             on the network path can read it — serve this agent over https"
+        );
+    }
+}
+
 /// Build an [`A2aUpstream`] from a registered [`A2aAgent`] resource.
 pub fn upstream_from_a2a_agent(agent: &A2aAgent) -> A2aUpstream {
+    warn_cleartext_credential(agent);
     let secret = agent.secret.clone().unwrap_or_default();
     let auth = match agent.auth_type {
         A2aAuthType::None => A2aAuth::None,

--- a/crates/aisix-mcp/src/bridge.rs
+++ b/crates/aisix-mcp/src/bridge.rs
@@ -486,7 +486,52 @@ fn into_mcp_tool(tool: rmcp::model::Tool) -> McpTool {
 /// then fails cleanly at connect time and that server degrades like any
 /// unreachable upstream (its tools drop out of `tools/list`, the failure is
 /// logged), instead of one bad row poisoning snapshot loading.
+/// Whether reaching this server sends a gateway-held credential over
+/// cleartext HTTP: any non-`none` auth type against an `http://` URL (for
+/// `oauth2`, `url` carries the minted access token; a cleartext `token_url`
+/// is flagged separately — it carries the client secret).
+fn sends_credential_over_cleartext(auth_type: McpAuthType, url: &str) -> bool {
+    auth_type != McpAuthType::None && url.starts_with("http://")
+}
+
+/// Warn — once per distinct message per process — that a credential travels
+/// unencrypted. Deliberately a warning, not a rejection: plain-HTTP MCP
+/// servers inside a private network are a lawful, common deployment, and
+/// request behavior (including redirect handling) stays aligned with the
+/// reference SDK baseline (#879). Deduped because the gateway is rebuilt
+/// from the snapshot on every request — an undeduped warn would log per
+/// call.
+fn warn_cleartext_credential(server: &McpServer) {
+    use std::sync::{Mutex, OnceLock};
+    static WARNED: OnceLock<Mutex<std::collections::HashSet<String>>> = OnceLock::new();
+    let emit = |what: &str, url: &str| {
+        let key = format!("{}|{url}", server.name);
+        let mut warned = WARNED
+            .get_or_init(Default::default)
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if warned.insert(key) {
+            tracing::warn!(
+                server = %server.name,
+                url = %url,
+                "{what} is sent over cleartext http; anyone on the network path can read \
+                 it — serve this upstream over https"
+            );
+        }
+    };
+    if sends_credential_over_cleartext(server.auth_type, &server.url) {
+        emit("the gateway-held MCP upstream credential", &server.url);
+    }
+    if server.auth_type == McpAuthType::OAuth2 {
+        let token_url = server.token_url.as_deref().unwrap_or_default();
+        if token_url.starts_with("http://") {
+            emit("the OAuth client secret", token_url);
+        }
+    }
+}
+
 pub fn upstream_from_mcp_server(server: &McpServer) -> McpUpstream {
+    warn_cleartext_credential(server);
     let auth = match server.auth_type {
         McpAuthType::None => McpAuth::None,
         McpAuthType::Bearer => McpAuth::Bearer(server.secret.clone().unwrap_or_default()),
@@ -552,6 +597,30 @@ impl McpBridge for EphemeralBridge {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cleartext_credential_detection() {
+        // A credentialed http:// URL is flagged; https, credential-less
+        // http, and non-URL edge shapes are not (https also starts with
+        // "http", so the scheme match must include the separator).
+        assert!(sends_credential_over_cleartext(
+            McpAuthType::Bearer,
+            "http://mcp.internal/mcp"
+        ));
+        assert!(sends_credential_over_cleartext(
+            McpAuthType::ApiKey,
+            "http://mcp.internal/mcp"
+        ));
+        assert!(!sends_credential_over_cleartext(
+            McpAuthType::Bearer,
+            "https://mcp.internal/mcp"
+        ));
+        assert!(!sends_credential_over_cleartext(
+            McpAuthType::None,
+            "http://mcp.internal/mcp"
+        ));
+        assert!(!sends_credential_over_cleartext(McpAuthType::Bearer, ""));
+    }
 
     /// The dial to an upstream that swallows SYNs must be cut by the
     /// shared client's `upstream.connect_timeout_ms` (default 5 s) —

--- a/crates/aisix-mcp/src/bridge.rs
+++ b/crates/aisix-mcp/src/bridge.rs
@@ -486,31 +486,55 @@ fn into_mcp_tool(tool: rmcp::model::Tool) -> McpTool {
 /// then fails cleanly at connect time and that server degrades like any
 /// unreachable upstream (its tools drop out of `tools/list`, the failure is
 /// logged), instead of one bad row poisoning snapshot loading.
-/// Whether reaching this server sends a gateway-held credential over
-/// cleartext HTTP: any non-`none` auth type against an `http://` URL (for
-/// `oauth2`, `url` carries the minted access token; a cleartext `token_url`
-/// is flagged separately — it carries the client secret).
-fn sends_credential_over_cleartext(auth_type: McpAuthType, url: &str) -> bool {
-    auth_type != McpAuthType::None && url.starts_with("http://")
+/// Whether a URL sends its traffic over cleartext HTTP. Matches how the
+/// HTTP stack will actually treat it (the URL parser lowercases the scheme
+/// and strips leading whitespace), so `HTTP://` and `" http://"` are
+/// flagged too; `https://` never is.
+fn is_cleartext(url: &str) -> bool {
+    let trimmed = url.trim_start();
+    trimmed
+        .get(..7)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("http://"))
 }
 
-/// Warn — once per distinct message per process — that a credential travels
-/// unencrypted. Deliberately a warning, not a rejection: plain-HTTP MCP
-/// servers inside a private network are a lawful, common deployment, and
+/// The cleartext-credential findings for a registered server: which
+/// gateway-held secret travels over plain HTTP, and to which URL. Applies
+/// to every credentialed auth type against an `http://` server URL —
+/// `type: mcp` and `type: openapi` rows share these fields — plus, for
+/// `oauth2`, a cleartext `token_url` (it carries the client secret; a
+/// distinct finding even when `token_url` equals `url`). Pure, so tests
+/// pin the selection.
+pub(crate) fn cleartext_findings(server: &McpServer) -> Vec<(&'static str, String)> {
+    let mut findings = Vec::new();
+    if server.auth_type != McpAuthType::None && is_cleartext(&server.url) {
+        findings.push(("the gateway-held upstream credential", server.url.clone()));
+    }
+    if server.auth_type == McpAuthType::OAuth2 {
+        let token_url = server.token_url.as_deref().unwrap_or_default();
+        if is_cleartext(token_url) {
+            findings.push(("the OAuth client secret", token_url.to_string()));
+        }
+    }
+    findings
+}
+
+/// Warn — once per distinct finding per process — that a credential travels
+/// unencrypted. Deliberately a warning, not a rejection: plain-HTTP
+/// upstreams inside a private network are a lawful, common deployment, and
 /// request behavior (including redirect handling) stays aligned with the
-/// reference SDK baseline (#879). Deduped because the gateway is rebuilt
-/// from the snapshot on every request — an undeduped warn would log per
-/// call.
-fn warn_cleartext_credential(server: &McpServer) {
+/// reference SDK baseline (#879). Deduped on the (server, finding, url)
+/// tuple because the gateway is rebuilt from the snapshot on every request
+/// — an undeduped warn would log per call.
+pub(crate) fn warn_cleartext_credential(server: &McpServer) {
     use std::sync::{Mutex, OnceLock};
-    static WARNED: OnceLock<Mutex<std::collections::HashSet<String>>> = OnceLock::new();
-    let emit = |what: &str, url: &str| {
-        let key = format!("{}|{url}", server.name);
+    type Warned = std::collections::HashSet<(String, &'static str, String)>;
+    static WARNED: OnceLock<Mutex<Warned>> = OnceLock::new();
+    for (what, url) in cleartext_findings(server) {
         let mut warned = WARNED
             .get_or_init(Default::default)
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if warned.insert(key) {
+        if warned.insert((server.name.clone(), what, url.clone())) {
             tracing::warn!(
                 server = %server.name,
                 url = %url,
@@ -518,20 +542,10 @@ fn warn_cleartext_credential(server: &McpServer) {
                  it — serve this upstream over https"
             );
         }
-    };
-    if sends_credential_over_cleartext(server.auth_type, &server.url) {
-        emit("the gateway-held MCP upstream credential", &server.url);
-    }
-    if server.auth_type == McpAuthType::OAuth2 {
-        let token_url = server.token_url.as_deref().unwrap_or_default();
-        if token_url.starts_with("http://") {
-            emit("the OAuth client secret", token_url);
-        }
     }
 }
 
 pub fn upstream_from_mcp_server(server: &McpServer) -> McpUpstream {
-    warn_cleartext_credential(server);
     let auth = match server.auth_type {
         McpAuthType::None => McpAuth::None,
         McpAuthType::Bearer => McpAuth::Bearer(server.secret.clone().unwrap_or_default()),
@@ -600,26 +614,52 @@ mod tests {
 
     #[test]
     fn cleartext_credential_detection() {
-        // A credentialed http:// URL is flagged; https, credential-less
-        // http, and non-URL edge shapes are not (https also starts with
-        // "http", so the scheme match must include the separator).
-        assert!(sends_credential_over_cleartext(
-            McpAuthType::Bearer,
-            "http://mcp.internal/mcp"
+        let server = |auth_type: &str, url: &str, token_url: Option<&str>| -> McpServer {
+            serde_json::from_value(serde_json::json!({
+                "display_name": "s",
+                "url": url,
+                "auth_type": auth_type,
+                "secret": "k",
+                "client_id": "c",
+                "token_url": token_url,
+            }))
+            .expect("valid server")
+        };
+
+        // A credentialed http:// URL is flagged; https and credential-less
+        // http are not (https also starts with "http", so the scheme match
+        // must include the separator). The URL parser lowercases the scheme
+        // and strips leading whitespace, so those shapes flag too.
+        for auth in ["bearer", "api_key"] {
+            assert_eq!(
+                cleartext_findings(&server(auth, "http://mcp.internal/mcp", None)).len(),
+                1,
+                "{auth} over http must be flagged"
+            );
+        }
+        assert!(cleartext_findings(&server("bearer", "https://mcp.internal/mcp", None)).is_empty());
+        assert!(cleartext_findings(&server("none", "http://mcp.internal/mcp", None)).is_empty());
+        assert!(cleartext_findings(&server("bearer", "", None)).is_empty());
+        assert_eq!(
+            cleartext_findings(&server("bearer", "HTTP://mcp.internal/mcp", None)).len(),
+            1
+        );
+        assert_eq!(
+            cleartext_findings(&server("bearer", " http://mcp.internal/mcp", None)).len(),
+            1
+        );
+
+        // oauth2: the server URL carries the minted token, the token URL the
+        // client secret — two distinct findings, even at the same URL.
+        let both = cleartext_findings(&server("oauth2", "http://x/mcp", Some("http://x/mcp")));
+        assert_eq!(both.len(), 2, "token_url == url must still flag twice");
+        let token_only = cleartext_findings(&server(
+            "oauth2",
+            "https://x/mcp",
+            Some("http://idp.internal/token"),
         ));
-        assert!(sends_credential_over_cleartext(
-            McpAuthType::ApiKey,
-            "http://mcp.internal/mcp"
-        ));
-        assert!(!sends_credential_over_cleartext(
-            McpAuthType::Bearer,
-            "https://mcp.internal/mcp"
-        ));
-        assert!(!sends_credential_over_cleartext(
-            McpAuthType::None,
-            "http://mcp.internal/mcp"
-        ));
-        assert!(!sends_credential_over_cleartext(McpAuthType::Bearer, ""));
+        assert_eq!(token_only.len(), 1);
+        assert_eq!(token_only[0].0, "the OAuth client secret");
     }
 
     /// The dial to an upstream that swallows SYNs must be cut by the

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -327,6 +327,10 @@ impl McpGateway {
             .into_iter()
             .filter(|entry| entry.value.enabled)
             .map(|entry| {
+                // Here, not inside one bridge constructor: `type: mcp` and
+                // `type: openapi` rows share the credential fields, so the
+                // cleartext warning covers both.
+                crate::bridge::warn_cleartext_credential(&entry.value);
                 let name = entry.value.name.clone();
                 let bridge: Arc<dyn McpBridge> = match entry.value.server_type {
                     McpServerType::Mcp => {
@@ -350,6 +354,7 @@ impl McpGateway {
         if !entry.value.enabled {
             return None;
         }
+        crate::bridge::warn_cleartext_credential(&entry.value);
         let name = entry.value.name.clone();
         let bridge: Arc<dyn McpBridge> = match entry.value.server_type {
             McpServerType::Mcp => {

--- a/tests/e2e/src/cases/mcp-cleartext-credential-warn-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-cleartext-credential-warn-e2e.test.ts
@@ -87,14 +87,19 @@ describe("mcp cleartext credential warning e2e", () => {
     if (!etcdReachable || !app) return ctx.skip();
 
     // The propagation probe already drove at least one request through the
-    // gateway, so the warning is present…
+    // gateway; poll for the line rather than racing the stderr pipe.
+    await waitConfigPropagation(async () => warnCount() >= 1);
     expect(warnCount()).toBe(1);
     expect(app.output()).toContain("alpha");
 
-    // …and stays at one across further requests (per-process dedup), while
-    // the endpoint keeps answering — a warning, not a rejection.
+    // …and it stays at one across further requests (per-process dedup),
+    // while the endpoint keeps answering — a warning, not a rejection. The
+    // short settle lets any (buggy) extra warn line reach the pipe buffer
+    // before the count is read, so a dedup regression can actually fail
+    // this assertion.
     expect(await initialize()).toBe(200);
     expect(await initialize()).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 250));
     expect(warnCount()).toBe(1);
   });
 });

--- a/tests/e2e/src/cases/mcp-cleartext-credential-warn-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-cleartext-credential-warn-e2e.test.ts
@@ -1,0 +1,100 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startMcpUpstream,
+  waitConfigPropagation,
+  type McpUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a credentialed MCP upstream reached over cleartext http logs one
+// warning — and exactly one, deduped across requests, because the gateway
+// is rebuilt from the snapshot per request. The warning never rejects:
+// plain-http upstreams inside a private network are a lawful deployment,
+// so calls keep working (#879).
+
+const KEY = "sk-cleartext-warn-e2e";
+const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
+const WARN_MARK = "sent over cleartext http";
+
+describe("mcp cleartext credential warning e2e", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: McpUpstream | undefined;
+  let etcdReachable = false;
+
+  const initialize = async (): Promise<number> => {
+    const res = await fetch(`${app!.proxyUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${KEY}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "cleartext-warn-e2e", version: "0.1" },
+        },
+      }),
+    });
+    return res.status;
+  };
+
+  const warnCount = (): number =>
+    app!.output().split(WARN_MARK).length - 1;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startMcpUpstream("alpha");
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    // Credentialed (bearer) server over plain http — the harness upstream
+    // ignores auth headers, so calls succeed while the credential is the
+    // warning's subject.
+    await seed.update("mcp_servers", randomUUID(), {
+      display_name: "alpha",
+      url: upstream.url,
+      enabled: true,
+      auth_type: "bearer",
+      secret: "warn-e2e-token",
+    });
+    await seed.createApiKey({
+      key_hash: sha256(KEY),
+      allowed_models: [],
+      allowed_tools: ["*"],
+    });
+
+    await waitConfigPropagation(async () => (await initialize()) === 200);
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("warns once about the cleartext credential and keeps serving", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    // The propagation probe already drove at least one request through the
+    // gateway, so the warning is present…
+    expect(warnCount()).toBe(1);
+    expect(app.output()).toContain("alpha");
+
+    // …and stays at one across further requests (per-process dedup), while
+    // the endpoint keeps answering — a warning, not a rejection.
+    expect(await initialize()).toBe(200);
+    expect(await initialize()).toBe(200);
+    expect(warnCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Logs one warning — per distinct (server, finding, url), per process — when a registered upstream with any non-`none` auth type is reached over `http://`: the gateway-held credential (bearer token, API key, or minted OAuth access token) travels unencrypted on every call. Covered surfaces:

- `mcp_servers` rows of **both** `type: mcp` and `type: openapi` — the warning sits in the gateway builders, the one chokepoint both types pass through.
- For `oauth2`, a cleartext `token_url` is a **separate finding** (it carries the client secret) — logged even when `token_url` equals `url`.
- `a2a_agents` — the identical pattern (gateway-held bearer/api-key against an agent URL, rebuilt per request) gets the mirrored warning.

The scheme check matches how the URL parser will actually treat the value (lowercased scheme, leading whitespace stripped), so `HTTP://` and `" http://"` are flagged and `https://` never is. Deduped per process because upstreams are rebuilt from the snapshot on every request.

## Why

Follow-up decided on #879. Scope deliberately chosen as **warning-only, zero behavior divergence**:

- Plain-http upstreams inside a private network are a lawful, common deployment — rejecting would break them.
- Redirect handling stays exactly aligned with the reference baseline: the official MCP SDK's streamable-HTTP client force-enables redirect following, and the reference LLM gateway uses that client for its upstream MCP calls. Changing that unilaterally was considered and rejected to avoid diverging from ecosystem behavior (the option remains open in #879's discussion if evidence of abuse appears).
- `x-api-key` values were already marked sensitive for debug redaction; nothing further to change there.

## Tests

- Unit (`cleartext_credential_detection`): the pure `cleartext_findings` selection — credentialed http flagged for bearer/api_key; https / credential-less / empty not (including the `https` starts-with-`http` trap); `HTTP://` and leading-whitespace shapes flagged; oauth2 with both URLs cleartext yields two findings even at the same URL; https server + http token_url yields exactly the client-secret finding.
- E2E (`mcp-cleartext-credential-warn-e2e.test.ts`): real gateway + etcd + real upstream with a bearer-credentialed `http://` registration — the warning appears (polled, not raced against the stderr pipe), stays at exactly one across repeated requests, names the server, and the endpoint keeps serving (warning, not rejection).

Fixes #879.