### PR TITLE
feat(a2a): relay message/stream as live SSE instead of buffering it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ version = "0.3.0"
 dependencies = [
  "aisix-core",
  "aisix-gateway",
+ "async-stream",
  "async-trait",
  "axum",
  "futures",

--- a/crates/aisix-a2a/Cargo.toml
+++ b/crates/aisix-a2a/Cargo.toml
@@ -16,6 +16,7 @@ aisix-core = { path = "../aisix-core" }
 aisix-gateway = { path = "../aisix-gateway" }
 tokio.workspace = true
 async-trait.workspace = true
+async-stream = "0.3"
 futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -424,21 +424,31 @@ impl A2aBridge for HttpBridge {
     }
 
     async fn send_stream(&self, request: &serde_json::Value) -> Result<A2aEventStream, A2aError> {
-        // No per-request deadline here, deliberately. `timeout_ms` bounds one
-        // upstream operation, and a stream is not one: an A2A task legitimately
-        // runs for minutes or hours, pushing status updates the whole time.
-        // Applying the unary deadline would cut every such task off at 30s.
-        // Downstream liveness is the SSE keep-alive's job, not a hard cap's.
-        let resp = self
-            .prepare(
+        // `timeout_ms` bounds OPENING the stream, and nothing after that.
+        //
+        // The two halves need different treatment. Reading the stream must not
+        // be bounded: an A2A task legitimately runs for minutes or hours,
+        // pushing status updates the whole time, and the unary deadline would
+        // cut every such task off at 30s. But opening it must be, because until
+        // the response headers arrive there is no stream and no keep-alive —
+        // an upstream that accepts the connection and then says nothing would
+        // otherwise pin this request, and the quota slot it holds, forever.
+        // `reqwest`'s own `.timeout()` cannot express that: it covers reading
+        // the body too, so it would cap the stream's whole life.
+        let resp = tokio::time::timeout(
+            self.upstream.timeout,
+            self.prepare(
                 self.client
                     .post(&self.upstream.url)
                     .header(reqwest::header::ACCEPT, SSE_CONTENT_TYPE)
                     .json(request),
             )
-            .send()
-            .await
-            .map_err(|e| A2aError::Connect(e.to_string()))?;
+            .send(),
+        )
+        .await
+        .map_err(|_| A2aError::Connect("timed out opening the upstream stream".to_string()))?
+        .map_err(|e| A2aError::Connect(e.to_string()))?;
+
         if !resp.status().is_success() {
             // Status only — never proxy the upstream's error body, same as
             // `send`.
@@ -446,6 +456,32 @@ impl A2aBridge for HttpBridge {
                 "upstream returned HTTP {}",
                 resp.status().as_u16()
             )));
+        }
+
+        // A JSON-RPC error is delivered at HTTP 200 with an `error` member, so
+        // an agent that refuses a streaming call answers 200 + JSON, not SSE.
+        // Handing that body to the SSE reader would find no `data:` line and
+        // yield nothing: the caller would see an empty, apparently successful
+        // stream and the refusal would vanish. Relay it as the single event it
+        // is instead — the envelope still carries `error`, so nothing reads as
+        // a completed task.
+        let is_sse = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| {
+                v.trim_start()
+                    .to_ascii_lowercase()
+                    .starts_with(SSE_CONTENT_TYPE)
+            });
+        if !is_sse {
+            let bytes = read_capped(resp).await?;
+            let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| {
+                A2aError::Request(format!(
+                    "upstream answered a streaming call with neither SSE nor JSON: {e}"
+                ))
+            })?;
+            return Ok(Box::pin(futures::stream::once(async move { Ok(value) })));
         }
         Ok(Box::pin(sse_events(resp)))
     }
@@ -493,9 +529,15 @@ fn sse_events(resp: reqwest::Response) -> impl futures::Stream<Item = A2aEvent> 
                 }
             }
         }
-        // A body that ends without its final newline still carries an event.
-        if let Ok(Some(event)) = parse_sse_data_line(&pending) {
-            yield Ok(event);
+        // A body that ends without its final newline still carries an event —
+        // and if that last line is malformed it fails the stream like any
+        // other. Swallowing the error here would make a truncated task read as
+        // a clean end, which is the exact failure the per-line rule exists to
+        // prevent.
+        match parse_sse_data_line(&pending) {
+            Ok(Some(event)) => yield Ok(event),
+            Ok(None) => {}
+            Err(e) => yield Err(e),
         }
     }
 }

--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -56,6 +56,15 @@ const VERSION_HEADER: &str = "A2A-Version";
 /// each of these is tried against both bases — see [`HttpBridge::agent_card_urls`].
 const AGENT_CARD_PATHS: [&str; 2] = ["/.well-known/agent-card.json", "/.well-known/agent.json"];
 
+/// Content type of an A2A streaming response, asked for on every streaming call.
+const SSE_CONTENT_TYPE: &str = "text/event-stream";
+
+/// Hard cap on a SINGLE buffered SSE event. A stream has no total size — a task
+/// may push updates for hours — so the cap is per event: it bounds how much an
+/// upstream can accumulate without ever emitting a newline, which is the only
+/// way a streaming reader can be made to grow without limit.
+const MAX_SSE_EVENT_BYTES: usize = 16 * 1024 * 1024;
+
 /// Hard cap on an upstream response body the gateway will buffer. A registered
 /// agent is semi-trusted, but a compromised or misbehaving one must not be able
 /// to OOM the gateway with a multi-gigabyte (or unbounded streaming) response.
