### PR TITLE
fix(obs): carry the full error source chain in sink failure details

### DIFF
--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -551,8 +551,13 @@ impl ObservabilitySink for OtlpSink {
                     Err(SinkError::Permanent(detail))
                 }
             }
-            // Connect / DNS / timeout — transient by nature.
-            Err(e) => Err(SinkError::Transient(format!("POST {}: {e}", self.endpoint))),
+            // Connect / DNS / timeout — transient by nature. reqwest's
+            // Display hides the cause in `source()` — chain it.
+            Err(e) => Err(SinkError::Transient(format!(
+                "POST {}: {}",
+                self.endpoint,
+                crate::sink::error_chain(&e)
+            ))),
         }
     }
 

--- a/crates/aisix-obs/src/sink/datadog.rs
+++ b/crates/aisix-obs/src/sink/datadog.rs
@@ -153,11 +153,13 @@ impl ObservabilitySink for DatadogSink {
         {
             Ok(resp) => resp,
             // Connect / DNS / timeout — transient by nature. The endpoint URL
-            // carries no secret, so it is safe in the error detail.
+            // carries no secret, so it is safe in the error detail. reqwest's
+            // Display hides the cause in `source()` — chain it.
             Err(e) => {
                 return Err(SinkError::Transient(format!(
-                    "datadog: POST {}: {e}",
-                    self.endpoint_url
+                    "datadog: POST {}: {}",
+                    self.endpoint_url,
+                    super::error_chain(&e)
                 )))
             }
         };

--- a/crates/aisix-obs/src/sink/mod.rs
+++ b/crates/aisix-obs/src/sink/mod.rs
@@ -91,6 +91,30 @@ impl SinkError {
     }
 }
 
+/// Render an error together with its full `source()` chain.
+///
+/// `Display` on a transport error usually names only the outermost layer
+/// ("error sending request", "Error performing PUT <url>") while the
+/// actionable cause — a DNS failure, a TLS verification error — sits levels
+/// deeper. The nightly objstore smoke burned five weeks on a detail that
+/// ended at the request URL before anyone saw the underlying
+/// "failed to lookup address information". Layers whose text the outer
+/// message already embeds are skipped, so wrappers that interpolate their
+/// source don't repeat it.
+pub(crate) fn error_chain(e: &dyn std::error::Error) -> String {
+    let mut out = e.to_string();
+    let mut cur = e.source();
+    while let Some(src) = cur {
+        let text = src.to_string();
+        if !out.contains(&text) {
+            out.push_str(": ");
+            out.push_str(&text);
+        }
+        cur = src.source();
+    }
+    out
+}
+
 /// Result of one [`ObservabilitySink::append_batch`] call.
 pub type SinkResult = Result<SinkAck, SinkError>;
 
@@ -214,5 +238,60 @@ mod tests {
         let bad = SinkHealth::unhealthy("endpoint unreachable");
         assert!(!bad.healthy);
         assert_eq!(bad.detail.as_deref(), Some("endpoint unreachable"));
+    }
+
+    #[derive(Debug)]
+    struct Layered {
+        text: &'static str,
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    }
+
+    impl std::fmt::Display for Layered {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.text)
+        }
+    }
+
+    impl std::error::Error for Layered {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.source
+                .as_deref()
+                .map(|s| s as &(dyn std::error::Error + 'static))
+        }
+    }
+
+    #[test]
+    fn error_chain_appends_hidden_sources() {
+        // The wrapper's Display names only itself — the shape reqwest and
+        // object_store's retry error have, which is what buried the DNS
+        // cause of the nightly objstore failure.
+        let e = Layered {
+            text: "error sending request",
+            source: Some(Box::new(Layered {
+                text: "dns error: failed to lookup address information",
+                source: None,
+            })),
+        };
+        assert_eq!(
+            error_chain(&e),
+            "error sending request: dns error: failed to lookup address information"
+        );
+    }
+
+    #[test]
+    fn error_chain_skips_sources_already_interpolated() {
+        // Wrappers that embed their source's Display (thiserror's
+        // `#[error("outer: {0}")]` pattern) must not repeat it.
+        let e = Layered {
+            text: "outer: inner detail",
+            source: Some(Box::new(Layered {
+                text: "inner detail",
+                source: Some(Box::new(Layered {
+                    text: "root cause",
+                    source: None,
+                })),
+            })),
+        };
+        assert_eq!(error_chain(&e), "outer: inner detail: root cause");
     }
 }

