### PR TITLE
fix(obs): stamp upstream TTFT on the first streamed frame of any type

### DIFF
--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -490,31 +490,6 @@ pub struct ChatDelta {
     pub reasoning_content: Option<String>,
 }
 
-impl ChatDelta {
-    /// Whether this delta carries generated output — the only frames a
-    /// time-to-first-token measurement may stop on. Every streaming
-    /// handler that records `upstream_ttft_ms` off a [`ChatChunk`] shares
-    /// this predicate so the family can't drift apart again.
-    ///
-    /// Reasoning text counts. A reasoning model streams its chain of
-    /// thought first and only emits `content` once it has stopped
-    /// thinking, so a predicate that ignores `reasoning_content` reports
-    /// the end of the thinking phase as the first token — 183.5s against
-    /// a real 1.2s on the request in AISIX-Cloud#1225.
-    ///
-    /// Empty strings do not count: OpenAI opens a stream with a role-only
-    /// `{"role":"assistant","content":""}` frame, which marks the stream
-    /// starting rather than a token arriving.
-    pub fn carries_generated_output(&self) -> bool {
-        self.content.as_deref().is_some_and(|s| !s.is_empty())
-            || self
-                .reasoning_content
-                .as_deref()
-                .is_some_and(|s| !s.is_empty())
-            || self.tool_calls.as_ref().is_some_and(|t| !t.is_empty())
-    }
-}
-
 // ─── Embeddings ──────────────────────────────────────────────────────────────
 
 /// The vector returned on one embedding object. Untagged enum so JSON

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -133,10 +133,16 @@ pub struct UsageEvent {
     /// is `downstream_latency_ms`.
     pub upstream_latency_ms: u32,
 
-    /// Time to the upstream's first token, in milliseconds — measured
-    /// from the start of THIS attempt to the first upstream SSE chunk
-    /// carrying generated output (role-only preamble chunks don't
-    /// count). Same attempt scope as `upstream_latency_ms`, so the two
+    /// Time to the upstream's first streamed frame, in milliseconds —
+    /// measured from the start of THIS attempt to the first SSE frame
+    /// the upstream delivered, whatever its type (metadata preambles
+    /// like `response.created` / `message_start` / a role-only chat
+    /// chunk included). This is the industry TTFT convention — LiteLLM
+    /// and front-side gateways stamp the same event — so the figure is
+    /// directly comparable with what a caller-side proxy reports. A
+    /// hidden-reasoning model that streams nothing while it thinks
+    /// (AISIX-Cloud#1225) shows the wait in `upstream_latency_ms`, not
+    /// here. Same attempt scope as `upstream_latency_ms`, so the two
     /// are directly comparable. 0 on non-streaming, error, and
     /// cache-hit paths (omitted from the wire via skip_serializing_if).
     ///

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -4819,10 +4819,11 @@ where
         while let Some(item) = upstream.next().await {
             let maybe_chunk = match item {
                 Ok(mut chunk) => {
-                    // Record TTFT on the first chunk carrying generated
-                    // output — reasoning text included, role-only frames
-                    // excluded. See `ChatDelta::carries_generated_output`.
-                    if !first_chunk_seen && chunk.delta.carries_generated_output() {
+                    // Record TTFT on the first upstream chunk of ANY type,
+                    // role-only preambles included — the industry convention
+                    // (LiteLLM, caller-side gateways), so the figure matches
+                    // what external observers report (AISIX-Cloud#1225).
+                    if !first_chunk_seen {
                         first_chunk_seen = true;
                         guard.comp().upstream_ttft_ms =
                             attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1852,7 +1852,7 @@ async fn cross_provider_dispatch(
                 }
             };
             // Re-prepend the peeked chunk so the SSE encoder sees the whole
-            // stream (and records TTFT on the first content chunk).
+            // stream (and records TTFT on the first chunk).
             Box::pin(
                 futures::stream::once(std::future::ready(Ok::<_, aisix_gateway::BridgeError>(
                     first_chunk,
@@ -2248,7 +2248,11 @@ fn build_anthropic_sse_stream(
         while let Some(item) = upstream.next().await {
             match item {
                 Ok(chunk) => {
-                    if !first_chunk_seen && chunk.delta.carries_generated_output() {
+                    // First upstream chunk of ANY type stops the TTFT clock —
+                    // the industry convention (LiteLLM, caller-side gateways),
+                    // so the figure matches external observers
+                    // (AISIX-Cloud#1225).
+                    if !first_chunk_seen {
                         first_chunk_seen = true;
                         guard.comp().upstream_ttft_ms =
                             attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
@@ -2883,7 +2887,8 @@ struct AnthropicStreamUsage {
     provider_request_id: String,
     provider_model_version: String,
     finish_reason: String,
-    /// Attempt-scoped time to the upstream's first content frame.
+    /// Attempt-scoped time to the upstream's first streamed frame,
+    /// whatever its type — see `UsageEvent::upstream_ttft_ms`.
     upstream_ttft_ms: u32,
     /// Request-scoped time until the caller got its first response
     /// bytes. Trails `upstream_ttft_ms` by whatever the gateway did
@@ -2914,15 +2919,21 @@ struct AnthropicStreamUsage {
 
 /// Update the accumulator from one parsed SSE `data:` JSON object.
 /// Best-effort: unrecognised `type` values are ignored. The TTFT
-/// measurement (first content frame) is driven by `attempt_started` and
-/// `first_token_seen`, and is attempt-scoped — see
-/// `UsageEvent::upstream_ttft_ms`.
+/// measurement is driven by `attempt_started` and `first_token_seen`,
+/// and is attempt-scoped — see `UsageEvent::upstream_ttft_ms`.
 fn update_anthropic_usage(
     acc: &mut AnthropicStreamUsage,
     json: &Value,
     attempt_started: Instant,
     first_token_seen: &mut bool,
 ) {
+    // First parsed frame of ANY type (`message_start` included) stops the
+    // TTFT clock — the industry convention (LiteLLM, caller-side gateways),
+    // so the figure matches external observers (AISIX-Cloud#1225).
+    if !*first_token_seen {
+        *first_token_seen = true;
+        acc.upstream_ttft_ms = attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+    }
     match json.get("type").and_then(Value::as_str) {
         Some("message_start") => {
             let msg = json.get("message");
@@ -2955,12 +2966,6 @@ fn update_anthropic_usage(
             }
         }
         Some("content_block_start") | Some("content_block_delta") => {
-            // First content frame → record time-to-first-token.
-            if !*first_token_seen {
-                *first_token_seen = true;
-                acc.upstream_ttft_ms =
-                    attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
-            }
             // Accumulate assistant output for the end-of-stream output
             // guardrail (#448). text streams as `delta.text`; tool_use
             // streams its name in `content_block.{name,input}` on

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -148,9 +148,11 @@ struct ResponseUsage {
     /// verbatim OpenAI path (OpenAI surfaces cache hits via
     /// `cached_prompt_tokens` instead).
     cache_read_tokens: u32,
-    /// Attempt-scoped time to the upstream's first content delta. 0 on the
-    /// non-streaming paths. Before this existed `/v1/responses` reported no
-    /// TTFT at all, so codex-class clients showed blank.
+    /// Attempt-scoped time to the upstream's first streamed frame, whatever
+    /// its type (`response.created` included) — see
+    /// `UsageEvent::upstream_ttft_ms`. 0 on the non-streaming paths. Before
+    /// this existed `/v1/responses` reported no TTFT at all, so codex-class
+    /// clients showed blank.
     upstream_ttft_ms: u32,
     /// Request-scoped time until the caller got its first response bytes.
     /// 0 until the stream forwards something (or the handler stamps it on
@@ -2303,37 +2305,12 @@ fn responses_sse_usage(bytes: &[u8]) -> Option<ResponseUsage> {
 /// an incomplete trailing frame is left in `buf` for the next chunk. Reuses
 /// the shared SSE framing helpers from the `/v1/messages` passthrough so the
 /// two surfaces parse identically.
-/// Whether this SSE event carries generated output. Mirrors the set
-/// `SseTextCapture::observe` accumulates, so TTFT lands on the same frame
-/// the capture considers the first real token.
-/// Frames that carry generated output, and so may stop the TTFT clock.
-///
-/// The reasoning arms are the Responses-API counterpart of
-/// [`ChatDelta::carries_generated_output`](aisix_gateway::ChatDelta::carries_generated_output):
-/// a reasoning model streams its summary (or, for models that expose it,
-/// its raw reasoning text) well before the first `output_text` frame, so
-/// leaving them out reports the end of the thinking phase as the first
-/// token — AISIX-Cloud#1225.
-fn is_responses_content_delta(json: &Value) -> bool {
-    matches!(
-        json.get("type").and_then(Value::as_str),
-        Some(
-            "response.output_text.delta"
-                | "response.function_call_arguments.delta"
-                | "response.mcp_call_arguments.delta"
-                | "response.custom_tool_call_input.delta"
-                | "response.reasoning_summary_text.delta"
-                | "response.reasoning_text.delta"
-        )
-    )
-}
-
 fn drain_responses_sse_frames(
     buf: &mut Vec<u8>,
     acc: &mut Option<ResponseUsage>,
     mut capture: Option<&mut SseTextCapture>,
     attempt_started: Instant,
-    first_token_seen: &mut bool,
+    first_frame_seen: &mut bool,
 ) {
     while let Some(end) = crate::messages::find_frame_end(buf) {
         let frame: Vec<u8> = buf.drain(..end).collect();
@@ -2342,11 +2319,14 @@ fn drain_responses_sse_frames(
                 continue;
             }
             if let Ok(json) = serde_json::from_slice::<Value>(data) {
-                // First content delta → upstream TTFT. `/v1/responses`
-                // reported none at all before this, so codex-class clients
-                // showed a blank figure.
-                if !*first_token_seen && is_responses_content_delta(&json) {
-                    *first_token_seen = true;
+                // First parsed frame of ANY type (`response.created`
+                // included) → upstream TTFT. The industry convention
+                // (LiteLLM, caller-side gateways) stamps the same event, so
+                // the figure matches external observers. A generated-output
+                // whitelist here reported the END of a silent thinking
+                // phase on hidden-reasoning upstreams — AISIX-Cloud#1225.
+                if !*first_frame_seen {
+                    *first_frame_seen = true;
                     acc.get_or_insert_with(Default::default).upstream_ttft_ms =
                         attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
                 }
@@ -2593,7 +2573,7 @@ where
         };
         futures::pin_mut!(upstream);
         let mut buf: Vec<u8> = Vec::new();
-        let mut first_token_seen = false;
+        let mut first_frame_seen = false;
         while let Some(item) = upstream.next().await {
             if let Ok(bytes) = &item {
                 // Side-channel parse: copy into the frame buffer (the original
@@ -2605,7 +2585,7 @@ where
                     usage_acc,
                     capture,
                     attempt_started,
-                    &mut first_token_seen,
+                    &mut first_frame_seen,
                 );
                 // Bound the frame buffer: the happy path drains complete frames
                 // above so `buf` only holds a partial trailing frame. A

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1037,7 +1037,11 @@ pub fn build_responses_bridge_stream(
         while let Some(item) = upstream.next().await {
             match item {
                 Ok(chunk) => {
-                    if !first_chunk_seen && chunk.delta.carries_generated_output() {
+                    // First upstream chunk of ANY type stops the TTFT clock —
+                    // the industry convention (LiteLLM, caller-side gateways),
+                    // so the figure matches external observers
+                    // (AISIX-Cloud#1225).
+                    if !first_chunk_seen {
                         first_chunk_seen = true;
                         guard.comp().upstream_ttft_ms =
                             attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;

--- a/tests/e2e/src/cases/ttft-first-frame-e2e.test.ts
+++ b/tests/e2e/src/cases/ttft-first-frame-e2e.test.ts
@@ -458,10 +458,13 @@ describe("upstream TTFT stops on the first streamed frame", () => {
 
     // Anthropic-shaped request, OpenAI-compatible upstream: the
     // cross-provider translation, not the byte-for-byte passthrough.
+    // The wide gap makes the assertion discriminate this call site's
+    // stamp: a generated-output predicate skips the opener and waits a
+    // full CHAT_GAP_MS for the first reasoning delta.
     const upstream = await startOpenAiUpstream({
-      streamEvents: openerThenQuietThenContent(),
+      streamEvents: openerThenQuietThenContent(2),
       firstEventDelayMs: LEAD_MS,
-      eventDelayMs: GAP_MS,
+      eventDelayMs: CHAT_GAP_MS,
     });
     upstreams.push(upstream);
     await createModel("ttft-ff-messages-bridge", upstream, "deepseek");
@@ -488,9 +491,12 @@ describe("upstream TTFT stops on the first streamed frame", () => {
     const span = await waitForSpan(otlp, requestId!);
     const ttft = Number(span["aisix.upstream_ttft_ms"]);
 
+    // Same discriminating bound as the chat case: the mock cannot
+    // deliver frame two before LEAD_MS + CHAT_GAP_MS, so a predicate
+    // that skips the opener always lands past this bound.
     expect(Number.isFinite(ttft)).toBe(true);
     expect(ttft).toBeGreaterThan(0);
-    expect(ttft).toBeLessThan(OUTPUT_STARTS_MS / 2);
+    expect(ttft).toBeLessThan(LEAD_MS + CHAT_GAP_MS);
   });
 
   test("the first bridged chunk stops the clock on the /v1/responses bridge", async (ctx) => {
@@ -500,11 +506,13 @@ describe("upstream TTFT stops on the first streamed frame", () => {
     }
 
     // A non-OpenAI provider serves /v1/responses through the
-    // chat-completions bridge, so the upstream speaks chat SSE.
+    // chat-completions bridge, so the upstream speaks chat SSE. Wide gap
+    // for the same reason as the messages bridge above: the bound must
+    // fail if this call site regains a generated-output predicate.
     const upstream = await startOpenAiUpstream({
-      streamEvents: openerThenQuietThenContent(),
+      streamEvents: openerThenQuietThenContent(2),
       firstEventDelayMs: LEAD_MS,
-      eventDelayMs: GAP_MS,
+      eventDelayMs: CHAT_GAP_MS,
     });
     upstreams.push(upstream);
     await createModel("ttft-ff-resp-bridge", upstream, "deepseek");
@@ -530,8 +538,10 @@ describe("upstream TTFT stops on the first streamed frame", () => {
     const span = await waitForSpan(otlp, requestId!);
     const ttft = Number(span["aisix.upstream_ttft_ms"]);
 
+    // Same discriminating bound as the chat case — see the messages
+    // bridge above.
     expect(Number.isFinite(ttft)).toBe(true);
     expect(ttft).toBeGreaterThan(0);
-    expect(ttft).toBeLessThan(OUTPUT_STARTS_MS / 2);
+    expect(ttft).toBeLessThan(LEAD_MS + CHAT_GAP_MS);
   });
 });

--- a/tests/e2e/src/cases/ttft-first-frame-e2e.test.ts
+++ b/tests/e2e/src/cases/ttft-first-frame-e2e.test.ts
@@ -12,40 +12,43 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: what `upstream_ttft_ms` is allowed to stop on (AISIX-Cloud#1225).
+// E2E: `upstream_ttft_ms` stops on the FIRST streamed frame of any type
+// (AISIX-Cloud#1225, both rounds).
 //
-// A reasoning model streams its chain of thought first and only emits
-// `content` once it has stopped thinking. The reported request spent
-// ~182s reasoning, so a TTFT that only recognises `content` frames read
-// 183,581 ms while the gateway in front of it measured the first token at
-// 1,175 ms. The clock must stop on the first frame carrying generated
-// output of ANY kind — reasoning text included.
+// The clock deliberately uses the industry convention — LiteLLM's
+// `completion_start_time` and caller-side gateways (istio/Higress-class
+// AI gateways) all stamp the first response chunk, whatever it carries.
+// A "generated output only" predicate looked more truthful but made the
+// figure structurally incomparable: a hidden-reasoning upstream that
+// streams nothing it considers output while thinking (Azure GPT-5.x on
+// /v1/responses without reasoning summaries) pushed our TTFT to the END
+// of the thinking phase (23,595 ms on a 23,903 ms attempt) while the
+// gateway in front measured the same request's first frame at 2,822 ms —
+// an inversion customers keep filing as a bug. Frame types no whitelist
+// anticipated (each provider adds its own) reopen that gap forever; the
+// first-frame convention closes it by construction.
 //
-// The mirror-image defect: OpenAI opens every stream with a role-only
-// `{"role":"assistant","content":""}` frame. Testing `content.is_some()`
-// accepted that empty string, so the clock stopped when the stream
-// opened rather than when a token arrived.
-//
-// Both are asserted per inbound protocol, since the predicate lives at
-// four sites across the handler family.
+// Asserted per inbound protocol, since the stamp lives at five sites
+// across the handler family (chat, /v1/messages native + bridge,
+// /v1/responses native + bridge).
 
-const CALLER_PLAINTEXT = "sk-ttft-reasoning-caller";
+const CALLER_PLAINTEXT = "sk-ttft-first-frame-caller";
 const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
 
 /** Inter-chunk gap. */
-const GAP_MS = 250;
+const GAP_MS = 300;
 /** Delay before the first SSE event, so a correct TTFT is measurably > 0. */
 const LEAD_MS = 250;
-/** Reasoning frames streamed before the first content frame. */
-const REASONING_FRAMES = 6;
+/** Frames streamed between the stream opener and the first visible output. */
+const QUIET_FRAMES = 6;
 /**
- * When the first content frame lands — what a `content`-only predicate
- * reports. A correct TTFT sits at the first reasoning frame instead, so
- * the midpoint separates the two by a wide margin either way.
+ * When the first visible-output frame lands — what a generated-output
+ * predicate reports. A first-frame TTFT sits at LEAD_MS instead, so the
+ * midpoint separates the two by a wide margin either way.
  */
-const CONTENT_STARTS_MS = LEAD_MS + REASONING_FRAMES * GAP_MS;
+const OUTPUT_STARTS_MS = LEAD_MS + (QUIET_FRAMES + 1) * GAP_MS;
 
 interface OtlpReceiver {
   url: string;
@@ -110,7 +113,7 @@ async function waitForSpan(
 
 function chatChunk(delta: unknown): string {
   return JSON.stringify({
-    id: "chatcmpl-ttft-reasoning",
+    id: "chatcmpl-ttft-first-frame",
     object: "chat.completion.chunk",
     created: 1,
     model: "gpt-4o-mini",
@@ -119,7 +122,7 @@ function chatChunk(delta: unknown): string {
 }
 
 const CHAT_TERMINAL = JSON.stringify({
-  id: "chatcmpl-ttft-reasoning",
+  id: "chatcmpl-ttft-first-frame",
   object: "chat.completion.chunk",
   created: 1,
   model: "gpt-4o-mini",
@@ -128,12 +131,15 @@ const CHAT_TERMINAL = JSON.stringify({
 });
 
 /**
- * The customer's shape: DeepSeek-class reasoning frames carry the text at
- * `reasoning_content` and leave `content` null, then real content follows.
+ * OpenAI's opener (a role-only frame carrying no output) followed by a
+ * long quiet phase, then the visible answer. The opener is the frame a
+ * front-side gateway stamps, so the clock must stop there — waiting for
+ * the first visible output re-opens the customer's inversion.
  */
-function reasoningThenContent(): string[] {
+function openerThenQuietThenContent(quietFrames = QUIET_FRAMES): string[] {
   return [
-    ...Array.from({ length: REASONING_FRAMES }, (_, i) =>
+    chatChunk({ role: "assistant", content: "" }),
+    ...Array.from({ length: quietFrames }, (_, i) =>
       chatChunk({ content: null, reasoning_content: `think${i} ` }),
     ),
     chatChunk({ content: "answer " }),
@@ -143,7 +149,91 @@ function reasoningThenContent(): string[] {
   ];
 }
 
-describe("upstream TTFT stops on the first generated-output frame", () => {
+/**
+ * Gap for the chat-opener case, where the discriminating distance is a
+ * single frame: the opener at LEAD_MS vs the first reasoning delta one
+ * gap later. Wide, so the assertion `ttft < LEAD_MS + CHAT_GAP_MS`
+ * separates the two stamps by a full 900 ms rather than scheduler
+ * noise.
+ */
+const CHAT_GAP_MS = 900;
+
+/**
+ * The Azure GPT-5.x /v1/responses shape from the second #1225 report:
+ * `response.created` arrives with the headers, the whole thinking phase
+ * emits only bookkeeping events (no reasoning summaries on that
+ * deployment), and the visible output lands as a late burst just before
+ * `response.completed`.
+ */
+function responsesSilentThinkingStream(): string[] {
+  return [
+    JSON.stringify({ type: "response.created", response: { id: "resp_ttft" } }),
+    JSON.stringify({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "reasoning", id: "rs_ttft", summary: [] },
+    }),
+    ...Array.from({ length: QUIET_FRAMES - 1 }, () =>
+      JSON.stringify({ type: "response.in_progress", response: { id: "resp_ttft" } }),
+    ),
+    JSON.stringify({ type: "response.output_text.delta", delta: "answer " }),
+    JSON.stringify({ type: "response.output_text.delta", delta: "here" }),
+    JSON.stringify({
+      type: "response.completed",
+      response: {
+        id: "resp_ttft",
+        status: "completed",
+        usage: {
+          input_tokens: 6,
+          output_tokens: 9,
+          output_tokens_details: { reasoning_tokens: 4 },
+        },
+      },
+    }),
+    "[DONE]",
+  ];
+}
+
+/**
+ * Anthropic-native stream whose thinking phase is only pings:
+ * `message_start` opens immediately, then nothing content-shaped until a
+ * late `content_block_start`/`delta` burst. `message_start` is what the
+ * caller side observes first, so it stops the clock.
+ */
+function anthropicQuietThinkingStream(): string[] {
+  return [
+    JSON.stringify({
+      type: "message_start",
+      message: {
+        id: "msg_ttft",
+        model: "mco-5",
+        usage: { input_tokens: 7, output_tokens: 1 },
+      },
+    }),
+    ...Array.from({ length: QUIET_FRAMES }, () =>
+      JSON.stringify({ type: "ping" }),
+    ),
+    JSON.stringify({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    }),
+    JSON.stringify({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "answer here" },
+    }),
+    JSON.stringify({ type: "content_block_stop", index: 0 }),
+    JSON.stringify({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: { output_tokens: 9 },
+    }),
+    JSON.stringify({ type: "message_stop" }),
+  ];
+}
+
+describe("upstream TTFT stops on the first streamed frame", () => {
   let etcdReachable = false;
   let app: SpawnedApp | undefined;
   let seed: SeedClient | undefined;
@@ -158,7 +248,7 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
     seed = new SeedClient(etcd, app.etcdPrefix);
     otlp = await startOtlpReceiver();
     await seed.createObservabilityExporter({
-      name: "ttft-reasoning-otlp",
+      name: "ttft-first-frame-otlp",
       enabled: true,
       kind: "otlp_http",
       endpoint: otlp.url,
@@ -177,15 +267,15 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
 
   /**
    * `provider` selects the dispatch path under test. `openai` takes the
-   * native routes; any other OpenAI-compatible provider (here `deepseek`)
-   * routes `/v1/messages` through the cross-provider translation and
-   * `/v1/responses` through the chat-completions bridge — the two sites
-   * that share the predicate but never see the native code paths.
+   * native routes; `anthropic` the /v1/messages byte passthrough; any
+   * other OpenAI-compatible provider (here `deepseek`) routes
+   * `/v1/messages` through the cross-provider translation and
+   * `/v1/responses` through the chat-completions bridge.
    */
   async function createModel(
     displayName: string,
     upstream: OpenAiUpstream,
-    provider: "openai" | "deepseek" = "openai",
+    provider: "openai" | "deepseek" | "anthropic" = "openai",
   ): Promise<void> {
     if (!seed) throw new Error("seed client not initialized");
     const pk = await seed.createProviderKey({
@@ -193,10 +283,15 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
       secret: "sk-mock",
       api_base: `${upstream.baseUrl}/v1`,
     });
+    const modelName = {
+      openai: "gpt-4o-mini",
+      deepseek: "deepseek-reasoner",
+      anthropic: "mco-5",
+    }[provider];
     await seed.createModel({
       display_name: displayName,
       provider,
-      model_name: provider === "openai" ? "gpt-4o-mini" : "deepseek-reasoner",
+      model_name: modelName,
       provider_key_id: pk.id,
     });
   }
@@ -216,20 +311,20 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
     });
   }
 
-  test("reasoning text stops the clock on /v1/chat/completions", async (ctx) => {
+  test("the role-only opener stops the clock on /v1/chat/completions", async (ctx) => {
     if (!etcdReachable || !app || !seed || !otlp) {
       ctx.skip();
       return;
     }
 
     const upstream = await startOpenAiUpstream({
-      streamEvents: reasoningThenContent(),
+      streamEvents: openerThenQuietThenContent(2),
       firstEventDelayMs: LEAD_MS,
-      eventDelayMs: GAP_MS,
+      eventDelayMs: CHAT_GAP_MS,
     });
     upstreams.push(upstream);
-    await createModel("ttft-reasoning-chat", upstream);
-    await awaitPropagation("reasoning-chat");
+    await createModel("ttft-ff-chat", upstream);
+    await awaitPropagation("ff-chat");
 
     const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
       method: "POST",
@@ -238,7 +333,7 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        model: "ttft-reasoning-chat",
+        model: "ttft-ff-chat",
         messages: [{ role: "user", content: "think then answer" }],
         stream: true,
       }),
@@ -252,83 +347,82 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
     const ttft = Number(span["aisix.upstream_ttft_ms"]);
     const downstream = Number(span["aisix.downstream_latency_ms"]);
 
-    // The first reasoning frame is a token arriving, so the clock stops
-    // near LEAD_MS — not at CONTENT_STARTS_MS, which is what a
-    // content-only predicate reported.
+    // The opener is the first frame, so the clock stops near LEAD_MS. A
+    // predicate that skips role-only frames waits at least one full gap
+    // for the first reasoning delta, so this bound separates the two
+    // stamps deterministically: the mock cannot deliver frame two before
+    // LEAD_MS + CHAT_GAP_MS.
     expect(Number.isFinite(ttft)).toBe(true);
     expect(ttft).toBeGreaterThan(0);
-    expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2);
+    expect(ttft).toBeLessThan(LEAD_MS + CHAT_GAP_MS);
 
-    // The caller-facing figure can never precede the upstream TTFT it
-    // waited on. Skipping reasoning frames broke exactly that: the
-    // gateway forwarded them (so downstream marked the first one) while
-    // TTFT held out for content a whole thinking phase later.
+    // The caller-facing figure can never precede the upstream frame it
+    // waited on. With both clocks stamping the same first frame (at
+    // request scope vs attempt scope) this holds by construction; an
+    // output-only TTFT inverted it — the customer's 2,726 ms caller
+    // latency against a 23,595 ms "first token".
     expect(downstream).toBeGreaterThanOrEqual(ttft);
   });
 
-  test("an empty role-only frame does not stop the clock", async (ctx) => {
+  test("silent thinking on native /v1/responses: created stops the clock (#1225 round 2)", async (ctx) => {
     if (!etcdReachable || !app || !seed || !otlp) {
       ctx.skip();
       return;
     }
 
-    // OpenAI's stream opener, then a long wait for the first real token.
     const upstream = await startOpenAiUpstream({
-      streamEvents: [
-        chatChunk({ role: "assistant", content: "" }),
-        chatChunk({ content: "answer " }),
-        chatChunk({ content: "here" }),
-        CHAT_TERMINAL,
-        "[DONE]",
-      ],
-      eventDelayMs: GAP_MS * 2,
+      streamEvents: responsesSilentThinkingStream(),
+      firstEventDelayMs: LEAD_MS,
+      eventDelayMs: GAP_MS,
     });
     upstreams.push(upstream);
-    await createModel("ttft-role-only-chat", upstream);
-    await awaitPropagation("role-only-chat");
+    await createModel("ttft-ff-responses", upstream);
+    await awaitPropagation("ff-responses");
 
-    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
       method: "POST",
       headers: {
         authorization: `Bearer ${CALLER_PLAINTEXT}`,
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        model: "ttft-role-only-chat",
-        messages: [{ role: "user", content: "answer" }],
+        model: "ttft-ff-responses",
+        input: "think silently then answer",
         stream: true,
       }),
     });
     expect(res.status).toBe(200);
-    const requestId = res.headers.get("x-aisix-call-id");
+    const requestId = res.headers.get("x-aisix-request-id");
     expect(requestId).toBeTruthy();
     await res.text();
 
     const span = await waitForSpan(otlp, requestId!);
     const ttft = Number(span["aisix.upstream_ttft_ms"]);
+    const downstream = Number(span["aisix.downstream_latency_ms"]);
 
-    // `content: ""` is the stream opening, not a token; the clock has to
-    // wait for the frame one gap later. Reading the opener put this at ~0.
+    // `response.created` is the first frame the caller side observes, so
+    // it stops the clock. A generated-output whitelist ran the clock
+    // through the whole quiet phase and landed at the late output burst.
     expect(Number.isFinite(ttft)).toBe(true);
-    expect(ttft).toBeGreaterThan(GAP_MS);
+    expect(ttft).toBeGreaterThan(0);
+    expect(ttft).toBeLessThan(OUTPUT_STARTS_MS / 2);
+    expect(downstream).toBeGreaterThanOrEqual(ttft);
   });
 
-  test("reasoning text stops the clock on the /v1/messages bridge", async (ctx) => {
+  test("quiet thinking on native /v1/messages: message_start stops the clock", async (ctx) => {
     if (!etcdReachable || !app || !seed || !otlp) {
       ctx.skip();
       return;
     }
 
-    // Anthropic-shaped request, OpenAI-compatible upstream: the
-    // cross-provider translation, not the byte-for-byte passthrough.
     const upstream = await startOpenAiUpstream({
-      streamEvents: reasoningThenContent(),
+      streamEvents: anthropicQuietThinkingStream(),
       firstEventDelayMs: LEAD_MS,
       eventDelayMs: GAP_MS,
     });
     upstreams.push(upstream);
-    await createModel("ttft-reasoning-messages", upstream, "deepseek");
-    await awaitPropagation("reasoning-messages");
+    await createModel("ttft-ff-messages-native", upstream, "anthropic");
+    await awaitPropagation("ff-messages-native");
 
     const res = await fetch(`${app.proxyUrl}/v1/messages`, {
       method: "POST",
@@ -337,7 +431,7 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        model: "ttft-reasoning-messages",
+        model: "ttft-ff-messages-native",
         max_tokens: 128,
         messages: [{ role: "user", content: "think then answer" }],
         stream: true,
@@ -353,10 +447,53 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
 
     expect(Number.isFinite(ttft)).toBe(true);
     expect(ttft).toBeGreaterThan(0);
-    expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2);
+    expect(ttft).toBeLessThan(OUTPUT_STARTS_MS / 2);
   });
 
-  test("reasoning text stops the clock on the /v1/responses bridge", async (ctx) => {
+  test("the first bridged chunk stops the clock on the /v1/messages bridge", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !otlp) {
+      ctx.skip();
+      return;
+    }
+
+    // Anthropic-shaped request, OpenAI-compatible upstream: the
+    // cross-provider translation, not the byte-for-byte passthrough.
+    const upstream = await startOpenAiUpstream({
+      streamEvents: openerThenQuietThenContent(),
+      firstEventDelayMs: LEAD_MS,
+      eventDelayMs: GAP_MS,
+    });
+    upstreams.push(upstream);
+    await createModel("ttft-ff-messages-bridge", upstream, "deepseek");
+    await awaitPropagation("ff-messages-bridge");
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "ttft-ff-messages-bridge",
+        max_tokens: 128,
+        messages: [{ role: "user", content: "think then answer" }],
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const requestId = res.headers.get("x-aisix-request-id");
+    expect(requestId).toBeTruthy();
+    await res.text();
+
+    const span = await waitForSpan(otlp, requestId!);
+    const ttft = Number(span["aisix.upstream_ttft_ms"]);
+
+    expect(Number.isFinite(ttft)).toBe(true);
+    expect(ttft).toBeGreaterThan(0);
+    expect(ttft).toBeLessThan(OUTPUT_STARTS_MS / 2);
+  });
+
+  test("the first bridged chunk stops the clock on the /v1/responses bridge", async (ctx) => {
     if (!etcdReachable || !app || !seed || !otlp) {
       ctx.skip();
       return;
@@ -365,13 +502,13 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
     // A non-OpenAI provider serves /v1/responses through the
     // chat-completions bridge, so the upstream speaks chat SSE.
     const upstream = await startOpenAiUpstream({
-      streamEvents: reasoningThenContent(),
+      streamEvents: openerThenQuietThenContent(),
       firstEventDelayMs: LEAD_MS,
       eventDelayMs: GAP_MS,
     });
     upstreams.push(upstream);
-    await createModel("ttft-reasoning-resp-bridge", upstream, "deepseek");
-    await awaitPropagation("reasoning-resp-bridge");
+    await createModel("ttft-ff-resp-bridge", upstream, "deepseek");
+    await awaitPropagation("ff-resp-bridge");
 
     const res = await fetch(`${app.proxyUrl}/v1/responses`, {
       method: "POST",
@@ -380,7 +517,7 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        model: "ttft-reasoning-resp-bridge",
+        model: "ttft-ff-resp-bridge",
         input: "think then answer",
         stream: true,
       }),
@@ -395,67 +532,6 @@ describe("upstream TTFT stops on the first generated-output frame", () => {
 
     expect(Number.isFinite(ttft)).toBe(true);
     expect(ttft).toBeGreaterThan(0);
-    expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2);
-  });
-
-  test("reasoning summaries stop the clock on /v1/responses", async (ctx) => {
-    if (!etcdReachable || !app || !seed || !otlp) {
-      ctx.skip();
-      return;
-    }
-
-    const upstream = await startOpenAiUpstream({
-      streamEvents: [
-        JSON.stringify({ type: "response.created", response: { id: "resp_ttft" } }),
-        ...Array.from({ length: REASONING_FRAMES }, (_, i) =>
-          JSON.stringify({
-            type: "response.reasoning_summary_text.delta",
-            delta: `think${i} `,
-          }),
-        ),
-        JSON.stringify({ type: "response.output_text.delta", delta: "answer" }),
-        JSON.stringify({
-          type: "response.completed",
-          response: {
-            id: "resp_ttft",
-            status: "completed",
-            usage: { input_tokens: 6, output_tokens: 9 },
-          },
-        }),
-        "[DONE]",
-      ],
-      firstEventDelayMs: LEAD_MS,
-      eventDelayMs: GAP_MS,
-    });
-    upstreams.push(upstream);
-    await createModel("ttft-reasoning-responses", upstream);
-    await awaitPropagation("reasoning-responses");
-
-    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${CALLER_PLAINTEXT}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "ttft-reasoning-responses",
-        input: "think then answer",
-        stream: true,
-      }),
-    });
-    expect(res.status).toBe(200);
-    const requestId = res.headers.get("x-aisix-request-id");
-    expect(requestId).toBeTruthy();
-    await res.text();
-
-    const span = await waitForSpan(otlp, requestId!);
-    const ttft = Number(span["aisix.upstream_ttft_ms"]);
-
-    // `response.created` is not generated output, so the clock runs past
-    // it; the first reasoning-summary delta stops it — one frame later,
-    // not REASONING_FRAMES later.
-    expect(Number.isFinite(ttft)).toBe(true);
-    expect(ttft).toBeGreaterThan(0);
-    expect(ttft).toBeLessThan(CONTENT_STARTS_MS / 2 + GAP_MS);
+    expect(ttft).toBeLessThan(OUTPUT_STARTS_MS / 2);
   });
 });


### PR DESCRIPTION
## Problem

`upstream_ttft_ms` stopped its clock on the first frame carrying *generated output* (content / reasoning / tool-call deltas, plus a per-endpoint event whitelist on the native passthroughs). A hidden-reasoning upstream that streams nothing it considers output while thinking breaks that predicate: on Azure GPT-5.x served over native `/v1/responses` (codex-class clients), `response.created` arrives with the headers, the whole thinking phase emits no whitelist-matching event, and the visible answer lands as a late burst.

Observed on a customer 0.8.0 deployment (second round of AISIX-Cloud#1225): a 23,903 ms attempt reported `upstream_ttft_ms = 23,595` while our own `downstream_latency_ms` was 2,726 — the gateway supposedly forwarded the first bytes 21 s before the upstream produced them. The gateway in front of AISIX measured the same request's first frame at 2,822 ms, so the figure was also incomparable with every external observer. Token-rate cross-check confirms the stamp is wrong: ~500+ visible tokens cannot be generated in the 308 ms left after 23,595.

No generated-output whitelist can anticipate every provider's event vocabulary, so this class of mismatch keeps reopening (round one was DeepSeek `reasoning_content`; this round is Responses-API silent thinking).

## Change

Stop the TTFT clock on the **first streamed frame of any type** — `response.created`, `message_start`, role-only chat openers included. This is the convention LiteLLM and caller-side gateways use, so the figure now matches what external observers report, and `downstream_latency_ms >= upstream_ttft_ms` holds by construction (both clocks stamp the same first frame, at request vs attempt scope).

All five recording sites change together so the handler family cannot drift:

- `/v1/chat/completions` streaming (`chat.rs`)
- `/v1/messages` native passthrough (`messages.rs`, stamp moved to any parsed event)
- `/v1/messages` cross-provider bridge (`messages.rs`)
- `/v1/responses` native passthrough (`responses.rs`, event whitelist dropped)
- `/v1/responses` chat-completions bridge (`responses_bridge.rs`)

`ChatDelta::carries_generated_output` and `is_responses_content_delta` had no remaining callers and are removed.

## Behavior change

For streams whose thinking phase is silent, `upstream_ttft_ms` now reports the first frame (≈ response start) instead of the end of the thinking phase; the thinking wait remains visible in `upstream_latency_ms`. Wire shape is unchanged (same fields, same scopes). Dashboards and alerting comparing TTFT against front-side gateway measurements will now agree.

## Tests

`ttft-reasoning-e2e.test.ts` is replaced by `ttft-first-frame-e2e.test.ts`, pinning the new contract per inbound protocol: role-only opener stops the clock on chat, `response.created` on native `/v1/responses` (the customer's silent-thinking shape, asserted against the late-burst stamp), `message_start` on native `/v1/messages` (ping-only thinking), first bridged chunk on both bridges, plus the `downstream >= ttft` invariant. The three discriminating cases fail against the pre-fix binary (1185/2385/2355 ms, all at the thinking-end stamp) and pass after. Existing latency-scope suites (`latency-upstream-downstream`, `latency-guardrail-holdback`) pass unchanged.

Fixes api7/AISIX-Cloud#1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming time-to-first-token (TTFT) reporting by measuring from the first upstream frame, including metadata and role-only preambles.
  - Applied consistent TTFT behavior across chat, Responses, Messages, and bridge-based streaming.
  - Preserved separate latency reporting for delays before generated output, such as hidden reasoning.

- **Tests**
  - Added end-to-end coverage for first-frame TTFT behavior across supported streaming paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->