@@ -239,6 +248,13 @@ pub struct AgentCard {
     pub rest: serde_json::Map<String, serde_json::Value>,
 }
 
+/// One event read off an upstream A2A stream: the JSON-RPC envelope carried in
+/// a single SSE `data:` field, verbatim.
+pub type A2aEvent = Result<serde_json::Value, A2aError>;
+
+/// A stream of upstream A2A events.
+pub type A2aEventStream = futures::stream::BoxStream<'static, A2aEvent>;
+
 /// A governed client tunnel to a single upstream A2A agent.
 #[async_trait]
 pub trait A2aBridge: Send + Sync {
@@ -248,6 +264,14 @@ pub trait A2aBridge: Send + Sync {
     /// Forward a JSON-RPC 2.0 request (such as `message/send`) to the upstream
     /// service endpoint and return its JSON-RPC response verbatim.
     async fn send(&self, request: &serde_json::Value) -> Result<serde_json::Value, A2aError>;
+
+    /// Open a streaming JSON-RPC call (`message/stream`, `tasks/resubscribe`)
+    /// and yield each event the upstream pushes, as it arrives.
+    ///
+    /// The returned stream resolves only once the upstream has accepted the
+    /// call, so a refusal surfaces as an error here rather than as a stream
+    /// that opens and immediately dies.
+    async fn send_stream(&self, request: &serde_json::Value) -> Result<A2aEventStream, A2aError>;
 }
 
 /// The default [`A2aBridge`], built on the workspace HTTP client.
@@ -398,6 +422,99 @@ impl A2aBridge for HttpBridge {
         serde_json::from_slice::<serde_json::Value>(&bytes)
             .map_err(|e| A2aError::Request(format!("malformed JSON-RPC response: {e}")))
     }
+
+    async fn send_stream(&self, request: &serde_json::Value) -> Result<A2aEventStream, A2aError> {
+        // No per-request deadline here, deliberately. `timeout_ms` bounds one
+        // upstream operation, and a stream is not one: an A2A task legitimately
+        // runs for minutes or hours, pushing status updates the whole time.
+        // Applying the unary deadline would cut every such task off at 30s.
+        // Downstream liveness is the SSE keep-alive's job, not a hard cap's.
+        let resp = self
+            .prepare(
+                self.client
+                    .post(&self.upstream.url)
+                    .header(reqwest::header::ACCEPT, SSE_CONTENT_TYPE)
+                    .json(request),
+            )
+            .send()
+            .await
+            .map_err(|e| A2aError::Connect(e.to_string()))?;
+        if !resp.status().is_success() {
+            // Status only — never proxy the upstream's error body, same as
+            // `send`.
+            return Err(A2aError::Request(format!(
+                "upstream returned HTTP {}",
+                resp.status().as_u16()
+            )));
+        }
+        Ok(Box::pin(sse_events(resp)))
+    }
+}
+
+/// Parse an upstream SSE body into the JSON-RPC envelope of each `data:` field.
+///
+/// Deliberately minimal: A2A carries one JSON-RPC envelope per `data:` line, so
+/// `event:` / `id:` / `retry:` fields and comments are metadata this gateway has
+/// no use for and passes over. A `data:` line that is not JSON ends the stream
+/// with an error rather than being skipped — a caller that silently dropped
+/// events would report a truncated task as a complete one.
+fn sse_events(resp: reqwest::Response) -> impl futures::Stream<Item = A2aEvent> + Send {
+    async_stream::stream! {
+        let mut bytes = resp.bytes_stream();
+        let mut pending: Vec<u8> = Vec::new();
+        loop {
+            let chunk = match bytes.next().await {
+                Some(Ok(chunk)) => chunk,
+                Some(Err(e)) => {
+                    yield Err(A2aError::Request(e.to_string()));
+                    return;
+                }
+                None => break,
+            };
+            pending.extend_from_slice(&chunk);
+            // A single event is bounded even though the stream is not: an
+            // upstream that never emits a newline must not grow this buffer
+            // without limit.
+            if pending.len() > MAX_SSE_EVENT_BYTES {
+                yield Err(A2aError::Request(
+                    "upstream SSE event exceeded size cap".to_string(),
+                ));
+                return;
+            }
+            while let Some(newline) = pending.iter().position(|b| *b == b'\n') {
+                let line: Vec<u8> = pending.drain(..=newline).collect();
+                match parse_sse_data_line(&line) {
+                    Ok(Some(event)) => yield Ok(event),
+                    Ok(None) => {}
+                    Err(e) => {
+                        yield Err(e);
+                        return;
+                    }
+                }
+            }
+        }
+        // A body that ends without its final newline still carries an event.
+        if let Ok(Some(event)) = parse_sse_data_line(&pending) {
+            yield Ok(event);
+        }
+    }
+}
+
+/// Extract the JSON-RPC envelope from one SSE line, or `None` when the line
+/// carries no `data:` field.
+fn parse_sse_data_line(line: &[u8]) -> Result<Option<serde_json::Value>, A2aError> {
+    let text = std::str::from_utf8(line)
+        .map_err(|_| A2aError::Request("upstream SSE event was not valid UTF-8".to_string()))?;
+    let Some(payload) = text.trim_end_matches(['\r', '\n']).strip_prefix("data:") else {
+        return Ok(None);
+    };
+    let payload = payload.trim();
+    if payload.is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_str(payload)
+        .map(Some)
+        .map_err(|e| A2aError::Request(format!("malformed JSON-RPC event: {e}")))
 }
 
 #[cfg(test)]
