### PR TITLE
bench: onthebench-style rig harness for same-rig baselines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ coverage/
 
 # Filled-in real-cloud objstore credentials (template: real-cloud.env.example)
 /crates/aisix-obs/tests/real-cloud.env
+
+# Local benchmark results collected by bench/onthebench/bench.sh
+/bench-results/

--- a/bench/onthebench/README.md
+++ b/bench/onthebench/README.md
@@ -1,0 +1,74 @@
+# onthebench-style rig harness
+
+Reproduces the public onthebench AI-gateway benchmark methodology on our own
+`m7g.4xlarge` (Graviton3, 16 cores, single NUMA node), so performance work can
+be measured on the same rig shape the public board uses — and so any published
+figure can be checked against a box we control.
+
+## One command
+
+```sh
+bench/onthebench/bench.sh                       # default rig, results under ./bench-results/
+bench/onthebench/bench.sh ubuntu@<rig-ip> /path/to/results
+```
+
+The tree you run it from is the tree that gets measured. The script rsyncs the
+source to the rig, provisions it (idempotently), builds a native release
+binary, runs every load point, and rsyncs the results back. The rig is
+disposable; a rebuilt box only needs passwordless ssh + sudo and this harness.
+
+## Methodology
+
+Replicates the published onthebench setup (https://onthebench.ai/gateways/performance):
+
+- **Core split** — three disjoint pinned groups via `taskset`: gateway `0-3`
+  (4 cores), load generator `4-9` (6), mock upstream `10-15` (6). Neither
+  instrument can starve the gateway or bottleneck it.
+- **Instruments** — the prebuilt, pinned `otb` load generator and `mock`
+  upstream from the public benchmark rig release (engine pin
+  `f3adbb1315b26129f5e317af5279decefb1cea8f`, tag `engine-v1`, from
+  https://github.com/GetBusbar/benchmarking). `rig-setup.sh` verifies their
+  sha256 so a re-provisioned rig either runs the byte-identical instrument or
+  fails loudly. These are the same binaries behind the public board and the
+  same `otb loadgen` used for the api7/aisix#891 / #902 tables.
+- **Default shipped config** — a setting may appear only if the process cannot
+  run the benchmark without it. The full claim set (in `run-baseline.sh`):
+  `resources_file` (boot: standalone source, else aisix demands etcd),
+  `proxy.addr` (bind: the port the harness drives), `admin.admin_keys` (boot:
+  config refuses to load without one), plus a resources file wiring the mock
+  as the only upstream and minting the single client key (boot: aisix has no
+  anonymous mode). Everything else — thread-per-core, worker count, telemetry —
+  is whatever the defaults do.
+- **Load grid** — fixed concurrency, the api7/aisix#891 grid: c=16/32/128
+  against the 0-delay mock, c=768 against the 10ms-TTFT mock
+  (`MOCK_TTFT_MS=10`). 25s windows, 5s warmup per point, ≥4 repetitions;
+  a window with any failed request (`fail`, `rigrefused`, `budgetexceeded`,
+  `spawnfailed`) is recorded but marked invalid, and the point retries until
+  4 valid windows or 8 attempts.
+- **Rig floor** — the load generator driving the mock directly (c=128 0-delay,
+  c=768 10ms), so every gateway number can be checked against the instrument's
+  own ceiling.
+- **Recorded per window** — rps, fail/ok counts, p50/p99 (µs, from otb),
+  gateway CPU% (`/proc/<pid>/stat` utime+stime across the window), gateway
+  peak RSS (VmRSS sampled at 5 Hz), the raw otb stats line. Idle RSS and
+  VmHWM are in the metadata, alongside commit, binary sha256, instrument
+  sha256s, core split, kernel, and the full method parameters.
+- **Flamegraph** — one on-CPU flamegraph at the c=128 saturation point per run
+  (`perf record -F 997 --call-graph dwarf` → inferno), the api7/aisix#847
+  workflow. `rig-setup.sh` sets `kernel.perf_event_paranoid=1` (session-scoped,
+  reverts on reboot) so an unprivileged run can sample its own process, and
+  `run-baseline.sh` refuses a stripped binary before wasting a run.
+
+## Output
+
+One directory per run: `results.jsonl` (one JSON object per measured window,
+`kind` gateway/floor), `meta.json`, `flamegraph-c128.svg`, the generated
+config files, and the gateway/mock logs.
+
+## Deviations from stock defaults, and why
+
+- `ulimit -n 65536` in the run shell: c=768 plus per-worker upstream pools
+  exceeds the 1024 default soft limit; without it the run measures fd
+  exhaustion, not the gateway.
+- `kernel.perf_event_paranoid=1`: flamegraph sampling only; not active during
+  measurement windows other than the dedicated flamegraph window.

--- a/bench/onthebench/README.md
+++ b/bench/onthebench/README.md
@@ -36,10 +36,10 @@ Replicates the published onthebench setup (https://onthebench.ai/gateways/perfor
   same `otb loadgen` used for the api7/aisix#891 / #902 tables.
 - **Default shipped config** — a setting may appear only if the process cannot
   run the benchmark without it. The full claim set (in `run-baseline.sh`):
-  `resources_file` (boot: standalone source, else aisix demands etcd),
+  `resources_file` (boot: standalone source, else AISIX demands etcd),
   `proxy.addr` (bind: the port the harness drives), `admin.admin_keys` (boot:
   config refuses to load without one), plus a resources file wiring the mock
-  as the only upstream and minting the single client key (boot: aisix has no
+  as the only upstream and minting the single client key (boot: AISIX has no
   anonymous mode). Everything else — thread-per-core, worker count, telemetry —
   is whatever the defaults do.
 - **Load grid** — fixed concurrency, the api7/aisix#891 grid: c=16/32/128
@@ -47,10 +47,12 @@ Replicates the published onthebench setup (https://onthebench.ai/gateways/perfor
   (`MOCK_TTFT_MS=10`). 25s windows, 5s warmup per point, ≥4 repetitions;
   a window with any failed request (`fail`, `rigrefused`, `budgetexceeded`,
   `spawnfailed`) is recorded but marked invalid, and the point retries until
-  4 valid windows or 8 attempts.
+  4 valid windows or 8 attempts. A run in which any point ends incomplete
+  exits nonzero so it can never be mistaken for a baseline.
 - **Rig floor** — the load generator driving the mock directly (c=128 0-delay,
   c=768 10ms), so every gateway number can be checked against the instrument's
-  own ceiling.
+  own ceiling; two valid windows per floor point, under the same
+  record-mark-retry validity policy as the gateway points.
 - **Recorded per window** — rps, fail/ok counts, p50/p99 (µs, from otb),
   gateway CPU% (`/proc/<pid>/stat` utime+stime across the window), gateway
   peak RSS (VmRSS sampled at 5 Hz), the raw otb stats line. Idle RSS and
@@ -65,8 +67,10 @@ Replicates the published onthebench setup (https://onthebench.ai/gateways/perfor
 ## Output
 
 One directory per run: `results.jsonl` (one JSON object per measured window,
-`kind` gateway/floor), `meta.json`, `flamegraph-c128.svg`, the generated
-config files, and the gateway/mock logs.
+`kind` gateway/floor), `meta.json`, the generated config files, and the
+gateway/mock logs. `flamegraph-c128.svg` is present when Inferno rendering
+succeeded; on a rendering failure the run keeps `perf.data` instead, so the
+SVG can be produced off-rig.
 
 ## Deviations from stock defaults, and why
 

--- a/bench/onthebench/README.md
+++ b/bench/onthebench/README.md
@@ -8,9 +8,12 @@ figure can be checked against a box we control.
 ## One command
 
 ```sh
-bench/onthebench/bench.sh                       # default rig, results under ./bench-results/
 bench/onthebench/bench.sh ubuntu@<rig-ip> /path/to/results
+BENCH_RIG=ubuntu@<rig-ip> bench/onthebench/bench.sh   # results under ./bench-results/
 ```
+
+The rig address is deliberately never committed: this is a public repository,
+and a committed default would publish a live passwordless-sudo box.
 
 The tree you run it from is the tree that gets measured. The script rsyncs the
 source to the rig, provisions it (idempotently), builds a native release
@@ -54,7 +57,7 @@ Replicates the published onthebench setup (https://onthebench.ai/gateways/perfor
   VmHWM are in the metadata, alongside commit, binary sha256, instrument
   sha256s, core split, kernel, and the full method parameters.
 - **Flamegraph** — one on-CPU flamegraph at the c=128 saturation point per run
-  (`perf record -F 997 --call-graph dwarf` → inferno), the api7/aisix#847
+  (`perf record -F 499 --call-graph dwarf` → inferno), the api7/aisix#847
   workflow. `rig-setup.sh` sets `kernel.perf_event_paranoid=1` (session-scoped,
   reverts on reboot) so an unprivileged run can sample its own process, and
   `run-baseline.sh` refuses a stripped binary before wasting a run.
@@ -72,3 +75,12 @@ config files, and the gateway/mock logs.
   exhaustion, not the gateway.
 - `kernel.perf_event_paranoid=1`: flamegraph sampling only; not active during
   measurement windows other than the dedicated flamegraph window.
+
+## Trust posture
+
+Provisioning executes third-party bytes as a passwordless-sudo user: rustup
+via its official `curl | sh` installer, and the prebuilt instrument binaries
+from the public benchmark release. The sha256 pins freeze reproducibility,
+not trustworthiness — the accepted trade is that the rig is a disposable,
+single-purpose box holding no secrets beyond its own ssh host key, rebuilt at
+will. Do not point this harness at a machine that matters.

--- a/bench/onthebench/bench.sh
+++ b/bench/onthebench/bench.sh
@@ -3,13 +3,17 @@
 # collect results. Run from any checkout; the tree you run it from is the tree
 # that gets measured.
 #
-#   bench/onthebench/bench.sh [user@rig-host] [local-results-dir]
+#   bench/onthebench/bench.sh <user@rig-host> [local-results-dir]
+#   BENCH_RIG=user@rig-host bench/onthebench/bench.sh
 #
 # The rig only needs to be a fresh Ubuntu 24.04 arm64 box with passwordless
-# ssh + sudo; rig-setup.sh provisions everything else idempotently.
+# ssh + sudo; rig-setup.sh provisions everything else idempotently. The rig
+# address is never committed here: this is a public repository, and a default
+# target would publish a live passwordless-sudo box.
 set -euo pipefail
 
-RIG="${1:-ubuntu@54.179.77.47}"
+RIG="${1:-${BENCH_RIG:-}}"
+[ -n "$RIG" ] || { echo "usage: bench.sh <user@rig-host> [results-dir] (or export BENCH_RIG)"; exit 2; }
 DEST="${2:-bench-results}"
 
 SRC_LOCAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -20,7 +24,7 @@ RUNID="$(date -u +%Y%m%d-%H%M%S)-${COMMIT:0:7}"
 
 echo "== rsync source -> $RIG (commit ${COMMIT:0:12}) =="
 rsync -az --delete --exclude=target --exclude=.git --exclude=docs/superpowers \
-    "$SRC_LOCAL"/ "$RIG":aisix-src/
+    --exclude=bench-results "$SRC_LOCAL"/ "$RIG":aisix-src/
 
 echo "== provision rig =="
 ssh "$RIG" 'bash aisix-src/bench/onthebench/rig-setup.sh'
@@ -32,10 +36,15 @@ echo "== run baseline ($RUNID) =="
 # BENCH_-prefixed, never AISIX_-prefixed: aisix reads AISIX_* environment
 # variables as config overrides, so an AISIX_COMMIT in the gateway's
 # environment becomes an unknown top-level config field and refuses boot.
+RUN_RC=0
 ssh "$RIG" "BENCH_SRC_COMMIT=$COMMIT BENCH_SRC_DIRTY=$DIRTY \
-    bash aisix-src/bench/onthebench/run-baseline.sh \"\$HOME/aisix-src\" \"\$HOME/bench-results/$RUNID\""
+    bash aisix-src/bench/onthebench/run-baseline.sh \"\$HOME/aisix-src\" \"\$HOME/bench-results/$RUNID\"" ||
+    RUN_RC=$?
 
+# Collect whatever the run produced even when it aborted mid-way: partial
+# results with their metadata beat stranded results on a disposable rig.
 echo "== collect results =="
 mkdir -p "$DEST/$RUNID"
-rsync -az "$RIG":"bench-results/$RUNID/" "$DEST/$RUNID/"
+rsync -az "$RIG":"bench-results/$RUNID/" "$DEST/$RUNID/" || true
 echo "results: $DEST/$RUNID"
+exit "$RUN_RC"

--- a/bench/onthebench/bench.sh
+++ b/bench/onthebench/bench.sh
@@ -19,18 +19,24 @@ DEST="${2:-bench-results}"
 SRC_LOCAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMMIT=$(git -C "$SRC_LOCAL" rev-parse HEAD)
 DIRTY=$(git -C "$SRC_LOCAL" status --porcelain | wc -l)
-RUNID="$(date -u +%Y%m%d-%H%M%S)-${COMMIT:0:7}"
+# The pid suffix keeps two same-commit runs started in the same second from
+# sharing a remote output directory and merging their results.
+RUNID="$(date -u +%Y%m%d-%H%M%S)-${COMMIT:0:7}-$$"
 [ "$DIRTY" = 0 ] || echo "WARNING: measuring a dirty tree ($DIRTY changed files); recorded in metadata" >&2
 
 echo "== rsync source -> $RIG (commit ${COMMIT:0:12}) =="
-rsync -az --delete --exclude=target --exclude=.git --exclude=docs/superpowers \
-    --exclude=bench-results "$SRC_LOCAL"/ "$RIG":aisix-src/
+# The gitignore filter keeps every ignored file off the rig — .env files and
+# other gitignored local material may hold credentials, and none of it belongs
+# in the measured tree. Untracked-but-not-ignored files still sync, preserving
+# "the tree you run it from is the tree that gets measured".
+rsync -az --delete --exclude=.git --filter=':- .gitignore' \
+    "$SRC_LOCAL"/ "$RIG":aisix-src/
 
 echo "== provision rig =="
 ssh "$RIG" 'bash aisix-src/bench/onthebench/rig-setup.sh'
 
 echo "== build (native release on the rig) =="
-ssh "$RIG" 'source ~/.cargo/env && cd aisix-src && cargo build --release --bin aisix'
+ssh "$RIG" 'source ~/.cargo/env && cd aisix-src && cargo build --locked --release --bin aisix'
 
 echo "== run baseline ($RUNID) =="
 # BENCH_-prefixed, never AISIX_-prefixed: aisix reads AISIX_* environment

--- a/bench/onthebench/bench.sh
+++ b/bench/onthebench/bench.sh
@@ -29,7 +29,10 @@ echo "== build (native release on the rig) =="
 ssh "$RIG" 'source ~/.cargo/env && cd aisix-src && cargo build --release --bin aisix'
 
 echo "== run baseline ($RUNID) =="
-ssh "$RIG" "AISIX_COMMIT=$COMMIT AISIX_DIRTY=$DIRTY \
+# BENCH_-prefixed, never AISIX_-prefixed: aisix reads AISIX_* environment
+# variables as config overrides, so an AISIX_COMMIT in the gateway's
+# environment becomes an unknown top-level config field and refuses boot.
+ssh "$RIG" "BENCH_SRC_COMMIT=$COMMIT BENCH_SRC_DIRTY=$DIRTY \
     bash aisix-src/bench/onthebench/run-baseline.sh \"\$HOME/aisix-src\" \"\$HOME/bench-results/$RUNID\""
 
 echo "== collect results =="

--- a/bench/onthebench/bench.sh
+++ b/bench/onthebench/bench.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# One command: build -> deploy to the rig -> pin -> run every load point ->
+# collect results. Run from any checkout; the tree you run it from is the tree
+# that gets measured.
+#
+#   bench/onthebench/bench.sh [user@rig-host] [local-results-dir]
+#
+# The rig only needs to be a fresh Ubuntu 24.04 arm64 box with passwordless
+# ssh + sudo; rig-setup.sh provisions everything else idempotently.
+set -euo pipefail
+
+RIG="${1:-ubuntu@54.179.77.47}"
+DEST="${2:-bench-results}"
+
+SRC_LOCAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMMIT=$(git -C "$SRC_LOCAL" rev-parse HEAD)
+DIRTY=$(git -C "$SRC_LOCAL" status --porcelain | wc -l)
+RUNID="$(date -u +%Y%m%d-%H%M%S)-${COMMIT:0:7}"
+[ "$DIRTY" = 0 ] || echo "WARNING: measuring a dirty tree ($DIRTY changed files); recorded in metadata" >&2
+
+echo "== rsync source -> $RIG (commit ${COMMIT:0:12}) =="
+rsync -az --delete --exclude=target --exclude=.git --exclude=docs/superpowers \
+    "$SRC_LOCAL"/ "$RIG":aisix-src/
+
+echo "== provision rig =="
+ssh "$RIG" 'bash aisix-src/bench/onthebench/rig-setup.sh'
+
+echo "== build (native release on the rig) =="
+ssh "$RIG" 'source ~/.cargo/env && cd aisix-src && cargo build --release --bin aisix'
+
+echo "== run baseline ($RUNID) =="
+ssh "$RIG" "AISIX_COMMIT=$COMMIT AISIX_DIRTY=$DIRTY \
+    bash aisix-src/bench/onthebench/run-baseline.sh \"\$HOME/aisix-src\" \"\$HOME/bench-results/$RUNID\""
+
+echo "== collect results =="
+mkdir -p "$DEST/$RUNID"
+rsync -az "$RIG":"bench-results/$RUNID/" "$DEST/$RUNID/"
+echo "results: $DEST/$RUNID"

--- a/bench/onthebench/rig-setup.sh
+++ b/bench/onthebench/rig-setup.sh
@@ -22,9 +22,13 @@ MOCK_SHA256="c32b9ff470eddf87d477098dac6e19a6c75eeef6e594dfc57005310d69e9049d"
 
 echo "== apt packages (build deps + perf) =="
 sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -q
+# Two transactions on purpose: apt is all-or-nothing, so bundling the
+# kernel-versioned linux-tools package (absent for some AWS kernels) with the
+# build deps would silently drop ALL of them and fail much later in the build.
 sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
     git curl build-essential pkg-config libssl-dev protobuf-compiler \
-    linux-tools-common "linux-tools-$(uname -r)" 2>/dev/null ||
+    python3 linux-tools-common
+sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q "linux-tools-$(uname -r)" ||
     sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q linux-tools-aws
 perf --version
 
@@ -50,7 +54,7 @@ mkdir -p "$TOOLS"
 fetch_pinned() {
     local name="$1" sha="$2" path="$TOOLS/$1"
     if [ ! -x "$path" ] || ! echo "$sha  $path" | sha256sum -c --quiet 2>/dev/null; then
-        curl -sL -o "$path" "$REL/${name}-arm64"
+        curl -fsSL -o "$path" "$REL/${name}-arm64"
         chmod +x "$path"
     fi
     echo "$sha  $path" | sha256sum -c --quiet ||

--- a/bench/onthebench/rig-setup.sh
+++ b/bench/onthebench/rig-setup.sh
@@ -33,9 +33,20 @@ sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q "linux-tools-$(unam
 perf --version
 
 echo "== rust toolchain =="
+# Pinned, checksum-verified rustup-init instead of the curl|sh installer: the
+# same rule as the bench instruments — every executed third-party artifact is
+# a fixed byte sequence or the setup fails loudly.
+RUSTUP_VERSION="1.28.2"
+RUSTUP_SHA256="e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c"
 if ! command -v "$HOME/.cargo/bin/cargo" >/dev/null 2>&1; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
-        sh -s -- -y --default-toolchain none
+    tmp=$(mktemp -d)
+    curl -fsSL -o "$tmp/rustup-init" \
+        "https://static.rust-lang.org/rustup/archive/$RUSTUP_VERSION/aarch64-unknown-linux-gnu/rustup-init"
+    echo "$RUSTUP_SHA256  $tmp/rustup-init" | sha256sum -c --quiet ||
+        { echo "setup: rustup-init does not match its pinned sha256"; exit 1; }
+    chmod +x "$tmp/rustup-init"
+    "$tmp/rustup-init" -y --default-toolchain none
+    rm -rf "$tmp"
 fi
 # shellcheck disable=SC1091
 source "$HOME/.cargo/env"
@@ -46,8 +57,12 @@ SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 (cd "$SRC_ROOT" && cargo --version)
 
 echo "== inferno (flamegraph rendering: perf script -> SVG) =="
-command -v inferno-flamegraph >/dev/null 2>&1 ||
-    (cd "$SRC_ROOT" && cargo install --locked inferno)
+# Version-pinned like every other instrument: --locked alone pins inferno's
+# dependencies, not inferno itself, and two rigs rendering with different
+# inferno versions would produce non-comparable artifacts.
+INFERNO_VERSION="0.12.8"
+inferno-flamegraph --version 2>/dev/null | grep -qF "$INFERNO_VERSION" ||
+    (cd "$SRC_ROOT" && cargo install --locked --force --version "$INFERNO_VERSION" inferno)
 
 echo "== pinned bench instruments (otb loadgen + mock upstream) =="
 mkdir -p "$TOOLS"

--- a/bench/onthebench/rig-setup.sh
+++ b/bench/onthebench/rig-setup.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Idempotent rig provisioning for the onthebench-style baseline harness.
+#
+# Installs everything a fresh m7g.4xlarge (Ubuntu 24.04, arm64) needs to build
+# aisix and run bench/onthebench/run-baseline.sh. Safe to re-run; a rebuilt rig
+# only needs this script to become a rig again.
+#
+# The load generator (otb) and the mock upstream are the PREBUILT, PINNED
+# instruments from the public onthebench benchmark rig release — the same
+# binaries every entrant on the public board is measured with, and the same
+# "otb loadgen" used for the api7/aisix#891 and #902 tables. The engine pin
+# behind the release tag is commit f3adbb1315b26129f5e317af5279decefb1cea8f
+# (tag engine-v1) of https://github.com/GetBusbar/benchmarking; the sha256s
+# below freeze the exact bytes so a re-provisioned rig either gets the
+# identical instrument or fails loudly.
+set -euo pipefail
+
+TOOLS="$HOME/bench-tools"
+REL="https://github.com/GetBusbar/benchmarking/releases/download/rig"
+OTB_SHA256="913702e09392846f5eb82ca749e5fa2d86357e818c0bbb1d047913c1ded0f82e"
+MOCK_SHA256="c32b9ff470eddf87d477098dac6e19a6c75eeef6e594dfc57005310d69e9049d"
+
+echo "== apt packages (build deps + perf) =="
+sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -q
+sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
+    git curl build-essential pkg-config libssl-dev protobuf-compiler \
+    linux-tools-common "linux-tools-$(uname -r)" 2>/dev/null ||
+    sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q linux-tools-aws
+perf --version
+
+echo "== rust toolchain =="
+if ! command -v "$HOME/.cargo/bin/cargo" >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+        sh -s -- -y --default-toolchain none
+fi
+# The actual toolchain version comes from the repo's rust-toolchain.toml the
+# first time cargo runs inside the source tree; nothing to pin here.
+# shellcheck disable=SC1091
+source "$HOME/.cargo/env"
+
+echo "== inferno (flamegraph rendering: perf script -> SVG) =="
+command -v inferno-flamegraph >/dev/null 2>&1 || cargo install --locked inferno
+
+echo "== pinned bench instruments (otb loadgen + mock upstream) =="
+mkdir -p "$TOOLS"
+fetch_pinned() {
+    local name="$1" sha="$2" path="$TOOLS/$1"
+    if [ ! -x "$path" ] || ! echo "$sha  $path" | sha256sum -c --quiet 2>/dev/null; then
+        curl -sL -o "$path" "$REL/${name}-arm64"
+        chmod +x "$path"
+    fi
+    echo "$sha  $path" | sha256sum -c --quiet ||
+        { echo "setup: $name does not match its pinned sha256 - refusing a divergent instrument"; exit 1; }
+}
+fetch_pinned otb "$OTB_SHA256"
+fetch_pinned mock "$MOCK_SHA256"
+
+echo "== perf sampling permission (session-scoped, documented in README) =="
+sudo -n sysctl -q kernel.perf_event_paranoid=1
+
+echo "setup: done"

--- a/bench/onthebench/rig-setup.sh
+++ b/bench/onthebench/rig-setup.sh
@@ -33,13 +33,17 @@ if ! command -v "$HOME/.cargo/bin/cargo" >/dev/null 2>&1; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
         sh -s -- -y --default-toolchain none
 fi
-# The actual toolchain version comes from the repo's rust-toolchain.toml the
-# first time cargo runs inside the source tree; nothing to pin here.
 # shellcheck disable=SC1091
 source "$HOME/.cargo/env"
+# No default toolchain is configured; every cargo invocation below runs inside
+# the source tree so the repo's rust-toolchain.toml pins the version. This also
+# front-loads the toolchain download out of the build step.
+SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+(cd "$SRC_ROOT" && cargo --version)
 
 echo "== inferno (flamegraph rendering: perf script -> SVG) =="
-command -v inferno-flamegraph >/dev/null 2>&1 || cargo install --locked inferno
+command -v inferno-flamegraph >/dev/null 2>&1 ||
+    (cd "$SRC_ROOT" && cargo install --locked inferno)
 
 echo "== pinned bench instruments (otb loadgen + mock upstream) =="
 mkdir -p "$TOOLS"

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# On-rig baseline runner, replicating the onthebench methodology on our own box:
+# 16-core m7g.4xlarge split into three disjoint pinned groups — gateway 4 cores,
+# load generator 6, mock upstream 6 — default shipped config, local mock, fixed
+# concurrency grid, 25s windows, >=4 valid (fail=0) repetitions per point.
+#
+# Usage: run-baseline.sh <aisix-src-dir> <out-dir>
+#
+# Load points (ttft_ms:concurrency): 0:16 0:32 0:128 10:768 — the same grid as
+# the api7/aisix#891 A/B tables. The rig floor (loadgen driving the mock
+# directly) is recorded for both mock variants so gateway numbers can always be
+# checked against the instrument's own ceiling. One on-CPU flamegraph is taken
+# at the c=128 saturation point (perf -> inferno, the #847 workflow).
+set -euo pipefail
+
+SRC="${1:?usage: run-baseline.sh <aisix-src-dir> <out-dir>}"
+OUT="${2:?usage: run-baseline.sh <aisix-src-dir> <out-dir>}"
+
+GW_CORES="0-3"; LOAD_CORES="4-9"; MOCK_CORES="10-15"
+GW_PORT=3000; MOCK_PORT=8000
+WINDOW=25; WARMUP=5; REPS=4; MAX_TRIES=8
+GRID="0:16 0:32 0:128 10:768"
+FLOOR_REPS=2
+BODY='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}],"max_tokens":16}'
+CHAT_PATH="/v1/chat/completions"
+# Same header shape the public board's engine sends for the OpenAI dialect.
+export OTB_LOADGEN_HEADERS='[["authorization","Bearer bench-token"]]'
+
+BIN="$SRC/target/release/aisix"
+TOOLS="$HOME/bench-tools"
+CLK_TCK=$(getconf CLK_TCK)
+
+mkdir -p "$OUT"
+RESULTS="$OUT/results.jsonl"; : > "$RESULTS"
+
+GW_PID=""; MOCK_PID=""; SAMPLER_PID=""
+cleanup() {
+    [ -n "$SAMPLER_PID" ] && kill "$SAMPLER_PID" 2>/dev/null || true
+    [ -n "$GW_PID" ] && kill "$GW_PID" 2>/dev/null || true
+    [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---- helpers ----------------------------------------------------------------
+
+field() { # field <key> <stats-line>  -> value or empty
+    sed -n "s/.*\b$1=\([^ ]*\).*/\1/p" <<<"$2"
+}
+
+cpu_ticks() { # utime+stime of the whole process, in clock ticks
+    awk '{print $14+$15}' "/proc/$1/stat"
+}
+
+rss_kb() { awk '/VmRSS/{print $2}' "/proc/$1/status"; }
+
+wait_http_200() { # wait_http_200 <url> <label> [max_s]
+    local url="$1" label="$2" max="${3:-30}" code
+    for _ in $(seq 1 $((max * 2))); do
+        code=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+            -H 'authorization: Bearer bench-token' -H 'content-type: application/json' \
+            -d "$BODY" "$url" || true)
+        [ "$code" = "200" ] && return 0
+        sleep 0.5
+    done
+    echo "FATAL: $label not answering 200 at $url (last code: $code)" >&2
+    return 1
+}
+
+start_mock() { # start_mock <ttft_ms>
+    [ -n "$MOCK_PID" ] && { kill "$MOCK_PID" 2>/dev/null || true; wait "$MOCK_PID" 2>/dev/null || true; }
+    MOCK_TTFT_MS="$1" taskset -c "$MOCK_CORES" "$TOOLS/mock" -port "$MOCK_PORT" \
+        >> "$OUT/mock.log" 2>&1 &
+    MOCK_PID=$!
+    wait_http_200 "http://127.0.0.1:$MOCK_PORT$CHAT_PATH" "mock (ttft=${1}ms)"
+}
+
+loadgen() { # loadgen <ip:port> <conc> <dur>  -> stats line on stdout
+    taskset -c "$LOAD_CORES" "$TOOLS/otb" loadgen "$1" "$CHAT_PATH" "$2" "$3" "$BODY"
+}
+
+# One measured window against the gateway: CPU% and peak RSS sampled around the
+# otb window, one JSON line appended to results.jsonl. Prints 1 if valid.
+measured_window() { # measured_window <point> <ttft> <conc> <rep>
+    local point="$1" ttft="$2" conc="$3" rep="$4"
+    local rssfile="$OUT/.rss.$$" line t0 t1 ticks0 ticks1 elapsed cpu_pct rss_peak
+    local rps fail ok p50 p99 rigref budget spawn valid
+
+    ( max=0; while :; do
+          v=$(awk '/VmRSS/{print $2}' "/proc/$GW_PID/status" 2>/dev/null || true)
+          v="${v:-0}"
+          if [ "$v" -gt "$max" ]; then max="$v"; echo "$max" > "$rssfile"; fi
+          sleep 0.2
+      done ) & SAMPLER_PID=$!
+
+    ticks0=$(cpu_ticks "$GW_PID"); t0=$(date +%s.%N)
+    line=$(loadgen "127.0.0.1:$GW_PORT" "$conc" "$WINDOW")
+    t1=$(date +%s.%N); ticks1=$(cpu_ticks "$GW_PID")
+    kill "$SAMPLER_PID" 2>/dev/null || true; wait "$SAMPLER_PID" 2>/dev/null || true; SAMPLER_PID=""
+    rss_peak=$(cat "$rssfile" 2>/dev/null || echo 0); rm -f "$rssfile"
+
+    elapsed=$(awk -v a="$t0" -v b="$t1" 'BEGIN{print b-a}')
+    cpu_pct=$(awk -v d=$((ticks1 - ticks0)) -v hz="$CLK_TCK" -v e="$elapsed" \
+        'BEGIN{printf "%.1f", d/hz/e*100}')
+
+    rps=$(field rps "$line"); fail=$(field fail "$line"); ok=$(field ok "$line")
+    p50=$(field p50us "$line"); p99=$(field p99us "$line")
+    rigref=$(field rigrefused "$line"); budget=$(field budgetexceeded "$line"); spawn=$(field spawnfailed "$line")
+    valid=true
+    [ "${fail:-1}" = "0" ] && [ "${rigref:-0}" = "0" ] && [ "${budget:-0}" = "0" ] \
+        && [ "${spawn:-0}" = "0" ] || valid=false
+
+    printf '{"kind":"gateway","point":"%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"ok":%s,"p50_us":%s,"p99_us":%s,"gw_cpu_pct":%s,"gw_rss_peak_kb":%s,"window_s":%s,"elapsed_s":%.2f,"otb_line":"%s"}\n' \
+        "$point" "$ttft" "$conc" "$rep" "$valid" "${rps:-null}" "${fail:-null}" "${ok:-null}" \
+        "${p50:-null}" "${p99:-null}" "$cpu_pct" "$rss_peak" "$WINDOW" "$elapsed" "$line" >> "$RESULTS"
+
+    echo "  [$point rep=$rep] rps=$rps fail=$fail p50us=$p50 p99us=$p99 cpu=${cpu_pct}% rss=${rss_peak}kB valid=$valid" >&2
+    [ "$valid" = true ] && echo 1 || echo 0
+}
+
+# ---- sanity -----------------------------------------------------------------
+
+[ -x "$BIN" ] || { echo "FATAL: $BIN missing - build first"; exit 1; }
+[ "$(nproc)" = 16 ] || { echo "FATAL: expected a 16-core box, got $(nproc)"; exit 1; }
+SYMS=$(nm "$BIN" 2>/dev/null | grep -c ' [tT] ' || true)
+[ "$SYMS" -gt 100 ] || { echo "FATAL: $BIN has $SYMS text symbols - stripped binary, flamegraph would be unreadable"; exit 1; }
+ulimit -n 65536
+
+# ---- config: the default-shipped-config claim set ---------------------------
+# Every line exists because the process cannot run the benchmark without it:
+#   resources_file  boot (standalone source; without it aisix demands etcd)
+#   proxy.addr      bind (the port the harness drives)
+#   admin.admin_keys boot (config refuses to load with no admin key)
+# The resources file wires the mock as the only upstream and mints the one
+# client key; aisix has no anonymous mode, so a key is boot-required.
+cat > "$OUT/config.yaml" <<EOF
+resources_file: "$OUT/resources.yaml"
+proxy:
+  addr: "0.0.0.0:$GW_PORT"
+admin:
+  admin_keys:
+    - "aisix-admin-dummy"
+EOF
+cat > "$OUT/resources.yaml" <<EOF
+_format_version: "1"
+provider_keys:
+  - display_name: mock-openai
+    provider: openai
+    adapter: openai
+    api_base: "http://127.0.0.1:$MOCK_PORT/v1"
+    api_key: "sk-mock"
+models:
+  - display_name: gpt-4o-mini
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: mock-openai
+api_keys:
+  - display_name: bench
+    key_env: BENCH_AISIX_KEY
+    allowed_models: ["*"]
+EOF
+
+# ---- rig floor (0-delay): loadgen -> mock directly, gateway not yet running --
+
+floor_point() { # floor_point <ttft> <conc>  (mock must already run with that ttft)
+    local ttft="$1" conc="$2" rep line
+    loadgen "127.0.0.1:$MOCK_PORT" "$conc" 5 > /dev/null   # warmup
+    for rep in $(seq 1 "$FLOOR_REPS"); do
+        line=$(loadgen "127.0.0.1:$MOCK_PORT" "$conc" "$WINDOW")
+        printf '{"kind":"floor","point":"floor-ttft%s-c%s","ttft_ms":%s,"conc":%s,"rep":%s,"rps":%s,"fail":%s,"p50_us":%s,"p99_us":%s,"otb_line":"%s"}\n' \
+            "$ttft" "$conc" "$ttft" "$conc" "$rep" "$(field rps "$line")" "$(field fail "$line")" \
+            "$(field p50us "$line")" "$(field p99us "$line")" "$line" >> "$RESULTS"
+        echo "  [floor ttft=$ttft c=$conc rep=$rep] $line" >&2
+    done
+}
+
+echo "== mock (0-delay) + rig floor ==" >&2
+start_mock 0
+floor_point 0 128
+
+# ---- gateway: default shipped config, pinned to its 4 cores -----------------
+
+echo "== gateway ==" >&2
+BENCH_AISIX_KEY=bench-token taskset -c "$GW_CORES" "$BIN" --config "$OUT/config.yaml" \
+    > "$OUT/gateway.log" 2>&1 &
+GW_PID=$!
+wait_http_200 "http://127.0.0.1:$GW_PORT$CHAT_PATH" "gateway"
+sleep 3
+RSS_IDLE=$(rss_kb "$GW_PID")
+TPC_WORKERS=$(ps -T -p "$GW_PID" | grep -c 'tpc-' || true)
+echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB tpc_workers=$TPC_WORKERS" >&2
+
+# ---- 0-delay grid -----------------------------------------------------------
+
+run_point() { # run_point <ttft> <conc>
+    local ttft="$1" conc="$2" point="ttft$1-c$2" valid_n=0 try=0
+    echo "== point $point ==" >&2
+    loadgen "127.0.0.1:$GW_PORT" "$conc" "$WARMUP" > /dev/null
+    while [ "$valid_n" -lt "$REPS" ] && [ "$try" -lt "$MAX_TRIES" ]; do
+        try=$((try + 1))
+        valid_n=$((valid_n + $(measured_window "$point" "$ttft" "$conc" "$try")))
+    done
+    [ "$valid_n" -ge "$REPS" ] ||
+        echo "WARNING: $point got only $valid_n valid reps in $MAX_TRIES tries" >&2
+}
+
+for spec in $GRID; do
+    ttft="${spec%%:*}"; conc="${spec##*:}"
+    [ "$ttft" = 0 ] || continue
+    run_point "$ttft" "$conc"
+done
+
+# ---- flamegraph at the c=128 saturation point (#847 workflow) ---------------
+
+echo "== flamegraph (c=128, 0-delay) ==" >&2
+loadgen "127.0.0.1:$GW_PORT" 128 45 > "$OUT/flamegraph-window.txt" & LOAD_BG=$!
+sleep 5
+perf record -F 997 --call-graph dwarf,16384 -p "$GW_PID" -o "$OUT/perf.data" -- sleep 25 \
+    >> "$OUT/perf.log" 2>&1 || echo "WARNING: perf record failed" >&2
+wait "$LOAD_BG" || true
+if [ -s "$OUT/perf.data" ]; then
+    perf script -i "$OUT/perf.data" 2>> "$OUT/perf.log" |
+        inferno-collapse-perf > "$OUT/flamegraph-c128.folded" 2>> "$OUT/perf.log"
+    inferno-flamegraph --title "aisix c=128 0-delay (4 pinned cores)" \
+        < "$OUT/flamegraph-c128.folded" > "$OUT/flamegraph-c128.svg" 2>> "$OUT/perf.log"
+    rm -f "$OUT/perf.data"
+fi
+
+# ---- 10ms-TTFT leg: mock restarted with the delay, floor then gateway -------
+
+echo "== mock (10ms TTFT) + floor ==" >&2
+start_mock 10
+floor_point 10 768
+
+for spec in $GRID; do
+    ttft="${spec%%:*}"; conc="${spec##*:}"
+    [ "$ttft" = 10 ] || continue
+    run_point "$ttft" "$conc"
+done
+
+# ---- metadata ---------------------------------------------------------------
+
+RSS_HWM=$(awk '/VmHWM/{print $2}' "/proc/$GW_PID/status")
+cat > "$OUT/meta.json" <<EOF
+{
+  "commit": "${AISIX_COMMIT:-unknown}",
+  "dirty_files": ${AISIX_DIRTY:-0},
+  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "rig": {
+    "host": "$(hostname)",
+    "kernel": "$(uname -r)",
+    "arch": "$(uname -m)",
+    "nproc": $(nproc),
+    "mem_total_kb": $(awk '/MemTotal/{print $2}' /proc/meminfo),
+    "cpu_part": "$(awk -F': ' '/CPU part/{print $2; exit}' /proc/cpuinfo)"
+  },
+  "cores": {"gateway": "$GW_CORES", "load": "$LOAD_CORES", "mock": "$MOCK_CORES"},
+  "instruments": {
+    "engine_pin": "f3adbb1315b26129f5e317af5279decefb1cea8f (engine-v1)",
+    "otb_sha256": "$(sha256sum "$TOOLS/otb" | cut -d' ' -f1)",
+    "mock_sha256": "$(sha256sum "$TOOLS/mock" | cut -d' ' -f1)"
+  },
+  "method": {
+    "window_s": $WINDOW, "warmup_s": $WARMUP, "reps": $REPS,
+    "grid": "$GRID", "body": $(printf '%s' "$BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
+    "path": "$CHAT_PATH", "clk_tck": $CLK_TCK, "nofile": $(ulimit -n)
+  },
+  "gateway": {
+    "binary_sha256": "$(sha256sum "$BIN" | cut -d' ' -f1)",
+    "rss_idle_kb": $RSS_IDLE, "rss_hwm_kb": $RSS_HWM,
+    "tpc_workers": $TPC_WORKERS
+  }
+}
+EOF
+
+echo "== done: $OUT ==" >&2

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -37,6 +37,10 @@ BODY_JSON=$(printf '%s' "$BODY" | python3 -c 'import json,sys; print(json.dumps(
 
 mkdir -p "$OUT"
 RESULTS="$OUT/results.jsonl"; : > "$RESULTS"
+# Flipped to 1 when any point ends with fewer valid windows than promised; the
+# run still completes and collects, but exits nonzero so an incomplete run can
+# never be mistaken for a baseline.
+HARNESS_RC=0
 
 GW_PID=""; MOCK_PID=""; SAMPLER_PID=""
 cleanup() {
@@ -141,6 +145,22 @@ measured_window() { # measured_window <point> <ttft> <conc> <rep>
 
 [ -x "$BIN" ] || { echo "FATAL: $BIN missing - build first"; exit 1; }
 [ "$(nproc)" = 16 ] || { echo "FATAL: expected a 16-core box, got $(nproc)"; exit 1; }
+[ "$(uname -m)" = "aarch64" ] || { echo "FATAL: expected an aarch64 rig, got $(uname -m)"; exit 1; }
+# Instance identity via IMDSv2: numbers from this harness are read as
+# m7g.4xlarge baselines, so a wrong instance type must refuse to measure.
+# IMDS being unreachable (non-EC2 lab box) is recorded rather than fatal.
+IMDS_TOKEN=$(curl -s --max-time 2 -X PUT \
+    -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' \
+    http://169.254.169.254/latest/api/token || true)
+INSTANCE_TYPE=$(curl -s --max-time 2 -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" \
+    http://169.254.169.254/latest/meta-data/instance-type || true)
+if [ -n "$INSTANCE_TYPE" ]; then
+    [ "$INSTANCE_TYPE" = "m7g.4xlarge" ] ||
+        { echo "FATAL: this core split is calibrated for m7g.4xlarge, got $INSTANCE_TYPE"; exit 1; }
+else
+    INSTANCE_TYPE="unknown"
+    echo "WARNING: no IMDS answer; recording instance_type=unknown" >&2
+fi
 SYMS=$(nm "$BIN" 2>/dev/null | grep -c ' [tT] ' || true)
 [ "$SYMS" -gt 100 ] || { echo "FATAL: $BIN has $SYMS text symbols - stripped binary, flamegraph would be unreadable"; exit 1; }
 ulimit -n 65536
@@ -182,19 +202,26 @@ EOF
 # ---- rig floor (0-delay): loadgen -> mock directly, gateway not yet running --
 
 floor_point() { # floor_point <ttft> <conc>  (mock must already run with that ttft)
-    local ttft="$1" conc="$2" rep line fail valid
+    # Same validity policy as gateway points, scaled to FLOOR_REPS: an invalid
+    # window is recorded, marked, and retried, and can never stand as the rig
+    # reference on its own.
+    local ttft="$1" conc="$2" valid_n=0 try=0 line fail valid
     loadgen "127.0.0.1:$MOCK_PORT" "$conc" 5 > /dev/null || true   # warmup
-    for rep in $(seq 1 "$FLOOR_REPS"); do
+    while [ "$valid_n" -lt "$FLOOR_REPS" ] && [ "$try" -lt "$MAX_TRIES" ]; do
+        try=$((try + 1))
         line=$(loadgen "127.0.0.1:$MOCK_PORT" "$conc" "$WINDOW") || line=""
         line=${line//[\"\\]/ }
         fail=$(field fail "$line")
         valid=true; [ "${fail:-1}" = "0" ] || valid=false
+        [ "$valid" = true ] && valid_n=$((valid_n + 1))
         printf '{"kind":"floor","point":"floor-ttft%s-c%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"p50_us":%s,"p99_us":%s,"otb_line":"%s"}\n' \
-            "$ttft" "$conc" "$ttft" "$conc" "$rep" "$valid" "$(field rps "$line")" "${fail:-null}" \
+            "$ttft" "$conc" "$ttft" "$conc" "$try" "$valid" "$(field rps "$line")" "${fail:-null}" \
             "$(field p50us "$line")" "$(field p99us "$line")" "$line" >> "$RESULTS"
-        echo "  [floor ttft=$ttft c=$conc rep=$rep] valid=$valid $line" >&2
-        [ "$valid" = true ] || echo "WARNING: floor window ttft=$ttft c=$conc rep=$rep had failures - reference ceiling tainted" >&2
+        echo "  [floor ttft=$ttft c=$conc rep=$try] valid=$valid $line" >&2
     done
+    [ "$valid_n" -ge "$FLOOR_REPS" ] ||
+        { echo "WARNING: floor ttft=$ttft c=$conc got only $valid_n valid windows in $MAX_TRIES tries" >&2
+          HARNESS_RC=1; }
 }
 
 echo "== mock (0-delay) + rig floor ==" >&2
@@ -216,10 +243,12 @@ RSS_IDLE=$(rss_kb "$GW_PID")
 TPC_WORKERS=$(ps -T -p "$GW_PID" | grep -c 'tpc-' || true)
 echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB tpc_workers=$TPC_WORKERS" >&2
 # Serving-mode self-check, asserted rather than merely recorded: measuring the
-# shared-runtime fallback while calling it the default would be a silently
-# wrong baseline (thread-per-core is the shipped default on Linux).
-[ "$TPC_WORKERS" -ge 1 ] ||
-    { echo "FATAL: no tpc- worker threads - gateway is not in thread-per-core mode"; exit 1; }
+# shared-runtime fallback (or a wrong worker count) while calling it the
+# default would be a silently wrong baseline. The expected count is derived
+# from the gateway's own affinity mask, not hardcoded.
+GW_NPROC=$(taskset -c "$GW_CORES" nproc)
+[ "$TPC_WORKERS" -eq "$GW_NPROC" ] ||
+    { echo "FATAL: expected $GW_NPROC tpc- workers under the $GW_CORES affinity, got $TPC_WORKERS"; exit 1; }
 
 # Metadata is written NOW, before the first measured window, so an aborted run
 # still leaves results.jsonl attributable to a commit and binary; the end of
@@ -232,6 +261,7 @@ write_meta() { # write_meta <rss_hwm_kb-or-null>
   "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "rig": {
     "host": "$(hostname)",
+    "instance_type": "$INSTANCE_TYPE",
     "kernel": "$(uname -r)",
     "arch": "$(uname -m)",
     "nproc": $(nproc),
@@ -273,7 +303,8 @@ run_point() { # run_point <ttft> <conc>
         valid_n=$((valid_n + $(measured_window "$point" "$ttft" "$conc" "$try")))
     done
     [ "$valid_n" -ge "$REPS" ] ||
-        echo "WARNING: $point got only $valid_n valid reps in $MAX_TRIES tries" >&2
+        { echo "WARNING: $point got only $valid_n valid reps in $MAX_TRIES tries" >&2
+          HARNESS_RC=1; }
 }
 
 for spec in $GRID; do
@@ -320,4 +351,7 @@ done
 RSS_HWM=$(awk '/VmHWM/{print $2}' "/proc/$GW_PID/status" 2>/dev/null || true)
 write_meta "${RSS_HWM:-null}"
 
+[ "$HARNESS_RC" = 0 ] ||
+    echo "FATAL: one or more points are incomplete - do not use this run as a baseline" >&2
 echo "== done: $OUT ==" >&2
+exit "$HARNESS_RC"

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -31,6 +31,9 @@ TOOLS="$HOME/bench-tools"
 CLK_TCK=$(getconf CLK_TCK)
 # Non-interactive ssh shells don't source the cargo env; inferno lives there.
 export PATH="$HOME/.cargo/bin:$PATH"
+# Plain assignment on purpose: a heredoc swallows a failing command
+# substitution under set -e, so this must fail loudly here instead.
+BODY_JSON=$(printf '%s' "$BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
 
 mkdir -p "$OUT"
 RESULTS="$OUT/results.jsonl"; : > "$RESULTS"
@@ -59,7 +62,7 @@ rss_kb() { awk '/VmRSS/{print $2}' "/proc/$1/status"; }
 wait_http_200() { # wait_http_200 <url> <label> [max_s]
     local url="$1" label="$2" max="${3:-30}" code
     for _ in $(seq 1 $((max * 2))); do
-        code=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+        code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' -X POST \
             -H 'authorization: Bearer bench-token' -H 'content-type: application/json' \
             -d "$BODY" "$url" || true)
         [ "$code" = "200" ] && return 0
@@ -75,6 +78,17 @@ start_mock() { # start_mock <ttft_ms>
         >> "$OUT/mock.log" 2>&1 &
     MOCK_PID=$!
     wait_http_200 "http://127.0.0.1:$MOCK_PORT$CHAT_PATH" "mock (ttft=${1}ms)"
+    # A mock that ignores MOCK_TTFT_MS would make the delayed leg silently
+    # measure a 0-delay upstream with fail=0 throughout; assert the delay is
+    # actually in effect before any window runs against it.
+    if [ "$1" -gt 0 ]; then
+        local ttfb
+        ttfb=$(curl -s --max-time 2 -o /dev/null -w '%{time_starttransfer}' -X POST \
+            -H 'content-type: application/json' -d "$BODY" \
+            "http://127.0.0.1:$MOCK_PORT$CHAT_PATH" || echo 0)
+        awk -v t="$ttfb" -v want="$1" 'BEGIN{exit !(t*1000 >= want*0.9)}' ||
+            { echo "FATAL: mock TTFT ${ttfb}s does not reflect ${1}ms"; exit 1; }
+    fi
 }
 
 loadgen() { # loadgen <ip:port> <conc> <dur>  -> stats line on stdout
@@ -88,7 +102,9 @@ measured_window() { # measured_window <point> <ttft> <conc> <rep>
     local rssfile="$OUT/.rss.$$" line t0 t1 ticks0 ticks1 elapsed cpu_pct rss_peak
     local rps fail ok p50 p99 rigref budget spawn valid
 
-    ( max=0; while :; do
+    # Self-terminating on gateway death: this function runs inside a command
+    # substitution subshell, so the EXIT trap can never see SAMPLER_PID.
+    ( max=0; while kill -0 "$GW_PID" 2>/dev/null; do
           v=$(awk '/VmRSS/{print $2}' "/proc/$GW_PID/status" 2>/dev/null || true)
           v="${v:-0}"
           if [ "$v" -gt "$max" ]; then max="$v"; echo "$max" > "$rssfile"; fi
@@ -96,7 +112,8 @@ measured_window() { # measured_window <point> <ttft> <conc> <rep>
       done ) & SAMPLER_PID=$!
 
     ticks0=$(cpu_ticks "$GW_PID"); t0=$(date +%s.%N)
-    line=$(loadgen "127.0.0.1:$GW_PORT" "$conc" "$WINDOW")
+    line=$(loadgen "127.0.0.1:$GW_PORT" "$conc" "$WINDOW") || line=""
+    line=${line//[\"\\]/ }
     t1=$(date +%s.%N); ticks1=$(cpu_ticks "$GW_PID")
     kill "$SAMPLER_PID" 2>/dev/null || true; wait "$SAMPLER_PID" 2>/dev/null || true; SAMPLER_PID=""
     rss_peak=$(cat "$rssfile" 2>/dev/null || echo 0); rm -f "$rssfile"
@@ -165,14 +182,18 @@ EOF
 # ---- rig floor (0-delay): loadgen -> mock directly, gateway not yet running --
 
 floor_point() { # floor_point <ttft> <conc>  (mock must already run with that ttft)
-    local ttft="$1" conc="$2" rep line
-    loadgen "127.0.0.1:$MOCK_PORT" "$conc" 5 > /dev/null   # warmup
+    local ttft="$1" conc="$2" rep line fail valid
+    loadgen "127.0.0.1:$MOCK_PORT" "$conc" 5 > /dev/null || true   # warmup
     for rep in $(seq 1 "$FLOOR_REPS"); do
-        line=$(loadgen "127.0.0.1:$MOCK_PORT" "$conc" "$WINDOW")
-        printf '{"kind":"floor","point":"floor-ttft%s-c%s","ttft_ms":%s,"conc":%s,"rep":%s,"rps":%s,"fail":%s,"p50_us":%s,"p99_us":%s,"otb_line":"%s"}\n' \
-            "$ttft" "$conc" "$ttft" "$conc" "$rep" "$(field rps "$line")" "$(field fail "$line")" \
+        line=$(loadgen "127.0.0.1:$MOCK_PORT" "$conc" "$WINDOW") || line=""
+        line=${line//[\"\\]/ }
+        fail=$(field fail "$line")
+        valid=true; [ "${fail:-1}" = "0" ] || valid=false
+        printf '{"kind":"floor","point":"floor-ttft%s-c%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"p50_us":%s,"p99_us":%s,"otb_line":"%s"}\n' \
+            "$ttft" "$conc" "$ttft" "$conc" "$rep" "$valid" "$(field rps "$line")" "${fail:-null}" \
             "$(field p50us "$line")" "$(field p99us "$line")" "$line" >> "$RESULTS"
-        echo "  [floor ttft=$ttft c=$conc rep=$rep] $line" >&2
+        echo "  [floor ttft=$ttft c=$conc rep=$rep] valid=$valid $line" >&2
+        [ "$valid" = true ] || echo "WARNING: floor window ttft=$ttft c=$conc rep=$rep had failures - reference ceiling tainted" >&2
     done
 }
 
@@ -194,13 +215,59 @@ sleep 3
 RSS_IDLE=$(rss_kb "$GW_PID")
 TPC_WORKERS=$(ps -T -p "$GW_PID" | grep -c 'tpc-' || true)
 echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB tpc_workers=$TPC_WORKERS" >&2
+# Serving-mode self-check, asserted rather than merely recorded: measuring the
+# shared-runtime fallback while calling it the default would be a silently
+# wrong baseline (thread-per-core is the shipped default on Linux).
+[ "$TPC_WORKERS" -ge 1 ] ||
+    { echo "FATAL: no tpc- worker threads - gateway is not in thread-per-core mode"; exit 1; }
+
+# Metadata is written NOW, before the first measured window, so an aborted run
+# still leaves results.jsonl attributable to a commit and binary; the end of
+# the run rewrites it with the final memory high-water mark.
+write_meta() { # write_meta <rss_hwm_kb-or-null>
+    cat > "$OUT/meta.json" <<EOF
+{
+  "commit": "${BENCH_SRC_COMMIT:-unknown}",
+  "dirty_files": ${BENCH_SRC_DIRTY:-0},
+  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "rig": {
+    "host": "$(hostname)",
+    "kernel": "$(uname -r)",
+    "arch": "$(uname -m)",
+    "nproc": $(nproc),
+    "mem_total_kb": $(awk '/MemTotal/{print $2}' /proc/meminfo),
+    "cpu_part": "$(awk -F': ' '/CPU part/{print $2; exit}' /proc/cpuinfo)"
+  },
+  "cores": {"gateway": "$GW_CORES", "load": "$LOAD_CORES", "mock": "$MOCK_CORES"},
+  "instruments": {
+    "engine_pin": "f3adbb1315b26129f5e317af5279decefb1cea8f (engine-v1)",
+    "otb_sha256": "$(sha256sum "$TOOLS/otb" | cut -d' ' -f1)",
+    "mock_sha256": "$(sha256sum "$TOOLS/mock" | cut -d' ' -f1)"
+  },
+  "method": {
+    "window_s": $WINDOW, "warmup_s": $WARMUP, "reps": $REPS,
+    "max_tries": $MAX_TRIES, "floor_reps": $FLOOR_REPS,
+    "grid": "$GRID", "body": $BODY_JSON,
+    "path": "$CHAT_PATH", "clk_tck": $CLK_TCK, "nofile": $(ulimit -n),
+    "loadgen_headers": $(printf '%s' "$OTB_LOADGEN_HEADERS" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
+    "flamegraph": {"freq_hz": 499, "callgraph": "dwarf", "window_s": 25, "conc": 128}
+  },
+  "gateway": {
+    "binary_sha256": "$(sha256sum "$BIN" | cut -d' ' -f1)",
+    "rss_idle_kb": $RSS_IDLE, "rss_hwm_kb": $1,
+    "tpc_workers": $TPC_WORKERS
+  }
+}
+EOF
+}
+write_meta null
 
 # ---- 0-delay grid -----------------------------------------------------------
 
 run_point() { # run_point <ttft> <conc>
     local ttft="$1" conc="$2" point="ttft$1-c$2" valid_n=0 try=0
     echo "== point $point ==" >&2
-    loadgen "127.0.0.1:$GW_PORT" "$conc" "$WARMUP" > /dev/null
+    loadgen "127.0.0.1:$GW_PORT" "$conc" "$WARMUP" > /dev/null || true
     while [ "$valid_n" -lt "$REPS" ] && [ "$try" -lt "$MAX_TRIES" ]; do
         try=$((try + 1))
         valid_n=$((valid_n + $(measured_window "$point" "$ttft" "$conc" "$try")))
@@ -248,39 +315,9 @@ for spec in $GRID; do
     run_point "$ttft" "$conc"
 done
 
-# ---- metadata ---------------------------------------------------------------
+# ---- final metadata (adds the memory high-water mark) -----------------------
 
-RSS_HWM=$(awk '/VmHWM/{print $2}' "/proc/$GW_PID/status")
-cat > "$OUT/meta.json" <<EOF
-{
-  "commit": "${BENCH_SRC_COMMIT:-unknown}",
-  "dirty_files": ${BENCH_SRC_DIRTY:-0},
-  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "rig": {
-    "host": "$(hostname)",
-    "kernel": "$(uname -r)",
-    "arch": "$(uname -m)",
-    "nproc": $(nproc),
-    "mem_total_kb": $(awk '/MemTotal/{print $2}' /proc/meminfo),
-    "cpu_part": "$(awk -F': ' '/CPU part/{print $2; exit}' /proc/cpuinfo)"
-  },
-  "cores": {"gateway": "$GW_CORES", "load": "$LOAD_CORES", "mock": "$MOCK_CORES"},
-  "instruments": {
-    "engine_pin": "f3adbb1315b26129f5e317af5279decefb1cea8f (engine-v1)",
-    "otb_sha256": "$(sha256sum "$TOOLS/otb" | cut -d' ' -f1)",
-    "mock_sha256": "$(sha256sum "$TOOLS/mock" | cut -d' ' -f1)"
-  },
-  "method": {
-    "window_s": $WINDOW, "warmup_s": $WARMUP, "reps": $REPS,
-    "grid": "$GRID", "body": $(printf '%s' "$BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
-    "path": "$CHAT_PATH", "clk_tck": $CLK_TCK, "nofile": $(ulimit -n)
-  },
-  "gateway": {
-    "binary_sha256": "$(sha256sum "$BIN" | cut -d' ' -f1)",
-    "rss_idle_kb": $RSS_IDLE, "rss_hwm_kb": $RSS_HWM,
-    "tpc_workers": $TPC_WORKERS
-  }
-}
-EOF
+RSS_HWM=$(awk '/VmHWM/{print $2}' "/proc/$GW_PID/status" 2>/dev/null || true)
+write_meta "${RSS_HWM:-null}"
 
 echo "== done: $OUT ==" >&2

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -181,6 +181,9 @@ floor_point 0 128
 # ---- gateway: default shipped config, pinned to its 4 cores -----------------
 
 echo "== gateway ==" >&2
+# aisix reads AISIX_* environment variables as config overrides; nothing from
+# the harness environment may leak into the measured process.
+while read -r v; do unset "$v"; done < <(compgen -v | grep '^AISIX_' || true)
 BENCH_AISIX_KEY=bench-token taskset -c "$GW_CORES" "$BIN" --config "$OUT/config.yaml" \
     > "$OUT/gateway.log" 2>&1 &
 GW_PID=$!
@@ -243,8 +246,8 @@ done
 RSS_HWM=$(awk '/VmHWM/{print $2}' "/proc/$GW_PID/status")
 cat > "$OUT/meta.json" <<EOF
 {
-  "commit": "${AISIX_COMMIT:-unknown}",
-  "dirty_files": ${AISIX_DIRTY:-0},
+  "commit": "${BENCH_SRC_COMMIT:-unknown}",
+  "dirty_files": ${BENCH_SRC_DIRTY:-0},
   "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "rig": {
     "host": "$(hostname)",

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -29,6 +29,8 @@ export OTB_LOADGEN_HEADERS='[["authorization","Bearer bench-token"]]'
 BIN="$SRC/target/release/aisix"
 TOOLS="$HOME/bench-tools"
 CLK_TCK=$(getconf CLK_TCK)
+# Non-interactive ssh shells don't source the cargo env; inferno lives there.
+export PATH="$HOME/.cargo/bin:$PATH"
 
 mkdir -p "$OUT"
 RESULTS="$OUT/results.jsonl"; : > "$RESULTS"
@@ -218,15 +220,20 @@ done
 echo "== flamegraph (c=128, 0-delay) ==" >&2
 loadgen "127.0.0.1:$GW_PORT" 128 45 > "$OUT/flamegraph-window.txt" & LOAD_BG=$!
 sleep 5
-perf record -F 997 --call-graph dwarf,16384 -p "$GW_PID" -o "$OUT/perf.data" -- sleep 25 \
+perf record -F 499 --call-graph dwarf -p "$GW_PID" -o "$OUT/perf.data" -- sleep 25 \
     >> "$OUT/perf.log" 2>&1 || echo "WARNING: perf record failed" >&2
 wait "$LOAD_BG" || true
+# Rendering must never kill the measurement: perf.data is kept on any failure
+# so the SVG can be produced off-rig.
 if [ -s "$OUT/perf.data" ]; then
-    perf script -i "$OUT/perf.data" 2>> "$OUT/perf.log" |
-        inferno-collapse-perf > "$OUT/flamegraph-c128.folded" 2>> "$OUT/perf.log"
-    inferno-flamegraph --title "aisix c=128 0-delay (4 pinned cores)" \
-        < "$OUT/flamegraph-c128.folded" > "$OUT/flamegraph-c128.svg" 2>> "$OUT/perf.log"
-    rm -f "$OUT/perf.data"
+    if perf script -i "$OUT/perf.data" 2>> "$OUT/perf.log" |
+           inferno-collapse-perf > "$OUT/flamegraph-c128.folded" 2>> "$OUT/perf.log" &&
+       inferno-flamegraph --title "aisix c=128 0-delay (4 pinned cores)" \
+           < "$OUT/flamegraph-c128.folded" > "$OUT/flamegraph-c128.svg" 2>> "$OUT/perf.log"; then
+        rm -f "$OUT/perf.data"
+    else
+        echo "WARNING: flamegraph rendering failed; perf.data kept" >&2
+    fi
 fi
 
 # ---- 10ms-TTFT leg: mock restarted with the delay, floor then gateway -------


### PR DESCRIPTION
## Why

Item 1 of the post-thread-per-core performance program (api7/AISIX-Cloud#1259) requires reproducing the public onthebench benchmark methodology on our own m7g.4xlarge, so that every optimization item in the program can be gated on same-rig before/after numbers instead of third-party published figures.

## What

A reproducible one-command harness under `bench/onthebench/`:

- `bench.sh` — rsyncs the working tree to the rig, provisions it, builds a native release binary, runs every load point, and collects results. The tree you run it from is the tree that gets measured; commit and dirty state are recorded in the run metadata.
- `rig-setup.sh` — idempotent provisioning (build deps, perf, rust toolchain via the repo's `rust-toolchain.toml`, inferno). The load generator and mock upstream are the prebuilt, pinned instruments from the public benchmark rig release (engine pin `f3adbb1315b26129f5e317af5279decefb1cea8f`, https://github.com/GetBusbar/benchmarking); their sha256s are frozen in the script, so a rebuilt rig either runs the byte-identical instrument or fails loudly.
- `run-baseline.sh` — the on-rig runner: three disjoint pinned core groups (gateway 0-3, load 4-9, mock 10-15), default shipped config, 25s windows, 5s warmup, 4 valid repetitions per point with `fail=0` as the validity gate (invalid windows are recorded and retried, never silently dropped), rig-floor reference windows against the mock directly, per-window gateway CPU% and peak-RSS capture, and one on-CPU flamegraph at the c=128 saturation point (perf + inferno, the #847 workflow, with a stripped-binary refusal gate).

Results land as one directory per run: `results.jsonl` (one JSON object per window), `meta.json` (commit, binary and instrument sha256s, core split, kernel, method parameters), the flamegraph SVG, generated configs, and logs.

## Default-config discipline

A config line exists only if the process cannot run the benchmark without it, following the published methodology's rule; the full claim set and per-line justification are in the README and the runner. Runtime deviations are limited to `ulimit -n 65536` (c=768 exceeds the 1024 default) and `kernel.perf_event_paranoid=1` (flamegraph sampling only, reverts on reboot).

Two hardening details worth review attention:

- The harness passes source metadata to the rig as `BENCH_SRC_*` variables and defensively unsets every `AISIX_*` variable before launching the gateway: aisix reads `AISIX_*` environment variables as config overrides, so harness metadata in the measured process's environment would either pollute the measurement or refuse boot.
- Flamegraph rendering failures downgrade to a warning and keep `perf.data`; a rendering problem must never abort or invalidate the measurement itself.

## Validation

One full pipeline run end-to-end on the rig (provision from a fresh box, native build, all four load points, both rig floors, flamegraph rendered): every measured window passed the `fail=0` validity gate on the first attempt, and the thread-per-core startup self-check (`tpc_workers`) confirmed the intended serving mode. Baseline numbers are tracked in the program's internal notes rather than in this PR.

## Not in scope

Multi-gateway comparison orchestration (program item 1's side-by-side legs) builds on this harness in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated benchmark harness for ARM64 systems.
  * Added one-command rig provisioning, project building, benchmark execution, and result collection.
  * Added baseline load testing across concurrency and time-to-first-byte scenarios.
  * Added latency, throughput, failure, CPU, and memory measurements in JSONL output.
  * Added validation, retries, metadata capture, and flamegraph generation.

* **Documentation**
  * Added comprehensive guidance covering setup, methodology, metrics, outputs, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->