### PR TITLE
test: freeze the unit-test rate-limit clock; widen the audio-timeout e2e margin

### DIFF
--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -258,10 +258,25 @@ impl ProxyState {
         let metrics = Arc::new(Metrics::new(false));
         let guardrail_index =
             LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
+        // Unit tests get a frozen rate-limit clock: on the wall clock, any
+        // "the next request 429s" assertion silently races the fixed-window
+        // minute boundary — a test that straddles :00 lands its two requests
+        // in different windows and the 429 never comes (seen flaking in the
+        // mcp per-server-limit tests under a loaded runner). Freezing the
+        // clock puts every request of a test in one window by construction.
+        // Only this crate's own test build is affected; other crates calling
+        // `ProxyState::new` (e.g. aisix-admin's playground) compile the
+        // system-clock arm.
+        #[cfg(test)]
+        let limiter = Arc::new(Limiter::local_with_clock(aisix_ratelimit::TestClock::new(
+            1_763_000_000,
+        )));
+        #[cfg(not(test))]
+        let limiter = Arc::new(Limiter::new());
         Self::from_inner(ProxyStateInner {
             snapshot,
             hub,
-            limiter: Arc::new(Limiter::new()),
+            limiter,
             metrics,
             cache: Some(CacheBackends::memory_only()),
             routing: Arc::new(RoutingRegistry::new()),

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -253,6 +253,11 @@ impl std::ops::DerefMut for ProxyState {
     }
 }
 
+/// Frozen `unix_secs` for unit-test limiters — an arbitrary mid-window
+/// instant; the exact value only shapes reported retry-after seconds.
+#[cfg(test)]
+const TEST_RATE_LIMIT_CLOCK_SECS: u64 = 1_763_000_000;
+
 impl ProxyState {
     pub fn new(snapshot: SnapshotHandle<AisixSnapshot>, hub: Arc<Hub>, cfg: &ProxyConfig) -> Self {
         let metrics = Arc::new(Metrics::new(false));
@@ -269,7 +274,7 @@ impl ProxyState {
         // system-clock arm.
         #[cfg(test)]
         let limiter = Arc::new(Limiter::local_with_clock(aisix_ratelimit::TestClock::new(
-            1_763_000_000,
+            TEST_RATE_LIMIT_CLOCK_SECS,
         )));
         #[cfg(not(test))]
         let limiter = Arc::new(Limiter::new());

--- a/tests/e2e/src/cases/audio-timeout-e2e.test.ts
+++ b/tests/e2e/src/cases/audio-timeout-e2e.test.ts
@@ -150,10 +150,13 @@ describe("audio request timeout (#911 [22])", () => {
     });
     const elapsed = Date.now() - started;
 
-    // The upstream stalls for SLOW_MS; the model timeout must abandon it well
+    // The upstream stalls for SLOW_MS; the model timeout must abandon it
     // before that. Before the fix no timeout was applied and this waited the
-    // full SLOW_MS, so the elapsed-time bound is what fails pre-fix.
+    // full SLOW_MS, so the elapsed-time bound is what fails pre-fix — any
+    // bound under SLOW_MS discriminates, since the stall is a hard floor.
+    // Keep the margin over TIMEOUT_MS wide: a loaded CI runner has been
+    // seen adding ~1.8s of overhead on top of the 400ms timeout.
     expect(res.ok).toBe(false);
-    expect(elapsed).toBeLessThan(SLOW_MS - 800);
+    expect(elapsed).toBeLessThan(SLOW_MS - 200);
   }, 30_000);
 });


### PR DESCRIPTION
Two CI de-flakes, both timing races a loaded runner can lose.

**Frozen rate-limit clock in proxy unit tests.** Every "the next request 429s" assertion implicitly requires both requests to land in the same fixed-window minute. On the wall clock, a test that straddles an :00 boundary puts them in different windows and the 429 never comes — reproduced on the `mcp` per-server-limit tests under a loaded machine (the two requests crossed the boundary), and any of the ~15 OK-then-429 tests in the crate can lose the same race. `ProxyState::new` now pins the limiter to `TestClock` under `#[cfg(test)]`, so every request a unit test makes lands in one window by construction. Production callers (including aisix-admin's playground, a separate crate) compile the system-clock arm; the deterministic-clock hook (`with_limiter`, previously unused) is what this wires up.

**Audio-timeout elapsed bound.** `audio-timeout-e2e` asserted `elapsed < SLOW_MS - 800` (2200ms) while the model timeout fires at 400ms — a CI run has been observed at 2202ms, failing by 2ms of runner overhead. The bound is now `SLOW_MS - 200`: still strictly below the upstream's 3000ms stall (the pre-fix behavior waits the full stall, so the regression still fails hard), with 600ms more headroom for a slow runner.

No behavior change outside test builds. Existing suite passes unchanged with the frozen clock (855/855).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio timeout handling in end-to-end testing to better accommodate CI timing variations while preserving the expected timeout behavior.
  * Made rate-limiter timing deterministic during automated tests, improving consistency and reliability of test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->