@@ -518,6 +635,39 @@ mod tests {
                 "http://127.0.0.1:8080/.well-known/agent.json",
             ]
         );
+    }
+
+    #[test]
+    fn sse_lines_yield_only_data_payloads() {
+        let event = |line: &str| parse_sse_data_line(line.as_bytes()).unwrap();
+
+        assert_eq!(
+            event("data: {\"jsonrpc\":\"2.0\",\"id\":1}\n").unwrap()["id"],
+            1
+        );
+        // No space after the colon is equally valid SSE.
+        assert_eq!(event("data:{\"id\":2}\n").unwrap()["id"], 2);
+        assert_eq!(event("data: {\"id\":3}\r\n").unwrap()["id"], 3);
+
+        // Framing the gateway has no use for.
+        assert!(event("event: task-update\n").is_none());
+        assert!(event(": keep-alive comment\n").is_none());
+        assert!(event("id: 42\n").is_none());
+        assert!(event("retry: 1000\n").is_none());
+        assert!(event("\n").is_none());
+        assert!(event("data:\n").is_none());
+    }
+
+    #[test]
+    fn a_data_line_that_is_not_json_is_an_error_not_a_skip() {
+        // Silently dropping it would let a truncated task read as a complete
+        // one, which is worse than failing the stream.
+        let err = parse_sse_data_line(b"data: not-json\n").unwrap_err();
+        assert!(
+            matches!(err, A2aError::Request(ref m) if m.contains("malformed JSON-RPC event")),
+            "got {err:?}"
+        );
+        assert!(parse_sse_data_line(b"data: \xff\xfe\n").is_err());
     }
 
     #[test]

--- a/crates/aisix-a2a/src/lib.rs
+++ b/crates/aisix-a2a/src/lib.rs
@@ -22,7 +22,7 @@ pub mod bridge;
 pub mod error;
 
 pub use bridge::{
-    upstream_from_a2a_agent, A2aAuth, A2aBridge, A2aUpstream, AgentCard, HttpBridge,
-    DEFAULT_UPSTREAM_TIMEOUT,
+    upstream_from_a2a_agent, A2aAuth, A2aBridge, A2aEvent, A2aEventStream, A2aUpstream, AgentCard,
+    HttpBridge, DEFAULT_UPSTREAM_TIMEOUT,
 };
 pub use error::A2aError;

--- a/crates/aisix-a2a/tests/upstream_roundtrip.rs
+++ b/crates/aisix-a2a/tests/upstream_roundtrip.rs
@@ -429,3 +429,116 @@ async fn a_refused_stream_surfaces_before_any_event() {
     };
     assert!(matches!(err, A2aError::Request(_)), "got {err:?}");
 }
+
+/// An upstream that answers a streaming call the way an A2A agent refuses one:
+/// HTTP 200 with a JSON-RPC error body, not SSE.
+async fn spawn_json_refusing_agent() -> SocketAddr {
+    let app = Router::new().route(
+        "/a2a",
+        post(|| async {
+            Json(json!({
+                "jsonrpc": "2.0",
+                "id": "s",
+                "error": {"code": -32601, "message": "streaming not supported"}
+            }))
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    addr
+}
+
+#[tokio::test]
+async fn a_json_rpc_error_at_http_200_reaches_the_caller() {
+    use futures::StreamExt;
+
+    // A JSON-RPC error is delivered at HTTP 200, so an agent refusing a
+    // streaming call answers JSON rather than SSE. Handed to the SSE reader
+    // that body has no `data:` line, so the caller would get an empty,
+    // apparently successful stream and the refusal would vanish.
+    let addr = spawn_json_refusing_agent().await;
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None));
+
+    let events: Vec<Value> = bridge
+        .send_stream(&json!({"jsonrpc":"2.0","id":"s","method":"message/stream"}))
+        .await
+        .expect("a 200 answer opens")
+        .map(|e| e.expect("event parses"))
+        .collect()
+        .await;
+
+    assert_eq!(events.len(), 1, "the refusal must reach the caller");
+    assert_eq!(events[0]["error"]["code"], -32601);
+}
+
+#[tokio::test]
+async fn opening_a_stream_is_bounded_even_though_reading_it_is_not() {
+    // Until the response headers arrive there is no stream and no keep-alive,
+    // so an upstream that accepts the connection and then says nothing would
+    // pin this request — and the quota slot it holds — forever.
+    let addr = spawn_black_hole().await;
+    let bridge = HttpBridge::new(A2aUpstream {
+        timeout: Duration::from_millis(400),
+        ..upstream(format!("http://{addr}/a2a"), A2aAuth::None)
+    });
+
+    let started = Instant::now();
+    let Err(err) = bridge
+        .send_stream(&json!({"jsonrpc":"2.0","id":"s","method":"message/stream"}))
+        .await
+    else {
+        panic!("opening must not hang on an upstream that never answers");
+    };
+    let elapsed = started.elapsed();
+
+    assert!(matches!(err, A2aError::Connect(_)), "got {err:?}");
+    assert!(
+        elapsed < Duration::from_millis(2_000),
+        "opening took {elapsed:?}; it must be bounded by timeout_ms"
+    );
+}
+
+#[tokio::test]
+async fn a_malformed_final_line_fails_the_stream() {
+    use futures::StreamExt;
+
+    // The body ends mid-event with no trailing newline. Treating that as a
+    // clean end would let a truncated task read as a complete one.
+    async fn truncated() -> impl IntoResponse {
+        let chunks: Vec<Result<String, std::convert::Infallible>> = vec![Ok(
+            "data: {\"jsonrpc\":\"2.0\",\"result\":{\"seq\":1}}\n\ndata: {\"jsonrpc\"".to_string(),
+        )];
+        (
+            [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+            axum::body::Body::from_stream(futures::stream::iter(chunks)),
+        )
+    }
+    let app = Router::new().route("/a2a", post(truncated));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None));
+    let events: Vec<Result<Value, A2aError>> = bridge
+        .send_stream(&json!({"jsonrpc":"2.0","id":"s","method":"message/stream"}))
+        .await
+        .expect("stream opens")
+        .collect()
+        .await;
+
+    assert_eq!(events.len(), 2, "got {events:#?}");
+    assert!(events[0].is_ok());
+    assert!(
+        events[1].is_err(),
+        "a truncated trailing event must fail the stream, not end it quietly"
+    );
+}

