### PR TITLE
ci(release): keep rolling pointers off pre-release tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,8 +8,15 @@ name: docker-image
 #   - push to poc               → :poc + :sha-<shortsha>
 #   - push tag vX.Y.Z           → :X.Y.Z + :X.Y + :X + :latest
 #                                 + :sha-<shortsha>
+#   - push tag vX.Y.Z-rc.N      → :X.Y.Z-rc.N + :sha-<shortsha>  (NO rolling tags)
 #   - pull request              → build-only (no push), sanity check
 #   - workflow_dispatch         → :sha-<shortsha> + optional tag input
+#
+# Pre-release tags exist so a release candidate can be QA'd on the exact
+# artifacts customers receive before anything points at it. They must move
+# no rolling pointer: docker/metadata-action already skips :X.Y and :X for
+# pre-release semver, and the guards below keep :latest and the published
+# `openapi-latest.json` on the last stable release.
 
 on:
   push:
@@ -83,6 +90,9 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             ${{ startsWith(github.ref, 'refs/tags/v') && format('{0}/{1}', secrets.DOCKER_REGISTRY, env.IMAGE_NAME) || '' }}
+          # `latest` is guarded on `!contains(ref_name, '-')` so a `-rc.N` tag
+          # cannot move it; metadata-action already skips {{major}}.{{minor}}
+          # and {{major}} for pre-release semver.
           tags: |
             type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=poc,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/poc' }}
@@ -91,7 +101,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
           labels: |
             org.opencontainers.image.title=aisix
@@ -293,8 +303,17 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           jq --arg version "$VERSION" '.info.version = $version' ./openapi.json > "openapi-${VERSION}.json"
           aws s3 cp "./openapi-${VERSION}.json" "s3://${S3_BUCKET}/ai-gateway/openapi-${VERSION}.json"
-          aws s3 cp "./openapi-${VERSION}.json" "s3://${S3_BUCKET}/ai-gateway/openapi-latest.json"
-          echo "/ai-gateway/openapi-${VERSION}.json /ai-gateway/openapi-latest.json" > .updated_openapi_files
+          PATHS="/ai-gateway/openapi-${VERSION}.json"
+          # A release candidate publishes its own version-pinned spec (QA reads
+          # it) but must leave `openapi-latest.json` on the last stable release.
+          case "$VERSION" in
+            *-*) echo "::notice::pre-release ${VERSION}: openapi-latest.json left untouched" ;;
+            *)
+              aws s3 cp "./openapi-${VERSION}.json" "s3://${S3_BUCKET}/ai-gateway/openapi-latest.json"
+              PATHS="$PATHS /ai-gateway/openapi-latest.json"
+              ;;
+          esac
+          echo "$PATHS" > .updated_openapi_files
 
       - name: Invalidate OpenAPI CloudFront paths
         if: steps.openapi-secrets.outputs.enabled == 'true'

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -67,8 +67,26 @@ jobs:
           # GitHub's auto-generated "What's Changed" skeleton, appended below the
           # header. Fall back to a bare heading so a transient API failure still
           # produces a draft (with the header) instead of no release at all.
+          #
+          # Pin the range start to the last published STABLE release instead of
+          # letting GitHub pick it. A release is now preceded by its own
+          # `-rc.N` candidate tags, and auto-detection choosing one of those
+          # would collapse the changelog to the (usually empty) rc → final
+          # delta. Omitted for the first-ever release, where there is no
+          # previous stable one and auto-detection is correct.
+          # /releases/latest is defined as the newest published release that is
+          # neither a draft nor a prerelease — exactly the range start we want.
+          # 404s when there is none yet.
+          PREV=$(gh api "repos/$REPO/releases/latest" --jq .tag_name 2>/dev/null || true)
+          if [ -n "$PREV" ] && [ "$PREV" != "null" ] && [ "$PREV" != "$TAG" ]; then
+            set -- -f previous_tag_name="$PREV"
+            echo "changelog range: $PREV..$TAG"
+          else
+            set --
+            echo "changelog range: auto-detected (no previous stable release)"
+          fi
           gh api "repos/$REPO/releases/generate-notes" \
-            -f tag_name="$TAG" --jq .body >> release-body.md \
+            -f tag_name="$TAG" "$@" --jq .body >> release-body.md \
             || printf '## What'"'"'s Changed\n' >> release-body.md
 
           # Pre-release tags (v0.4.0-rc.1) get the prerelease flag.


### PR DESCRIPTION
## Problem

A `vX.Y.Z-rc.N` tag is treated exactly like a stable release: it publishes `:latest` and overwrites `openapi-latest.json`. So the moment a release is built it is also what anyone pulling `api7/aisix` gets — there is no point in the pipeline where a candidate exists as a real, installable artifact but is not yet the default users receive. That is the point where release QA needs to run.

## Change

A pre-release tag now publishes only its own version-pinned artifacts:

- `:latest` gains a `!contains(github.ref_name, '-')` guard. `metadata-action` already omits `{{major}}.{{minor}}` and `{{major}}` for pre-release semver (as `release-draft.yml` already notes), so with this guard no rolling tag moves at all.
- The release OpenAPI step still uploads `openapi-<version>.json` for a candidate — QA and the docs build can read it — but skips `openapi-latest.json` and drops it from the CloudFront invalidation list.

`vX.Y.Z-rc.N` therefore yields `:X.Y.Z-rc.N` + `:sha-<short>` and nothing else. `release-draft.yml` already flags `-rc` tags as prerelease, keeps the release a draft, and omits the rolling-tag sentence from the notes — but it asked GitHub to auto-detect where the changelog range starts, and with candidate tags now preceding every release that can land on a candidate and collapse "What's Changed" to the near-empty rc → final delta. It now starts the range at `/releases/latest`, which GitHub defines as the newest published release that is neither draft nor prerelease, falling back to auto-detection for the first-ever release.

## Behaviour change

Stable tags are unaffected — same tags, same uploads, and the changelog range they get is the one auto-detection was already producing. Only pre-release tags behave differently, and they have never been used in this repo.

## Tests

Workflow trigger conditions are not reachable from the repo's test suites; the real proof is the first `-rc` tag. Locally verified: `actionlint` clean on both changed files, `bash -n` on every `run` block, the pre-release branch of the OpenAPI upload simulated over both tag shapes (`v0.9.0` → publishes latest, `v0.9.0-rc.1` → does not), and the changelog-range branch simulated for a stable tag, a candidate tag, and a repo with no published release. The `# comment` sits above the `tags:` block rather than inside it, so nothing depends on how `metadata-action` parses comments in that input.