### PR TITLE
fix(proxy): treat api_base as the upstream root on every OpenAI-family endpoint

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -119,7 +119,7 @@ pub async fn transcriptions(
         &auth,
         multipart,
         // Version-independent path — multipart_dispatch's URL builder
-        // (build_v1_url) owns the `/v1` prefix.
+        // appends it to the configured api_base.
         "/audio/transcriptions",
         &request_id,
         &client,
@@ -241,7 +241,7 @@ pub async fn translations(
         &auth,
         multipart,
         // Version-independent path — multipart_dispatch's URL builder
-        // (build_v1_url) owns the `/v1` prefix.
+        // appends it to the configured api_base.
         "/audio/translations",
         &request_id,
         &client,
@@ -644,10 +644,7 @@ async fn multipart_dispatch(
     let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?;
 
     let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
-    // build_v1_url owns the /v1 prefix; callers pass the suffix
-    // (e.g. `/audio/transcriptions`) so this code is agnostic to
-    // whether the customer's api_base ends in /v1 or not.
-    let url = crate::dispatch::build_v1_url(&base, upstream_path);
+    let url = crate::dispatch::build_openai_url(&base, upstream_path);
     let provider_label = provider.to_ascii_lowercase();
     // Static label for retry tracing — this dispatch serves both audio
     // sub-routes, and logging translations under the transcription label
@@ -1137,7 +1134,7 @@ async fn speech_dispatch(
     );
 
     let client = crate::http_client::client_for(pk_entry.value.tls.as_ref());
-    let speech_url = crate::dispatch::build_v1_url(&base, "/audio/speech");
+    let speech_url = crate::dispatch::build_openai_url(&base, "/audio/speech");
     let tracker = &state.runtime_status;
     let model_id: &str = &model_entry.id;
     let cooldown_cfg = model.cooldown.as_ref();

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -396,11 +396,11 @@ async fn count_tokens_to_target(
         );
     }
 
-    // `build_v1_url` tolerates an api_base with or without `/v1` (the
+    // `build_anthropic_url` tolerates an api_base with or without `/v1` (the
     // Anthropic dashboard placeholder and copy-pasted full URLs both
     // resolve to `…/v1/messages/count_tokens`).
     let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
-    let url = crate::dispatch::build_v1_url(&base, "/messages/count_tokens");
+    let url = crate::dispatch::build_anthropic_url(&base, "/messages/count_tokens");
 
     // Build the outbound HeaderMap explicitly so the PK's
     // `request.default_headers` / `request.forward_client_headers` can

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -149,27 +149,17 @@ pub(crate) fn require_upstream_model(model: &Model) -> Result<&str, ProxyError> 
     })
 }
 
-/// Path suffixes the proxy-side handlers (audio, responses, messages)
-/// build via [`build_v1_url`]. If an operator accidentally pasted the
-/// full upstream URL into `api_base`, strip the suffix here so the
-/// later [`build_v1_url`] call does not double-append. The list mirrors
-/// every concrete endpoint the proxy currently routes to upstream,
-/// covered in both the bare (`/responses`) and `/v1`-prefixed
-/// (`/v1/responses`) form an operator might paste.
+/// Endpoint suffixes the proxy-side handlers append themselves. If an
+/// operator accidentally pasted the full upstream URL into `api_base`,
+/// strip the suffix here so the later URL build does not double-append.
 ///