--- a/crates/aisix-obs/src/sink/object_store.rs
+++ b/crates/aisix-obs/src/sink/object_store.rs
@@ -36,7 +36,9 @@ use super::{
 };
 
 /// Cap on a masked error-detail string surfaced to logs / health.
-const DETAIL_MAX_CHARS: usize = 200;
+// Wide enough that a bucket URL (~180 chars for a partitioned object key)
+// leaves room for the error source chain behind it.
+const DETAIL_MAX_CHARS: usize = 500;
 
 /// A delivery target for one object-storage bucket (any provider).
 pub struct ObjectStoreSink {
@@ -559,7 +561,10 @@ fn partition(occurred_at: &str) -> (String, String) {
 /// does not echo secrets in error text.
 fn map_object_store_err(e: object_store::Error) -> SinkError {
     use object_store::Error as E;
-    let detail = truncate(&e.to_string());
+    // The full source chain, not just the outer Display: object_store's
+    // retry error stops at "Error performing PUT <url>" and keeps the
+    // connect/DNS/TLS cause in `source()`.
+    let detail = truncate(&super::error_chain(&e));
     match e {
         E::PermissionDenied { .. }
         | E::Unauthenticated { .. }
@@ -1057,6 +1062,39 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn mapped_detail_carries_the_error_source_chain() {
+        // A Generic transport error's Display stops at the outer layer
+        // ("Error performing PUT <url>"); the connect/DNS cause lives in
+        // `source()`. The nightly real-cloud smoke failed for five weeks
+        // with a detail that never named the cause — the mapped detail
+        // must include the chain.
+        #[derive(Debug)]
+        struct Outer(std::io::Error);
+        impl std::fmt::Display for Outer {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("error performing PUT https://acct.example.net/container/key")
+            }
+        }
+        impl std::error::Error for Outer {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let e = object_store::Error::Generic {
+            store: "MicrosoftAzure",
+            source: Box::new(Outer(std::io::Error::other(
+                "failed to lookup address information: Name or service not known",
+            ))),
+        };
+        let (SinkError::Transient(detail) | SinkError::Permanent(detail)) = map_object_store_err(e);
+        assert!(
+            detail.contains("failed to lookup address information"),
+            "detail must surface the underlying cause, got: {detail}"
+        );
+    }
 }
 
 /// Real-emulator smoke tests — the one-off validation that the sink's real
@@ -1122,7 +1160,7 @@ mod smoke {
 
         sink.append_batch(&batch, &IdempotencyMarker::None)
             .await
-            .expect("real put accepted by the emulator");
+            .expect("real put accepted by the object store");
 
         let keys = list_under(&store, &prefix).await;
         assert_eq!(keys.len(), 1, "exactly one object written");

--- a/crates/aisix-obs/src/sink/pipeline.rs
+++ b/crates/aisix-obs/src/sink/pipeline.rs
@@ -339,9 +339,12 @@ fn backoff(base: Duration, cap: Duration, attempt: u32) -> Duration {
 
 /// Trim a sink error to a bounded, log-safe excerpt. The sink is responsible
 /// for not embedding secrets in its error text; this only caps length so a
-/// verbose upstream body can't flood the logs.
+/// verbose upstream body can't flood the logs. Wide enough that a sink's
+/// own 500-char detail (object URL + error source chain) survives with the
+/// enum prefix — this cap is the last one before the log line / `last_error`,
+/// so trimming tighter than the sinks re-hides the cause they now carry.
 fn masked(err: &SinkError) -> String {
-    err.to_string().chars().take(200).collect()
+    err.to_string().chars().take(600).collect()
 }
 
 #[cfg(test)]
@@ -364,6 +367,8 @@ mod tests {
         TransientThenOk(AtomicU32),
         AlwaysTransient,
         Permanent,
+        /// Permanent failure carrying a caller-chosen detail string.
+        PermanentDetail(String),
     }
 
     /// A configurable sink that records the batch sizes it was handed.
@@ -428,6 +433,7 @@ mod tests {
                 }
                 Mode::AlwaysTransient => Err(SinkError::Transient("always failing".into())),
                 Mode::Permanent => Err(SinkError::Permanent("bad credentials".into())),
+                Mode::PermanentDetail(detail) => Err(SinkError::Permanent(detail.clone())),
             }
         }
 
@@ -565,6 +571,31 @@ mod tests {
         assert_eq!(s.retries, 0, "permanent errors are not retried");
         assert_eq!(s.dropped, 1);
         assert_eq!(s.sent, 0);
+    }
+
+    #[tokio::test]
+    async fn long_error_detail_keeps_its_cause_in_last_error() {
+        // The sinks put the actionable cause (DNS/TLS failure) at the END of
+        // a detail that can run ~500 chars — a partitioned object URL alone
+        // is ~180. `masked` is the last cap before the warn line and
+        // `last_error`; trimming tighter than the sinks' own caps re-hides
+        // the cause they now carry (this fails with the old 200-char cap).
+        let host = "h".repeat(400);
+        let sink = FakeSink::new(Mode::PermanentDetail(format!(
+            "PUT https://{host}/k: dns error: failed to lookup address information"
+        )));
+        let (handle, worker) = SinkPipeline::new(sink.clone(), cfg());
+        assert!(handle.try_enqueue(rec(0)));
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let jh = tokio::spawn(worker.run(cancel_rx));
+        cancel_tx.send(true).unwrap();
+        jh.await.unwrap();
+
+        let last = handle.stats().last_error.expect("error recorded");
+        assert!(
+            last.contains("failed to lookup address information"),
+            "the cause at the end of the detail must survive masking, got: {last}"
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-obs/src/sink/sls.rs
+++ b/crates/aisix-obs/src/sink/sls.rs
@@ -178,11 +178,13 @@ impl ObservabilitySink for AliyunSlsSink {
             .await
         {
             Ok(resp) => resp,
-            // Connect / DNS / timeout — transient by nature.
+            // Connect / DNS / timeout — transient by nature. reqwest's
+            // Display hides the cause in `source()` — chain it.
             Err(e) => {
                 return Err(SinkError::Transient(format!(
-                    "sls: POST {}: {e}",
-                    self.endpoint_url
+                    "sls: POST {}: {}",
+                    self.endpoint_url,
+                    super::error_chain(&e)
                 )))
             }
         };


### PR DESCRIPTION
The nightly `objstore-real-cloud` smoke has failed every run since 2026-07-07, and the recorded detail never said why: `Transient("Generic MicrosoftAzure error: Error performing PUT https://<account>.blob.core.windows.net/<container>/…")` — the outer `Display` ends at the request URL, the 200-char detail cap ate whatever followed, and the actual cause (`failed to lookup address information: Name or service not known`, i.e. the storage account's DNS name no longer resolves) only surfaced after re-running the smoke with a debug probe. Five weeks of red runs with an unactionable error string.

Transport errors keep their cause in `source()`, not in `Display`: object_store's retry error stops at "Error performing PUT <url>", and reqwest's is just "error sending request". This adds a shared `error_chain` helper that renders the error together with its full source chain (skipping layers the outer message already interpolates, so thiserror-style wrappers don't repeat), and uses it in all three places that swallow transport causes today:

- `map_object_store_err` — with the detail cap raised 200 → 500, since a partitioned object URL alone is ~180 chars;
- the datadog and sls transport-failure arms, which formatted bare `{e}`.

Tests: `error_chain` unit tests (hidden source appended, interpolated source not repeated) and a regression test that a `Generic` object_store error's mapped detail names the underlying cause (fails on the old `e.to_string()` mapping). Also retitles the smoke-test expect message that claimed "emulator" — the same round-trip runs against real cloud in the nightly.

The nightly itself stays red until the Azure storage account is recreated (or its leg is re-pointed); that is an infra credential/account issue, not something this PR can fix — with this change the failure line will at least name the cause directly.