### PR TITLE
feat(cache): shared semantic store on redis vector search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis:7-alpine
+        # redis:8 ships the vector-search query engine the semantic
+        # cache needs; a superset of redis:7 for the exact-cache tests.
+        image: redis:8-alpine
         ports: ["6379:6379"]
       # Real etcd for crates/aisix-admin/tests/etcd_integration.rs —
       # exercises the full Admin handler → EtcdConfigStore →
@@ -105,6 +107,13 @@ jobs:
       # every Config::load_from_path test as `redis_url` and breaks
       # the entire `aisix-core::config::tests` module.
       CACHE_TEST_REDIS_URL: redis://127.0.0.1:6379
+      # Picked up by crates/aisix-cache/tests/semantic_redis_integration.rs
+      # — needs the vector-capable redis:8 service above. The PLAIN url
+      # points at a cluster node (redis:7, no vector search) to pin the
+      # capability probe's failure path. Same skip-if-unset /
+      # no-AISIX_-prefix rules.
+      CACHE_TEST_REDIS_VECTOR_URL: redis://127.0.0.1:6379
+      CACHE_TEST_REDIS_PLAIN_URL: redis://127.0.0.1:7000
       # Picked up by crates/aisix-ratelimit/tests/redis_integration.rs
       # (shared cluster-level counters, #798). Same skip-if-unset /
       # no-AISIX_-prefix rules as CACHE_TEST_REDIS_URL above.
@@ -245,7 +254,9 @@ jobs:
           ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
         ports: ["2379:2379"]
       redis:
-        image: redis:7-alpine
+        # redis:8 = vector-capable, so the semantic-cache redis e2e
+        # exercises the real path against AISIX_E2E_REDIS.
+        image: redis:8-alpine
         ports: ["6379:6379"]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,12 @@ jobs:
         # exercises the real path against AISIX_E2E_REDIS.
         image: redis:8-alpine
         ports: ["6379:6379"]
