### PR TITLE
fix(proxy): gate the Anthropic-native routes on the adapter, not the vendor id

### DIFF
--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -243,10 +243,10 @@ async fn dispatch(
     let mut last_err: Option<ProxyError> = None;
     let mut any_anthropic = false;
     for (target_idx, target) in attempt_models.iter().enumerate() {
-        // count_tokens has no upstream equivalent for non-Anthropic
-        // providers; skip foreign targets in a mixed group rather than
+        // count_tokens has no upstream equivalent outside the Anthropic
+        // protocol; skip foreign targets in a mixed group rather than
         // dispatching to an upstream that would 404.
-        if target.model.provider.as_deref() != Some("anthropic") {
+        if !crate::dispatch::speaks_anthropic(&snapshot, &target.model) {
             continue;
         }
         any_anthropic = true;
@@ -283,7 +283,7 @@ async fn dispatch(
         // target that can actually serve the request.
         let has_usable_fallback = attempt_models[target_idx + 1..]
             .iter()
-            .any(|t| t.model.provider.as_deref() == Some("anthropic"));
+            .any(|t| crate::dispatch::speaks_anthropic(&snapshot, &t.model));
         let budget = crate::routing::effective_retries(
             &target.model,
             model_entry.value.routing.as_ref(),
@@ -344,16 +344,17 @@ async fn dispatch(
     // dispatching to an upstream that would 404.
     if !any_anthropic {
         return Err(ProxyError::InvalidRequest(format!(
-            "model `{model_name}` is not an Anthropic provider; \
-             /v1/messages/count_tokens requires an Anthropic-backed model"
+            "model `{model_name}` is not backed by an Anthropic-protocol upstream; \
+             /v1/messages/count_tokens requires a model whose provider key uses \
+             the anthropic adapter"
         )));
     }
     Err(last_err.unwrap_or(ProxyError::ProviderUnavailable))
 }
 
 /// Dispatch one concrete Anthropic target's count_tokens passthrough to
-/// `{api_base}/v1/messages/count_tokens`. The caller has already
-/// confirmed `model.provider == anthropic`.
+/// `{api_base}/v1/messages/count_tokens`. The caller has already confirmed
+/// the target speaks the Anthropic protocol (`dispatch::speaks_anthropic`).
 #[allow(clippy::too_many_arguments)]
 async fn count_tokens_to_target(
     state: &ProxyState,
@@ -881,6 +882,54 @@ mod tests {
         let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
         assert_eq!(sent["model"], "claude-haiku-4-5-20251001");
         assert_eq!(sent["messages"][0]["content"], "hello");
+    }
+
+    /// A `provider: "byo"` model whose ProviderKey carries
+    /// `adapter: anthropic` fronts an Anthropic-protocol upstream, so
+    /// count_tokens must serve it exactly like the catalog vendor.
+    /// Gating on the vendor id rejected it with a 400 while its sibling
+    /// `/v1/messages` happily served the same model.
+    #[tokio::test]
+    async fn byo_model_on_the_anthropic_adapter_is_served() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .and(header("x-api-key", "sk-byo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "input_tokens": 23
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        let pk_json = format!(
+            r#"{{"display_name":"byo-anthropic","secret":"sk-byo","api_base":"{}","provider":"byo","adapter":"anthropic"}}"#,
+            upstream.uri()
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();
+        snap.provider_keys.insert(ResourceEntry::new(PK_ID, pk, 1));
+        let model_json = format!(
+            r#"{{"display_name":"byo-claude","provider":"byo","model_name":"claude-sonnet-4-5","provider_key_id":"{PK_ID}"}}"#
+        );
+        let m: Model = serde_json::from_str(&model_json).unwrap();
+        snap.models.insert(ResourceEntry::new("m-1", m, 1));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let app = build_app(snap);
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "byo-claude",
+                "messages": [{"role": "user", "content": "hello"}]
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["input_tokens"], 23);
+        let received = upstream.received_requests().await.unwrap();
+        assert_eq!(received[0].url.path(), "/v1/messages/count_tokens");
     }
 
     // ─── PK request.* overrides must apply identically to /v1/messages ──

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -139,6 +139,31 @@ pub(crate) fn check_ip_access(model: &Model, source_ip: &str) -> Result<(), Prox
     Err(ProxyError::ModelIpRestricted(model.display_name.clone()))
 }
 
+/// Whether this Model's upstream speaks the Anthropic wire protocol, i.e.
+/// whether `/v1/messages` and `/v1/messages/count_tokens` may forward the
+/// caller's Anthropic-native body verbatim instead of round-tripping it
+/// through the cross-provider bridge.
+///
+/// Keyed on the ProviderKey's `adapter`, not on the vendor id:
+/// `provider: "byo"` + `adapter: anthropic` is the documented way to front a
+/// self-hosted or proxied Anthropic endpoint, and such an upstream serves
+/// both routes exactly like the catalog vendor does. Gating on the vendor id
+/// alone made `/v1/messages` bridge a body that needed no translation (which
+/// drops caller-owned fields such as `cache_control`) and made
+/// `/v1/messages/count_tokens` reject the model outright.
+///
+/// `model.provider` is still honoured so a ProviderKey written without an
+/// adapter — cp-api's AdapterMap-absent degenerate boot — keeps dispatching
+/// as before. A dangling `provider_key_id` likewise falls back to the vendor
+/// id, leaving the dispatch path (not this gate) to report it.
+pub(crate) fn speaks_anthropic(snapshot: &AisixSnapshot, model: &Model) -> bool {
+    if model.provider.as_deref() == Some("anthropic") {
+        return true;
+    }
+    resolve_provider_key(snapshot, model)
+        .is_ok_and(|pk| pk.value.adapter == Some(aisix_core::Adapter::Anthropic))
+}
+
 /// Required upstream model id (`model_name`) for a non-routing Model.
 pub(crate) fn require_upstream_model(model: &Model) -> Result<&str, ProxyError> {
     model.model_name.as_deref().ok_or_else(|| {

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -862,9 +862,10 @@ async fn dispatch(
     })
 }
 
-/// Dispatch one concrete (non-routing) target Model. Branches on the
-/// target's provider: Anthropic upstreams go through the byte-for-byte
-/// passthrough, everything else through the cross-provider translation.
+/// Dispatch one concrete (non-routing) target Model. Branches on the wire
+/// protocol the target's upstream speaks (`dispatch::speaks_anthropic`):
+/// Anthropic-protocol upstreams go through the byte-for-byte passthrough,
+/// everything else through the cross-provider translation.
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_to_target(
     state: &ProxyState,
@@ -913,7 +914,7 @@ async fn dispatch_to_target(
     let model = &target.model;
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
 
-    if model.provider.as_deref() != Some("anthropic") {
+    if !crate::dispatch::speaks_anthropic(snapshot, model) {
         return cross_provider_dispatch(
             state,
             body,
@@ -3670,6 +3671,67 @@ mod tests {
             "stop_reason": "end_turn",
             "usage": {"input_tokens": 10, "output_tokens": 3}
         })
+    }
+
+    /// A `provider: "byo"` model whose ProviderKey carries
+    /// `adapter: anthropic` fronts an Anthropic-protocol upstream, so
+    /// `/v1/messages` must forward the caller's body verbatim just like it
+    /// does for the catalog vendor. Branching on the vendor id instead sent
+    /// it through the cross-provider bridge, which re-encodes the body from
+    /// the normalized form and silently drops caller-owned fields — here
+    /// `cache_control`, whose loss changes both prompt-cache behavior and
+    /// what the upstream bills.
+    #[tokio::test]
+    async fn byo_model_on_the_anthropic_adapter_passes_the_body_through() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .and(header("x-api-key", "sk-byo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_response()))
+            .mount(&upstream)
+            .await;
+
+        let snap = AisixSnapshot::new();
+        let pk_json = format!(
+            r#"{{"display_name":"byo-anthropic","secret":"sk-byo","api_base":"{}","provider":"byo","adapter":"anthropic"}}"#,
+            upstream.uri()
+        );
+        let pk: aisix_core::ProviderKey = serde_json::from_str(&pk_json).unwrap();
+        snap.provider_keys
+            .insert(ResourceEntry::new(ANTHROPIC_PK_ID, pk, 1));
+        let model_json = format!(
+            r#"{{"display_name":"byo-claude","provider":"byo","model_name":"claude-sonnet-4-5","provider_key_id":"{ANTHROPIC_PK_ID}"}}"#
+        );
+        let m: Model = serde_json::from_str(&model_json).unwrap();
+        snap.models.insert(ResourceEntry::new("m-1", m, 1));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let app = build_app(snap);
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "byo-claude",
+                "max_tokens": 100,
+                "system": [{
+                    "type": "text",
+                    "text": "long shared preamble",
+                    "cache_control": {"type": "ephemeral", "ttl": "5m"}
+                }],
+                "messages": [{"role": "user", "content": "Hello"}]
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let received = upstream.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/v1/messages");
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["model"], "claude-sonnet-4-5");
+        assert_eq!(
+            sent["system"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral", "ttl": "5m"}),
+            "the caller's cache_control must reach the upstream unchanged"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/src/cases/byo-anthropic-adapter-e2e.test.ts
+++ b/tests/e2e/src/cases/byo-anthropic-adapter-e2e.test.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a `provider: "byo"` model whose ProviderKey uses `adapter: anthropic`
+// fronts a self-hosted / proxied Anthropic endpoint. Both Anthropic-native
+// routes must treat it exactly like the catalog vendor:
+//
+//   - `/v1/messages` forwards the caller's body VERBATIM. The gateway used
+//     to branch on the vendor id, so this model went through the
+//     cross-provider bridge, which re-encodes the body from its normalized
+//     form and drops caller-owned fields — `cache_control` among them,
+//     which changes both prompt-cache behavior and what the upstream bills
+//     (a 1h cache write is 2x the base input rate, 5m is 1.25x).
+//   - `/v1/messages/count_tokens` serves it. The same vendor-id gate
+//     rejected it outright with a 400, while its sibling `/v1/messages`
+//     happily served the very same model.
+
+const CALLER_PLAINTEXT = "sk-byo-anthropic-e2e";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const UPSTREAM_MODEL_ID = "claude-sonnet-4-5";
+const MODEL_ALIAS = "byo-claude-e2e";
+
+const anthropicHeaders = {
+  "content-type": "application/json",
+  "x-api-key": CALLER_PLAINTEXT,
+  "anthropic-version": "2023-06-01",
+};
+
+describe("byo + anthropic adapter e2e: the Anthropic-native routes key on the adapter", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      // Serves both routes: the count_tokens body is what
+      // `/v1/messages/count_tokens` returns; `/v1/messages` only needs a
+      // 200 here since the assertions are on the REQUEST the DP sent.
+      nonStreamBody: { input_tokens: 42 },
+    });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "byo-anthropic-pk",
+      secret: "sk-byo-upstream",
+      api_base: upstream.baseUrl,
+      // The combination under test: a vendor id that is NOT "anthropic",
+      // with the Anthropic protocol declared on the adapter.
+      provider: "byo",
+      adapter: "anthropic",
+    });
+    await seed.createModel({
+      display_name: MODEL_ALIAS,
+      provider: "byo",
+      model_name: UPSTREAM_MODEL_ID,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [MODEL_ALIAS],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("/v1/messages forwards the caller's cache_control unchanged", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const send = () =>
+      fetch(`${app!.proxyUrl}/v1/messages`, {
+        method: "POST",
+        headers: anthropicHeaders,
+        body: JSON.stringify({
+          model: MODEL_ALIAS,
+          max_tokens: 64,
+          system: [
+            {
+              type: "text",
+              text: "long shared preamble",
+              cache_control: { type: "ephemeral", ttl: "5m" },
+            },
+          ],
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+
+    await waitConfigPropagation(async () => {
+      try {
+        return (await send()).ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+    const res = await send();
+    expect(res.status).toBe(200);
+
+    const req = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages");
+    expect(req).toBeDefined();
+
+    const sent = JSON.parse(req!.body) as {
+      model?: string;
+      system?: Array<{ cache_control?: unknown }>;
+    };
+    // Alias rewritten to the upstream id, everything else verbatim.
+    expect(sent.model).toBe(UPSTREAM_MODEL_ID);
+    expect(sent.system?.[0]?.cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "5m",
+    });
+    // Anthropic auth shape, not Bearer.
+    expect(req!.headers["x-api-key"]).toBe("sk-byo-upstream");
+    expect(req!.headers["authorization"]).toBeUndefined();
+  });
+
+  test("/v1/messages/count_tokens serves the model instead of rejecting it", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const baseline = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/messages/count_tokens`, {
+      method: "POST",
+      headers: anthropicHeaders,
+      body: JSON.stringify({
+        model: MODEL_ALIAS,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { input_tokens?: unknown };
+    expect(body.input_tokens).toBe(42);
+
+    const req = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages/count_tokens");
+    expect(req).toBeDefined();
+    expect((JSON.parse(req!.body) as { model?: string }).model).toBe(
+      UPSTREAM_MODEL_ID,
+    );
+  });
+});


### PR DESCRIPTION
## 问题

`/v1/messages` 与 `/v1/messages/count_tokens` 判断"上游是不是 Anthropic"用的是 `model.provider == "anthropic"`。而 `provider: "byo"` + `adapter: anthropic` 是文档化的"指向自建/代理 Anthropic 端点"的配置方式，这类模型两条路都走岔了：

- **`/v1/messages`**：被送进 cross-provider bridge。bridge 会把请求体按归一化表示重新编码，调用方自带的字段在这一步丢失——`cache_control` 被整个丢弃；模型开了 `auto_prompt_caching` 时还会被改写成模型配置的 ttl。这既改变了 prompt cache 行为，也改变了上游计费口径（1h 写入是基础输入价的 2×，5m 是 1.25×）。
- **`/v1/messages/count_tokens`**：直接 400 `not an Anthropic provider` 拒绝，而同一个模型在兄弟端点 `/v1/messages` 上是能正常服务的。

同族端点判据不一致，是这次 QA 里同时暴露的两个现象。

## 实现

两处收口到同一个谓词 `dispatch::speaks_anthropic`：按 ProviderKey 的 `adapter` 判定，同时保留 `provider == "anthropic"` 这一支，因此 adapter 缺失的 ProviderKey（cp-api 在 AdapterMap 缺失的退化启动下写出的形态）行为不变。

`count_tokens` 里的 `has_usable_fallback`（混合模型组中判断后面还有没有可服务的目标）用的是同一个谓词，避免两处判据再次漂移。

## 行为变化

- `provider: byo` + `adapter: anthropic` 的模型：`/v1/messages` 改走字节级透传（body 原样转发），`/v1/messages/count_tokens` 从 400 变为正常服务。
- 认证形态不变：透传路径与 Anthropic bridge 发的都是 `x-api-key` + `anthropic-version`。
- 其它 provider/adapter 组合行为不变。

## 测试

- `count_tokens.rs` / `messages.rs` 各加一条单测，覆盖 byo + anthropic adapter 的两条路径（后者断言 `cache_control` 原样到达上游）。两条在修复前均失败（400、以及 `cache_control` 丢失），修复后通过。
- 新增 e2e `tests/e2e/src/cases/byo-anthropic-adapter-e2e.test.ts`：真实 DP + etcd + mock 上游，验证 `/v1/messages` 透传 `cache_control`、`/v1/messages/count_tokens` 返回 200。
- 回归：`cargo test -p aisix-proxy --lib` 848 项全过；`anthropic-count-tokens` / `anthropic-upstream` / `messages-model-group` / `messages-cross-provider-extras` / `anthropic-cache-tpm-commit` 五个 e2e 套件 18 项全过。
