### PR TITLE
bench(onthebench): shared measurement lib, generic entrant runner, method overrides

### DIFF
--- a/bench/onthebench/README.md
+++ b/bench/onthebench/README.md
@@ -76,6 +76,11 @@ match the #891 grid exactly): `BENCH_GRID` (`"ttft_ms:conc ..."`, e.g.
 A changed knob is recorded in `meta.json`, so a non-default run can never
 pass silently as the standard grid.
 
+Values are validated at startup and nonsense refuses to run: grid entries
+must be `ttft_ms:conc` with a positive concurrency; window, reps, max tries
+and floor reps must be positive integers (warmup may be `0`);
+`BENCH_FLAMEGRAPH` is `0` or `1`.
+
 ## Measuring another target ("entrant")
 
 `run-entrant.sh <entrant-dir> <out-dir>` measures any gateway-shaped process

--- a/bench/onthebench/README.md
+++ b/bench/onthebench/README.md
@@ -42,17 +42,19 @@ Replicates the published onthebench setup (https://onthebench.ai/gateways/perfor
   as the only upstream and minting the single client key (boot: AISIX has no
   anonymous mode). Everything else — thread-per-core, worker count, telemetry —
   is whatever the defaults do.
-- **Load grid** — fixed concurrency, the api7/aisix#891 grid: c=16/32/128
-  against the 0-delay mock, c=768 against the 10ms-TTFT mock
+- **Load grid** — fixed concurrency, the api7/aisix#891 grid by default:
+  c=16/32/128 against the 0-delay mock, c=768 against the 10ms-TTFT mock
   (`MOCK_TTFT_MS=10`). 25s windows, 5s warmup per point, ≥4 repetitions;
   a window with any failed request (`fail`, `rigrefused`, `budgetexceeded`,
   `spawnfailed`) is recorded but marked invalid, and the point retries until
   4 valid windows or 8 attempts. A run in which any point ends incomplete
   exits nonzero so it can never be mistaken for a baseline.
-- **Rig floor** — the load generator driving the mock directly (c=128 0-delay,
-  c=768 10ms), so every gateway number can be checked against the instrument's
-  own ceiling; two valid windows per floor point, under the same
-  record-mark-retry validity policy as the gateway points.
+- **Rig floor** — the load generator driving the mock directly, so every
+  gateway number can be checked against the instrument's own ceiling; two
+  valid windows per floor point, under the same record-mark-retry validity
+  policy as the gateway points. The 0-delay tier gets one floor at its
+  largest concurrency (the ceiling barely moves with c); each delayed tier
+  gets a floor per concurrency, because there the ceiling is ~conc/delay.
 - **Recorded per window** — rps, fail/ok counts, p50/p99 (µs, from otb),
   gateway CPU% (`/proc/<pid>/stat` utime+stime across the window), gateway
   peak RSS (VmRSS sampled at 5 Hz), the raw otb stats line. Idle RSS and
@@ -64,13 +66,37 @@ Replicates the published onthebench setup (https://onthebench.ai/gateways/perfor
   reverts on reboot) so an unprivileged run can sample its own process, and
   `run-baseline.sh` refuses a stripped binary before wasting a run.
 
+## Method overrides
+
+Every method knob is a `BENCH_*` environment variable (defaults in `lib.sh`
+match the #891 grid exactly): `BENCH_GRID` (`"ttft_ms:conc ..."`, e.g.
+`"20:1536 20:2048"` for an added delay tier, `"0:128"` for a spot-check),
+`BENCH_REPS`, `BENCH_WINDOW`, `BENCH_WARMUP`, `BENCH_MAX_TRIES`,
+`BENCH_FLOOR_REPS`, `BENCH_FLAMEGRAPH`. `bench.sh` forwards them to the rig.
+A changed knob is recorded in `meta.json`, so a non-default run can never
+pass silently as the standard grid.
+
+## Measuring another target ("entrant")
+
+`run-entrant.sh <entrant-dir> <out-dir>` measures any gateway-shaped process
+with the same instruments, floors, windows and validity policy — both runners
+source `lib.sh`, so cross-target numbers are comparable by construction. The
+entrant dir provides an `entrant.sh` implementing the contract documented at
+the top of `run-entrant.sh` (start the target pinned to the gateway cores on
+the harness port, upstream at the mock; optionally a prepare/teardown step,
+identity metadata, and a request-shape override for targets whose ingress
+speaks a dialect other than OpenAI chat). Entrant dirs are deliberately not
+part of this repository; flamegraphs default off for entrants because shipped
+release binaries are usually stripped (a stripped target skips the flamegraph
+with a warning rather than failing the run).
+
 ## Output
 
 One directory per run: `results.jsonl` (one JSON object per measured window,
-`kind` gateway/floor), `meta.json`, the generated config files, and the
-gateway/mock logs. `flamegraph-c128.svg` is present when Inferno rendering
-succeeded; on a rendering failure the run keeps `perf.data` instead, so the
-SVG can be produced off-rig.
+`kind` gateway/floor, `entrant` naming the measured target), `meta.json`, the
+generated config files, and the gateway/mock logs. `flamegraph-c128.svg` is
+present when Inferno rendering succeeded; on a rendering failure the run
+keeps `perf.data` instead, so the SVG can be produced off-rig.
 
 ## Deviations from stock defaults, and why
 

--- a/bench/onthebench/bench.sh
+++ b/bench/onthebench/bench.sh
@@ -42,8 +42,17 @@ echo "== run baseline ($RUNID) =="
 # BENCH_-prefixed, never AISIX_-prefixed: aisix reads AISIX_* environment
 # variables as config overrides, so an AISIX_COMMIT in the gateway's
 # environment becomes an unknown top-level config field and refuses boot.
+#
+# Method overrides (BENCH_GRID, BENCH_REPS, ...) forward to the rig so a
+# spot-check or an extra delay tier is a local env var, not a script edit;
+# printf %q keeps values with spaces intact through the remote shell.
+ENVPASS="BENCH_SRC_COMMIT=$COMMIT BENCH_SRC_DIRTY=$DIRTY"
+for v in BENCH_GRID BENCH_REPS BENCH_WINDOW BENCH_WARMUP BENCH_MAX_TRIES \
+         BENCH_FLOOR_REPS BENCH_FLAMEGRAPH; do
+    [ -n "${!v:-}" ] && ENVPASS="$ENVPASS $v=$(printf %q "${!v}")"
+done
 RUN_RC=0
-ssh "$RIG" "BENCH_SRC_COMMIT=$COMMIT BENCH_SRC_DIRTY=$DIRTY \
+ssh "$RIG" "$ENVPASS \
     bash aisix-src/bench/onthebench/run-baseline.sh \"\$HOME/aisix-src\" \"\$HOME/bench-results/$RUNID\"" ||
     RUN_RC=$?
 

--- a/bench/onthebench/bench.sh
+++ b/bench/onthebench/bench.sh
@@ -49,7 +49,9 @@ echo "== run baseline ($RUNID) =="
 ENVPASS="BENCH_SRC_COMMIT=$COMMIT BENCH_SRC_DIRTY=$DIRTY"
 for v in BENCH_GRID BENCH_REPS BENCH_WINDOW BENCH_WARMUP BENCH_MAX_TRIES \
          BENCH_FLOOR_REPS BENCH_FLAMEGRAPH; do
-    [ -n "${!v:-}" ] && ENVPASS="$ENVPASS $v=$(printf %q "${!v}")"
+    # if, not `[ ] &&`: harmless here, but the && form as a function's last
+    # statement is exactly how the grid_concs regression happened once.
+    if [ -n "${!v:-}" ]; then ENVPASS="$ENVPASS $v=$(printf %q "${!v}")"; fi
 done
 RUN_RC=0
 ssh "$RIG" "$ENVPASS \

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -28,18 +28,33 @@ DEFAULT_BODY='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello
 BODY="${BODY:-$DEFAULT_BODY}"
 AUTH_HEADER="${AUTH_HEADER:-authorization: Bearer bench-token}"
 # Same header shape the public board's engine sends for the chosen dialect.
-# json.dumps, not string splicing: a quote or backslash in the header value
-# must not produce an invalid header list the loadgen then misparses.
-if [ -z "${OTB_LOADGEN_HEADERS:-}" ]; then
-    OTB_LOADGEN_HEADERS=$(python3 -c 'import json,sys
+# Always derived from AUTH_HEADER — an ambient OTB_LOADGEN_HEADERS would let
+# measured requests carry credentials the wait_http_200 readiness check never
+# exercised. json.dumps, not string splicing: a quote or backslash in the
+# header value must not produce an invalid header list.
+OTB_LOADGEN_HEADERS=$(python3 -c 'import json,sys
 k, _, v = sys.argv[1].partition(":")
 print(json.dumps([[k.strip(), v.strip()]]))' "$AUTH_HEADER")
-fi
 export OTB_LOADGEN_HEADERS
 
 # The name stamped into every result line, so mixed result sets stay
 # attributable; run-baseline.sh sets "aisix", run-entrant.sh requires one.
 ENTRANT_NAME="${ENTRANT_NAME:-}"
+
+# Overrides are operator input; nonsense must refuse to measure rather than
+# succeed while collecting nothing (BENCH_REPS=0 would "pass" every point).
+is_pos_int() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
+is_pos_int "$WINDOW" || { echo "FATAL: BENCH_WINDOW must be a positive integer, got '$WINDOW'"; exit 1; }
+[[ "$WARMUP" =~ ^[0-9]+$ ]] || { echo "FATAL: BENCH_WARMUP must be a non-negative integer, got '$WARMUP'"; exit 1; }
+is_pos_int "$REPS" || { echo "FATAL: BENCH_REPS must be a positive integer, got '$REPS'"; exit 1; }
+is_pos_int "$MAX_TRIES" || { echo "FATAL: BENCH_MAX_TRIES must be a positive integer, got '$MAX_TRIES'"; exit 1; }
+is_pos_int "$FLOOR_REPS" || { echo "FATAL: BENCH_FLOOR_REPS must be a positive integer, got '$FLOOR_REPS'"; exit 1; }
+case "$FLAMEGRAPH" in 0|1) ;; *) echo "FATAL: BENCH_FLAMEGRAPH must be 0 or 1, got '$FLAMEGRAPH'"; exit 1 ;; esac
+[ -n "$GRID" ] || { echo "FATAL: BENCH_GRID is empty"; exit 1; }
+for _spec in $GRID; do
+    [[ "$_spec" =~ ^[0-9]+:[1-9][0-9]*$ ]] ||
+        { echo "FATAL: BENCH_GRID entry '$_spec' is not ttft_ms:conc"; exit 1; }
+done
 
 TOOLS="$HOME/bench-tools"
 CLK_TCK=$(getconf CLK_TCK)
