### PR TITLE
test: keep tracing callsites enabled so log-capture tests stop flaking

### DIFF
--- a/crates/aisix-guardrails/src/aliyun.rs
+++ b/crates/aisix-guardrails/src/aliyun.rs
@@ -976,6 +976,7 @@ mod tests {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = ()>,
     {
+        crate::keep_callsites_enabled();
         // One capture test at a time, process-wide (see TRACING_CAPTURE_LOCK).
         let _capture_guard = crate::TRACING_CAPTURE_LOCK.lock().await;
         let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));

--- a/crates/aisix-guardrails/src/aliyun_ai_guardrail.rs
+++ b/crates/aisix-guardrails/src/aliyun_ai_guardrail.rs
@@ -1483,6 +1483,7 @@ mod tests {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = ()>,
     {
+        crate::keep_callsites_enabled();
         // One capture test at a time, process-wide (see TRACING_CAPTURE_LOCK).
         let _capture_guard = crate::TRACING_CAPTURE_LOCK.lock().await;
         let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -642,6 +642,34 @@ pub trait Guardrail: Send + Sync + 'static {
 #[cfg(test)]
 pub(crate) static TRACING_CAPTURE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+/// Keep every callsite emittable for the whole test binary; call it before
+/// installing a capturing subscriber.
+///
+/// The lock above only orders the capture tests against each other. It does
+/// nothing about the *other* piece of tracing global state: a callsite's
+/// `Interest` is cached process-wide the first time that callsite is hit,
+/// from whichever dispatcher the hitting thread has. With no global default
+/// that is `NoSubscriber`, so any unrelated test reaching a guardrail's log
+/// line first caches `Interest::never()` and the event is then skipped
+/// everywhere — the capture sees only the events of crates whose callsites
+/// happened to be registered under a subscriber.
+///
+/// A permissive global default removes both failure modes at once: no thread
+/// ever falls back to `NoSubscriber`, and a permanently registered TRACE
+/// dispatcher pins the global max-level hint. Registering it also
+/// re-evaluates the callsites seen so far, so a lazy install still repairs a
+/// cache poisoned earlier in the run.
+#[cfg(test)]
+pub(crate) fn keep_callsites_enabled() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // A bare registry writes nothing and formats nothing; it is here only
+        // so that callsites register as enabled. The captured events are
+        // rendered by each capture helper's own scoped subscriber.
+        let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -264,6 +264,31 @@ mod tests {
     /// Only one test at a time may install a process-wide subscriber.
     static CAPTURE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+    /// Keep every callsite emittable for the whole test binary.
+    ///
+    /// `set_default` below is thread-local, but a callsite's `Interest` is
+    /// cached *process-wide* the first time that callsite is hit, from
+    /// whichever dispatcher the hitting thread has. With no global default
+    /// that is `NoSubscriber`, so a sibling test reaching the denial path on
+    /// another thread caches `Interest::never()` and the event is then
+    /// skipped everywhere — including inside the capture, which sees an
+    /// empty buffer. Dozens of router tests hit the unauthenticated path, so
+    /// under the parallel harness that race is routine, not exotic.
+    ///
+    /// A permissive global default removes the outcome: no thread ever falls
+    /// back to `NoSubscriber`. Registering it also re-evaluates the
+    /// callsites seen so far, so installing it lazily still repairs a cache
+    /// poisoned earlier in the run.
+    fn keep_callsites_enabled() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            // A bare registry writes nothing and formats nothing; it is here
+            // only so that callsites register as enabled. The captured events
+            // are rendered by the scoped subscriber below.
+            let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+        });
+    }
+
     /// Run `f` with a log-capturing subscriber installed and return
     /// everything it emitted. `unknown_key` / `missing_credentials` are the
     /// scanner-probe shapes and log at DEBUG on purpose, so widen past the
@@ -273,6 +298,7 @@ mod tests {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = ()>,
     {
+        keep_callsites_enabled();
         let _capture_guard = CAPTURE_LOCK.lock().await;
         let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::fmt()


### PR DESCRIPTION
## Problem

`auth::tests::a_missing_credential_denial_names_the_caller_and_the_route` fails intermittently on `main` — it took down the `rust unit + coverage` job on the push run for #904 (run 31137791884):

```
panicked at crates/aisix-proxy/src/auth.rs:367:9:
got: 
```

The captured buffer is empty even though the subscriber is installed and the denial is emitted. Adding a marker event inside the same capture scope shows the marker but not the denial, so the subscriber and the thread are fine — the specific callsite is disabled.

## Root cause

A callsite's `Interest` is cached **process-wide** the first time that callsite is hit, and it is computed from whatever dispatcher the *hitting* thread has (`tracing_core::callsite::rebuild_callsite_interest`, which falls through to `dispatcher::get_default` on that thread while only one dispatcher is registered).

`capture_logs` installs its subscriber with `set_default`, which is thread-local. When a sibling test reaches the same unauthenticated request path on another thread, that thread resolves to `NoSubscriber`, the callsite is cached as `Interest::never()`, and the event is skipped everywhere from then on — including inside the capture. Dozens of router tests hit the unauthenticated path, so under the parallel harness this is routine rather than exotic.

## Fix

Install a bare `Registry` as the global default before capturing. It formats and writes nothing, but it means no thread ever falls back to `NoSubscriber`, so no callsite is ever cached as disabled. Registering a dispatcher also re-evaluates the callsites seen so far, so the lazy install repairs a cache already poisoned earlier in the run.

The same helper shape in `aisix-guardrails` (`aliyun.rs`, `aliyun_ai_guardrail.rs`) has the same defect and gets the same guard — its existing `TRACING_CAPTURE_LOCK` only orders capture tests against each other and does nothing about callsites registered by unrelated tests. A permanently registered dispatcher also pins the global max-level hint, which is the symptom that lock was originally added for.

`aisix-obs`'s three `with_default` sites are audited and **not** exposed: the access-log callsite is only ever emitted from inside those captures, so every thread that can register it already has a subscriber. Left unchanged.

## Verification

Same command, same machine, `--test-threads=64` to raise the interleaving pressure:

| | before | after |
|---|---|---|
| `aisix-proxy --lib` | 4 of 6 runs failed | 0 of 8 failed (plus 3/3 at default threads) |
| `aisix-guardrails --lib` | 5 of 6 runs failed | 0 of 16 failed |

Suite wall-clock is unchanged (`aisix-proxy` 12.69s → 12.66s at default threads), which is why the fix uses a bare registry rather than a discarding `fmt` subscriber — the latter formats every event and cost ~1s on the guardrails suite.

Workspace `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.

## No new test

The trigger is a process-global, order-dependent race in tracing's callsite cache: a callsite is registered at most once per process and cannot be un-registered, so the poisoning window cannot be forced deterministically from inside the same test binary. Verified statistically instead, as above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test log capture so denial and guardrail-related tracing messages are consistently retained.
  * Prevented previously cached tracing settings from suppressing captured logs during authentication and guardrail tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->