### PR TITLE
feat(cache): semantic (embedding-similarity) matching layer on cache policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "aisix-gateway",
  "aisix-redis",
  "async-trait",
+ "dashmap",
  "moka",
  "redis",
  "serde_json",

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3991,7 +3991,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
     },
     {
       "name": "Cache Policies",
-      "description": "Semantic cache policies attached to models."
+      "description": "Response cache rules: exact-match caching, with optional embedding-similarity (semantic) matching per policy."
     },
     {
       "name": "Observability Exporters",
@@ -4257,6 +4257,10 @@ fn add_variant_titles(doc: &mut Value) {
         (
             "/components/schemas/BedrockLatencyMode/oneOf",
             &["Serial", "Timed"],
+        ),
+        (
+            "/components/schemas/CacheScope/oneOf",
+            &["Per API key", "Environment-wide"],
         ),
         (
             "/components/schemas/Guardrail/oneOf",

--- a/crates/aisix-cache/Cargo.toml
+++ b/crates/aisix-cache/Cargo.toml
@@ -14,6 +14,7 @@ aisix-core = { path = "../aisix-core" }
 aisix-redis = { path = "../aisix-redis", optional = true }
 tokio.workspace = true
 async-trait.workspace = true
+dashmap.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 moka.workspace = true

--- a/crates/aisix-cache/src/key.rs
+++ b/crates/aisix-cache/src/key.rs
@@ -136,19 +136,28 @@ impl Hash for CacheKey {
 
 /// Canonical text the semantic layer embeds for a request: one
 /// `role: content` line per message, preserving roles and message
-/// boundaries so `["ab"]` and `["a","b"]` embed differently.
+/// boundaries so `["ab"]` and `["a","b"]` embed differently. Backslash
+/// and newline inside message text are escaped (`\\`, `\n`), so content
+/// that *contains* a `\nrole: ` sequence cannot forge a message
+/// boundary and collide with a genuinely multi-message conversation.
 ///
 /// Returns `None` — semantic matching is skipped, exact matching still
-/// applies — when the request is not entirely text: any non-`text`
-/// content block (image, audio, …) disqualifies it, because a text
-/// embedding cannot represent the non-text part and similar prompts
-/// about *different* images must never match. Also `None` when there is
-/// no non-whitespace text at all (embedding an empty string could match
-/// almost anything).
+/// applies — when a text embedding cannot faithfully represent the
+/// request:
+/// - any non-`text` content block (image, audio, …): similar prompts
+///   about *different* images must never match;
+/// - any message carrying `name`, `tool_call_id`, or forward-compat
+///   `extra` fields (`tool_calls`, …): tool traffic differing only in
+///   those fields would embed identically and replay the wrong answer;
+/// - no non-whitespace text at all (embedding an empty string could
+///   match almost anything).
 pub fn semantic_prompt_text(req: &ChatFormat) -> Option<String> {
     let mut out = String::new();
     let mut has_text = false;
     for m in &req.messages {
+        if m.name.is_some() || m.tool_call_id.is_some() || !m.extra.is_empty() {
+            return None;
+        }
         let text = match m.content_blocks.as_ref() {
             Some(blocks) => {
                 let mut t = String::new();
@@ -172,7 +181,7 @@ pub fn semantic_prompt_text(req: &ChatFormat) -> Option<String> {
         }
         out.push_str(role_str(m.role));
         out.push_str(": ");
-        out.push_str(&text);
+        out.push_str(&text.replace('\\', "\\\\").replace('\n', "\\n"));
         out.push('\n');
     }
     has_text.then_some(out)
@@ -235,7 +244,22 @@ fn message_pair(m: &ChatMessage) -> (String, String) {
         Some(blocks) => canonical_json_string(&serde_json::Value::Array(blocks.clone())),
         None => m.content_str().to_string(),
     };
-    (role_str(m.role).to_string(), content_repr)
+    // Message-level identity beyond the content changes what the
+    // upstream sees just as much as the content does: `name`,
+    // `tool_call_id`, and the forward-compat `extra` bag (`tool_calls`,
+    // `refusal`, …). Two histories that differ only in an assistant's
+    // `tool_calls` MUST NOT share a fingerprint. The common no-tools
+    // case keeps the plain content representation.
+    if m.name.is_none() && m.tool_call_id.is_none() && m.extra.is_empty() {
+        return (role_str(m.role).to_string(), content_repr);
+    }
+    let decorated = serde_json::json!({
+        "content": content_repr,
+        "name": m.name,
+        "tool_call_id": m.tool_call_id,
+        "extra": canonicalise(&serde_json::Value::Object(m.extra.clone())),
+    });
+    (role_str(m.role).to_string(), decorated.to_string())
 }
 
 fn role_str(role: Role) -> &'static str {
@@ -601,5 +625,107 @@ mod tests {
     fn semantic_text_none_for_empty_content() {
         let r = req("m", vec![ChatMessage::user("   ")], None);
         assert_eq!(semantic_prompt_text(&r), None);
+    }
+
+    #[test]
+    fn histories_differing_only_in_tool_calls_never_share_a_fingerprint() {
+        // Assistant `tool_calls` ride the message-level `extra` bag; the
+        // upstream sees them, so the fingerprint must too. Pre-fix, two
+        // agent turns whose only difference was the tool call shared an
+        // exact key and replayed each other's answers.
+        let mk = |args: &str| {
+            let mut asst = ChatMessage::assistant("");
+            asst.extra.insert(
+                "tool_calls".into(),
+                serde_json::json!([{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": args}
+                }]),
+            );
+            req(
+                "m",
+                vec![ChatMessage::user("check the weather"), asst],
+                None,
+            )
+        };
+        assert_ne!(
+            CacheKey::from_request(&mk("{\"city\":\"paris\"}")).fingerprint(),
+            CacheKey::from_request(&mk("{\"city\":\"tokyo\"}")).fingerprint(),
+        );
+        // And tool_calls present vs absent must differ too.
+        let plain = req(
+            "m",
+            vec![
+                ChatMessage::user("check the weather"),
+                ChatMessage::assistant(""),
+            ],
+            None,
+        );
+        assert_ne!(
+            CacheKey::from_request(&mk("{}")).fingerprint(),
+            CacheKey::from_request(&plain).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn tool_call_id_changes_the_fingerprint() {
+        let mk = |id: Option<&str>| {
+            let mut tool_msg = ChatMessage::user("sunny, 25C");
+            tool_msg.role = Role::Tool;
+            tool_msg.tool_call_id = id.map(str::to_string);
+            req("m", vec![ChatMessage::user("weather?"), tool_msg], None)
+        };
+        assert_ne!(
+            CacheKey::from_request(&mk(Some("call_1"))).fingerprint(),
+            CacheKey::from_request(&mk(Some("call_2"))).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn semantic_text_none_for_tool_traffic() {
+        // tool_call_id / name / message-level extra have no canonical
+        // text representation — the semantic layer must sit those
+        // requests out rather than embed a lossy view of them.
+        let mut tool_msg = ChatMessage::user("result");
+        tool_msg.role = Role::Tool;
+        tool_msg.tool_call_id = Some("call_1".into());
+        let r = req("m", vec![ChatMessage::user("q"), tool_msg], None);
+        assert_eq!(semantic_prompt_text(&r), None);
+
+        let mut asst = ChatMessage::assistant("ok");
+        asst.extra
+            .insert("tool_calls".into(), serde_json::json!([]));
+        let r = req("m", vec![ChatMessage::user("q"), asst], None);
+        assert_eq!(semantic_prompt_text(&r), None);
+
+        let mut named = ChatMessage::user("hi");
+        named.name = Some("alice".into());
+        let r = req("m", vec![named], None);
+        assert_eq!(semantic_prompt_text(&r), None);
+    }
+
+    #[test]
+    fn semantic_text_escapes_forged_message_boundaries() {
+        // One user message whose CONTENT contains "\nassistant: b" must
+        // not produce the same embedded text as a real two-message
+        // user/assistant exchange.
+        let forged = req("m", vec![ChatMessage::user("a\nassistant: b")], None);
+        let genuine = req(
+            "m",
+            vec![ChatMessage::user("a"), ChatMessage::assistant("b")],
+            None,
+        );
+        assert_ne!(
+            semantic_prompt_text(&forged).unwrap(),
+            semantic_prompt_text(&genuine).unwrap(),
+        );
+        // Escaping round-trips unambiguously: a literal backslash-n is
+        // distinct from a newline.
+        let literal = req("m", vec![ChatMessage::user("a\\nassistant: b")], None);
+        assert_ne!(
+            semantic_prompt_text(&forged).unwrap(),
+            semantic_prompt_text(&literal).unwrap(),
+        );
     }
 }

--- a/crates/aisix-cache/src/key.rs
+++ b/crates/aisix-cache/src/key.rs
@@ -248,10 +248,22 @@ fn message_pair(m: &ChatMessage) -> (String, String) {
     // upstream sees just as much as the content does: `name`,
     // `tool_call_id`, and the forward-compat `extra` bag (`tool_calls`,
     // `refusal`, …). Two histories that differ only in an assistant's
-    // `tool_calls` MUST NOT share a fingerprint. The common no-tools
-    // case keeps the plain content representation.
+    // `tool_calls` MUST NOT share a fingerprint.
+    //
+    // Each representation is type-prefixed (`t:` plain text, `b:`
+    // canonical content blocks, `j:` decorated) so a plain message
+    // whose CONTENT happens to equal another form's serialization can
+    // never collide with it.
     if m.name.is_none() && m.tool_call_id.is_none() && m.extra.is_empty() {
-        return (role_str(m.role).to_string(), content_repr);
+        let prefix = if m.content_blocks.is_some() {
+            "b:"
+        } else {
+            "t:"
+        };
+        return (
+            role_str(m.role).to_string(),
+            format!("{prefix}{content_repr}"),
+        );
     }
     let decorated = serde_json::json!({
         "content": content_repr,
@@ -259,7 +271,7 @@ fn message_pair(m: &ChatMessage) -> (String, String) {
         "tool_call_id": m.tool_call_id,
         "extra": canonicalise(&serde_json::Value::Object(m.extra.clone())),
     });
-    (role_str(m.role).to_string(), decorated.to_string())
+    (role_str(m.role).to_string(), format!("j:{decorated}"))
 }
 
 fn role_str(role: Role) -> &'static str {
@@ -703,6 +715,26 @@ mod tests {
         named.name = Some("alice".into());
         let r = req("m", vec![named], None);
         assert_eq!(semantic_prompt_text(&r), None);
+    }
+
+    #[test]
+    fn representation_forms_never_collide() {
+        // A plain message whose content IS another form's serialization
+        // must not share a fingerprint with that form. The decorated
+        // (`j:`) form of a tool message vs a plain message carrying the
+        // same JSON as literal text:
+        let mut tool_msg = ChatMessage::user("result");
+        tool_msg.role = Role::Tool;
+        tool_msg.tool_call_id = Some("call_1".into());
+        let decorated = req("m", vec![tool_msg.clone()], None);
+        let (_, decorated_repr) = message_pair(&tool_msg);
+        let mut spoof = ChatMessage::user(decorated_repr.trim_start_matches("j:").to_string());
+        spoof.role = Role::Tool;
+        let plain = req("m", vec![spoof], None);
+        assert_ne!(
+            CacheKey::from_request(&decorated).fingerprint(),
+            CacheKey::from_request(&plain).fingerprint(),
+        );
     }
 
     #[test]

--- a/crates/aisix-cache/src/key.rs
+++ b/crates/aisix-cache/src/key.rs
@@ -36,12 +36,28 @@ pub struct CacheKey {
     /// deterministic and so two requests that differ only in JSON key
     /// order collapse to the same fingerprint.
     pub extras: Vec<(String, String)>,
+    /// The matched `CachePolicy`'s resource id. Scopes entries per
+    /// policy so two policies never share entries even on the same
+    /// backend instance.
+    pub policy_id: String,
+    /// The policy's `purge_generation` at request time. A purge bumps
+    /// the generation, so every earlier entry's key becomes
+    /// unreachable at once (entries are then reclaimed by TTL).
+    pub purge_generation: u32,
+    /// The caller's api_key id when the policy's `scope` is `api_key`;
+    /// `None` under `scope: env`. Part of BOTH fingerprints, so scoped
+    /// entries are invisible across callers.
+    pub scope_api_key: Option<String>,
 }
 
 impl CacheKey {
     /// Build a key from the proxy's normalised `ChatFormat`. Streaming
     /// requests are *not* cached at this layer — callers should skip the
     /// cache when `req.is_streaming()`.
+    ///
+    /// The scope fields (`policy_id`, `purge_generation`,
+    /// `scope_api_key`) start empty; the proxy fills them via
+    /// [`CacheKey::with_scope`] once it knows the matched policy.
     pub fn from_request(req: &ChatFormat) -> Self {
         Self {
             model: req.model.clone(),
@@ -50,7 +66,25 @@ impl CacheKey {
             top_p_milli: req.top_p.map(quantise_milli),
             max_tokens: req.max_tokens,
             extras: canonical_extras(&req.extra),
+            policy_id: String::new(),
+            purge_generation: 0,
+            scope_api_key: None,
         }
+    }
+
+    /// Attach the matched policy's scope: its resource id, its current
+    /// purge generation, and — when the policy isolates per caller —
+    /// the caller's api_key id.
+    pub fn with_scope(
+        mut self,
+        policy_id: &str,
+        purge_generation: u32,
+        scope_api_key: Option<&str>,
+    ) -> Self {
+        self.policy_id = policy_id.to_string();
+        self.purge_generation = purge_generation;
+        self.scope_api_key = scope_api_key.map(str::to_string);
+        self
     }
 
     /// Hex-encoded u64 hash, used as the cache backend's lookup key.
@@ -59,15 +93,24 @@ impl CacheKey {
         self.hash(&mut h);
         format!("{:016x}", h.finish())
     }
-}
 
-impl Hash for CacheKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
+    /// Fingerprint of everything EXCEPT the messages — the semantic
+    /// layer's candidate filter. Two requests share a scope fingerprint
+    /// iff they agree on model, sampling params, extras, policy,
+    /// generation, and caller scope; only then may they match by
+    /// embedding similarity. This is what keeps a tool-calling request
+    /// from ever being answered by a similar-but-toolless entry.
+    pub fn scope_fingerprint(&self) -> String {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        self.hash_scope(&mut h);
+        format!("{:016x}", h.finish())
+    }
+
+    /// Hash the non-message fields. Shared by [`Hash`] and
+    /// [`CacheKey::scope_fingerprint`] so the two can never disagree on
+    /// which fields scope an entry.
+    fn hash_scope<H: Hasher>(&self, state: &mut H) {
         self.model.hash(state);
-        for (role, content) in &self.messages {
-            role.hash(state);
-            content.hash(state);
-        }
         self.temperature_milli.hash(state);
         self.top_p_milli.hash(state);
         self.max_tokens.hash(state);
@@ -75,7 +118,64 @@ impl Hash for CacheKey {
             k.hash(state);
             v.hash(state);
         }
+        self.policy_id.hash(state);
+        self.purge_generation.hash(state);
+        self.scope_api_key.hash(state);
     }
+}
+
+impl Hash for CacheKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.hash_scope(state);
+        for (role, content) in &self.messages {
+            role.hash(state);
+            content.hash(state);
+        }
+    }
+}
+
+/// Canonical text the semantic layer embeds for a request: one
+/// `role: content` line per message, preserving roles and message
+/// boundaries so `["ab"]` and `["a","b"]` embed differently.
+///
+/// Returns `None` — semantic matching is skipped, exact matching still
+/// applies — when the request is not entirely text: any non-`text`
+/// content block (image, audio, …) disqualifies it, because a text
+/// embedding cannot represent the non-text part and similar prompts
+/// about *different* images must never match. Also `None` when there is
+/// no non-whitespace text at all (embedding an empty string could match
+/// almost anything).
+pub fn semantic_prompt_text(req: &ChatFormat) -> Option<String> {
+    let mut out = String::new();
+    let mut has_text = false;
+    for m in &req.messages {
+        let text = match m.content_blocks.as_ref() {
+            Some(blocks) => {
+                let mut t = String::new();
+                for b in blocks {
+                    let obj = b.as_object()?;
+                    match obj.get("type").and_then(|v| v.as_str()) {
+                        Some("text") => {
+                            if let Some(s) = obj.get("text").and_then(|v| v.as_str()) {
+                                t.push_str(s);
+                            }
+                        }
+                        _ => return None,
+                    }
+                }
+                t
+            }
+            None => m.content_str().to_string(),
+        };
+        if !text.trim().is_empty() {
+            has_text = true;
+        }
+        out.push_str(role_str(m.role));
+        out.push_str(": ");
+        out.push_str(&text);
+        out.push('\n');
+    }
+    has_text.then_some(out)
 }
 
 /// Sort `extra` by key (recursively, into nested objects too) and emit
@@ -392,5 +492,114 @@ mod tests {
         assert_eq!(quantise_milli(0.0), 0);
         assert_eq!(quantise_milli(0.5), 500);
         assert_eq!(quantise_milli(f32::INFINITY), u32::MAX);
+    }
+
+    #[test]
+    fn different_policies_never_share_a_fingerprint() {
+        let r = req("m", vec![ChatMessage::user("hi")], None);
+        let a = CacheKey::from_request(&r).with_scope("policy-a", 0, None);
+        let b = CacheKey::from_request(&r).with_scope("policy-b", 0, None);
+        assert_ne!(a.fingerprint(), b.fingerprint());
+        assert_ne!(a.scope_fingerprint(), b.scope_fingerprint());
+    }
+
+    #[test]
+    fn purge_generation_bump_invalidates_both_fingerprints() {
+        let r = req("m", vec![ChatMessage::user("hi")], None);
+        let a = CacheKey::from_request(&r).with_scope("p", 0, None);
+        let b = CacheKey::from_request(&r).with_scope("p", 1, None);
+        assert_ne!(a.fingerprint(), b.fingerprint());
+        assert_ne!(a.scope_fingerprint(), b.scope_fingerprint());
+    }
+
+    #[test]
+    fn api_key_scope_isolates_callers_env_scope_shares() {
+        let r = req("m", vec![ChatMessage::user("hi")], None);
+        let a = CacheKey::from_request(&r).with_scope("p", 0, Some("key-a"));
+        let b = CacheKey::from_request(&r).with_scope("p", 0, Some("key-b"));
+        let shared_a = CacheKey::from_request(&r).with_scope("p", 0, None);
+        let shared_b = CacheKey::from_request(&r).with_scope("p", 0, None);
+        assert_ne!(a.fingerprint(), b.fingerprint());
+        assert_ne!(a.scope_fingerprint(), b.scope_fingerprint());
+        assert_eq!(shared_a.fingerprint(), shared_b.fingerprint());
+    }
+
+    #[test]
+    fn scope_fingerprint_ignores_messages_but_tracks_params() {
+        let a = req("m", vec![ChatMessage::user("hello there")], Some(0.2));
+        let b = req("m", vec![ChatMessage::user("совершенно другой")], Some(0.2));
+        let c = req("m", vec![ChatMessage::user("hello there")], Some(0.7));
+        let (ka, kb, kc) = (
+            CacheKey::from_request(&a).with_scope("p", 0, None),
+            CacheKey::from_request(&b).with_scope("p", 0, None),
+            CacheKey::from_request(&c).with_scope("p", 0, None),
+        );
+        assert_eq!(ka.scope_fingerprint(), kb.scope_fingerprint());
+        assert_ne!(ka.fingerprint(), kb.fingerprint());
+        assert_ne!(ka.scope_fingerprint(), kc.scope_fingerprint());
+    }
+
+    #[test]
+    fn scope_fingerprint_tracks_extras() {
+        let mut a = req("m", vec![ChatMessage::user("hi")], None);
+        let b = req("m", vec![ChatMessage::user("hi")], None);
+        a.extra.insert(
+            "tools".into(),
+            serde_json::json!([{"type": "function", "function": {"name": "f"}}]),
+        );
+        assert_ne!(
+            CacheKey::from_request(&a).scope_fingerprint(),
+            CacheKey::from_request(&b).scope_fingerprint(),
+        );
+    }
+
+    #[test]
+    fn semantic_text_preserves_roles_and_message_boundaries() {
+        let a = req(
+            "m",
+            vec![ChatMessage::system("be brief"), ChatMessage::user("hi")],
+            None,
+        );
+        let text = semantic_prompt_text(&a).unwrap();
+        assert_eq!(text, "system: be brief\nuser: hi\n");
+        // One message "ab" vs two messages "a"/"b" must differ.
+        let one = req("m", vec![ChatMessage::user("ab")], None);
+        let two = req(
+            "m",
+            vec![ChatMessage::user("a"), ChatMessage::user("b")],
+            None,
+        );
+        assert_ne!(
+            semantic_prompt_text(&one).unwrap(),
+            semantic_prompt_text(&two).unwrap(),
+        );
+    }
+
+    #[test]
+    fn semantic_text_none_for_non_text_blocks() {
+        let mut msg = ChatMessage::user("what's in this image?");
+        msg.content_blocks = Some(vec![
+            serde_json::json!({"type": "text", "text": "what's in this image?"}),
+            serde_json::json!({"type": "image_url", "image_url": {"url": "https://x/cat.jpg"}}),
+        ]);
+        let r = req("m", vec![msg], None);
+        assert_eq!(semantic_prompt_text(&r), None);
+    }
+
+    #[test]
+    fn semantic_text_accepts_text_only_blocks() {
+        let mut msg = ChatMessage::user("hello");
+        msg.content_blocks = Some(vec![
+            serde_json::json!({"type": "text", "text": "hel"}),
+            serde_json::json!({"type": "text", "text": "lo"}),
+        ]);
+        let r = req("m", vec![msg], None);
+        assert_eq!(semantic_prompt_text(&r).unwrap(), "user: hello\n");
+    }
+
+    #[test]
+    fn semantic_text_none_for_empty_content() {
+        let r = req("m", vec![ChatMessage::user("   ")], None);
+        assert_eq!(semantic_prompt_text(&r), None);
     }
 }

--- a/crates/aisix-cache/src/lib.rs
+++ b/crates/aisix-cache/src/lib.rs
@@ -1,12 +1,17 @@
-//! aisix-cache — exact-match response cache for chat completions.
+//! aisix-cache — response cache for chat completions: an exact-match
+//! layer, plus an embedding-similarity (semantic) layer for policies
+//! that configure one.
 //!
 //! The proxy looks up the cache before dispatching to the upstream
 //! Bridge. On hit it returns the cached `ChatResponse` directly with an
 //! `x-aisix-cache: hit` header; on miss it falls through to the bridge
-//! and stores the response with `x-aisix-cache: miss`.
+//! and stores the response with `x-aisix-cache: miss`. When the matched
+//! policy carries a `semantic` block, an exact miss additionally probes
+//! [`SemanticCacheStore`] with the request's embedding.
 //!
 //! Backends:
-//! - [`MemoryCache`] (moka, in-process) — always available.
+//! - [`MemoryCache`] / [`MemorySemanticCache`] (in-process) — always
+//!   available.
 //! - `RedisCache` (behind the `redis` feature) — built when the boot
 //!   config carries `cache.redis`.
 //!
@@ -25,11 +30,13 @@ mod key;
 mod memory;
 #[cfg(feature = "redis")]
 mod redis;
+mod semantic;
 
 pub use cache::{Cache, CacheError, CacheOutcome};
-pub use key::CacheKey;
+pub use key::{semantic_prompt_text, CacheKey};
 pub use memory::{MemoryCache, DEFAULT_CAPACITY, DEFAULT_TTL};
 #[cfg(feature = "redis")]
 pub use redis::{
     RedisCache, DEFAULT_PREFIX as REDIS_DEFAULT_PREFIX, DEFAULT_TTL as REDIS_DEFAULT_TTL,
 };
+pub use semantic::{MemorySemanticCache, SemanticCacheStore, SemanticHit};

--- a/crates/aisix-cache/src/semantic.rs
+++ b/crates/aisix-cache/src/semantic.rs
@@ -50,7 +50,10 @@ pub struct SemanticHit {
 #[async_trait]
 pub trait SemanticCacheStore: Send + Sync + 'static {
     /// Nearest stored entry in the partition with cosine similarity
-    /// `>= threshold`, or `None`.
+    /// `>= threshold`, or `None`. A similarity of exactly `0.0` never
+    /// matches regardless of threshold: `0.0` is also the fold value
+    /// for degenerate comparisons (dimension mismatch, zero vector),
+    /// and a `threshold: 0.0` policy must not turn those into hits.
     async fn lookup(
         &self,
         policy_id: &str,
@@ -60,16 +63,20 @@ pub trait SemanticCacheStore: Send + Sync + 'static {
         threshold: f32,
     ) -> Result<Option<SemanticHit>, CacheError>;
 
-    /// Store a response under the partition. `max_entries` caps the
-    /// policy's entry count where the backend enforces one (the memory
-    /// backend evicts oldest-first; shared backends may ignore it and
-    /// bound growth by TTL).
+    /// Store a response under the partition. `exact_key` is the
+    /// request's exact-layer fingerprint: an existing entry with the
+    /// same `exact_key` is REPLACED (a `Cache-Control: no-cache`
+    /// refresh must update the entry, not stack a duplicate beside
+    /// it). `max_entries` caps the policy's entry count where the
+    /// backend enforces one (the memory backend evicts oldest-first;
+    /// shared backends may ignore it and bound growth by TTL).
     #[allow(clippy::too_many_arguments)]
     async fn store(
         &self,
         policy_id: &str,
         generation: u32,
         scope_fp: &str,
+        exact_key: &str,
         embedding: Vec<f32>,
         response: ChatResponse,
         ttl: Duration,
@@ -100,6 +107,7 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 
 struct SemanticEntry {
     scope_fp: String,
+    exact_key: String,
     embedding: Vec<f32>,
     response: ChatResponse,
     expires_at: Instant,
@@ -160,8 +168,11 @@ impl SemanticCacheStore for MemorySemanticCache {
                 continue;
             }
             let similarity = cosine_similarity(embedding, &entry.embedding);
+            // `> 0.0` (not just `>= threshold`): 0.0 is the degenerate
+            // fold — see the trait docs.
             if similarity >= threshold
-                && best.as_ref().map(|b| similarity > b.similarity) != Some(false)
+                && similarity > 0.0
+                && best.as_ref().is_none_or(|b| similarity > b.similarity)
             {
                 best = Some(SemanticHit {
                     response: entry.response.clone(),
@@ -178,6 +189,7 @@ impl SemanticCacheStore for MemorySemanticCache {
         policy_id: &str,
         generation: u32,
         scope_fp: &str,
+        exact_key: &str,
         embedding: Vec<f32>,
         response: ChatResponse,
         ttl: Duration,
@@ -223,8 +235,13 @@ impl SemanticCacheStore for MemorySemanticCache {
         while policy.entries.front().is_some_and(|e| e.expires_at <= now) {
             policy.entries.pop_front();
         }
+        // Upsert by exact wording: a refresh replaces, never duplicates.
+        policy
+            .entries
+            .retain(|e| e.exact_key != exact_key || e.scope_fp != scope_fp);
         policy.entries.push_back(SemanticEntry {
             scope_fp: scope_fp.to_string(),
+            exact_key: exact_key.to_string(),
             embedding,
             response,
             expires_at: now + ttl,
@@ -257,11 +274,20 @@ mod tests {
     async fn nearest_entry_above_threshold_wins() {
         let store = MemorySemanticCache::new();
         store
-            .store("p", 0, "fp", vec![1.0, 0.0], resp("exact"), TTL, 100)
+            .store("p", 0, "fp", "k1", vec![1.0, 0.0], resp("exact"), TTL, 100)
             .await
             .unwrap();
         store
-            .store("p", 0, "fp", vec![0.9, 0.4359], resp("near"), TTL, 100)
+            .store(
+                "p",
+                0,
+                "fp",
+                "k2",
+                vec![0.9, 0.4359],
+                resp("near"),
+                TTL,
+                100,
+            )
             .await
             .unwrap();
         // Query aligned with the second entry: both clear 0.8, nearest wins.
@@ -278,7 +304,7 @@ mod tests {
     async fn below_threshold_misses() {
         let store = MemorySemanticCache::new();
         store
-            .store("p", 0, "fp", vec![1.0, 0.0], resp("a"), TTL, 100)
+            .store("p", 0, "fp", "k3", vec![1.0, 0.0], resp("a"), TTL, 100)
             .await
             .unwrap();
         // cos = 0.7071 < 0.9.
@@ -290,7 +316,7 @@ mod tests {
     async fn scope_fp_partitions_candidates() {
         let store = MemorySemanticCache::new();
         store
-            .store("p", 0, "fp-a", vec![1.0, 0.0], resp("a"), TTL, 100)
+            .store("p", 0, "fp-a", "k4", vec![1.0, 0.0], resp("a"), TTL, 100)
             .await
             .unwrap();
         let got = store
@@ -304,7 +330,7 @@ mod tests {
     async fn policies_partition_candidates() {
         let store = MemorySemanticCache::new();
         store
-            .store("p1", 0, "fp", vec![1.0, 0.0], resp("a"), TTL, 100)
+            .store("p1", 0, "fp", "k5", vec![1.0, 0.0], resp("a"), TTL, 100)
             .await
             .unwrap();
         let got = store.lookup("p2", 0, "fp", &[1.0, 0.0], 0.5).await.unwrap();
@@ -315,7 +341,7 @@ mod tests {
     async fn generation_bump_purges_lookups_and_resets_on_store() {
         let store = MemorySemanticCache::new();
         store
-            .store("p", 0, "fp", vec![1.0, 0.0], resp("old"), TTL, 100)
+            .store("p", 0, "fp", "k6", vec![1.0, 0.0], resp("old"), TTL, 100)
             .await
             .unwrap();
         // Purge: lookups under the new generation miss.
@@ -323,7 +349,7 @@ mod tests {
         assert!(got.is_none());
         // First store under the new generation resets the list.
         store
-            .store("p", 1, "fp", vec![0.0, 1.0], resp("new"), TTL, 100)
+            .store("p", 1, "fp", "k7", vec![0.0, 1.0], resp("new"), TTL, 100)
             .await
             .unwrap();
         assert_eq!(store.entry_count("p"), 1);
@@ -337,13 +363,13 @@ mod tests {
         let store = MemorySemanticCache::new();
         // Purged bucket already re-warmed at generation 1.
         store
-            .store("p", 1, "fp", vec![0.0, 1.0], resp("new"), TTL, 100)
+            .store("p", 1, "fp", "k8", vec![0.0, 1.0], resp("new"), TTL, 100)
             .await
             .unwrap();
         // A request that read the pre-purge policy snapshot finishes its
         // upstream call late and stores under generation 0: dropped.
         store
-            .store("p", 0, "fp", vec![1.0, 0.0], resp("stale"), TTL, 100)
+            .store("p", 0, "fp", "k9", vec![1.0, 0.0], resp("stale"), TTL, 100)
             .await
             .unwrap();
         assert_eq!(store.entry_count("p"), 1);
@@ -368,6 +394,7 @@ mod tests {
                 "idle",
                 0,
                 "fp",
+                "k10",
                 vec![1.0, 0.0],
                 resp("orphan"),
                 Duration::from_millis(20),
@@ -378,7 +405,16 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(40)).await;
         // A store on ANY other policy sweeps the fully-expired bucket.
         store
-            .store("busy", 0, "fp", vec![0.0, 1.0], resp("live"), TTL, 100)
+            .store(
+                "busy",
+                0,
+                "fp",
+                "k11",
+                vec![0.0, 1.0],
+                resp("live"),
+                TTL,
+                100,
+            )
             .await
             .unwrap();
         assert_eq!(store.entry_count("idle"), 0);
@@ -390,7 +426,7 @@ mod tests {
         let store = MemorySemanticCache::new();
         let ttl = Duration::from_secs(60);
         store
-            .store("p", 0, "fp", vec![1.0, 0.0], resp("a"), ttl, 100)
+            .store("p", 0, "fp", "k12", vec![1.0, 0.0], resp("a"), ttl, 100)
             .await
             .unwrap();
         let hit = store
@@ -413,6 +449,7 @@ mod tests {
                 "p",
                 0,
                 "fp",
+                "k13",
                 vec![1.0, 0.0],
                 resp("a"),
                 Duration::from_millis(20),
@@ -429,15 +466,15 @@ mod tests {
     async fn max_entries_evicts_oldest_first() {
         let store = MemorySemanticCache::new();
         store
-            .store("p", 0, "fp", vec![1.0, 0.0], resp("first"), TTL, 2)
+            .store("p", 0, "fp", "k14", vec![1.0, 0.0], resp("first"), TTL, 2)
             .await
             .unwrap();
         store
-            .store("p", 0, "fp", vec![0.0, 1.0], resp("second"), TTL, 2)
+            .store("p", 0, "fp", "k15", vec![0.0, 1.0], resp("second"), TTL, 2)
             .await
             .unwrap();
         store
-            .store("p", 0, "fp", vec![-1.0, 0.0], resp("third"), TTL, 2)
+            .store("p", 0, "fp", "k16", vec![-1.0, 0.0], resp("third"), TTL, 2)
             .await
             .unwrap();
         assert_eq!(store.entry_count("p"), 2);
@@ -451,6 +488,72 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(hit.response.message.content_str(), "second");
+    }
+
+    #[tokio::test]
+    async fn store_upserts_by_exact_key() {
+        let store = MemorySemanticCache::new();
+        store
+            .store(
+                "p",
+                0,
+                "fp",
+                "same-wording",
+                vec![1.0, 0.0],
+                resp("v1"),
+                TTL,
+                100,
+            )
+            .await
+            .unwrap();
+        // A refresh of the SAME wording replaces the entry in place.
+        store
+            .store(
+                "p",
+                0,
+                "fp",
+                "same-wording",
+                vec![1.0, 0.0],
+                resp("v2"),
+                TTL,
+                100,
+            )
+            .await
+            .unwrap();
+        assert_eq!(store.entry_count("p"), 1);
+        let hit = store
+            .lookup("p", 0, "fp", &[1.0, 0.0], 0.9)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(hit.response.message.content_str(), "v2");
+        // Same wording under a DIFFERENT scope partition is untouched.
+        store
+            .store(
+                "p",
+                0,
+                "fp-b",
+                "same-wording",
+                vec![1.0, 0.0],
+                resp("other"),
+                TTL,
+                100,
+            )
+            .await
+            .unwrap();
+        assert_eq!(store.entry_count("p"), 2);
+    }
+
+    #[tokio::test]
+    async fn zero_similarity_never_matches_even_at_threshold_zero() {
+        let store = MemorySemanticCache::new();
+        // Dimension mismatch folds to 0.0; threshold 0.0 must still miss.
+        store
+            .store("p", 0, "fp", "k", vec![1.0, 0.0, 0.0], resp("a"), TTL, 100)
+            .await
+            .unwrap();
+        let got = store.lookup("p", 0, "fp", &[1.0, 0.0], 0.0).await.unwrap();
+        assert!(got.is_none());
     }
 
     #[test]

--- a/crates/aisix-cache/src/semantic.rs
+++ b/crates/aisix-cache/src/semantic.rs
@@ -14,10 +14,13 @@
 //! generation makes every earlier entry unreachable.
 //!
 //! [`MemorySemanticCache`] is the in-process implementation (`backend:
-//! memory`): per-policy entry lists scanned with brute-force cosine.
-//! At the schema-capped 100k entries × 1536 dims that is a few ms; at
-//! the default 1000 entries it is microseconds. Like the exact memory
-//! backend, it is per-instance — replicas do not share entries.
+//! memory`): per-policy entry lists scanned with brute-force cosine
+//! under a map-shard read guard. The `max_entries` schema cap (10 000)
+//! bounds the scan at ~15M f32 ops ≈ low-ms worst case and ~60 MB of
+//! vectors per policy at 1536 dims; the 1000 default is microseconds.
+//! Workloads beyond that belong on the shared (redis vector) backend.
+//! Like the exact memory backend, it is per-instance — replicas do not
+//! share entries.
 
 use aisix_gateway::ChatResponse;
 use async_trait::async_trait;
@@ -33,6 +36,11 @@ use crate::cache::CacheError;
 pub struct SemanticHit {
     pub response: ChatResponse,
     pub similarity: f32,
+    /// When the matched entry expires. Callers that copy the response
+    /// into another layer (the exact-layer backfill) must cap that
+    /// copy's TTL to this deadline, so a near-expiry entry cannot be
+    /// granted a fresh full lifetime on every similar request.
+    pub expires_at: Instant,
 }
 
 /// Storage seam for the semantic layer. Implementations must treat
@@ -158,6 +166,7 @@ impl SemanticCacheStore for MemorySemanticCache {
                 best = Some(SemanticHit {
                     response: entry.response.clone(),
                     similarity,
+                    expires_at: entry.expires_at,
                 });
             }
         }
@@ -175,6 +184,22 @@ impl SemanticCacheStore for MemorySemanticCache {
         max_entries: u32,
     ) -> Result<(), CacheError> {
         let now = Instant::now();
+        // Opportunistic reclamation of OTHER policies' storage: a policy
+        // that was deleted (or just went idle) never runs its own store
+        // path again, so front-drain its expired entries here and drop
+        // buckets that emptied. Bounds orphaned memory at one TTL
+        // (≤ 7 days) past the last write instead of process lifetime.
+        // O(#policies) per store — policies are operator-configured and
+        // few, and stores only happen on upstream misses.
+        self.policies.retain(|id, p| {
+            if id == policy_id {
+                return true;
+            }
+            while p.entries.front().is_some_and(|e| e.expires_at <= now) {
+                p.entries.pop_front();
+            }
+            !p.entries.is_empty()
+        });
         let mut policy = self
             .policies
             .entry(policy_id.to_string())
@@ -182,7 +207,14 @@ impl SemanticCacheStore for MemorySemanticCache {
                 generation,
                 entries: VecDeque::new(),
             });
-        if policy.generation != generation {
+        // A store from a request that read the policy BEFORE a purge
+        // must not roll the bucket back and wipe post-purge entries:
+        // drop the stale write instead. (Generations only ever move
+        // forward — cp-api increments on purge.)
+        if generation < policy.generation {
+            return Ok(());
+        }
+        if generation > policy.generation {
             policy.generation = generation;
             policy.entries.clear();
         }
@@ -298,6 +330,79 @@ mod tests {
         // Old-generation entry is gone even for old-generation lookups.
         let got = store.lookup("p", 0, "fp", &[1.0, 0.0], 0.5).await.unwrap();
         assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_generation_store_is_dropped_not_rolled_back() {
+        let store = MemorySemanticCache::new();
+        // Purged bucket already re-warmed at generation 1.
+        store
+            .store("p", 1, "fp", vec![0.0, 1.0], resp("new"), TTL, 100)
+            .await
+            .unwrap();
+        // A request that read the pre-purge policy snapshot finishes its
+        // upstream call late and stores under generation 0: dropped.
+        store
+            .store("p", 0, "fp", vec![1.0, 0.0], resp("stale"), TTL, 100)
+            .await
+            .unwrap();
+        assert_eq!(store.entry_count("p"), 1);
+        let hit = store
+            .lookup("p", 1, "fp", &[0.0, 1.0], 0.9)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(hit.response.message.content_str(), "new");
+        assert!(store
+            .lookup("p", 0, "fp", &[1.0, 0.0], 0.5)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn store_reclaims_other_policies_expired_buckets() {
+        let store = MemorySemanticCache::new();
+        store
+            .store(
+                "idle",
+                0,
+                "fp",
+                vec![1.0, 0.0],
+                resp("orphan"),
+                Duration::from_millis(20),
+                100,
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        // A store on ANY other policy sweeps the fully-expired bucket.
+        store
+            .store("busy", 0, "fp", vec![0.0, 1.0], resp("live"), TTL, 100)
+            .await
+            .unwrap();
+        assert_eq!(store.entry_count("idle"), 0);
+        assert_eq!(store.entry_count("busy"), 1);
+    }
+
+    #[tokio::test]
+    async fn lookup_reports_entry_expiry_for_backfill_capping() {
+        let store = MemorySemanticCache::new();
+        let ttl = Duration::from_secs(60);
+        store
+            .store("p", 0, "fp", vec![1.0, 0.0], resp("a"), ttl, 100)
+            .await
+            .unwrap();
+        let hit = store
+            .lookup("p", 0, "fp", &[1.0, 0.0], 0.9)
+            .await
+            .unwrap()
+            .unwrap();
+        // `expires_at` was set at store time, so measured from any later
+        // instant the remaining lifetime is within (ttl - ε, ttl].
+        let remaining = hit.expires_at.saturating_duration_since(Instant::now());
+        assert!(remaining <= ttl);
+        assert!(remaining > ttl - Duration::from_secs(5));
     }
 
     #[tokio::test]

--- a/crates/aisix-cache/src/semantic.rs
+++ b/crates/aisix-cache/src/semantic.rs
@@ -1,0 +1,358 @@
+//! Semantic (embedding-similarity) storage — the L2 matching layer.
+//!
+//! Entries live *beside* the exact cache, not inside it: the [`Cache`]
+//! trait is keyed by an opaque fingerprint string, while a semantic
+//! lookup needs the candidate scope, the request embedding, and a
+//! similarity threshold. The proxy consults the exact layer first and
+//! only reaches for [`SemanticCacheStore`] on an exact miss.
+//!
+//! Scoping mirrors the exact key: candidates are pre-filtered by
+//! `scope_fp` ([`crate::CacheKey::scope_fingerprint`] — model, sampling
+//! params, extras, policy, generation, caller scope) so only the
+//! *messages* are ever fuzzy. Purge works generationally: entries are
+//! stored under the policy's `purge_generation`, and a bumped
+//! generation makes every earlier entry unreachable.
+//!
+//! [`MemorySemanticCache`] is the in-process implementation (`backend:
+//! memory`): per-policy entry lists scanned with brute-force cosine.
+//! At the schema-capped 100k entries × 1536 dims that is a few ms; at
+//! the default 1000 entries it is microseconds. Like the exact memory
+//! backend, it is per-instance — replicas do not share entries.
+
+use aisix_gateway::ChatResponse;
+use async_trait::async_trait;
+use dashmap::DashMap;
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use crate::cache::CacheError;
+
+/// A semantic lookup match: the stored response plus how similar the
+/// stored request was to the incoming one (cosine, `[0, 1]`-ish).
+#[derive(Debug, Clone)]
+pub struct SemanticHit {
+    pub response: ChatResponse,
+    pub similarity: f32,
+}
+
+/// Storage seam for the semantic layer. Implementations must treat
+/// `(policy_id, generation, scope_fp)` as the candidate partition:
+/// lookups only ever compare against entries stored under the same
+/// triple.
+#[async_trait]
+pub trait SemanticCacheStore: Send + Sync + 'static {
+    /// Nearest stored entry in the partition with cosine similarity
+    /// `>= threshold`, or `None`.
+    async fn lookup(
+        &self,
+        policy_id: &str,
+        generation: u32,
+        scope_fp: &str,
+        embedding: &[f32],
+        threshold: f32,
+    ) -> Result<Option<SemanticHit>, CacheError>;
+
+    /// Store a response under the partition. `max_entries` caps the
+    /// policy's entry count where the backend enforces one (the memory
+    /// backend evicts oldest-first; shared backends may ignore it and
+    /// bound growth by TTL).
+    #[allow(clippy::too_many_arguments)]
+    async fn store(
+        &self,
+        policy_id: &str,
+        generation: u32,
+        scope_fp: &str,
+        embedding: Vec<f32>,
+        response: ChatResponse,
+        ttl: Duration,
+        max_entries: u32,
+    ) -> Result<(), CacheError>;
+}
+
+/// Cosine similarity of two equal-length vectors. Returns `0.0` for a
+/// length mismatch or a zero-magnitude vector so a degenerate embedding
+/// can never produce `NaN` (which would poison the max-tracking scan).
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+struct SemanticEntry {
+    scope_fp: String,
+    embedding: Vec<f32>,
+    response: ChatResponse,
+    expires_at: Instant,
+}
+
+/// One policy's entries. `generation` is the `purge_generation` the
+/// entries were stored under; a store or lookup with a different
+/// generation treats the whole list as stale (lookups miss, the next
+/// store resets it) — that lazy check is what makes purge O(1) without
+/// any watch/callback plumbing.
+struct PolicyEntries {
+    generation: u32,
+    entries: VecDeque<SemanticEntry>,
+}
+
+/// In-process semantic store for `backend: memory` policies.
+#[derive(Default)]
+pub struct MemorySemanticCache {
+    policies: DashMap<String, PolicyEntries>,
+}
+
+impl MemorySemanticCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(test)]
+    fn entry_count(&self, policy_id: &str) -> usize {
+        self.policies
+            .get(policy_id)
+            .map(|p| p.entries.len())
+            .unwrap_or(0)
+    }
+}
+
+#[async_trait]
+impl SemanticCacheStore for MemorySemanticCache {
+    async fn lookup(
+        &self,
+        policy_id: &str,
+        generation: u32,
+        scope_fp: &str,
+        embedding: &[f32],
+        threshold: f32,
+    ) -> Result<Option<SemanticHit>, CacheError> {
+        let Some(policy) = self.policies.get(policy_id) else {
+            return Ok(None);
+        };
+        if policy.generation != generation {
+            // Purged since these entries were written; read path stays
+            // immutable, the next store resets the list.
+            return Ok(None);
+        }
+        let now = Instant::now();
+        let mut best: Option<SemanticHit> = None;
+        for entry in &policy.entries {
+            if entry.scope_fp != scope_fp || entry.expires_at <= now {
+                continue;
+            }
+            let similarity = cosine_similarity(embedding, &entry.embedding);
+            if similarity >= threshold
+                && best.as_ref().map(|b| similarity > b.similarity) != Some(false)
+            {
+                best = Some(SemanticHit {
+                    response: entry.response.clone(),
+                    similarity,
+                });
+            }
+        }
+        Ok(best)
+    }
+
+    async fn store(
+        &self,
+        policy_id: &str,
+        generation: u32,
+        scope_fp: &str,
+        embedding: Vec<f32>,
+        response: ChatResponse,
+        ttl: Duration,
+        max_entries: u32,
+    ) -> Result<(), CacheError> {
+        let now = Instant::now();
+        let mut policy = self
+            .policies
+            .entry(policy_id.to_string())
+            .or_insert_with(|| PolicyEntries {
+                generation,
+                entries: VecDeque::new(),
+            });
+        if policy.generation != generation {
+            policy.generation = generation;
+            policy.entries.clear();
+        }
+        // Drop expired entries from the front (insertion order ≈ expiry
+        // order for a fixed TTL; mixed TTLs just expire lazily later).
+        while policy.entries.front().is_some_and(|e| e.expires_at <= now) {
+            policy.entries.pop_front();
+        }
+        policy.entries.push_back(SemanticEntry {
+            scope_fp: scope_fp.to_string(),
+            embedding,
+            response,
+            expires_at: now + ttl,
+        });
+        while policy.entries.len() > max_entries as usize {
+            policy.entries.pop_front();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aisix_gateway::{ChatMessage, FinishReason, UsageStats};
+
+    fn resp(text: &str) -> ChatResponse {
+        ChatResponse {
+            id: "cmpl-1".into(),
+            model: "m".into(),
+            message: ChatMessage::assistant(text),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(2, 3),
+        }
+    }
+
+    const TTL: Duration = Duration::from_secs(60);
+
+    #[tokio::test]
+    async fn nearest_entry_above_threshold_wins() {
+        let store = MemorySemanticCache::new();
+        store
+            .store("p", 0, "fp", vec![1.0, 0.0], resp("exact"), TTL, 100)
+            .await
+            .unwrap();
+        store
+            .store("p", 0, "fp", vec![0.9, 0.4359], resp("near"), TTL, 100)
+            .await
+            .unwrap();
+        // Query aligned with the second entry: both clear 0.8, nearest wins.
+        let hit = store
+            .lookup("p", 0, "fp", &[0.9, 0.4359], 0.8)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(hit.response.message.content_str(), "near");
+        assert!(hit.similarity > 0.99);
+    }
+
+    #[tokio::test]
+    async fn below_threshold_misses() {
+        let store = MemorySemanticCache::new();
+        store
+            .store("p", 0, "fp", vec![1.0, 0.0], resp("a"), TTL, 100)
+            .await
+            .unwrap();
+        // cos = 0.7071 < 0.9.
+        let got = store.lookup("p", 0, "fp", &[1.0, 1.0], 0.9).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn scope_fp_partitions_candidates() {
+        let store = MemorySemanticCache::new();
+        store
+            .store("p", 0, "fp-a", vec![1.0, 0.0], resp("a"), TTL, 100)
+            .await
+            .unwrap();
+        let got = store
+            .lookup("p", 0, "fp-b", &[1.0, 0.0], 0.5)
+            .await
+            .unwrap();
+        assert!(got.is_none(), "entries must not cross scope fingerprints");
+    }
+
+    #[tokio::test]
+    async fn policies_partition_candidates() {
+        let store = MemorySemanticCache::new();
+        store
+            .store("p1", 0, "fp", vec![1.0, 0.0], resp("a"), TTL, 100)
+            .await
+            .unwrap();
+        let got = store.lookup("p2", 0, "fp", &[1.0, 0.0], 0.5).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn generation_bump_purges_lookups_and_resets_on_store() {
+        let store = MemorySemanticCache::new();
+        store
+            .store("p", 0, "fp", vec![1.0, 0.0], resp("old"), TTL, 100)
+            .await
+            .unwrap();
+        // Purge: lookups under the new generation miss.
+        let got = store.lookup("p", 1, "fp", &[1.0, 0.0], 0.5).await.unwrap();
+        assert!(got.is_none());
+        // First store under the new generation resets the list.
+        store
+            .store("p", 1, "fp", vec![0.0, 1.0], resp("new"), TTL, 100)
+            .await
+            .unwrap();
+        assert_eq!(store.entry_count("p"), 1);
+        // Old-generation entry is gone even for old-generation lookups.
+        let got = store.lookup("p", 0, "fp", &[1.0, 0.0], 0.5).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn expired_entries_never_match() {
+        let store = MemorySemanticCache::new();
+        store
+            .store(
+                "p",
+                0,
+                "fp",
+                vec![1.0, 0.0],
+                resp("a"),
+                Duration::from_millis(20),
+                100,
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        let got = store.lookup("p", 0, "fp", &[1.0, 0.0], 0.5).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn max_entries_evicts_oldest_first() {
+        let store = MemorySemanticCache::new();
+        store
+            .store("p", 0, "fp", vec![1.0, 0.0], resp("first"), TTL, 2)
+            .await
+            .unwrap();
+        store
+            .store("p", 0, "fp", vec![0.0, 1.0], resp("second"), TTL, 2)
+            .await
+            .unwrap();
+        store
+            .store("p", 0, "fp", vec![-1.0, 0.0], resp("third"), TTL, 2)
+            .await
+            .unwrap();
+        assert_eq!(store.entry_count("p"), 2);
+        // "first" ([1,0]) was evicted; an aligned query now misses.
+        let got = store.lookup("p", 0, "fp", &[1.0, 0.0], 0.9).await.unwrap();
+        assert!(got.is_none());
+        // "second" survives.
+        let hit = store
+            .lookup("p", 0, "fp", &[0.0, 1.0], 0.9)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(hit.response.message.content_str(), "second");
+    }
+
+    #[test]
+    fn cosine_degenerate_inputs_are_zero_not_nan() {
+        assert_eq!(cosine_similarity(&[0.0, 0.0], &[1.0, 1.0]), 0.0);
+        assert_eq!(cosine_similarity(&[1.0, 2.0, 3.0], &[1.0, 2.0]), 0.0);
+        assert!((cosine_similarity(&[1.0, 1.0], &[5.0, 5.0]) - 1.0).abs() < 1e-6);
+        assert!(!cosine_similarity(&[0.0], &[0.0]).is_nan());
+    }
+}

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -50,6 +50,11 @@ pub enum CacheScope {
 /// similarity is served. Only requests whose messages are entirely text
 /// participate — requests containing images or audio never match by
 /// similarity.
+///
+/// Similarity matching currently requires `backend: memory`. A policy
+/// with `backend: redis` accepts this configuration but keeps serving
+/// exact matches only (a warning is logged) until shared semantic
+/// storage ships.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct SemanticCacheConfig {
     /// Name of the `embedding` model used to embed requests. The model
@@ -135,7 +140,10 @@ pub struct CachePolicy {
     /// Invalidation counter. Entries are readable only while their
     /// stored generation matches; a purge bumps this value, making
     /// every earlier entry unreachable at once. Managed by the purge
-    /// operation — not set directly.
+    /// operation — not set directly. Full-document updates must carry
+    /// the current value forward: writing a lower (or omitted, i.e.
+    /// `0`) value re-exposes entries stored under that earlier
+    /// generation until their TTL passes.
     #[serde(default)]
     pub purge_generation: u32,
 

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -3,10 +3,10 @@
 //! `/aisix/<env>/cache_policies/<uuid>`; the DP loads them on watch
 //! and `aisix-proxy::cache_gate` consults them on every chat request.
 //!
-//! Backends supported: `memory` + `redis`. Semantic backends were
-//! removed pending DP-side wiring of the embedding client +
-//! chat-dispatch integration — see ai-gateway issue #116 and the
-//! TODO issue tracking re-introduction.
+//! Backends supported: `memory` + `redis` — the *storage* dimension.
+//! Matching is layered: every policy does exact-fingerprint matching,
+//! and a policy that carries a [`SemanticCacheConfig`] additionally
+//! matches by embedding similarity when the exact layer misses.
 //!
 //! See `crates/aisix-cache` for the cache backend itself; this module
 //! is the wire shape only.
@@ -26,7 +26,77 @@ pub enum CacheBackend {
     Redis,
 }
 
-/// Semantic cache policy for chat requests.
+/// Sharing boundary for cache entries created under a policy. Applies to
+/// both matching layers: an entry written in one scope bucket is never
+/// served to a request in another.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheScope {
+    /// Entries are private to the API key that created them. The safe
+    /// default: one caller's answers are never replayed to another.
+    #[default]
+    ApiKey,
+    /// Entries are shared by every API key in the environment. Pick this
+    /// for shared-knowledge traffic (FAQ, documentation Q&A) where
+    /// cross-caller reuse is the point.
+    Env,
+}
+
+/// Embedding-similarity matching for a cache policy. When present, a
+/// request that misses the exact layer is embedded and compared against
+/// stored entries; the nearest entry at or above `threshold` cosine
+/// similarity is served. Only requests whose messages are entirely text
+/// participate — requests containing images or audio never match by
+/// similarity.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+pub struct SemanticCacheConfig {
+    /// Name of the `embedding` model used to embed requests. The model
+    /// must exist in the same environment and carry an `embedding`
+    /// block; its `dimensions` value fixes the vector size for this
+    /// policy's entries.
+    #[schemars(length(min = 1))]
+    pub embedding_model: String,
+
+    /// Minimum cosine similarity for a stored entry to be served, in
+    /// `[0, 1]`. Higher is stricter. Values below `0.9` noticeably
+    /// increase wrong-answer risk for most embedding models.
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub threshold: f32,
+
+    /// Upper bound on stored entries for this policy on the `memory`
+    /// backend; the oldest entry is evicted first. Shared backends
+    /// bound growth by TTL instead and ignore this value.
+    #[serde(default = "default_semantic_max_entries")]
+    #[schemars(range(min = 1, max = 100000))]
+    pub max_entries: u32,
+
+    /// Per-call deadline for the embedding request in milliseconds.
+    /// `0` or absent disables the embedding-specific deadline. On
+    /// timeout the request proceeds to the upstream uncached.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_timeout_ms: Option<u64>,
+}
+
+impl SemanticCacheConfig {
+    /// Per-call embedding deadline. Folds the `0`/absent sentinel into
+    /// `None` so callers can apply it unconditionally.
+    pub fn embedding_timeout(&self) -> Option<std::time::Duration> {
+        self.embedding_timeout_ms
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis)
+    }
+}
+
+fn default_semantic_max_entries() -> u32 {
+    1000
+}
+
+/// A prompt-response cache rule. Requests covered by an enabled policy
+/// are served from cache when an identical request was answered before
+/// (exact matching), and — when `semantic` is configured — when a
+/// sufficiently similar request was.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct CachePolicy {
     /// Operator-facing name that surfaces in metric labels and cache headers.
@@ -52,6 +122,24 @@ pub struct CachePolicy {
     #[serde(default = "default_applies_to")]
     #[schemars(length(min = 1, max = 255))]
     pub applies_to: String,
+
+    /// Sharing boundary for entries created under this policy:
+    /// `api_key` (default) keeps entries private to the caller that
+    /// created them; `env` shares them across the environment.
+    #[serde(default)]
+    pub scope: CacheScope,
+
+    /// Invalidation counter. Entries are readable only while their
+    /// stored generation matches; a purge bumps this value, making
+    /// every earlier entry unreachable at once. Managed by the purge
+    /// operation — not set directly.
+    #[serde(default)]
+    pub purge_generation: u32,
+
+    /// Embedding-similarity matching. Absent: the policy matches
+    /// exactly-identical requests only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic: Option<SemanticCacheConfig>,
 
     /// Set by the loader from the kine path's UUID segment. The DP
     /// uses this for metric labels and log correlation. Not part of
@@ -248,5 +336,78 @@ mod tests {
         });
         let p: CachePolicy = serde_json::from_value(v).unwrap();
         assert_eq!(p.name, "future");
+    }
+
+    #[test]
+    fn scope_and_generation_default_for_legacy_rows() {
+        // Rows written before the semantic-cache release carry neither
+        // field; they must parse with the documented defaults.
+        let p: CachePolicy =
+            serde_json::from_value(json!({"name": "old", "backend": "memory"})).unwrap();
+        assert_eq!(p.scope, CacheScope::ApiKey);
+        assert_eq!(p.purge_generation, 0);
+        assert!(p.semantic.is_none());
+    }
+
+    #[test]
+    fn deserialises_full_semantic_policy() {
+        let v = json!({
+            "name": "faq",
+            "backend": "memory",
+            "scope": "env",
+            "purge_generation": 3,
+            "semantic": {
+                "embedding_model": "text-embedding-3-small",
+                "threshold": 0.92,
+                "embedding_timeout_ms": 2000
+            }
+        });
+        let p: CachePolicy = serde_json::from_value(v).unwrap();
+        assert_eq!(p.scope, CacheScope::Env);
+        assert_eq!(p.purge_generation, 3);
+        let sem = p.semantic.as_ref().unwrap();
+        assert_eq!(sem.embedding_model, "text-embedding-3-small");
+        assert!((sem.threshold - 0.92).abs() < 1e-6);
+        assert_eq!(sem.max_entries, 1000, "max_entries defaults to 1000");
+        assert_eq!(
+            sem.embedding_timeout(),
+            Some(std::time::Duration::from_millis(2000))
+        );
+    }
+
+    #[test]
+    fn semantic_block_tolerates_unknown_fields_for_forward_compat() {
+        // Same forward-compat contract as the policy root: a future
+        // knob inside `semantic` must not make this DP drop the row.
+        let v = json!({
+            "name": "faq",
+            "semantic": {
+                "embedding_model": "e",
+                "threshold": 0.9,
+                "future_knob": true
+            }
+        });
+        let p: CachePolicy = serde_json::from_value(v).unwrap();
+        assert!(p.semantic.is_some());
+    }
+
+    #[test]
+    fn semantic_zero_timeout_means_no_deadline() {
+        let sem: SemanticCacheConfig = serde_json::from_value(json!({
+            "embedding_model": "e",
+            "threshold": 0.9,
+            "embedding_timeout_ms": 0
+        }))
+        .unwrap();
+        assert_eq!(sem.embedding_timeout(), None);
+    }
+
+    #[test]
+    fn semantic_threshold_is_required() {
+        let v = json!({
+            "name": "faq",
+            "semantic": {"embedding_model": "e"}
+        });
+        assert!(serde_json::from_value::<CachePolicy>(v).is_err());
     }
 }

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -67,9 +67,12 @@ pub struct SemanticCacheConfig {
 
     /// Upper bound on stored entries for this policy on the `memory`
     /// backend; the oldest entry is evicted first. Shared backends
-    /// bound growth by TTL instead and ignore this value.
+    /// bound growth by TTL instead and ignore this value. The ceiling
+    /// keeps the per-request similarity scan and the per-policy vector
+    /// memory bounded; workloads needing more entries belong on a
+    /// shared backend.
     #[serde(default = "default_semantic_max_entries")]
-    #[schemars(range(min = 1, max = 100000))]
+    #[schemars(range(min = 1, max = 10000))]
     pub max_entries: u32,
 
     /// Per-call deadline for the embedding request in milliseconds.

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -37,7 +37,7 @@ pub mod snapshot;
 
 pub use a2a_agent::{A2aAgent, A2aAuthType, A2aProtocolVersion};
 pub use apikey::ApiKey;
-pub use cache_policy::{AppliesTo, CacheBackend, CachePolicy};
+pub use cache_policy::{AppliesTo, CacheBackend, CachePolicy, CacheScope, SemanticCacheConfig};
 pub use embedding::EmbeddingConfig;
 pub use ensemble::{EnsembleConfig, Judge, PanelMember};
 pub use guardrail::{

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -158,6 +158,29 @@ pub const M_GUARDRAIL_LATENCY_SECONDS: &str = "aisix_guardrail_latency_seconds";
 /// Paired with `aisix_usage_event_drops_total{reason}` for the
 /// `try_send` failure paths (sink full / closed).
 pub const M_USAGE_EVENT_EMITS_TOTAL: &str = "aisix_usage_events_emitted_total";
+/// Cache gate outcomes, one increment per request that reached an
+/// enabled cache policy with an available backend. Labels:
+/// - `policy`: the policy's operator-facing name (bounded by the
+///   configured policy count).
+/// - `outcome`: `hit_exact` / `hit_semantic` / `miss` / `bypass`
+///   (`bypass` = the caller's `Cache-Control: no-cache` skipped the
+///   read path).
+///
+/// Requests with no matching policy or an unavailable backend
+/// (`cache_status=disabled`) are not counted — the gate never opened.
+pub const M_CACHE_REQUESTS_TOTAL: &str = "aisix_cache_requests_total";
+/// Latency of the cache semantic layer's embedding calls, by `policy`.
+/// Summary series (no fixed buckets), like the other legacy
+/// `histogram!` series here.
+pub const M_CACHE_SEMANTIC_EMBED_SECONDS: &str = "aisix_cache_semantic_embedding_seconds";
+/// Embedding failures on the cache semantic layer, by `policy` and
+/// `cause` (`resolve` = embedding model missing or not an embedding
+/// model; `embed` = the provider call failed or timed out). Each
+/// failure degrades that request to exact-only matching, so a nonzero
+/// rate here with a flat `hit_semantic` outcome is the "semantic layer
+/// silently down" signal.
+pub const M_CACHE_SEMANTIC_EMBED_FAILURES_TOTAL: &str =
+    "aisix_cache_semantic_embedding_failures_total";
 pub const M_OTLP_FANOUT_DROPS_TOTAL: &str = "aisix_otlp_fanout_drops_total";
 pub const M_OTLP_FANOUT_FAILURES_TOTAL: &str = "aisix_otlp_fanout_failures_total";
 /// AISIX-Cloud#1011: SLO-grade latency distributions as REAL bucketed
@@ -847,6 +870,45 @@ impl Metrics {
                 "scope" => scope.to_string(),
                 "layer" => layer.to_string(),
                 "policy_id" => policy_id.unwrap_or_default().to_string(),
+            )
+            .increment(1);
+        });
+    }
+
+    /// Count one cache-gate outcome. `policy` is the matched policy's
+    /// name, `outcome` one of the fixed [`M_CACHE_REQUESTS_TOTAL`]
+    /// values.
+    pub fn record_cache_event(&self, policy: &str, outcome: &str) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_CACHE_REQUESTS_TOTAL,
+                "policy" => policy.to_string(),
+                "outcome" => outcome.to_string(),
+            )
+            .increment(1);
+        });
+    }
+
+    /// Record one successful cache semantic-layer embedding call.
+    pub fn record_cache_semantic_embed(&self, policy: &str, elapsed: Duration) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::histogram!(
+                M_CACHE_SEMANTIC_EMBED_SECONDS,
+                "policy" => policy.to_string(),
+            )
+            .record(elapsed.as_secs_f64());
+        });
+    }
+
+    /// Count one failed cache semantic-layer embedding attempt. `cause`
+    /// is one of the fixed [`M_CACHE_SEMANTIC_EMBED_FAILURES_TOTAL`]
+    /// values.
+    pub fn record_cache_semantic_embed_failure(&self, policy: &str, cause: &str) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_CACHE_SEMANTIC_EMBED_FAILURES_TOTAL,
+                "policy" => policy.to_string(),
+                "cause" => cause.to_string(),
             )
             .increment(1);
         });

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -174,11 +174,13 @@ pub const M_CACHE_REQUESTS_TOTAL: &str = "aisix_cache_requests_total";
 /// `histogram!` series here.
 pub const M_CACHE_SEMANTIC_EMBED_SECONDS: &str = "aisix_cache_semantic_embedding_seconds";
 /// Embedding failures on the cache semantic layer, by `policy` and
-/// `cause` (`resolve` = embedding model missing or not an embedding
-/// model; `embed` = the provider call failed or timed out). Each
-/// failure degrades that request to exact-only matching, so a nonzero
-/// rate here with a flat `hit_semantic` outcome is the "semantic layer
-/// silently down" signal.
+/// `cause`. `resolve` (embedding model missing or not an embedding
+/// model) is counted once per eligible request — including requests
+/// that then hit the exact layer; `embed` (provider call failed or
+/// timed out) is counted per attempted call. Each failure leaves that
+/// request exact-only, so a nonzero rate here with a flat
+/// `hit_semantic` outcome is the "semantic layer silently down"
+/// signal.
 pub const M_CACHE_SEMANTIC_EMBED_FAILURES_TOTAL: &str =
     "aisix_cache_semantic_embedding_failures_total";
 /// Semantic-store operation failures, by `policy` and `op`

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -181,6 +181,12 @@ pub const M_CACHE_SEMANTIC_EMBED_SECONDS: &str = "aisix_cache_semantic_embedding
 /// silently down" signal.
 pub const M_CACHE_SEMANTIC_EMBED_FAILURES_TOTAL: &str =
     "aisix_cache_semantic_embedding_failures_total";
+/// Semantic-store operation failures, by `policy` and `op`
+/// (`lookup` / `store`). Failures degrade to an ordinary miss, which
+/// makes a broken store indistinguishable from a healthy low hit rate
+/// in the outcome counter alone — this series is the disambiguator.
+/// The in-process store cannot fail today; shared (redis) stores can.
+pub const M_CACHE_SEMANTIC_STORE_FAILURES_TOTAL: &str = "aisix_cache_semantic_store_failures_total";
 pub const M_OTLP_FANOUT_DROPS_TOTAL: &str = "aisix_otlp_fanout_drops_total";
 pub const M_OTLP_FANOUT_FAILURES_TOTAL: &str = "aisix_otlp_fanout_failures_total";
 /// AISIX-Cloud#1011: SLO-grade latency distributions as REAL bucketed
@@ -909,6 +915,19 @@ impl Metrics {
                 M_CACHE_SEMANTIC_EMBED_FAILURES_TOTAL,
                 "policy" => policy.to_string(),
                 "cause" => cause.to_string(),
+            )
+            .increment(1);
+        });
+    }
+
+    /// Count one failed semantic-store operation. `op` is one of the
+    /// fixed [`M_CACHE_SEMANTIC_STORE_FAILURES_TOTAL`] values.
+    pub fn record_cache_semantic_store_failure(&self, policy: &str, op: &str) {
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            metrics::counter!(
+                M_CACHE_SEMANTIC_STORE_FAILURES_TOTAL,
+                "policy" => policy.to_string(),
+                "op" => op.to_string(),
             )
             .increment(1);
         });

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -287,6 +287,19 @@ pub struct UsageEvent {
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub cache_hit_saved_output_tokens: u32,
 
+    /// On a cache hit, which matching layer served it: `"exact"` (a
+    /// byte-identical request) or `"semantic"` (an
+    /// embedding-similarity match above the policy's threshold).
+    /// Empty on every other outcome — `/dp/telemetry` binds JSON
+    /// leniently, so older CP images ignore the unknown field.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub cache_hit_layer: String,
+
+    /// On a semantic cache hit, the cosine similarity between the
+    /// request and the stored entry, in `[0, 1]`. `None` otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_similarity: Option<f32>,
+
     /// Which client-facing protocol the request used:
     ///
     /// - `"openai"` — `/v1/chat/completions` / `/v1/responses` /

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -260,6 +260,9 @@ pub struct UsageEvent {
     ///   upstream response was just stored
     /// - `"disabled"` — no enabled `cache_policy` in snapshot for
     ///   this env, the cache gate was closed
+    /// - `"bypass"` — the gate was open but the caller sent
+    ///   `Cache-Control: no-cache`, so the read path was skipped and
+    ///   the upstream served the request (the entry was refreshed)
     ///
     /// Empty string = cache state unknown / not applicable (error
     /// paths that fail before the cache lookup). cp-api persists

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -16,9 +16,10 @@
 //!    line. Errors surface via [`ProxyError`] which carries the right
 //!    status, error type, and (for rate-limits) Retry-After.
 
-use aisix_cache::{Cache, CacheKey};
-use aisix_core::AppliedGuardrail;
-use aisix_gateway::{BridgeError, ChatFormat};
+use aisix_cache::{semantic_prompt_text, Cache, CacheKey, SemanticCacheStore};
+use aisix_core::models::{CacheScope, SemanticCacheConfig};
+use aisix_core::{AisixSnapshot, AppliedGuardrail};
+use aisix_gateway::{BridgeError, ChatFormat, ChatResponse};
 use aisix_guardrails::GuardrailVerdict;
 use aisix_obs::{
     content_capture_cap, AccessLog, CapturedContent, LatencyLabels, Metrics, UsageEvent,
@@ -44,8 +45,17 @@ use crate::routing::{is_retryable, resolve_attempt_models, AttemptModel, Routing
 use crate::state::ProxyState;
 
 /// Header set on every non-streaming response indicating whether the
-/// response came from the cache (`hit`) or the upstream (`miss`).
+/// response came from the cache (`hit`), the upstream (`miss`), or the
+/// upstream because the caller sent `Cache-Control: no-cache` (`bypass`).
 pub const CACHE_HEADER: &str = "x-aisix-cache";
+
+/// On a cache hit, which matching layer served it: `exact` or
+/// `semantic`. Absent on miss/bypass.
+pub const CACHE_LAYER_HEADER: &str = "x-aisix-cache-layer";
+
+/// On a semantic cache hit, the cosine similarity between the request
+/// and the stored entry (4 decimal places). Absent otherwise.
+pub const CACHE_SIMILARITY_HEADER: &str = "x-aisix-cache-similarity";
 
 struct DispatchFailure {
     model_id: Option<String>,
@@ -230,6 +240,11 @@ pub async fn chat_completions(
                         finish_reason: success.finish_reason.clone(),
                         bypass_reason: success.bypass_reason.clone().unwrap_or_default(),
                         cache_status: success.cache_status.as_str().to_string(),
+                        cache_hit_layer: success
+                            .cache_hit_layer
+                            .map(|l| l.as_str().to_string())
+                            .unwrap_or_default(),
+                        cache_similarity: success.cache_similarity,
                         cache_hit_saved_input_tokens: success.cache_hit_saved_input_tokens,
                         cache_hit_saved_output_tokens: success.cache_hit_saved_output_tokens,
                         // Non-streaming: nothing was streamed, so there is no
@@ -502,6 +517,10 @@ pub async fn chat_completions(
                             finish_reason: c.finish_reason,
                             bypass_reason: c.bypass_reason,
                             cache_status: c.cache_status.as_str().to_string(),
+                            // Output-blocked responses were upstream-served,
+                            // never cache hits — no layer / similarity.
+                            cache_hit_layer: String::new(),
+                            cache_similarity: None,
                             cache_hit_saved_input_tokens: 0,
                             cache_hit_saved_output_tokens: 0,
                             upstream_ttft_ms: 0,
@@ -620,6 +639,12 @@ struct Success {
     /// the dashboard's /logs column. See `aisix-core::CachePolicy`
     /// (Stage 2) and `aisix-cache::Cache` for the source of truth.
     cache_status: CacheStatus,
+    /// On a cache hit, the matching layer that served it. `None` on
+    /// every other outcome. Lands on `usage_events.cache_hit_layer`.
+    cache_hit_layer: Option<CacheHitLayer>,
+    /// On a semantic cache hit, the request↔entry cosine similarity.
+    /// `None` otherwise. Lands on `usage_events.cache_similarity`.
+    cache_similarity: Option<f32>,
     /// True when telemetry emission is wired into the SSE stream's
     /// on_complete callback (streaming path). The top-level handler
     /// must NOT call `emit_usage_event` again — that would emit one
@@ -680,6 +705,10 @@ pub(crate) enum CacheStatus {
     /// Cache consulted, entry returned without an upstream call. Maps
     /// to `x-aisix-cache: hit` on the response header.
     Hit,
+    /// The gate was open but the caller sent `Cache-Control: no-cache`,
+    /// so the read path was skipped and the upstream served the
+    /// request. Maps to `x-aisix-cache: bypass` on the response header.
+    Bypass,
 }
 
 impl CacheStatus {
@@ -689,6 +718,194 @@ impl CacheStatus {
             CacheStatus::Disabled => "disabled",
             CacheStatus::Miss => "miss",
             CacheStatus::Hit => "hit",
+            CacheStatus::Bypass => "bypass",
+        }
+    }
+}
+
+/// Which matching layer served a cache hit. Surfaced on the
+/// [`CACHE_LAYER_HEADER`] response header and the usage event's
+/// `cache_hit_layer` field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CacheHitLayer {
+    /// The exact-fingerprint (L1) layer: a byte-identical request.
+    Exact,
+    /// The embedding-similarity (L2) layer: a semantically similar
+    /// request cleared the policy's threshold.
+    Semantic,
+}
+
+impl CacheHitLayer {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            CacheHitLayer::Exact => "exact",
+            CacheHitLayer::Semantic => "semantic",
+        }
+    }
+}
+
+/// Request-side `Cache-Control` directives the gate honors (per-request
+/// bypass): `no-cache` skips the read path but still stores the fresh
+/// response; `no-store` suppresses the write. Anything else in the
+/// header is ignored.
+#[derive(Debug, Clone, Copy, Default)]
+struct CacheControlDirectives {
+    no_cache: bool,
+    no_store: bool,
+}
+
+fn cache_control_directives(headers: &axum::http::HeaderMap) -> CacheControlDirectives {
+    let mut out = CacheControlDirectives::default();
+    for value in headers.get_all(axum::http::header::CACHE_CONTROL) {
+        let Ok(s) = value.to_str() else { continue };
+        for token in s.split(',') {
+            let token = token.trim();
+            if token.eq_ignore_ascii_case("no-cache") {
+                out.no_cache = true;
+            } else if token.eq_ignore_ascii_case("no-store") {
+                out.no_store = true;
+            }
+        }
+    }
+    out
+}
+
+/// Everything the semantic (L2) layer needs for this request, resolved
+/// once at the gate: the store for the policy's backend, the policy's
+/// semantic config, the candidate partition, and the canonical request
+/// text to embed. Built only when the matched policy configures
+/// semantic matching AND the request is embeddable — `None` runs the
+/// policy exact-only.
+struct SemanticGateCtx {
+    store: Arc<dyn SemanticCacheStore>,
+    cfg: SemanticCacheConfig,
+    policy_id: String,
+    policy_name: String,
+    generation: u32,
+    scope_fp: String,
+    text: String,
+}
+
+/// Embed the request text for the cache's semantic layer. `None` on any
+/// failure — the cache is an optimization layer, so a broken embedding
+/// path degrades to an ordinary miss instead of failing the request.
+async fn cache_semantic_embed(
+    state: &ProxyState,
+    snapshot: &AisixSnapshot,
+    sem: &SemanticGateCtx,
+    request_id: &str,
+) -> Option<Vec<f32>> {
+    let embed_entry = match snapshot.models.get_by_name(&sem.cfg.embedding_model) {
+        Some(e) if e.value.is_embedding() => e,
+        other => {
+            tracing::warn!(
+                target: "aisix::cache",
+                policy_name = %sem.policy_name,
+                embedding_model = %sem.cfg.embedding_model,
+                found = other.is_some(),
+                "cache policy references a missing or non-embedding embedding_model; \
+                 semantic matching skipped for this request",
+            );
+            state
+                .metrics
+                .record_cache_semantic_embed_failure(&sem.policy_name, "resolve");
+            return None;
+        }
+    };
+    let started = Instant::now();
+    let texts = [sem.text.clone()];
+    match crate::semantic::embed_texts(
+        state,
+        snapshot,
+        &embed_entry,
+        sem.cfg.embedding_timeout(),
+        request_id,
+        &texts,
+    )
+    .await
+    {
+        Ok(vectors) => {
+            state
+                .metrics
+                .record_cache_semantic_embed(&sem.policy_name, started.elapsed());
+            vectors.into_iter().next()
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "aisix::cache",
+                policy_name = %sem.policy_name,
+                error = %err,
+                "cache semantic embedding call failed; request proceeds uncached",
+            );
+            state
+                .metrics
+                .record_cache_semantic_embed_failure(&sem.policy_name, "embed");
+            None
+        }
+    }
+}
+
+/// Read path of the cache gate: exact (L1) lookup first, then — on an
+/// exact miss, when the policy configures it — the semantic (L2)
+/// similarity lookup. A semantic hit backfills the exact layer so the
+/// same wording takes the cheap L1 path next time.
+///
+/// `semantic_embedding` hands the L2 request embedding back to the
+/// caller on a miss, so the post-upstream write reuses it instead of
+/// paying a second embedding call.
+#[allow(clippy::too_many_arguments)]
+async fn resolve_cache_hit(
+    state: &ProxyState,
+    snapshot: &AisixSnapshot,
+    cache: &Arc<dyn Cache>,
+    key: &str,
+    ttl: Option<Duration>,
+    semantic_gate: Option<&SemanticGateCtx>,
+    request_id: &str,
+    semantic_embedding: &mut Option<Vec<f32>>,
+) -> Option<(ChatResponse, CacheHitLayer, Option<f32>)> {
+    match cache.get(key).await {
+        Ok(Some(cached)) => return Some((cached, CacheHitLayer::Exact, None)),
+        Ok(None) => {}
+        Err(err) => {
+            tracing::warn!(error = %err, key = %key, "cache lookup failed");
+        }
+    }
+    let sem = semantic_gate?;
+    let vector = cache_semantic_embed(state, snapshot, sem, request_id).await?;
+    match sem
+        .store
+        .lookup(
+            &sem.policy_id,
+            sem.generation,
+            &sem.scope_fp,
+            &vector,
+            sem.cfg.threshold,
+        )
+        .await
+    {
+        Ok(Some(hit)) => {
+            if let Some(ttl) = ttl {
+                if let Err(err) = cache.put_with_ttl(key, hit.response.clone(), ttl).await {
+                    tracing::warn!(error = %err, key = %key, "cache backfill write failed");
+                }
+            }
+            Some((hit.response, CacheHitLayer::Semantic, Some(hit.similarity)))
+        }
+        Ok(None) => {
+            *semantic_embedding = Some(vector);
+            None
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "aisix::cache",
+                policy_name = %sem.policy_name,
+                error = %err,
+                "semantic cache lookup failed",
+            );
+            // The embedding is still good — keep it for the write path.
+            *semantic_embedding = Some(vector);
+            None
         }
     }
 }
@@ -1706,6 +1923,8 @@ async fn dispatch(
                         // local at that point. Tracking issue to be filed
                         // alongside the streaming-cache implementation.
                         cache_status: CacheStatus::Disabled.as_str().to_string(),
+                        cache_hit_layer: String::new(),
+                        cache_similarity: None,
                         cache_hit_saved_input_tokens: 0,
                         cache_hit_saved_output_tokens: 0,
                         upstream_ttft_ms: comp.upstream_ttft_ms,
@@ -1851,6 +2070,8 @@ async fn dispatch(
             // crates/aisix-cache/src/lib.rs. Always surface as
             // `disabled` on the streaming path.
             cache_status: CacheStatus::Disabled,
+            cache_hit_layer: None,
+            cache_similarity: None,
             cache_hit_saved_input_tokens: 0,
             cache_hit_saved_output_tokens: 0,
             telemetry_handled_by_stream: true,
@@ -1918,21 +2139,90 @@ async fn dispatch(
         .and(matched_policy.as_ref())
         .map(|entry| Duration::from_secs(u64::from(entry.value.ttl_seconds)));
 
+    // Per-request bypass: standard `Cache-Control` request directives.
+    // `no-cache` skips the read path (both layers) but still refreshes
+    // the stored entry on success; `no-store` suppresses the writes.
+    let cc = cache_control_directives(client.headers.as_ref());
+
     // Cache lookup keyed on the *virtual* model name so a re-request
-    // hits the cache regardless of which target served the original.
-    let cache_key = policy_cache
-        .as_ref()
-        .map(|_| CacheKey::from_request(req).fingerprint());
+    // hits the cache regardless of which target served the original,
+    // scoped by the matched policy (id + purge generation) and — under
+    // `scope: api_key` — by the caller, so entries never leak across
+    // policies, purges, or callers.
+    let cache_key_full = match (policy_cache.as_ref(), matched_policy.as_ref()) {
+        (Some(_), Some(entry)) => {
+            let scope_api_key = match entry.value.scope {
+                CacheScope::ApiKey => Some(auth.entry.id.as_str()),
+                CacheScope::Env => None,
+            };
+            Some(CacheKey::from_request(req).with_scope(
+                &entry.id,
+                entry.value.purge_generation,
+                scope_api_key,
+            ))
+        }
+        _ => None,
+    };
+    let cache_key = cache_key_full.as_ref().map(|k| k.fingerprint());
 
     let cache_status = if policy_cache.is_some() {
-        CacheStatus::Miss
+        if cc.no_cache {
+            CacheStatus::Bypass
+        } else {
+            CacheStatus::Miss
+        }
     } else {
         CacheStatus::Disabled
     };
 
+    // Semantic (L2) context — present only when the matched policy
+    // carries a `semantic` block, its backend has a semantic store, and
+    // this request is embeddable (all-text messages). Absent, the
+    // policy runs exact-only.
+    let semantic_gate: Option<SemanticGateCtx> =
+        match (matched_policy.as_ref(), cache_key_full.as_ref()) {
+            (Some(entry), Some(key_full)) => entry.value.semantic.as_ref().and_then(|cfg| {
+                let store = state
+                    .cache
+                    .as_ref()?
+                    .semantic_for_policy_backend(entry.value.backend, &entry.id, &entry.value.name)?
+                    .clone();
+                let text = semantic_prompt_text(req)?;
+                Some(SemanticGateCtx {
+                    store,
+                    cfg: cfg.clone(),
+                    policy_id: entry.id.clone(),
+                    policy_name: entry.value.name.clone(),
+                    generation: entry.value.purge_generation,
+                    scope_fp: key_full.scope_fingerprint(),
+                    text,
+                })
+            }),
+            _ => None,
+        };
+
+    // Handed from the read path (L2 miss) to the write path so a full
+    // miss costs exactly one embedding call.
+    let mut semantic_embedding: Option<Vec<f32>> = None;
+
     if let (Some(cache), Some(key)) = (policy_cache.as_ref(), cache_key.as_ref()) {
-        match cache.get(key).await {
-            Ok(Some(mut cached)) => {
+        let resolved = if cc.no_cache {
+            None
+        } else {
+            resolve_cache_hit(
+                state,
+                &snapshot,
+                cache,
+                key,
+                matched_policy_ttl,
+                semantic_gate.as_ref(),
+                request_id,
+                &mut semantic_embedding,
+            )
+            .await
+        };
+        match resolved {
+            Some((mut cached, hit_layer, hit_similarity)) => {
                 reservation.commit_tokens(0).await;
                 // #448: a cache hit is client-visible output just like a
                 // fresh upstream response, so it must run output guardrails
@@ -2061,10 +2351,29 @@ async fn dispatch(
                         cap as usize,
                     )
                 });
+                state.metrics.record_cache_event(
+                    matched_policy
+                        .as_ref()
+                        .map(|e| e.value.name.as_str())
+                        .unwrap_or_default(),
+                    match hit_layer {
+                        CacheHitLayer::Exact => "hit_exact",
+                        CacheHitLayer::Semantic => "hit_semantic",
+                    },
+                );
                 let mut response = Json(render_response(now, cached, &req.model)).into_response();
                 response
                     .headers_mut()
                     .insert(CACHE_HEADER, HeaderValue::from_static("hit"));
+                response.headers_mut().insert(
+                    CACHE_LAYER_HEADER,
+                    HeaderValue::from_static(hit_layer.as_str()),
+                );
+                if let Some(similarity) = hit_similarity {
+                    if let Ok(v) = HeaderValue::try_from(format!("{similarity:.4}")) {
+                        response.headers_mut().insert(CACHE_SIMILARITY_HEADER, v);
+                    }
+                }
                 return Ok(Success {
                     response,
                     provider: provider_label,
@@ -2091,6 +2400,8 @@ async fn dispatch(
                     cost_usd: 0.0,
                     bypass_reason: bypass_reason.clone(),
                     cache_status: CacheStatus::Hit,
+                    cache_hit_layer: Some(hit_layer),
+                    cache_similarity: hit_similarity,
                     // The whole point of #88: cache hit replays the
                     // upstream's prompt + completion tokens. Surfacing
                     // them as a dedicated counter (rather than relying
@@ -2110,9 +2421,17 @@ async fn dispatch(
                     captured_content,
                 });
             }
-            Ok(None) => {}
-            Err(err) => {
-                tracing::warn!(error = %err, key = %key, "cache lookup failed");
+            None => {
+                // Consulted-but-not-served: count the outcome now
+                // (`miss` or `bypass`) so the metric reflects every gate
+                // decision, including requests that later fail upstream.
+                state.metrics.record_cache_event(
+                    matched_policy
+                        .as_ref()
+                        .map(|e| e.value.name.as_str())
+                        .unwrap_or_default(),
+                    cache_status.as_str(),
+                );
             }
         }
     }
@@ -2576,13 +2895,51 @@ async fn dispatch(
     // not the cache backend's global fallback. Backends without
     // per-entry support (defined via `Cache::put_with_ttl`'s default
     // impl) silently fall back to `put`.
-    if let (Some(ttl), Some(cache), Some(key)) = (
+    if let (Some(ttl), Some(cache), Some(key), false) = (
         matched_policy_ttl,
         policy_cache.as_ref(),
         cache_key.as_ref(),
+        // `Cache-Control: no-store` suppresses both layers' writes.
+        cc.no_store,
     ) {
         if let Err(err) = cache.put_with_ttl(key, upstream.clone(), ttl).await {
             tracing::warn!(error = %err, key = %key, "cache write failed");
+        }
+        // Semantic (L2) write. Reuses the read path's embedding; when
+        // the read path was bypassed (`no-cache`) compute one now so
+        // the refreshed entry is findable by similarity too. A `None`
+        // without `no-cache` means the read path already tried and
+        // failed to embed this request — don't pay a second doomed call.
+        if let Some(sem) = semantic_gate.as_ref() {
+            let vector = match semantic_embedding.take() {
+                Some(v) => Some(v),
+                None if cc.no_cache => {
+                    cache_semantic_embed(state, &snapshot, sem, request_id).await
+                }
+                None => None,
+            };
+            if let Some(vector) = vector {
+                if let Err(err) = sem
+                    .store
+                    .store(
+                        &sem.policy_id,
+                        sem.generation,
+                        &sem.scope_fp,
+                        vector,
+                        upstream.clone(),
+                        ttl,
+                        sem.cfg.max_entries,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        target: "aisix::cache",
+                        policy_name = %sem.policy_name,
+                        error = %err,
+                        "semantic cache write failed",
+                    );
+                }
+            }
         }
     }
 
@@ -2599,13 +2956,22 @@ async fn dispatch(
     });
 
     let mut response = Json(render_response(now, upstream, &req.model)).into_response();
-    if matches!(cache_status, CacheStatus::Miss) {
-        // Miss header only when the cache was actually consulted —
-        // policy-disabled requests have no cache header at all so a
-        // user can tell at a glance whether the gate was open.
-        response
-            .headers_mut()
-            .insert(CACHE_HEADER, HeaderValue::from_static("miss"));
+    // Header only when the gate was open — policy-disabled requests have
+    // no cache header at all so a user can tell at a glance whether the
+    // gate ran. `bypass` = the caller's `Cache-Control: no-cache`
+    // skipped the read path.
+    match cache_status {
+        CacheStatus::Miss => {
+            response
+                .headers_mut()
+                .insert(CACHE_HEADER, HeaderValue::from_static("miss"));
+        }
+        CacheStatus::Bypass => {
+            response
+                .headers_mut()
+                .insert(CACHE_HEADER, HeaderValue::from_static("bypass"));
+        }
+        _ => {}
     }
 
     // Header presence is the wire signal for "routing happened" —
@@ -2637,6 +3003,8 @@ async fn dispatch(
         cost_usd,
         bypass_reason,
         cache_status,
+        cache_hit_layer: None,
+        cache_similarity: None,
         // Cache-saved counters are zero on the upstream-served path —
         // the request *did* hit the upstream, no work was saved.
         cache_hit_saved_input_tokens: 0,
@@ -3260,6 +3628,8 @@ async fn dispatch_ensemble(
             finish_reason: String::new(),
             bypass_reason,
             cache_status: CacheStatus::Disabled,
+            cache_hit_layer: None,
+            cache_similarity: None,
             cache_hit_saved_input_tokens: 0,
             cache_hit_saved_output_tokens: 0,
             // Per-sub-call usage is emitted from on_complete; suppress the
@@ -3517,6 +3887,8 @@ async fn dispatch_ensemble(
         cost_usd: 0.0,
         bypass_reason,
         cache_status: CacheStatus::Disabled,
+        cache_hit_layer: None,
+        cache_similarity: None,
         cache_hit_saved_input_tokens: 0,
         cache_hit_saved_output_tokens: 0,
         // Telemetry already emitted per-sub-call above; suppress the
@@ -3706,6 +4078,8 @@ fn emit_usage_event(
         redacted_entity_counts: extras.redacted_entity_counts,
         guardrail_monitor_hits: extras.guardrail_monitor_hits,
         cache_status: extras.cache_status,
+        cache_hit_layer: extras.cache_hit_layer,
+        cache_similarity: extras.cache_similarity,
         cache_hit_saved_input_tokens: extras.cache_hit_saved_input_tokens,
         cache_hit_saved_output_tokens: extras.cache_hit_saved_output_tokens,
         upstream_ttft_ms: extras.upstream_ttft_ms,
@@ -3814,10 +4188,16 @@ struct UsageExtras {
     /// `dpmgr_usage_events.guardrail_bypassed_reason`. Default empty
     /// string = no bypass; cp-api stores NULL in that case.
     bypass_reason: String,
-    /// Lowercased `CacheStatus` (`"hit"` / `"miss"` / `"disabled"`).
-    /// Empty default for the error path where the cache lookup never
-    /// fired. Goes onto `dpmgr_usage_events.cache_status`.
+    /// Lowercased `CacheStatus` (`"hit"` / `"miss"` / `"disabled"` /
+    /// `"bypass"`). Empty default for the error path where the cache
+    /// lookup never fired. Goes onto `dpmgr_usage_events.cache_status`.
     cache_status: String,
+    /// On a cache hit, the matching layer (`"exact"` / `"semantic"`).
+    /// Empty otherwise. Goes onto `usage_events.cache_hit_layer`.
+    cache_hit_layer: String,
+    /// On a semantic cache hit, the request↔entry cosine similarity.
+    /// `None` otherwise. Goes onto `usage_events.cache_similarity`.
+    cache_similarity: Option<f32>,
     /// On a cache HIT, the cached response's prompt + completion
     /// tokens. Zero otherwise. cp-api derives `cost_saved_usd` on
     /// ingest from these + its pricing catalog (see #88).

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2235,11 +2235,15 @@ async fn dispatch(
                     .map(|e| e.dimensions)
                     .unwrap_or(0);
                 // Partition = scope fingerprint + embedding model
-                // identity: see the `SemanticGateCtx::scope_fp` docs.
+                // identity (resource id, upstream model name, and
+                // dimensions — the upstream name catches an in-place
+                // `model_name` edit that keeps id + dims): see the
+                // `SemanticGateCtx::scope_fp` docs.
                 let scope_fp = format!(
-                    "{}:{}:{}",
+                    "{}:{}:{}:{}",
                     key_full.scope_fingerprint(),
                     embed_entry.id,
+                    embed_entry.value.model_name.as_deref().unwrap_or(""),
                     dims
                 );
                 Some(SemanticGateCtx {

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2205,14 +2205,23 @@ async fn dispatch(
                 let embed_entry = match snapshot.models.get_by_name(&cfg.embedding_model) {
                     Some(e) if e.value.is_embedding() => e.clone(),
                     other => {
-                        tracing::warn!(
-                            target: "aisix::cache",
-                            policy_name = %entry.value.name,
-                            embedding_model = %cfg.embedding_model,
-                            found = other.is_some(),
-                            "cache policy references a missing or non-embedding \
-                             embedding_model; semantic matching skipped for this request",
-                        );
+                        // A stable config error, not a per-request one:
+                        // log once per policy, count every request.
+                        if state
+                            .cache
+                            .as_ref()
+                            .is_some_and(|c| c.semantic_resolve_warn_once(&entry.id))
+                        {
+                            tracing::warn!(
+                                target: "aisix::cache",
+                                policy_name = %entry.value.name,
+                                embedding_model = %cfg.embedding_model,
+                                found = other.is_some(),
+                                "cache policy references a missing or non-embedding \
+                                 embedding_model; semantic matching is skipped until \
+                                 the reference resolves",
+                            );
+                        }
                         state
                             .metrics
                             .record_cache_semantic_embed_failure(&entry.value.name, "resolve");
@@ -2971,6 +2980,7 @@ async fn dispatch(
                         &sem.policy_id,
                         sem.generation,
                         &sem.scope_fp,
+                        key,
                         vector,
                         upstream.clone(),
                         ttl,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -759,6 +759,9 @@ fn cache_control_directives(headers: &axum::http::HeaderMap) -> CacheControlDire
     for value in headers.get_all(axum::http::header::CACHE_CONTROL) {
         let Ok(s) = value.to_str() else { continue };
         for token in s.split(',') {
+            // Token match only — RFC 9111 request directives we honor
+            // carry no arguments, and an argument form (`no-cache=...`)
+            // deliberately does NOT match rather than over-matching.
             let token = token.trim();
             if token.eq_ignore_ascii_case("no-cache") {
                 out.no_cache = true;
@@ -772,16 +775,27 @@ fn cache_control_directives(headers: &axum::http::HeaderMap) -> CacheControlDire
 
 /// Everything the semantic (L2) layer needs for this request, resolved
 /// once at the gate: the store for the policy's backend, the policy's
-/// semantic config, the candidate partition, and the canonical request
-/// text to embed. Built only when the matched policy configures
-/// semantic matching AND the request is embeddable — `None` runs the
-/// policy exact-only.
+/// semantic config, the resolved embedding model, the candidate
+/// partition, and the canonical request text to embed. Built only when
+/// the matched policy configures semantic matching, the embedding model
+/// resolves, AND the request is embeddable — `None` runs the policy
+/// exact-only.
 struct SemanticGateCtx {
     store: Arc<dyn SemanticCacheStore>,
     cfg: SemanticCacheConfig,
+    /// Resolved at gate time so the partition can carry the embedding
+    /// model's identity, and so a dangling reference is one metric'd
+    /// warn instead of a per-lookup surprise.
+    embed_entry: Arc<aisix_core::ResourceEntry<aisix_core::Model>>,
     policy_id: String,
     policy_name: String,
     generation: u32,
+    /// Candidate partition: the request scope fingerprint PLUS the
+    /// embedding model's resource id + dimensions. Vectors from two
+    /// different embedding models live in unrelated spaces — cosine
+    /// across them is meaningless — so swapping a policy's
+    /// `embedding_model` (even at equal dimensions) must orphan the old
+    /// entries rather than compare against them.
     scope_fp: String,
     text: String,
 }
@@ -795,29 +809,12 @@ async fn cache_semantic_embed(
     sem: &SemanticGateCtx,
     request_id: &str,
 ) -> Option<Vec<f32>> {
-    let embed_entry = match snapshot.models.get_by_name(&sem.cfg.embedding_model) {
-        Some(e) if e.value.is_embedding() => e,
-        other => {
-            tracing::warn!(
-                target: "aisix::cache",
-                policy_name = %sem.policy_name,
-                embedding_model = %sem.cfg.embedding_model,
-                found = other.is_some(),
-                "cache policy references a missing or non-embedding embedding_model; \
-                 semantic matching skipped for this request",
-            );
-            state
-                .metrics
-                .record_cache_semantic_embed_failure(&sem.policy_name, "resolve");
-            return None;
-        }
-    };
     let started = Instant::now();
     let texts = [sem.text.clone()];
     match crate::semantic::embed_texts(
         state,
         snapshot,
-        &embed_entry,
+        &sem.embed_entry,
         sem.cfg.embedding_timeout(),
         request_id,
         &texts,
@@ -885,12 +882,26 @@ async fn resolve_cache_hit(
         .await
     {
         Ok(Some(hit)) => {
-            if let Some(ttl) = ttl {
-                if let Err(err) = cache.put_with_ttl(key, hit.response.clone(), ttl).await {
+            // Backfill TTL is capped at the matched entry's own
+            // remaining lifetime: a paraphrase near expiry must not
+            // grant the stored response a fresh full TTL, or repeated
+            // paraphrases could keep stale data alive indefinitely.
+            let remaining = hit
+                .expires_at
+                .saturating_duration_since(std::time::Instant::now());
+            let backfill_ttl = ttl.map(|t| t.min(remaining)).unwrap_or(remaining);
+            if !backfill_ttl.is_zero() {
+                if let Err(err) = cache
+                    .put_with_ttl(key, hit.response.clone(), backfill_ttl)
+                    .await
+                {
                     tracing::warn!(error = %err, key = %key, "cache backfill write failed");
                 }
             }
-            Some((hit.response, CacheHitLayer::Semantic, Some(hit.similarity)))
+            // 4-dp similarity everywhere it surfaces (header, usage
+            // event) so the stored value matches what callers see.
+            let similarity = (hit.similarity * 10_000.0).round() / 10_000.0;
+            Some((hit.response, CacheHitLayer::Semantic, Some(similarity)))
         }
         Ok(None) => {
             *semantic_embedding = Some(vector);
@@ -903,6 +914,9 @@ async fn resolve_cache_hit(
                 error = %err,
                 "semantic cache lookup failed",
             );
+            state
+                .metrics
+                .record_cache_semantic_store_failure(&sem.policy_name, "lookup");
             // The embedding is still good — keep it for the write path.
             *semantic_embedding = Some(vector);
             None
@@ -2188,13 +2202,45 @@ async fn dispatch(
                     .semantic_for_policy_backend(entry.value.backend, &entry.id, &entry.value.name)?
                     .clone();
                 let text = semantic_prompt_text(req)?;
+                let embed_entry = match snapshot.models.get_by_name(&cfg.embedding_model) {
+                    Some(e) if e.value.is_embedding() => e.clone(),
+                    other => {
+                        tracing::warn!(
+                            target: "aisix::cache",
+                            policy_name = %entry.value.name,
+                            embedding_model = %cfg.embedding_model,
+                            found = other.is_some(),
+                            "cache policy references a missing or non-embedding \
+                             embedding_model; semantic matching skipped for this request",
+                        );
+                        state
+                            .metrics
+                            .record_cache_semantic_embed_failure(&entry.value.name, "resolve");
+                        return None;
+                    }
+                };
+                let dims = embed_entry
+                    .value
+                    .embedding
+                    .as_ref()
+                    .map(|e| e.dimensions)
+                    .unwrap_or(0);
+                // Partition = scope fingerprint + embedding model
+                // identity: see the `SemanticGateCtx::scope_fp` docs.
+                let scope_fp = format!(
+                    "{}:{}:{}",
+                    key_full.scope_fingerprint(),
+                    embed_entry.id,
+                    dims
+                );
                 Some(SemanticGateCtx {
                     store,
                     cfg: cfg.clone(),
+                    embed_entry,
                     policy_id: entry.id.clone(),
                     policy_name: entry.value.name.clone(),
                     generation: entry.value.purge_generation,
-                    scope_fp: key_full.scope_fingerprint(),
+                    scope_fp,
                     text,
                 })
             }),
@@ -2938,6 +2984,9 @@ async fn dispatch(
                         error = %err,
                         "semantic cache write failed",
                     );
+                    state
+                        .metrics
+                        .record_cache_semantic_store_failure(&sem.policy_name, "store");
                 }
             }
         }

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -4824,8 +4824,12 @@ data: [DONE]\n\n";
         // The entry must live in the redis instance and ONLY there —
         // a dispatch bug that wrote to the memory instance would
         // still produce a "hit" above, so pin the instance directly.
+        // The stored key carries the gate's scope: policy id, purge
+        // generation 0, and (scope defaults to `api_key`) the caller.
         let req: aisix_gateway::ChatFormat = serde_json::from_value(body).unwrap();
-        let key = CacheKey::from_request(&req).fingerprint();
+        let key = CacheKey::from_request(&req)
+            .with_scope("cp-id-redis-cache", 0, Some("key-id-1"))
+            .fingerprint();
         assert!(
             redis_standin.get(&key).await.unwrap().is_some(),
             "cache entry must be written to the policy's redis backend",

--- a/crates/aisix-proxy/src/semantic.rs
+++ b/crates/aisix-proxy/src/semantic.rs
@@ -203,7 +203,7 @@ pub(crate) async fn resolve(
         state,
         snapshot,
         &embed_entry,
-        semantic,
+        semantic.embedding_timeout(),
         request_id,
         &to_embed,
     )
@@ -289,12 +289,15 @@ fn attempt_for_target(snapshot: &AisixSnapshot, alias: &str) -> Result<AttemptMo
 }
 
 /// Embed `texts` through the embedding model's bridge in one batched call,
-/// returning one float vector per input in input order.
-async fn embed_texts(
+/// returning one float vector per input in input order. Shared by the
+/// semantic router (route matching) and the cache gate's semantic layer
+/// (`aisix-proxy::chat`), which is why the deadline arrives as a plain
+/// `Option<Duration>` rather than either feature's config type.
+pub(crate) async fn embed_texts(
     state: &ProxyState,
     snapshot: &AisixSnapshot,
     embed_entry: &ResourceEntry<Model>,
-    semantic: &Semantic,
+    timeout: Option<std::time::Duration>,
     request_id: &str,
     texts: &[String],
 ) -> Result<Vec<Vec<f32>>, ProxyError> {
@@ -322,7 +325,7 @@ async fn embed_texts(
             Arc::new(pk_entry.value.clone()),
             None,
         );
-        match semantic.embedding_timeout() {
+        match timeout {
             Some(d) => base.with_deadline(d),
             None => base,
         }

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -14,7 +14,7 @@
 //!
 //! Cheap to clone: every field is either an `Arc` or a small Copy scalar.
 
-use aisix_cache::{Cache, MemoryCache};
+use aisix_cache::{Cache, MemoryCache, MemorySemanticCache, SemanticCacheStore};
 use aisix_core::models::CacheBackend;
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
@@ -43,9 +43,16 @@ use crate::routing::RoutingRegistry;
 pub struct CacheBackends {
     memory: Arc<dyn Cache>,
     redis: Option<Arc<dyn Cache>>,
+    /// Semantic (L2) store for `backend: memory` policies. Always
+    /// built — in-process, no config needed, zero cost until a policy
+    /// with a `semantic` block matches a request.
+    semantic_memory: Arc<dyn SemanticCacheStore>,
     /// Policy ids already warned about an unavailable redis backend,
     /// so the gate logs once per policy instead of once per request.
     redis_warned: Arc<DashSet<String>>,
+    /// Policy ids already warned about the redis semantic layer being
+    /// unavailable (same warn-once discipline as `redis_warned`).
+    semantic_redis_warned: Arc<DashSet<String>>,
 }
 
 impl CacheBackends {
@@ -53,7 +60,9 @@ impl CacheBackends {
         Self {
             memory,
             redis,
+            semantic_memory: Arc::new(MemorySemanticCache::new()),
             redis_warned: Arc::new(DashSet::new()),
+            semantic_redis_warned: Arc::new(DashSet::new()),
         }
     }
 
@@ -88,6 +97,38 @@ impl CacheBackends {
                     );
                 }
                 redis
+            }
+        }
+    }
+
+    /// Resolve the semantic (L2) store for a matched policy's
+    /// `backend`. Same never-fall-back discipline as
+    /// [`Self::for_policy_backend`]: a policy whose backend has no
+    /// semantic store gets NO semantic matching (exact matching still
+    /// works) rather than a silent per-node stand-in with different
+    /// sharing semantics.
+    pub fn semantic_for_policy_backend(
+        &self,
+        backend: CacheBackend,
+        policy_id: &str,
+        policy_name: &str,
+    ) -> Option<&Arc<dyn SemanticCacheStore>> {
+        match backend {
+            CacheBackend::Memory => Some(&self.semantic_memory),
+            CacheBackend::Redis => {
+                // The shared (redis) semantic store ships separately;
+                // until then a redis-backed policy runs exact-only.
+                if self.semantic_redis_warned.insert(policy_id.to_string()) {
+                    tracing::warn!(
+                        target: "aisix::cache",
+                        policy_id = %policy_id,
+                        policy_name = %policy_name,
+                        "cache policy configures semantic matching on backend=redis, \
+                         which this gateway version does not support yet; requests \
+                         fall back to exact matching only"
+                    );
+                }
+                None
             }
         }
     }

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -53,6 +53,10 @@ pub struct CacheBackends {
     /// Policy ids already warned about the redis semantic layer being
     /// unavailable (same warn-once discipline as `redis_warned`).
     semantic_redis_warned: Arc<DashSet<String>>,
+    /// Policy ids already warned about a stable semantic config error
+    /// (missing / non-embedding `embedding_model`). The per-request
+    /// metric keeps counting; only the log line is deduplicated.
+    semantic_resolve_warned: Arc<DashSet<String>>,
 }
 
 impl CacheBackends {
@@ -63,7 +67,14 @@ impl CacheBackends {
             semantic_memory: Arc::new(MemorySemanticCache::new()),
             redis_warned: Arc::new(DashSet::new()),
             semantic_redis_warned: Arc::new(DashSet::new()),
+            semantic_resolve_warned: Arc::new(DashSet::new()),
         }
+    }
+
+    /// True the FIRST time `policy_id` reports a stable semantic config
+    /// error, so the gate logs once per policy instead of per request.
+    pub fn semantic_resolve_warn_once(&self, policy_id: &str) -> bool {
+        self.semantic_resolve_warned.insert(policy_id.to_string())
     }
 
     /// Memory cache only — the default for self-hosted dev and tests.

--- a/schemas/resources/cache_policy.schema.json
+++ b/schemas/resources/cache_policy.schema.json
@@ -29,7 +29,7 @@
       ]
     },
     "SemanticCacheConfig": {
-      "description": "Embedding-similarity matching for a cache policy. When present, a request that misses the exact layer is embedded and compared against stored entries; the nearest entry at or above `threshold` cosine similarity is served. Only requests whose messages are entirely text participate — requests containing images or audio never match by similarity.",
+      "description": "Embedding-similarity matching for a cache policy. When present, a request that misses the exact layer is embedded and compared against stored entries; the nearest entry at or above `threshold` cosine similarity is served. Only requests whose messages are entirely text participate — requests containing images or audio never match by similarity.\n\nSimilarity matching currently requires `backend: memory`. A policy with `backend: redis` accepts this configuration but keeps serving exact matches only (a warning is logged) until shared semantic storage ships.",
       "properties": {
         "embedding_model": {
           "description": "Name of the `embedding` model used to embed requests. The model must exist in the same environment and carry an `embedding` block; its `dimensions` value fixes the vector size for this policy's entries.",
@@ -96,7 +96,7 @@
     },
     "purge_generation": {
       "default": 0,
-      "description": "Invalidation counter. Entries are readable only while their stored generation matches; a purge bumps this value, making every earlier entry unreachable at once. Managed by the purge operation — not set directly.",
+      "description": "Invalidation counter. Entries are readable only while their stored generation matches; a purge bumps this value, making every earlier entry unreachable at once. Managed by the purge operation — not set directly. Full-document updates must carry the current value forward: writing a lower (or omitted, i.e. `0`) value re-exposes entries stored under that earlier generation until their TTL passes.",
       "format": "uint32",
       "minimum": 0.0,
       "type": "integer"

--- a/schemas/resources/cache_policy.schema.json
+++ b/schemas/resources/cache_policy.schema.json
@@ -8,9 +8,64 @@
         "redis"
       ],
       "type": "string"
+    },
+    "CacheScope": {
+      "description": "Sharing boundary for cache entries created under a policy. Applies to both matching layers: an entry written in one scope bucket is never served to a request in another.",
+      "oneOf": [
+        {
+          "description": "Entries are private to the API key that created them. The safe default: one caller's answers are never replayed to another.",
+          "enum": [
+            "api_key"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Entries are shared by every API key in the environment. Pick this for shared-knowledge traffic (FAQ, documentation Q&A) where cross-caller reuse is the point.",
+          "enum": [
+            "env"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "SemanticCacheConfig": {
+      "description": "Embedding-similarity matching for a cache policy. When present, a request that misses the exact layer is embedded and compared against stored entries; the nearest entry at or above `threshold` cosine similarity is served. Only requests whose messages are entirely text participate — requests containing images or audio never match by similarity.",
+      "properties": {
+        "embedding_model": {
+          "description": "Name of the `embedding` model used to embed requests. The model must exist in the same environment and carry an `embedding` block; its `dimensions` value fixes the vector size for this policy's entries.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "embedding_timeout_ms": {
+          "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline. On timeout the request proceeds to the upstream uncached.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "max_entries": {
+          "default": 1000,
+          "description": "Upper bound on stored entries for this policy on the `memory` backend; the oldest entry is evicted first. Shared backends bound growth by TTL instead and ignore this value.",
+          "format": "uint32",
+          "maximum": 100000.0,
+          "minimum": 1.0,
+          "type": "integer"
+        },
+        "threshold": {
+          "description": "Minimum cosine similarity for a stored entry to be served, in `[0, 1]`. Higher is stricter. Values below `0.9` noticeably increase wrong-answer risk for most embedding models.",
+          "format": "float",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "embedding_model",
+        "threshold"
+      ],
+      "type": "object"
     }
   },
-  "description": "Semantic cache policy for chat requests.",
+  "description": "A prompt-response cache rule. Requests covered by an enabled policy are served from cache when an identical request was answered before (exact matching), and — when `semantic` is configured — when a sufficiently similar request was.",
   "properties": {
     "applies_to": {
       "default": "all",
@@ -38,6 +93,30 @@
       "maxLength": 120,
       "minLength": 1,
       "type": "string"
+    },
+    "purge_generation": {
+      "default": 0,
+      "description": "Invalidation counter. Entries are readable only while their stored generation matches; a purge bumps this value, making every earlier entry unreachable at once. Managed by the purge operation — not set directly.",
+      "format": "uint32",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "scope": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CacheScope"
+        }
+      ],
+      "default": "api_key",
+      "description": "Sharing boundary for entries created under this policy: `api_key` (default) keeps entries private to the caller that created them; `env` shares them across the environment."
+    },
+    "semantic": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SemanticCacheConfig"
+        }
+      ],
+      "description": "Embedding-similarity matching. Absent: the policy matches exactly-identical requests only."
     },
     "ttl_seconds": {
       "default": 3600,

--- a/schemas/resources/cache_policy.schema.json
+++ b/schemas/resources/cache_policy.schema.json
@@ -44,9 +44,9 @@
         },
         "max_entries": {
           "default": 1000,
-          "description": "Upper bound on stored entries for this policy on the `memory` backend; the oldest entry is evicted first. Shared backends bound growth by TTL instead and ignore this value.",
+          "description": "Upper bound on stored entries for this policy on the `memory` backend; the oldest entry is evicted first. Shared backends bound growth by TTL instead and ignore this value. The ceiling keeps the per-request similarity scan and the per-policy vector memory bounded; workloads needing more entries belong on a shared backend.",
           "format": "uint32",
-          "maximum": 100000.0,
+          "maximum": 10000.0,
           "minimum": 1.0,
           "type": "integer"
         },

--- a/tests/e2e/src/cases/cache-policy-backend-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-policy-backend-e2e.test.ts
@@ -3,6 +3,7 @@ import { connect } from "node:net";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
@@ -88,10 +89,6 @@ async function seedApp(
       provider_key_id: pk.id,
     });
   }
-  await seed.createApiKey({
-    key_hash: CALLER_KEY_HASH,
-    allowed_models: [modelAlias, canaryAlias],
-  });
   // Order matters: redis policy FIRST, canary memory policy SECOND.
   await seed.createCachePolicy({
     name: `${modelAlias}-redis-policy`,
@@ -105,7 +102,25 @@ async function seedApp(
     backend: "memory",
     applies_to: `model:${canaryAlias}`,
   });
+  // The caller key is seeded LAST: once it authenticates, revision
+  // order implies every resource above is in the snapshot
+  // (tests/e2e/AGENTS.md).
+  await seed.createApiKey({
+    key_hash: CALLER_KEY_HASH,
+    allowed_models: [modelAlias, canaryAlias],
+  });
   return { app };
+}
+
+/** Non-throwing readiness gate per tests/e2e/AGENTS.md: the caller key
+ *  (seeded last) authenticating via listModels proves the whole seed
+ *  batch is live; a transient non-200 is the normal pre-propagation
+ *  state and nothing else is swallowed. */
+async function waitSeedLive(proxyUrl: string): Promise<void> {
+  const probe = new ProxyClient(proxyUrl, CALLER_PLAINTEXT);
+  await waitConfigPropagation(
+    async () => (await probe.listModels()).status === 200,
+  );
 }
 
 function chatRequest(
@@ -218,8 +233,8 @@ describe("cache policy backend=redis with a configured redis is shared across DP
     appA = await spawnApp({ extra: redisExtra });
     appB = await spawnApp({ extra: redisExtra, etcdPrefix: appA.etcdPrefix });
     await seedApp(appA, upstream.baseUrl, "cache-redis-shared", "canary-a");
-    await waitCanaryPolicyLive(appA.proxyUrl, "canary-a");
-    await waitCanaryPolicyLive(appB.proxyUrl, "canary-a");
+    await waitSeedLive(appA.proxyUrl);
+    await waitSeedLive(appB.proxyUrl);
   });
 
   afterAll(async () => {

--- a/tests/e2e/src/cases/cache-policy-backend-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-policy-backend-e2e.test.ts
@@ -207,16 +207,19 @@ describe("cache policy backend=redis with a configured redis is shared across DP
     const redisExtra = {
       cache: { backend: "memory", redis: { url: REDIS_URL } },
     };
-    // Two DP instances sharing one redis. A hit on the instance that
-    // never served the original request proves the entry really lives
-    // in redis — an (incorrect) memory-cache write could only produce
-    // hits on the same instance.
+    // Two DP replicas of ONE environment (same etcd prefix, so the
+    // same policy/api-key resource identities) sharing one redis. A
+    // hit on the instance that never served the original request
+    // proves the entry really lives in redis — an (incorrect)
+    // memory-cache write could only produce hits on the same instance.
+    // Cache keys are scoped by resource ids (policy id, caller id), so
+    // replicas MUST share the resource rows, exactly as they do behind
+    // one environment in production.
     appA = await spawnApp({ extra: redisExtra });
-    appB = await spawnApp({ extra: redisExtra });
+    appB = await spawnApp({ extra: redisExtra, etcdPrefix: appA.etcdPrefix });
     await seedApp(appA, upstream.baseUrl, "cache-redis-shared", "canary-a");
-    await seedApp(appB, upstream.baseUrl, "cache-redis-shared", "canary-b");
     await waitCanaryPolicyLive(appA.proxyUrl, "canary-a");
-    await waitCanaryPolicyLive(appB.proxyUrl, "canary-b");
+    await waitCanaryPolicyLive(appB.proxyUrl, "canary-a");
   });
 
   afterAll(async () => {

--- a/tests/e2e/src/cases/cache-semantic-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-semantic-e2e.test.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
@@ -18,14 +19,14 @@ import { pickFreePort } from "../harness/ports.js";
 // above the policy's cosine threshold (L2). Real `aisix` binary + etcd +
 // mock chat upstreams + a deterministic mock embedding endpoint; no CP.
 //
-// The embedding mock maps input text to fixed 8-dim vectors by keyword,
+// The embedding mock maps input text to fixed 12-dim vectors by keyword,
 // so similarity is fully deterministic. Each test owns an orthogonal
 // axis (entries persist across tests within a policy+scope partition,
 // so unrelated tests must never share a vector):
 //   "topic-a-near" -> 0.9*topic-a + spill   (cos 0.9 vs topic-a)
 //   "topic-c-near" -> 0.9*topic-c + spill   (same pair on another axis)
 //   "topic-a" / "topic-b" / "topic-c" / "no-store" / "refresh" /
-//   "purge" / default -> one distinct axis each
+//   "purge" / "params-x" / "scope-x" / default -> one distinct axis each
 //
 // Observable contract under test (headers are the wire surface):
 //   x-aisix-cache: hit | miss | bypass
@@ -41,19 +42,37 @@ const OTHER_CALLER_KEY_HASH = createHash("sha256")
   .update(OTHER_CALLER_PLAINTEXT)
   .digest("hex");
 
+const DIMS = 12;
+
+function axis(i: number, weight = 1): number[] {
+  const v = new Array<number>(DIMS).fill(0);
+  v[i] = weight;
+  return v;
+}
+
 function keywordVector(text: string): number[] {
   const t = text.toLowerCase();
   const spill = Math.sqrt(0.19); // makes the *-near vectors unit-length
   // Longest keyword first: "topic-a-near" contains "topic-a".
-  if (t.includes("topic-a-near")) return [0.9, 0, 0, 0, spill, 0, 0, 0];
-  if (t.includes("topic-a")) return [1, 0, 0, 0, 0, 0, 0, 0];
-  if (t.includes("topic-b")) return [0, 1, 0, 0, 0, 0, 0, 0];
-  if (t.includes("topic-c-near")) return [0, 0, 0.9, 0, spill, 0, 0, 0];
-  if (t.includes("topic-c")) return [0, 0, 1, 0, 0, 0, 0, 0];
-  if (t.includes("no-store")) return [0, 0, 0, 0, 0, 1, 0, 0];
-  if (t.includes("refresh")) return [0, 0, 0, 0, 0, 0, 1, 0];
-  if (t.includes("purge")) return [0, 0, 0, 0, 0, 0, 0, 1];
-  return [0, 0, 0, 1, 0, 0, 0, 0];
+  if (t.includes("topic-a-near")) {
+    const v = axis(0, 0.9);
+    v[4] = spill;
+    return v;
+  }
+  if (t.includes("topic-a")) return axis(0);
+  if (t.includes("topic-b")) return axis(1);
+  if (t.includes("topic-c-near")) {
+    const v = axis(2, 0.9);
+    v[4] = spill;
+    return v;
+  }
+  if (t.includes("topic-c")) return axis(2);
+  if (t.includes("no-store")) return axis(5);
+  if (t.includes("refresh")) return axis(6);
+  if (t.includes("purge")) return axis(7);
+  if (t.includes("params-x")) return axis(8);
+  if (t.includes("scope-x")) return axis(9);
+  return axis(3);
 }
 
 interface EmbeddingMock {
@@ -211,8 +230,7 @@ describe("semantic cache e2e", () => {
   const embedMocks: EmbeddingMock[] = [];
   let embed: EmbeddingMock;
   let upstreamA: OpenAiUpstream;
-  let sharedPolicyId: string | undefined;
-  let sharedPolicyBody: Record<string, unknown>;
+  let canarySeq = 0;
 
   async function createDirectModel(
     displayName: string,
@@ -247,8 +265,26 @@ describe("semantic cache e2e", () => {
       provider: "openai",
       model_name: "embed-mock",
       provider_key_id: pk.id,
-      embedding: { dimensions: 8, normalize: true },
+      embedding: { dimensions: 12, normalize: true },
     });
+  }
+
+  // Convention (tests/e2e/AGENTS.md): resources land as etcd watch
+  // events in revision order, so a throwaway key seeded AFTER a batch
+  // authenticating proves the whole batch is in the snapshot. The gate
+  // is the non-throwing ProxyClient.listModels — never the cache
+  // behavior under test — and a non-200 is the normal transient state.
+  async function sealSeedBatch(): Promise<void> {
+    if (!seed || !app) throw new Error("seed not ready");
+    const plaintext = `sk-semcache-canary-${++canarySeq}`;
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(plaintext).digest("hex"),
+      allowed_models: ["*"],
+    });
+    const probe = new ProxyClient(app.proxyUrl, plaintext);
+    await waitConfigPropagation(
+      async () => (await probe.listModels()).status === 200,
+    );
   }
 
   async function chat(
@@ -308,14 +344,6 @@ describe("semantic cache e2e", () => {
 
     app = await spawnApp();
     seed = new SeedClient(etcd, app.etcdPrefix);
-    await seed.createApiKey({
-      key_hash: CALLER_KEY_HASH,
-      allowed_models: ["*"],
-    });
-    await seed.createApiKey({
-      key_hash: OTHER_CALLER_KEY_HASH,
-      allowed_models: ["*"],
-    });
 
     embed = await startEmbeddingMock();
     embedMocks.push(embed);
@@ -324,26 +352,28 @@ describe("semantic cache e2e", () => {
     upstreamA = await chatUpstreamReplying("answer-a");
     upstreams.push(upstreamA);
     await createDirectModel("chat-a", upstreamA);
-    const created = await seed.createCachePolicy({
+    await seed.createCachePolicy({
       name: "sem-default",
       backend: "memory",
       applies_to: "model:chat-a",
       ttl_seconds: 600,
       semantic: { embedding_model: "embed-cache", threshold: 0.85 },
     });
-    sharedPolicyId = created.id;
-    sharedPolicyBody = created.value;
 
-    // Gate open = the policy propagated (header present on a covered
-    // request).
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("chat-a", "warmup probe please");
-        return r.status === 200 && r.cache !== null;
-      } catch {
-        return false;
-      }
+    // Caller keys are seeded LAST: once one authenticates, revision
+    // order implies every resource above is in the snapshot.
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
     });
+    await seed.createApiKey({
+      key_hash: OTHER_CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    const probe = new ProxyClient(app.proxyUrl, OTHER_CALLER_PLAINTEXT);
+    await waitConfigPropagation(
+      async () => (await probe.listModels()).status === 200,
+    );
   });
 
   afterAll(async () => {
@@ -409,10 +439,12 @@ describe("semantic cache e2e", () => {
       ctx.skip();
       return;
     }
-    // "topic-a" entries exist from the first test at default params; the
-    // same meaning with temperature set must not be served from them —
-    // the stored answer was generated under different parameters.
-    const r = await chat("chat-a", "tell me about topic-a", {
+    // Self-seeded on a dedicated axis: store at default params, then
+    // the same meaning with temperature set must not be served from it
+    // — the stored answer was generated under different parameters.
+    const seeded = await chat("chat-a", "params-x probe question");
+    expect(seeded.cache).toBe("miss");
+    const r = await chat("chat-a", "params-x probe question", {
       temperature: 0.9,
     });
     expect(r.status).toBe(200);
@@ -434,14 +466,7 @@ describe("semantic cache e2e", () => {
       ttl_seconds: 600,
       semantic: { embedding_model: "embed-cache", threshold: 0.95 },
     });
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("chat-strict", "warmup probe please");
-        return r.status === 200 && r.cache !== null;
-      } catch {
-        return false;
-      }
-    });
+    await sealSeedBatch();
 
     const seeded = await chat("chat-strict", "tell me about topic-a");
     expect(seeded.cache).toBe("miss");
@@ -467,9 +492,12 @@ describe("semantic cache e2e", () => {
       ctx.skip();
       return;
     }
-    // Default scope (api_key): the other caller's identical + similar
-    // requests both miss.
-    const otherExact = await chat("chat-a", "tell me about topic-a", {
+    // Default scope (api_key), self-seeded on a dedicated axis:
+    // caller 1 stores, then the other caller's identical request must
+    // miss BOTH layers (scoped exact key + scoped semantic partition).
+    const mine = await chat("chat-a", "scope-x probe question");
+    expect(mine.cache).toBe("miss");
+    const otherExact = await chat("chat-a", "scope-x probe question", {
       bearer: OTHER_CALLER_PLAINTEXT,
     });
     expect(otherExact.status).toBe(200);
@@ -488,14 +516,7 @@ describe("semantic cache e2e", () => {
       scope: "env",
       semantic: { embedding_model: "embed-cache", threshold: 0.85 },
     });
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("chat-shared", "warmup probe please");
-        return r.status === 200 && r.cache !== null;
-      } catch {
-        return false;
-      }
-    });
+    await sealSeedBatch();
 
     const store = await chat("chat-shared", "tell me about topic-a");
     expect(store.cache).toBe("miss");
@@ -588,14 +609,7 @@ describe("semantic cache e2e", () => {
       ttl_seconds: 600,
       semantic: { embedding_model: "embed-cache", threshold: 0.85 },
     });
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("chat-refresh", "warmup probe please");
-        return r.status === 200 && r.cache !== null;
-      } catch {
-        return false;
-      }
-    });
+    await sealSeedBatch();
 
     const seeded = await chat("chat-refresh", "refresh probe unique");
     expect(seeded.cache).toBe("miss");
@@ -649,14 +663,7 @@ describe("semantic cache e2e", () => {
       ttl_seconds: 600,
       semantic: { embedding_model: "embed-broken", threshold: 0.85 },
     });
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("chat-broken", "warmup probe please");
-        return r.status === 200 && r.cache !== null;
-      } catch {
-        return false;
-      }
-    });
+    await sealSeedBatch();
 
     const first = await chat("chat-broken", "tell me about topic-a");
     expect(first.status).toBe(200);
@@ -692,14 +699,7 @@ describe("semantic cache e2e", () => {
       ttl_seconds: 600,
       semantic: { embedding_model: "embed-cache", threshold: 0.85 },
     });
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("chat-swap", "warmup probe please");
-        return r.status === 200 && r.cache !== null;
-      } catch {
-        return false;
-      }
-    });
+    await sealSeedBatch();
 
     const seeded = await chat("chat-swap", "tell me about topic-a");
     expect(seeded.cache).toBe("miss");
@@ -711,16 +711,14 @@ describe("semantic cache e2e", () => {
       ...policy.value,
       semantic: { embedding_model: "embed-cache-b", threshold: 0.85 },
     });
-    // A FRESH same-meaning wording (L1-cold) flips from semantic-hit to
-    // miss once the swap propagates — the old partition is orphaned.
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("chat-swap", "describe topic-a now");
-        return r.status === 200 && r.cache === "miss";
-      } catch {
-        return false;
-      }
-    });
+    await sealSeedBatch();
+
+    // A FRESH same-meaning wording (L1-cold) misses once the swap has
+    // landed — the old partition is orphaned even though both models
+    // produce identical vectors.
+    const fresh = await chat("chat-swap", "describe topic-a now");
+    expect(fresh.status).toBe(200);
+    expect(fresh.cache).toBe("miss");
     // …and the new partition warms normally.
     const rewarmed = await chat("chat-swap", "topic-a summary please");
     expect(rewarmed.cache).toBe("hit");
@@ -729,40 +727,47 @@ describe("semantic cache e2e", () => {
   });
 
   test("purge_generation bump invalidates both layers at once", async (ctx) => {
-    if (!etcdReachable || !app || !seed || !sharedPolicyId) {
+    if (!etcdReachable || !app || !seed) {
       ctx.skip();
       return;
     }
-    const seeded = await chat("chat-a", "purge probe unique");
-    expect(seeded.cache).toBe("miss");
-    expect(
-      (await chat("chat-a", "purge probe unique")).cache,
-    ).toBe("hit");
+    // Dedicated model + policy: purging must not disturb (or depend
+    // on) any other test's partition.
+    const upstream = await chatUpstreamReplying("answer-purge");
+    upstreams.push(upstream);
+    await createDirectModel("chat-purge", upstream);
+    const policy = await seed.createCachePolicy({
+      name: "sem-purge",
+      backend: "memory",
+      applies_to: "model:chat-purge",
+      ttl_seconds: 600,
+      semantic: { embedding_model: "embed-cache", threshold: 0.85 },
+    });
+    await sealSeedBatch();
 
-    await seed.update("cache_policies", sharedPolicyId, {
-      ...sharedPolicyBody,
+    const seeded = await chat("chat-purge", "purge probe unique");
+    expect(seeded.cache).toBe("miss");
+    expect((await chat("chat-purge", "purge probe unique")).cache).toBe("hit");
+
+    await seed.update("cache_policies", policy.id, {
+      ...policy.value,
       purge_generation: 1,
     });
-    // Propagation probe on an UNRELATED axis (the keyword-free warmup
-    // text): its pre-purge entry stops being served once the new
-    // generation lands. Probing with the purge-axis text would re-store
-    // a fresh same-axis entry and hand the paraphrase below a
-    // legitimate new-generation hit, masking what this test pins.
-    await waitConfigPropagation(async () => {
-      try {
-        const r = await chat("chat-a", "warmup probe please");
-        return r.status === 200 && r.cache === "miss";
-      } catch {
-        return false;
-      }
-    });
+    await sealSeedBatch();
 
     // Both layers are gone: a paraphrase of the pre-purge entry misses
-    // (nothing on its axis was re-stored since the purge)…
-    const paraphrase = await chat("chat-a", "purge probe reworded");
+    // (nothing on its axis exists in the new generation)…
+    const paraphrase = await chat("chat-purge", "purge probe reworded");
     expect(paraphrase.cache).toBe("miss");
+    // …the pre-purge WORDING is no longer exact-served either: it now
+    // matches the paraphrase's fresh entry SEMANTICALLY, proving the
+    // old exact entry (which would win as `layer: exact`) is gone…
+    const oldWording = await chat("chat-purge", "purge probe unique");
+    expect(oldWording.cache).toBe("hit");
+    expect(oldWording.layer).toBe("semantic");
     // …and the cache works normally under the new generation.
-    const rewarm = await chat("chat-a", "purge probe reworded");
+    const rewarm = await chat("chat-purge", "purge probe reworded");
     expect(rewarm.cache).toBe("hit");
+    expect(rewarm.layer).toBe("exact");
   });
 });

--- a/tests/e2e/src/cases/cache-semantic-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-semantic-e2e.test.ts
@@ -1,0 +1,605 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { pickFreePort } from "../harness/ports.js";
+
+// E2E: semantic cache (AISIX-Cloud#558). A CachePolicy carrying a
+// `semantic` block serves an exact-fingerprint (L1) hit first and, on an
+// L1 miss, embeds the request and serves the nearest stored entry at or
+// above the policy's cosine threshold (L2). Real `aisix` binary + etcd +
+// mock chat upstreams + a deterministic mock embedding endpoint; no CP.
+//
+// The embedding mock maps input text to fixed 8-dim vectors by keyword,
+// so similarity is fully deterministic. Each test owns an orthogonal
+// axis (entries persist across tests within a policy+scope partition,
+// so unrelated tests must never share a vector):
+//   "topic-a-near" -> 0.9*topic-a + spill   (cos 0.9 vs topic-a)
+//   "topic-c-near" -> 0.9*topic-c + spill   (same pair on another axis)
+//   "topic-a" / "topic-b" / "topic-c" / "no-store" / "refresh" /
+//   "purge" / default -> one distinct axis each
+//
+// Observable contract under test (headers are the wire surface):
+//   x-aisix-cache: hit | miss | bypass
+//   x-aisix-cache-layer: exact | semantic   (hits only)
+//   x-aisix-cache-similarity: <float>       (semantic hits only)
+
+const CALLER_PLAINTEXT = "sk-semcache-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+const OTHER_CALLER_PLAINTEXT = "sk-semcache-other";
+const OTHER_CALLER_KEY_HASH = createHash("sha256")
+  .update(OTHER_CALLER_PLAINTEXT)
+  .digest("hex");
+
+function keywordVector(text: string): number[] {
+  const t = text.toLowerCase();
+  const spill = Math.sqrt(0.19); // makes the *-near vectors unit-length
+  // Longest keyword first: "topic-a-near" contains "topic-a".
+  if (t.includes("topic-a-near")) return [0.9, 0, 0, 0, spill, 0, 0, 0];
+  if (t.includes("topic-a")) return [1, 0, 0, 0, 0, 0, 0, 0];
+  if (t.includes("topic-b")) return [0, 1, 0, 0, 0, 0, 0, 0];
+  if (t.includes("topic-c-near")) return [0, 0, 0.9, 0, spill, 0, 0, 0];
+  if (t.includes("topic-c")) return [0, 0, 1, 0, 0, 0, 0, 0];
+  if (t.includes("no-store")) return [0, 0, 0, 0, 0, 1, 0, 0];
+  if (t.includes("refresh")) return [0, 0, 0, 0, 0, 0, 1, 0];
+  if (t.includes("purge")) return [0, 0, 0, 0, 0, 0, 0, 1];
+  return [0, 0, 0, 1, 0, 0, 0, 0];
+}
+
+interface EmbeddingMock {
+  baseUrl: string;
+  callCount(): number;
+  close(): Promise<void>;
+}
+
+async function startEmbeddingMock(
+  opts: { fail?: boolean } = {},
+): Promise<EmbeddingMock> {
+  let calls = 0;
+  const server: Server = createServer((req, res) => {
+    res.on("error", () => {});
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      if (!req.url?.includes("/embeddings")) {
+        res.statusCode = 404;
+        res.end("{}");
+        return;
+      }
+      calls++;
+      if (opts.fail) {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({ error: { message: "embedding upstream down" } }),
+        );
+        return;
+      }
+      const body = JSON.parse(raw || "{}") as { input?: string | string[] };
+      const inputs = Array.isArray(body.input)
+        ? body.input
+        : [body.input ?? ""];
+      const data = inputs.map((text, index) => ({
+        object: "embedding",
+        index,
+        embedding: keywordVector(text),
+      }));
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          object: "list",
+          model: "embed-mock",
+          data,
+          usage: { prompt_tokens: inputs.length, total_tokens: inputs.length },
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) =>
+    server.listen(port, "127.0.0.1", resolve),
+  );
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    callCount: () => calls,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+function chatUpstreamReplying(content: string): Promise<OpenAiUpstream> {
+  return startOpenAiUpstream({
+    nonStreamBody: {
+      id: `cmpl-${content}`,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: "gpt-4o-mini",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 7, completion_tokens: 5, total_tokens: 12 },
+    },
+  });
+}
+
+interface ChatResult {
+  status: number;
+  content: string | undefined;
+  cache: string | null;
+  layer: string | null;
+  similarity: number | null;
+}
+
+describe("semantic cache e2e", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+  const embedMocks: EmbeddingMock[] = [];
+  let embed: EmbeddingMock;
+  let upstreamA: OpenAiUpstream;
+  let sharedPolicyId: string | undefined;
+  let sharedPolicyBody: Record<string, unknown>;
+
+  async function createDirectModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!seed) throw new Error("seed not ready");
+    const pk = await seed.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+  }
+
+  async function createEmbeddingModel(
+    displayName: string,
+    mock: EmbeddingMock,
+  ): Promise<void> {
+    if (!seed) throw new Error("seed not ready");
+    const pk = await seed.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${mock.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "embed-mock",
+      provider_key_id: pk.id,
+      embedding: { dimensions: 8, normalize: true },
+    });
+  }
+
+  async function chat(
+    model: string,
+    prompt: string,
+    opts: {
+      bearer?: string;
+      cacheControl?: string;
+      temperature?: number;
+      contentBlocks?: unknown[];
+    } = {},
+  ): Promise<ChatResult> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      authorization: `Bearer ${opts.bearer ?? CALLER_PLAINTEXT}`,
+    };
+    if (opts.cacheControl) headers["cache-control"] = opts.cacheControl;
+    const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model,
+        messages: [
+          {
+            role: "user",
+            content: opts.contentBlocks ?? prompt,
+          },
+        ],
+        ...(opts.temperature !== undefined
+          ? { temperature: opts.temperature }
+          : {}),
+      }),
+    });
+    let content: string | undefined;
+    if (res.status === 200) {
+      const json = (await res.json()) as {
+        choices?: { message?: { content?: string } }[];
+      };
+      content = json.choices?.[0]?.message?.content;
+    } else {
+      await res.text();
+    }
+    const sim = res.headers.get("x-aisix-cache-similarity");
+    return {
+      status: res.status,
+      content,
+      cache: res.headers.get("x-aisix-cache"),
+      layer: res.headers.get("x-aisix-cache-layer"),
+      similarity: sim === null ? null : Number(sim),
+    };
+  }
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await seed.createApiKey({
+      key_hash: OTHER_CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+
+    embed = await startEmbeddingMock();
+    embedMocks.push(embed);
+    await createEmbeddingModel("embed-cache", embed);
+
+    upstreamA = await chatUpstreamReplying("answer-a");
+    upstreams.push(upstreamA);
+    await createDirectModel("chat-a", upstreamA);
+    const created = await seed.createCachePolicy({
+      name: "sem-default",
+      backend: "memory",
+      applies_to: "model:chat-a",
+      ttl_seconds: 600,
+      semantic: { embedding_model: "embed-cache", threshold: 0.85 },
+    });
+    sharedPolicyId = created.id;
+    sharedPolicyBody = created.value;
+
+    // Gate open = the policy propagated (header present on a covered
+    // request).
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("chat-a", "warmup probe please");
+        return r.status === 200 && r.cache !== null;
+      } catch {
+        return false;
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+    await Promise.all(embedMocks.map((m) => m.close()));
+  });
+
+  test("paraphrase above threshold hits semantically; same wording then hits exactly", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const first = await chat("chat-a", "tell me about topic-a");
+    expect(first.status).toBe(200);
+    expect(first.cache).toBe("miss");
+    expect(first.content).toBe("answer-a");
+
+    const upstreamCallsAfterMiss = upstreamA.receivedRequests.length;
+
+    // Different wording, same meaning (same mock vector): L1 misses,
+    // L2 serves the stored answer without an upstream call.
+    const paraphrase = await chat("chat-a", "please explain topic-a to me");
+    expect(paraphrase.status).toBe(200);
+    expect(paraphrase.cache).toBe("hit");
+    expect(paraphrase.layer).toBe("semantic");
+    expect(paraphrase.content).toBe("answer-a");
+    expect(paraphrase.similarity).not.toBeNull();
+    expect(paraphrase.similarity!).toBeGreaterThanOrEqual(0.85);
+    expect(paraphrase.similarity!).toBeLessThanOrEqual(1.0);
+    expect(upstreamA.receivedRequests.length).toBe(upstreamCallsAfterMiss);
+
+    // The semantic hit backfilled the exact layer: the SAME paraphrase
+    // again is now an exact hit (no embedding call either).
+    const embedCallsBefore = embed.callCount();
+    const repeat = await chat("chat-a", "please explain topic-a to me");
+    expect(repeat.cache).toBe("hit");
+    expect(repeat.layer).toBe("exact");
+    expect(repeat.content).toBe("answer-a");
+    expect(embed.callCount()).toBe(embedCallsBefore);
+    expect(upstreamA.receivedRequests.length).toBe(upstreamCallsAfterMiss);
+  });
+
+  test("unrelated prompt misses and goes upstream", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const before = upstreamA.receivedRequests.length;
+    const r = await chat("chat-a", "tell me about topic-b");
+    expect(r.status).toBe(200);
+    expect(r.cache).toBe("miss");
+    expect(upstreamA.receivedRequests.length).toBe(before + 1);
+  });
+
+  test("same meaning but different sampling params never matches", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    // "topic-a" entries exist from the first test at default params; the
+    // same meaning with temperature set must not be served from them —
+    // the stored answer was generated under different parameters.
+    const r = await chat("chat-a", "tell me about topic-a", {
+      temperature: 0.9,
+    });
+    expect(r.status).toBe(200);
+    expect(r.cache).toBe("miss");
+  });
+
+  test("below-threshold similarity misses", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const strictUpstream = await chatUpstreamReplying("answer-strict");
+    upstreams.push(strictUpstream);
+    await createDirectModel("chat-strict", strictUpstream);
+    await seed.createCachePolicy({
+      name: "sem-strict",
+      backend: "memory",
+      applies_to: "model:chat-strict",
+      ttl_seconds: 600,
+      semantic: { embedding_model: "embed-cache", threshold: 0.95 },
+    });
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("chat-strict", "warmup probe please");
+        return r.status === 200 && r.cache !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    const seeded = await chat("chat-strict", "tell me about topic-a");
+    expect(seeded.cache).toBe("miss");
+    // cos(topic-a-near, topic-a) = 0.9 < 0.95 -> upstream again.
+    const near = await chat("chat-strict", "tell me about topic-a-near");
+    expect(near.status).toBe(200);
+    expect(near.cache).toBe("miss");
+
+    // Sibling check on the looser policy (0.85): the same pair DOES
+    // match semantically, pinning that 0.9 sits between the two
+    // thresholds rather than being flattened to 1.0 or 0.0.
+    const seededLoose = await chat("chat-a", "note down topic-c");
+    expect(seededLoose.cache).toBe("miss");
+    const nearLoose = await chat("chat-a", "note down topic-c-near");
+    expect(nearLoose.cache).toBe("hit");
+    expect(nearLoose.layer).toBe("semantic");
+    expect(nearLoose.similarity!).toBeGreaterThanOrEqual(0.85);
+    expect(nearLoose.similarity!).toBeLessThan(0.95);
+  });
+
+  test("scope defaults to api_key: another caller never sees the entry; scope env shares it", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    // Default scope (api_key): the other caller's identical + similar
+    // requests both miss.
+    const otherExact = await chat("chat-a", "tell me about topic-a", {
+      bearer: OTHER_CALLER_PLAINTEXT,
+    });
+    expect(otherExact.status).toBe(200);
+    expect(otherExact.cache).toBe("miss");
+
+    // scope: env policy on a separate model: caller 1 stores, caller 2
+    // hits — both exactly and semantically.
+    const sharedUpstream = await chatUpstreamReplying("answer-shared");
+    upstreams.push(sharedUpstream);
+    await createDirectModel("chat-shared", sharedUpstream);
+    await seed.createCachePolicy({
+      name: "sem-shared",
+      backend: "memory",
+      applies_to: "model:chat-shared",
+      ttl_seconds: 600,
+      scope: "env",
+      semantic: { embedding_model: "embed-cache", threshold: 0.85 },
+    });
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("chat-shared", "warmup probe please");
+        return r.status === 200 && r.cache !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    const store = await chat("chat-shared", "tell me about topic-a");
+    expect(store.cache).toBe("miss");
+    const crossExact = await chat("chat-shared", "tell me about topic-a", {
+      bearer: OTHER_CALLER_PLAINTEXT,
+    });
+    expect(crossExact.cache).toBe("hit");
+    expect(crossExact.layer).toBe("exact");
+    expect(crossExact.content).toBe("answer-shared");
+    const crossSemantic = await chat(
+      "chat-shared",
+      "explain topic-a in short",
+      { bearer: OTHER_CALLER_PLAINTEXT },
+    );
+    expect(crossSemantic.cache).toBe("hit");
+    expect(crossSemantic.layer).toBe("semantic");
+    expect(crossSemantic.content).toBe("answer-shared");
+  });
+
+  test("requests with non-text content never match semantically", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const blocks = (url: string) => [
+      { type: "text", text: "what is in this picture of topic-a" },
+      { type: "image_url", image_url: { url } },
+    ];
+    const first = await chat("chat-a", "", {
+      contentBlocks: blocks("https://example.com/cat.jpg"),
+    });
+    expect(first.status).toBe(200);
+    expect(first.cache).toBe("miss");
+
+    // Same question about a DIFFERENT image: same text, so a text
+    // embedding could not tell them apart — must go upstream, not match.
+    const otherImage = await chat("chat-a", "", {
+      contentBlocks: blocks("https://example.com/dog.jpg"),
+    });
+    expect(otherImage.cache).toBe("miss");
+
+    // Identical multimodal request still hits the exact layer.
+    const exactRepeat = await chat("chat-a", "", {
+      contentBlocks: blocks("https://example.com/cat.jpg"),
+    });
+    expect(exactRepeat.cache).toBe("hit");
+    expect(exactRepeat.layer).toBe("exact");
+  });
+
+  test("Cache-Control: no-store keeps the response out of both layers", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const first = await chat("chat-a", "no-store probe unique", {
+      cacheControl: "no-store",
+    });
+    expect(first.status).toBe(200);
+    expect(first.cache).toBe("miss");
+    // Nothing was stored: the identical request misses again.
+    const repeat = await chat("chat-a", "no-store probe unique");
+    expect(repeat.cache).toBe("miss");
+  });
+
+  test("Cache-Control: no-cache bypasses the read path and refreshes the entry", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const seeded = await chat("chat-a", "refresh probe unique");
+    expect(seeded.cache).toBe("miss");
+    const cachedNow = await chat("chat-a", "refresh probe unique");
+    expect(cachedNow.cache).toBe("hit");
+
+    const before = upstreamA.receivedRequests.length;
+    const bypass = await chat("chat-a", "refresh probe unique", {
+      cacheControl: "no-cache",
+    });
+    expect(bypass.status).toBe(200);
+    expect(bypass.cache).toBe("bypass");
+    expect(bypass.layer).toBeNull();
+    expect(upstreamA.receivedRequests.length).toBe(before + 1);
+
+    // The bypass refreshed (re-stored) the entry — still served after.
+    const after = await chat("chat-a", "refresh probe unique");
+    expect(after.cache).toBe("hit");
+  });
+
+  test("embedding failure degrades to exact-only, never fails the request", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const brokenEmbed = await startEmbeddingMock({ fail: true });
+    embedMocks.push(brokenEmbed);
+    await createEmbeddingModel("embed-broken", brokenEmbed);
+    const upstream = await chatUpstreamReplying("answer-degraded");
+    upstreams.push(upstream);
+    await createDirectModel("chat-broken", upstream);
+    await seed.createCachePolicy({
+      name: "sem-broken",
+      backend: "memory",
+      applies_to: "model:chat-broken",
+      ttl_seconds: 600,
+      semantic: { embedding_model: "embed-broken", threshold: 0.85 },
+    });
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("chat-broken", "warmup probe please");
+        return r.status === 200 && r.cache !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    const first = await chat("chat-broken", "tell me about topic-a");
+    expect(first.status).toBe(200);
+    expect(first.cache).toBe("miss");
+    expect(first.content).toBe("answer-degraded");
+    // Similar wording cannot match (no embeddings) -> upstream.
+    const similar = await chat("chat-broken", "explain topic-a briefly");
+    expect(similar.status).toBe(200);
+    expect(similar.cache).toBe("miss");
+    // The exact layer still works.
+    const exact = await chat("chat-broken", "tell me about topic-a");
+    expect(exact.cache).toBe("hit");
+    expect(exact.layer).toBe("exact");
+  });
+
+  test("purge_generation bump invalidates both layers at once", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !sharedPolicyId) {
+      ctx.skip();
+      return;
+    }
+    const seeded = await chat("chat-a", "purge probe unique");
+    expect(seeded.cache).toBe("miss");
+    expect(
+      (await chat("chat-a", "purge probe unique")).cache,
+    ).toBe("hit");
+
+    await seed.update("cache_policies", sharedPolicyId, {
+      ...sharedPolicyBody,
+      purge_generation: 1,
+    });
+    // Propagation probe on an UNRELATED axis (the keyword-free warmup
+    // text): its pre-purge entry stops being served once the new
+    // generation lands. Probing with the purge-axis text would re-store
+    // a fresh same-axis entry and hand the paraphrase below a
+    // legitimate new-generation hit, masking what this test pins.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("chat-a", "warmup probe please");
+        return r.status === 200 && r.cache === "miss";
+      } catch {
+        return false;
+      }
+    });
+
+    // Both layers are gone: a paraphrase of the pre-purge entry misses
+    // (nothing on its axis was re-stored since the purge)…
+    const paraphrase = await chat("chat-a", "purge probe reworded");
+    expect(paraphrase.cache).toBe("miss");
+    // …and the cache works normally under the new generation.
+    const rewarm = await chat("chat-a", "purge probe reworded");
+    expect(rewarm.cache).toBe("hit");
+  });
+});

--- a/tests/e2e/src/cases/cache-semantic-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-semantic-e2e.test.ts
@@ -121,6 +121,60 @@ async function startEmbeddingMock(
   };
 }
 
+interface CountingUpstream {
+  baseUrl: string;
+  callCount(): number;
+  close(): Promise<void>;
+}
+
+/**
+ * A chat upstream whose reply body CHANGES on every call
+ * (`reply-1`, `reply-2`, …). Refresh contracts need this: with a
+ * fixed-body mock, "the entry was re-stored" and "the old entry
+ * survived" are indistinguishable.
+ */
+async function countingChatUpstream(): Promise<CountingUpstream> {
+  let calls = 0;
+  const server: Server = createServer((req, res) => {
+    res.on("error", () => {});
+    req.on("data", () => {});
+    req.on("end", () => {
+      calls++;
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          id: `cmpl-${calls}`,
+          object: "chat.completion",
+          created: Math.floor(Date.now() / 1000),
+          model: "gpt-4o-mini",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: `reply-${calls}` },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 7, completion_tokens: 5, total_tokens: 12 },
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) =>
+    server.listen(port, "127.0.0.1", resolve),
+  );
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    callCount: () => calls,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
 function chatUpstreamReplying(content: string): Promise<OpenAiUpstream> {
   return startOpenAiUpstream({
     nonStreamBody: {
@@ -153,6 +207,7 @@ describe("semantic cache e2e", () => {
   let seed: SeedClient | undefined;
   let etcdReachable = false;
   const upstreams: OpenAiUpstream[] = [];
+  const countingUpstreams: CountingUpstream[] = [];
   const embedMocks: EmbeddingMock[] = [];
   let embed: EmbeddingMock;
   let upstreamA: OpenAiUpstream;
@@ -294,6 +349,7 @@ describe("semantic cache e2e", () => {
   afterAll(async () => {
     await app?.exit();
     await Promise.all(upstreams.map((u) => u.close()));
+    await Promise.all(countingUpstreams.map((u) => u.close()));
     await Promise.all(embedMocks.map((m) => m.close()));
   });
 
@@ -302,10 +358,14 @@ describe("semantic cache e2e", () => {
       ctx.skip();
       return;
     }
+    const embedCallsBeforeMiss = embed.callCount();
     const first = await chat("chat-a", "tell me about topic-a");
     expect(first.status).toBe(200);
     expect(first.cache).toBe("miss");
     expect(first.content).toBe("answer-a");
+    // One embedding call covers BOTH the L2 lookup and the store —
+    // a miss must never pay twice.
+    expect(embed.callCount()).toBe(embedCallsBeforeMiss + 1);
 
     const upstreamCallsAfterMiss = upstreamA.receivedRequests.length;
 
@@ -500,28 +560,75 @@ describe("semantic cache e2e", () => {
     expect(repeat.cache).toBe("miss");
   });
 
-  test("Cache-Control: no-cache bypasses the read path and refreshes the entry", async (ctx) => {
+  test("Cache-Control: no-cache bypasses the read path and refreshes BOTH layers", async (ctx) => {
     if (!etcdReachable || !app || !seed) {
       ctx.skip();
       return;
     }
-    const seeded = await chat("chat-a", "refresh probe unique");
-    expect(seeded.cache).toBe("miss");
-    const cachedNow = await chat("chat-a", "refresh probe unique");
-    expect(cachedNow.cache).toBe("hit");
+    // Dedicated model on a counting upstream: every upstream call
+    // returns a DIFFERENT body, so "refreshed" vs "stale entry
+    // survived" is distinguishable in the served content.
+    const counting = await countingChatUpstream();
+    countingUpstreams.push(counting);
+    const pk = await seed.createProviderKey({
+      display_name: "chat-refresh-pk",
+      secret: "sk-mock",
+      api_base: `${counting.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "chat-refresh",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createCachePolicy({
+      name: "sem-refresh",
+      backend: "memory",
+      applies_to: "model:chat-refresh",
+      ttl_seconds: 600,
+      semantic: { embedding_model: "embed-cache", threshold: 0.85 },
+    });
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("chat-refresh", "warmup probe please");
+        return r.status === 200 && r.cache !== null;
+      } catch {
+        return false;
+      }
+    });
 
-    const before = upstreamA.receivedRequests.length;
-    const bypass = await chat("chat-a", "refresh probe unique", {
+    const seeded = await chat("chat-refresh", "refresh probe unique");
+    expect(seeded.cache).toBe("miss");
+    const originalBody = seeded.content!;
+    const cachedNow = await chat("chat-refresh", "refresh probe unique");
+    expect(cachedNow.cache).toBe("hit");
+    expect(cachedNow.content).toBe(originalBody);
+
+    const upstreamBefore = counting.callCount();
+    const bypass = await chat("chat-refresh", "refresh probe unique", {
       cacheControl: "no-cache",
     });
     expect(bypass.status).toBe(200);
     expect(bypass.cache).toBe("bypass");
     expect(bypass.layer).toBeNull();
-    expect(upstreamA.receivedRequests.length).toBe(before + 1);
+    expect(counting.callCount()).toBe(upstreamBefore + 1);
+    const refreshedBody = bypass.content!;
+    expect(refreshedBody).not.toBe(originalBody);
 
-    // The bypass refreshed (re-stored) the entry — still served after.
-    const after = await chat("chat-a", "refresh probe unique");
-    expect(after.cache).toBe("hit");
+    // The bypass refreshed the EXACT layer: the identical request now
+    // serves the NEW body, not the pre-bypass one.
+    const exactAfter = await chat("chat-refresh", "refresh probe unique");
+    expect(exactAfter.cache).toBe("hit");
+    expect(exactAfter.layer).toBe("exact");
+    expect(exactAfter.content).toBe(refreshedBody);
+
+    // …and the SEMANTIC layer: the bypass path re-embedded and
+    // upserted, so a paraphrase serves the new body too (upsert —
+    // the stale entry was replaced, not shadowed).
+    const semanticAfter = await chat("chat-refresh", "refresh probe reworded");
+    expect(semanticAfter.cache).toBe("hit");
+    expect(semanticAfter.layer).toBe("semantic");
+    expect(semanticAfter.content).toBe(refreshedBody);
   });
 
   test("embedding failure degrades to exact-only, never fails the request", async (ctx) => {

--- a/tests/e2e/src/cases/cache-semantic-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-semantic-e2e.test.ts
@@ -565,6 +565,62 @@ describe("semantic cache e2e", () => {
     expect(exact.layer).toBe("exact");
   });
 
+  test("swapping the embedding model orphans old entries even at identical vectors", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    // Second embedding model on the SAME mock: identical vectors, new
+    // identity. If the candidate partition keyed only on vectors, the
+    // swap would keep serving old entries; the contract is that vectors
+    // from a different embedding model are never compared.
+    await createEmbeddingModel("embed-cache-b", embed);
+    const upstream = await chatUpstreamReplying("answer-swap");
+    upstreams.push(upstream);
+    await createDirectModel("chat-swap", upstream);
+    const policy = await seed.createCachePolicy({
+      name: "sem-swap",
+      backend: "memory",
+      applies_to: "model:chat-swap",
+      ttl_seconds: 600,
+      semantic: { embedding_model: "embed-cache", threshold: 0.85 },
+    });
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("chat-swap", "warmup probe please");
+        return r.status === 200 && r.cache !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    const seeded = await chat("chat-swap", "tell me about topic-a");
+    expect(seeded.cache).toBe("miss");
+    const baseline = await chat("chat-swap", "explain topic-a please");
+    expect(baseline.cache).toBe("hit");
+    expect(baseline.layer).toBe("semantic");
+
+    await seed.update("cache_policies", policy.id, {
+      ...policy.value,
+      semantic: { embedding_model: "embed-cache-b", threshold: 0.85 },
+    });
+    // A FRESH same-meaning wording (L1-cold) flips from semantic-hit to
+    // miss once the swap propagates — the old partition is orphaned.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("chat-swap", "describe topic-a now");
+        return r.status === 200 && r.cache === "miss";
+      } catch {
+        return false;
+      }
+    });
+    // …and the new partition warms normally.
+    const rewarmed = await chat("chat-swap", "topic-a summary please");
+    expect(rewarmed.cache).toBe("hit");
+    expect(rewarmed.layer).toBe("semantic");
+    expect(rewarmed.content).toBe("answer-swap");
+  });
+
   test("purge_generation bump invalidates both layers at once", async (ctx) => {
     if (!etcdReachable || !app || !seed || !sharedPolicyId) {
       ctx.skip();


### PR DESCRIPTION
## Summary

Adds the semantic (L2) matching layer to cache policies: a `CachePolicy` carrying the new `semantic` block embeds a request on an exact-fingerprint (L1) miss and serves the nearest stored entry at or above the policy's cosine `threshold`. Part of the semantic-cache feature tracked in api7/AISIX-Cloud#558; this PR is the DP half with the in-process store — the shared redis (vector search) store and the control-plane surface (schema, purge endpoint, dashboard) land in follow-up PRs.

```jsonc
{
  "name": "support-faq",
  "backend": "memory",                 // unchanged: storage choice
  "ttl_seconds": 3600,
  "applies_to": "model:support-assistant",
  "scope": "api_key",                  // NEW: api_key (default) | env
  "purge_generation": 0,               // NEW: purge = bump, entries die at once
  "semantic": {                        // NEW: presence enables L2
    "embedding_model": "text-embedding-3-small",  // an `embedding`-modality Model
    "threshold": 0.92,
    "max_entries": 1000,               // memory backend cap (≤ 10k), oldest-first eviction
    "embedding_timeout_ms": 2000
  }
}
```

## Design

- **Layered, not either/or.** Exact matching stays first and free; similarity only runs on an exact miss. A semantic hit backfills the exact layer (TTL capped at the matched entry's own remaining lifetime) so the same wording takes the L1 path next time. A full miss reuses the request embedding for the store — one embedding call per uncached request, not two. (Mainstream gateways that model semantic caching as a separate cache *type* force operators to give up exact determinism to get similarity; layering avoids that.)
- **Only the messages are fuzzy.** Semantic candidates are pre-filtered by a partition key — model, sampling params, `tools`/`response_format`/`seed`/… extras, policy id, purge generation, the **embedding model's identity + dimensions** (swapping `semantic.embedding_model` orphans old vectors instead of comparing across unrelated vector spaces), and (under `scope: api_key`) the caller. A tool-calling request can never be served a similar-but-toolless answer; requests containing images/audio or message-level tool fields (`tool_calls`, `tool_call_id`, `name`) skip similarity entirely — no faithful text-only representation exists for them.
- **Isolation by default.** `scope: api_key` keeps entries private to the caller that created them; `scope: env` opts a policy into environment-wide sharing for shared-knowledge traffic. The exact-cache key now carries the policy id + generation + scope too, closing the pre-existing gap where two policies (or two callers) shared entries implicitly — and the pre-existing blindness of the exact fingerprint to message-level `tool_calls`/`tool_call_id`/`name` is fixed in the same stroke (same bug class).
- **Purge is generational.** The control plane will bump `purge_generation` (CP PR); stores/lookups treat a mismatched generation as empty, so a purge invalidates both layers at once with no delete plumbing. Stale in-flight writers cannot roll a bucket back (lower-generation stores are dropped), and orphaned entries — including deleted policies' — are reclaimed within one TTL (capped at 7 days) by an opportunistic sweep on the store path.
- **Fail-open everywhere.** Embedding resolve/call failures, store errors, and timeouts degrade the request to an ordinary miss — a broken cache optimization must never fail traffic. Failures are logged (`aisix::cache` target; stable config errors warn once per policy) and counted.
- **Per-request bypass** honors standard `Cache-Control` request directives: `no-cache` skips the read path (surfaced as `bypass`) but still refreshes both layers — the semantic entry is **upserted** by exact wording, never duplicated; `no-store` suppresses writes. Body-level cache parameters (non-OpenAI-spec fields some gateways use) are deliberately not adopted.
- The embedding call reuses the semantic router's bridge path (`embed_texts`, no client request attached) and the existing `embedding`-modality Model resource — no new credential surface. Reference: OpenAI embeddings API (`POST /v1/embeddings`, `encoding_format=float`) <https://platform.openai.com/docs/api-reference/embeddings/create>.

## Wire / observability changes

- `x-aisix-cache` gains `bypass`; new `x-aisix-cache-layer: exact|semantic` + `x-aisix-cache-similarity` (4 decimal places, same value the usage event stores) on hits.
- UsageEvent: new `cache_hit_layer` / `cache_similarity` fields; `cache_status` gains `bypass`. `/dp/telemetry` binds leniently, so older CP images ignore them.
- First cache Prometheus series: `aisix_cache_requests_total{policy,outcome}`, `aisix_cache_semantic_embedding_seconds{policy}`, `aisix_cache_semantic_embedding_failures_total{policy,cause}`, `aisix_cache_semantic_store_failures_total{policy,op}`.

## Compatibility

- **Upgrade invalidation (accepted):** the exact-key shape change invalidates existing cache entries once on upgrade; TTL bounds the impact at 7 days max. Cross-caller sharing that was previously implicit now requires `scope: env` — release notes will call this out.
- **`Cache-Control` request directives are now honored** (previously ignored): clients habitually sending `no-cache`/`no-store` will now bypass reads / suppress writes on cache-covered requests. Goes in release notes alongside the two breaking changes above.
- **Old gateway + new row:** `CachePolicy` stays open-on-write with lenient etcd reads; serde tests pin that rows carrying the new fields (or future unknown fields inside `semantic`) still load on a pre-semantic gateway, which simply keeps exact-only behavior.
- **Redis-backend policies:** `semantic` on a `backend: redis` policy warns once and runs exact-only until the shared vector store lands (follow-up PR) — no silent per-node stand-in.
- Cache remains chat-completions-only and non-streaming-only, unchanged from the exact cache's existing boundary (`TODO(streaming-cache)` still tracks the streaming side).

## Review hardening (bot review + independent audit, all findings addressed)

Candidate partition now carries the embedding-model identity; message-level tool fields folded into the exact fingerprint and excluded from semantic matching; embedded text escapes forged message boundaries; stale-generation stores dropped instead of rolling buckets back; orphaned buckets swept within one TTL; `max_entries` ceiling 10k; backfill TTL capped at the source entry's remaining lifetime; L2 upsert by exact wording; zero-similarity can never match (degenerate-comparison fold); similarity rounded once at the source; store-failure counter added.

## Test plan

- `cargo test --workspace` green (49 targets); `cargo clippy --workspace --all-targets -- -D warnings` + `cargo fmt --check` clean.
- Full vitest e2e suite green locally (etcd + redis provisioned): `cache-semantic-e2e.test.ts` (11 cases) pins paraphrase hit + L1 backfill, one-embedding-per-miss (mock call count), both sides of the threshold boundary, sampling-param partition, `api_key`/`env` scope isolation, multimodal skip, embedding-model swap orphaning (two models, identical vectors), `no-store`, a **falsifiable** `no-cache` refresh contract (counting upstream: post-bypass hits on both layers must serve the new body), embedding-failure degradation, and generational purge — against a real `aisix` binary with a deterministic mock embedding endpoint.
- `cache-policy-backend-e2e` cross-instance redis sharing now runs two replicas on one etcd prefix (one environment) — cache keys carry resource identity, so distinct-prefix "replicas" no longer model production topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional semantic cache matching alongside exact matching.
  * Added configurable similarity thresholds, embedding models, timeouts, entry limits, and cache scopes.
  * Added API response headers and usage telemetry showing cache-hit type and similarity.
  * Added cache-control support for bypassing or refreshing cached responses.
  * Added cache policy documentation and schema updates.

* **Observability**
  * Added metrics for cache outcomes, embedding performance, and semantic-store failures.

* **Bug Fixes**
  * Improved cache isolation by policy, caller scope, and purge generation.
  * Added graceful fallback to exact matching when semantic caching is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes api7/AISIX-Cloud#558
