### PR TITLE
test(e2e): stop the SLS masking spec asserting over its own warm-up traffic

### DIFF
--- a/tests/e2e/src/cases/sls-content-capture-masked-e2e.test.ts
+++ b/tests/e2e/src/cases/sls-content-capture-masked-e2e.test.ts
@@ -191,6 +191,13 @@ describe("sls content capture e2e: streaming capture is post-mask (#932 × AISIX
         }
       });
 
+      // Everything above is warm-up: those requests were served while the
+      // guardrail was still propagating, so the exporter shipped their
+      // UNMASKED replies — which is correct behaviour for a gateway that had
+      // no masking rule yet, and not what this test is about. Assert only on
+      // what was exported from here on.
+      const afterWarmup = sls.requests.length;
+
       // -- streaming chat (hold-back release path) --
       const chatRes = await postJson(app, "/v1/chat/completions", {
         model: "masked-chat-model",
@@ -202,8 +209,8 @@ describe("sls content capture e2e: streaming capture is post-mask (#932 × AISIX
       expect(chatBody).toContain(MASK); // client got masked text
       expect(chatBody).not.toContain(EMAIL);
 
-      await waitForToken(sls, FULL_LOGSTORE, CHAT_PROMPT_TOKEN);
-      let fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      await waitForToken(sls, FULL_LOGSTORE, CHAT_PROMPT_TOKEN, 10_000, afterWarmup);
+      let fullText = decodedTextFor(sls, FULL_LOGSTORE, afterWarmup);
       expect(fullText).toContain(CHAT_PROMPT_TOKEN);
       expect(fullText).toContain(MASK); // capture carries the masked reply
       expect(fullText).not.toContain(EMAIL); // and never the raw PII
@@ -219,13 +226,13 @@ describe("sls content capture e2e: streaming capture is post-mask (#932 × AISIX
       expect(bridgeBody).toContain(MASK);
       expect(bridgeBody).not.toContain(EMAIL);
 
-      await waitForToken(sls, FULL_LOGSTORE, BRIDGE_PROMPT_TOKEN);
-      fullText = decodedTextFor(sls, FULL_LOGSTORE);
+      await waitForToken(sls, FULL_LOGSTORE, BRIDGE_PROMPT_TOKEN, 10_000, afterWarmup);
+      fullText = decodedTextFor(sls, FULL_LOGSTORE, afterWarmup);
       expect(fullText).toContain(BRIDGE_PROMPT_TOKEN);
       expect(fullText).not.toContain(EMAIL);
 
       // metadata_only exporter never sees content at all.
-      const metaText = decodedTextFor(sls, META_LOGSTORE);
+      const metaText = decodedTextFor(sls, META_LOGSTORE, afterWarmup);
       expect(metaText).not.toContain(EMAIL);
       expect(metaText).not.toContain(MASK);
       expect(metaText).not.toContain(CHAT_PROMPT_TOKEN);

--- a/tests/e2e/src/cases/sls-content-capture-masked-e2e.test.ts
+++ b/tests/e2e/src/cases/sls-content-capture-masked-e2e.test.ts
@@ -35,6 +35,7 @@ const EMAIL = "alice@example.com";
 const MASK = "[EMAIL_REDACTED]";
 const CHAT_PROMPT_TOKEN = "masked-chat-prompt-tok-1f2e3d";
 const BRIDGE_PROMPT_TOKEN = "masked-bridge-prompt-tok-4c5b6a";
+const DRAIN_TOKEN = "masked-drain-marker-tok-9a8b7c";
 
 /** OpenAI chat chunks with the email split across two deltas (channel
  * reassembly): neither wire chunk carries the whole value; only the
@@ -196,6 +197,22 @@ describe("sls content capture e2e: streaming capture is post-mask (#932 × AISIX
       // UNMASKED replies — which is correct behaviour for a gateway that had
       // no masking rule yet, and not what this test is about. Assert only on
       // what was exported from here on.
+      //
+      // An index boundary alone would not separate them: the sink buffers
+      // records and flushes on a 5s tick, so a warm-up record still sitting
+      // in that buffer would ship in the SAME PutLogs body as the requests
+      // below. Send one marker request — masked, since the guardrail is live
+      // now — and wait for it to arrive. The sink flushes its buffer in
+      // order, so the marker being visible proves every warm-up record has
+      // already shipped, and only then does the boundary mean anything.
+      await (
+        await postJson(app, "/v1/chat/completions", {
+          model: "masked-chat-model",
+          stream: true,
+          messages: [{ role: "user", content: `note ${DRAIN_TOKEN}` }],
+        })
+      ).text();
+      await waitForToken(sls, FULL_LOGSTORE, DRAIN_TOKEN, 20_000);
       const afterWarmup = sls.requests.length;
 
       // -- streaming chat (hold-back release path) --

--- a/tests/e2e/src/harness/sls-mock.ts
+++ b/tests/e2e/src/harness/sls-mock.ts
@@ -93,9 +93,23 @@ export async function startMockSls(): Promise<MockSls> {
   };
 }
 
-/** Decompress every PutLogs body for a logstore and join as one searchable string. */
-export function decodedTextFor(sls: MockSls, logstore: string): string {
+/**
+ * Decompress PutLogs bodies for a logstore and join as one searchable string.
+ *
+ * `fromIndex` skips everything the mock had already received at that point.
+ * A test that drives warm-up traffic to wait for config propagation exports
+ * those warm-up requests too, and they were served by whatever config was
+ * live at the time — asserting over them means asserting about a
+ * deliberately-unconverged gateway. Snapshot `sls.requests.length` once the
+ * config is confirmed live and pass it here.
+ */
+export function decodedTextFor(
+  sls: MockSls,
+  logstore: string,
+  fromIndex = 0,
+): string {
   return sls.requests
+    .slice(fromIndex)
     .filter((r) => r.logstore === logstore && r.rawSize > 0 && r.body.length > 0)
     .map((r) => lz4DecompressBlock(r.body, r.rawSize).toString("utf8"))
     .join(" ");
@@ -114,16 +128,20 @@ export async function waitForLogstore(
   throw new Error(`no PutLogs to logstore '${logstore}' within ${timeoutMs}ms`);
 }
 
-/** Poll until the decoded logstore text contains `token` (or time out). */
+/**
+ * Poll until the decoded logstore text contains `token` (or time out).
+ * `fromIndex` has the same meaning as in [`decodedTextFor`].
+ */
 export async function waitForToken(
   sls: MockSls,
   logstore: string,
   token: string,
   timeoutMs = 10_000,
+  fromIndex = 0,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (decodedTextFor(sls, logstore).includes(token)) return;
+    if (decodedTextFor(sls, logstore, fromIndex).includes(token)) return;
     await new Promise((r) => setTimeout(r, 50));
   }
   throw new Error(`token '${token}' not seen in logstore '${logstore}' within ${timeoutMs}ms`);


### PR DESCRIPTION
Fixes #889

Fixes a CI-only failure in `sls-content-capture-masked-e2e`, seen on api7/aisix#888:

```
AssertionError: expected '...' not to contain 'alice@example.com'
```

## Cause

The spec waits for config propagation by sending warm-up chats until the masked form shows up on the wire. Those warm-up requests are exported to SLS too, and the ones served *before* the guardrail went live carry the unmasked reply — which is correct behaviour for a gateway that has no masking rule yet.

`decodedTextFor` joins every PutLogs body the mock has ever received, so `expect(fullText).not.toContain(EMAIL)` was also asserting over those pre-propagation exports. On a fast machine the guardrail is live by the first warm-up, nothing unmasked is ever exported, and the spec passes; on slower CI it is not, and the raw address is there.

The product behaviour under test is fine — the assertion population was wrong.

## Fix

Snapshot `sls.requests.length` once the config is confirmed live, and scope the assertions to what was exported after it. `decodedTextFor` and `waitForToken` take a `fromIndex` (default `0`, so the other SLS specs are unchanged).

## Verification

The condition is timing-dependent, so I forced it rather than guessing: inserting one request that is served after the model is live but before the guardrail exists reproduces the CI failure exactly with the old assertion scope, and passes with this change. All four SLS specs pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end validation of masked chat and bridge responses.
  * Excluded configuration warm-up traffic from exporter assertions to prevent false results.
  * Enhanced test polling and decoding to focus on responses received after setup.
  * Continued verifying that masked responses contain no raw email data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