-/// Longer suffixes appear first so `/v1/audio/transcriptions` matches
-/// before `/audio/transcriptions`, etc.
+/// Only the **bare** endpoint is stripped, never a `/v1/` prefixed form:
+/// the version segment belongs to the base and must survive, or a
+/// pasted `https://proxy.corp/shim/v1/responses` would collapse to
+/// `https://proxy.corp/shim` and rebuild as `…/shim/responses`.
+/// Stripping just `/responses` leaves `…/shim/v1`, which
+/// [`build_openai_url`] then preserves verbatim.
 const API_BASE_ENDPOINT_SUFFIXES: &[&str] = &[
-    "/v1/audio/transcriptions",
-    "/v1/audio/translations",
-    "/v1/audio/speech",
-    "/v1/chat/completions",
-    "/v1/images/generations",
-    "/v1/completions",
-    "/v1/embeddings",
-    "/v1/responses",
-    "/v1/messages",
-    "/v1/rerank",
     "/audio/transcriptions",
     "/audio/translations",
     "/audio/speech",
@@ -199,8 +189,7 @@ fn strip_endpoint_suffix(base: &str) -> &str {
 /// The upstream base URL: `provider_key.api_base` override if set,
 /// otherwise the `Provider`'s built-in default. Tolerates an operator
 /// pasting the full upstream URL into `api_base` by stripping any
-/// trailing endpoint suffix — see [`API_BASE_ENDPOINT_SUFFIXES`] for
-/// the full list and [`build_v1_url`] for the matching `/v1` synthesis.
+/// trailing endpoint suffix — see [`API_BASE_ENDPOINT_SUFFIXES`].
 pub(crate) fn resolve_base_url(provider_key: &ProviderKey) -> Result<String, ProxyError> {
     match provider_key.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => Ok(strip_endpoint_suffix(b.trim()).to_string()),
@@ -213,44 +202,73 @@ pub(crate) fn resolve_base_url(provider_key: &ProviderKey) -> Result<String, Pro
     }
 }
 
-/// Build a `/v1`-prefixed upstream URL while tolerating either
-/// convention for the configured `api_base`:
+/// True when `base` carries a path component beyond the host — i.e. the
+/// operator (or the CP catalog) pinned an explicit upstream root such as
+/// `…/v2`, `…/api/paas/v4` or `…/v1beta/openai`, rather than leaving the
+/// bare host. Callers pass a slash-trimmed base.
+fn base_has_path(base: &str) -> bool {
+    base.split_once("://")
+        .map_or(base, |(_, rest)| rest)
+        .contains('/')
+}
+
+/// Join an OpenAI-family upstream base with a version-independent
+/// endpoint path (`/responses`, `/rerank`, `/audio/speech`, `/files`, …).
 ///
-/// * `https://api.openai.com` builds `…/v1/<path>` — the bare-host
-///   convention `OpenAiBridge::resolve_base` synthesizes when the
-///   operator leaves the trailing `/v1` off (the same form
-///   `aisix-proxy`'s pre-existing handlers use directly).
-/// * `https://api.openai.com/v1` also builds `…/v1/<path>` — the
-///   OpenAI SDK convention every published example uses, and the
-///   exact placeholder the dashboard's provider-keys form pre-fills.
+/// In this family `api_base` **is** the versioned root, so whatever path
+/// the operator or the CP catalog configured is preserved verbatim and
+/// the endpoint is appended to it. Only a bare host — no path at all —
+/// gets the canonical `/v1` synthesized, because several vendor defaults
+/// ship that form (`https://api.deepseek.com`, `https://api.cohere.com`,
+/// `https://api.dev.runwayml.com`).
 ///
-/// Without this normalization, a customer who follows OpenAI SDK
-/// docs (api_base = `…/v1`) hits `…/v1/v1/responses` upstream — the
-/// upstream 404s, the DP wraps it as 502 upstream_error, and the
-/// failure surfaces as "intermittent SDK-incompatible behaviour"
-/// (chat works because aisix-provider-openai/src/bridge.rs uses
-/// the OpenAI-SDK convention; the proxy crate handlers — responses,
-/// rerank, audio — follow the provider-default convention, so the
-/// customer's api_base satisfies one but not the other).
+/// Preserving the path is what makes non-`/v1` roots reachable: Baidu
+/// Qianfan serves `…/v2/responses`, Zhipu `…/api/paas/v4/…`, Volcengine
+/// Ark `…/api/v3/…`, Gemini `…/v1beta/openai/…`. Synthesizing `/v1`
+/// there built `…/v2/v1/responses`, which every one of those upstreams
+/// 404s. It also matches how `OpenAiBridge` has always built
+/// `/chat/completions`, so both halves of the gateway now agree on what
+/// `api_base` means — before this, chat worked while responses, rerank,
+/// audio, realtime and the batch/files routes 404'd on the same key.
 ///
-/// `path` MUST start with `/` and SHOULD start with the version-
-/// independent route (e.g. `/responses`, not `/v1/responses`); this
-/// helper owns the `/v1` prefix.
-pub(crate) fn build_v1_url(base: &str, path: &str) -> String {
+/// `path` MUST start with `/` and MUST be the version-independent route
+/// (`/responses`, not `/v1/responses`).
+pub(crate) fn build_openai_url(base: &str, path: &str) -> String {
     // assert!, not debug_assert! — the cost of a single bounds check
     // per upstream dispatch is negligible compared to the network
     // round-trip, and a release-mode caller passing a malformed path
     // would silently produce a wrong URL (e.g. `…/v1responses`).
     assert!(
         path.starts_with('/'),
-        "build_v1_url path must start with /, got {path:?}",
+        "build_openai_url path must start with /, got {path:?}",
     );
     let trimmed = base.trim_end_matches('/');
-    if trimmed.ends_with("/v1") {
+    if base_has_path(trimmed) {
         format!("{trimmed}{path}")
     } else {
         format!("{trimmed}/v1{path}")
     }
+}
+
+/// Join an Anthropic upstream base with a version-independent endpoint
+/// path (`/messages`, `/messages/count_tokens`).
+///
+/// Anthropic's convention is the mirror image of the OpenAI family's:
+/// the documented `api_base` is the bare host and the `/v1` belongs to
+/// the endpoint (`POST {base}/v1/messages`). So `/v1` is synthesized for
+/// every base, including one that carries a path — a self-hosted
+/// Anthropic-compatible gateway mounted at `…/anthropic` serves
+/// `…/anthropic/v1/messages`. A base that already ends in `/v1` is an
+/// operator importing the OpenAI habit; collapse it so it can't double.
+/// Mirrors `AnthropicBridge::normalize_api_base`.
+pub(crate) fn build_anthropic_url(base: &str, path: &str) -> String {
+    assert!(
+        path.starts_with('/'),
+        "build_anthropic_url path must start with /, got {path:?}",
+    );
+    let trimmed = base.trim_end_matches('/');
+    let root = trimmed.strip_suffix("/v1").unwrap_or(trimmed);
+    format!("{root}/v1{path}")
 }
 
 /// The upstream API key — `provider_key.api_key`. Empty string is
@@ -516,10 +534,10 @@ mod tests {
     }
 
     /// Every OpenAI-shape paste an operator might make must, when fed
-    /// to `build_v1_url(base, "/<endpoint>")`, produce the canonical
+    /// to `build_openai_url(base, "/<endpoint>")`, produce the canonical
     /// upstream URL. The intermediate `resolve_base_url` result may be
-    /// either bare-host or `<host>/v1` — `build_v1_url` accepts both —
-    /// so the assertion is on the final URL the handler dispatches to,
+    /// either bare-host or `<host>/v1` — `build_openai_url` accepts both
+    /// — so the assertion is on the final URL the handler dispatches to,
     /// not on the intermediate base.
     ///
     /// Without suffix stripping, pasting `…/v1/audio/transcriptions`
@@ -554,7 +572,7 @@ mod tests {
         for (paste, endpoint) in cases {
             let pk = pk_with_base(paste);
             let base = resolve_base_url(&pk).unwrap();
-            let url = build_v1_url(&base, endpoint);
+            let url = build_openai_url(&base, endpoint);
             let expected = format!("https://api.openai.com/v1{endpoint}");
             assert_eq!(
                 url, expected,
@@ -575,7 +593,7 @@ mod tests {
         ] {
             let pk = pk_with_base(paste);
             let base = resolve_base_url(&pk).unwrap();
-            let url = build_v1_url(&base, "/chat/completions");
+            let url = build_openai_url(&base, "/chat/completions");
             assert_eq!(
                 url, "https://api.deepseek.com/v1/chat/completions",
                 "paste {paste:?} must build to the canonical chat-completions URL",
@@ -584,8 +602,9 @@ mod tests {
     }
 
     /// Anthropic: the messages handler builds `…/v1/messages`. A paste
-    /// of the full upstream URL must strip so `build_v1_url("/messages")`
-    /// does not produce `…/v1/messages/v1/messages`.
+    /// of the full upstream URL must strip so
+    /// `build_anthropic_url("/messages")` does not produce
+    /// `…/v1/messages/v1/messages`.
     #[test]
     fn resolve_base_url_strips_anthropic_messages_suffix() {
         for paste in [
@@ -598,7 +617,7 @@ mod tests {
             let pk = pk_with_base(paste);
             let base = resolve_base_url(&pk).unwrap();
             assert_eq!(
-                build_v1_url(&base, "/messages"),
+                build_anthropic_url(&base, "/messages"),
                 "https://api.anthropic.com/v1/messages",
                 "paste {paste:?} must build to the canonical messages URL",
             );
@@ -618,10 +637,13 @@ mod tests {
 
         // Suffix stripping still applies on non-canonical hosts —
         // operator pasting the full upstream URL is still recovered.
+        // Only the bare `/responses` is stripped, so the `/v1` the
+        // operator wrote survives into the rebuilt URL.
         let pk = pk_with_base("https://proxy.example.com/openai-shim/v1/responses");
         let base = resolve_base_url(&pk).unwrap();
+        assert_eq!(base, "https://proxy.example.com/openai-shim/v1");
         assert_eq!(
-            build_v1_url(&base, "/responses"),
+            build_openai_url(&base, "/responses"),
             "https://proxy.example.com/openai-shim/v1/responses",
         );
     }
@@ -632,69 +654,175 @@ mod tests {
         let pk = pk_with_base("  https://api.openai.com/v1/chat/completions/  ");
         let base = resolve_base_url(&pk).unwrap();
         assert_eq!(
-            build_v1_url(&base, "/chat/completions"),
+            build_openai_url(&base, "/chat/completions"),
             "https://api.openai.com/v1/chat/completions",
         );
     }
 
     // ---------------------------------------------------------------
-    // build_v1_url — the path-doubling regression fixture.
+    // build_openai_url — the path-doubling regression fixture.
     // ---------------------------------------------------------------
 
     #[test]
-    fn build_v1_url_appends_v1_when_base_lacks_it() {
+    fn build_openai_url_appends_v1_only_for_a_bare_host() {
         // Bare-host convention: the operator pasted
-        // `https://api.openai.com` without the trailing `/v1`.
+        // `https://api.openai.com` without the trailing `/v1`, or the
+        // vendor default ships that form (deepseek, cohere, runwayml).
         assert_eq!(
-            build_v1_url("https://api.openai.com", "/responses"),
+            build_openai_url("https://api.openai.com", "/responses"),
             "https://api.openai.com/v1/responses",
+        );
+        assert_eq!(
+            build_openai_url("https://api.deepseek.com", "/chat/completions"),
+            "https://api.deepseek.com/v1/chat/completions",
+        );
+        // Host:port with no path is still a bare host.
+        assert_eq!(
+            build_openai_url("http://127.0.0.1:8080", "/rerank"),
+            "http://127.0.0.1:8080/v1/rerank",
         );
     }
 
     #[test]
-    fn build_v1_url_skips_v1_when_base_already_has_it() {
+    fn build_openai_url_preserves_v1_base_without_doubling() {
         // Customer follows the OpenAI SDK convention + the dashboard's
         // provider-keys form pre-fill (`https://api.openai.com/v1`).
         // A naive `format!("{base}/v1/responses")` would produce
         // `https://api.openai.com/v1/v1/responses` and 404 upstream.
         assert_eq!(
-            build_v1_url("https://api.openai.com/v1", "/responses"),
+            build_openai_url("https://api.openai.com/v1", "/responses"),
             "https://api.openai.com/v1/responses",
         );
     }
 
+    /// AISIX-Cloud#1244: an `api_base` whose root is not `/v1` must be
+    /// preserved verbatim. Synthesizing `/v1` built `…/v2/v1/responses`,
+    /// which the upstream 404s. Every value here is a real upstream root
+    /// — three of them ship as CP catalog defaults.
     #[test]
-    fn build_v1_url_strips_trailing_slash() {
+    fn build_openai_url_preserves_non_v1_roots() {
+        let cases: &[(&str, &str, &str)] = &[
+            // Baidu Qianfan — the reported customer config.
+            (
+                "https://qianfan.baidubce.com/v2",
+                "/responses",
+                "https://qianfan.baidubce.com/v2/responses",
+            ),
+            // Zhipu — CP catalog default.
+            (
+                "https://open.bigmodel.cn/api/paas/v4",
+                "/audio/speech",
+                "https://open.bigmodel.cn/api/paas/v4/audio/speech",
+            ),
+            // Volcengine Ark — CP catalog default.
+            (
+                "https://ark.cn-beijing.volces.com/api/v3",
+                "/files",
+                "https://ark.cn-beijing.volces.com/api/v3/files",
+            ),
+            // Gemini's OpenAI-compat surface — CP catalog default, and
+            // the case a "does the last segment look like a version?"
+            // heuristic would miss.
+            (
+                "https://generativelanguage.googleapis.com/v1beta/openai",
+                "/realtime",
+                "https://generativelanguage.googleapis.com/v1beta/openai/realtime",
+            ),
+            // Alibaba DashScope's compatible mode.
+            (
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                "/rerank",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1/rerank",
+            ),
+        ];
+        for (base, path, expected) in cases {
+            assert_eq!(
+                &build_openai_url(base, path),
+                expected,
+                "base {base:?} + path {path:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn build_openai_url_strips_trailing_slash() {
         assert_eq!(
-            build_v1_url("https://api.openai.com/", "/rerank"),
+            build_openai_url("https://api.openai.com/", "/rerank"),
             "https://api.openai.com/v1/rerank",
         );
         assert_eq!(
-            build_v1_url("https://api.openai.com/v1/", "/rerank"),
+            build_openai_url("https://api.openai.com/v1/", "/rerank"),
             "https://api.openai.com/v1/rerank",
+        );
+        // A trailing slash must not make a bare host look path-bearing.
+        assert_eq!(
+            build_openai_url("https://api.deepseek.com/", "/embeddings"),
+            "https://api.deepseek.com/v1/embeddings",
         );
     }
 
     #[test]
-    fn build_v1_url_handles_nested_paths() {
+    fn build_openai_url_handles_nested_paths() {
         // /audio/speech, /audio/transcriptions, /audio/translations all
         // pass nested paths — make sure the helper doesn't try to be
         // clever about them.
         assert_eq!(
-            build_v1_url("https://api.openai.com", "/audio/speech"),
+            build_openai_url("https://api.openai.com", "/audio/speech"),
             "https://api.openai.com/v1/audio/speech",
         );
         assert_eq!(
-            build_v1_url("https://api.openai.com/v1", "/audio/transcriptions"),
+            build_openai_url("https://api.openai.com/v1", "/audio/transcriptions"),
             "https://api.openai.com/v1/audio/transcriptions",
         );
     }
 
     #[test]
-    #[should_panic(expected = "build_v1_url path must start with /")]
-    fn build_v1_url_rejects_path_without_leading_slash() {
+    #[should_panic(expected = "build_openai_url path must start with /")]
+    fn build_openai_url_rejects_path_without_leading_slash() {
         // Misuse — handlers should always pass a `/`-prefixed path.
-        let _ = build_v1_url("https://api.openai.com", "responses");
+        let _ = build_openai_url("https://api.openai.com", "responses");
+    }
+
+    // ---------------------------------------------------------------
+    // build_anthropic_url — the mirror-image convention: `/v1` belongs
+    // to the endpoint, so it is synthesized for a path-bearing base too.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn build_anthropic_url_synthesizes_v1_for_every_base_shape() {
+        assert_eq!(
+            build_anthropic_url("https://api.anthropic.com", "/messages"),
+            "https://api.anthropic.com/v1/messages",
+        );
+        assert_eq!(
+            build_anthropic_url("https://api.anthropic.com/", "/messages"),
+            "https://api.anthropic.com/v1/messages",
+        );
+        // Operator importing the OpenAI habit — must not double.
+        assert_eq!(
+            build_anthropic_url("https://api.anthropic.com/v1", "/messages"),
+            "https://api.anthropic.com/v1/messages",
+        );
+        // A self-hosted Anthropic-compatible gateway mounted under a
+        // path still serves `<mount>/v1/messages` — unlike the OpenAI
+        // family, the path here does NOT suppress the `/v1`.
+        assert_eq!(
+            build_anthropic_url("https://gw.corp.example/anthropic", "/messages"),
+            "https://gw.corp.example/anthropic/v1/messages",
+        );
+        assert_eq!(
+            build_anthropic_url(
+                "https://gw.corp.example/anthropic",
+                "/messages/count_tokens"
+            ),
+            "https://gw.corp.example/anthropic/v1/messages/count_tokens",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "build_anthropic_url path must start with /")]
+    fn build_anthropic_url_rejects_path_without_leading_slash() {
+        let _ = build_anthropic_url("https://api.anthropic.com", "messages");
     }
 
     // --- resolve_bridge tests -------------------------------------

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -280,7 +280,7 @@ fn upstream_url(target: &JobTarget, path: &str, query: &str) -> Result<String, P
     match target.adapter {
         Adapter::Openai => {
             let base = crate::dispatch::resolve_base_url(&target.pk_entry.value)?;
-            let url = crate::dispatch::build_v1_url(&base, path);
+            let url = crate::dispatch::build_openai_url(&base, path);
             if query.is_empty() {
                 Ok(url)
             } else {
@@ -1717,7 +1717,7 @@ async fn attribute_batch_usage(
                 .map(str::trim)
                 .filter(|b| !b.is_empty())
                 .ok_or("provider_key has no api_base")?;
-            crate::dispatch::build_v1_url(
+            crate::dispatch::build_openai_url(
                 base.trim_end_matches('/'),
                 &format!("/files/{output_file_id}/content"),
             )

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1033,12 +1033,12 @@ async fn anthropic_passthrough_dispatch(
         );
     }
 
-    // Build the target URL. build_v1_url tolerates the rare case
+    // Build the target URL. build_anthropic_url tolerates the rare case
     // where the customer mistakenly puts `/v1` in the Anthropic
     // api_base (the dashboard placeholder uses the OpenAI form, so
     // this is a copy-paste hazard).
     let base = crate::dispatch::resolve_base_url(pk_value)?;
-    let url = crate::dispatch::build_v1_url(&base, "/messages");
+    let url = crate::dispatch::build_anthropic_url(&base, "/messages");
 
     // Check if the request wants streaming.
     let is_stream = body

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -230,7 +230,7 @@ async fn prepare(
     let upstream_request = match pk_entry.value.adapter {
         Some(Adapter::Openai) => {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
-            let url = crate::dispatch::build_v1_url(&base, "/realtime");
+            let url = crate::dispatch::build_openai_url(&base, "/realtime");
             let url = format!(
                 "{}?model={}",
                 to_ws_scheme(&url)?,

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -377,11 +377,6 @@ async fn dispatch(
         aisix_provider_openai::overrides::apply_default_body_fields(body, &r.default_body_fields);
     }
 
-    // Build upstream URL. build_v1_url tolerates either base form —
-    // `https://api.cohere.com` (bare host) and `https://api.openai.com/v1`
-    // (OpenAI-SDK convention, with /v1) both end up at `…/v1/rerank`
-    // instead of `…/v1/v1/rerank`.
-    //
     // The provider arm of `default_base_for_provider` is guaranteed to
     // return `Some` here because the gate above already rejected any
     // provider label outside `{"openai", "cohere", "jina"}` — all three
@@ -395,7 +390,7 @@ async fn dispatch(
         _ => default_base_for_provider(&provider_label)
             .unwrap_or_else(|| "https://api.openai.com".to_string()),
     };
-    let url = crate::dispatch::build_v1_url(&base, "/rerank");
+    let url = crate::dispatch::build_openai_url(&base, "/rerank");
 
     // Build headers explicitly so the PK's `request.default_headers` and
     // `request.forward_client_headers` can inject operator/client headers
@@ -707,7 +702,7 @@ fn default_base_for_provider(provider: &str) -> Option<String> {
     match provider {
         "openai" => Some("https://api.openai.com".to_string()),
         // Cohere v1 path (deprecated by Cohere but still functional)
-        // is what the gateway's `build_v1_url` produces from this
+        // is what the gateway's `build_openai_url` produces from this
         // base. Operators who want the Cohere v2 path can override
         // `api_base` to `https://api.cohere.com/v2` — see #213's v2
         // follow-up for the version-routing extension if needed.
@@ -1134,7 +1129,7 @@ mod tests {
 
         let snap = AisixSnapshot::new();
         // Operator-style configuration: bare host, no /v1 suffix.
-        // The gateway's `build_v1_url` produces `/v1/rerank` correctly
+        // The gateway's `build_openai_url` produces `/v1/rerank` correctly
         // for both `https://api.jina.ai` and `https://api.jina.ai/v1`.
         let pk_json = format!(
             r#"{{"display_name":"jina-up","secret":"jina_mock_secret","api_base":"{}","provider":"jina"}}"#,
@@ -1210,7 +1205,7 @@ mod tests {
 
         let snap = AisixSnapshot::new();
         // Cohere's API base form: bare host, no /v1 suffix. The
-        // gateway's `build_v1_url` appends /v1/rerank correctly for
+        // gateway's `build_openai_url` appends /v1/rerank correctly for
         // both `https://api.cohere.com` and `https://api.cohere.com/v1`.
         let pk_json = format!(
             r#"{{"display_name":"cohere-up","secret":"sk-cohere-mock","api_base":"{}","provider":"cohere","adapter":"openai"}}"#,

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1030,12 +1030,7 @@ async fn responses_to_target(
     }
 
     let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
-    // build_v1_url tolerates both `https://api.openai.com` (provider
-    // default) and `https://api.openai.com/v1` (the OpenAI-SDK form
-    // the dashboard's provider-keys placeholder pre-fills). Without
-    // it, the SDK convention double-prefixes to `/v1/v1/responses`
-    // and 404s.
-    let url = crate::dispatch::build_v1_url(&base, "/responses");
+    let url = crate::dispatch::build_openai_url(&base, "/responses");
 
     let is_stream = body
         .get("stream")

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -118,8 +118,8 @@ const RUNWAY_TASK_PATH: &str = "/v1/tasks";
 /// and <https://docs.dev.runwayml.com/api-details/versions/2024-11-06/>.
 const RUNWAY_VERSION_HEADER: &str = "X-Runway-Version";
 const RUNWAY_VERSION_VALUE: &str = "2024-11-06";
-/// OpenAI Sora videos base path (version-independent — `build_v1_url` owns
-/// the `/v1` prefix). Submit POSTs it, poll GETs `{path}/{id}`, content
+/// OpenAI Sora videos base path (version-independent — `build_openai_url`
+/// joins it onto the api_base). Submit POSTs it, poll GETs `{path}/{id}`, content
 /// GETs `{path}/{id}/content`. Source: official `openai-python` SDK,
 /// `resources/videos.py` (`self._post("/videos", …)`,
 /// `self._get("/videos/{video_id}", …)`,
@@ -624,9 +624,9 @@ impl VideoProvider {
             // endpoint paths, not the base — so there is no version suffix
             // to strip (no stripper invented per the PR brief).
             Self::Runway => &[],
-            // OpenAI composes its URLs via `build_v1_url` (which owns the
-            // `/v1` prefix and tolerates both the bare-host and `…/v1`
-            // conventions), so `root` is never consulted for it.
+            // OpenAI composes its URLs via `build_openai_url`, which
+            // preserves whatever root the api_base carries, so `root`
+            // is never consulted for it.
             Self::Openai => &[],
         };
         for suffix in suffixes {
@@ -639,10 +639,10 @@ impl VideoProvider {
 
     fn submit_url(self, base: &str) -> String {
         // OpenAI uses the version-independent `/videos` path under the
-        // shared `build_v1_url` normalizer; the other four compose the
+        // shared `build_openai_url` joiner; the other four compose the
         // vendor's versioned path onto the stripped host root.
         if self == Self::Openai {
-            return crate::dispatch::build_v1_url(base, OPENAI_VIDEOS_PATH);
+            return crate::dispatch::build_openai_url(base, OPENAI_VIDEOS_PATH);
         }
         let root = self.root(base);
         match self {
@@ -656,7 +656,10 @@ impl VideoProvider {
 
     fn poll_url(self, base: &str, task_id: &str) -> String {
         if self == Self::Openai {
-            return crate::dispatch::build_v1_url(base, &format!("{OPENAI_VIDEOS_PATH}/{task_id}"));
+            return crate::dispatch::build_openai_url(
+                base,
+                &format!("{OPENAI_VIDEOS_PATH}/{task_id}"),
+            );
         }
         let root = self.root(base);
         match self {
@@ -954,7 +957,7 @@ impl VideoProvider {
             Self::Openai => {
                 crate::jobs::require_safe_upstream_id(task_id)?;
                 Ok(ContentDelivery::Proxy {
-                    url: crate::dispatch::build_v1_url(
+                    url: crate::dispatch::build_openai_url(
                         base,
                         &format!("{OPENAI_VIDEOS_PATH}/{task_id}/content"),
                     ),

--- a/tests/e2e/src/cases/api-base-path-prefix-e2e.test.ts
+++ b/tests/e2e/src/cases/api-base-path-prefix-e2e.test.ts
@@ -1,0 +1,302 @@
+import { WebSocket } from "undici";
+import { WebSocketServer, type WebSocket as WsSocket } from "ws";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  spawnApp,
+  startOpenAiUpstream,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: `api_base` is the upstream root — whatever path it carries is
+// preserved, and every endpoint is appended to it (AISIX-Cloud#1244).
+//
+// Before the fix the gateway used two different conventions on one
+// provider key: the OpenAI-family bridge appended `/chat/completions` to
+// the configured base verbatim, while the proxy-side handlers injected a
+// `/v1` segment unless the base already ended in `/v1`. A key pointing at
+// a non-`/v1` root — Baidu Qianfan's `…/v2`, Zhipu's `…/api/paas/v4`,
+// Volcengine Ark's `…/api/v3`, Gemini's `…/v1beta/openai` — therefore
+// served chat correctly while responses, rerank, audio, realtime and the
+// batch/files routes all dispatched to `…/v2/v1/<endpoint>` and 404'd.
+//
+// The mock upstream answers every path with the same canned body, so the
+// assertion is purely on the path the gateway dialled.
+
+const CALLER_PLAINTEXT = "sk-apibase-e2e-caller";
+const CALLER_KEY_ENV = "APIBASE_E2E_CALLER_KEY";
+
+/** `/v2` — the reported Qianfan shape; also stands in for every other
+ *  vendor whose OpenAI-compatible root is not `/v1`. */
+function resources(upstreamBase: string, realtimeBase: string): string {
+  return `
+_format_version: "1"
+provider_keys:
+  - display_name: pk-v2-root
+    provider: openai
+    adapter: openai
+    api_key: sk-mock
+    api_base: ${upstreamBase}/v2
+  - display_name: pk-bare-host
+    provider: openai
+    adapter: openai
+    api_key: sk-mock
+    api_base: ${upstreamBase}
+  - display_name: pk-anthropic-mounted
+    provider: anthropic
+    adapter: anthropic
+    api_key: sk-mock
+    api_base: ${upstreamBase}/anthropic
+  - display_name: pk-realtime-v2-root
+    provider: openai
+    adapter: openai
+    api_key: sk-upstream-realtime
+    api_base: ${realtimeBase}/v2
+models:
+  - display_name: m-v2-root
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: pk-v2-root
+  - display_name: m-bare-host
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: pk-bare-host
+  - display_name: m-anthropic-mounted
+    provider: anthropic
+    model_name: claude-3-5-sonnet
+    provider_key: pk-anthropic-mounted
+  - display_name: m-realtime-v2-root
+    provider: openai
+    model_name: gpt-realtime-mock
+    provider_key: pk-realtime-v2-root
+api_keys:
+  - display_name: apibase-caller
+    key_env: ${CALLER_KEY_ENV}
+    allowed_models:
+      ["m-v2-root", "m-bare-host", "m-anthropic-mounted", "m-realtime-v2-root"]
+`;
+}
+
+interface RealtimeUpstream {
+  baseUrl: string;
+  handshakes: string[];
+  close(): Promise<void>;
+}
+
+/** Records the upgrade path of every realtime handshake it receives. */
+async function startRealtimeUpstream(): Promise<RealtimeUpstream> {
+  const handshakes: string[] = [];
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  wss.on("connection", (socket: WsSocket, req) => {
+    handshakes.push(req.url ?? "");
+    socket.close();
+  });
+  await new Promise<void>((resolve) => wss.on("listening", resolve));
+  const addr = wss.address();
+  if (addr === null || typeof addr === "string") throw new Error("no port");
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    handshakes,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        wss.close((e) => (e ? reject(e) : resolve())),
+      ),
+  };
+}
+
+describe("api_base path prefix is preserved on every endpoint", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let realtime: RealtimeUpstream | undefined;
+
+  const auth = { authorization: `Bearer ${CALLER_PLAINTEXT}` };
+
+  /** Path the gateway dialled for the request this call brackets. */
+  async function upstreamPathOf(run: () => Promise<unknown>): Promise<string> {
+    if (!upstream) throw new Error("setup failed");
+    const before = upstream.receivedRequests.length;
+    await run();
+    const seen = upstream.receivedRequests.slice(before);
+    expect(seen.length).toBe(1);
+    return seen[0].path;
+  }
+
+  beforeAll(async () => {
+    upstream = await startOpenAiUpstream();
+    realtime = await startRealtimeUpstream();
+    // File mode: resources load synchronously at boot, no etcd needed.
+    app = await spawnApp({
+      resourcesFile: resources(upstream.baseUrl, realtime.baseUrl),
+      extraEnv: { [CALLER_KEY_ENV]: CALLER_PLAINTEXT },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await realtime?.close();
+  });
+
+  test("chat completions keeps the /v2 root (the leg that always worked)", async () => {
+    if (!app) throw new Error("setup failed");
+    const path = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "m-v2-root",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }),
+    );
+    expect(path).toBe("/v2/chat/completions");
+  });
+
+  test("responses keeps the /v2 root instead of building /v2/v1/responses", async () => {
+    if (!app) throw new Error("setup failed");
+    const path = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/responses`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({ model: "m-v2-root", input: "hello" }),
+      }),
+    );
+    expect(path).toBe("/v2/responses");
+  });
+
+  test("rerank keeps the /v2 root", async () => {
+    if (!app) throw new Error("setup failed");
+    const path = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/rerank`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "m-v2-root",
+          query: "q",
+          documents: ["a", "b"],
+        }),
+      }),
+    );
+    expect(path).toBe("/v2/rerank");
+  });
+
+  test("audio speech keeps the /v2 root", async () => {
+    if (!app) throw new Error("setup failed");
+    const path = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/audio/speech`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "m-v2-root",
+          input: "hi",
+          voice: "alloy",
+        }),
+      }),
+    );
+    expect(path).toBe("/v2/audio/speech");
+  });
+
+  test("audio transcriptions keeps the /v2 root", async () => {
+    if (!app) throw new Error("setup failed");
+    const form = new FormData();
+    form.set("model", "m-v2-root");
+    form.set("file", new Blob(["fake audio"]), "clip.mp3");
+    const path = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/audio/transcriptions`, {
+        method: "POST",
+        headers: auth,
+        body: form,
+      }),
+    );
+    expect(path).toBe("/v2/audio/transcriptions");
+  });
+
+  test("the batch/files family keeps the /v2 root", async () => {
+    if (!app) throw new Error("setup failed");
+
+    const listPath = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/files?model=m-v2-root`, { headers: auth }),
+    );
+    expect(listPath).toBe("/v2/files");
+
+    const batchPath = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/batches`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "m-v2-root",
+          input_file_id: "file-1",
+          endpoint: "/v1/chat/completions",
+          completion_window: "24h",
+        }),
+      }),
+    );
+    expect(batchPath).toBe("/v2/batches");
+  });
+
+  test("realtime keeps the /v2 root on the upstream upgrade", async () => {
+    if (!app || !realtime) throw new Error("setup failed");
+    const ws = new WebSocket(
+      `${app.proxyUrl.replace("http://", "ws://")}/v1/realtime?model=m-realtime-v2-root`,
+      ["realtime", `openai-insecure-api-key.${CALLER_PLAINTEXT}`],
+    );
+    await new Promise<void>((resolve) => {
+      ws.addEventListener("open", () => resolve(), { once: true });
+      ws.addEventListener("error", () => resolve(), { once: true });
+    });
+    // The relay dials upstream during the client handshake; give the
+    // recorded upgrade a moment to land before asserting on it.
+    for (let i = 0; i < 50 && realtime.handshakes.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    ws.close();
+    expect(realtime.handshakes.length).toBe(1);
+    expect(realtime.handshakes[0]).toBe("/v2/realtime?model=gpt-realtime-mock");
+  });
+
+  test("a bare host still gets the canonical /v1 synthesized", async () => {
+    if (!app) throw new Error("setup failed");
+    // Several vendor defaults ship the bare host (deepseek, cohere,
+    // runwayml) — dropping the synthesis would break all of them.
+    const path = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/responses`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({ model: "m-bare-host", input: "hello" }),
+      }),
+    );
+    expect(path).toBe("/v1/responses");
+  });
+
+  test("anthropic keeps /v1 in the endpoint even under a mounted path", async () => {
+    if (!app) throw new Error("setup failed");
+    // Mirror image of the OpenAI family: Anthropic documents the bare
+    // host and owns `/v1` in the endpoint, so a gateway mounted at
+    // `/anthropic` serves `/anthropic/v1/messages` — the path must NOT
+    // suppress the version segment here.
+    const messagesPath = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/messages`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "m-anthropic-mounted",
+          max_tokens: 16,
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }),
+    );
+    expect(messagesPath).toBe("/anthropic/v1/messages");
+
+    const countPath = await upstreamPathOf(() =>
+      fetch(`${app!.proxyUrl}/v1/messages/count_tokens`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "m-anthropic-mounted",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }),
+    );
+    expect(countPath).toBe("/anthropic/v1/messages/count_tokens");
+  });
+});

--- a/tests/e2e/src/cases/api-base-path-prefix-e2e.test.ts
+++ b/tests/e2e/src/cases/api-base-path-prefix-e2e.test.ts
@@ -17,18 +17,25 @@ import {
 // `/v1` segment unless the base already ended in `/v1`. A key pointing at
 // a non-`/v1` root — Baidu Qianfan's `…/v2`, Zhipu's `…/api/paas/v4`,
 // Volcengine Ark's `…/api/v3`, Gemini's `…/v1beta/openai` — therefore
-// served chat correctly while responses, rerank, audio, realtime and the
-// batch/files routes all dispatched to `…/v2/v1/<endpoint>` and 404'd.
+// served chat correctly while responses, rerank, audio, realtime, videos
+// and the batch/files routes all dispatched to `…/v2/v1/<endpoint>` and
+// 404'd.
 //
-// The mock upstream answers every path with the same canned body, so the
-// assertion is purely on the path the gateway dialled.
+// Each case asserts BOTH that the gateway answered 200 and the exact path
+// it dialled: the mock accepts any path, so a status-only assertion would
+// not catch a wrong path, and a path-only assertion would not catch the
+// gateway failing after a correct dispatch.
 
 const CALLER_PLAINTEXT = "sk-apibase-e2e-caller";
 const CALLER_KEY_ENV = "APIBASE_E2E_CALLER_KEY";
 
 /** `/v2` — the reported Qianfan shape; also stands in for every other
  *  vendor whose OpenAI-compatible root is not `/v1`. */
-function resources(upstreamBase: string, realtimeBase: string): string {
+function resources(
+  upstreamBase: string,
+  realtimeBase: string,
+  videosBase: string,
+): string {
   return `
 _format_version: "1"
 provider_keys:
@@ -52,6 +59,11 @@ provider_keys:
     adapter: openai
     api_key: sk-upstream-realtime
     api_base: ${realtimeBase}/v2
+  - display_name: pk-videos-v2-root
+    provider: openai
+    adapter: openai
+    api_key: sk-mock
+    api_base: ${videosBase}/v2
 models:
   - display_name: m-v2-root
     provider: openai
@@ -69,11 +81,21 @@ models:
     provider: openai
     model_name: gpt-realtime-mock
     provider_key: pk-realtime-v2-root
+  - display_name: m-videos-v2-root
+    provider: openai
+    model_name: sora-2
+    provider_key: pk-videos-v2-root
 api_keys:
   - display_name: apibase-caller
     key_env: ${CALLER_KEY_ENV}
     allowed_models:
-      ["m-v2-root", "m-bare-host", "m-anthropic-mounted", "m-realtime-v2-root"]
+      [
+        "m-v2-root",
+        "m-bare-host",
+        "m-anthropic-mounted",
+        "m-realtime-v2-root",
+        "m-videos-v2-root",
+      ]
 `;
 }
 
@@ -83,13 +105,14 @@ interface RealtimeUpstream {
   close(): Promise<void>;
 }
 
-/** Records the upgrade path of every realtime handshake it receives. */
+/** Records the upgrade path of every realtime handshake, then holds the
+ *  socket open so a successful relay handshake is observable as `open`
+ *  rather than being indistinguishable from a rejected one. */
 async function startRealtimeUpstream(): Promise<RealtimeUpstream> {
   const handshakes: string[] = [];
   const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
-  wss.on("connection", (socket: WsSocket, req) => {
+  wss.on("connection", (_socket: WsSocket, req) => {
     handshakes.push(req.url ?? "");
-    socket.close();
   });
   await new Promise<void>((resolve) => wss.on("listening", resolve));
   const addr = wss.address();
@@ -107,26 +130,54 @@ async function startRealtimeUpstream(): Promise<RealtimeUpstream> {
 describe("api_base path prefix is preserved on every endpoint", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
+  let videosUpstream: OpenAiUpstream | undefined;
   let realtime: RealtimeUpstream | undefined;
 
   const auth = { authorization: `Bearer ${CALLER_PLAINTEXT}` };
 
-  /** Path the gateway dialled for the request this call brackets. */
-  async function upstreamPathOf(run: () => Promise<unknown>): Promise<string> {
-    if (!upstream) throw new Error("setup failed");
-    const before = upstream.receivedRequests.length;
-    await run();
-    const seen = upstream.receivedRequests.slice(before);
+  /**
+   * Run one proxied request and return the path the gateway dialled.
+   * Asserts a 200 so a correctly-routed request that the gateway then
+   * mishandles still fails the case.
+   */
+  async function dialledPath(
+    mock: () => OpenAiUpstream | undefined,
+    run: () => Promise<Response>,
+  ): Promise<string> {
+    const up = mock();
+    if (!up) throw new Error("setup failed");
+    const before = up.receivedRequests.length;
+    const res = await run();
+    const body = await res.text();
+    expect(
+      res.status,
+      `gateway answered ${res.status}: ${body.slice(0, 300)}`,
+    ).toBe(200);
+    expect(body.length).toBeGreaterThan(0);
+    const seen = up.receivedRequests.slice(before);
     expect(seen.length).toBe(1);
     return seen[0].path;
   }
 
+  /** The shared OpenAI/Anthropic mock (canned chat-shaped body). */
+  const onShared = (run: () => Promise<Response>) =>
+    dialledPath(() => upstream, run);
+
   beforeAll(async () => {
     upstream = await startOpenAiUpstream();
+    // The videos route decodes `{id, status}` from the submit response,
+    // so it needs its own mock body rather than the shared chat one.
+    videosUpstream = await startOpenAiUpstream({
+      nonStreamBody: { id: "video-mock-1", status: "queued" },
+    });
     realtime = await startRealtimeUpstream();
     // File mode: resources load synchronously at boot, no etcd needed.
     app = await spawnApp({
-      resourcesFile: resources(upstream.baseUrl, realtime.baseUrl),
+      resourcesFile: resources(
+        upstream.baseUrl,
+        realtime.baseUrl,
+        videosUpstream.baseUrl,
+      ),
       extraEnv: { [CALLER_KEY_ENV]: CALLER_PLAINTEXT },
     });
   });
@@ -134,12 +185,13 @@ describe("api_base path prefix is preserved on every endpoint", () => {
   afterAll(async () => {
     await app?.exit();
     await upstream?.close();
+    await videosUpstream?.close();
     await realtime?.close();
   });
 
   test("chat completions keeps the /v2 root (the leg that always worked)", async () => {
     if (!app) throw new Error("setup failed");
-    const path = await upstreamPathOf(() =>
+    const path = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/chat/completions`, {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
@@ -154,7 +206,7 @@ describe("api_base path prefix is preserved on every endpoint", () => {
 
   test("responses keeps the /v2 root instead of building /v2/v1/responses", async () => {
     if (!app) throw new Error("setup failed");
-    const path = await upstreamPathOf(() =>
+    const path = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/responses`, {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
@@ -166,7 +218,7 @@ describe("api_base path prefix is preserved on every endpoint", () => {
 
   test("rerank keeps the /v2 root", async () => {
     if (!app) throw new Error("setup failed");
-    const path = await upstreamPathOf(() =>
+    const path = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/rerank`, {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
@@ -182,7 +234,7 @@ describe("api_base path prefix is preserved on every endpoint", () => {
 
   test("audio speech keeps the /v2 root", async () => {
     if (!app) throw new Error("setup failed");
-    const path = await upstreamPathOf(() =>
+    const path = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/audio/speech`, {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
@@ -201,7 +253,7 @@ describe("api_base path prefix is preserved on every endpoint", () => {
     const form = new FormData();
     form.set("model", "m-v2-root");
     form.set("file", new Blob(["fake audio"]), "clip.mp3");
-    const path = await upstreamPathOf(() =>
+    const path = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/audio/transcriptions`, {
         method: "POST",
         headers: auth,
@@ -214,12 +266,12 @@ describe("api_base path prefix is preserved on every endpoint", () => {
   test("the batch/files family keeps the /v2 root", async () => {
     if (!app) throw new Error("setup failed");
 
-    const listPath = await upstreamPathOf(() =>
+    const listPath = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/files?model=m-v2-root`, { headers: auth }),
     );
     expect(listPath).toBe("/v2/files");
 
-    const batchPath = await upstreamPathOf(() =>
+    const batchPath = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/batches`, {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
@@ -234,23 +286,49 @@ describe("api_base path prefix is preserved on every endpoint", () => {
     expect(batchPath).toBe("/v2/batches");
   });
 
+  test("videos submit keeps the /v2 root", async () => {
+    if (!app) throw new Error("setup failed");
+    const path = await dialledPath(
+      () => videosUpstream,
+      () =>
+        fetch(`${app!.proxyUrl}/v1/videos`, {
+          method: "POST",
+          headers: { ...auth, "content-type": "application/json" },
+          body: JSON.stringify({
+            model: "m-videos-v2-root",
+            prompt: "a cat wearing a hat",
+          }),
+        }),
+    );
+    expect(path).toBe("/v2/videos");
+  });
+
   test("realtime keeps the /v2 root on the upstream upgrade", async () => {
     if (!app || !realtime) throw new Error("setup failed");
     const ws = new WebSocket(
       `${app.proxyUrl.replace("http://", "ws://")}/v1/realtime?model=m-realtime-v2-root`,
       ["realtime", `openai-insecure-api-key.${CALLER_PLAINTEXT}`],
     );
-    await new Promise<void>((resolve) => {
+    // A relay that fails to reach the upstream must fail the case, not be
+    // swallowed — the upstream holds the socket open on success.
+    await new Promise<void>((resolve, reject) => {
       ws.addEventListener("open", () => resolve(), { once: true });
-      ws.addEventListener("error", () => resolve(), { once: true });
+      ws.addEventListener(
+        "error",
+        () => reject(new Error("realtime relay handshake failed")),
+        { once: true },
+      );
     });
-    // The relay dials upstream during the client handshake; give the
-    // recorded upgrade a moment to land before asserting on it.
-    for (let i = 0; i < 50 && realtime.handshakes.length === 0; i++) {
+    // The gateway answers the client upgrade first and dials upstream
+    // right after, so the recorded handshake trails the client `open`.
+    for (let i = 0; i < 100 && realtime.handshakes.length === 0; i++) {
       await new Promise((r) => setTimeout(r, 20));
     }
     ws.close();
-    expect(realtime.handshakes.length).toBe(1);
+    expect(
+      realtime.handshakes.length,
+      "gateway never dialled the realtime upstream",
+    ).toBe(1);
     expect(realtime.handshakes[0]).toBe("/v2/realtime?model=gpt-realtime-mock");
   });
 
@@ -258,7 +336,7 @@ describe("api_base path prefix is preserved on every endpoint", () => {
     if (!app) throw new Error("setup failed");
     // Several vendor defaults ship the bare host (deepseek, cohere,
     // runwayml) — dropping the synthesis would break all of them.
-    const path = await upstreamPathOf(() =>
+    const path = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/responses`, {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
@@ -274,7 +352,7 @@ describe("api_base path prefix is preserved on every endpoint", () => {
     // host and owns `/v1` in the endpoint, so a gateway mounted at
     // `/anthropic` serves `/anthropic/v1/messages` — the path must NOT
     // suppress the version segment here.
-    const messagesPath = await upstreamPathOf(() =>
+    const messagesPath = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/messages`, {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
@@ -287,7 +365,7 @@ describe("api_base path prefix is preserved on every endpoint", () => {
     );
     expect(messagesPath).toBe("/anthropic/v1/messages");
 
-    const countPath = await upstreamPathOf(() =>
+    const countPath = await onShared(() =>
       fetch(`${app!.proxyUrl}/v1/messages/count_tokens`, {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },


### PR DESCRIPTION
## Problem

The gateway used two different conventions for `api_base` on one and the same provider key:

- `OpenAiBridge` appends the endpoint to the configured base **verbatim** — `chat/completions`, `completions`, `embeddings`, `images/generations` resolve correctly for any base.
- The proxy-side handlers went through a shared helper that **injected a `/v1` segment** unless the base already ended in `/v1`.

So a key whose upstream root is not `/v1` served chat correctly while every proxy-side endpoint dispatched to `<base>/v1/<endpoint>` and 404'd. With `api_base = https://qianfan.baidubce.com/v2`:

| client request | upstream path before | upstream path after |
|---|---|---|
| `/v1/chat/completions` | `/v2/chat/completions` ✅ | unchanged |
| `/v1/responses` | `/v2/v1/responses` ❌ | `/v2/responses` |
| `/v1/rerank` | `/v2/v1/rerank` ❌ | `/v2/rerank` |
| `/v1/audio/{speech,transcriptions,translations}` | `/v2/v1/audio/…` ❌ | `/v2/audio/…` |
| `/v1/realtime` | `/v2/v1/realtime` ❌ | `/v2/realtime` |
| `/v1/files`, `/v1/batches`, `/v1/fine_tuning/jobs` | `/v2/v1/…` ❌ | `/v2/…` |
| `/v1/videos` (OpenAI arm) | `/v2/v1/videos` ❌ | `/v2/videos` |

This is not limited to a hand-written base. Three catalog defaults carry a non-`/v1` root — `https://open.bigmodel.cn/api/paas/v4`, `https://ark.cn-beijing.volces.com/api/v3`, `https://generativelanguage.googleapis.com/v1beta/openai` — and the realtime and files/batches/fine-tuning routes gate on `adapter == openai`, so every OpenAI-adapter vendor in the catalog was affected on those routes.

## Fix

Split the helper along the two upstream conventions instead of guessing from the base:

- **`build_openai_url`** — `api_base` **is** the versioned root: its path is preserved verbatim and the endpoint is appended. Only a bare host (no path at all) gets the canonical `/v1` synthesized, because several vendor defaults ship that form (deepseek, cohere, jina, runwayml). This is also what the OpenAI-family bridge has always done, so both halves of the gateway now agree on what `api_base` means.
- **`build_anthropic_url`** — the mirror image. Anthropic documents the bare host and owns `/v1` in the endpoint (`POST {base}/v1/messages`), so the version is synthesized for a path-bearing base too: a self-hosted Anthropic-compatible gateway mounted at `…/anthropic` keeps serving `…/anthropic/v1/messages`. Mirrors `AnthropicBridge::normalize_api_base`.

`API_BASE_ENDPOINT_SUFFIXES` now strips only the bare endpoint, never a `/v1/`-prefixed form — the version segment belongs to the base and has to survive, or a pasted `https://proxy.corp/shim/v1/responses` would collapse to `…/shim` and rebuild as `…/shim/responses`.

`videos.rs` is untouched for the four non-OpenAI vendors: they already carry their own root-stripping table (`/api/paas/v4`, `/api/v3`, `/compatible-mode/v1`) and were correct.

## Behavior change

A base that carries a path but **no** version segment (`https://proxy.corp/openai-shim`) now builds `…/openai-shim/responses` instead of `…/openai-shim/v1/responses`. That is already what the same key produces for chat today, so the two stop disagreeing — but an operator relying on the old proxy-side synthesis needs to move the `/v1` into `api_base`.

## Compatibility

- Bare-host bases keep the `/v1` synthesis (`https://api.deepseek.com` → `/v1/chat/completions`), so no vendor default regresses.
- Bases ending in `/v1` are unchanged.
- Anthropic (`/v1/messages`, `/v1/messages/count_tokens`) is unchanged in every base shape.

## Docs

No paired docs change: the published provider docs already describe the fixed behavior — `providers/openai-compatible-vendors.md` ("AISIX appends the endpoint path to `api_base`. Include provider-specific prefixes such as `/v1`, `/openai`, or `/openai/v1`…") and `providers/volcengine-ark.md` ("AISIX appends the endpoint path to `api_base` verbatim"). The code was the side that disagreed.

## Tests

`tests/e2e/src/cases/api-base-path-prefix-e2e.test.ts` — 9 cases against a real `aisix` binary, asserting the exact path the gateway dialled: the `/v2` root across chat / responses / rerank / audio speech + transcriptions / files + batches / realtime, plus two guardrails (a bare host still gets `/v1`; Anthropic keeps `/v1` under a mounted path). Verified red before the change — 6 cases failed with exactly the reported `/v2/v1/…` paths — and green after.

`dispatch.rs` unit tests pin both helpers directly, including the five real non-`/v1` roots and the case a "does the last segment look like a version?" heuristic would miss (`/v1beta/openai`).

Fixes api7/AISIX-Cloud#1244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved configured API path prefixes across OpenAI-compatible and Anthropic endpoints.
  * Added consistent `/v1` handling for bare hosts and mounted gateway paths.
  * Improved support for chat, responses, reranking, audio, files, batches, realtime, video, and transcription requests.

* **Bug Fixes**
  * Prevented duplicated or incorrectly placed version paths in upstream URLs.

* **Tests**
  * Added end-to-end coverage for prefixed API bases, WebSocket endpoints, and Anthropic routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->