### PR TITLE
fix(obs): report token and spend metrics on every endpoint, not just chat and messages

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -153,6 +153,7 @@ pub async fn transcriptions(
             emit_audio_usage(
                 &state,
                 &request_id,
+                "/v1/audio/transcriptions",
                 &success,
                 &api_key_id,
                 status,
@@ -274,6 +275,7 @@ pub async fn translations(
             emit_audio_usage(
                 &state,
                 &request_id,
+                "/v1/audio/translations",
                 &success,
                 &api_key_id,
                 status,
@@ -401,6 +403,9 @@ pub async fn speech(
                 &model_name,
                 &api_key_id,
                 &success.provider_key_id,
+                "/v1/audio/speech",
+                &success.provider,
+                &success.upstream_model,
                 &success.applied_guardrails,
                 status,
                 elapsed,
@@ -1356,9 +1361,11 @@ fn record_audio_metrics(
 /// Emit a UsageEvent for a successful transcription/translation. Tokens
 /// come from the upstream `usage` block when present (gpt-4o-transcribe);
 /// zero otherwise (whisper-1) — the request is still visible/attributed.
+#[allow(clippy::too_many_arguments)]
 fn emit_audio_usage(
     state: &ProxyState,
     request_id: &str,
+    endpoint: &'static str,
     success: &AudioDispatchSuccess,
     api_key_id: &str,
     status: u16,
@@ -1373,6 +1380,9 @@ fn emit_audio_usage(
         &success.model_name,
         api_key_id,
         &success.provider_key_id,
+        endpoint,
+        &success.provider,
+        &success.upstream_model,
         &success.applied_guardrails,
         status,
         elapsed,
@@ -1402,6 +1412,12 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    // Metric labels the UsageEvent has no field for (AISIX-Cloud#1234
+    // follow-up). `endpoint` too: the three audio routes share this emitter
+    // but are three distinct series.
+    endpoint: &'static str,
+    provider: &str,
+    upstream_model: &str,
     applied_guardrails: &[AppliedGuardrail],
     status_code: u16,
     elapsed: Duration,
@@ -1454,6 +1470,28 @@ fn emit_usage_event(
     state
         .otlp_fan_out
         .fan_out(&event, content, exporters.iter().map(|e| &e.value));
+    // Speech (TTS) reports no tokens at all, so this is a no-op there; the
+    // transcription routes report them when the model supplies a usage block.
+    let owned_caller = crate::request_metrics::Caller::from_api_key_id(&snap, api_key_id);
+    crate::request_metrics::record_usage(
+        state,
+        endpoint,
+        owned_caller.as_caller(),
+        crate::request_metrics::Upstream {
+            provider,
+            model: requested_model,
+            upstream_model,
+            provider_key_id,
+            ..Default::default()
+        },
+        crate::request_metrics::Tokens {
+            input: prompt_tokens,
+            output: completion_tokens,
+            total: prompt_tokens.saturating_add(completion_tokens),
+            spend_usd: 0.0,
+            client_type: state.client_classifier.classify(&client.user_agent),
+        },
+    );
 }
 
 fn copy_response_header(src: &HeaderMap, dst: &mut Response, name: header::HeaderName) {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -21,7 +21,7 @@ use aisix_core::AppliedGuardrail;
 use aisix_gateway::{BridgeError, ChatFormat};
 use aisix_guardrails::GuardrailVerdict;
 use aisix_obs::{
-    content_capture_cap, AccessLog, CapturedContent, LatencyLabels, LlmUsage, Metrics, UsageEvent,
+    content_capture_cap, AccessLog, CapturedContent, LatencyLabels, Metrics, UsageEvent,
     UsageLabels,
 };
 use axum::extract::State;
@@ -142,19 +142,13 @@ pub async fn chat_completions(
         Ok(mut success) => {
             let status = 200;
             let elapsed = started.elapsed();
-            // #890 req-3/req-4: resolve the readable provider-key name from the
-            // snapshot and normalise the inbound client type once.
-            let provider_key_name = {
-                let snap = state.snapshot.load();
-                crate::usage_attr::provider_key_metric_name(&snap, &success.provider_key_id)
-            };
+            // #890 req-4: normalise the inbound client type once.
             let client_type = state.client_classifier.classify(&client.user_agent);
             record_success(
                 &state,
                 &auth,
                 &success.provider,
                 &model_name,
-                &provider_key_name,
                 client_type,
                 req.is_streaming(),
                 success.routing.fallback_count() > 0,
@@ -1881,39 +1875,33 @@ async fn dispatch(
                         _ => None,
                     },
                 );
-                metrics_for_stream.record_llm_usage(
-                    UsageLabels {
-                        endpoint: "/v1/chat/completions",
-                        inbound_protocol: "openai",
-                        provider: &provider_for_metrics,
-                        model: &model_for_metrics,
-                        upstream_model: &upstream_model_for_metrics,
-                        provider_key_id: &provider_key_id_for_metrics,
-                        provider_key_name: &provider_key_name_for_metrics,
+                // #1002: comp.total_tokens is the cache-inclusive total (an
+                // Anthropic upstream bridged to an OpenAI-shape client folds
+                // cache tokens into total_tokens per #679).
+                crate::request_metrics::record_usage(
+                    &state_for_telem,
+                    "/v1/chat/completions",
+                    crate::request_metrics::Caller {
                         api_key_id: &api_key_id_for_telem,
                         team_id: team_id_for_metrics.as_deref().unwrap_or("unknown"),
                         user_id: user_id_for_metrics.as_deref().unwrap_or("unknown"),
                         user_name: user_name_for_metrics.as_deref().unwrap_or("unknown"),
                     },
-                    LlmUsage {
-                        input_tokens: comp.prompt_tokens,
-                        output_tokens: comp.completion_tokens,
-                        total_tokens: comp.total_tokens.min(u64::from(u32::MAX)) as u32,
-                        spend_usd: 0.0,
+                    crate::request_metrics::Upstream {
+                        provider: &provider_for_metrics,
+                        model: &model_for_metrics,
+                        upstream_model: &upstream_model_for_metrics,
+                        provider_key_id: &provider_key_id_for_metrics,
+                        stream: true,
+                        is_fallback: mid_stream_fallbacks > 0,
                     },
-                );
-                // #890 req-4: streaming token volume by inbound client type.
-                // #1002: comp.total_tokens is the cache-inclusive total (an
-                // Anthropic upstream bridged to an OpenAI-shape client folds
-                // cache tokens into total_tokens per #679).
-                // AISIX-Cloud#1044: same requested logical model as the
-                // UsageLabels above.
-                metrics_for_stream.record_llm_tokens_by_client(
-                    &client_type_for_metrics,
-                    &model_for_metrics,
-                    u64::from(comp.prompt_tokens),
-                    u64::from(comp.completion_tokens),
-                    comp.total_tokens,
+                    crate::request_metrics::Tokens {
+                        input: comp.prompt_tokens,
+                        output: comp.completion_tokens,
+                        total: comp.total_tokens.min(u64::from(u32::MAX)) as u32,
+                        spend_usd: 0.0,
+                        client_type: &client_type_for_metrics,
+                    },
                 );
                 metrics_for_stream.record_request_e2e_latency(
                     LatencyLabels {
@@ -3692,8 +3680,8 @@ fn record_success(
     auth: &AuthenticatedKey,
     provider: &str,
     model: &str,
-    // #890 req-3 readable name + req-4 client type + req-1/req-2 dimensions.
-    provider_key_name: &str,
+    // #890 req-4 client type + req-1/req-2 dimensions. The readable
+    // provider-key name is resolved inside `request_metrics`.
     client_type: &str,
     stream: bool,
     is_fallback: bool,
@@ -3733,42 +3721,29 @@ fn record_success(
             elapsed,
         );
     }
-    if let Some(total) = s.total_tokens {
-        metrics.record_tokens(provider, model, total);
-    }
-    metrics.record_llm_usage(
-        UsageLabels {
-            endpoint: "/v1/chat/completions",
-            inbound_protocol: "openai",
+    // Non-streaming path only; streaming tokens arrive in the SSE
+    // on_complete and are recorded there. All-zero is a no-op, which is what
+    // the streaming branch reaching here produces.
+    // #1002: `s.total_tokens` is the cache-inclusive canonical total.
+    crate::request_metrics::record_usage(
+        state,
+        "/v1/chat/completions",
+        caller,
+        crate::request_metrics::Upstream {
             provider,
             model,
             upstream_model: &s.upstream_model,
             provider_key_id: &s.provider_key_id,
-            provider_key_name,
-            api_key_id: caller.api_key_id,
-            team_id: caller.team_id,
-            user_id: caller.user_id,
-            user_name: caller.user_name,
+            stream,
+            is_fallback,
         },
-        LlmUsage {
-            input_tokens: s.prompt_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
-            output_tokens: s.completion_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
-            total_tokens: s.total_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
+        crate::request_metrics::Tokens {
+            input: s.prompt_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
+            output: s.completion_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
+            total: s.total_tokens.unwrap_or(0).min(u64::from(u32::MAX)) as u32,
             spend_usd: s.cost_usd,
+            client_type,
         },
-    );
-    // #890 req-4: token volume by inbound client type (non-streaming path;
-    // streaming tokens arrive in the SSE on_complete and are recorded there).
-    // No-op when all counts are zero (e.g. the streaming branch here).
-    // #1002: s.total_tokens is the cache-inclusive canonical total.
-    // AISIX-Cloud#1044: `model` is the same requested logical model recorded
-    // on the UsageLabels above.
-    metrics.record_llm_tokens_by_client(
-        client_type,
-        model,
-        s.prompt_tokens.unwrap_or(0),
-        s.completion_tokens.unwrap_or(0),
-        s.total_tokens.unwrap_or(0),
     );
 }
 

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -170,6 +170,8 @@ pub async fn completions(
                     &model_name,
                     &api_key_id,
                     &success.provider_key_id,
+                    &success.provider,
+                    &success.upstream_model,
                     status,
                     elapsed,
                     &usage,
@@ -655,6 +657,11 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    // Metric labels the UsageEvent has no field for (AISIX-Cloud#1234
+    // follow-up): the wire struct is the CP contract, so they ride
+    // alongside rather than in it.
+    provider: &str,
+    upstream_model: &str,
     status_code: u16,
     elapsed: Duration,
     usage: &CompletionUsage,
@@ -699,8 +706,27 @@ fn emit_usage_event(
     state
         .otlp_fan_out
         .fan_out(&event, content, exporters.iter().map(|e| &e.value));
+    let owned_caller = crate::request_metrics::Caller::from_api_key_id(&snap, api_key_id);
+    crate::request_metrics::record_usage(
+        state,
+        "/v1/completions",
+        owned_caller.as_caller(),
+        crate::request_metrics::Upstream {
+            provider,
+            model: requested_model,
+            upstream_model,
+            provider_key_id,
+            ..Default::default()
+        },
+        crate::request_metrics::Tokens {
+            input: usage.prompt_tokens,
+            output: usage.completion_tokens,
+            total: usage.prompt_tokens.saturating_add(usage.completion_tokens),
+            spend_usd: 0.0,
+            client_type: state.client_classifier.classify(&client.user_agent),
+        },
+    );
 }
-
 fn emit_access_log(
     model: &str,
     provider: &str,

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -170,6 +170,8 @@ pub async fn embeddings(
                     &model_name,
                     &api_key_id,
                     &success.provider_key_id,
+                    &success.provider,
+                    &success.upstream_model,
                     &success.applied_guardrails,
                     status,
                     elapsed,
@@ -597,6 +599,11 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    // Metric labels the UsageEvent has no field for (AISIX-Cloud#1234
+    // follow-up): the wire struct is the CP contract, so they ride
+    // alongside rather than in it.
+    provider: &str,
+    upstream_model: &str,
     applied_guardrails: &[AppliedGuardrail],
     status_code: u16,
     elapsed: Duration,
@@ -669,8 +676,27 @@ fn emit_usage_event(
     state
         .otlp_fan_out
         .fan_out(&event, content, exporters.iter().map(|e| &e.value));
+    let owned_caller = crate::request_metrics::Caller::from_api_key_id(&snap, api_key_id);
+    crate::request_metrics::record_usage(
+        state,
+        "/v1/embeddings",
+        owned_caller.as_caller(),
+        crate::request_metrics::Upstream {
+            provider,
+            model: requested_model,
+            upstream_model,
+            provider_key_id,
+            ..Default::default()
+        },
+        crate::request_metrics::Tokens {
+            input: prompt_tokens,
+            output: 0,
+            total: prompt_tokens,
+            spend_usd: 0.0,
+            client_type: state.client_classifier.classify(&client.user_agent),
+        },
+    );
 }
-
 #[cfg(test)]
 mod tests {
 

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -148,6 +148,8 @@ pub async fn image_generations(
                     &model_name,
                     &api_key_id,
                     &success.provider_key_id,
+                    &success.provider,
+                    &success.upstream_model,
                     &success.applied_guardrails,
                     200,
                     elapsed,
@@ -461,6 +463,11 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    // Metric labels the UsageEvent has no field for (AISIX-Cloud#1234
+    // follow-up): the wire struct is the CP contract, so they ride
+    // alongside rather than in it.
+    provider: &str,
+    upstream_model: &str,
     applied_guardrails: &[AppliedGuardrail],
     status_code: u16,
     elapsed: Duration,
@@ -504,8 +511,27 @@ fn emit_usage_event(
     state
         .otlp_fan_out
         .fan_out(&event, content, exporters.iter().map(|e| &e.value));
+    let owned_caller = crate::request_metrics::Caller::from_api_key_id(&snap, api_key_id);
+    crate::request_metrics::record_usage(
+        state,
+        "/v1/images/generations",
+        owned_caller.as_caller(),
+        crate::request_metrics::Upstream {
+            provider,
+            model: requested_model,
+            upstream_model,
+            provider_key_id,
+            ..Default::default()
+        },
+        crate::request_metrics::Tokens {
+            input: prompt_tokens,
+            output: completion_tokens,
+            total: prompt_tokens.saturating_add(completion_tokens),
+            spend_usd: 0.0,
+            client_type: state.client_classifier.classify(&client.user_agent),
+        },
+    );
 }
-
 fn emit_access_log(
     model: &str,
     provider: &str,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -37,8 +37,7 @@
 
 use aisix_core::AppliedGuardrail;
 use aisix_obs::{
-    content_capture_cap, AccessLog, CapturedContent, LatencyLabels, LlmUsage, UsageEvent,
-    UsageLabels,
+    content_capture_cap, AccessLog, CapturedContent, LatencyLabels, UsageEvent, UsageLabels,
 };
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
@@ -2780,37 +2779,31 @@ fn emit_anthropic_usage_event(
         metrics.cache_creation_tokens,
         metrics.cache_read_tokens,
     );
-    state.metrics.record_llm_usage(
-        UsageLabels {
-            endpoint: "/v1/messages",
-            inbound_protocol: "anthropic",
-            provider,
-            model,
-            upstream_model,
-            provider_key_id,
-            provider_key_name: &provider_key_name,
+    // Covers streaming and non-streaming — every /v1/messages usage event
+    // flows through here.
+    crate::request_metrics::record_usage(
+        state,
+        "/v1/messages",
+        crate::request_metrics::Caller {
             api_key_id,
             team_id: team_id.unwrap_or("unknown"),
             user_id: user_id.unwrap_or("unknown"),
             user_name: user_name.unwrap_or("unknown"),
         },
-        LlmUsage {
-            input_tokens: metrics.prompt_tokens,
-            output_tokens: metrics.completion_tokens,
-            total_tokens: total_tokens_all.min(u64::from(u32::MAX)) as u32,
-            spend_usd: 0.0,
+        crate::request_metrics::Upstream {
+            provider,
+            model,
+            upstream_model,
+            provider_key_id,
+            ..Default::default()
         },
-    );
-    // #890 req-4: token volume by inbound client type (covers streaming and
-    // non-streaming — every /v1/messages usage event flows through here).
-    // #1002: total_tokens_all folds in the Anthropic cache counters.
-    // AISIX-Cloud#1044: same requested logical model as the UsageLabels above.
-    state.metrics.record_llm_tokens_by_client(
-        state.client_classifier.classify(&client.user_agent),
-        model,
-        u64::from(metrics.prompt_tokens),
-        u64::from(metrics.completion_tokens),
-        total_tokens_all,
+        crate::request_metrics::Tokens {
+            input: metrics.prompt_tokens,
+            output: metrics.completion_tokens,
+            total: total_tokens_all.min(u64::from(u32::MAX)) as u32,
+            spend_usd: 0.0,
+            client_type: state.client_classifier.classify(&client.user_agent),
+        },
     );
     if metrics.upstream_ttft_ms > 0 {
         state.metrics.record_request_ttft(

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -726,6 +726,29 @@ async fn run_session(
     state
         .otlp_fan_out
         .fan_out(&event, None, exporters.iter().map(|e| &e.value));
+    // A realtime session bills real tokens against a real model, and this is
+    // the only place that knows the session's totals. Its cost is resolved
+    // here too, unlike the other endpoints, so it is the one non-chat surface
+    // that also feeds `aisix_llm_spend_micro_usd_total`.
+    crate::request_metrics::record_usage(
+        &state,
+        "/v1/realtime",
+        crate::request_metrics::Caller::new(&auth),
+        crate::request_metrics::Upstream {
+            provider: &provider_label,
+            model: &model_entry.value.display_name,
+            upstream_model: model_entry.value.upstream_model().unwrap_or("unknown"),
+            provider_key_id: &pk_id,
+            ..Default::default()
+        },
+        crate::request_metrics::Tokens {
+            input: usage.input_tokens.min(u32::MAX as u64) as u32,
+            output: usage.output_tokens.min(u32::MAX as u64) as u32,
+            total: total_tokens.min(u32::MAX as u64) as u32,
+            spend_usd: event.cost_usd,
+            client_type: state.client_classifier.classify(&client.user_agent),
+        },
+    );
 }
 
 enum Dir {

--- a/crates/aisix-proxy/src/request_metrics.rs
+++ b/crates/aisix-proxy/src/request_metrics.rs
@@ -21,14 +21,24 @@
 //! success-rate and request-count queries built on them while still showing
 //! up in the legacy series.
 //!
-//! Handlers call [`record`] instead of touching `Metrics` directly, and the
-//! tier is decided from the endpoint rather than by the caller, so a new
-//! endpoint cannot land with a half-wired label set — the same anti-drift
-//! move `usage_attr` makes for the UsageEvent side.
+//! [`record_usage`] is the companion emit for what the request consumed —
+//! the token and spend families, which had the same coverage problem, in
+//! three different shapes (see its own docs).
+//!
+//! Handlers call [`record`] and [`record_usage`] instead of touching
+//! `Metrics` directly, and the tier is decided from the endpoint rather than
+//! by the caller, so a new endpoint cannot land with a half-wired label set —
+//! the same anti-drift move `usage_attr` makes for the UsageEvent side.
+//!
+//! Two endpoints are model inference but report no tokens by nature —
+//! `/v1/audio/speech` (billed per input character) and `/v1/videos` (per
+//! video). They count as requests and contribute nothing to the token
+//! families, so aggregate tokens-per-request is only meaningful per
+//! `endpoint`, never summed across all of them.
 
 use std::time::Duration;
 
-use aisix_obs::{RequestLabels, RequestOutcome};
+use aisix_obs::{LlmUsage, RequestLabels, RequestOutcome, UsageLabels};
 
 use crate::auth::AuthenticatedKey;
 use crate::state::ProxyState;
@@ -58,6 +68,30 @@ impl<'a> Caller<'a> {
         }
     }
 
+    /// Recover the caller from an api-key id alone.
+    ///
+    /// The streaming emits run from a detached task or a Drop guard that was
+    /// handed an `api_key_id: &str` rather than the key itself, and threading
+    /// the team / user / name triple down every dispatch signature to reach
+    /// them would be a lot of plumbing for three labels. The id resolves back
+    /// to the same row the auth extractor matched, so the labels come out
+    /// identical to [`Caller::new`]; an id that no longer resolves (the key
+    /// was deleted mid-stream) degrades to `unknown` rather than dropping the
+    /// sample.
+    pub(crate) fn from_api_key_id(
+        snap: &aisix_core::AisixSnapshot,
+        api_key_id: &'a str,
+    ) -> Owned<'a> {
+        let entry = snap.apikeys.get_by_id(api_key_id);
+        let key = entry.as_ref().map(|e| &e.value);
+        Owned {
+            api_key_id,
+            team_id: key.and_then(|k| k.team_id.clone()),
+            user_id: key.and_then(|k| k.user_id.clone()),
+            user_name: key.and_then(|k| k.user_name.clone()),
+        }
+    }
+
     /// A path that gave up before it could attribute the request to a team
     /// or user — the pre-dispatch rejections. `api_key_id` is `Some` once
     /// the auth extractor has run and `None` for the middleware
@@ -68,6 +102,26 @@ impl<'a> Caller<'a> {
             team_id: UNKNOWN,
             user_id: UNKNOWN,
             user_name: UNKNOWN,
+        }
+    }
+}
+
+/// Owning form of [`Caller`], for the snapshot lookup whose strings cannot
+/// outlive the guard. Call [`Owned::as_caller`] at the emit.
+pub(crate) struct Owned<'a> {
+    api_key_id: &'a str,
+    team_id: Option<String>,
+    user_id: Option<String>,
+    user_name: Option<String>,
+}
+
+impl<'a> Owned<'a> {
+    pub(crate) fn as_caller(&'a self) -> Caller<'a> {
+        Caller {
+            api_key_id: self.api_key_id,
+            team_id: self.team_id.as_deref().unwrap_or(UNKNOWN),
+            user_id: self.user_id.as_deref().unwrap_or(UNKNOWN),
+            user_name: self.user_name.as_deref().unwrap_or(UNKNOWN),
         }
     }
 }
@@ -114,10 +168,12 @@ impl Default for Upstream<'_> {
 /// - `/passthrough/:provider/*rest` — an opaque tunnel; the gateway parses
 ///   nothing and cannot attribute a model.
 /// - `/v1/files`, `/v1/batches`, `/v1/fine_tuning/jobs` — management calls.
-/// - `/v1/realtime` — does reach a model, but feeds none of the
-///   `aisix_llm_*_tokens_total` families (still chat + messages only), so
-///   counting it here would inflate the denominator of every
-///   tokens-per-request query.
+///
+/// `/v1/realtime` was in that list until the token families reached it too.
+/// It was held out because it fed none of them, so counting it here would
+/// have inflated the denominator of every tokens-per-request query; now that
+/// a session reports its tokens and cost, that reason is gone and it belongs
+/// with the rest.
 const LLM_ENDPOINTS: &[&str] = &[
     "/v1/chat/completions",
     "/v1/completions",
@@ -132,6 +188,7 @@ const LLM_ENDPOINTS: &[&str] = &[
     "/v1/audio/speech",
     "/v1/videos",
     "/v1/videos/:id",
+    "/v1/realtime",
 ];
 
 /// Whether this endpoint's requests are model inference.
@@ -195,6 +252,87 @@ pub(crate) fn record(
     } else {
         state.metrics.record_proxy_request(labels, elapsed);
     }
+}
+
+/// What one request consumed. Every counter below no-ops on an all-zero
+/// value, so the zero-token paths — a failed attempt, a 501, `/v1/files` —
+/// cost nothing and create no series.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct Tokens<'a> {
+    pub input: u32,
+    pub output: u32,
+    /// The canonical, CACHE-INCLUSIVE total. Use
+    /// `usage_attr::total_tokens_with_cache` wherever cache counters exist
+    /// (#740/#1002) — a bare input+output silently undercounts cached
+    /// traffic, and this value is what the by-client series reports as
+    /// `token_type="total"`.
+    pub total: u32,
+    pub spend_usd: f64,
+    /// Normalised inbound client for the by-client series
+    /// (`state.client_classifier.classify(&client.user_agent)`).
+    pub client_type: &'a str,
+}
+
+/// Terminal token/spend emit, shared by every handler — the companion to
+/// [`record`].
+///
+/// Three families ride along, and each had a DIFFERENT endpoint coverage
+/// before AISIX-Cloud#1234's follow-up: the `aisix_llm_*_tokens_total` and
+/// `aisix_llm_spend_micro_usd_total` families were chat and messages only,
+/// `aisix_llm_tokens_by_client_total` was chat, messages and responses, and
+/// the legacy `aisix_tokens_consumed_total` was chat ALONE. A gateway that
+/// billed a customer for `/v1/embeddings` reported none of those tokens.
+///
+/// Labels come from the same [`Caller`] / [`Upstream`] pair [`record`] uses,
+/// so a query joining requests to tokens lines up by construction, and this
+/// adds no series dimension the request families don't already carry.
+pub(crate) fn record_usage(
+    state: &ProxyState,
+    endpoint: &'static str,
+    caller: Caller<'_>,
+    upstream: Upstream<'_>,
+    tokens: Tokens<'_>,
+) {
+    // Legacy compatibility series (provider × model).
+    state
+        .metrics
+        .record_tokens(upstream.provider, upstream.model, u64::from(tokens.total));
+    // Held in a binding: `UsageLabels` borrows it.
+    let provider_key_name = {
+        let snap = state.snapshot.load();
+        provider_key_metric_name(&snap, upstream.provider_key_id)
+    };
+    state.metrics.record_llm_usage(
+        UsageLabels {
+            endpoint,
+            inbound_protocol: crate::inbound_protocol_for_endpoint(endpoint),
+            provider: upstream.provider,
+            model: upstream.model,
+            upstream_model: upstream.upstream_model,
+            provider_key_id: upstream.provider_key_id,
+            provider_key_name: &provider_key_name,
+            api_key_id: caller.api_key_id,
+            team_id: caller.team_id,
+            user_id: caller.user_id,
+            user_name: caller.user_name,
+        },
+        LlmUsage {
+            input_tokens: tokens.input,
+            output_tokens: tokens.output,
+            total_tokens: tokens.total,
+            spend_usd: tokens.spend_usd,
+        },
+    );
+    // Deliberately NOT keyed on the labels above: this family is
+    // client_type × model × token_type only, so the per-key dimensions
+    // never multiply it (#890 req-4).
+    state.metrics.record_llm_tokens_by_client(
+        tokens.client_type,
+        upstream.model,
+        u64::from(tokens.input),
+        u64::from(tokens.output),
+        u64::from(tokens.total),
+    );
 }
 
 #[cfg(test)]
@@ -281,6 +419,8 @@ mod tests {
             "/v1/embeddings",
             "/v1/audio/speech",
             "/v1/videos/vid_abc123/content",
+            // Moved in once realtime started reporting its tokens + cost.
+            "/v1/realtime",
         ] {
             assert!(
                 is_llm_endpoint(crate::normalize_endpoint_label(route)),
@@ -290,7 +430,6 @@ mod tests {
         for route in [
             "/mcp/some-server",
             "/a2a/some-agent",
-            "/v1/realtime",
             "/v1/batches/batch_abc123",
             "/passthrough/openai/v1/anything",
             "/livez",

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -146,6 +146,8 @@ pub async fn rerank(
                     &model_name,
                     &api_key_id,
                     &success.provider_key_id,
+                    &success.provider,
+                    &success.upstream_model,
                     &success.applied_guardrails,
                     status,
                     elapsed,
@@ -621,6 +623,11 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    // Metric labels the UsageEvent has no field for (AISIX-Cloud#1234
+    // follow-up): the wire struct is the CP contract, so they ride
+    // alongside rather than in it.
+    provider: &str,
+    upstream_model: &str,
     applied_guardrails: &[AppliedGuardrail],
     status_code: u16,
     elapsed: Duration,
@@ -664,8 +671,27 @@ fn emit_usage_event(
     state
         .otlp_fan_out
         .fan_out(&event, content, exporters.iter().map(|e| &e.value));
+    let owned_caller = crate::request_metrics::Caller::from_api_key_id(&snap, api_key_id);
+    crate::request_metrics::record_usage(
+        state,
+        "/v1/rerank",
+        owned_caller.as_caller(),
+        crate::request_metrics::Upstream {
+            provider,
+            model: requested_model,
+            upstream_model,
+            provider_key_id,
+            ..Default::default()
+        },
+        crate::request_metrics::Tokens {
+            input: usage.prompt_tokens,
+            output: 0,
+            total: usage.prompt_tokens,
+            spend_usd: 0.0,
+            client_type: state.client_classifier.classify(&client.user_agent),
+        },
+    );
 }
-
 /// Default upstream host for the rerank-supporting providers,
 /// keyed by the lowercase `Model.provider` string. Per #302 Phase A
 /// this is a string-keyed match: the `Provider` enum has been

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -313,6 +313,8 @@ pub async fn responses(
                         &model_name,
                         &api_key_id,
                         &success.provider_key_id,
+                        &success.provider,
+                        &success.upstream_model,
                         status,
                         winner_latency,
                         &usage,
@@ -1405,6 +1407,7 @@ async fn responses_to_target(
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
+        let upstream_model_c = upstream_model.clone();
         let client_c = client_ctx.clone();
         // #688: carry the reservation into the end-of-stream guard — keys drive
         // post-stream TPM/TPD accounting, the hold keeps the concurrency slot(s)
@@ -1516,6 +1519,8 @@ async fn responses_to_target(
                     &requested_model_c,
                     &api_key_id_c,
                     &provider_key_id_c,
+                    &provider_c,
+                    &upstream_model_c,
                     // A stream the consumer abandoned mid-flight is reported
                     // as 499, matching LiteLLM. The upstream work still
                     // happened, so the event is emitted either way — only
@@ -1889,6 +1894,7 @@ async fn responses_cross_provider_to_target(
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
+        let upstream_model_c = model.upstream_model().unwrap_or("unknown").to_string();
         let client_c = client_ctx.clone();
         let attempt_c = attempt.clone();
         // #688: carry the reservation into the end-of-stream guard — keys drive
@@ -1990,6 +1996,8 @@ async fn responses_cross_provider_to_target(
                     &requested_model_c,
                     &api_key_id_c,
                     &provider_key_id_c,
+                    &provider_c,
+                    &upstream_model_c,
                     status,
                     // Attempt-scoped — see the sibling verbatim path.
                     attempt_started.elapsed(),
@@ -2839,6 +2847,11 @@ fn emit_usage_event(
     requested_model: &str,
     api_key_id: &str,
     provider_key_id: &str,
+    // Metric labels the UsageEvent has no field for (AISIX-Cloud#1234
+    // follow-up): the wire struct is the CP contract, so they ride
+    // alongside rather than in it.
+    provider: &str,
+    upstream_model: &str,
     status_code: u16,
     elapsed: Duration,
     usage: &ResponseUsage,
@@ -2909,17 +2922,31 @@ fn emit_usage_event(
     // intentionally stays chat/messages-scoped (cross-API audit #646-652).
     // #1002: cache-inclusive total via the shared helper — cache counters are
     // non-zero only on the #825 Anthropic bridge path.
-    state.metrics.record_llm_tokens_by_client(
-        state.client_classifier.classify(&client.user_agent),
-        requested_model,
-        u64::from(usage.prompt_tokens),
-        u64::from(usage.completion_tokens),
-        total_tokens_with_cache(
-            usage.prompt_tokens,
-            usage.completion_tokens,
-            usage.cache_creation_tokens,
-            usage.cache_read_tokens,
-        ),
+    let total_all = total_tokens_with_cache(
+        usage.prompt_tokens,
+        usage.completion_tokens,
+        usage.cache_creation_tokens,
+        usage.cache_read_tokens,
+    );
+    let owned_caller = crate::request_metrics::Caller::from_api_key_id(&snap, api_key_id);
+    crate::request_metrics::record_usage(
+        state,
+        "/v1/responses",
+        owned_caller.as_caller(),
+        crate::request_metrics::Upstream {
+            provider,
+            model: requested_model,
+            upstream_model,
+            provider_key_id,
+            ..Default::default()
+        },
+        crate::request_metrics::Tokens {
+            input: usage.prompt_tokens,
+            output: usage.completion_tokens,
+            total: total_all.min(u64::from(u32::MAX)) as u32,
+            spend_usd: 0.0,
+            client_type: state.client_classifier.classify(&client.user_agent),
+        },
     );
 }
 

--- a/tests/e2e/src/cases/token-metrics-endpoint-coverage-e2e.test.ts
+++ b/tests/e2e/src/cases/token-metrics-endpoint-coverage-e2e.test.ts
@@ -1,0 +1,281 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// The follow-up half of AISIX-Cloud#1234. Where that fixed the request
+// counters, the token families had the same gap in three different shapes:
+//
+//   aisix_llm_{input,output,total}_tokens_total  chat + messages
+//   aisix_llm_spend_micro_usd_total              chat + messages
+//   aisix_llm_tokens_by_client_total             chat + messages + responses
+//   aisix_tokens_consumed_total (legacy)         chat ALONE
+//
+// So a gateway that billed a customer for /v1/embeddings reported none of
+// those tokens. These specs pin the per-endpoint coverage.
+
+const CALLER_PLAINTEXT = "sk-token-metrics-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const RESP_MODEL = "tokmetrics-resp";
+const EMBED_MODEL = "tokmetrics-embed";
+
+describe("token metrics endpoint coverage e2e", () => {
+  let app: SpawnedApp | undefined;
+  let respUpstream: OpenAiUpstream | undefined;
+  let embedUpstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    respUpstream = await startOpenAiUpstream({ nonStreamBody: responsesBody() });
+    embedUpstream = await startOpenAiUpstream({ nonStreamBody: embeddingBody() });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    for (const [name, up] of [
+      [RESP_MODEL, respUpstream],
+      [EMBED_MODEL, embedUpstream],
+    ] as const) {
+      const pk = await seed.createProviderKey({
+        display_name: `${name}-pk`,
+        secret: "sk-mock",
+        api_base: `${up.baseUrl}/v1`,
+      });
+      await seed.createModel({
+        display_name: name,
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+    }
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [RESP_MODEL, EMBED_MODEL],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await respUpstream?.close();
+    await embedUpstream?.close();
+  });
+
+  test("/v1/responses reports its tokens on every token family", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      const r = await post(app!, "/v1/responses", {
+        model: RESP_MODEL,
+        input: "ready",
+      });
+      return r.status === 200;
+    });
+
+    // The propagation probe above also billed tokens, so measure the DELTA
+    // one request adds rather than the absolute counter.
+    const before = await scrape(app);
+
+    expect(
+      (await post(app, "/v1/responses", { model: RESP_MODEL, input: "hi" }))
+        .status,
+    ).toBe(200);
+
+    const text = await scrape(app);
+
+    // The per-key families — absent for this endpoint before the fix.
+    for (const metric of [
+      "aisix_llm_input_tokens_total",
+      "aisix_llm_output_tokens_total",
+      "aisix_llm_total_tokens_total",
+    ]) {
+      const lines = seriesFor(text, metric, "/v1/responses");
+      expect(lines, `${metric} missing for /v1/responses`).not.toHaveLength(0);
+      expect(lines.join("\n")).toContain(`model="${RESP_MODEL}"`);
+      expect(lines.join("\n")).toContain('provider="openai"');
+    }
+
+    // The upstream reported 11 in / 13 out; the counters must carry the real
+    // values, not merely exist.
+    expect(delta(before, text, "aisix_llm_input_tokens_total", "/v1/responses")).toBe(11);
+    expect(delta(before, text, "aisix_llm_output_tokens_total", "/v1/responses")).toBe(13);
+    expect(delta(before, text, "aisix_llm_total_tokens_total", "/v1/responses")).toBe(24);
+
+    // The legacy series, which was chat-only.
+    expect(
+      text
+        .split("\n")
+        .filter(
+          (l) =>
+            l.startsWith("aisix_tokens_consumed_total{") &&
+            l.includes(`model="${RESP_MODEL}"`),
+        ),
+    ).not.toHaveLength(0);
+  }, 30_000);
+
+  test("/v1/embeddings reports its tokens too", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      const r = await post(app!, "/v1/embeddings", {
+        model: EMBED_MODEL,
+        input: "ready",
+      });
+      return r.status === 200;
+    });
+
+    expect(
+      (await post(app, "/v1/embeddings", { model: EMBED_MODEL, input: "hi" }))
+        .status,
+    ).toBe(200);
+
+    const text = await scrape(app);
+
+    const input = seriesFor(text, "aisix_llm_input_tokens_total", "/v1/embeddings");
+    expect(input, "embeddings reported no input tokens").not.toHaveLength(0);
+    expect(input.join("\n")).toContain(`model="${EMBED_MODEL}"`);
+
+    // Embeddings produce no completion tokens, so that family must stay
+    // absent rather than report a zero series.
+    expect(
+      seriesFor(text, "aisix_llm_output_tokens_total", "/v1/embeddings"),
+    ).toHaveLength(0);
+
+    // The by-client family reaches this endpoint now as well.
+    expect(
+      text
+        .split("\n")
+        .filter(
+          (l) =>
+            l.startsWith("aisix_llm_tokens_by_client_total{") &&
+            l.includes(`model="${EMBED_MODEL}"`),
+        ),
+    ).not.toHaveLength(0);
+  }, 30_000);
+
+  test("token labels line up with the request families", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const text = await scrape(app);
+    // Both families are keyed on the same Caller/Upstream pair, so a join on
+    // endpoint+model+provider+api_key_id has to match — that is the whole
+    // point of sharing the label structs.
+    const req = seriesFor(text, "aisix_llm_requests_total", "/v1/responses")[0];
+    const tok = seriesFor(text, "aisix_llm_input_tokens_total", "/v1/responses")[0];
+    expect(req).toBeDefined();
+    expect(tok).toBeDefined();
+    for (const label of ["provider", "model", "upstream_model", "api_key_id", "team_id", "user_id"]) {
+      expect(labelOf(tok, label), `${label} differs between the families`).toBe(
+        labelOf(req, label),
+      );
+    }
+  }, 30_000);
+});
+
+async function post(
+  app: SpawnedApp,
+  path: string,
+  body: unknown,
+): Promise<{ status: number }> {
+  const res = await fetch(`${app.proxyUrl}${path}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  await res.text();
+  return { status: res.status };
+}
+
+async function scrape(app: SpawnedApp): Promise<string> {
+  const res = await fetch(`${app.metricsUrl}/metrics`);
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+function seriesFor(
+  scrapeText: string,
+  metric: string,
+  endpoint: string,
+): string[] {
+  return scrapeText
+    .split("\n")
+    .filter(
+      (line) =>
+        line.startsWith(`${metric}{`) &&
+        line.includes(`endpoint="${endpoint}"`),
+    );
+}
+
+function valueOf(line: string | undefined): number {
+  if (!line) return 0;
+  return Number(line.split("}").at(-1)?.trim());
+}
+
+/** How much one request added to `metric` on `endpoint`. */
+function delta(
+  before: string,
+  after: string,
+  metric: string,
+  endpoint: string,
+): number {
+  return (
+    valueOf(seriesFor(after, metric, endpoint)[0]) -
+    valueOf(seriesFor(before, metric, endpoint)[0])
+  );
+}
+
+function labelOf(line: string, label: string): string | undefined {
+  return new RegExp(`${label}="([^"]*)"`).exec(line)?.[1];
+}
+
+function responsesBody() {
+  return {
+    id: "resp_tokmetrics",
+    object: "response",
+    created_at: 0,
+    status: "completed",
+    model: "gpt-4o-mini",
+    output: [
+      {
+        id: "msg_tokmetrics",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "hello" }],
+      },
+    ],
+    usage: { input_tokens: 11, output_tokens: 13, total_tokens: 24 },
+  };
+}
+
+function embeddingBody() {
+  return {
+    object: "list",
+    model: "gpt-4o-mini",
+    data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }],
+    usage: { prompt_tokens: 7, total_tokens: 7 },
+  };
+}


### PR DESCRIPTION
The follow-up half of api7/AISIX-Cloud#1234, flagged in that issue's closing comment. #888 fixed the request counters; the token families had the same gap — in three different shapes:

| family | coverage before |
|---|---|
| `aisix_llm_{input,output,total}_tokens_total` | chat + messages |
| `aisix_llm_spend_micro_usd_total` | chat + messages |
| `aisix_llm_tokens_by_client_total` | chat + messages + responses |
| `aisix_tokens_consumed_total` (legacy) | chat **alone** |

So a gateway that billed a customer for `/v1/embeddings`, `/v1/rerank`, `/v1/audio/*` or `/v1/images/generations` reported none of those tokens, and `/v1/responses` — the endpoint Codex talks to — reported them only on the by-client series.

## Implementation

All of them now emit through `request_metrics::record_usage`, the companion to the request emit #888 added. It takes the same `Caller` / `Upstream` pair, which matters for two reasons: the token and request families agree by construction (a query joining them lines up — pinned by a test), and it adds **no series dimension the request families do not already carry**, so the cardinality cost of this change is zero beyond the counters themselves.

`Caller::from_api_key_id` recovers the team / user / name triple from the snapshot for the streaming emits, which run from a detached task or a Drop guard holding only an `api_key_id: &str`. Threading three labels down every dispatch signature to reach them would have been a lot of plumbing; the id resolves back to the row the auth extractor matched, so the labels come out identical to `Caller::new`.

## `/v1/realtime` moves into the LLM tier

#888 held it out of `LLM_ENDPOINTS` for one stated reason: it fed none of the token families, so counting it as an LLM request would inflate the denominator of every tokens-per-request query. It now reports its session tokens and — uniquely among the non-chat endpoints — a real cost, since realtime is the only one that resolves pricing at emit time. That reason is gone, so it belongs with the rest.

## Endpoints that stay tokenless

`/v1/audio/speech` (billed per input character) and `/v1/videos` (per video) report no tokens by nature. They count as requests and contribute nothing here — which is why aggregate tokens-per-request is only meaningful per `endpoint`, never summed across all of them. Noted in the module docs.

## On the prior "intentional" scoping

`responses.rs` carried a comment saying the per-key family "intentionally stays chat/messages-scoped (cross-API audit #646-652 judgment)". I checked those PRs before overriding it: #646/#647 are per-PK attribution tags, #648/#649 per-PK request overrides, #650 failed-request UsageEvents, #651 routing retries, #652 applied_guardrails. None of them discusses the token metrics. The citation was inherited rather than decided — the same shape as the docs that described #888's gap as if it were the design. Flagging it explicitly in case someone knows a reason the audit does not record.

## Tests

`tests/e2e/src/cases/token-metrics-endpoint-coverage-e2e.test.ts`, verified failing before and passing after:

- `/v1/responses` reports on every token family including the legacy series, with the **real** counts (delta-measured, so the propagation probe's own tokens don't mask a wrong value).
- `/v1/embeddings` reports input tokens and the by-client series — and no output-token series, since embeddings produce none.
- the token labels equal the request labels for the same request, which is the property the shared `Caller`/`Upstream` buys.

Full DP E2E suite passes (184 files, 495 tests); workspace unit tests pass.