+      redis-plain:
+        # A vector-LESS redis so the semantic-cache degradation suite
+        # (exact-only on plain redis) actually runs in CI instead of
+        # skipping forever now that the main service is redis:8.
+        image: redis:7-alpine
+        ports: ["6377:6379"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
@@ -303,6 +309,9 @@ jobs:
         # mode and the second would prove nothing.
         env:
           E2E_THREAD_PER_CORE: ${{ matrix.thread_per_core }}
+          # Vector-less redis for the semantic-cache degradation suite;
+          # the main 6379 service is redis:8 (vector-capable).
+          AISIX_E2E_REDIS_PLAIN: redis://127.0.0.1:6377
         run: pnpm test
       - name: tag coverage by leg
         # The gate downloads every leg with `merge-multiple: true`, which

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -166,6 +166,11 @@ cache:
   # Legacy knob — no longer selects a single global cache. Kept for
   # config compatibility; `backend: "redis"` still requires the
   # `redis` block below (validated at boot).
+  #
+  # Cache policies with a `semantic` block additionally need vector
+  # search on this Redis (Redis 8+, or the search module) in `single`
+  # or `sentinel` mode; without it, `backend: redis` policies serve
+  # exact matches only (probed and logged at boot).
   backend: "memory"   # memory | redis
   # redis:
   #   # mode picks the topology. Credentials travel inside the URLs, as

--- a/crates/aisix-cache/src/lib.rs
+++ b/crates/aisix-cache/src/lib.rs
@@ -31,6 +31,8 @@ mod memory;
 #[cfg(feature = "redis")]
 mod redis;
 mod semantic;
+#[cfg(feature = "redis")]
+mod semantic_redis;
 
 pub use cache::{Cache, CacheError, CacheOutcome};
 pub use key::{semantic_prompt_text, CacheKey};
@@ -40,3 +42,5 @@ pub use redis::{
     RedisCache, DEFAULT_PREFIX as REDIS_DEFAULT_PREFIX, DEFAULT_TTL as REDIS_DEFAULT_TTL,
 };
 pub use semantic::{MemorySemanticCache, SemanticCacheStore, SemanticHit};
+#[cfg(feature = "redis")]
+pub use semantic_redis::{RedisSemanticCache, DEFAULT_PREFIX as SEMANTIC_REDIS_DEFAULT_PREFIX};

--- a/crates/aisix-cache/src/semantic_redis.rs
+++ b/crates/aisix-cache/src/semantic_redis.rs
@@ -92,12 +92,27 @@ impl RedisSemanticCache {
     }
 
     /// One-shot capability probe: succeeds iff the server speaks the
-    /// vector-search command family. The bootstrap calls this once and
-    /// skips wiring the store when it fails, so a plain Redis 6/7
-    /// degrades semantic matching visibly at boot, never silently at
-    /// request time.
+    /// vector-search command family AND the connection talks RESP2.
+    /// The bootstrap calls this once and skips wiring the store when it
+    /// fails, so a plain Redis 6/7 — or a `?protocol=resp3` connection,
+    /// whose `FT.SEARCH` replies use a nested map shape this parser
+    /// does not speak — degrades semantic matching visibly at boot,
+    /// never silently at request time.
     pub async fn probe(&self) -> Result<(), CacheError> {
         let mut conn = self.acquire().await?;
+        let proto: redis::Value = redis::cmd("HELLO")
+            .query_async(&mut conn)
+            .await
+            .unwrap_or(redis::Value::Nil);
+        if let redis::Value::Map(_) = proto {
+            // A map HELLO reply means the connection negotiated RESP3.
+            return Err(CacheError::Backend(
+                "RESP3 connections are not supported by the semantic cache \
+                 (FT.SEARCH reply parsing assumes RESP2); remove \
+                 protocol=resp3 from cache.redis"
+                    .into(),
+            ));
+        }
         redis::cmd("FT._LIST")
             .query_async::<()>(&mut conn)
             .await

--- a/crates/aisix-cache/src/semantic_redis.rs
+++ b/crates/aisix-cache/src/semantic_redis.rs
@@ -192,38 +192,79 @@ impl RedisSemanticCache {
                 return Err(CacheError::Backend(format!("redis FT.CREATE: {e}")));
             }
         }
-        // Rotate away the previously ensured identity, documents
-        // included — its entries belong to a purged generation or a
-        // different vector space and must never serve again. Guarded by
-        // the monotonic check above, so this only ever drops an OLDER
-        // identity.
-        if let Some((_, old)) = self.ensured.remove(policy_id) {
-            if old.index != index {
+        // Publish under the entry lock, re-checking monotonicity: a
+        // concurrent task may have ensured a NEWER identity while our
+        // FT.CREATE was in flight (two generation bumps straddled by
+        // slow requests). Whoever is newest wins; the loser's
+        // just-created index is dropped, never the winner's — a plain
+        // remove+insert here could regress the memo and delete the live
+        // index. Decision happens under the lock, redis IO outside it.
+        enum Rotate {
+            Publish(Option<String>),
+            LostRace,
+        }
+        let outcome = match self.ensured.entry(policy_id.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(mut e) => {
+                if generation < e.get().generation {
+                    Rotate::LostRace
+                } else {
+                    let old = (e.get().index != index).then(|| e.get().index.clone());
+                    e.insert(EnsuredIndex {
+                        generation,
+                        dims,
+                        index: index.clone(),
+                    });
+                    Rotate::Publish(old)
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(v) => {
+                v.insert(EnsuredIndex {
+                    generation,
+                    dims,
+                    index: index.clone(),
+                });
+                Rotate::Publish(None)
+            }
+        };
+        match outcome {
+            Rotate::LostRace => {
+                // Our index (re-created empty above) must not linger
+                // beside the newer one that won.
                 let _ = redis::cmd("FT.DROPINDEX")
-                    .arg(&old.index)
+                    .arg(&index)
                     .arg("DD")
                     .query_async::<()>(&mut conn)
                     .await;
+                Ok(None)
+            }
+            Rotate::Publish(old) => {
+                // Drop the rotated-away identity, documents included —
+                // its entries belong to a purged generation or a
+                // different vector space and must never serve again.
+                if let Some(old) = old {
+                    let _ = redis::cmd("FT.DROPINDEX")
+                        .arg(&old)
+                        .arg("DD")
+                        .query_async::<()>(&mut conn)
+                        .await;
+                }
+                Ok(Some(index))
             }
         }
-        self.ensured.insert(
-            policy_id.to_string(),
-            EnsuredIndex {
-                generation,
-                dims,
-                index: index.clone(),
-            },
-        );
-        Ok(Some(index))
     }
 
-    /// Forget a memoized index after the server reported it missing
-    /// (`no such index`): the server lost state (restart / external
-    /// cleanup / a concurrent boot sweep), so the next call must
-    /// re-create instead of trusting the memo forever.
+    /// Forget a memoized index after the server reported it missing:
+    /// the server lost state (restart / failover to an empty replica /
+    /// external cleanup / a concurrent boot sweep), so the next call
+    /// must re-create instead of trusting the memo forever. Matches
+    /// every known wording — redis 8 reports `Index not found`, older
+    /// search modules `no such index` / `Unknown index name`.
     fn forget_missing_index(&self, policy_id: &str, err: &CacheError) {
         let msg = err.to_string().to_ascii_lowercase();
-        if msg.contains("no such index") || msg.contains("unknown index") {
+        if msg.contains("index not found")
+            || msg.contains("no such index")
+            || msg.contains("unknown index")
+        {
             self.ensured.remove(policy_id);
         }
     }
@@ -392,11 +433,17 @@ impl SemanticCacheStore for RedisSemanticCache {
         // Remaining lifetime for the exact-layer backfill cap.
         let doc_key = value_str(doc_key)
             .ok_or_else(|| CacheError::Backend("redis FT.SEARCH: bad document key".into()))?;
-        let pttl_ms: i64 = redis::cmd("PTTL")
+        let pttl_ms: i64 = match redis::cmd("PTTL")
             .arg(&doc_key)
             .query_async(&mut conn)
             .await
-            .map_err(|e| CacheError::Backend(format!("redis PTTL: {e}")))?;
+        {
+            Ok(v) => v,
+            Err(e) => {
+                self.conn.note_error().await;
+                return Err(CacheError::Backend(format!("redis PTTL: {e}")));
+            }
+        };
         let expires_at = Instant::now() + Duration::from_millis(pttl_ms.max(0) as u64);
         Ok(Some(SemanticHit {
             response,

--- a/crates/aisix-cache/src/semantic_redis.rs
+++ b/crates/aisix-cache/src/semantic_redis.rs
@@ -1,0 +1,362 @@
+//! Redis-backed semantic (embedding-similarity) store — the shared
+//! counterpart of [`crate::MemorySemanticCache`], for `backend: redis`
+//! policies. Requires a Redis server with the vector-search query
+//! engine (Redis 8+; earlier versions need the search module). The
+//! server bootstrap probes support once ([`RedisSemanticCache::probe`])
+//! and only wires this store when the probe passes, so the per-request
+//! path never re-checks capability.
+//!
+//! Layout per `(policy, generation, dims)`:
+//! - one vector index `<prefix>:idx:<policy>:<gen>:<dims>` over HASH
+//!   documents with prefix `<prefix>:doc:<policy>:<gen>:<dims>:`;
+//! - one HASH document per exact wording, keyed by the exact-layer
+//!   fingerprint — a refresh of the same wording overwrites in place
+//!   (the upsert contract), and every document carries its own TTL, so
+//!   growth is TTL-bounded and `max_entries` is intentionally ignored
+//!   (see the trait docs).
+//!
+//! Purge / embedding-model changes rotate the index identity: a new
+//! `(generation, dims)` gets a fresh index, and the previous one is
+//! dropped (documents included) the next time this instance touches the
+//! policy. Replicas that never touch it again leave only expired
+//! documents plus an empty index definition behind.
+//!
+//! The candidate partition (`scope_fp`) is stored as a TAG field. TAG
+//! values tokenize on punctuation, so the raw fingerprint string (which
+//! contains `:` separators) is hashed to a plain hex token first.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::{Duration, Instant};
+
+use aisix_core::RedisConnConfig;
+use aisix_gateway::ChatResponse;
+use aisix_redis::RedisConn;
+use async_trait::async_trait;
+use dashmap::DashMap;
+
+use crate::cache::CacheError;
+use crate::semantic::{SemanticCacheStore, SemanticHit};
+
+/// Default key/index namespace. Distinct from the exact cache's
+/// `aisix:cache` so `FT` index prefixes never overlap plain keys.
+pub const DEFAULT_PREFIX: &str = "aisix:semcache";
+
+/// One ensured index identity for a policy. A mismatch on either field
+/// rotates the index (drop old, create new).
+struct EnsuredIndex {
+    generation: u32,
+    dims: usize,
+    index: String,
+}
+
+pub struct RedisSemanticCache {
+    conn: RedisConn,
+    prefix: String,
+    /// Per-policy memo of the index this instance has ensured, so the
+    /// hot path pays one `DashMap` read instead of an `FT.CREATE`
+    /// round-trip per request.
+    ensured: DashMap<String, EnsuredIndex>,
+}
+
+impl std::fmt::Debug for RedisSemanticCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedisSemanticCache")
+            .field("prefix", &self.prefix)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RedisSemanticCache {
+    /// Connect using the operator's `cache.redis` config — the same
+    /// config the exact redis cache uses; this opens its own
+    /// connection so the two caches don't serialize on one pipeline.
+    pub async fn connect(cfg: &RedisConnConfig) -> Result<Self, CacheError> {
+        let conn = aisix_redis::connect(cfg)
+            .await
+            .map_err(|e| CacheError::Backend(format!("redis connect: {e}")))?;
+        Ok(Self {
+            conn,
+            prefix: DEFAULT_PREFIX.into(),
+            ensured: DashMap::new(),
+        })
+    }
+
+    /// Namespace by environment id, mirroring the exact cache's
+    /// isolation on a shared user-provided Redis.
+    pub fn with_env_namespace(mut self, env_id: &str) -> Self {
+        if !env_id.is_empty() {
+            self.prefix = format!("{}:{}", self.prefix, env_id);
+        }
+        self
+    }
+
+    /// One-shot capability probe: succeeds iff the server speaks the
+    /// vector-search command family. The bootstrap calls this once and
+    /// skips wiring the store when it fails, so a plain Redis 6/7
+    /// degrades semantic matching visibly at boot, never silently at
+    /// request time.
+    pub async fn probe(&self) -> Result<(), CacheError> {
+        let mut conn = self.acquire().await?;
+        redis::cmd("FT._LIST")
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| {
+                CacheError::Backend(format!(
+                    "vector search unsupported (requires Redis 8+ or the search module): {e}"
+                ))
+            })
+    }
+
+    async fn acquire(&self) -> Result<aisix_redis::RedisConnHandle, CacheError> {
+        self.conn
+            .acquire()
+            .await
+            .map_err(|e| CacheError::Backend(format!("redis acquire: {e}")))
+    }
+
+    fn index_name(&self, policy_id: &str, generation: u32, dims: usize) -> String {
+        format!("{}:idx:{policy_id}:{generation}:{dims}", self.prefix)
+    }
+
+    fn doc_prefix(&self, policy_id: &str, generation: u32, dims: usize) -> String {
+        format!("{}:doc:{policy_id}:{generation}:{dims}:", self.prefix)
+    }
+
+    /// TAG-safe token for the partition fingerprint: TAG fields
+    /// tokenize on punctuation and the raw value contains separators,
+    /// so it is hashed to bare hex (same 64-bit space as the cache
+    /// fingerprints themselves).
+    fn scope_tag(scope_fp: &str) -> String {
+        let mut h = DefaultHasher::new();
+        scope_fp.hash(&mut h);
+        format!("{:016x}", h.finish())
+    }
+
+    /// Make sure the index for `(policy, generation, dims)` exists,
+    /// rotating (drop + recreate) when either component changed since
+    /// this instance last saw the policy.
+    async fn ensure_index(
+        &self,
+        policy_id: &str,
+        generation: u32,
+        dims: usize,
+    ) -> Result<String, CacheError> {
+        if let Some(e) = self.ensured.get(policy_id) {
+            if e.generation == generation && e.dims == dims {
+                return Ok(e.index.clone());
+            }
+        }
+        let index = self.index_name(policy_id, generation, dims);
+        let doc_prefix = self.doc_prefix(policy_id, generation, dims);
+        let mut conn = self.acquire().await?;
+        let created = redis::cmd("FT.CREATE")
+            .arg(&index)
+            .arg("ON")
+            .arg("HASH")
+            .arg("PREFIX")
+            .arg(1)
+            .arg(&doc_prefix)
+            .arg("SCHEMA")
+            .arg("scope_fp")
+            .arg("TAG")
+            .arg("embedding")
+            .arg("VECTOR")
+            .arg("HNSW")
+            .arg(6)
+            .arg("TYPE")
+            .arg("FLOAT32")
+            .arg("DIM")
+            .arg(dims)
+            .arg("DISTANCE_METRIC")
+            .arg("COSINE")
+            .query_async::<()>(&mut conn)
+            .await;
+        match created {
+            Ok(()) => {}
+            // Another replica (or an earlier run) already created it.
+            Err(e)
+                if e.to_string()
+                    .to_ascii_lowercase()
+                    .contains("already exists") => {}
+            Err(e) => {
+                self.conn.note_error().await;
+                return Err(CacheError::Backend(format!("redis FT.CREATE: {e}")));
+            }
+        }
+        // Rotate away the previously ensured identity, documents
+        // included — its entries belong to a purged generation or a
+        // different vector space and must never serve again.
+        if let Some((_, old)) = self.ensured.remove(policy_id) {
+            if old.index != index {
+                let _ = redis::cmd("FT.DROPINDEX")
+                    .arg(&old.index)
+                    .arg("DD")
+                    .query_async::<()>(&mut conn)
+                    .await;
+            }
+        }
+        self.ensured.insert(
+            policy_id.to_string(),
+            EnsuredIndex {
+                generation,
+                dims,
+                index: index.clone(),
+            },
+        );
+        Ok(index)
+    }
+}
+
+fn vector_blob(embedding: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(embedding.len() * 4);
+    for f in embedding {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+/// Pull a named field out of an `FT.SEARCH` document field list
+/// (`[name, value, name, value, …]`).
+fn field<'a>(fields: &'a [redis::Value], name: &str) -> Option<&'a redis::Value> {
+    let mut it = fields.iter();
+    while let (Some(k), Some(v)) = (it.next(), it.next()) {
+        if matches!(k, redis::Value::BulkString(b) if b == name.as_bytes()) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn value_str(v: &redis::Value) -> Option<String> {
+    match v {
+        redis::Value::BulkString(b) => String::from_utf8(b.clone()).ok(),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl SemanticCacheStore for RedisSemanticCache {
+    async fn lookup(
+        &self,
+        policy_id: &str,
+        generation: u32,
+        scope_fp: &str,
+        embedding: &[f32],
+        threshold: f32,
+    ) -> Result<Option<SemanticHit>, CacheError> {
+        let index = self
+            .ensure_index(policy_id, generation, embedding.len())
+            .await?;
+        let mut conn = self.acquire().await?;
+        let query = format!(
+            "(@scope_fp:{{{}}})=>[KNN 1 @embedding $vec AS dist]",
+            Self::scope_tag(scope_fp)
+        );
+        let reply = redis::cmd("FT.SEARCH")
+            .arg(&index)
+            .arg(&query)
+            .arg("PARAMS")
+            .arg(2)
+            .arg("vec")
+            .arg(vector_blob(embedding))
+            .arg("SORTBY")
+            .arg("dist")
+            .arg("RETURN")
+            .arg(2)
+            .arg("response")
+            .arg("dist")
+            .arg("LIMIT")
+            .arg(0)
+            .arg(1)
+            .arg("DIALECT")
+            .arg(2)
+            .query_async::<redis::Value>(&mut conn)
+            .await;
+        let reply = match reply {
+            Ok(v) => v,
+            Err(e) => {
+                self.conn.note_error().await;
+                return Err(CacheError::Backend(format!("redis FT.SEARCH: {e}")));
+            }
+        };
+        // Reply shape: [total, key, [field, value, …], …].
+        let redis::Value::Array(items) = reply else {
+            return Err(CacheError::Backend(
+                "redis FT.SEARCH: non-array reply".into(),
+            ));
+        };
+        let (Some(doc_key), Some(redis::Value::Array(fields))) = (items.get(1), items.get(2))
+        else {
+            return Ok(None); // total == 0
+        };
+        let dist: f32 = field(fields, "dist")
+            .and_then(value_str)
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| CacheError::Backend("redis FT.SEARCH: missing dist".into()))?;
+        let similarity = 1.0 - dist;
+        if !(similarity >= threshold && similarity > 0.0) {
+            return Ok(None);
+        }
+        let response: ChatResponse = field(fields, "response")
+            .and_then(value_str)
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .ok_or_else(|| CacheError::Backend("redis FT.SEARCH: bad response field".into()))?;
+        // Remaining lifetime for the exact-layer backfill cap.
+        let doc_key = value_str(doc_key)
+            .ok_or_else(|| CacheError::Backend("redis FT.SEARCH: bad document key".into()))?;
+        let pttl_ms: i64 = redis::cmd("PTTL")
+            .arg(&doc_key)
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| CacheError::Backend(format!("redis PTTL: {e}")))?;
+        let expires_at = Instant::now() + Duration::from_millis(pttl_ms.max(0) as u64);
+        Ok(Some(SemanticHit {
+            response,
+            similarity,
+            expires_at,
+        }))
+    }
+
+    async fn store(
+        &self,
+        policy_id: &str,
+        generation: u32,
+        scope_fp: &str,
+        exact_key: &str,
+        embedding: Vec<f32>,
+        response: ChatResponse,
+        ttl: Duration,
+        _max_entries: u32,
+    ) -> Result<(), CacheError> {
+        let dims = embedding.len();
+        self.ensure_index(policy_id, generation, dims).await?;
+        let doc_key = format!(
+            "{}{exact_key}",
+            self.doc_prefix(policy_id, generation, dims)
+        );
+        let json = serde_json::to_string(&response)
+            .map_err(|e| CacheError::Backend(format!("redis encode: {e}")))?;
+        let mut conn = self.acquire().await?;
+        let mut pipe = redis::pipe();
+        pipe.cmd("HSET")
+            .arg(&doc_key)
+            .arg("scope_fp")
+            .arg(Self::scope_tag(scope_fp))
+            .arg("response")
+            .arg(json)
+            .arg("embedding")
+            .arg(vector_blob(&embedding))
+            .ignore()
+            .cmd("PEXPIRE")
+            .arg(&doc_key)
+            .arg(ttl.as_millis().max(1) as u64)
+            .ignore();
+        if let Err(e) = pipe.query_async::<()>(&mut conn).await {
+            self.conn.note_error().await;
+            return Err(CacheError::Backend(format!("redis HSET: {e}")));
+        }
+        Ok(())
+    }
+}

--- a/crates/aisix-cache/src/semantic_redis.rs
+++ b/crates/aisix-cache/src/semantic_redis.rs
@@ -134,17 +134,25 @@ impl RedisSemanticCache {
     }
 
     /// Make sure the index for `(policy, generation, dims)` exists,
-    /// rotating (drop + recreate) when either component changed since
-    /// this instance last saw the policy.
+    /// rotating (drop + recreate) when the identity moved FORWARD since
+    /// this instance last saw the policy. Returns `Ok(None)` for a
+    /// STALE caller — one whose generation is lower than the ensured
+    /// one (an in-flight request holding a pre-purge policy snapshot):
+    /// rotating backwards would recreate the old index empty and then
+    /// drop the live one, documents included. Stale lookups miss, stale
+    /// stores are dropped, mirroring the in-process store's contract.
     async fn ensure_index(
         &self,
         policy_id: &str,
         generation: u32,
         dims: usize,
-    ) -> Result<String, CacheError> {
+    ) -> Result<Option<String>, CacheError> {
         if let Some(e) = self.ensured.get(policy_id) {
             if e.generation == generation && e.dims == dims {
-                return Ok(e.index.clone());
+                return Ok(Some(e.index.clone()));
+            }
+            if generation < e.generation {
+                return Ok(None);
             }
         }
         let index = self.index_name(policy_id, generation, dims);
@@ -186,7 +194,9 @@ impl RedisSemanticCache {
         }
         // Rotate away the previously ensured identity, documents
         // included — its entries belong to a purged generation or a
-        // different vector space and must never serve again.
+        // different vector space and must never serve again. Guarded by
+        // the monotonic check above, so this only ever drops an OLDER
+        // identity.
         if let Some((_, old)) = self.ensured.remove(policy_id) {
             if old.index != index {
                 let _ = redis::cmd("FT.DROPINDEX")
@@ -204,7 +214,67 @@ impl RedisSemanticCache {
                 index: index.clone(),
             },
         );
-        Ok(index)
+        Ok(Some(index))
+    }
+
+    /// Forget a memoized index after the server reported it missing
+    /// (`no such index`): the server lost state (restart / external
+    /// cleanup / a concurrent boot sweep), so the next call must
+    /// re-create instead of trusting the memo forever.
+    fn forget_missing_index(&self, policy_id: &str, err: &CacheError) {
+        let msg = err.to_string().to_ascii_lowercase();
+        if msg.contains("no such index") || msg.contains("unknown index") {
+            self.ensured.remove(policy_id);
+        }
+    }
+
+    /// Boot-time GC: drop indexes under this instance's prefix whose
+    /// document count is zero. Index DEFINITIONS never expire on their
+    /// own, so deleted policies and rotated-away generations would
+    /// otherwise accumulate empty definitions forever. Dropping a
+    /// still-live empty index is safe: the next request that touches
+    /// its policy re-creates it (the missing-index guard above clears
+    /// any stale memo). Best-effort — errors are returned for the
+    /// caller to log, never fatal.
+    pub async fn sweep_empty_indexes(&self) -> Result<usize, CacheError> {
+        let mut conn = self.acquire().await?;
+        let names: Vec<String> = redis::cmd("FT._LIST")
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| CacheError::Backend(format!("redis FT._LIST: {e}")))?;
+        let ours = format!("{}:idx:", self.prefix);
+        let mut dropped = 0usize;
+        for name in names.iter().filter(|n| n.starts_with(&ours)) {
+            let info: redis::Value =
+                match redis::cmd("FT.INFO").arg(name).query_async(&mut conn).await {
+                    Ok(v) => v,
+                    Err(_) => continue, // racing another sweep; skip
+                };
+            let redis::Value::Array(items) = info else {
+                continue;
+            };
+            let mut it = items.iter();
+            let mut num_docs: Option<i64> = None;
+            while let (Some(k), Some(v)) = (it.next(), it.next()) {
+                if value_name_eq(k, "num_docs") {
+                    num_docs = match v {
+                        redis::Value::Int(n) => Some(*n),
+                        other => value_str(other).and_then(|s| s.parse().ok()),
+                    };
+                    break;
+                }
+            }
+            if num_docs == Some(0)
+                && redis::cmd("FT.DROPINDEX")
+                    .arg(name)
+                    .query_async::<()>(&mut conn)
+                    .await
+                    .is_ok()
+            {
+                dropped += 1;
+            }
+        }
+        Ok(dropped)
     }
 }
 
@@ -221,11 +291,21 @@ fn vector_blob(embedding: &[f32]) -> Vec<u8> {
 fn field<'a>(fields: &'a [redis::Value], name: &str) -> Option<&'a redis::Value> {
     let mut it = fields.iter();
     while let (Some(k), Some(v)) = (it.next(), it.next()) {
-        if matches!(k, redis::Value::BulkString(b) if b == name.as_bytes()) {
+        if value_name_eq(k, name) {
             return Some(v);
         }
     }
     None
+}
+
+/// Field names in `FT.*` replies arrive as either simple or bulk
+/// strings depending on the server version — match both.
+fn value_name_eq(v: &redis::Value, name: &str) -> bool {
+    match v {
+        redis::Value::BulkString(b) => b == name.as_bytes(),
+        redis::Value::SimpleString(s) => s == name,
+        _ => false,
+    }
 }
 
 fn value_str(v: &redis::Value) -> Option<String> {
@@ -246,9 +326,13 @@ impl SemanticCacheStore for RedisSemanticCache {
         embedding: &[f32],
         threshold: f32,
     ) -> Result<Option<SemanticHit>, CacheError> {
-        let index = self
+        let Some(index) = self
             .ensure_index(policy_id, generation, embedding.len())
-            .await?;
+            .await?
+        else {
+            // Stale generation: miss, never rotate backwards.
+            return Ok(None);
+        };
         let mut conn = self.acquire().await?;
         let query = format!(
             "(@scope_fp:{{{}}})=>[KNN 1 @embedding $vec AS dist]",
@@ -278,7 +362,9 @@ impl SemanticCacheStore for RedisSemanticCache {
             Ok(v) => v,
             Err(e) => {
                 self.conn.note_error().await;
-                return Err(CacheError::Backend(format!("redis FT.SEARCH: {e}")));
+                let err = CacheError::Backend(format!("redis FT.SEARCH: {e}"));
+                self.forget_missing_index(policy_id, &err);
+                return Err(err);
             }
         };
         // Reply shape: [total, key, [field, value, …], …].
@@ -331,7 +417,15 @@ impl SemanticCacheStore for RedisSemanticCache {
         _max_entries: u32,
     ) -> Result<(), CacheError> {
         let dims = embedding.len();
-        self.ensure_index(policy_id, generation, dims).await?;
+        if self
+            .ensure_index(policy_id, generation, dims)
+            .await?
+            .is_none()
+        {
+            // Stale generation: drop the write, mirroring the
+            // in-process store.
+            return Ok(());
+        }
         let doc_key = format!(
             "{}{exact_key}",
             self.doc_prefix(policy_id, generation, dims)
@@ -355,7 +449,9 @@ impl SemanticCacheStore for RedisSemanticCache {
             .ignore();
         if let Err(e) = pipe.query_async::<()>(&mut conn).await {
             self.conn.note_error().await;
-            return Err(CacheError::Backend(format!("redis HSET: {e}")));
+            let err = CacheError::Backend(format!("redis HSET: {e}"));
+            self.forget_missing_index(policy_id, &err);
+            return Err(err);
         }
         Ok(())
     }

--- a/crates/aisix-cache/tests/semantic_redis_integration.rs
+++ b/crates/aisix-cache/tests/semantic_redis_integration.rs
@@ -445,11 +445,19 @@ async fn ttl_expires_documents() {
         )
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(400)).await;
-    let miss = store
-        .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.5)
-        .await
-        .unwrap();
+    // Redis expires documents lazily; poll until the reclaim lands
+    // instead of trusting one fixed sleep.
+    let mut miss = None;
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        miss = store
+            .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.5)
+            .await
+            .unwrap();
+        if miss.is_none() {
+            break;
+        }
+    }
     assert!(miss.is_none(), "expired document must not match");
 }
 

--- a/crates/aisix-cache/tests/semantic_redis_integration.rs
+++ b/crates/aisix-cache/tests/semantic_redis_integration.rs
@@ -1,0 +1,347 @@
+//! End-to-end tests for the Redis semantic store against a live
+//! vector-capable Redis (Redis 8+ / search module).
+//!
+//! Runs only when `CACHE_TEST_REDIS_VECTOR_URL` is set (CI points it at
+//! the same `redis:8-alpine` service the exact-cache tests use). Each
+//! test uses unique policy ids so runs never collide with leftovers of
+//! earlier ones on a long-lived server.
+
+#![cfg(feature = "redis")]
+
+use std::time::Duration;
+
+use aisix_cache::{RedisSemanticCache, SemanticCacheStore};
+use aisix_core::{RedisConnConfig, RedisMode};
+use aisix_gateway::{ChatMessage, ChatResponse, FinishReason, UsageStats};
+
+fn vector_url() -> Option<String> {
+    std::env::var("CACHE_TEST_REDIS_VECTOR_URL").ok()
+}
+
+fn single(url: &str) -> RedisConnConfig {
+    RedisConnConfig {
+        mode: RedisMode::Single,
+        url: Some(url.to_string()),
+        ..Default::default()
+    }
+}
+
+async fn connect(url: &str) -> RedisSemanticCache {
+    let store = RedisSemanticCache::connect(&single(url))
+        .await
+        .expect("connect");
+    store.probe().await.expect("vector-capable redis required");
+    store
+}
+
+fn resp(content: &str) -> ChatResponse {
+    ChatResponse {
+        id: "cmpl-sem-1".into(),
+        model: "openai/gpt-4o".into(),
+        message: ChatMessage::assistant(content),
+        finish_reason: FinishReason::Stop,
+        usage: UsageStats::new(3, 5),
+    }
+}
+
+fn unique(name: &str) -> String {
+    format!(
+        "{name}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )
+}
+
+const TTL: Duration = Duration::from_secs(60);
+
+#[tokio::test]
+async fn nearest_above_threshold_round_trips() {
+    let Some(url) = vector_url() else { return };
+    let store = connect(&url).await;
+    let policy = unique("p-roundtrip");
+
+    store
+        .store(
+            &policy,
+            0,
+            "fp",
+            "k1",
+            vec![1.0, 0.0, 0.0, 0.0],
+            resp("a"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    let hit = store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0, 0.0, 0.0], 0.9)
+        .await
+        .unwrap()
+        .expect("identical vector must hit");
+    assert_eq!(hit.response.message.content_str(), "a");
+    assert!(hit.similarity > 0.999, "got {}", hit.similarity);
+    // Remaining lifetime is reported for the backfill cap.
+    let remaining = hit
+        .expires_at
+        .saturating_duration_since(std::time::Instant::now());
+    assert!(remaining <= TTL && remaining > TTL - Duration::from_secs(10));
+
+    // Below threshold: orthogonal vector misses.
+    let miss = store
+        .lookup(&policy, 0, "fp", &[0.0, 1.0, 0.0, 0.0], 0.9)
+        .await
+        .unwrap();
+    assert!(miss.is_none());
+}
+
+#[tokio::test]
+async fn scope_fp_partitions_candidates() {
+    let Some(url) = vector_url() else { return };
+    let store = connect(&url).await;
+    let policy = unique("p-scope");
+
+    store
+        .store(
+            &policy,
+            0,
+            "fp-a",
+            "k1",
+            vec![1.0, 0.0],
+            resp("a"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    let cross = store
+        .lookup(&policy, 0, "fp-b", &[1.0, 0.0], 0.5)
+        .await
+        .unwrap();
+    assert!(cross.is_none(), "entries must not cross scope fingerprints");
+    let same = store
+        .lookup(&policy, 0, "fp-a", &[1.0, 0.0], 0.5)
+        .await
+        .unwrap();
+    assert!(same.is_some());
+}
+
+#[tokio::test]
+async fn store_upserts_by_exact_key() {
+    let Some(url) = vector_url() else { return };
+    let store = connect(&url).await;
+    let policy = unique("p-upsert");
+
+    store
+        .store(
+            &policy,
+            0,
+            "fp",
+            "same-key",
+            vec![1.0, 0.0],
+            resp("v1"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    store
+        .store(
+            &policy,
+            0,
+            "fp",
+            "same-key",
+            vec![1.0, 0.0],
+            resp("v2"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    let hit = store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.9)
+        .await
+        .unwrap()
+        .expect("hit");
+    assert_eq!(
+        hit.response.message.content_str(),
+        "v2",
+        "refresh must replace the document in place",
+    );
+}
+
+#[tokio::test]
+async fn generation_rotation_orphans_old_entries() {
+    let Some(url) = vector_url() else { return };
+    let store = connect(&url).await;
+    let policy = unique("p-gen");
+
+    store
+        .store(
+            &policy,
+            0,
+            "fp",
+            "k1",
+            vec![1.0, 0.0],
+            resp("old"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    // Purged: lookups under the new generation must miss even though
+    // the old document still physically exists.
+    let miss = store
+        .lookup(&policy, 1, "fp", &[1.0, 0.0], 0.5)
+        .await
+        .unwrap();
+    assert!(miss.is_none());
+    // Rewarm under the new generation.
+    store
+        .store(
+            &policy,
+            1,
+            "fp",
+            "k2",
+            vec![0.0, 1.0],
+            resp("new"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    let hit = store
+        .lookup(&policy, 1, "fp", &[0.0, 1.0], 0.9)
+        .await
+        .unwrap()
+        .expect("new-generation hit");
+    assert_eq!(hit.response.message.content_str(), "new");
+    // The old generation's entries never resurface.
+    let old = store
+        .lookup(&policy, 1, "fp", &[1.0, 0.0], 0.5)
+        .await
+        .unwrap();
+    assert!(old.is_none());
+}
+
+#[tokio::test]
+async fn dims_change_rotates_the_index() {
+    let Some(url) = vector_url() else { return };
+    let store = connect(&url).await;
+    let policy = unique("p-dims");
+
+    store
+        .store(
+            &policy,
+            0,
+            "fp",
+            "k1",
+            vec![1.0, 0.0],
+            resp("two-dim"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    // Same generation, different embedding dimensions (an in-place
+    // embedding-model change): a separate index — no cross-space hits,
+    // and storing works.
+    let miss = store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0, 0.0], 0.0)
+        .await
+        .unwrap();
+    assert!(miss.is_none());
+    store
+        .store(
+            &policy,
+            0,
+            "fp",
+            "k2",
+            vec![1.0, 0.0, 0.0],
+            resp("three-dim"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    let hit = store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0, 0.0], 0.9)
+        .await
+        .unwrap()
+        .expect("three-dim hit");
+    assert_eq!(hit.response.message.content_str(), "three-dim");
+}
+
+#[tokio::test]
+async fn entries_are_shared_across_store_instances() {
+    let Some(url) = vector_url() else { return };
+    let store_a = connect(&url).await;
+    let store_b = connect(&url).await;
+    let policy = unique("p-shared");
+
+    store_a
+        .store(
+            &policy,
+            0,
+            "fp",
+            "k1",
+            vec![1.0, 0.0],
+            resp("from-a"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    let hit = store_b
+        .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.9)
+        .await
+        .unwrap()
+        .expect("replica B must see replica A's entry");
+    assert_eq!(hit.response.message.content_str(), "from-a");
+}
+
+#[tokio::test]
+async fn ttl_expires_documents() {
+    let Some(url) = vector_url() else { return };
+    let store = connect(&url).await;
+    let policy = unique("p-ttl");
+
+    store
+        .store(
+            &policy,
+            0,
+            "fp",
+            "k1",
+            vec![1.0, 0.0],
+            resp("short"),
+            Duration::from_millis(150),
+            100,
+        )
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let miss = store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.5)
+        .await
+        .unwrap();
+    assert!(miss.is_none(), "expired document must not match");
+}
+
+#[tokio::test]
+async fn probe_fails_on_plain_redis() {
+    // Uses the PLAIN redis the exact-cache tests run against; skip when
+    // absent or when it actually has vector support (e.g. local dev
+    // pointing both vars at one Redis 8).
+    let Some(url) = std::env::var("CACHE_TEST_REDIS_PLAIN_URL").ok() else {
+        return;
+    };
+    let store = RedisSemanticCache::connect(&single(&url))
+        .await
+        .expect("connect");
+    assert!(
+        store.probe().await.is_err(),
+        "probe must fail on a server without vector search",
+    );
+}

--- a/crates/aisix-cache/tests/semantic_redis_integration.rs
+++ b/crates/aisix-cache/tests/semantic_redis_integration.rs
@@ -227,6 +227,124 @@ async fn generation_rotation_orphans_old_entries() {
 }
 
 #[tokio::test]
+async fn stale_generation_never_rotates_backwards() {
+    let Some(url) = vector_url() else { return };
+    let store = connect(&url).await;
+    let policy = unique("p-stale");
+
+    // Live at generation 1 with a document.
+    store
+        .store(
+            &policy,
+            1,
+            "fp",
+            "k-new",
+            vec![0.0, 1.0],
+            resp("new"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    // A stale in-flight writer (pre-purge snapshot) must be dropped —
+    // NOT recreate the generation-0 index and drop generation 1's
+    // documents.
+    store
+        .store(
+            &policy,
+            0,
+            "fp",
+            "k-old",
+            vec![1.0, 0.0],
+            resp("stale"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    let hit = store
+        .lookup(&policy, 1, "fp", &[0.0, 1.0], 0.9)
+        .await
+        .unwrap()
+        .expect("generation-1 document must survive the stale write");
+    assert_eq!(hit.response.message.content_str(), "new");
+    // Stale lookups miss rather than rotating.
+    let stale = store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.5)
+        .await
+        .unwrap();
+    assert!(stale.is_none());
+}
+
+#[tokio::test]
+async fn sweep_drops_only_empty_indexes() {
+    let Some(url) = vector_url() else { return };
+    let store = connect(&url).await;
+    let live = unique("p-sweep-live");
+    let dead = unique("p-sweep-dead");
+
+    store
+        .store(&live, 0, "fp", "k1", vec![1.0, 0.0], resp("live"), TTL, 100)
+        .await
+        .unwrap();
+    // An index whose documents all expired — the orphan shape a
+    // deleted policy leaves behind.
+    store
+        .store(
+            &dead,
+            0,
+            "fp",
+            "k1",
+            vec![1.0, 0.0],
+            resp("dead"),
+            Duration::from_millis(100),
+            100,
+        )
+        .await
+        .unwrap();
+    // Redis expires documents lazily — `num_docs` catches up when the
+    // active-expiry cycle reclaims the hash. Poll rather than assuming
+    // one fixed sleep is enough.
+    let mut dropped = 0;
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        dropped = store.sweep_empty_indexes().await.unwrap();
+        if dropped >= 1 {
+            break;
+        }
+    }
+    assert!(dropped >= 1, "the emptied index must be reclaimed");
+    // The live policy still serves.
+    let hit = store
+        .lookup(&live, 0, "fp", &[1.0, 0.0], 0.9)
+        .await
+        .unwrap()
+        .expect("live index must survive the sweep");
+    assert_eq!(hit.response.message.content_str(), "live");
+    // Even if the sweep raced the live index away, the store self-heals
+    // on the next touch (missing-index guard) — pin that too by
+    // storing + looking up once more.
+    store
+        .store(
+            &live,
+            0,
+            "fp",
+            "k2",
+            vec![0.0, 1.0],
+            resp("live2"),
+            TTL,
+            100,
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .lookup(&live, 0, "fp", &[0.0, 1.0], 0.9)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
 async fn dims_change_rotates_the_index() {
     let Some(url) = vector_url() else { return };
     let store = connect(&url).await;

--- a/crates/aisix-cache/tests/semantic_redis_integration.rs
+++ b/crates/aisix-cache/tests/semantic_redis_integration.rs
@@ -26,10 +26,16 @@ fn single(url: &str) -> RedisConnConfig {
     }
 }
 
-async fn connect(url: &str) -> RedisSemanticCache {
+/// Every test gets its own key/index namespace (via the env-namespace
+/// hook) so concurrent tests — and concurrent CI runs against one
+/// long-lived server — can never see each other's indexes. Without
+/// this, the sweep test races sibling tests' just-created (still
+/// empty) indexes away.
+async fn connect_ns(url: &str, ns: &str) -> RedisSemanticCache {
     let store = RedisSemanticCache::connect(&single(url))
         .await
-        .expect("connect");
+        .expect("connect")
+        .with_env_namespace(ns);
     store.probe().await.expect("vector-capable redis required");
     store
 }
@@ -60,8 +66,8 @@ const TTL: Duration = Duration::from_secs(60);
 #[tokio::test]
 async fn nearest_above_threshold_round_trips() {
     let Some(url) = vector_url() else { return };
-    let store = connect(&url).await;
     let policy = unique("p-roundtrip");
+    let store = connect_ns(&url, &policy).await;
 
     store
         .store(
@@ -100,8 +106,8 @@ async fn nearest_above_threshold_round_trips() {
 #[tokio::test]
 async fn scope_fp_partitions_candidates() {
     let Some(url) = vector_url() else { return };
-    let store = connect(&url).await;
     let policy = unique("p-scope");
+    let store = connect_ns(&url, &policy).await;
 
     store
         .store(
@@ -131,8 +137,8 @@ async fn scope_fp_partitions_candidates() {
 #[tokio::test]
 async fn store_upserts_by_exact_key() {
     let Some(url) = vector_url() else { return };
-    let store = connect(&url).await;
     let policy = unique("p-upsert");
+    let store = connect_ns(&url, &policy).await;
 
     store
         .store(
@@ -175,8 +181,8 @@ async fn store_upserts_by_exact_key() {
 #[tokio::test]
 async fn generation_rotation_orphans_old_entries() {
     let Some(url) = vector_url() else { return };
-    let store = connect(&url).await;
     let policy = unique("p-gen");
+    let store = connect_ns(&url, &policy).await;
 
     store
         .store(
@@ -229,8 +235,8 @@ async fn generation_rotation_orphans_old_entries() {
 #[tokio::test]
 async fn stale_generation_never_rotates_backwards() {
     let Some(url) = vector_url() else { return };
-    let store = connect(&url).await;
     let policy = unique("p-stale");
+    let store = connect_ns(&url, &policy).await;
 
     // Live at generation 1 with a document.
     store
@@ -279,9 +285,9 @@ async fn stale_generation_never_rotates_backwards() {
 #[tokio::test]
 async fn sweep_drops_only_empty_indexes() {
     let Some(url) = vector_url() else { return };
-    let store = connect(&url).await;
     let live = unique("p-sweep-live");
     let dead = unique("p-sweep-dead");
+    let store = connect_ns(&url, &live).await;
 
     store
         .store(&live, 0, "fp", "k1", vec![1.0, 0.0], resp("live"), TTL, 100)
@@ -347,8 +353,8 @@ async fn sweep_drops_only_empty_indexes() {
 #[tokio::test]
 async fn dims_change_rotates_the_index() {
     let Some(url) = vector_url() else { return };
-    let store = connect(&url).await;
     let policy = unique("p-dims");
+    let store = connect_ns(&url, &policy).await;
 
     store
         .store(
@@ -395,9 +401,9 @@ async fn dims_change_rotates_the_index() {
 #[tokio::test]
 async fn entries_are_shared_across_store_instances() {
     let Some(url) = vector_url() else { return };
-    let store_a = connect(&url).await;
-    let store_b = connect(&url).await;
     let policy = unique("p-shared");
+    let store_a = connect_ns(&url, &policy).await;
+    let store_b = connect_ns(&url, &policy).await;
 
     store_a
         .store(
@@ -423,8 +429,8 @@ async fn entries_are_shared_across_store_instances() {
 #[tokio::test]
 async fn ttl_expires_documents() {
     let Some(url) = vector_url() else { return };
-    let store = connect(&url).await;
     let policy = unique("p-ttl");
+    let store = connect_ns(&url, &policy).await;
 
     store
         .store(
@@ -449,17 +455,74 @@ async fn ttl_expires_documents() {
 
 #[tokio::test]
 async fn probe_fails_on_plain_redis() {
-    // Uses the PLAIN redis the exact-cache tests run against; skip when
-    // absent or when it actually has vector support (e.g. local dev
-    // pointing both vars at one Redis 8).
+    // `CACHE_TEST_REDIS_PLAIN_URL` points at a server WITHOUT vector
+    // search (CI: a redis:7 cluster node). Skip when absent — and skip
+    // rather than fail when the target actually has vector support,
+    // so local setups pointing it at a Redis 8 stay honest.
     let Some(url) = std::env::var("CACHE_TEST_REDIS_PLAIN_URL").ok() else {
         return;
     };
     let store = RedisSemanticCache::connect(&single(&url))
         .await
         .expect("connect");
-    assert!(
-        store.probe().await.is_err(),
-        "probe must fail on a server without vector search",
-    );
+    if store.probe().await.is_ok() {
+        return; // vector-capable target: nothing to pin here
+    }
+    // Reaching here means the probe failed — which IS the assertion;
+    // make it explicit for readers.
+    assert!(store.probe().await.is_err());
+}
+
+#[tokio::test]
+async fn lookup_recovers_after_external_index_loss() {
+    // Redis restarting empty (or an operator dropping the index) must
+    // not permanently disable the semantic layer: the memoized index
+    // is evicted on the "index not found" error and the next touch
+    // re-creates it.
+    let Some(url) = vector_url() else { return };
+    let policy = unique("p-recover");
+    let store = connect_ns(&url, &policy).await;
+
+    store
+        .store(&policy, 0, "fp", "k1", vec![1.0, 0.0], resp("a"), TTL, 100)
+        .await
+        .unwrap();
+    assert!(store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.9)
+        .await
+        .unwrap()
+        .is_some());
+
+    // Simulate the loss out-of-band through a raw connection.
+    let raw = aisix_redis::connect(&single(&url)).await.expect("raw conn");
+    let mut conn = raw.acquire().await.expect("acquire");
+    redis::cmd("FT.DROPINDEX")
+        .arg(format!("aisix:semcache:{policy}:idx:{policy}:0:2"))
+        .arg("DD")
+        .query_async::<()>(&mut conn)
+        .await
+        .expect("external drop");
+
+    // First call fails visibly (fail-open at the gate) and evicts the
+    // memo…
+    assert!(store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.9)
+        .await
+        .is_err());
+    // …the next one re-creates the (empty) index and misses cleanly…
+    assert!(store
+        .lookup(&policy, 0, "fp", &[1.0, 0.0], 0.9)
+        .await
+        .unwrap()
+        .is_none());
+    // …and the layer is fully functional again.
+    store
+        .store(&policy, 0, "fp", "k2", vec![0.0, 1.0], resp("b"), TTL, 100)
+        .await
+        .unwrap();
+    assert!(store
+        .lookup(&policy, 0, "fp", &[0.0, 1.0], 0.9)
+        .await
+        .unwrap()
+        .is_some());
 }

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -51,10 +51,11 @@ pub enum CacheScope {
 /// participate — requests containing images or audio never match by
 /// similarity.
 ///
-/// Similarity matching currently requires `backend: memory`. A policy
-/// with `backend: redis` accepts this configuration but keeps serving
-/// exact matches only (a warning is logged) until shared semantic
-/// storage ships.
+/// On `backend: redis`, similarity matching requires a Redis server
+/// with vector search (Redis 8 or later, or the search module) in
+/// `single` or `sentinel` mode; without it — or in `cluster` mode —
+/// the policy keeps serving exact matches only and a warning is
+/// logged.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct SemanticCacheConfig {
     /// Name of the `embedding` model used to embed requests. The model

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -47,6 +47,11 @@ pub struct CacheBackends {
     /// built — in-process, no config needed, zero cost until a policy
     /// with a `semantic` block matches a request.
     semantic_memory: Arc<dyn SemanticCacheStore>,
+    /// Semantic (L2) store for `backend: redis` policies. Wired by the
+    /// bootstrap only when `cache.redis` is configured, is not cluster
+    /// mode, AND the server passed the vector-search capability probe —
+    /// so its absence here IS the degradation signal.
+    semantic_redis: Option<Arc<dyn SemanticCacheStore>>,
     /// Policy ids already warned about an unavailable redis backend,
     /// so the gate logs once per policy instead of once per request.
     redis_warned: Arc<DashSet<String>>,
@@ -65,10 +70,18 @@ impl CacheBackends {
             memory,
             redis,
             semantic_memory: Arc::new(MemorySemanticCache::new()),
+            semantic_redis: None,
             redis_warned: Arc::new(DashSet::new()),
             semantic_redis_warned: Arc::new(DashSet::new()),
             semantic_resolve_warned: Arc::new(DashSet::new()),
         }
+    }
+
+    /// Attach the shared semantic store for `backend: redis` policies.
+    /// The bootstrap calls this only after the capability probe passed.
+    pub fn with_semantic_redis(mut self, store: Arc<dyn SemanticCacheStore>) -> Self {
+        self.semantic_redis = Some(store);
+        self
     }
 
     /// True the FIRST time `policy_id` reports a stable semantic config
@@ -127,19 +140,19 @@ impl CacheBackends {
         match backend {
             CacheBackend::Memory => Some(&self.semantic_memory),
             CacheBackend::Redis => {
-                // The shared (redis) semantic store ships separately;
-                // until then a redis-backed policy runs exact-only.
-                if self.semantic_redis_warned.insert(policy_id.to_string()) {
+                let store = self.semantic_redis.as_ref();
+                if store.is_none() && self.semantic_redis_warned.insert(policy_id.to_string()) {
                     tracing::warn!(
                         target: "aisix::cache",
                         policy_id = %policy_id,
                         policy_name = %policy_name,
-                        "cache policy configures semantic matching on backend=redis, \
-                         which this gateway version does not support yet; requests \
-                         fall back to exact matching only"
+                        "cache policy configures semantic matching on backend=redis but \
+                         the configured cache.redis has no vector-search support \
+                         (requires Redis 8+ or the search module; cluster mode is not \
+                         supported yet); requests fall back to exact matching only"
                     );
                 }
-                None
+                store
             }
         }
     }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -751,10 +751,56 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         }
         None => None,
     };
-    let cache = Some(CacheBackends::new(
-        Arc::new(MemoryCache::with_defaults()),
-        redis_cache,
-    ));
+    // Shared semantic (L2) store for `backend: redis` policies. Wired
+    // only when the server passes the vector-search probe — a plain
+    // Redis 6/7 (or cluster mode, unsupported yet) degrades those
+    // policies to exact-only, loudly, HERE at boot rather than
+    // silently per request.
+    let semantic_redis: Option<Arc<dyn aisix_cache::SemanticCacheStore>> =
+        match cfg.cache.redis.as_ref() {
+            Some(redis_cfg) if redis_cfg.mode == aisix_core::RedisMode::Cluster => {
+                tracing::warn!(
+                    target: "aisix::cache",
+                    "cache.redis is in cluster mode; semantic matching on backend=redis \
+                     policies is not supported yet and stays exact-only"
+                );
+                None
+            }
+            Some(redis_cfg) => {
+                let store = aisix_cache::RedisSemanticCache::connect(redis_cfg)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("redis semantic cache connect failed (cache.redis): {e}")
+                    })?
+                    .with_env_namespace(&cfg.etcd.env_id);
+                match store.probe().await {
+                    Ok(()) => {
+                        tracing::info!(
+                            target: "aisix::cache",
+                            "cache.redis supports vector search; semantic matching \
+                             enabled for backend=redis policies"
+                        );
+                        Some(Arc::new(store) as Arc<dyn aisix_cache::SemanticCacheStore>)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "aisix::cache",
+                            error = %e,
+                            "cache.redis has no vector-search support; semantic matching \
+                             on backend=redis policies stays exact-only"
+                        );
+                        None
+                    }
+                }
+            }
+            None => None,
+        };
+    let mut cache_backends =
+        CacheBackends::new(Arc::new(MemoryCache::with_defaults()), redis_cache);
+    if let Some(store) = semantic_redis {
+        cache_backends = cache_backends.with_semantic_redis(store);
+    }
+    let cache = Some(cache_backends);
 
     let mut proxy_state = ProxyState::with_components(
         snapshot_handle.clone(),

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -767,29 +767,57 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 None
             }
             Some(redis_cfg) => {
-                let store = aisix_cache::RedisSemanticCache::connect(redis_cfg)
-                    .await
-                    .map_err(|e| {
-                        anyhow::anyhow!("redis semantic cache connect failed (cache.redis): {e}")
-                    })?
-                    .with_env_namespace(&cfg.etcd.env_id);
-                match store.probe().await {
-                    Ok(()) => {
-                        tracing::info!(
-                            target: "aisix::cache",
-                            "cache.redis supports vector search; semantic matching \
-                             enabled for backend=redis policies"
-                        );
-                        Some(Arc::new(store) as Arc<dyn aisix_cache::SemanticCacheStore>)
-                    }
+                // Degrade (never abort) on any failure here: the exact
+                // redis cache above is the load-bearing connection; the
+                // semantic store is an optimization layer.
+                match aisix_cache::RedisSemanticCache::connect(redis_cfg).await {
                     Err(e) => {
                         tracing::warn!(
                             target: "aisix::cache",
                             error = %e,
-                            "cache.redis has no vector-search support; semantic matching \
+                            "redis semantic cache connect failed; semantic matching \
                              on backend=redis policies stays exact-only"
                         );
                         None
+                    }
+                    Ok(store) => {
+                        let store = store.with_env_namespace(&cfg.etcd.env_id);
+                        match store.probe().await {
+                            Ok(()) => {
+                                match store.sweep_empty_indexes().await {
+                                    Ok(dropped) if dropped > 0 => {
+                                        tracing::info!(
+                                            target: "aisix::cache",
+                                            dropped,
+                                            "reclaimed empty semantic-cache indexes"
+                                        );
+                                    }
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            target: "aisix::cache",
+                                            error = %e,
+                                            "semantic-cache index sweep failed; continuing"
+                                        );
+                                    }
+                                }
+                                tracing::info!(
+                                    target: "aisix::cache",
+                                    "cache.redis supports vector search; semantic matching \
+                                     enabled for backend=redis policies"
+                                );
+                                Some(Arc::new(store) as Arc<dyn aisix_cache::SemanticCacheStore>)
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    target: "aisix::cache",
+                                    error = %e,
+                                    "cache.redis has no vector-search support; semantic matching \
+                                     on backend=redis policies stays exact-only"
+                                );
+                                None
+                            }
+                        }
                     }
                 }
             }

--- a/schemas/resources/cache_policy.schema.json
+++ b/schemas/resources/cache_policy.schema.json
@@ -29,7 +29,7 @@
       ]
     },
     "SemanticCacheConfig": {
-      "description": "Embedding-similarity matching for a cache policy. When present, a request that misses the exact layer is embedded and compared against stored entries; the nearest entry at or above `threshold` cosine similarity is served. Only requests whose messages are entirely text participate — requests containing images or audio never match by similarity.\n\nSimilarity matching currently requires `backend: memory`. A policy with `backend: redis` accepts this configuration but keeps serving exact matches only (a warning is logged) until shared semantic storage ships.",
+      "description": "Embedding-similarity matching for a cache policy. When present, a request that misses the exact layer is embedded and compared against stored entries; the nearest entry at or above `threshold` cosine similarity is served. Only requests whose messages are entirely text participate — requests containing images or audio never match by similarity.\n\nOn `backend: redis`, similarity matching requires a Redis server with vector search (Redis 8 or later, or the search module) in `single` or `sentinel` mode; without it — or in `cluster` mode — the policy keeps serving exact matches only and a warning is logged.",
       "properties": {
         "embedding_model": {
           "description": "Name of the `embedding` model used to embed requests. The model must exist in the same environment and carry an `embedding` block; its `dimensions` value fixes the vector size for this policy's entries.",

--- a/tests/e2e/src/cases/cache-semantic-redis-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-semantic-redis-e2e.test.ts
@@ -345,6 +345,11 @@ describe("semantic cache on shared redis (vector-capable)", () => {
   });
 });
 
+// A dedicated vector-LESS redis for this suite when provided (CI sets
+// AISIX_E2E_REDIS_PLAIN to a redis:7 service); otherwise fall back to
+// the main URL and run only when IT happens to lack vector support.
+const PLAIN_REDIS_URL = process.env.AISIX_E2E_REDIS_PLAIN ?? REDIS_URL;
+
 describe("semantic on backend=redis degrades to exact-only without vector support", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
@@ -354,12 +359,12 @@ describe("semantic on backend=redis degrades to exact-only without vector suppor
   beforeAll(async () => {
     const etcd = new EtcdClient();
     if (!(await etcd.ping())) return;
-    if ((await redisVectorSupport(REDIS_URL)) !== false) return;
+    if ((await redisVectorSupport(PLAIN_REDIS_URL)) !== false) return;
 
     embedMock = await startEmbeddingMock();
     upstream = await startOpenAiUpstream();
     app = await spawnApp({
-      extra: { cache: { backend: "memory", redis: { url: REDIS_URL } } },
+      extra: { cache: { backend: "memory", redis: { url: PLAIN_REDIS_URL } } },
     });
     const seed = new SeedClient(etcd, app.etcdPrefix);
     await seedFixtures(seed, embedMock.baseUrl, upstream.baseUrl);

--- a/tests/e2e/src/cases/cache-semantic-redis-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-semantic-redis-e2e.test.ts
@@ -37,6 +37,10 @@ const CALLER_KEY_HASH = createHash("sha256")
 /** RESP-level probe: does the server speak FT.* (vector search)?
  *  `null` = server unreachable (both suites skip). */
 async function redisVectorSupport(url: string): Promise<boolean | null> {
+  // Plaintext RESP probe: a rediss:// target cannot be probed this way
+  // — that is "unknown", not "unsupported", so both suites skip
+  // honestly rather than mislabeling a TLS server as vector-less.
+  if (/^rediss:\/\//.test(url)) return null;
   const m = /^redis:\/\/(?:[^@/]*@)?([^:/]+)(?::(\d+))?/.exec(url);
   if (!m) return null;
   const host = m[1];
@@ -50,8 +54,11 @@ async function redisVectorSupport(url: string): Promise<boolean | null> {
     sock.once("data", (buf) => {
       const head = buf.toString();
       if (head.startsWith("*")) return done(true); // array reply = supported
-      if (head.startsWith("-ERR unknown command")) return done(false);
-      done(false);
+      // Only an explicit unknown-command error PROVES the capability is
+      // absent; anything else (auth required, loading, protocol noise)
+      // proves nothing either way.
+      if (/^-ERR unknown command/i.test(head)) return done(false);
+      done(null);
     });
     sock.once("error", () => done(null));
     sock.setTimeout(1000, () => done(null));

--- a/tests/e2e/src/cases/cache-semantic-redis-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-semantic-redis-e2e.test.ts
@@ -1,0 +1,401 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { connect } from "node:net";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { pickFreePort } from "../harness/ports.js";
+
+// E2E: semantic cache on the SHARED redis backend (AISIX-Cloud#558,
+// follow-up to the in-process store). Two DP replicas of one
+// environment (same etcd prefix) share one vector-capable Redis: an
+// entry stored by replica A must serve replica B both exactly AND
+// semantically, and a purge must invalidate across replicas.
+//
+// Capability-conditional: the vector suite runs iff AISIX_E2E_REDIS
+// speaks the vector-search command family (redis:8+ — what CI
+// provisions); the degradation suite runs iff it does NOT (a plain
+// redis 6/7), pinning that `semantic` on a backend=redis policy then
+// stays exact-only without failing traffic. Each suite skips honestly
+// when its capability precondition doesn't hold.
+
+const REDIS_URL = process.env.AISIX_E2E_REDIS ?? "redis://127.0.0.1:6379";
+
+const CALLER_PLAINTEXT = "sk-semredis-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+/** RESP-level probe: does the server speak FT.* (vector search)?
+ *  `null` = server unreachable (both suites skip). */
+async function redisVectorSupport(url: string): Promise<boolean | null> {
+  const m = /^redis:\/\/(?:[^@/]*@)?([^:/]+)(?::(\d+))?/.exec(url);
+  if (!m) return null;
+  const host = m[1];
+  const port = m[2] ? Number(m[2]) : 6379;
+  return new Promise((resolve) => {
+    const sock = connect({ host, port }, () => sock.write("FT._LIST\r\n"));
+    const done = (v: boolean | null) => {
+      sock.destroy();
+      resolve(v);
+    };
+    sock.once("data", (buf) => {
+      const head = buf.toString();
+      if (head.startsWith("*")) return done(true); // array reply = supported
+      if (head.startsWith("-ERR unknown command")) return done(false);
+      done(false);
+    });
+    sock.once("error", () => done(null));
+    sock.setTimeout(1000, () => done(null));
+  });
+}
+
+function keywordVector(text: string): number[] {
+  const t = text.toLowerCase();
+  if (t.includes("shared-topic")) return [1, 0, 0, 0];
+  if (t.includes("purge-topic")) return [0, 1, 0, 0];
+  return [0, 0, 0, 1];
+}
+
+interface EmbeddingMock {
+  baseUrl: string;
+  close(): Promise<void>;
+}
+
+async function startEmbeddingMock(): Promise<EmbeddingMock> {
+  const server: Server = createServer((req, res) => {
+    res.on("error", () => {});
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      const body = JSON.parse(raw || "{}") as { input?: string | string[] };
+      const inputs = Array.isArray(body.input)
+        ? body.input
+        : [body.input ?? ""];
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          object: "list",
+          model: "embed-mock",
+          data: inputs.map((text, index) => ({
+            object: "embedding",
+            index,
+            embedding: keywordVector(text),
+          })),
+          usage: { prompt_tokens: inputs.length, total_tokens: inputs.length },
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) =>
+    server.listen(port, "127.0.0.1", resolve),
+  );
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+interface ChatResult {
+  status: number;
+  content: string | undefined;
+  cache: string | null;
+  layer: string | null;
+  similarity: number | null;
+}
+
+async function chatOn(
+  proxyUrl: string,
+  model: string,
+  prompt: string,
+): Promise<ChatResult> {
+  const res = await fetch(`${proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  let content: string | undefined;
+  if (res.status === 200) {
+    const json = (await res.json()) as {
+      choices?: { message?: { content?: string } }[];
+    };
+    content = json.choices?.[0]?.message?.content;
+  } else {
+    await res.text();
+  }
+  const sim = res.headers.get("x-aisix-cache-similarity");
+  return {
+    status: res.status,
+    content,
+    cache: res.headers.get("x-aisix-cache"),
+    layer: res.headers.get("x-aisix-cache-layer"),
+    similarity: sim === null ? null : Number(sim),
+  };
+}
+
+/** Seed the full fixture set (embed model, chat model, redis+semantic
+ *  policy, caller key LAST per tests/e2e/AGENTS.md), returning the
+ *  policy handle for the purge test. */
+async function seedFixtures(
+  seed: SeedClient,
+  embedBase: string,
+  upstreamBase: string,
+): Promise<{ policyId: string; policyBody: Record<string, unknown> }> {
+  const embedPk = await seed.createProviderKey({
+    display_name: "semredis-embed-pk",
+    secret: "sk-mock",
+    api_base: `${embedBase}/v1`,
+  });
+  await seed.createModel({
+    display_name: "embed-redis",
+    provider: "openai",
+    model_name: "embed-mock",
+    provider_key_id: embedPk.id,
+    embedding: { dimensions: 4, normalize: true },
+  });
+  const chatPk = await seed.createProviderKey({
+    display_name: "semredis-chat-pk",
+    secret: "sk-mock",
+    api_base: `${upstreamBase}/v1`,
+  });
+  await seed.createModel({
+    display_name: "chat-redis",
+    provider: "openai",
+    model_name: "gpt-4o-mini",
+    provider_key_id: chatPk.id,
+  });
+  const policy = await seed.createCachePolicy({
+    name: "sem-redis",
+    backend: "redis",
+    applies_to: "model:chat-redis",
+    ttl_seconds: 600,
+    semantic: { embedding_model: "embed-redis", threshold: 0.85 },
+  });
+  await seed.createApiKey({
+    key_hash: CALLER_KEY_HASH,
+    allowed_models: ["*"],
+  });
+  return { policyId: policy.id, policyBody: policy.value };
+}
+
+async function waitKeyLive(proxyUrl: string): Promise<void> {
+  const probe = new ProxyClient(proxyUrl, CALLER_PLAINTEXT);
+  await waitConfigPropagation(
+    async () => (await probe.listModels()).status === 200,
+  );
+}
+
+describe("semantic cache on shared redis (vector-capable)", () => {
+  let appA: SpawnedApp | undefined;
+  let appB: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let embedMock: EmbeddingMock | undefined;
+  let policyId: string;
+  let policyBody: Record<string, unknown>;
+  let ready = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    if (!(await etcd.ping())) return;
+    if ((await redisVectorSupport(REDIS_URL)) !== true) return;
+
+    embedMock = await startEmbeddingMock();
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-shared",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "answer-shared-redis" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 7, completion_tokens: 5, total_tokens: 12 },
+      },
+    });
+    const redisExtra = {
+      cache: { backend: "memory", redis: { url: REDIS_URL } },
+    };
+    appA = await spawnApp({ extra: redisExtra });
+    appB = await spawnApp({ extra: redisExtra, etcdPrefix: appA.etcdPrefix });
+    seed = new SeedClient(etcd, appA.etcdPrefix);
+    ({ policyId, policyBody } = await seedFixtures(
+      seed,
+      embedMock.baseUrl,
+      upstream.baseUrl,
+    ));
+    await waitKeyLive(appA.proxyUrl);
+    await waitKeyLive(appB.proxyUrl);
+    ready = true;
+  });
+
+  afterAll(async () => {
+    await appA?.exit();
+    await appB?.exit();
+    await upstream?.close();
+    await embedMock?.close();
+  });
+
+  test("replica A's entry serves replica B exactly AND semantically", async (ctx) => {
+    if (!ready) {
+      ctx.skip();
+      return;
+    }
+    const baseline = upstream!.receivedRequests.length;
+    // Unique-enough prompt per run: redis outlives the test process.
+    const runTag = `${process.pid}-${Date.now()}`;
+    const prompt = `shared-topic question ${runTag}`;
+
+    const first = await chatOn(appA!.proxyUrl, "chat-redis", prompt);
+    expect(first.status).toBe(200);
+    expect(first.cache).toBe("miss");
+    expect(upstream!.receivedRequests.length).toBe(baseline + 1);
+
+    // Same wording on the OTHER replica: exact layer through redis.
+    const exactB = await chatOn(appB!.proxyUrl, "chat-redis", prompt);
+    expect(exactB.cache).toBe("hit");
+    expect(exactB.layer).toBe("exact");
+    expect(exactB.content).toBe("answer-shared-redis");
+
+    // Different wording, same meaning, on the OTHER replica: the
+    // semantic layer itself is shared — the entry was stored by A.
+    const semanticB = await chatOn(
+      appB!.proxyUrl,
+      "chat-redis",
+      `shared-topic rephrased ${runTag}`,
+    );
+    expect(semanticB.cache).toBe("hit");
+    expect(semanticB.layer).toBe("semantic");
+    expect(semanticB.similarity).not.toBeNull();
+    expect(semanticB.similarity!).toBeGreaterThanOrEqual(0.85);
+    expect(semanticB.content).toBe("answer-shared-redis");
+    expect(upstream!.receivedRequests.length).toBe(baseline + 1);
+  });
+
+  test("purge invalidates across replicas", async (ctx) => {
+    if (!ready) {
+      ctx.skip();
+      return;
+    }
+    const runTag = `${process.pid}-${Date.now()}`;
+    const prompt = `purge-topic question ${runTag}`;
+    const seeded = await chatOn(appA!.proxyUrl, "chat-redis", prompt);
+    expect(seeded.cache).toBe("miss");
+    expect((await chatOn(appB!.proxyUrl, "chat-redis", prompt)).cache).toBe(
+      "hit",
+    );
+
+    await seed!.update("cache_policies", policyId, {
+      ...policyBody,
+      purge_generation: 1,
+    });
+    // Seal the update on BOTH replicas: a canary key seeded after the
+    // update authenticating proves the new generation landed
+    // (tests/e2e/AGENTS.md).
+    const canary = `sk-semredis-canary-${runTag}`;
+    await seed!.createApiKey({
+      key_hash: createHash("sha256").update(canary).digest("hex"),
+      allowed_models: ["*"],
+    });
+    for (const app of [appA!, appB!]) {
+      const probe = new ProxyClient(app.proxyUrl, canary);
+      await waitConfigPropagation(
+        async () => (await probe.listModels()).status === 200,
+      );
+    }
+
+    // Semantic first, on the axis nothing has re-stored yet: the
+    // pre-purge entry is unreachable from the OTHER replica.
+    const semanticB = await chatOn(
+      appB!.proxyUrl,
+      "chat-redis",
+      `purge-topic rephrased ${runTag}`,
+    );
+    expect(semanticB.cache).toBe("miss");
+    // The pre-purge WORDING on replica A is no longer exact-served: it
+    // matches the rephrased request's fresh entry SEMANTICALLY (layer
+    // discriminates — an un-purged exact entry would win as `exact`).
+    const oldWording = await chatOn(appA!.proxyUrl, "chat-redis", prompt);
+    expect(oldWording.cache).toBe("hit");
+    expect(oldWording.layer).toBe("semantic");
+  });
+});
+
+describe("semantic on backend=redis degrades to exact-only without vector support", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let embedMock: EmbeddingMock | undefined;
+  let ready = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    if (!(await etcd.ping())) return;
+    if ((await redisVectorSupport(REDIS_URL)) !== false) return;
+
+    embedMock = await startEmbeddingMock();
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp({
+      extra: { cache: { backend: "memory", redis: { url: REDIS_URL } } },
+    });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    await seedFixtures(seed, embedMock.baseUrl, upstream.baseUrl);
+    await waitKeyLive(app.proxyUrl);
+    ready = true;
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await embedMock?.close();
+  });
+
+  test("exact matching keeps working; similar wording pays the upstream", async (ctx) => {
+    if (!ready) {
+      ctx.skip();
+      return;
+    }
+    const runTag = `${process.pid}-${Date.now()}`;
+    const prompt = `shared-topic question ${runTag}`;
+    const first = await chatOn(app!.proxyUrl, "chat-redis", prompt);
+    expect(first.status).toBe(200);
+    expect(first.cache).toBe("miss");
+
+    const exact = await chatOn(app!.proxyUrl, "chat-redis", prompt);
+    expect(exact.cache).toBe("hit");
+    expect(exact.layer).toBe("exact");
+
+    // Same meaning, different wording: no semantic layer available —
+    // the request pays the upstream and still succeeds.
+    const similar = await chatOn(
+      app!.proxyUrl,
+      "chat-redis",
+      `shared-topic rephrased ${runTag}`,
+    );
+    expect(similar.status).toBe(200);
+    expect(similar.cache).toBe("miss");
+  });
+});


### PR DESCRIPTION
## Summary

Completes the semantic cache's storage story (follow-up to #918, part of the feature tracked in api7/AISIX-Cloud#558): a `backend: redis` cache policy carrying a `semantic` block now matches by embedding similarity through the operator's existing `cache.redis`, **shared across gateway replicas** — where #918's in-process store left those policies exact-only with a warning.

## Design

- **`RedisSemanticCache`** implements the `SemanticCacheStore` seam from #918 over the shared connection layer (`single`/`sentinel` honored; its own connection so the exact cache's pipeline isn't serialized).
- **Layout**: one vector index per `(policy, generation, dims)` — HNSW, cosine — over HASH documents; the candidate partition rides a TAG field (the partition fingerprint is hashed to a tag-safe token, since TAG values tokenize on punctuation). One document per exact wording, keyed by the exact-layer fingerprint: a `Cache-Control: no-cache` refresh overwrites in place (the upsert contract for free), and every document carries its own TTL — growth is TTL-bounded, so `max_entries` is intentionally ignored per the trait docs.
- **Purge / embedding-model changes rotate the index identity**: a new `(generation, dims)` gets a fresh index and the previous one is dropped with its documents (`FT.DROPINDEX DD`) on the instance's next touch of the policy. Lookup hits report the document's remaining `PTTL` so the exact-layer backfill cap from #918 keeps working.
- **Capability is probed once at boot** (`FT._LIST`): a `cache.redis` without vector search — plain Redis 6/7 — or in cluster mode (unsupported yet: `FT.*` routing across shards) does NOT get the store wired, and `backend: redis` policies degrade to exact-only through #918's existing warn-once path. Loud at boot, zero per-request capability checks. Requires **Redis 8+** (vector search ships in core) or the search module.
- Reference: Redis vector search (`FT.CREATE ... VECTOR HNSW`, `FT.SEARCH ... KNN`, `DIALECT 2`) <https://redis.io/docs/latest/develop/interact/search-and-query/query/vector-search/>. Mainstream gateways gate their shared semantic caches on the same server capability (search-module Redis or a dedicated vector database); probing at boot and degrading visibly instead of failing traffic follows the fail-open contract #918 established.

## CI

The redis services bump `redis:7-alpine` → `redis:8-alpine` (a superset — every existing exact-cache/ratelimit test keeps its semantics). New env: `CACHE_TEST_REDIS_VECTOR_URL` (the redis:8 service) for the integration suite, and `CACHE_TEST_REDIS_PLAIN_URL` (a redis:7 cluster node) pinning the capability probe's failure path.

## Test plan

- `cargo test --workspace` green (50 targets); clippy `-D warnings` + fmt clean.
- **8 Rust integration cases** against a live vector-capable redis: identical-vector roundtrip incl. remaining-TTL reporting, threshold miss, scope-partition isolation, upsert-by-exact-key, generation rotation (old entries never resurface), dims rotation (in-place embedding-model change), cross-instance sharing, TTL expiry — plus the probe-failure case against plain redis.
- **E2E** (`cache-semantic-redis-e2e.test.ts`, capability-conditional both ways): two replicas on one etcd prefix sharing one redis — replica A's entry serves replica B **exactly and semantically** with zero extra upstream calls; a purge invalidates across replicas (semantic-first assertion order and a layer-discriminated old-wording check avoid the re-store trap the memory suite documented); on a vector-less redis the same policy serves exact-only and similar wording pays the upstream without failing.
- Full cache e2e regression (12 files, 28 passed) against redis:8 locally; the degradation suite verified against a local redis:7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis-backed semantic caching with similarity matching when Redis vector search is available.
  * Supports shared semantic cache behavior across proxy instances, including expiration, invalidation, and policy isolation.
  * Added automatic capability detection and index maintenance.

* **Bug Fixes**
  * Redis configurations without vector-search support now safely fall back to exact matching instead of preventing startup.

* **Documentation**
  * Updated cache configuration guidance and schema descriptions for Redis semantic caching requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes api7/AISIX-Cloud#558