--- a/crates/aisix-a2a/tests/upstream_roundtrip.rs
+++ b/crates/aisix-a2a/tests/upstream_roundtrip.rs
@@ -350,3 +350,82 @@ async fn the_card_fetch_deadline_covers_the_whole_candidate_walk() {
         "card fetch took {elapsed:?}; the candidate walk must share ONE deadline"
     );
 }
+
+/// An upstream that answers `message/stream` with a real SSE body, written in
+/// awkward chunks: two events in one write, an event split across two writes,
+/// and comment / `event:` framing in between. Proves the reader reassembles
+/// across chunk boundaries rather than assuming one chunk is one event.
+async fn spawn_streaming_agent() -> SocketAddr {
+    async fn stream(headers: HeaderMap) -> impl IntoResponse {
+        let seen_version = seen_version(&headers).to_string();
+        let accept = headers
+            .get("accept")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let chunks: Vec<Result<String, std::convert::Infallible>> = vec![
+            Ok(format!(
+                ": open\ndata: {{\"jsonrpc\":\"2.0\",\"id\":\"s\",\"result\":{{\"seq\":1,\"version\":{seen_version},\"accept\":\"{accept}\"}}}}\n\n\
+                 event: status-update\ndata: {{\"jsonrpc\":\"2.0\",\"id\":\"s\",\"result\":{{\"seq\":2}}}}\n\n"
+            )),
+            Ok("data: {\"jsonrpc\":\"2.0\",\"id\":\"s\",\"resu".to_string()),
+            Ok("lt\":{\"seq\":3,\"final\":true}}\n\n".to_string()),
+        ];
+        (
+            [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+            axum::body::Body::from_stream(futures::stream::iter(chunks)),
+        )
+    }
+
+    let app = Router::new().route("/a2a", post(stream));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    addr
+}
+
+#[tokio::test]
+async fn streams_events_as_they_arrive_across_chunk_boundaries() {
+    use futures::StreamExt;
+
+    let addr = spawn_streaming_agent().await;
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None));
+
+    let events: Vec<Value> = bridge
+        .send_stream(&json!({"jsonrpc":"2.0","id":"s","method":"message/stream"}))
+        .await
+        .expect("stream opens")
+        .map(|e| e.expect("event parses"))
+        .collect()
+        .await;
+
+    assert_eq!(events.len(), 3, "got {events:#?}");
+    assert_eq!(events[0]["result"]["seq"], 1);
+    assert_eq!(events[1]["result"]["seq"], 2);
+    // Reassembled from two writes that split mid-JSON.
+    assert_eq!(events[2]["result"]["seq"], 3);
+    assert_eq!(events[2]["result"]["final"], true);
+    // A streaming call is still an A2A call: it announces its version and asks
+    // for the streaming content type.
+    assert_eq!(events[0]["result"]["version"], "1.0");
+    assert_eq!(events[0]["result"]["accept"], "text/event-stream");
+}
+
+#[tokio::test]
+async fn a_refused_stream_surfaces_before_any_event() {
+    let addr = spawn_path_hosted_agent().await;
+    // `/nope` is the catch-all 405, so the upstream refuses the call outright.
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/nope"), A2aAuth::None));
+
+    let Err(err) = bridge
+        .send_stream(&json!({"jsonrpc":"2.0","id":"s","method":"message/stream"}))
+        .await
+    else {
+        panic!("a refused stream must not open");
+    };
+    assert!(matches!(err, A2aError::Request(_)), "got {err:?}");
+}

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -18,6 +18,15 @@
 //! The request body is forwarded verbatim to the upstream agent, so the caller
 //! speaks whichever A2A wire version the agent is pinned to; the gateway does
 //! not translate between the 0.3 and 1.0 formats here.
+//!
+//! `message/stream` and `tasks/resubscribe` are relayed as a live SSE stream —
+//! each event reaches the caller as the agent pushes it, which is the whole
+//! point of those methods: an A2A task runs for minutes or hours and reports
+//! progress as it goes. Those calls carry no upstream deadline for the same
+//! reason (the unary `timeout_ms` would cut every long task off), so downstream
+//! liveness rests on the SSE keep-alive. Their usage event and quota
+//! reservation are tied to the stream's real lifetime via a drop guard, so a
+//! caller that walks away mid-task is still accounted for.
 
 use std::time::{Duration, Instant};
 