@@ -170,23 +185,32 @@ measured_window() { # measured_window <point> <ttft> <conc> <rep>
           sleep 0.2
       done ) & SAMPLER_PID=$!
 
-    ticks0=$(cpu_ticks "$GW_PID"); t0=$(date +%s.%N)
+    # Tick reads are fallible on purpose: a target that dies mid-window takes
+    # /proc/<pid>/stat with it, and that must record an invalid window, not
+    # kill the runner before the JSONL line lands.
+    ticks0=$(cpu_ticks "$GW_PID" 2>/dev/null) || ticks0=""
+    t0=$(date +%s.%N)
     line=$(loadgen "127.0.0.1:$GW_PORT" "$conc" "$WINDOW") || line=""
     line=${line//[\"\\]/ }
-    t1=$(date +%s.%N); ticks1=$(cpu_ticks "$GW_PID")
+    t1=$(date +%s.%N)
+    ticks1=$(cpu_ticks "$GW_PID" 2>/dev/null) || ticks1=""
     kill "$SAMPLER_PID" 2>/dev/null || true; wait "$SAMPLER_PID" 2>/dev/null || true; SAMPLER_PID=""
     rss_peak=$(cat "$rssfile" 2>/dev/null || echo 0); rm -f "$rssfile"
 
     elapsed=$(awk -v a="$t0" -v b="$t1" 'BEGIN{print b-a}')
-    cpu_pct=$(awk -v d=$((ticks1 - ticks0)) -v hz="$CLK_TCK" -v e="$elapsed" \
-        'BEGIN{printf "%.1f", d/hz/e*100}')
+    if [ -n "$ticks0" ] && [ -n "$ticks1" ]; then
+        cpu_pct=$(awk -v d=$((ticks1 - ticks0)) -v hz="$CLK_TCK" -v e="$elapsed" \
+            'BEGIN{printf "%.1f", d/hz/e*100}')
+    else
+        cpu_pct=null
+    fi
 
     rps=$(field rps "$line"); fail=$(field fail "$line"); ok=$(field ok "$line")
     p50=$(field p50us "$line"); p99=$(field p99us "$line")
     rigref=$(field rigrefused "$line"); budget=$(field budgetexceeded "$line"); spawn=$(field spawnfailed "$line")
     valid=true
-    [ "${fail:-1}" = "0" ] && [ "${rigref:-0}" = "0" ] && [ "${budget:-0}" = "0" ] \
-        && [ "${spawn:-0}" = "0" ] || valid=false
+    [ "$cpu_pct" != null ] && [ "${fail:-1}" = "0" ] && [ "${rigref:-0}" = "0" ] \
+        && [ "${budget:-0}" = "0" ] && [ "${spawn:-0}" = "0" ] || valid=false
 
     printf '{"kind":"gateway","entrant":"%s","point":"%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"ok":%s,"p50_us":%s,"p99_us":%s,"gw_cpu_pct":%s,"gw_rss_peak_kb":%s,"window_s":%s,"elapsed_s":%.2f,"otb_line":"%s"}\n' \
         "$ENTRANT_NAME" "$point" "$ttft" "$conc" "$rep" "$valid" "${rps:-null}" "${fail:-null}" "${ok:-null}" \
@@ -202,18 +226,26 @@ floor_point() { # floor_point <ttft> <conc>  (mock must already run with that tt
     # Same validity policy as gateway points, scaled to FLOOR_REPS: an invalid
     # window is recorded, marked, and retried, and can never stand as the rig
     # reference on its own.
-    local ttft="$1" conc="$2" valid_n=0 try=0 line fail valid
+    local ttft="$1" conc="$2" valid_n=0 try=0
+    local line fail rigref budget spawn rps p50 p99 valid
     loadgen "127.0.0.1:$MOCK_PORT" "$conc" 5 > /dev/null || true   # warmup
     while [ "$valid_n" -lt "$FLOOR_REPS" ] && [ "$try" -lt "$MAX_TRIES" ]; do
         try=$((try + 1))
         line=$(loadgen "127.0.0.1:$MOCK_PORT" "$conc" "$WINDOW") || line=""
         line=${line//[\"\\]/ }
-        fail=$(field fail "$line")
-        valid=true; [ "${fail:-1}" = "0" ] || valid=false
+        # Same validity fields as measured_window: a floor window that was
+        # refused or over budget must not become the rig reference, and an
+        # empty loadgen line must record nulls, not invalid JSON.
+        rps=$(field rps "$line"); fail=$(field fail "$line")
+        p50=$(field p50us "$line"); p99=$(field p99us "$line")
+        rigref=$(field rigrefused "$line"); budget=$(field budgetexceeded "$line"); spawn=$(field spawnfailed "$line")
+        valid=true
+        [ "${fail:-1}" = "0" ] && [ "${rigref:-0}" = "0" ] && [ "${budget:-0}" = "0" ] \
+            && [ "${spawn:-0}" = "0" ] || valid=false
         [ "$valid" = true ] && valid_n=$((valid_n + 1))
         printf '{"kind":"floor","entrant":"%s","point":"floor-ttft%s-c%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"p50_us":%s,"p99_us":%s,"otb_line":"%s"}\n' \
-            "$ENTRANT_NAME" "$ttft" "$conc" "$ttft" "$conc" "$try" "$valid" "$(field rps "$line")" "${fail:-null}" \
-            "$(field p50us "$line")" "$(field p99us "$line")" "$line" >> "$RESULTS"
+            "$ENTRANT_NAME" "$ttft" "$conc" "$ttft" "$conc" "$try" "$valid" "${rps:-null}" "${fail:-null}" \
+            "${p50:-null}" "${p99:-null}" "$line" >> "$RESULTS"
         echo "  [floor ttft=$ttft c=$conc rep=$try] valid=$valid $line" >&2
     done
     [ "$valid_n" -ge "$FLOOR_REPS" ] ||

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -28,8 +28,12 @@ DEFAULT_BODY='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello
 BODY="${BODY:-$DEFAULT_BODY}"
 AUTH_HEADER="${AUTH_HEADER:-authorization: Bearer bench-token}"
 # Same header shape the public board's engine sends for the chosen dialect.
+# json.dumps, not string splicing: a quote or backslash in the header value
+# must not produce an invalid header list the loadgen then misparses.
 if [ -z "${OTB_LOADGEN_HEADERS:-}" ]; then
-    OTB_LOADGEN_HEADERS='[["'"${AUTH_HEADER%%:*}"'","'"${AUTH_HEADER#*: }"'"]]'
+    OTB_LOADGEN_HEADERS=$(python3 -c 'import json,sys
+k, _, v = sys.argv[1].partition(":")
+print(json.dumps([[k.strip(), v.strip()]]))' "$AUTH_HEADER")
 fi
 export OTB_LOADGEN_HEADERS
 
@@ -237,8 +241,13 @@ grid_ttfts() { # distinct delay tiers, in grid order
 }
 
 grid_concs() { # grid_concs <ttft>  -> the tier's concurrencies, in grid order
+    # if, not &&: with && the function returns 1 whenever the LAST grid
+    # element is another tier's, and a `conc=$(grid_concs 0 | ...)`
+    # assignment under set -e + pipefail then kills the run silently.
     local t="$1" s
-    for s in $GRID; do [ "${s%%:*}" = "$t" ] && printf '%s\n' "${s##*:}"; done
+    for s in $GRID; do
+        if [ "${s%%:*}" = "$t" ]; then printf '%s\n' "${s##*:}"; fi
+    done
 }
 
 grid_has() { # grid_has <ttft> <conc>
@@ -322,7 +331,7 @@ meta_method_json() {
     "grid": "$GRID", "body": $BODY_JSON,
     "path": "$REQ_PATH", "clk_tck": $CLK_TCK, "nofile": $(ulimit -n),
     "loadgen_headers": $HEADERS_JSON,
-    "flamegraph": {"enabled": $([ "$FLAMEGRAPH" = 1 ] && echo true || echo false), "freq_hz": 499, "callgraph": "dwarf", "window_s": 25, "conc": 128}
+    "flamegraph": {"enabled": $([ "$FLAMEGRAPH" = 1 ] && grid_has 0 128 && echo true || echo false), "freq_hz": 499, "callgraph": "dwarf", "window_s": 25, "conc": 128}
   }
 EOF
 }

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -1,0 +1,328 @@
+# Shared measurement core for the onthebench-style harness. Sourced by
+# run-baseline.sh (the aisix baseline) and run-entrant.sh (any target
+# process). Every reported number comes out of the same functions here, so
+# two runs are comparable by construction instead of by code review.
+#
+# Contract: the sourcing runner calls bench_init after setting OUT, starts
+# the measured process itself, and leaves its pid in GW_PID. Method knobs
+# are env-overridable (BENCH_*) so a spot-check or an extra delay tier is
+# an invocation, not a script edit; every default below is exactly what
+# run-baseline.sh has always run (the api7/aisix#891 grid).
+
+GW_CORES="0-3"; LOAD_CORES="4-9"; MOCK_CORES="10-15"
+GW_PORT=3000; MOCK_PORT=8000
+
+WINDOW="${BENCH_WINDOW:-25}"
+WARMUP="${BENCH_WARMUP:-5}"
+REPS="${BENCH_REPS:-4}"
+MAX_TRIES="${BENCH_MAX_TRIES:-8}"
+GRID="${BENCH_GRID:-0:16 0:32 0:128 10:768}"
+FLOOR_REPS="${BENCH_FLOOR_REPS:-2}"
+FLAMEGRAPH="${BENCH_FLAMEGRAPH:-1}"
+
+# Request shape. An entrant overrides these before sourcing when its only
+# ingress speaks a different dialect (the pinned loadgen and mock both serve
+# several); the defaults are the OpenAI chat shape the baseline always used.
+REQ_PATH="${REQ_PATH:-/v1/chat/completions}"
+DEFAULT_BODY='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}],"max_tokens":16}'
+BODY="${BODY:-$DEFAULT_BODY}"
+AUTH_HEADER="${AUTH_HEADER:-authorization: Bearer bench-token}"
+# Same header shape the public board's engine sends for the chosen dialect.
+if [ -z "${OTB_LOADGEN_HEADERS:-}" ]; then
+    OTB_LOADGEN_HEADERS='[["'"${AUTH_HEADER%%:*}"'","'"${AUTH_HEADER#*: }"'"]]'
+fi
+export OTB_LOADGEN_HEADERS
+
+# The name stamped into every result line, so mixed result sets stay
+# attributable; run-baseline.sh sets "aisix", run-entrant.sh requires one.
+ENTRANT_NAME="${ENTRANT_NAME:-}"
+
+TOOLS="$HOME/bench-tools"
+CLK_TCK=$(getconf CLK_TCK)
+# Non-interactive ssh shells don't source the cargo env; inferno lives there.
+export PATH="$HOME/.cargo/bin:$PATH"
+
+json_str() { python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'; }
+# Plain assignment on purpose: a heredoc swallows a failing command
+# substitution under set -e, so this must fail loudly here instead.
+BODY_JSON=$(printf '%s' "$BODY" | json_str)
+HEADERS_JSON=$(printf '%s' "$OTB_LOADGEN_HEADERS" | json_str)
+
+bench_init() {
+    mkdir -p "$OUT"
+    RESULTS="$OUT/results.jsonl"; : > "$RESULTS"
+    # Flipped to 1 when any point ends with fewer valid windows than promised;
+    # the run still completes and collects, but exits nonzero so an incomplete
+    # run can never be mistaken for a baseline.
+    HARNESS_RC=0
+    GW_PID=""; MOCK_PID=""; SAMPLER_PID=""
+    trap bench_cleanup EXIT
+}
+
+bench_cleanup() {
+    [ -n "$SAMPLER_PID" ] && kill "$SAMPLER_PID" 2>/dev/null || true
+    # An entrant that needs more than a kill (a container, a supervisor)
+    # provides entrant_stop; it runs first so GW_PID is still meaningful.
+    type entrant_stop >/dev/null 2>&1 && { entrant_stop || true; }
+    [ -n "$GW_PID" ] && kill "$GW_PID" 2>/dev/null || true
+    [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+
+# ---- rig identity ------------------------------------------------------------
+
+rig_sanity() {
+    [ "$(nproc)" = 16 ] || { echo "FATAL: expected a 16-core box, got $(nproc)"; exit 1; }
+    [ "$(uname -m)" = "aarch64" ] || { echo "FATAL: expected an aarch64 rig, got $(uname -m)"; exit 1; }
+    # Instance identity via IMDSv2: numbers from this harness are read as
+    # m7g.4xlarge baselines, so a wrong instance type must refuse to measure.
+    # IMDS being unreachable (non-EC2 lab box) is recorded rather than fatal.
+    local imds_token
+    imds_token=$(curl -s --max-time 2 -X PUT \
+        -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' \
+        http://169.254.169.254/latest/api/token || true)
+    INSTANCE_TYPE=$(curl -s --max-time 2 -H "X-aws-ec2-metadata-token: $imds_token" \
+        http://169.254.169.254/latest/meta-data/instance-type || true)
+    if [ -n "$INSTANCE_TYPE" ]; then
+        [ "$INSTANCE_TYPE" = "m7g.4xlarge" ] ||
+            { echo "FATAL: this core split is calibrated for m7g.4xlarge, got $INSTANCE_TYPE"; exit 1; }
+    else
+        INSTANCE_TYPE="unknown"
+        echo "WARNING: no IMDS answer; recording instance_type=unknown" >&2
+    fi
+    ulimit -n 65536
+}
+
+require_symbols() { # require_symbols <binary>  -> fails on a stripped binary
+    local syms
+    syms=$(nm "$1" 2>/dev/null | grep -c ' [tT] ' || true)
+    [ "$syms" -gt 100 ] ||
+        { echo "FATAL: $1 has $syms text symbols - stripped binary, flamegraph would be unreadable"; exit 1; }
+}
+
+# ---- primitives --------------------------------------------------------------
+
+field() { # field <key> <stats-line>  -> value or empty
+    sed -n "s/.*\b$1=\([^ ]*\).*/\1/p" <<<"$2"
+}
+
+cpu_ticks() { # utime+stime of the whole process, in clock ticks
+    awk '{print $14+$15}' "/proc/$1/stat"
+}
+
+rss_kb() { awk '/VmRSS/{print $2}' "/proc/$1/status"; }
+
+wait_http_200() { # wait_http_200 <url> <label> [max_s]
+    local url="$1" label="$2" max="${3:-30}" code
+    for _ in $(seq 1 $((max * 2))); do
+        code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' -X POST \
+            -H "$AUTH_HEADER" -H 'content-type: application/json' \
+            -d "$BODY" "$url" || true)
+        [ "$code" = "200" ] && return 0
+        sleep 0.5
+    done
+    echo "FATAL: $label not answering 200 at $url (last code: $code)" >&2
+    return 1
+}
+
+start_mock() { # start_mock <ttft_ms>
+    [ -n "$MOCK_PID" ] && { kill "$MOCK_PID" 2>/dev/null || true; wait "$MOCK_PID" 2>/dev/null || true; }
+    MOCK_TTFT_MS="$1" taskset -c "$MOCK_CORES" "$TOOLS/mock" -port "$MOCK_PORT" \
+        >> "$OUT/mock.log" 2>&1 &
+    MOCK_PID=$!
+    wait_http_200 "http://127.0.0.1:$MOCK_PORT$REQ_PATH" "mock (ttft=${1}ms)"
+    # A mock that ignores MOCK_TTFT_MS would make the delayed leg silently
+    # measure a 0-delay upstream with fail=0 throughout; assert the delay is
+    # actually in effect before any window runs against it.
+    if [ "$1" -gt 0 ]; then
+        local ttfb
+        ttfb=$(curl -s --max-time 2 -o /dev/null -w '%{time_starttransfer}' -X POST \
+            -H 'content-type: application/json' -d "$BODY" \
+            "http://127.0.0.1:$MOCK_PORT$REQ_PATH" || echo 0)
+        awk -v t="$ttfb" -v want="$1" 'BEGIN{exit !(t*1000 >= want*0.9)}' ||
+            { echo "FATAL: mock TTFT ${ttfb}s does not reflect ${1}ms"; exit 1; }
+    fi
+}
+
+loadgen() { # loadgen <ip:port> <conc> <dur>  -> stats line on stdout
+    taskset -c "$LOAD_CORES" "$TOOLS/otb" loadgen "$1" "$REQ_PATH" "$2" "$3" "$BODY"
+}
+
+# One measured window against the target: CPU% and peak RSS sampled around the
+# otb window, one JSON line appended to results.jsonl. Prints 1 if valid.
+measured_window() { # measured_window <point> <ttft> <conc> <rep>
+    local point="$1" ttft="$2" conc="$3" rep="$4"
+    local rssfile="$OUT/.rss.$$" line t0 t1 ticks0 ticks1 elapsed cpu_pct rss_peak
+    local rps fail ok p50 p99 rigref budget spawn valid
+
+    # Self-terminating on target death: this function runs inside a command
+    # substitution subshell, so the EXIT trap can never see SAMPLER_PID.
+    # /proc existence, not kill -0: a containerized target's pid belongs to
+    # another user, where kill -0 reports EPERM and would read as death.
+    ( max=0; while [ -d "/proc/$GW_PID" ]; do
+          v=$(awk '/VmRSS/{print $2}' "/proc/$GW_PID/status" 2>/dev/null || true)
+          v="${v:-0}"
+          if [ "$v" -gt "$max" ]; then max="$v"; echo "$max" > "$rssfile"; fi
+          sleep 0.2
+      done ) & SAMPLER_PID=$!
+
+    ticks0=$(cpu_ticks "$GW_PID"); t0=$(date +%s.%N)
+    line=$(loadgen "127.0.0.1:$GW_PORT" "$conc" "$WINDOW") || line=""
+    line=${line//[\"\\]/ }
+    t1=$(date +%s.%N); ticks1=$(cpu_ticks "$GW_PID")
+    kill "$SAMPLER_PID" 2>/dev/null || true; wait "$SAMPLER_PID" 2>/dev/null || true; SAMPLER_PID=""
+    rss_peak=$(cat "$rssfile" 2>/dev/null || echo 0); rm -f "$rssfile"
+
+    elapsed=$(awk -v a="$t0" -v b="$t1" 'BEGIN{print b-a}')
+    cpu_pct=$(awk -v d=$((ticks1 - ticks0)) -v hz="$CLK_TCK" -v e="$elapsed" \
+        'BEGIN{printf "%.1f", d/hz/e*100}')
+
+    rps=$(field rps "$line"); fail=$(field fail "$line"); ok=$(field ok "$line")
+    p50=$(field p50us "$line"); p99=$(field p99us "$line")
+    rigref=$(field rigrefused "$line"); budget=$(field budgetexceeded "$line"); spawn=$(field spawnfailed "$line")
+    valid=true
+    [ "${fail:-1}" = "0" ] && [ "${rigref:-0}" = "0" ] && [ "${budget:-0}" = "0" ] \
+        && [ "${spawn:-0}" = "0" ] || valid=false
+
+    printf '{"kind":"gateway","entrant":"%s","point":"%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"ok":%s,"p50_us":%s,"p99_us":%s,"gw_cpu_pct":%s,"gw_rss_peak_kb":%s,"window_s":%s,"elapsed_s":%.2f,"otb_line":"%s"}\n' \
+        "$ENTRANT_NAME" "$point" "$ttft" "$conc" "$rep" "$valid" "${rps:-null}" "${fail:-null}" "${ok:-null}" \
+        "${p50:-null}" "${p99:-null}" "$cpu_pct" "$rss_peak" "$WINDOW" "$elapsed" "$line" >> "$RESULTS"
+
+    echo "  [$point rep=$rep] rps=$rps fail=$fail p50us=$p50 p99us=$p99 cpu=${cpu_pct}% rss=${rss_peak}kB valid=$valid" >&2
+    [ "$valid" = true ] && echo 1 || echo 0
+}
+
+# ---- points ------------------------------------------------------------------
+
+floor_point() { # floor_point <ttft> <conc>  (mock must already run with that ttft)
+    # Same validity policy as gateway points, scaled to FLOOR_REPS: an invalid
+    # window is recorded, marked, and retried, and can never stand as the rig
+    # reference on its own.
+    local ttft="$1" conc="$2" valid_n=0 try=0 line fail valid
+    loadgen "127.0.0.1:$MOCK_PORT" "$conc" 5 > /dev/null || true   # warmup
+    while [ "$valid_n" -lt "$FLOOR_REPS" ] && [ "$try" -lt "$MAX_TRIES" ]; do
+        try=$((try + 1))
+        line=$(loadgen "127.0.0.1:$MOCK_PORT" "$conc" "$WINDOW") || line=""
+        line=${line//[\"\\]/ }
+        fail=$(field fail "$line")
+        valid=true; [ "${fail:-1}" = "0" ] || valid=false
+        [ "$valid" = true ] && valid_n=$((valid_n + 1))
+        printf '{"kind":"floor","entrant":"%s","point":"floor-ttft%s-c%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"p50_us":%s,"p99_us":%s,"otb_line":"%s"}\n' \
+            "$ENTRANT_NAME" "$ttft" "$conc" "$ttft" "$conc" "$try" "$valid" "$(field rps "$line")" "${fail:-null}" \
+            "$(field p50us "$line")" "$(field p99us "$line")" "$line" >> "$RESULTS"
+        echo "  [floor ttft=$ttft c=$conc rep=$try] valid=$valid $line" >&2
+    done
+    [ "$valid_n" -ge "$FLOOR_REPS" ] ||
+        { echo "WARNING: floor ttft=$ttft c=$conc got only $valid_n valid windows in $MAX_TRIES tries" >&2
+          HARNESS_RC=1; }
+}
+
+run_point() { # run_point <ttft> <conc>
+    local ttft="$1" conc="$2" point="ttft$1-c$2" valid_n=0 try=0
+    echo "== point $point ==" >&2
+    loadgen "127.0.0.1:$GW_PORT" "$conc" "$WARMUP" > /dev/null || true
+    while [ "$valid_n" -lt "$REPS" ] && [ "$try" -lt "$MAX_TRIES" ]; do
+        try=$((try + 1))
+        valid_n=$((valid_n + $(measured_window "$point" "$ttft" "$conc" "$try")))
+    done
+    [ "$valid_n" -ge "$REPS" ] ||
+        { echo "WARNING: $point got only $valid_n valid reps in $MAX_TRIES tries" >&2
+          HARNESS_RC=1; }
+}
+
+# ---- grid helpers ------------------------------------------------------------
+
+grid_ttfts() { # distinct delay tiers, in grid order
+    printf '%s\n' $GRID | cut -d: -f1 | awk '!seen[$0]++'
+}
+
+grid_concs() { # grid_concs <ttft>  -> the tier's concurrencies, in grid order
+    local t="$1" s
+    for s in $GRID; do [ "${s%%:*}" = "$t" ] && printf '%s\n' "${s##*:}"; done
+}
+
+grid_has() { # grid_has <ttft> <conc>
+    local s
+    for s in $GRID; do [ "$s" = "$1:$2" ] && return 0; done
+    return 1
+}
+
+floor_tier() { # floor_tier <ttft>  -> the floor points this tier needs
+    # 0-delay: the instrument ceiling barely moves with concurrency, so one
+    # floor at the tier's max concurrency stands for the tier. Delayed tiers:
+    # the ceiling is ~conc/delay, so every concurrency gets its own floor.
+    local ttft="$1" conc
+    if [ "$ttft" = 0 ]; then
+        conc=$(grid_concs 0 | sort -n | tail -1)
+        [ -n "$conc" ] && floor_point 0 "$conc"
+    else
+        for conc in $(grid_concs "$ttft"); do floor_point "$ttft" "$conc"; done
+    fi
+}
+
+# ---- flamegraph --------------------------------------------------------------
+
+flamegraph_point() { # flamegraph_point <conc> <title>  (0-delay mock running)
+    local conc="$1" title="$2" load_bg
+    echo "== flamegraph (c=$conc, 0-delay) ==" >&2
+    loadgen "127.0.0.1:$GW_PORT" "$conc" 45 > "$OUT/flamegraph-window.txt" & load_bg=$!
+    sleep 5
+    perf record -F 499 --call-graph dwarf -p "$GW_PID" -o "$OUT/perf.data" -- sleep 25 \
+        >> "$OUT/perf.log" 2>&1 || echo "WARNING: perf record failed" >&2
+    wait "$load_bg" || true
+    # Rendering must never kill the measurement: perf.data is kept on any
+    # failure so the SVG can be produced off-rig.
+    if [ -s "$OUT/perf.data" ]; then
+        if perf script -i "$OUT/perf.data" 2>> "$OUT/perf.log" |
+               inferno-collapse-perf > "$OUT/flamegraph-c$conc.folded" 2>> "$OUT/perf.log" &&
+           inferno-flamegraph --title "$title" \
+               < "$OUT/flamegraph-c$conc.folded" > "$OUT/flamegraph-c$conc.svg" 2>> "$OUT/perf.log"; then
+            rm -f "$OUT/perf.data"
+        else
+            echo "WARNING: flamegraph rendering failed; perf.data kept" >&2
+        fi
+    fi
+}
+
+# ---- shared metadata fragments -----------------------------------------------
+
+meta_rig_json() {
+    cat <<EOF
+{
+    "host": "$(hostname)",
+    "instance_type": "$INSTANCE_TYPE",
+    "kernel": "$(uname -r)",
+    "arch": "$(uname -m)",
+    "nproc": $(nproc),
+    "mem_total_kb": $(awk '/MemTotal/{print $2}' /proc/meminfo),
+    "cpu_part": "$(awk -F': ' '/CPU part/{print $2; exit}' /proc/cpuinfo)"
+  }
+EOF
+}
+
+meta_cores_json() {
+    printf '{"gateway": "%s", "load": "%s", "mock": "%s"}' "$GW_CORES" "$LOAD_CORES" "$MOCK_CORES"
+}
+
+meta_instruments_json() {
+    cat <<EOF
+{
+    "engine_pin": "f3adbb1315b26129f5e317af5279decefb1cea8f (engine-v1)",
+    "otb_sha256": "$(sha256sum "$TOOLS/otb" | cut -d' ' -f1)",
+    "mock_sha256": "$(sha256sum "$TOOLS/mock" | cut -d' ' -f1)"
+  }
+EOF
+}
+
+meta_method_json() {
+    cat <<EOF
+{
+    "window_s": $WINDOW, "warmup_s": $WARMUP, "reps": $REPS,
+    "max_tries": $MAX_TRIES, "floor_reps": $FLOOR_REPS,
+    "grid": "$GRID", "body": $BODY_JSON,
+    "path": "$REQ_PATH", "clk_tck": $CLK_TCK, "nofile": $(ulimit -n),
+    "loadgen_headers": $HEADERS_JSON,
+    "flamegraph": {"enabled": $([ "$FLAMEGRAPH" = 1 ] && echo true || echo false), "freq_hz": 499, "callgraph": "dwarf", "window_s": 25, "conc": 128}
+  }
+EOF
+}

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -29,7 +29,7 @@ BIN="$SRC/target/release/aisix"
 
 [ -x "$BIN" ] || { echo "FATAL: $BIN missing - build first"; exit 1; }
 rig_sanity
-[ "$FLAMEGRAPH" = 1 ] && require_symbols "$BIN"
+if [ "$FLAMEGRAPH" = 1 ]; then require_symbols "$BIN"; fi
 
 bench_init
 

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -6,164 +6,32 @@
 #
 # Usage: run-baseline.sh <aisix-src-dir> <out-dir>
 #
-# Load points (ttft_ms:concurrency): 0:16 0:32 0:128 10:768 — the same grid as
-# the api7/aisix#891 A/B tables. The rig floor (loadgen driving the mock
-# directly) is recorded for both mock variants so gateway numbers can always be
-# checked against the instrument's own ceiling. One on-CPU flamegraph is taken
-# at the c=128 saturation point (perf -> inferno, the #847 workflow).
+# The default grid (ttft_ms:concurrency): 0:16 0:32 0:128 10:768 — the same
+# grid as the api7/aisix#891 A/B tables. BENCH_GRID / BENCH_REPS / the other
+# BENCH_* knobs in lib.sh override it, so a two-window spot-check or an extra
+# delay tier is an invocation, not a script edit. The rig floor (loadgen
+# driving the mock directly) is recorded per tier so gateway numbers can
+# always be checked against the instrument's own ceiling. One on-CPU
+# flamegraph is taken at the 0-delay c=128 saturation point when the grid has
+# one (perf -> inferno, the #847 workflow).
 set -euo pipefail
 
 SRC="${1:?usage: run-baseline.sh <aisix-src-dir> <out-dir>}"
 OUT="${2:?usage: run-baseline.sh <aisix-src-dir> <out-dir>}"
 
-GW_CORES="0-3"; LOAD_CORES="4-9"; MOCK_CORES="10-15"
-GW_PORT=3000; MOCK_PORT=8000
-WINDOW=25; WARMUP=5; REPS=4; MAX_TRIES=8
-GRID="0:16 0:32 0:128 10:768"
-FLOOR_REPS=2
-BODY='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}],"max_tokens":16}'
-CHAT_PATH="/v1/chat/completions"
-# Same header shape the public board's engine sends for the OpenAI dialect.
-export OTB_LOADGEN_HEADERS='[["authorization","Bearer bench-token"]]'
+ENTRANT_NAME=aisix
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 BIN="$SRC/target/release/aisix"
-TOOLS="$HOME/bench-tools"
-CLK_TCK=$(getconf CLK_TCK)
-# Non-interactive ssh shells don't source the cargo env; inferno lives there.
-export PATH="$HOME/.cargo/bin:$PATH"
-# Plain assignment on purpose: a heredoc swallows a failing command
-# substitution under set -e, so this must fail loudly here instead.
-BODY_JSON=$(printf '%s' "$BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
-
-mkdir -p "$OUT"
-RESULTS="$OUT/results.jsonl"; : > "$RESULTS"
-# Flipped to 1 when any point ends with fewer valid windows than promised; the
-# run still completes and collects, but exits nonzero so an incomplete run can
-# never be mistaken for a baseline.
-HARNESS_RC=0
-
-GW_PID=""; MOCK_PID=""; SAMPLER_PID=""
-cleanup() {
-    [ -n "$SAMPLER_PID" ] && kill "$SAMPLER_PID" 2>/dev/null || true
-    [ -n "$GW_PID" ] && kill "$GW_PID" 2>/dev/null || true
-    [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
-    wait 2>/dev/null || true
-}
-trap cleanup EXIT
-
-# ---- helpers ----------------------------------------------------------------
-
-field() { # field <key> <stats-line>  -> value or empty
-    sed -n "s/.*\b$1=\([^ ]*\).*/\1/p" <<<"$2"
-}
-
-cpu_ticks() { # utime+stime of the whole process, in clock ticks
-    awk '{print $14+$15}' "/proc/$1/stat"
-}
-
-rss_kb() { awk '/VmRSS/{print $2}' "/proc/$1/status"; }
-
-wait_http_200() { # wait_http_200 <url> <label> [max_s]
-    local url="$1" label="$2" max="${3:-30}" code
-    for _ in $(seq 1 $((max * 2))); do
-        code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' -X POST \
-            -H 'authorization: Bearer bench-token' -H 'content-type: application/json' \
-            -d "$BODY" "$url" || true)
-        [ "$code" = "200" ] && return 0
-        sleep 0.5
-    done
-    echo "FATAL: $label not answering 200 at $url (last code: $code)" >&2
-    return 1
-}
-
-start_mock() { # start_mock <ttft_ms>
-    [ -n "$MOCK_PID" ] && { kill "$MOCK_PID" 2>/dev/null || true; wait "$MOCK_PID" 2>/dev/null || true; }
-    MOCK_TTFT_MS="$1" taskset -c "$MOCK_CORES" "$TOOLS/mock" -port "$MOCK_PORT" \
-        >> "$OUT/mock.log" 2>&1 &
-    MOCK_PID=$!
-    wait_http_200 "http://127.0.0.1:$MOCK_PORT$CHAT_PATH" "mock (ttft=${1}ms)"
-    # A mock that ignores MOCK_TTFT_MS would make the delayed leg silently
-    # measure a 0-delay upstream with fail=0 throughout; assert the delay is
-    # actually in effect before any window runs against it.
-    if [ "$1" -gt 0 ]; then
-        local ttfb
-        ttfb=$(curl -s --max-time 2 -o /dev/null -w '%{time_starttransfer}' -X POST \
-            -H 'content-type: application/json' -d "$BODY" \
-            "http://127.0.0.1:$MOCK_PORT$CHAT_PATH" || echo 0)
-        awk -v t="$ttfb" -v want="$1" 'BEGIN{exit !(t*1000 >= want*0.9)}' ||
-            { echo "FATAL: mock TTFT ${ttfb}s does not reflect ${1}ms"; exit 1; }
-    fi
-}
-
-loadgen() { # loadgen <ip:port> <conc> <dur>  -> stats line on stdout
-    taskset -c "$LOAD_CORES" "$TOOLS/otb" loadgen "$1" "$CHAT_PATH" "$2" "$3" "$BODY"
-}
-
-# One measured window against the gateway: CPU% and peak RSS sampled around the
-# otb window, one JSON line appended to results.jsonl. Prints 1 if valid.
-measured_window() { # measured_window <point> <ttft> <conc> <rep>
-    local point="$1" ttft="$2" conc="$3" rep="$4"
-    local rssfile="$OUT/.rss.$$" line t0 t1 ticks0 ticks1 elapsed cpu_pct rss_peak
-    local rps fail ok p50 p99 rigref budget spawn valid
-
-    # Self-terminating on gateway death: this function runs inside a command
-    # substitution subshell, so the EXIT trap can never see SAMPLER_PID.
-    ( max=0; while kill -0 "$GW_PID" 2>/dev/null; do
-          v=$(awk '/VmRSS/{print $2}' "/proc/$GW_PID/status" 2>/dev/null || true)
-          v="${v:-0}"
-          if [ "$v" -gt "$max" ]; then max="$v"; echo "$max" > "$rssfile"; fi
-          sleep 0.2
-      done ) & SAMPLER_PID=$!
-
-    ticks0=$(cpu_ticks "$GW_PID"); t0=$(date +%s.%N)
-    line=$(loadgen "127.0.0.1:$GW_PORT" "$conc" "$WINDOW") || line=""
-    line=${line//[\"\\]/ }
-    t1=$(date +%s.%N); ticks1=$(cpu_ticks "$GW_PID")
-    kill "$SAMPLER_PID" 2>/dev/null || true; wait "$SAMPLER_PID" 2>/dev/null || true; SAMPLER_PID=""
-    rss_peak=$(cat "$rssfile" 2>/dev/null || echo 0); rm -f "$rssfile"
-
-    elapsed=$(awk -v a="$t0" -v b="$t1" 'BEGIN{print b-a}')
-    cpu_pct=$(awk -v d=$((ticks1 - ticks0)) -v hz="$CLK_TCK" -v e="$elapsed" \
-        'BEGIN{printf "%.1f", d/hz/e*100}')
-
-    rps=$(field rps "$line"); fail=$(field fail "$line"); ok=$(field ok "$line")
-    p50=$(field p50us "$line"); p99=$(field p99us "$line")
-    rigref=$(field rigrefused "$line"); budget=$(field budgetexceeded "$line"); spawn=$(field spawnfailed "$line")
-    valid=true
-    [ "${fail:-1}" = "0" ] && [ "${rigref:-0}" = "0" ] && [ "${budget:-0}" = "0" ] \
-        && [ "${spawn:-0}" = "0" ] || valid=false
-
-    printf '{"kind":"gateway","point":"%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"ok":%s,"p50_us":%s,"p99_us":%s,"gw_cpu_pct":%s,"gw_rss_peak_kb":%s,"window_s":%s,"elapsed_s":%.2f,"otb_line":"%s"}\n' \
-        "$point" "$ttft" "$conc" "$rep" "$valid" "${rps:-null}" "${fail:-null}" "${ok:-null}" \
-        "${p50:-null}" "${p99:-null}" "$cpu_pct" "$rss_peak" "$WINDOW" "$elapsed" "$line" >> "$RESULTS"
-
-    echo "  [$point rep=$rep] rps=$rps fail=$fail p50us=$p50 p99us=$p99 cpu=${cpu_pct}% rss=${rss_peak}kB valid=$valid" >&2
-    [ "$valid" = true ] && echo 1 || echo 0
-}
 
 # ---- sanity -----------------------------------------------------------------
 
 [ -x "$BIN" ] || { echo "FATAL: $BIN missing - build first"; exit 1; }
-[ "$(nproc)" = 16 ] || { echo "FATAL: expected a 16-core box, got $(nproc)"; exit 1; }
-[ "$(uname -m)" = "aarch64" ] || { echo "FATAL: expected an aarch64 rig, got $(uname -m)"; exit 1; }
-# Instance identity via IMDSv2: numbers from this harness are read as
-# m7g.4xlarge baselines, so a wrong instance type must refuse to measure.
-# IMDS being unreachable (non-EC2 lab box) is recorded rather than fatal.
-IMDS_TOKEN=$(curl -s --max-time 2 -X PUT \
-    -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' \
-    http://169.254.169.254/latest/api/token || true)
-INSTANCE_TYPE=$(curl -s --max-time 2 -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" \
-    http://169.254.169.254/latest/meta-data/instance-type || true)
-if [ -n "$INSTANCE_TYPE" ]; then
-    [ "$INSTANCE_TYPE" = "m7g.4xlarge" ] ||
-        { echo "FATAL: this core split is calibrated for m7g.4xlarge, got $INSTANCE_TYPE"; exit 1; }
-else
-    INSTANCE_TYPE="unknown"
-    echo "WARNING: no IMDS answer; recording instance_type=unknown" >&2
-fi
-SYMS=$(nm "$BIN" 2>/dev/null | grep -c ' [tT] ' || true)
-[ "$SYMS" -gt 100 ] || { echo "FATAL: $BIN has $SYMS text symbols - stripped binary, flamegraph would be unreadable"; exit 1; }
-ulimit -n 65536
+rig_sanity
+[ "$FLAMEGRAPH" = 1 ] && require_symbols "$BIN"
+
+bench_init
 
 # ---- config: the default-shipped-config claim set ---------------------------
 # Every line exists because the process cannot run the benchmark without it:
@@ -199,89 +67,43 @@ api_keys:
     allowed_models: ["*"]
 EOF
 
-# ---- rig floor (0-delay): loadgen -> mock directly, gateway not yet running --
-
-floor_point() { # floor_point <ttft> <conc>  (mock must already run with that ttft)
-    # Same validity policy as gateway points, scaled to FLOOR_REPS: an invalid
-    # window is recorded, marked, and retried, and can never stand as the rig
-    # reference on its own.
-    local ttft="$1" conc="$2" valid_n=0 try=0 line fail valid
-    loadgen "127.0.0.1:$MOCK_PORT" "$conc" 5 > /dev/null || true   # warmup
-    while [ "$valid_n" -lt "$FLOOR_REPS" ] && [ "$try" -lt "$MAX_TRIES" ]; do
-        try=$((try + 1))
-        line=$(loadgen "127.0.0.1:$MOCK_PORT" "$conc" "$WINDOW") || line=""
-        line=${line//[\"\\]/ }
-        fail=$(field fail "$line")
-        valid=true; [ "${fail:-1}" = "0" ] || valid=false
-        [ "$valid" = true ] && valid_n=$((valid_n + 1))
-        printf '{"kind":"floor","point":"floor-ttft%s-c%s","ttft_ms":%s,"conc":%s,"rep":%s,"valid":%s,"rps":%s,"fail":%s,"p50_us":%s,"p99_us":%s,"otb_line":"%s"}\n' \
-            "$ttft" "$conc" "$ttft" "$conc" "$try" "$valid" "$(field rps "$line")" "${fail:-null}" \
-            "$(field p50us "$line")" "$(field p99us "$line")" "$line" >> "$RESULTS"
-        echo "  [floor ttft=$ttft c=$conc rep=$try] valid=$valid $line" >&2
-    done
-    [ "$valid_n" -ge "$FLOOR_REPS" ] ||
-        { echo "WARNING: floor ttft=$ttft c=$conc got only $valid_n valid windows in $MAX_TRIES tries" >&2
-          HARNESS_RC=1; }
+start_gateway() {
+    echo "== gateway ==" >&2
+    # aisix reads AISIX_* environment variables as config overrides; nothing
+    # from the harness environment may leak into the measured process.
+    while read -r v; do unset "$v"; done < <(compgen -v | grep '^AISIX_' || true)
+    BENCH_AISIX_KEY=bench-token taskset -c "$GW_CORES" "$BIN" --config "$OUT/config.yaml" \
+        > "$OUT/gateway.log" 2>&1 &
+    GW_PID=$!
+    wait_http_200 "http://127.0.0.1:$GW_PORT$REQ_PATH" "gateway"
+    sleep 3
+    RSS_IDLE=$(rss_kb "$GW_PID")
+    TPC_WORKERS=$(ps -T -p "$GW_PID" | grep -c 'tpc-' || true)
+    echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB tpc_workers=$TPC_WORKERS" >&2
+    # Serving-mode self-check, asserted rather than merely recorded: measuring
+    # the shared-runtime fallback (or a wrong worker count) while calling it
+    # the default would be a silently wrong baseline. The expected count is
+    # derived from the gateway's own affinity mask, not hardcoded.
+    local gw_nproc
+    gw_nproc=$(taskset -c "$GW_CORES" nproc)
+    [ "$TPC_WORKERS" -eq "$gw_nproc" ] ||
+        { echo "FATAL: expected $gw_nproc tpc- workers under the $GW_CORES affinity, got $TPC_WORKERS"; exit 1; }
 }
 
-echo "== mock (0-delay) + rig floor ==" >&2
-start_mock 0
-floor_point 0 128
-
-# ---- gateway: default shipped config, pinned to its 4 cores -----------------
-
-echo "== gateway ==" >&2
-# aisix reads AISIX_* environment variables as config overrides; nothing from
-# the harness environment may leak into the measured process.
-while read -r v; do unset "$v"; done < <(compgen -v | grep '^AISIX_' || true)
-BENCH_AISIX_KEY=bench-token taskset -c "$GW_CORES" "$BIN" --config "$OUT/config.yaml" \
-    > "$OUT/gateway.log" 2>&1 &
-GW_PID=$!
-wait_http_200 "http://127.0.0.1:$GW_PORT$CHAT_PATH" "gateway"
-sleep 3
-RSS_IDLE=$(rss_kb "$GW_PID")
-TPC_WORKERS=$(ps -T -p "$GW_PID" | grep -c 'tpc-' || true)
-echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB tpc_workers=$TPC_WORKERS" >&2
-# Serving-mode self-check, asserted rather than merely recorded: measuring the
-# shared-runtime fallback (or a wrong worker count) while calling it the
-# default would be a silently wrong baseline. The expected count is derived
-# from the gateway's own affinity mask, not hardcoded.
-GW_NPROC=$(taskset -c "$GW_CORES" nproc)
-[ "$TPC_WORKERS" -eq "$GW_NPROC" ] ||
-    { echo "FATAL: expected $GW_NPROC tpc- workers under the $GW_CORES affinity, got $TPC_WORKERS"; exit 1; }
-
-# Metadata is written NOW, before the first measured window, so an aborted run
-# still leaves results.jsonl attributable to a commit and binary; the end of
-# the run rewrites it with the final memory high-water mark.
+# Metadata is written right after the gateway starts, before the first
+# measured window, so an aborted run still leaves results.jsonl attributable
+# to a commit and binary; the end of the run rewrites it with the final
+# memory high-water mark.
 write_meta() { # write_meta <rss_hwm_kb-or-null>
     cat > "$OUT/meta.json" <<EOF
 {
   "commit": "${BENCH_SRC_COMMIT:-unknown}",
   "dirty_files": ${BENCH_SRC_DIRTY:-0},
   "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "rig": {
-    "host": "$(hostname)",
-    "instance_type": "$INSTANCE_TYPE",
-    "kernel": "$(uname -r)",
-    "arch": "$(uname -m)",
-    "nproc": $(nproc),
-    "mem_total_kb": $(awk '/MemTotal/{print $2}' /proc/meminfo),
-    "cpu_part": "$(awk -F': ' '/CPU part/{print $2; exit}' /proc/cpuinfo)"
-  },
-  "cores": {"gateway": "$GW_CORES", "load": "$LOAD_CORES", "mock": "$MOCK_CORES"},
-  "instruments": {
-    "engine_pin": "f3adbb1315b26129f5e317af5279decefb1cea8f (engine-v1)",
-    "otb_sha256": "$(sha256sum "$TOOLS/otb" | cut -d' ' -f1)",
-    "mock_sha256": "$(sha256sum "$TOOLS/mock" | cut -d' ' -f1)"
-  },
-  "method": {
-    "window_s": $WINDOW, "warmup_s": $WARMUP, "reps": $REPS,
-    "max_tries": $MAX_TRIES, "floor_reps": $FLOOR_REPS,
-    "grid": "$GRID", "body": $BODY_JSON,
-    "path": "$CHAT_PATH", "clk_tck": $CLK_TCK, "nofile": $(ulimit -n),
-    "loadgen_headers": $(printf '%s' "$OTB_LOADGEN_HEADERS" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),
-    "flamegraph": {"freq_hz": 499, "callgraph": "dwarf", "window_s": 25, "conc": 128}
-  },
+  "rig": $(meta_rig_json),
+  "cores": $(meta_cores_json),
+  "instruments": $(meta_instruments_json),
+  "method": $(meta_method_json),
   "gateway": {
     "binary_sha256": "$(sha256sum "$BIN" | cut -d' ' -f1)",
     "rss_idle_kb": $RSS_IDLE, "rss_hwm_kb": $1,
@@ -290,60 +112,28 @@ write_meta() { # write_meta <rss_hwm_kb-or-null>
 }
 EOF
 }
-write_meta null
 
-# ---- 0-delay grid -----------------------------------------------------------
+# ---- tiers: per tier, mock -> floor -> gateway points -----------------------
+# The gateway starts once, after the first tier's floor (so the 0-delay floor
+# never competes with an idle gateway for anything), and stays up across mock
+# restarts exactly as it would across upstream churn.
 
-run_point() { # run_point <ttft> <conc>
-    local ttft="$1" conc="$2" point="ttft$1-c$2" valid_n=0 try=0
-    echo "== point $point ==" >&2
-    loadgen "127.0.0.1:$GW_PORT" "$conc" "$WARMUP" > /dev/null || true
-    while [ "$valid_n" -lt "$REPS" ] && [ "$try" -lt "$MAX_TRIES" ]; do
-        try=$((try + 1))
-        valid_n=$((valid_n + $(measured_window "$point" "$ttft" "$conc" "$try")))
-    done
-    [ "$valid_n" -ge "$REPS" ] ||
-        { echo "WARNING: $point got only $valid_n valid reps in $MAX_TRIES tries" >&2
-          HARNESS_RC=1; }
-}
-
-for spec in $GRID; do
-    ttft="${spec%%:*}"; conc="${spec##*:}"
-    [ "$ttft" = 0 ] || continue
-    run_point "$ttft" "$conc"
-done
-
-# ---- flamegraph at the c=128 saturation point (#847 workflow) ---------------
-
-echo "== flamegraph (c=128, 0-delay) ==" >&2
-loadgen "127.0.0.1:$GW_PORT" 128 45 > "$OUT/flamegraph-window.txt" & LOAD_BG=$!
-sleep 5
-perf record -F 499 --call-graph dwarf -p "$GW_PID" -o "$OUT/perf.data" -- sleep 25 \
-    >> "$OUT/perf.log" 2>&1 || echo "WARNING: perf record failed" >&2
-wait "$LOAD_BG" || true
-# Rendering must never kill the measurement: perf.data is kept on any failure
-# so the SVG can be produced off-rig.
-if [ -s "$OUT/perf.data" ]; then
-    if perf script -i "$OUT/perf.data" 2>> "$OUT/perf.log" |
-           inferno-collapse-perf > "$OUT/flamegraph-c128.folded" 2>> "$OUT/perf.log" &&
-       inferno-flamegraph --title "aisix c=128 0-delay (4 pinned cores)" \
-           < "$OUT/flamegraph-c128.folded" > "$OUT/flamegraph-c128.svg" 2>> "$OUT/perf.log"; then
-        rm -f "$OUT/perf.data"
-    else
-        echo "WARNING: flamegraph rendering failed; perf.data kept" >&2
+FIRST_TIER=1
+for TTFT in $(grid_ttfts); do
+    echo "== mock (${TTFT}ms TTFT) + rig floor ==" >&2
+    start_mock "$TTFT"
+    floor_tier "$TTFT"
+    if [ "$FIRST_TIER" = 1 ]; then
+        start_gateway
+        write_meta null
+        FIRST_TIER=0
     fi
-fi
-
-# ---- 10ms-TTFT leg: mock restarted with the delay, floor then gateway -------
-
-echo "== mock (10ms TTFT) + floor ==" >&2
-start_mock 10
-floor_point 10 768
-
-for spec in $GRID; do
-    ttft="${spec%%:*}"; conc="${spec##*:}"
-    [ "$ttft" = 10 ] || continue
-    run_point "$ttft" "$conc"
+    for CONC in $(grid_concs "$TTFT"); do
+        run_point "$TTFT" "$CONC"
+    done
+    if [ "$TTFT" = 0 ] && [ "$FLAMEGRAPH" = 1 ] && grid_has 0 128; then
+        flamegraph_point 128 "aisix c=128 0-delay (4 pinned cores)"
+    fi
 done
 
 # ---- final metadata (adds the memory high-water mark) -----------------------

--- a/bench/onthebench/run-entrant.sh
+++ b/bench/onthebench/run-entrant.sh
@@ -18,10 +18,16 @@
 # and may provide:
 #
 #   entrant_prepare <out-dir>  one-time fetch/build, before any measurement
-#   entrant_stop               teardown beyond `kill $GW_PID` (containers)
+#   entrant_stop               teardown beyond `kill $GW_PID` (containers);
+#                            must tolerate being called when entrant_start
+#                            never ran (cleanup on a prepare failure)
 #   entrant_meta_json          extra identity JSON object (version, digest, …)
 #   REQ_PATH / BODY / AUTH_HEADER  request shape, when the entrant's ingress
 #                            speaks a dialect other than OpenAI chat
+#
+# entrant.sh is sourced before lib.sh: harness variables (GW_PORT, GW_CORES,
+# MOCK_PORT, ...) are available inside the hook functions when they are
+# called, but NOT at the entrant.sh top level.
 #
 # The entrant dir itself is deliberately not part of this repository: the
 # harness carries the method; what it points at is the operator's business.
@@ -55,9 +61,16 @@ if type entrant_prepare >/dev/null 2>&1; then
     echo "== prepare ($ENTRANT_NAME) ==" >&2
     # The pipe puts entrant_prepare in a subshell: state it wants to hand to
     # entrant_start or entrant_meta_json must go through files, not variables.
-    # pipefail carries a prepare failure out of the pipeline; the || names it.
-    entrant_prepare "$OUT" 2>&1 | tee "$OUT/prepare.log" >&2 ||
-        { echo "FATAL: entrant_prepare failed (see $OUT/prepare.log)"; exit 1; }
+    # The explicit subshell re-arms errexit — a `prepare || die` form would
+    # disable set -e inside the hook and let a mid-prepare failure (a failed
+    # fetch before a succeeding final step) pass as success, measuring stale
+    # artifacts; the rc capture keeps pipefail out of the decision.
+    set +e
+    ( set -e; entrant_prepare "$OUT" ) 2>&1 | tee "$OUT/prepare.log" >&2
+    PREP_RC=${PIPESTATUS[0]}
+    set -e
+    [ "$PREP_RC" -eq 0 ] ||
+        { echo "FATAL: entrant_prepare failed (rc=$PREP_RC, see $OUT/prepare.log)"; exit 1; }
 fi
 
 start_target() {
@@ -75,8 +88,14 @@ start_target() {
     wait_http_200 "http://127.0.0.1:$GW_PORT$REQ_PATH" "$ENTRANT_NAME"
     sleep 3
     RSS_IDLE=$(rss_kb "$GW_PID")
-    THREADS=$(ps -T -p "$GW_PID" 2>/dev/null | tail -n +2 | wc -l || echo 0)
-    echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB threads=$THREADS" >&2
+    THREADS=$(ps -T -p "$GW_PID" 2>/dev/null | tail -n +2 | wc -l) || THREADS=0
+    # CPU% and RSS cover GW_PID alone. A multi-process target (master +
+    # workers) would be silently understated; surface it loudly and record
+    # the count so the numbers can never pass unannotated.
+    CHILDREN=$(pgrep -cP "$GW_PID" 2>/dev/null) || CHILDREN=0
+    [ "$CHILDREN" -eq 0 ] ||
+        echo "WARNING: target pid $GW_PID has $CHILDREN child processes; CPU%/RSS cover this pid only" >&2
+    echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB threads=$THREADS children=$CHILDREN" >&2
 }
 
 write_meta() { # write_meta <rss_hwm_kb-or-null>
@@ -97,6 +116,7 @@ write_meta() { # write_meta <rss_hwm_kb-or-null>
     "binary_sha256": "${bin_sha:-unknown}",
     "rss_idle_kb": ${RSS_IDLE:-null}, "rss_hwm_kb": $1,
     "threads": ${THREADS:-null},
+    "children": ${CHILDREN:-null},
     "identity": $(type entrant_meta_json >/dev/null 2>&1 && entrant_meta_json || echo null)
   }
 }
@@ -119,10 +139,15 @@ for TTFT in $(grid_ttfts); do
         run_point "$TTFT" "$CONC"
     done
     if [ "$TTFT" = 0 ] && [ "$FLAMEGRAPH" = 1 ] && grid_has 0 128; then
-        if nm "/proc/$GW_PID/exe" 2>/dev/null | grep -q ' [tT] '; then
+        # Same >100 symbol threshold as the baseline's require_symbols: a
+        # nearly-stripped binary would render a noise flamegraph, not a
+        # useful one. Soft skip, unlike the baseline - the throughput
+        # numbers stand on their own.
+        SYMS=$(nm "/proc/$GW_PID/exe" 2>/dev/null | grep -c ' [tT] ') || SYMS=0
+        if [ "$SYMS" -gt 100 ]; then
             flamegraph_point 128 "$ENTRANT_NAME c=128 0-delay (4 pinned cores)"
         else
-            echo "WARNING: target binary is stripped or unreadable; skipping flamegraph" >&2
+            echo "WARNING: target binary is stripped or unreadable ($SYMS text symbols); skipping flamegraph" >&2
         fi
     fi
 done

--- a/bench/onthebench/run-entrant.sh
+++ b/bench/onthebench/run-entrant.sh
@@ -52,7 +52,10 @@ source "$ENTRANT_DIR/entrant.sh"
 # shellcheck source=lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-[ -n "$ENTRANT_NAME" ] || { echo "FATAL: entrant.sh must set ENTRANT_NAME"; exit 1; }
+# The name is spliced verbatim into meta.json and every JSONL record; a
+# constrained identifier set keeps that safe without escaping at every site.
+[[ "${ENTRANT_NAME:-}" =~ ^[A-Za-z0-9._-]+$ ]] ||
+    { echo "FATAL: entrant.sh must set ENTRANT_NAME matching [A-Za-z0-9._-]+ (got '${ENTRANT_NAME:-}')"; exit 1; }
 
 rig_sanity
 bench_init
@@ -102,8 +105,17 @@ write_meta() { # write_meta <rss_hwm_kb-or-null>
     # /proc/<pid>/exe may belong to another user (a container's init); sudo -n
     # is how the rest of the rig already escalates, and "unknown" is recorded
     # rather than failing the run — entrant_meta_json carries identity anyway.
-    local bin_sha
+    local bin_sha identity=null
     bin_sha=$(sudo -n sha256sum "/proc/$GW_PID/exe" 2>/dev/null | cut -d' ' -f1 || true)
+    # The identity hook is evaluated and validated before the heredoc: a hook
+    # that fails or emits partial output must fail the run loudly, not ship a
+    # meta.json that is silently null or unparseable.
+    if type entrant_meta_json >/dev/null 2>&1; then
+        identity=$(entrant_meta_json) ||
+            { echo "FATAL: entrant_meta_json failed"; exit 1; }
+        printf '%s' "$identity" | python3 -c 'import json,sys; json.load(sys.stdin)' ||
+            { echo "FATAL: entrant_meta_json returned invalid JSON: $identity"; exit 1; }
+    fi
     cat > "$OUT/meta.json" <<EOF
 {
   "entrant": "$ENTRANT_NAME",
@@ -117,7 +129,7 @@ write_meta() { # write_meta <rss_hwm_kb-or-null>
     "rss_idle_kb": ${RSS_IDLE:-null}, "rss_hwm_kb": $1,
     "threads": ${THREADS:-null},
     "children": ${CHILDREN:-null},
-    "identity": $(type entrant_meta_json >/dev/null 2>&1 && entrant_meta_json || echo null)
+    "identity": $identity
   }
 }
 EOF

--- a/bench/onthebench/run-entrant.sh
+++ b/bench/onthebench/run-entrant.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# On-rig runner for ANY gateway-shaped process ("entrant"): same instruments,
+# same core split, same windows, floors and validity policy as run-baseline.sh
+# measures aisix — both source lib.sh, so a cross-target comparison is
+# apples-to-apples by construction.
+#
+# Usage: run-entrant.sh <entrant-dir> <out-dir>
+#
+# <entrant-dir>/entrant.sh is sourced (before lib.sh, so it can override the
+# request shape) and must provide:
+#
+#   ENTRANT_NAME             short identifier stamped into results and meta
+#   entrant_start <out-dir>  boot the target listening on 127.0.0.1:$GW_PORT,
+#                            upstream pointed at 127.0.0.1:$MOCK_PORT, pinned
+#                            to $GW_CORES; must set GW_PID to the pid whose
+#                            /proc CPU and RSS are sampled
+#
+# and may provide:
+#
+#   entrant_prepare <out-dir>  one-time fetch/build, before any measurement
+#   entrant_stop               teardown beyond `kill $GW_PID` (containers)
+#   entrant_meta_json          extra identity JSON object (version, digest, …)
+#   REQ_PATH / BODY / AUTH_HEADER  request shape, when the entrant's ingress
+#                            speaks a dialect other than OpenAI chat
+#
+# The entrant dir itself is deliberately not part of this repository: the
+# harness carries the method; what it points at is the operator's business.
+#
+# Flamegraphs default OFF here (BENCH_FLAMEGRAPH=1 opts in): most shipped
+# release binaries are stripped, and a symbol-less flamegraph is noise. A
+# stripped binary skips the flamegraph with a warning instead of failing the
+# run — the throughput numbers stand on their own.
+set -euo pipefail
+
+ENTRANT_DIR="${1:?usage: run-entrant.sh <entrant-dir> <out-dir>}"
+OUT="${2:?usage: run-entrant.sh <entrant-dir> <out-dir>}"
+
+[ -f "$ENTRANT_DIR/entrant.sh" ] || { echo "FATAL: $ENTRANT_DIR/entrant.sh missing"; exit 1; }
+ENTRANT_DIR="$(cd "$ENTRANT_DIR" && pwd)"
+
+# The entrant script first (it may set REQ_PATH/BODY/AUTH_HEADER), then the
+# lib, which resolves defaults from whatever the entrant left unset.
+BENCH_FLAMEGRAPH="${BENCH_FLAMEGRAPH:-0}"
+# shellcheck source=/dev/null
+source "$ENTRANT_DIR/entrant.sh"
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+[ -n "$ENTRANT_NAME" ] || { echo "FATAL: entrant.sh must set ENTRANT_NAME"; exit 1; }
+
+rig_sanity
+bench_init
+
+if type entrant_prepare >/dev/null 2>&1; then
+    echo "== prepare ($ENTRANT_NAME) ==" >&2
+    # The pipe puts entrant_prepare in a subshell: state it wants to hand to
+    # entrant_start or entrant_meta_json must go through files, not variables.
+    # pipefail carries a prepare failure out of the pipeline; the || names it.
+    entrant_prepare "$OUT" 2>&1 | tee "$OUT/prepare.log" >&2 ||
+        { echo "FATAL: entrant_prepare failed (see $OUT/prepare.log)"; exit 1; }
+fi
+
+start_target() {
+    echo "== target ($ENTRANT_NAME) ==" >&2
+    # aisix reads AISIX_* environment variables as config overrides; no
+    # measured process gets them, whatever it is — same hygiene for every
+    # entrant, and one less variable between two entrants' environments.
+    while read -r v; do unset "$v"; done < <(compgen -v | grep '^AISIX_' || true)
+    GW_PID=""
+    entrant_start "$OUT"
+    # /proc existence, not kill -0: a containerized target's pid belongs to
+    # another user, where kill -0 reports EPERM and would read as death.
+    [ -n "$GW_PID" ] && [ -d "/proc/$GW_PID" ] ||
+        { echo "FATAL: entrant_start did not leave a live pid in GW_PID"; exit 1; }
+    wait_http_200 "http://127.0.0.1:$GW_PORT$REQ_PATH" "$ENTRANT_NAME"
+    sleep 3
+    RSS_IDLE=$(rss_kb "$GW_PID")
+    THREADS=$(ps -T -p "$GW_PID" 2>/dev/null | tail -n +2 | wc -l || echo 0)
+    echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB threads=$THREADS" >&2
+}
+
+write_meta() { # write_meta <rss_hwm_kb-or-null>
+    # /proc/<pid>/exe may belong to another user (a container's init); sudo -n
+    # is how the rest of the rig already escalates, and "unknown" is recorded
+    # rather than failing the run — entrant_meta_json carries identity anyway.
+    local bin_sha
+    bin_sha=$(sudo -n sha256sum "/proc/$GW_PID/exe" 2>/dev/null | cut -d' ' -f1 || true)
+    cat > "$OUT/meta.json" <<EOF
+{
+  "entrant": "$ENTRANT_NAME",
+  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "rig": $(meta_rig_json),
+  "cores": $(meta_cores_json),
+  "instruments": $(meta_instruments_json),
+  "method": $(meta_method_json),
+  "target": {
+    "binary_sha256": "${bin_sha:-unknown}",
+    "rss_idle_kb": ${RSS_IDLE:-null}, "rss_hwm_kb": $1,
+    "threads": ${THREADS:-null},
+    "identity": $(type entrant_meta_json >/dev/null 2>&1 && entrant_meta_json || echo null)
+  }
+}
+EOF
+}
+
+# ---- tiers: per tier, mock -> floor -> target points ------------------------
+
+FIRST_TIER=1
+for TTFT in $(grid_ttfts); do
+    echo "== mock (${TTFT}ms TTFT) + rig floor ==" >&2
+    start_mock "$TTFT"
+    floor_tier "$TTFT"
+    if [ "$FIRST_TIER" = 1 ]; then
+        start_target
+        write_meta null
+        FIRST_TIER=0
+    fi
+    for CONC in $(grid_concs "$TTFT"); do
+        run_point "$TTFT" "$CONC"
+    done
+    if [ "$TTFT" = 0 ] && [ "$FLAMEGRAPH" = 1 ] && grid_has 0 128; then
+        if nm "/proc/$GW_PID/exe" 2>/dev/null | grep -q ' [tT] '; then
+            flamegraph_point 128 "$ENTRANT_NAME c=128 0-delay (4 pinned cores)"
+        else
+            echo "WARNING: target binary is stripped or unreadable; skipping flamegraph" >&2
+        fi
+    fi
+done
+
+# ---- final metadata (adds the memory high-water mark) -----------------------
+
+RSS_HWM=$(awk '/VmHWM/{print $2}' "/proc/$GW_PID/status" 2>/dev/null || true)
+write_meta "${RSS_HWM:-null}"
+
+[ "$HARNESS_RC" = 0 ] ||
+    echo "FATAL: one or more points are incomplete - do not use this run as a reference" >&2
+echo "== done: $OUT ==" >&2
+exit "$HARNESS_RC"


### PR DESCRIPTION
## What

Follow-up to #917. Three changes to the same-rig harness, no default-behavior change:

1. **`lib.sh`** — the measurement core (mock lifecycle + TTFT assertion, rig floor, measured windows with CPU%/RSS sampling, validity policy, flamegraph, meta fragments) extracted from `run-baseline.sh` into one shared file. Both runners below source it, so any two runs are comparable by construction instead of by code review.
2. **`run-entrant.sh`** — a generic runner that measures any gateway-shaped process ("entrant") through the exact same code path: same instruments, core split, windows, floors and validity policy. The entrant contract (documented in the script header) is a sourced `entrant.sh` providing a start hook that leaves the measured pid in `GW_PID`, plus optional prepare/teardown hooks, identity metadata, and a request-shape override (`REQ_PATH`/`BODY`/`AUTH_HEADER`) for targets whose only ingress speaks a dialect other than OpenAI chat. Entrant definitions live outside the repository on purpose.
3. **`BENCH_*` method overrides** — grid, reps, window, warmup, max tries, floor reps and flamegraph become env-overridable (defaults unchanged, forwarded by `bench.sh`), so a two-window spot-check or an added delay tier is an invocation rather than a script edit. Overrides are recorded in `meta.json`, so a non-default run can never pass silently as the standard grid.

Floors now derive from the grid: one floor per 0-delay tier at its max concurrency (the instrument ceiling barely moves with concurrency there), one floor per concurrency on delayed tiers (the ceiling is ~conc/delay). Under the default grid this reproduces exactly the floors the harness always ran.

Two correctness fixes that fall out of generalizing:

- Liveness checks use `/proc/<pid>` existence instead of `kill -0`, which reports EPERM — reading as death — for a containerized target owned by another user (the RSS sampler would silently record 0).
- `entrant_prepare` failures propagate through the `tee` pipeline (pipefail + explicit message) instead of aborting with no context; the pipeline-subshell semantics are documented in the contract (state hand-off through files, not variables).

## Why

The performance program needs same-rig, same-instrument comparisons of multiple gateway targets, and extra load points (e.g. an added delay tier at higher concurrency), without forking the measurement methodology per target. One chokepoint (`lib.sh`) keeps the family from drifting.

## Validation

- `bash -n` on all five scripts.
- Same-rig spot-check of the refactored `run-baseline.sh` (`BENCH_GRID="0:128"`, byte-identical product binary vs the #917 baseline run) — results recorded in the program tracker, not here.
- `run-entrant.sh` exercised against native and containerized targets in the program's measurement session (entrant definitions are deliberately out-of-repo; the results land in the internal tracker).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added benchmarking for gateway-shaped entrant processes, including preparation, validation, resource measurements, and optional flamegraphs.
  - Added configurable benchmark parameters through `BENCH_*` environment variables.
  - Added concurrency floors across delayed load tiers.
  - Benchmark results now identify the measured entrant and include expanded run metadata.

- **Improvements**
  - Standardized measurements, readiness checks, retries, cleanup, and validity tracking across benchmark runs.
  - Configuration overrides are forwarded to remote baseline executions.
  - Improved benchmark documentation covering load grids, validation tiers, configuration, and entrant requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->