### PR TITLE
fix(proxy): route Path-extractor rejections through the reject chokepoint

### DIFF
--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -24,12 +24,13 @@ use std::time::{Duration, Instant};
 use aisix_a2a::{upstream_from_a2a_agent, A2aBridge, A2aError, HttpBridge};
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::body::to_bytes;
-use axum::extract::{Path, Request, State};
+use axum::extract::{Request, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 
 use crate::auth::AuthenticatedKey;
+use crate::reject::AisixPath;
 use crate::request_id::new_request_id;
 use crate::state::ProxyState;
 
@@ -52,7 +53,7 @@ struct JsonRpcPeek {
 /// emitted either way.
 pub async fn a2a_endpoint(
     auth: AuthenticatedKey,
-    Path(agent): Path<String>,
+    AisixPath(agent): AisixPath<String>,
     State(state): State<ProxyState>,
     request: Request,
 ) -> Response {
@@ -216,7 +217,7 @@ async fn dispatch(
 /// callers discover the agent through `/a2a/<agent>`.
 pub async fn a2a_agent_card(
     auth: AuthenticatedKey,
-    Path(agent): Path<String>,
+    AisixPath(agent): AisixPath<String>,
     State(state): State<ProxyState>,
     headers: HeaderMap,
 ) -> Response {

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -86,11 +86,30 @@ pub async fn transcriptions(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    multipart: Multipart,
+    multipart: Result<Multipart, axum::extract::multipart::MultipartRejection>,
 ) -> Response {
     let started = Instant::now();
     let request_id = client.request_id.clone();
     let api_key_id = auth.entry.id.clone();
+
+    // Same silent class as the body-extractor rejections #863 collected: a
+    // non-multipart content-type answered axum's bare 400 with no access
+    // log, metrics, or envelope.
+    let multipart = match multipart {
+        Ok(multipart) => multipart,
+        Err(_) => {
+            return crate::reject::reject_before_dispatch(
+                &state,
+                "POST",
+                "/v1/audio/transcriptions",
+                &request_id,
+                Some(&api_key_id),
+                started,
+                crate::reject::Envelope::OpenAi,
+                ProxyError::InvalidRequest("invalid multipart form data".into()),
+            );
+        }
+    };
 
     match multipart_dispatch(
         &state,
@@ -186,11 +205,28 @@ pub async fn translations(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    multipart: Multipart,
+    multipart: Result<Multipart, axum::extract::multipart::MultipartRejection>,
 ) -> Response {
     let started = Instant::now();
     let request_id = client.request_id.clone();
     let api_key_id = auth.entry.id.clone();
+
+    // See `transcriptions`: the rejection is recorded, not silently bare.
+    let multipart = match multipart {
+        Ok(multipart) => multipart,
+        Err(_) => {
+            return crate::reject::reject_before_dispatch(
+                &state,
+                "POST",
+                "/v1/audio/translations",
+                &request_id,
+                Some(&api_key_id),
+                started,
+                crate::reject::Envelope::OpenAi,
+                ProxyError::InvalidRequest("invalid multipart form data".into()),
+            );
+        }
+    };
 
     match multipart_dispatch(
         &state,

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -777,10 +777,29 @@ pub(crate) async fn create_file(
     client: ClientContext,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
-    mut multipart: Multipart,
+    multipart: Result<Multipart, axum::extract::multipart::MultipartRejection>,
 ) -> Response {
     let started = Instant::now();
     let request_id = client.request_id.clone();
+
+    // Same silent class as the body-extractor rejections #863 collected: a
+    // non-multipart content-type answered axum's bare 400 with no access
+    // log, metrics, or envelope.
+    let mut multipart = match multipart {
+        Ok(multipart) => multipart,
+        Err(_) => {
+            return crate::reject::reject_before_dispatch(
+                &state,
+                "POST",
+                "/v1/files",
+                &request_id,
+                Some(&auth.entry.id),
+                started,
+                crate::reject::Envelope::OpenAi,
+                ProxyError::InvalidRequest("invalid multipart form data".into()),
+            );
+        }
+    };
     let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
 
     let result = async {

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -55,7 +55,7 @@ use aisix_core::resource::ResourceEntry;
 use aisix_core::{Model, ProviderKey};
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
 use axum::body::Body;
-use axum::extract::{Multipart, Path, Query, State};
+use axum::extract::{Multipart, Query, State};
 use axum::http::{header, HeaderMap, HeaderValue, Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -66,6 +66,7 @@ use serde_json::Value;
 use crate::auth::AuthenticatedKey;
 use crate::client_ip::ClientContext;
 use crate::error::ProxyError;
+use crate::reject::AisixPath;
 use crate::state::ProxyState;
 
 /// Marker prefix for gateway-minted routed ids.
@@ -928,7 +929,7 @@ pub(crate) async fn get_file(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(id): Path<String>,
+    AisixPath(id): AisixPath<String>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Response {
@@ -958,7 +959,7 @@ pub(crate) async fn delete_file(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(id): Path<String>,
+    AisixPath(id): AisixPath<String>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Response {
@@ -988,7 +989,7 @@ pub(crate) async fn file_content(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(id): Path<String>,
+    AisixPath(id): AisixPath<String>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Response {
@@ -1135,7 +1136,7 @@ pub(crate) async fn get_batch(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(id): Path<String>,
+    AisixPath(id): AisixPath<String>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Response {
@@ -1205,7 +1206,7 @@ pub(crate) async fn cancel_batch(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(id): Path<String>,
+    AisixPath(id): AisixPath<String>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Response {
@@ -1378,7 +1379,7 @@ pub(crate) async fn get_ft_job(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(id): Path<String>,
+    AisixPath(id): AisixPath<String>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Response {
@@ -1408,7 +1409,7 @@ pub(crate) async fn cancel_ft_job(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(id): Path<String>,
+    AisixPath(id): AisixPath<String>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Response {

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -78,7 +78,7 @@ pub async fn mcp_endpoint(
 /// nothing about which servers exist).
 pub async fn mcp_scoped_endpoint(
     auth: AuthenticatedKey,
-    axum::extract::Path(server): axum::extract::Path<String>,
+    crate::reject::AisixPath(server): crate::reject::AisixPath<String>,
     State(state): State<ProxyState>,
     request: Request,
 ) -> Response {

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -24,7 +24,7 @@
 
 use aisix_obs::{AccessLog, RequestOutcome};
 use axum::body::Body;
-use axum::extract::{Path, Request, State};
+use axum::extract::{Request, State};
 use axum::http::{header, HeaderMap, HeaderValue, Method};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
@@ -32,6 +32,7 @@ use std::time::{Duration, Instant};
 
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
+use crate::reject::AisixPath;
 use crate::state::ProxyState;
 
 /// Bounded `model` metric label for passthrough requests. The wildcard
@@ -131,7 +132,7 @@ pub async fn passthrough(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: crate::client_ip::ClientContext,
-    Path((provider, rest)): Path<(String, String)>,
+    AisixPath((provider, rest)): AisixPath<(String, String)>,
     req: Request,
 ) -> Response {
     let started = Instant::now();

--- a/crates/aisix-proxy/src/reject.rs
+++ b/crates/aisix-proxy/src/reject.rs
@@ -14,12 +14,18 @@
 //! the family can't drift again: the rendered envelope and the telemetry are
 //! produced by the same call.
 
+use std::sync::Arc;
 use std::time::Instant;
 
+use aisix_core::{ApiKey, ResourceEntry};
 use aisix_obs::{AccessLog, RequestOutcome};
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
+use serde::de::DeserializeOwned;
 
 use crate::error::ProxyError;
+use crate::request_id::{new_request_id, RequestId};
 use crate::state::ProxyState;
 use crate::usage_attr::UNRESOLVED_MODEL_LABEL;
 
@@ -89,5 +95,163 @@ pub(crate) fn reject_before_dispatch(
     match envelope {
         Envelope::OpenAi => err.into_response(),
         Envelope::Anthropic => err.into_anthropic_response(),
+    }
+}
+
+/// `axum::extract::Path` with the rejection routed through
+/// [`reject_before_dispatch`].
+///
+/// A `:param` segment that fails extraction — invalid percent-encoding such
+/// as `/v1/files/%ff` — otherwise answers axum's bare 400: no access log,
+/// no request metrics, no caller envelope (#880, the same silent class
+/// #863 collected for body rejections). Every handler on a `:param` route
+/// takes this instead of `Path`, so the family can't drift back.
+///
+/// Declared after `auth: AuthenticatedKey` in handler signatures, like
+/// `Path` was — extractors run in order, so authentication still precedes
+/// the path parse (an unauthenticated caller gets 401, not a 400 that
+/// confirms anything about the route) and the resolved key published by the
+/// auth extractor attributes the rejection.
+pub(crate) struct AisixPath<T>(pub(crate) T);
+
+#[axum::async_trait]
+impl<T> FromRequestParts<ProxyState> for AisixPath<T>
+where
+    T: DeserializeOwned + Send + 'static,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &ProxyState,
+    ) -> Result<Self, Self::Rejection> {
+        match axum::extract::Path::<T>::from_request_parts(parts, state).await {
+            Ok(axum::extract::Path(value)) => Ok(Self(value)),
+            Err(_) => {
+                let request_id = parts
+                    .extensions
+                    .get::<RequestId>()
+                    .map(|r| r.0.clone())
+                    .unwrap_or_else(new_request_id);
+                let api_key_id = parts
+                    .extensions
+                    .get::<Arc<ResourceEntry<ApiKey>>>()
+                    .map(|entry| entry.id.clone());
+                // The raw path, not a route template: the malformed segment
+                // IS the subject of this rejection, and the access log is
+                // per-request (the bounded labels live in the metrics).
+                Err(reject_before_dispatch(
+                    state,
+                    parts.method.as_str(),
+                    parts.uri.path(),
+                    &request_id,
+                    api_key_id.as_deref(),
+                    Instant::now(),
+                    Envelope::OpenAi,
+                    ProxyError::InvalidRequest("invalid path parameter".into()),
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aisix_core::snapshot::SnapshotHandle;
+    use aisix_core::{AisixSnapshot, ApiKey, ProxyConfig, ResourceEntry};
+    use axum::body::Body;
+    use axum::http::{Request as HttpRequest, StatusCode};
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    use crate::state::ProxyState;
+
+    const TOKEN: &str = "sk-path-reject-test";
+
+    fn router() -> axum::Router {
+        let apikey: ApiKey = serde_json::from_value(serde_json::json!({
+            "key_hash": ApiKey::hash_bearer(TOKEN),
+            "allowed_models": ["*"],
+        }))
+        .expect("valid apikey");
+        let snapshot = AisixSnapshot::new();
+        snapshot
+            .apikeys
+            .insert(ResourceEntry::new("ak-1", apikey, 1));
+        let cfg = ProxyConfig {
+            addr: "127.0.0.1:0".into(),
+            request_body_limit_bytes: 0,
+            tls: None,
+            real_ip: Default::default(),
+            url_rewrites: Vec::new(),
+        };
+        let state = ProxyState::new(
+            SnapshotHandle::new(snapshot),
+            Arc::new(aisix_gateway::Hub::new()),
+            &cfg,
+        )
+        .without_cache();
+        crate::build_router(state)
+    }
+
+    async fn send(
+        router: axum::Router,
+        method: &str,
+        path: &str,
+        auth: bool,
+    ) -> (StatusCode, String) {
+        let mut builder = HttpRequest::builder().method(method).uri(path);
+        if auth {
+            builder = builder.header("authorization", format!("Bearer {TOKEN}"));
+        }
+        let response = router
+            .oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .expect("router responds");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+            .await
+            .unwrap_or_default();
+        (status, String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    #[tokio::test]
+    async fn malformed_path_params_answer_the_openai_envelope_across_the_family() {
+        // `%ff` is valid percent-encoding but invalid UTF-8 after decoding —
+        // the `Path` extractor rejects it. Pre-#880 that was axum's bare 400
+        // text; every `:param` route must now answer the caller envelope
+        // (and, mechanically via `reject_before_dispatch`, emit the access
+        // log + metrics every other pre-dispatch rejection gets).
+        let router = router();
+        for (method, path) in [
+            ("POST", "/a2a/%ff"),
+            ("GET", "/a2a/%ff/.well-known/agent-card.json"),
+            ("GET", "/mcp/%ff"),
+            ("GET", "/v1/files/%ff"),
+            ("GET", "/v1/files/%ff/content"),
+            ("GET", "/v1/batches/%ff"),
+            ("POST", "/v1/batches/%ff/cancel"),
+            ("GET", "/v1/fine_tuning/jobs/%ff"),
+            ("POST", "/v1/fine_tuning/jobs/%ff/cancel"),
+            ("GET", "/v1/videos/%ff"),
+            ("GET", "/v1/videos/%ff/content"),
+            ("POST", "/passthrough/%ff/v1/chat"),
+        ] {
+            let (status, body) = send(router.clone(), method, path, true).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{method} {path}: {body}");
+            assert!(
+                body.contains("invalid_request_error"),
+                "{method} {path} must answer the OpenAI envelope, got: {body}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_still_precedes_the_path_parse() {
+        // Extractor order is unchanged: an unauthenticated caller gets 401,
+        // not a 400 that reveals how the path would have parsed.
+        let router = router();
+        let (status, _) = send(router, "GET", "/v1/files/%ff", false).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
     }
 }

--- a/crates/aisix-proxy/src/reject.rs
+++ b/crates/aisix-proxy/src/reject.rs
@@ -127,7 +127,18 @@ where
     ) -> Result<Self, Self::Rejection> {
         match axum::extract::Path::<T>::from_request_parts(parts, state).await {
             Ok(axum::extract::Path(value)) => Ok(Self(value)),
-            Err(_) => {
+            Err(rejection) => {
+                // axum classifies wrong parameter arity / unsupported types
+                // as 500 — a server wiring bug, not caller input. Keep that
+                // loud and unenveloped; only caller-caused 400s are recorded
+                // as refused requests below.
+                let axum_response = rejection.into_response();
+                if axum_response.status() != axum::http::StatusCode::BAD_REQUEST {
+                    return Err(axum_response);
+                }
+                // Fallback mirrors the handlers' own idiom (see mcp.rs /
+                // a2a.rs); unreachable in the real router, where
+                // `ensure_request_id` runs before routing.
                 let request_id = parts
                     .extensions
                     .get::<RequestId>()
@@ -168,7 +179,7 @@ mod tests {
 
     const TOKEN: &str = "sk-path-reject-test";
 
-    fn router() -> axum::Router {
+    fn state() -> ProxyState {
         let apikey: ApiKey = serde_json::from_value(serde_json::json!({
             "key_hash": ApiKey::hash_bearer(TOKEN),
             "allowed_models": ["*"],
@@ -185,13 +196,16 @@ mod tests {
             real_ip: Default::default(),
             url_rewrites: Vec::new(),
         };
-        let state = ProxyState::new(
+        ProxyState::new(
             SnapshotHandle::new(snapshot),
             Arc::new(aisix_gateway::Hub::new()),
             &cfg,
         )
-        .without_cache();
-        crate::build_router(state)
+        .without_cache()
+    }
+
+    fn router() -> axum::Router {
+        crate::build_router(state())
     }
 
     async fn send(
@@ -222,12 +236,14 @@ mod tests {
         // text; every `:param` route must now answer the caller envelope
         // (and, mechanically via `reject_before_dispatch`, emit the access
         // log + metrics every other pre-dispatch rejection gets).
-        let router = router();
+        let state = state();
+        let router = crate::build_router(state.clone());
         for (method, path) in [
             ("POST", "/a2a/%ff"),
             ("GET", "/a2a/%ff/.well-known/agent-card.json"),
             ("GET", "/mcp/%ff"),
             ("GET", "/v1/files/%ff"),
+            ("DELETE", "/v1/files/%ff"),
             ("GET", "/v1/files/%ff/content"),
             ("GET", "/v1/batches/%ff"),
             ("POST", "/v1/batches/%ff/cancel"),
@@ -242,6 +258,70 @@ mod tests {
             assert!(
                 body.contains("invalid_request_error"),
                 "{method} {path} must answer the OpenAI envelope, got: {body}"
+            );
+        }
+
+        // The refusals are RECORDED, not just enveloped: the chokepoint
+        // counts them with the unresolved labels.
+        let scrape = state.metrics.render();
+        assert!(
+            scrape.contains(r#"status="400""#) && scrape.contains(r#"provider="unknown""#),
+            "the 400s must be counted with unresolved labels, got: {scrape}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wiring_bugs_keep_their_500_instead_of_blaming_the_caller() {
+        // A handler whose tuple arity doesn't match the route's captures is
+        // a server wiring bug — axum classifies it 500, and the extractor
+        // must pass that through rather than record a caller-caused 400.
+        async fn miswired(
+            crate::reject::AisixPath(_x): crate::reject::AisixPath<String>,
+            axum::extract::State(_): axum::extract::State<ProxyState>,
+        ) -> &'static str {
+            "unreachable"
+        }
+        let router = axum::Router::new()
+            .route("/wired/:a/:b", axum::routing::get(miswired))
+            .with_state(state());
+        let (status, body) = send(router, "GET", "/wired/x/y", false).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "{body}");
+        assert!(
+            !body.contains("invalid_request_error"),
+            "a wiring bug must not wear the caller envelope: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn multipart_content_type_mismatch_answers_the_envelope() {
+        // Sending JSON to a multipart endpoint is a common client mistake —
+        // the same silent bare-400 class, one extractor over (#880 review
+        // follow-up). Every multipart route must answer the envelope.
+        let router = router();
+        for path in [
+            "/v1/audio/transcriptions",
+            "/v1/audio/translations",
+            "/v1/files",
+        ] {
+            let request = HttpRequest::post(path)
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap();
+            let response = router
+                .clone()
+                .oneshot(request)
+                .await
+                .expect("router responds");
+            let status = response.status();
+            let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+                .await
+                .unwrap_or_default();
+            let body = String::from_utf8_lossy(&bytes);
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{path}: {body}");
+            assert!(
+                body.contains("invalid_request_error"),
+                "{path} must answer the OpenAI envelope, got: {body}"
             );
         }
     }

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -71,7 +71,7 @@
 
 use aisix_core::AppliedGuardrail;
 use aisix_obs::{AccessLog, RequestOutcome, UsageEvent};
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -83,6 +83,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use crate::auth::AuthenticatedKey;
 use crate::client_ip::ClientContext;
 use crate::error::{ErrorEnvelope, ProxyError};
+use crate::reject::AisixPath;
 use crate::state::ProxyState;
 
 /// DashScope video-synthesis submit path (relative to the ProviderKey's
@@ -1762,7 +1763,7 @@ pub async fn get_video(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(video_id): Path<String>,
+    AisixPath(video_id): AisixPath<String>,
 ) -> Response {
     let telemetry = Telemetry {
         state: &state,
@@ -1813,7 +1814,7 @@ pub async fn video_content(
     State(state): State<ProxyState>,
     auth: AuthenticatedKey,
     client: ClientContext,
-    Path(video_id): Path<String>,
+    AisixPath(video_id): AisixPath<String>,
 ) -> Response {
     let telemetry = Telemetry {
         state: &state,

--- a/tests/e2e/src/cases/path-param-reject-e2e.test.ts
+++ b/tests/e2e/src/cases/path-param-reject-e2e.test.ts
@@ -1,0 +1,83 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a `:param` segment that fails path extraction (valid percent-encoding,
+// invalid UTF-8 after decoding — `%ff`) answers the caller envelope instead
+// of axum's bare 400, across the `:param` route family (#880). The access
+// log + metrics side rides the same `reject_before_dispatch` call every
+// other pre-dispatch rejection uses; the envelope is the e2e-observable
+// contract. Authentication still precedes the path parse.
+
+const KEY = "sk-path-reject-e2e";
+const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
+
+describe("path-param rejection e2e: :param routes answer the envelope", () => {
+  let app: SpawnedApp | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    await seed.createApiKey({
+      key_hash: sha256(KEY),
+      allowed_models: ["*"],
+    });
+
+    // Propagation probe: the key authenticates (any status but 401).
+    for (let i = 0; i < 100; i += 1) {
+      const res = await fetch(`${app.proxyUrl}/v1/files/probe`, {
+        headers: { authorization: `Bearer ${KEY}` },
+      });
+      if (res.status !== 401) return;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error("seeded key never became active");
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.exit();
+  });
+
+  test("malformed :param answers the OpenAI envelope on every family member", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    for (const [method, path] of [
+      ["POST", "/a2a/%ff"],
+      ["GET", "/mcp/%ff"],
+      ["GET", "/v1/files/%ff"],
+      ["GET", "/v1/batches/%ff"],
+      ["GET", "/v1/fine_tuning/jobs/%ff"],
+      ["GET", "/v1/videos/%ff"],
+      ["POST", "/passthrough/%ff/v1/chat"],
+    ] as const) {
+      const res = await fetch(`${app.proxyUrl}${path}`, {
+        method,
+        headers: { authorization: `Bearer ${KEY}` },
+      });
+      expect(res.status, `${method} ${path}`).toBe(400);
+      const body = (await res.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(body.error?.type, `${method} ${path}`).toBe(
+        "invalid_request_error",
+      );
+    }
+  });
+
+  test("an unauthenticated malformed :param is still 401 first", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    const res = await fetch(`${app.proxyUrl}/v1/files/%ff`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/e2e/src/cases/path-param-reject-e2e.test.ts
+++ b/tests/e2e/src/cases/path-param-reject-e2e.test.ts
@@ -74,6 +74,30 @@ describe("path-param rejection e2e: :param routes answer the envelope", () => {
     }
   });
 
+  test("multipart content-type mismatch answers the envelope too", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    // Same silent class one extractor over: JSON sent to a multipart
+    // endpoint used to get axum's bare 400.
+    for (const path of [
+      "/v1/audio/transcriptions",
+      "/v1/audio/translations",
+      "/v1/files",
+    ]) {
+      const res = await fetch(`${app.proxyUrl}${path}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${KEY}`,
+          "content-type": "application/json",
+        },
+        body: "{}",
+      });
+      expect(res.status, path).toBe(400);
+      const body = (await res.json()) as { error?: { type?: string } };
+      expect(body.error?.type, path).toBe("invalid_request_error");
+    }
+  });
+
   test("an unauthenticated malformed :param is still 401 first", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 


### PR DESCRIPTION
## What

A `:param` segment that fails path extraction — valid percent-encoding that decodes to invalid UTF-8, like `/v1/files/%ff` — answered axum's bare 400 from inside the extractor: no access log line, no request metrics, no caller envelope. That is the same silent pre-dispatch class #863 collected into `crate::reject` for body rejections: the caller sees an error the operator has no record of.

New `AisixPath<T>` extractor (in `reject.rs`, next to the chokepoint it feeds) wraps `axum::extract::Path` and routes the rejection through `reject_before_dispatch`:

- caller-caused 400s render the OpenAI error envelope (`invalid_request_error`) **and** emit the access log + request metrics every other pre-dispatch rejection gets (unresolved provider/model labels — cardinality unchanged; the raw path only reaches the access log);
- axum's **500-class** path rejections (wrong parameter arity / unsupported type — server wiring bugs) keep axum's own loud 500 instead of being recorded as caller input;
- the resolved key published by the auth extractor attributes the rejection (`api_key_id`).

Every `:param` handler takes `AisixPath` instead of `Path` — 13 sites across `/a2a/:agent` (+card), `/mcp/:server`, `/v1/files/:id` (+content/DELETE), `/v1/batches/:id` (+cancel), `/v1/fine_tuning/jobs/:id` (+cancel), `/v1/videos/:id` (+content), and `/passthrough/:provider/*rest`. Behavior for valid parameters is byte-identical (pure delegation to axum's `Path`); extractor order is unchanged, so authentication still precedes the path parse.

**Same class, one extractor over (review follow-up):** JSON sent to a multipart endpoint — `/v1/audio/transcriptions`, `/v1/audio/translations`, `/v1/files` upload — was the identical silent bare-400; all three now route through the chokepoint. The `WebSocketUpgrade` rejection on `/v1/realtime` is **deferred to #885**: its correct refusal is `426 Upgrade Required` and `ProxyError` has no such variant, so folding it in here would mis-report the status.

Envelope note: all touched routes speak the OpenAI error shape; the Anthropic-envelope routes (`/v1/messages*`) carry no path parameters and no multipart.

## Tests

- Router-level (`reject.rs`): the whole `:param` family — 13 malformed-path requests assert 400 + envelope **and** that the refusals are counted (metrics scrape with unresolved labels); the three multipart routes assert the envelope on a content-type mismatch; a deliberately mis-wired route pins that arity bugs keep their 500 without the caller envelope; auth-precedes-parse pinned.
- E2E (`path-param-reject-e2e.test.ts`): real binary + etcd — every `:param` family member answers the envelope on `%ff`, the multipart mismatch answers it too, and the unauthenticated variant stays 401-first.

No LiteLLM baseline applies: gateway-internal rejection telemetry/envelope consistency with no equivalent surface there.

Fixes #880.