### PR TITLE
test(auth): self-diagnose an empty log capture

### DIFF
--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -339,7 +339,11 @@ mod tests {
             let probe_captured = !probe_buf.lock().unwrap().is_empty();
             eprintln!(
                 "capture_logs: probe after empty capture {} — {}",
-                if probe_captured { "captured" } else { "ALSO EMPTY" },
+                if probe_captured {
+                    "captured"
+                } else {
+                    "ALSO EMPTY"
+                },
                 if probe_captured {
                     "transient race during f()"
                 } else {

--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -311,7 +311,43 @@ mod tests {
             f().await;
         }
         let bytes = buf.lock().unwrap().clone();
-        String::from_utf8(bytes).unwrap()
+        let text = String::from_utf8(bytes).unwrap();
+        if text.is_empty() {
+            // An empty capture has flaked exactly once on main (run
+            // 31137791884, `got: ` with nothing behind it) and did not
+            // reproduce in ~390 stressed suite executions, so it cannot be
+            // studied on demand. Self-diagnose instead: report the global
+            // max-level hint and whether a fresh scoped subscriber can
+            // capture at all, so the next natural occurrence says which
+            // mechanism ate the events (a persistently poisoned
+            // callsite/filter state would also swallow the probe; a
+            // transient race during `f()` would not).
+            eprintln!(
+                "capture_logs: EMPTY capture; LevelFilter::current()={:?}",
+                tracing::level_filters::LevelFilter::current(),
+            );
+            let probe_buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let probe_sub = tracing_subscriber::fmt()
+                .with_ansi(false)
+                .with_max_level(tracing::Level::DEBUG)
+                .with_writer(BufWriter(probe_buf.clone()))
+                .finish();
+            {
+                let _g = tracing::subscriber::set_default(probe_sub);
+                tracing::debug!(target: "aisix::auth", probe = true, "capture-probe");
+            }
+            let probe_captured = !probe_buf.lock().unwrap().is_empty();
+            eprintln!(
+                "capture_logs: probe after empty capture {} — {}",
+                if probe_captured { "captured" } else { "ALSO EMPTY" },
+                if probe_captured {
+                    "transient race during f()"
+                } else {
+                    "persistent poisoning"
+                },
+            );
+        }
+        text
     }
 
     const GOOD_TOKEN: &str = "sk-auth-ctx-good";

--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -295,61 +295,63 @@ mod tests {
     /// builder's INFO default.
     async fn capture_logs<F, Fut>(f: F) -> String
     where
-        F: FnOnce() -> Fut,
+        F: Fn() -> Fut,
         Fut: std::future::Future<Output = ()>,
     {
+        /// One capture pass: run `emit` with a fresh buffer-backed scoped
+        /// subscriber installed and return what it wrote.
+        async fn scoped_capture<Fut: std::future::Future<Output = ()>>(
+            emit: impl FnOnce() -> Fut,
+        ) -> String {
+            let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let subscriber = tracing_subscriber::fmt()
+                .with_ansi(false)
+                .with_max_level(tracing::Level::DEBUG)
+                .with_writer(BufWriter(buf.clone()))
+                .finish();
+            {
+                let _guard = tracing::subscriber::set_default(subscriber);
+                emit().await;
+            }
+            let bytes = buf.lock().unwrap().clone();
+            String::from_utf8(bytes).unwrap()
+        }
+
         keep_callsites_enabled();
         let _capture_guard = CAPTURE_LOCK.lock().await;
-        let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let subscriber = tracing_subscriber::fmt()
-            .with_ansi(false)
-            .with_max_level(tracing::Level::DEBUG)
-            .with_writer(BufWriter(buf.clone()))
-            .finish();
-        {
-            let _guard = tracing::subscriber::set_default(subscriber);
-            f().await;
-        }
-        let bytes = buf.lock().unwrap().clone();
-        let text = String::from_utf8(bytes).unwrap();
+        let text = scoped_capture(&f).await;
         if text.is_empty() {
             // An empty capture has flaked exactly once on main (run
             // 31137791884, `got: ` with nothing behind it) and did not
             // reproduce in ~390 stressed suite executions, so it cannot be
-            // studied on demand. Self-diagnose instead: report the global
-            // max-level hint and whether a fresh scoped subscriber can
-            // capture at all, so the next natural occurrence says which
-            // mechanism ate the events (a persistently poisoned
-            // callsite/filter state would also swallow the probe; a
-            // transient race during `f()` would not).
+            // studied on demand. Self-diagnose instead, splitting the
+            // mechanism space three ways for the next natural occurrence:
+            // re-run `f` — driving the SAME production callsites — under a
+            // fresh scope, and emit a probe through a fresh callsite. The
+            // rerun capturing means the original callsites work now (the
+            // emptiness was confined to the first scope); only the probe
+            // capturing means those specific callsites stay suppressed
+            // while the machinery works (per-callsite Interest poisoning);
+            // neither capturing means global suppression (max-level hint /
+            // dispatcher state).
             eprintln!(
                 "capture_logs: EMPTY capture; LevelFilter::current()={:?}",
                 tracing::level_filters::LevelFilter::current(),
             );
-            let probe_buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-            let probe_sub = tracing_subscriber::fmt()
-                .with_ansi(false)
-                .with_max_level(tracing::Level::DEBUG)
-                .with_writer(BufWriter(probe_buf.clone()))
-                .finish();
-            {
-                let _g = tracing::subscriber::set_default(probe_sub);
+            let rerun_captured = !scoped_capture(&f).await.is_empty();
+            let probe_captured = !scoped_capture(|| async {
                 tracing::debug!(target: "aisix::auth", probe = true, "capture-probe");
-            }
-            let probe_captured = !probe_buf.lock().unwrap().is_empty();
-            eprintln!(
-                "capture_logs: probe after empty capture {} — {}",
-                if probe_captured {
-                    "captured"
-                } else {
-                    "ALSO EMPTY"
-                },
-                if probe_captured {
-                    "transient race during f()"
-                } else {
-                    "persistent poisoning"
-                },
-            );
+            })
+            .await
+            .is_empty();
+            let verdict = match (rerun_captured, probe_captured) {
+                (true, _) => "rerun captured — emptiness was confined to the first scope",
+                (false, true) => {
+                    "rerun EMPTY, fresh-callsite probe captured — original callsites suppressed"
+                }
+                (false, false) => "rerun and probe both EMPTY — global suppression",
+            };
+            eprintln!("capture_logs: {verdict}");
         }
         text
     }


### PR DESCRIPTION
The auth log-capture suite flaked once on main (run 31137791884): `a_missing_credential_denial_names_the_caller_and_the_route` asserted against an empty capture — `got: ` with nothing behind it — even though the `keep_callsites_enabled` global-registry guard from the earlier callsite-Interest fix is in place. The occurrence did not reproduce in ~390 stressed suite executions on Actions (llvm-cov at CI thread counts, 64-thread oversubscription, and whole-workspace coverage), so it cannot be studied on demand.

Instead of waiting for another bare `got: `, make the failure self-diagnosing: when a capture comes back empty, `capture_logs` now reports the global `LevelFilter::current()` hint and re-emits a probe event under a fresh scoped subscriber before the assertions fail. Whether the probe is captured splits the mechanism space in two — a persistently poisoned callsite/filter state also swallows the probe, while a transient race confined to the original scope does not — so the next natural occurrence carries the evidence with it.

Diagnostics only; no assertion or behavior change, and nothing runs on the green path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test diagnostics for capture-related failures.
  * Added clearer categorization and additional diagnostic output when expected captured data is missing.
  * Enhanced test utilities to support more reusable verification scenarios and more reliable repeat checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->