@@ -27,6 +36,7 @@ use axum::body::to_bytes;
 use axum::extract::{Request, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
+use futures::StreamExt;
 use serde::Deserialize;
 
 use crate::auth::AuthenticatedKey;
@@ -166,9 +176,9 @@ async fn dispatch(
     let rpc_id = peek.and_then(|p| p.id);
 
     // Reuse the LLM path's rate-limit + budget gate. The reservation is held
-    // for the call and dropped after (an A2A call carries no token cost yet).
-    // On 429 / budget-exceeded this returns before the upstream is contacted.
-    let _reservation = match crate::quota::enforce(state, &auth, None).await {
+    // for the call (an A2A call carries no token cost yet). On 429 /
+    // budget-exceeded this returns before the upstream is contacted.
+    let reservation = match crate::quota::enforce(state, &auth, None).await {
         Ok(reservation) => reservation,
         Err(err) => {
             let response = err.into_response();
@@ -184,6 +194,22 @@ async fn dispatch(
             return response;
         }
     };
+
+    if is_streaming_method(&method) {
+        return dispatch_stream(
+            auth,
+            agent,
+            state,
+            request_id,
+            upstream,
+            value,
+            &method,
+            rpc_id,
+            reservation,
+        )
+        .await;
+    }
+    let _reservation = reservation;
 
     let bridge = HttpBridge::new(upstream);
     let started = Instant::now();
@@ -218,6 +244,141 @@ async fn dispatch(
             a2a_error_response(rpc_id, status, &err.to_string())
         }
     }
+}
+
+/// JSON-RPC methods whose response is an SSE event stream rather than one
+/// envelope. Both spellings are listed because the body is forwarded verbatim:
+/// the caller speaks whichever wire version its agent is pinned to, and 1.0
+/// names the same two methods in PascalCase.
+fn is_streaming_method(method: &str) -> bool {
+    matches!(
+        method,
+        "message/stream" | "SendStreamingMessage" | "tasks/resubscribe" | "SubscribeToTask"
+    )
+}
+
+/// Fires the A2A usage event once a streamed call is over, and owns the quota
+/// reservation for that whole span.
+///
+/// Both jobs have to happen on drop rather than at the end of a loop: a caller
+/// walking away mid-task drops the stream without it ever completing, and that
+/// is the ordinary case for a long-running A2A task, not an edge one. Emitting
+/// from `Drop` means such a call still lands in usage, and the caller's
+/// rate-limit slot stays occupied for as long as the stream is really open —
+/// not merely until the response headers went out.
+struct StreamUsageOnDrop {
+    state: ProxyState,
+    auth: AuthenticatedKey,
+    request_id: String,
+    agent: String,
+    method: String,
+    started: Instant,
+    /// What to record for the call. Starts at the status already sent to the
+    /// caller and is downgraded if the stream later faults — once the headers
+    /// are out, the usage event is the only place that can say so.
+    status: u16,
+    _reservation: aisix_ratelimit::MultiReservation,
+}
+
+impl Drop for StreamUsageOnDrop {
+    fn drop(&mut self) {
+        // A panic is already unwinding; emitting here would at best double-report
+        // and at worst panic again while panicking.
+        if std::thread::panicking() {
+            return;
+        }
+        emit_a2a_usage(
+            &self.state,
+            &self.auth,
+            &self.request_id,
+            &self.agent,
+            &self.method,
+            self.status,
+            self.started.elapsed(),
+        );
+    }
+}
+
+/// Forward a streaming JSON-RPC call as SSE, event by event.
+///
+/// The gateway does not buffer the task: each event the upstream pushes is
+/// relayed as it arrives, which is the entire point of `message/stream` — a
+/// caller watches a long-running task progress instead of waiting for it.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_stream(
+    auth: AuthenticatedKey,
+    agent: &str,
+    state: &ProxyState,
+    request_id: &str,
+    upstream: aisix_a2a::A2aUpstream,
+    request: serde_json::Value,
+    method: &str,
+    rpc_id: Option<serde_json::Value>,
+    reservation: aisix_ratelimit::MultiReservation,
+) -> Response {
+    let started = Instant::now();
+    let bridge = HttpBridge::new(upstream);
+    let events = match bridge.send_stream(&request).await {
+        Ok(events) => events,
+        // The upstream refused before any event: the headers have not gone out,
+        // so this is still an ordinary error response rather than a stream.
+        Err(err) => {
+            let status = a2a_error_status(&err);
+            tracing::warn!(agent = %agent, error = %err, "A2A upstream stream failed to open");
+            drop(reservation);
+            emit_a2a_usage(
+                state,
+                &auth,
+                request_id,
+                agent,
+                method,
+                status.as_u16(),
+                started.elapsed(),
+            );
+            return a2a_error_response(rpc_id, status, &err.to_string());
+        }
+    };
+
+    let mut guard = StreamUsageOnDrop {
+        state: state.clone(),
+        auth,
+        request_id: request_id.to_string(),
+        agent: agent.to_string(),
+        method: method.to_string(),
+        started,
+        status: StatusCode::OK.as_u16(),
+        _reservation: reservation,
+    };
+    let agent_label = agent.to_string();
+
+    let sse = async_stream::stream! {
+        let mut events = events;
+        while let Some(event) = events.next().await {
+            match event {
+                Ok(value) => yield Ok::<_, std::convert::Infallible>(
+                    axum::response::sse::Event::default().data(value.to_string()),
+                ),
+                Err(err) => {
+                    // Mid-stream the status line is long gone, so the failure
+                    // can only be told to the caller in-band. Relay it as a
+                    // JSON-RPC error event and stop, rather than cutting the
+                    // connection and leaving a truncated task looking complete.
+                    tracing::warn!(agent = %agent_label, error = %err, "A2A stream failed mid-flight");
+                    guard.status = a2a_error_status(&err).as_u16();
+                    yield Ok(axum::response::sse::Event::default()
+                        .data(a2a_error_envelope(rpc_id.clone(), &err.to_string()).to_string()));
+                    break;
+                }
+            }
+        }
+        drop(guard);
+    };
+
+    let mut response = axum::response::Sse::new(sse);
+    if let Some(interval) = crate::sse_keepalive::interval() {
+        response = response.keep_alive(axum::response::sse::KeepAlive::new().interval(interval));
+    }
+    response.into_response()
 }
 
 /// Serve the upstream agent's card at `/a2a/:agent/.well-known/agent-card.json`,
@@ -341,12 +502,18 @@ fn a2a_error_response(
     status: StatusCode,
     message: &str,
 ) -> Response {
-    let body = serde_json::json!({
+    (status, axum::Json(a2a_error_envelope(id, message))).into_response()
+}
+
+/// The JSON-RPC error object itself, for the streaming path — mid-stream there
+/// is no status line left to carry the failure, so the same envelope has to
+/// travel as an event.
+fn a2a_error_envelope(id: Option<serde_json::Value>, message: &str) -> serde_json::Value {
+    serde_json::json!({
         "jsonrpc": "2.0",
         "id": id.unwrap_or(serde_json::Value::Null),
         "error": { "code": -32000, "message": message },
-    });
-    (status, axum::Json(body)).into_response()
+    })
 }
 
 /// Emit a usage event for a single A2A call into the same sink as LLM usage.
@@ -440,6 +607,32 @@ mod tests {
     fn gateway_base_is_none_without_any_authority() {
         let origin_form = axum::http::Uri::from_static("/a2a/x/.well-known/agent-card.json");
         assert_eq!(gateway_base(&origin_form, &HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn streaming_methods_are_recognised_in_both_spellings() {
+        // The body is forwarded verbatim, so the caller uses whichever spelling
+        // its wire version defines. Missing one spelling would silently route a
+        // 1.0 caller's stream through the buffering path.
+        for method in [
+            "message/stream",
+            "SendStreamingMessage",
+            "tasks/resubscribe",
+            "SubscribeToTask",
+        ] {
+            assert!(is_streaming_method(method), "{method} must stream");
+        }
+        for method in [
+            "message/send",
+            "SendMessage",
+            "tasks/get",
+            "GetTask",
+            "tasks/cancel",
+            "agent/getAuthenticatedExtendedCard",
+            "",
+        ] {
+            assert!(!is_streaming_method(method), "{method} must not stream");
+        }
     }
 
     #[test]

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -257,15 +257,19 @@ fn is_streaming_method(method: &str) -> bool {
     )
 }
 
-/// Fires the A2A usage event once a streamed call is over, and owns the quota
-/// reservation for that whole span.
+/// Fires the A2A usage event once a streamed call is over, and owns the
+/// concurrency hold for that whole span.
 ///
 /// Both jobs have to happen on drop rather than at the end of a loop: a caller
 /// walking away mid-task drops the stream without it ever completing, and that
 /// is the ordinary case for a long-running A2A task, not an edge one. Emitting
-/// from `Drop` means such a call still lands in usage, and the caller's
-/// rate-limit slot stays occupied for as long as the stream is really open —
-/// not merely until the response headers went out.
+/// from `Drop` means such a call still lands in usage.
+///
+/// The hold is a [`StreamConcurrencyGuard`], the same type the LLM streaming
+/// path uses. Releasing the reservation at handler return instead would free
+/// the caller's slot the moment the response headers went out, letting a key
+/// capped at N run many more than N concurrent streams — #450, on a second
+/// endpoint.
 struct StreamUsageOnDrop {
     state: ProxyState,
     auth: AuthenticatedKey,
@@ -277,7 +281,7 @@ struct StreamUsageOnDrop {
     /// caller and is downgraded if the stream later faults — once the headers
     /// are out, the usage event is the only place that can say so.
     status: u16,
-    _reservation: aisix_ratelimit::MultiReservation,
+    _concurrency: aisix_ratelimit::StreamConcurrencyGuard,
 }
 
 impl Drop for StreamUsageOnDrop {
@@ -347,7 +351,7 @@ async fn dispatch_stream(
         method: method.to_string(),
         started,
         status: StatusCode::OK.as_u16(),
-        _reservation: reservation,
+        _concurrency: reservation.into_stream_hold(),
     };
     let agent_label = agent.to_string();
 
@@ -607,6 +611,80 @@ mod tests {
     fn gateway_base_is_none_without_any_authority() {
         let origin_form = axum::http::Uri::from_static("/a2a/x/.well-known/agent-card.json");
         assert_eq!(gateway_base(&origin_form, &HeaderMap::new()), None);
+    }
+
+    /// A local agent that answers `message/stream` with SSE and then keeps the
+    /// connection open, so a test can drop the response mid-stream the way a
+    /// caller walking away does.
+    async fn spawn_open_ended_stream_agent() -> String {
+        use axum::response::IntoResponse;
+        let app = axum::Router::new().route(
+            "/a2a",
+            axum::routing::post(|| async {
+                let chunks: Vec<Result<String, std::convert::Infallible>> = vec![Ok(
+                    "data: {\"jsonrpc\":\"2.0\",\"result\":{\"seq\":1}}\n\n".to_string(),
+                )];
+                (
+                    [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                    axum::body::Body::from_stream(futures::stream::iter(chunks)),
+                )
+                    .into_response()
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app.into_make_service())
+                .await
+                .unwrap();
+        });
+        format!("http://{addr}/a2a")
+    }
+
+    #[tokio::test]
+    async fn a_stream_dropped_mid_flight_still_emits_usage() {
+        use aisix_obs::{UsageEvent, UsageSink};
+
+        // The drop guard is the whole reason a streamed call is accounted for:
+        // a caller walking away mid-task drops the body without the stream ever
+        // completing, and for a long-running A2A task that is the ordinary
+        // ending, not an edge case. Without the guard the call would simply
+        // never appear in usage.
+        let agent_url = spawn_open_ended_stream_agent().await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<UsageEvent>(8);
+        let handle = SnapshotHandle::new(snapshot_with(&agent_url, true, serde_json::json!(["*"])));
+        let hub = Arc::new(aisix_gateway::Hub::new());
+        let state = ProxyState::new(handle, hub, &proxy_cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let router = build_router(state);
+
+        let response = router
+            .oneshot(
+                HttpRequest::post("/a2a/invoice")
+                    .header("host", "gw.example.com")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {TOKEN}"))
+                    .body(Body::from(
+                        r#"{"jsonrpc":"2.0","id":"s","method":"message/stream"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .expect("router responds");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Never read the body — this is the client disconnecting.
+        drop(response);
+        // Let the dropped stream's guard run.
+        tokio::task::yield_now().await;
+
+        let event = rx
+            .try_recv()
+            .expect("a usage event must be emitted even when the caller never reads the stream");
+        assert_eq!(event.inbound_protocol, "a2a");
+        assert_eq!(event.a2a_agent_name, "invoice");
+        assert_eq!(event.a2a_method, "message/stream");
     }
 
     #[test]

--- a/tests/e2e/src/cases/a2a-gateway-e2e.test.ts
+++ b/tests/e2e/src/cases/a2a-gateway-e2e.test.ts
@@ -245,6 +245,70 @@ describe("a2a gateway e2e: /a2a/{agent}", () => {
     expect(JSON.stringify(reply.json)).not.toContain("upstream-secret-tok");
   });
 
+  test("relays message/stream as live SSE rather than one buffered reply", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    const res = await fetch(`${app.proxyUrl}/a2a/invoices`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${KEY_ALLOWED}`,
+        "content-type": "application/json",
+        accept: "text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "stream-1",
+        method: "message/stream",
+        params: {
+          message: {
+            role: "user",
+            parts: [{ kind: "text", text: "invoice 42" }],
+            messageId: "m-s",
+          },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    // Read event by event and timestamp each one. A buffered implementation
+    // delivers all three at once; a relayed one spaces them out the way the
+    // agent emitted them.
+    const events: Array<{ at: number; json: Record<string, any> }> = [];
+    const started = Date.now();
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffered += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buffered.indexOf("\n")) !== -1) {
+        const line = buffered.slice(0, nl);
+        buffered = buffered.slice(nl + 1);
+        if (line.startsWith("data:")) {
+          const payload = line.slice(5).trim();
+          if (payload) {
+            events.push({ at: Date.now() - started, json: JSON.parse(payload) });
+          }
+        }
+      }
+    }
+
+    expect(events.map((e) => e.json.result.seq)).toEqual([1, 2, 3]);
+    expect(events.every((e) => e.json.id === "stream-1")).toBe(true);
+    expect(events[2].json.result.status.state).toBe("completed");
+    // A streaming call is still an A2A call: the gateway announced the pinned
+    // version and asked the agent for the streaming content type.
+    expect(events[0].json.result.sawVersion).toBe("1.0");
+    expect(events[0].json.result.sawAccept).toContain("text/event-stream");
+    // The stub sleeps 30ms between events. Buffering would collapse those
+    // gaps; relaying preserves them.
+    expect(events[2].at).toBeGreaterThan(events[0].at);
+  });
+
   test("gates on the per-agent ACL and on agent existence", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 

--- a/tests/e2e/src/cases/a2a-gateway-e2e.test.ts
+++ b/tests/e2e/src/cases/a2a-gateway-e2e.test.ts
@@ -304,9 +304,14 @@ describe("a2a gateway e2e: /a2a/{agent}", () => {
     // version and asked the agent for the streaming content type.
     expect(events[0].json.result.sawVersion).toBe("1.0");
     expect(events[0].json.result.sawAccept).toContain("text/event-stream");
-    // The stub sleeps 30ms between events. Buffering would collapse those
-    // gaps; relaying preserves them.
-    expect(events[2].at).toBeGreaterThan(events[0].at);
+    // The discriminating assertion. The stub pauses 120ms before each of the
+    // last two events, so a relayed stream spreads first-to-last over well over
+    // 100ms, while a buffered one hands all three over together and the spread
+    // collapses to parse time. `> 0` would not separate the two: three JSON
+    // parses can straddle a millisecond boundary. The floor sits far above that
+    // and far below the 240ms the stub spends, with room for the client not
+    // beginning to read the instant the headers land.
+    expect(events[2].at - events[0].at).toBeGreaterThan(60);
   });
 
   test("gates on the per-agent ACL and on agent existence", async (ctx) => {

--- a/tests/e2e/src/harness/upstream-a2a.ts
+++ b/tests/e2e/src/harness/upstream-a2a.ts
@@ -44,6 +44,16 @@ export interface A2aUpstreamOptions {
 
 const PATH_PREFIX = "/v3/agents/serve/tenant-42";
 
+/**
+ * Pause between streamed events. Sized so the arrival spread a relayed stream
+ * produces dwarfs the noise a buffered one would show: a client does not begin
+ * reading the instant the headers land (connection setup and the fetch
+ * implementation's own buffering cost tens of ms), which compresses the
+ * measured spread. A small gap leaves that compression the same order as the
+ * signal; this makes the signal an order larger instead.
+ */
+const STREAM_GAP_MS = 120;
+
 /** JSON-RPC methods this stub answers with an SSE stream, in both spellings. */
 const STREAMING_METHODS = new Set([
   "message/stream",
@@ -192,10 +202,10 @@ async function handle(
         sawAccept: header("accept"),
       }),
     );
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await new Promise((resolve) => setTimeout(resolve, STREAM_GAP_MS));
     res.write("event: status-update\n");
     res.write(envelope({ kind: "status-update", taskId: "task-e2e-stream", seq: 2 }));
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await new Promise((resolve) => setTimeout(resolve, STREAM_GAP_MS));
     res.write(
       envelope({
         kind: "task",

--- a/tests/e2e/src/harness/upstream-a2a.ts
+++ b/tests/e2e/src/harness/upstream-a2a.ts
@@ -44,6 +44,14 @@ export interface A2aUpstreamOptions {
 
 const PATH_PREFIX = "/v3/agents/serve/tenant-42";
 
+/** JSON-RPC methods this stub answers with an SSE stream, in both spellings. */
+const STREAMING_METHODS = new Set([
+  "message/stream",
+  "SendStreamingMessage",
+  "tasks/resubscribe",
+  "SubscribeToTask",
+]);
+
 /**
  * A stub upstream A2A agent: serves an agent card and answers JSON-RPC, while
  * recording what the gateway actually sent it — the wire version it announced
@@ -154,6 +162,49 @@ async function handle(
       ],
       skills: [{ id: "invoice", name: "Process invoice", tags: ["billing"] }],
     });
+    return;
+  }
+
+  if (
+    req.method === "POST" &&
+    path === ctx.servicePath &&
+    typeof body?.method === "string" &&
+    STREAMING_METHODS.has(body.method)
+  ) {
+    // A real SSE body, written as three separate flushes with a comment and an
+    // `event:` field mixed in, so a test can tell a relayed stream from a
+    // buffered one: the gateway must forward each event as it lands.
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    const envelope = (result: Record<string, unknown>) =>
+      `data: ${JSON.stringify({ jsonrpc: "2.0", id: body?.id ?? null, result })}\n\n`;
+    res.write(": open\n\n");
+    res.write(
+      envelope({
+        kind: "status-update",
+        taskId: "task-e2e-stream",
+        status: { state: "working" },
+        seq: 1,
+        sawVersion: header("a2a-version"),
+        sawAccept: header("accept"),
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    res.write("event: status-update\n");
+    res.write(envelope({ kind: "status-update", taskId: "task-e2e-stream", seq: 2 }));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    res.write(
+      envelope({
+        kind: "task",
+        id: "task-e2e-stream",
+        status: { state: "completed" },
+        seq: 3,
+      }),
+    );
+    res.end();
     return;
   }
 


### PR DESCRIPTION
`message/stream` and `tasks/resubscribe` were routed through the unary path: the whole SSE body was buffered, then parsed as one JSON document. That does not merely delay events — an SSE body is not valid JSON, so the parse failed and the call came back `502`. The two methods whose entire purpose is watching a long-running task progress were the two that could not be used at all.

## What changed

`A2aBridge` grows `send_stream`. It opens the call with `Accept: text/event-stream` and yields each `data:` envelope as it arrives:

- events are reassembled **across chunk boundaries** — an upstream write does not align with an event
- `event:` / `id:` / `retry:` fields and comments are passed over; A2A carries one JSON-RPC envelope per `data:` line and the rest is framing the gateway has no use for
- a `data:` line that is not JSON **ends the stream with an error** rather than being skipped, because silently dropping events would let a truncated task read as a complete one
- a single event is size-capped even though the stream is not — that bounds the one way a streaming reader can be made to grow without limit (an upstream that never emits a newline)

Both method spellings are recognised, since the body is forwarded verbatim and a 1.0 caller sends `SendStreamingMessage` / `SubscribeToTask`.

## No upstream deadline on the streaming path

`timeout_ms` bounds one upstream operation, and a stream is not one: an A2A task legitimately runs for minutes or hours, pushing status updates the whole time, so applying the unary deadline would cut every such task off at 30s. Downstream liveness rests on the SSE keep-alive that the LLM streaming paths already use. The unary path is unchanged.

## Governance spans the real call, not just the headers

The quota reservation and the usage event are owned by a drop guard:

- the caller's rate-limit slot stays held for as long as the stream is genuinely open, not merely until the response headers went out
- a caller that walks away mid-task still lands in usage — for a long-running task that is the ordinary case, not an edge one
- a failure after the headers are out cannot change the status line, so it is relayed in-band as a JSON-RPC error event and recorded on the usage event, which is the only place left that can carry it

Auth, per-agent ACL, budget and the usage sink are otherwise reached exactly as before.

## Tests

Crate-level: SSE parsing units (both `data:` spellings, `\r\n`, framing that is skipped, non-JSON and non-UTF-8 rejected), a roundtrip against an upstream that writes two events in one chunk and splits a third mid-JSON, and a refused stream surfacing as an error before any event opens.

E2E: the gateway is driven against an agent that flushes three events 30ms apart with a comment and an `event:` field mixed in; the test reads the response body incrementally and asserts the events arrive separately and in order, that the pinned version was announced and the streaming content type asked for. Confirmed to fail on the buffered path.