### PR TITLE
feat(a2a): record the operation, task, context and task state of every call

### DIFF
--- a/crates/aisix-a2a/src/lib.rs
+++ b/crates/aisix-a2a/src/lib.rs
@@ -27,7 +27,4 @@ pub use bridge::{
     HttpBridge, DEFAULT_UPSTREAM_TIMEOUT,
 };
 pub use error::A2aError;
-pub use telemetry::{
-    canonical_operation, is_streaming_operation, normalize_task_state, A2aCallFacts,
-    UNKNOWN_OPERATION, UNKNOWN_TASK_STATE,
-};
+pub use telemetry::{canonical_operation, is_streaming_operation, A2aCallFacts};

--- a/crates/aisix-a2a/src/lib.rs
+++ b/crates/aisix-a2a/src/lib.rs
@@ -20,9 +20,14 @@
 
 pub mod bridge;
 pub mod error;
+pub mod telemetry;
 
 pub use bridge::{
     upstream_from_a2a_agent, A2aAuth, A2aBridge, A2aEvent, A2aEventStream, A2aUpstream, AgentCard,
     HttpBridge, DEFAULT_UPSTREAM_TIMEOUT,
 };
 pub use error::A2aError;
+pub use telemetry::{
+    canonical_operation, is_streaming_operation, normalize_task_state, A2aCallFacts,
+    UNKNOWN_OPERATION, UNKNOWN_TASK_STATE,
+};

--- a/crates/aisix-a2a/src/telemetry.rs
+++ b/crates/aisix-a2a/src/telemetry.rs
@@ -1,0 +1,432 @@
+//! Reading the protocol-level facts of an A2A call out of its JSON-RPC
+//! envelopes: which operation was invoked, and which task / context / task
+//! state the call touched.
+//!
+//! The gateway forwards A2A bodies verbatim (see [`crate::bridge`]), so an
+//! operator running a mix of agents sees BOTH wire vocabularies on the same
+//! endpoint: an agent pinned to 0.3 is called with `message/send`, one pinned
+//! to 1.0 with `SendMessage`, and those are the same operation. Everything
+//! here exists to record one fact once — a canonical operation name, a task
+//! id, a task state — regardless of which version produced it.
+//!
+//! Wire references:
+//! - Methods: the 1.0 RPC names (`SendMessage`, `GetTask`, …) are section 9.4
+//!   of the specification; the `message/send`-style names are their 0.3
+//!   spelling. <https://a2a-protocol.org/latest/specification/>
+//! - `TaskState`: the 1.0 enum is `TASK_STATE_<NAME>`; its 0.3 wire string is
+//!   the name lowercased with `_` → `-`, which is why [`normalize_task_state`]
+//!   needs no per-value table.
+//! - A `Task` carries `id`, `contextId` and `status.state`; the streaming
+//!   update events carry `taskId` / `contextId` instead. Both shapes are read
+//!   by [`A2aCallFacts::observe_result`].
+
+use serde_json::Value;
+
+/// Bounded label for an operation this gateway does not recognise. A caller
+/// picks the JSON-RPC method, so the raw value can be anything at all; it is
+/// kept in `a2a_method` for forensics and collapsed to this in every
+/// aggregated position.
+pub const UNKNOWN_OPERATION: &str = "unknown";
+
+/// Bounded label for a task state that is absent, unspecified, or not one the
+/// specification defines.
+pub const UNKNOWN_TASK_STATE: &str = "unknown";
+
+/// The canonical operation names, in their 0.3 spelling — the vocabulary the
+/// dashboard, metrics and docs use. The 1.0 PascalCase RPC name for the same
+/// operation maps onto the same entry.
+const OPERATIONS: &[(&str, &str)] = &[
+    // (wire method, canonical operation)
+    ("message/send", "message/send"),
+    ("SendMessage", "message/send"),
+    ("message/stream", "message/stream"),
+    ("SendStreamingMessage", "message/stream"),
+    ("tasks/get", "tasks/get"),
+    ("GetTask", "tasks/get"),
+    ("tasks/list", "tasks/list"),
+    ("ListTasks", "tasks/list"),
+    ("tasks/cancel", "tasks/cancel"),
+    ("CancelTask", "tasks/cancel"),
+    ("tasks/resubscribe", "tasks/resubscribe"),
+    ("SubscribeToTask", "tasks/resubscribe"),
+    (
+        "tasks/pushNotificationConfig/set",
+        "tasks/pushNotificationConfig/set",
+    ),
+    (
+        "CreateTaskPushNotificationConfig",
+        "tasks/pushNotificationConfig/set",
+    ),
+    (
+        "tasks/pushNotificationConfig/get",
+        "tasks/pushNotificationConfig/get",
+    ),
+    (
+        "GetTaskPushNotificationConfig",
+        "tasks/pushNotificationConfig/get",
+    ),
+    (
+        "tasks/pushNotificationConfig/list",
+        "tasks/pushNotificationConfig/list",
+    ),
+    (
+        "ListTaskPushNotificationConfigs",
+        "tasks/pushNotificationConfig/list",
+    ),
+    (
+        "tasks/pushNotificationConfig/delete",
+        "tasks/pushNotificationConfig/delete",
+    ),
+    (
+        "DeleteTaskPushNotificationConfig",
+        "tasks/pushNotificationConfig/delete",
+    ),
+    (
+        "agent/getAuthenticatedExtendedCard",
+        "agent/getAuthenticatedExtendedCard",
+    ),
+    ("GetExtendedAgentCard", "agent/getAuthenticatedExtendedCard"),
+];
+
+/// The task states the specification defines, in their 0.3 wire spelling.
+const TASK_STATES: &[&str] = &[
+    "submitted",
+    "working",
+    "input-required",
+    "completed",
+    "canceled",
+    "failed",
+    "rejected",
+    "auth-required",
+];
+
+/// Map a wire method to its canonical operation, collapsing an unrecognised
+/// one to [`UNKNOWN_OPERATION`] so it is safe to use as a metric label.
+///
+/// Both wire vocabularies map onto the 0.3 spelling: `SendStreamingMessage`
+/// and `message/stream` are one operation, so a deployment fronting agents on
+/// both versions still aggregates as one.
+pub fn canonical_operation(method: &str) -> &'static str {
+    OPERATIONS
+        .iter()
+        .find(|(wire, _)| *wire == method)
+        .map(|(_, canonical)| *canonical)
+        .unwrap_or(UNKNOWN_OPERATION)
+}
+
+/// Whether an operation's response is an SSE event stream rather than a single
+/// JSON-RPC envelope.
+///
+/// Takes the CANONICAL operation, so a 1.0 caller's `SendStreamingMessage`
+/// cannot be routed down the buffering path just because the match arm listed
+/// only the 0.3 spelling.
+pub fn is_streaming_operation(operation: &str) -> bool {
+    matches!(operation, "message/stream" | "tasks/resubscribe")
+}
+
+/// Normalize a wire task state to its 0.3 spelling, or [`UNKNOWN_TASK_STATE`]
+/// when it is absent, `TASK_STATE_UNSPECIFIED`, or not a state the
+/// specification defines.
+///
+/// The 1.0 protobuf enum name (`TASK_STATE_INPUT_REQUIRED`) becomes the 0.3
+/// wire string (`input-required`) by dropping the prefix, lowercasing and
+/// swapping `_` for `-`; the result is validated against the defined set, so a
+/// state invented by an upstream lands on `unknown` rather than becoming an
+/// unbounded label.
+pub fn normalize_task_state(state: &str) -> &'static str {
+    let stripped = state.strip_prefix("TASK_STATE_").unwrap_or(state);
+    let candidate = stripped.to_ascii_lowercase().replace('_', "-");
+    TASK_STATES
+        .iter()
+        .find(|known| **known == candidate)
+        .copied()
+        .unwrap_or(UNKNOWN_TASK_STATE)
+}
+
+/// What one A2A call touched, accumulated as its request and response(s) are
+/// seen.
+///
+/// A streaming call feeds every event through [`Self::observe_result`], so the
+/// recorded state is the LAST one the upstream reported — the state the task
+/// was actually left in when the caller stopped watching, which is what an
+/// operator auditing a task needs. A caller that walks away mid-task leaves
+/// the last state it did see, not a fabricated terminal one.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct A2aCallFacts {
+    /// Task the call created or acted on. Empty when the call names no task
+    /// (a first `message/send` whose agent answers with a bare message).
+    pub task_id: String,
+    /// Context (conversation) the call belongs to; empty when none was seen.
+    pub context_id: String,
+    /// Last task state reported, in its 0.3 spelling. Empty when no response
+    /// carried one — a state is never invented for a call that failed before
+    /// the upstream answered.
+    pub task_state: String,
+}
+
+impl A2aCallFacts {
+    /// Read what the REQUEST already tells us: `message/send` and
+    /// `message/stream` carry the task and context they continue on
+    /// `params.message`, while the task operations name the task directly.
+    ///
+    /// Called before the upstream is contacted, so a call that fails outright
+    /// still records which task the caller was asking about.
+    pub fn observe_request(&mut self, request: &Value) {
+        let Some(params) = request.get("params") else {
+            return;
+        };
+        // A send / stream continues a task from its message; the
+        // push-notification operations name the task on params itself; and
+        // `tasks/get` / `tasks/cancel` / `tasks/resubscribe` carry it as
+        // `params.id`. The three are mutually exclusive per operation, and the
+        // field names are identical in both wire versions (1.0's protobuf JSON
+        // renders `task_id` / `context_id` in camelCase).
+        for source in [params.get("message"), Some(params)].into_iter().flatten() {
+            self.set_task_id(str_field(source, "taskId"));
+            self.set_context_id(str_field(source, "contextId"));
+        }
+        self.set_task_id(str_field(params, "id"));
+    }
+
+    /// Read a JSON-RPC response envelope — or one streamed event — for the
+    /// task it concerns and the state it reports.
+    ///
+    /// Handles every `result` shape the protocol defines: a `Task` (ids on
+    /// `id` / `contextId`, state under `status`), a `Message` (no state), and
+    /// the streaming status / artifact update events (ids on `taskId`).
+    pub fn observe_result(&mut self, response: &Value) {
+        let Some(result) = response.get("result") else {
+            return;
+        };
+        self.set_context_id(str_field(result, "contextId"));
+        self.set_task_id(str_field(result, "taskId"));
+        // A `Task` names itself in `id`, but so does a `Message` — and a
+        // message id is not a task id. `status` is the discriminator: every
+        // Task has one and no Message does, in either wire version.
+        if let Some(status) = result.get("status") {
+            self.set_task_id(str_field(result, "id"));
+            if let Some(state) = str_field(status, "state") {
+                self.task_state = normalize_task_state(state).to_string();
+            }
+        }
+    }
+
+    fn set_task_id(&mut self, value: Option<&str>) {
+        if let Some(value) = value {
+            self.task_id = value.to_string();
+        }
+    }
+
+    fn set_context_id(&mut self, value: Option<&str>) {
+        if let Some(value) = value {
+            self.context_id = value.to_string();
+        }
+    }
+}
+
+/// A non-empty string field, or `None` — an absent field and an empty one are
+/// the same "nothing was said" to a caller accumulating facts, and an empty
+/// string must never overwrite an id read earlier in the call.
+fn str_field<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn both_wire_vocabularies_map_to_one_operation() {
+        // The whole point: a gateway fronting a 0.3 agent and a 1.0 agent must
+        // aggregate their identical operations as one, not as two.
+        for (v03, v10) in [
+            ("message/send", "SendMessage"),
+            ("message/stream", "SendStreamingMessage"),
+            ("tasks/get", "GetTask"),
+            ("tasks/list", "ListTasks"),
+            ("tasks/cancel", "CancelTask"),
+            ("tasks/resubscribe", "SubscribeToTask"),
+            (
+                "tasks/pushNotificationConfig/set",
+                "CreateTaskPushNotificationConfig",
+            ),
+            (
+                "tasks/pushNotificationConfig/get",
+                "GetTaskPushNotificationConfig",
+            ),
+            (
+                "tasks/pushNotificationConfig/list",
+                "ListTaskPushNotificationConfigs",
+            ),
+            (
+                "tasks/pushNotificationConfig/delete",
+                "DeleteTaskPushNotificationConfig",
+            ),
+            ("agent/getAuthenticatedExtendedCard", "GetExtendedAgentCard"),
+        ] {
+            assert_eq!(canonical_operation(v03), v03, "0.3 name is the canonical");
+            assert_eq!(
+                canonical_operation(v10),
+                v03,
+                "{v10} must canonicalise to {v03}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unrecognised_method_is_bounded() {
+        // A caller picks the method, so this is the cardinality gate.
+        for method in ["", "message/sendx", "../../etc/passwd", "SendMessage "] {
+            assert_eq!(canonical_operation(method), UNKNOWN_OPERATION);
+        }
+    }
+
+    #[test]
+    fn streaming_is_decided_on_the_canonical_operation() {
+        for method in [
+            "message/stream",
+            "SendStreamingMessage",
+            "tasks/resubscribe",
+            "SubscribeToTask",
+        ] {
+            assert!(is_streaming_operation(canonical_operation(method)));
+        }
+        for method in ["message/send", "SendMessage", "tasks/get", "GetTask", ""] {
+            assert!(!is_streaming_operation(canonical_operation(method)));
+        }
+    }
+
+    #[test]
+    fn task_states_normalise_across_versions() {
+        for (v10, v03) in [
+            ("TASK_STATE_SUBMITTED", "submitted"),
+            ("TASK_STATE_WORKING", "working"),
+            ("TASK_STATE_INPUT_REQUIRED", "input-required"),
+            ("TASK_STATE_COMPLETED", "completed"),
+            ("TASK_STATE_CANCELED", "canceled"),
+            ("TASK_STATE_FAILED", "failed"),
+            ("TASK_STATE_REJECTED", "rejected"),
+            ("TASK_STATE_AUTH_REQUIRED", "auth-required"),
+        ] {
+            assert_eq!(normalize_task_state(v10), v03);
+            assert_eq!(normalize_task_state(v03), v03);
+        }
+        // Unspecified and anything an upstream invents are bounded, so a
+        // task-state metric cannot be blown up from the far side.
+        for state in ["TASK_STATE_UNSPECIFIED", "", "wat", "unknown"] {
+            assert_eq!(normalize_task_state(state), UNKNOWN_TASK_STATE);
+        }
+    }
+
+    #[test]
+    fn a_send_that_continues_a_task_is_read_from_the_request() {
+        // Recorded before the upstream is contacted, so a call that fails
+        // outright still says which task the caller was asking about.
+        let mut facts = A2aCallFacts::default();
+        facts.observe_request(&json!({
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"taskId": "t-1", "contextId": "c-1", "role": "user"}}
+        }));
+        assert_eq!(facts.task_id, "t-1");
+        assert_eq!(facts.context_id, "c-1");
+        assert_eq!(facts.task_state, "");
+    }
+
+    #[test]
+    fn task_operations_name_their_subject_in_either_version() {
+        // `GetTaskRequest` / `CancelTaskRequest` / `SubscribeToTaskRequest`
+        // all carry the task as `id` in both wire versions.
+        for method in ["tasks/get", "GetTask", "tasks/cancel", "tasks/resubscribe"] {
+            let mut facts = A2aCallFacts::default();
+            facts.observe_request(&json!({"method": method, "params": {"id": "t-7"}}));
+            assert_eq!(facts.task_id, "t-7", "{method} names its task");
+        }
+
+        // The push-notification operations name the parent task instead.
+        let mut cfg = A2aCallFacts::default();
+        cfg.observe_request(&json!({
+            "method": "GetTaskPushNotificationConfig",
+            "params": {"taskId": "t-8", "configId": "c-9"}
+        }));
+        assert_eq!(cfg.task_id, "t-8");
+    }
+
+    #[test]
+    fn a_task_result_yields_the_task_and_its_state() {
+        let mut facts = A2aCallFacts::default();
+        facts.observe_result(&json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": {
+                "kind": "task", "id": "t-2", "contextId": "c-2",
+                "status": {"state": "working"}
+            }
+        }));
+        assert_eq!(facts.task_id, "t-2");
+        assert_eq!(facts.context_id, "c-2");
+        assert_eq!(facts.task_state, "working");
+    }
+
+    #[test]
+    fn a_message_result_is_not_mistaken_for_a_task() {
+        // An agent may answer `message/send` with a bare Message, whose `id`
+        // is a MESSAGE id. Recording it as the task id would attach the call
+        // to a task that does not exist.
+        let mut facts = A2aCallFacts::default();
+        facts.observe_result(&json!({
+            "result": {"kind": "message", "id": "m-1", "role": "agent", "contextId": "c-3"}
+        }));
+        assert_eq!(facts.task_id, "");
+        assert_eq!(facts.context_id, "c-3");
+        assert_eq!(facts.task_state, "");
+    }
+
+    #[test]
+    fn a_stream_records_the_last_state_the_caller_saw() {
+        // Streamed status updates carry `taskId`, not `id`, and the state
+        // advances event by event. The recorded state is the last one the
+        // upstream reported — including when the caller walks away mid-task,
+        // where inventing a terminal state would be a lie.
+        let mut facts = A2aCallFacts::default();
+        for state in ["submitted", "working", "input-required"] {
+            facts.observe_result(&json!({
+                "result": {
+                    "kind": "status-update", "taskId": "t-4", "contextId": "c-4",
+                    "status": {"state": state}, "final": false
+                }
+            }));
+        }
+        assert_eq!(facts.task_id, "t-4");
+        assert_eq!(facts.context_id, "c-4");
+        assert_eq!(facts.task_state, "input-required");
+    }
+
+    #[test]
+    fn an_error_envelope_leaves_the_request_facts_standing() {
+        // A JSON-RPC error carries no `result`; the task the caller named in
+        // the request must survive, so a failed `tasks/get` is still
+        // attributable to its task.
+        let mut facts = A2aCallFacts::default();
+        facts.observe_request(&json!({"method": "tasks/get", "params": {"id": "t-5"}}));
+        facts.observe_result(&json!({
+            "jsonrpc": "2.0", "id": 1,
+            "error": {"code": -32001, "message": "task not found"}
+        }));
+        assert_eq!(facts.task_id, "t-5");
+        assert_eq!(facts.task_state, "");
+    }
+
+    #[test]
+    fn an_empty_id_never_erases_one_already_seen() {
+        let mut facts = A2aCallFacts::default();
+        facts.observe_request(&json!({"method": "message/send", "params": {
+            "message": {"taskId": "t-6", "contextId": "c-6"}
+        }}));
+        facts.observe_result(&json!({"result": {"taskId": "", "contextId": null}}));
+        assert_eq!(facts.task_id, "t-6");
+        assert_eq!(facts.context_id, "c-6");
+    }
+}

--- a/crates/aisix-a2a/src/telemetry.rs
+++ b/crates/aisix-a2a/src/telemetry.rs
@@ -176,16 +176,22 @@ impl A2aCallFacts {
             return;
         };
         // A send / stream continues a task from its message; the
-        // push-notification operations name the task on params itself; and
-        // `tasks/get` / `tasks/cancel` / `tasks/resubscribe` carry it as
-        // `params.id`. The three are mutually exclusive per operation, and the
-        // field names are identical in both wire versions (1.0's protobuf JSON
+        // push-notification operations name it as `params.taskId`. Both spell
+        // the field the same way in either wire version (1.0's protobuf JSON
         // renders `task_id` / `context_id` in camelCase).
         for source in [params.get("message"), Some(params)].into_iter().flatten() {
             self.set_task_id(str_field(source, "taskId"));
             self.set_context_id(str_field(source, "contextId"));
         }
-        self.set_task_id(str_field(params, "id"));
+        // `params.id` is a FALLBACK, never an override: it is the task for
+        // `tasks/get` / `tasks/cancel` / `tasks/resubscribe` (both versions)
+        // and for the 0.3 push-notification operations, but on their 1.0
+        // counterparts it is the push-notification CONFIG's id sitting
+        // alongside the task's own `taskId`. Applying it unconditionally would
+        // file those calls under a task that does not exist.
+        if self.task_id.is_empty() {
+            self.set_task_id(str_field(params, "id"));
+        }
     }
 
     /// Read a JSON-RPC response envelope — or one streamed event — for the
@@ -346,13 +352,25 @@ mod tests {
             assert_eq!(facts.task_id, "t-7", "{method} names its task");
         }
 
-        // The push-notification operations name the parent task instead.
-        let mut cfg = A2aCallFacts::default();
-        cfg.observe_request(&json!({
+        // The push-notification operations name the parent task instead — and
+        // in 1.0 they carry the CONFIG's id in `params.id` right next to it.
+        // Reading `id` last would file the call under a task that does not
+        // exist, so an explicit `taskId` has to win.
+        let mut v10_cfg = A2aCallFacts::default();
+        v10_cfg.observe_request(&json!({
             "method": "GetTaskPushNotificationConfig",
-            "params": {"taskId": "t-8", "configId": "c-9"}
+            "params": {"taskId": "t-8", "id": "cfg-9"}
         }));
-        assert_eq!(cfg.task_id, "t-8");
+        assert_eq!(v10_cfg.task_id, "t-8");
+
+        // 0.3 spells the same request with the TASK in `id`, so the fallback
+        // still has to fire when no `taskId` is present.
+        let mut v03_cfg = A2aCallFacts::default();
+        v03_cfg.observe_request(&json!({
+            "method": "tasks/pushNotificationConfig/get",
+            "params": {"id": "t-8", "pushNotificationConfigId": "cfg-9"}
+        }));
+        assert_eq!(v03_cfg.task_id, "t-8");
     }
 
     #[test]

--- a/crates/aisix-a2a/src/telemetry.rs
+++ b/crates/aisix-a2a/src/telemetry.rs
@@ -32,9 +32,13 @@ pub const UNKNOWN_OPERATION: &str = "unknown";
 /// specification defines.
 pub const UNKNOWN_TASK_STATE: &str = "unknown";
 
-/// The canonical operation names, in their 0.3 spelling — the vocabulary the
-/// dashboard, metrics and docs use. The 1.0 PascalCase RPC name for the same
-/// operation maps onto the same entry.
+/// The canonical operation names — the vocabulary the dashboard, metrics and
+/// docs use. Each is a method's 0.3 spelling where 0.3 defines the operation,
+/// and the 1.0 PascalCase RPC name for the same operation maps onto it.
+///
+/// `ListTasks` is the exception: 1.0 added it, so there is no 0.3 spelling to
+/// borrow and only the 1.0 method appears on the left. Its canonical name
+/// follows the same shape as the rest so the vocabulary stays uniform.
 const OPERATIONS: &[(&str, &str)] = &[
     // (wire method, canonical operation)
     ("message/send", "message/send"),
@@ -43,7 +47,6 @@ const OPERATIONS: &[(&str, &str)] = &[
     ("SendStreamingMessage", "message/stream"),
     ("tasks/get", "tasks/get"),
     ("GetTask", "tasks/get"),
-    ("tasks/list", "tasks/list"),
     ("ListTasks", "tasks/list"),
     ("tasks/cancel", "tasks/cancel"),
     ("CancelTask", "tasks/cancel"),
@@ -89,6 +92,11 @@ const OPERATIONS: &[(&str, &str)] = &[
 ];
 
 /// The task states the specification defines, in their 0.3 wire spelling.
+///
+/// 0.3's own enum also carries a literal `unknown` (1.0 replaced it with
+/// `TASK_STATE_UNSPECIFIED`). It is deliberately absent here so it falls
+/// through to [`UNKNOWN_TASK_STATE`] — the recorded string is the same either
+/// way, and listing it would only imply the two are distinguishable.
 const TASK_STATES: &[&str] = &[
     "submitted",
     "working",
@@ -204,13 +212,16 @@ impl A2aCallFacts {
         let Some(result) = response.get("result") else {
             return;
         };
-        self.set_context_id(str_field(result, "contextId"));
-        self.set_task_id(str_field(result, "taskId"));
-        // A `Task` names itself in `id`, but so does a `Message` — and a
-        // message id is not a task id. `status` is the discriminator: every
-        // Task has one and no Message does, in either wire version.
-        if let Some(status) = result.get("status") {
-            self.set_task_id(str_field(result, "id"));
+        let payload = unwrap_payload(result);
+        self.set_context_id(str_field(payload, "contextId"));
+        self.set_task_id(str_field(payload, "taskId"));
+        // `status` is the discriminator between a Task and a Message: every
+        // Task has one and no Message does, in either wire version. Neither
+        // spells a message id as `id` (both use `messageId`), so this guards
+        // only against a nonstandard shape — it costs nothing and keeps a
+        // message from ever being filed as a task.
+        if let Some(status) = payload.get("status") {
+            self.set_task_id(str_field(payload, "id"));
             if let Some(state) = str_field(status, "state") {
                 self.task_state = normalize_task_state(state).to_string();
             }
@@ -228,6 +239,31 @@ impl A2aCallFacts {
             self.context_id = value.to_string();
         }
     }
+}
+
+/// The 1.0 payload `oneof` field names, in `SendMessageResponse` /
+/// `StreamResponse` order.
+const V1_PAYLOAD_KEYS: [&str; 4] = ["task", "message", "statusUpdate", "artifactUpdate"];
+
+/// Reach the Task / Message / update event a `result` carries.
+///
+/// 0.3 puts the object directly at `result`, tagged with `kind`. 1.0's
+/// `SendMessage` and streaming responses instead wrap it in a `oneof payload`,
+/// which protobuf JSON renders as the set field's own name — so the same task
+/// arrives as `{"task": {…}}` there. Reading only the 0.3 shape found nothing
+/// at all on 1.0, which is the DEFAULT version for a registered agent.
+///
+/// A `kind` settles it as 0.3 outright; no 1.0 payload has one. Anything else
+/// is returned untouched, which is also right for the 1.0 operations that
+/// answer with a bare `Task` (`GetTask`, `CancelTask` define no wrapper).
+fn unwrap_payload(result: &Value) -> &Value {
+    if result.get("kind").is_some() {
+        return result;
+    }
+    V1_PAYLOAD_KEYS
+        .iter()
+        .find_map(|key| result.get(*key).filter(|value| value.is_object()))
+        .unwrap_or(result)
 }
 
 /// A non-empty string field, or `None` — an absent field and an empty one are
@@ -253,7 +289,6 @@ mod tests {
             ("message/send", "SendMessage"),
             ("message/stream", "SendStreamingMessage"),
             ("tasks/get", "GetTask"),
-            ("tasks/list", "ListTasks"),
             ("tasks/cancel", "CancelTask"),
             ("tasks/resubscribe", "SubscribeToTask"),
             (
@@ -281,6 +316,15 @@ mod tests {
                 "{v10} must canonicalise to {v03}"
             );
         }
+    }
+
+    #[test]
+    fn a_1_0_only_operation_has_no_0_3_spelling_to_accept() {
+        // `ListTasks` was added in 1.0, so `tasks/list` is a name this
+        // gateway's own vocabulary uses — not a method any version defines.
+        // Accepting it on the wire would invent a 0.3 method.
+        assert_eq!(canonical_operation("ListTasks"), "tasks/list");
+        assert_eq!(canonical_operation("tasks/list"), UNKNOWN_OPERATION);
     }
 
     #[test]
@@ -390,16 +434,75 @@ mod tests {
 
     #[test]
     fn a_message_result_is_not_mistaken_for_a_task() {
-        // An agent may answer `message/send` with a bare Message, whose `id`
-        // is a MESSAGE id. Recording it as the task id would attach the call
-        // to a task that does not exist.
+        // An agent may answer `message/send` with a bare Message rather than a
+        // Task. It carries a context but no task and no state, and none of
+        // those may be invented for it.
         let mut facts = A2aCallFacts::default();
         facts.observe_result(&json!({
-            "result": {"kind": "message", "id": "m-1", "role": "agent", "contextId": "c-3"}
+            "result": {"kind": "message", "messageId": "m-1", "role": "agent", "contextId": "c-3"}
         }));
         assert_eq!(facts.task_id, "");
         assert_eq!(facts.context_id, "c-3");
         assert_eq!(facts.task_state, "");
+    }
+
+    #[test]
+    fn a_1_0_result_is_read_through_its_payload_wrapper() {
+        // 1.0 — the DEFAULT version for a registered agent — wraps the object
+        // in the response's `oneof payload`, which protobuf JSON renders as
+        // the set field's name. Reading only 0.3's flat shape found nothing at
+        // all here, so every field this module exists to record came back
+        // empty on the default version.
+        let mut send = A2aCallFacts::default();
+        send.observe_result(&json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": {"task": {
+                "id": "t-10", "contextId": "c-10",
+                "status": {"state": "TASK_STATE_COMPLETED"}
+            }}
+        }));
+        assert_eq!(send.task_id, "t-10");
+        assert_eq!(send.context_id, "c-10");
+        assert_eq!(send.task_state, "completed");
+
+        // The streaming wrapper has two more variants.
+        let mut status = A2aCallFacts::default();
+        status.observe_result(&json!({
+            "result": {"statusUpdate": {
+                "taskId": "t-11", "contextId": "c-11",
+                "status": {"state": "TASK_STATE_WORKING"}
+            }}
+        }));
+        assert_eq!(status.task_id, "t-11");
+        assert_eq!(status.task_state, "working");
+
+        let mut artifact = A2aCallFacts::default();
+        artifact.observe_result(&json!({
+            "result": {"artifactUpdate": {"taskId": "t-12", "contextId": "c-12"}}
+        }));
+        assert_eq!(artifact.task_id, "t-12");
+        assert_eq!(artifact.context_id, "c-12");
+
+        // A 1.0 Message payload still yields its context and no task.
+        let mut message = A2aCallFacts::default();
+        message.observe_result(&json!({
+            "result": {"message": {"messageId": "m-2", "contextId": "c-13", "role": "agent"}}
+        }));
+        assert_eq!(message.task_id, "");
+        assert_eq!(message.context_id, "c-13");
+    }
+
+    #[test]
+    fn a_1_0_bare_task_result_is_read_without_a_wrapper() {
+        // `GetTask` and `CancelTask` define no response wrapper — they answer
+        // with the Task itself, so the unwrapping must not require one.
+        let mut facts = A2aCallFacts::default();
+        facts.observe_result(&json!({
+            "result": {"id": "t-14", "contextId": "c-14", "status": {"state": "TASK_STATE_CANCELED"}}
+        }));
+        assert_eq!(facts.task_id, "t-14");
+        assert_eq!(facts.context_id, "c-14");
+        assert_eq!(facts.task_state, "canceled");
     }
 
     #[test]

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -613,7 +613,7 @@ fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
 
     let mut attributes = vec![
         attr_string("gen_ai.system", "aisix"),
-        attr_string("gen_ai.operation.name", "chat"),
+        attr_string("gen_ai.operation.name", operation_name(event)),
     ];
     // The model alias the client sent (`model` field) — a Model-Group
     // name for routed requests (AISIX-Cloud#790). Semconv key for the
@@ -716,6 +716,43 @@ fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
             &event.client_user_agent,
         ));
     }
+    // Gateway-protocol attribution. An A2A or MCP call is not a model
+    // inference, and encoding one as a bare `chat` span left every agent and
+    // tool call in a trace backend indistinguishable from an LLM request —
+    // with the agent, the method and the task it touched recorded nowhere at
+    // all (AISIX-Cloud#1215).
+    match event.inbound_protocol.as_str() {
+        "a2a" => {
+            if !event.a2a_agent_name.is_empty() {
+                attributes.push(attr_string("gen_ai.agent.name", &event.a2a_agent_name));
+            }
+            // An A2A context ties a multi-turn exchange's tasks together —
+            // exactly what semconv means by a conversation id.
+            if !event.a2a_context_id.is_empty() {
+                attributes.push(attr_string("gen_ai.conversation.id", &event.a2a_context_id));
+            }
+            for (key, value) in [
+                ("aisix.a2a.method", &event.a2a_method),
+                ("aisix.a2a.operation", &event.a2a_operation),
+                ("aisix.a2a.protocol_version", &event.a2a_protocol_version),
+                ("aisix.a2a.task_id", &event.a2a_task_id),
+                ("aisix.a2a.task_state", &event.a2a_task_state),
+            ] {
+                if !value.is_empty() {
+                    attributes.push(attr_string(key, value));
+                }
+            }
+        }
+        "mcp" => {
+            if !event.mcp_tool_name.is_empty() {
+                attributes.push(attr_string("gen_ai.tool.name", &event.mcp_tool_name));
+            }
+            if !event.mcp_server_name.is_empty() {
+                attributes.push(attr_string("aisix.mcp.server_name", &event.mcp_server_name));
+            }
+        }
+        _ => {}
+    }
     // Opt-in captured content (#519 B.2) — present ONLY on a record built by
     // [`content_record`] for a `content_mode = full` exporter. Keys match the
     // Datadog sink's flattened content fields, so one query vocabulary works
@@ -731,13 +768,44 @@ fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
     json!({
         "traceId": trace_id,
         "spanId":  span_id,
-        "name":    "chat.completions",
-        "kind":    3, // SPAN_KIND_CLIENT (DP → upstream LLM)
+        "name":    span_name(event),
+        "kind":    3, // SPAN_KIND_CLIENT (DP → upstream LLM / agent / MCP server)
         "startTimeUnixNano": start_unix_nano.to_string(),
         "endTimeUnixNano":   end_unix_nano.to_string(),
         "attributes": attributes,
         "status": { "code": status_code },
     })
+}
+
+/// The OpenTelemetry GenAI operation this event describes.
+///
+/// The gateway fronts three kinds of upstream, and only one of them is a model
+/// inference. `invoke_agent` and `execute_tool` are the semconv's own
+/// well-known values for the other two, so an A2A or MCP span lands in the
+/// same bucket a trace backend already understands.
+fn operation_name(event: &UsageEvent) -> &'static str {
+    match event.inbound_protocol.as_str() {
+        "a2a" => "invoke_agent",
+        "mcp" => "execute_tool",
+        _ => "chat",
+    }
+}
+
+/// The span's name: `{operation} {target}` where the target is low-cardinality
+/// and known, per the semconv's naming rule for agent and tool spans. LLM
+/// traffic keeps the name it has always had.
+fn span_name(event: &UsageEvent) -> String {
+    let operation = operation_name(event);
+    let target = match event.inbound_protocol.as_str() {
+        "a2a" => &event.a2a_agent_name,
+        "mcp" => &event.mcp_tool_name,
+        _ => return "chat.completions".to_string(),
+    };
+    if target.is_empty() {
+        operation.to_string()
+    } else {
+        format!("{operation} {target}")
+    }
 }
 
 /// Wrap one or more spans into an OTLP/HTTP-JSON `ExportTraceServiceRequest`.
@@ -1318,6 +1386,101 @@ mod tests {
         assert!(keys.contains(&"aisix.model_id"));
         assert!(keys.contains(&"aisix.exporter_name"));
         assert!(keys.contains(&"aisix.request_id"));
+    }
+
+    #[test]
+    fn an_a2a_call_exports_as_an_agent_span_not_a_chat_one() {
+        // Every gateway-protocol event used to be encoded as `chat` /
+        // `chat.completions`, so an agent call was indistinguishable from a
+        // model inference in a trace backend and the agent, method and task it
+        // touched appeared nowhere (AISIX-Cloud#1215).
+        let mut ev = sample_event();
+        ev.inbound_protocol = "a2a".into();
+        ev.a2a_agent_name = "invoice-processor".into();
+        ev.a2a_method = "SendStreamingMessage".into();
+        ev.a2a_operation = "message/stream".into();
+        ev.a2a_protocol_version = "1.0".into();
+        ev.a2a_task_id = "task-9".into();
+        ev.a2a_context_id = "ctx-4".into();
+        ev.a2a_task_state = "working".into();
+
+        let body = build_otlp_traces_payload(&ev, "test-exp");
+        let span = &body["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+        assert_eq!(span["name"], "invoke_agent invoice-processor");
+        let attrs = span["attributes"].as_array().unwrap();
+        let find = |k: &str| attrs.iter().find(|a| a["key"] == k);
+        let string_at = |k: &str| find(k).unwrap()["value"]["stringValue"].clone();
+        assert_eq!(string_at("gen_ai.operation.name"), "invoke_agent");
+        assert_eq!(string_at("gen_ai.agent.name"), "invoice-processor");
+        // A2A's context id is semconv's conversation id — the thread a
+        // multi-turn exchange's tasks hang off.
+        assert_eq!(string_at("gen_ai.conversation.id"), "ctx-4");
+        assert_eq!(string_at("aisix.a2a.method"), "SendStreamingMessage");
+        assert_eq!(string_at("aisix.a2a.operation"), "message/stream");
+        assert_eq!(string_at("aisix.a2a.protocol_version"), "1.0");
+        assert_eq!(string_at("aisix.a2a.task_id"), "task-9");
+        assert_eq!(string_at("aisix.a2a.task_state"), "working");
+    }
+
+    #[test]
+    fn an_mcp_call_exports_as_a_tool_span() {
+        let mut ev = sample_event();
+        ev.inbound_protocol = "mcp".into();
+        ev.mcp_server_name = "github".into();
+        ev.mcp_tool_name = "create_issue".into();
+
+        let body = build_otlp_traces_payload(&ev, "test-exp");
+        let span = &body["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+        assert_eq!(span["name"], "execute_tool create_issue");
+        let attrs = span["attributes"].as_array().unwrap();
+        let find = |k: &str| attrs.iter().find(|a| a["key"] == k);
+        assert_eq!(
+            find("gen_ai.operation.name").unwrap()["value"]["stringValue"],
+            "execute_tool"
+        );
+        assert_eq!(
+            find("gen_ai.tool.name").unwrap()["value"]["stringValue"],
+            "create_issue"
+        );
+        assert_eq!(
+            find("aisix.mcp.server_name").unwrap()["value"]["stringValue"],
+            "github"
+        );
+    }
+
+    #[test]
+    fn a_gateway_protocol_span_without_a_target_keeps_a_bare_name() {
+        // A pre-dispatch rejection resolves no agent, so there is no
+        // low-cardinality target to append — semconv says name the span after
+        // the operation alone rather than inventing one.
+        let mut ev = sample_event();
+        ev.inbound_protocol = "a2a".into();
+        let body = build_otlp_traces_payload(&ev, "test-exp");
+        assert_eq!(
+            body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["name"],
+            "invoke_agent"
+        );
+    }
+
+    #[test]
+    fn llm_traffic_keeps_its_chat_span_shape() {
+        // The protocol switch must not move LLM spans: dashboards and saved
+        // trace queries are written against these two values.
+        for protocol in ["", "openai", "anthropic"] {
+            let mut ev = sample_event();
+            ev.inbound_protocol = protocol.into();
+            let body = build_otlp_traces_payload(&ev, "test-exp");
+            let span = &body["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+            assert_eq!(span["name"], "chat.completions", "protocol={protocol:?}");
+            let attrs = span["attributes"].as_array().unwrap();
+            assert_eq!(
+                attrs
+                    .iter()
+                    .find(|a| a["key"] == "gen_ai.operation.name")
+                    .unwrap()["value"]["stringValue"],
+                "chat"
+            );
+        }
     }
 
     #[test]

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -729,7 +729,10 @@ fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
             // An A2A context ties a multi-turn exchange's tasks together —
             // exactly what semconv means by a conversation id.
             if !event.a2a_context_id.is_empty() {
-                attributes.push(attr_string("gen_ai.conversation.id", &event.a2a_context_id));
+                attributes.push(attr_string_capped(
+                    "gen_ai.conversation.id",
+                    &event.a2a_context_id,
+                ));
             }
             for (key, value) in [
                 ("aisix.a2a.method", &event.a2a_method),
@@ -739,13 +742,13 @@ fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
                 ("aisix.a2a.task_state", &event.a2a_task_state),
             ] {
                 if !value.is_empty() {
-                    attributes.push(attr_string(key, value));
+                    attributes.push(attr_string_capped(key, value));
                 }
             }
         }
         "mcp" => {
             if !event.mcp_tool_name.is_empty() {
-                attributes.push(attr_string("gen_ai.tool.name", &event.mcp_tool_name));
+                attributes.push(attr_string_capped("gen_ai.tool.name", &event.mcp_tool_name));
             }
             if !event.mcp_server_name.is_empty() {
                 attributes.push(attr_string("aisix.mcp.server_name", &event.mcp_server_name));
@@ -769,7 +772,10 @@ fn build_otlp_span(record: &SinkRecord, exporter_name: &str) -> Value {
         "traceId": trace_id,
         "spanId":  span_id,
         "name":    span_name(event),
-        "kind":    3, // SPAN_KIND_CLIENT (DP → upstream LLM / agent / MCP server)
+        // SPAN_KIND_CLIENT for all three: the gateway is the client of a
+        // remote LLM, agent or MCP server. The conventions name INTERNAL for
+        // a tool executed in-process, which is not what this span describes.
+        "kind":    3,
         "startTimeUnixNano": start_unix_nano.to_string(),
         "endTimeUnixNano":   end_unix_nano.to_string(),
         "attributes": attributes,
@@ -791,9 +797,23 @@ fn operation_name(event: &UsageEvent) -> &'static str {
     }
 }
 
+/// Longest target this will append to a span name.
+///
+/// An A2A agent name is a registered resource, but an MCP tool name is the
+/// caller's own `tools/call` `params.name` and is recorded before the tool is
+/// known to exist — including on the quota-rejection path, which emits without
+/// ever contacting an upstream. A trace backend indexes span names and most
+/// derive RED metrics from them, so the one field a caller picks freely is
+/// bounded before it gets there.
+const MAX_SPAN_NAME_TARGET: usize = 64;
+
 /// The span's name: `{operation} {target}` where the target is low-cardinality
 /// and known, per the semconv's naming rule for agent and tool spans. LLM
 /// traffic keeps the name it has always had.
+///
+/// A target that is absent or outside [`MAX_SPAN_NAME_TARGET`] leaves the bare
+/// operation, which the conventions name as the fallback for exactly this
+/// case. The raw value is still on the span as an attribute either way.
 fn span_name(event: &UsageEvent) -> String {
     let operation = operation_name(event);
     let target = match event.inbound_protocol.as_str() {
@@ -801,7 +821,7 @@ fn span_name(event: &UsageEvent) -> String {
         "mcp" => &event.mcp_tool_name,
         _ => return "chat.completions".to_string(),
     };
-    if target.is_empty() {
+    if target.is_empty() || target.len() > MAX_SPAN_NAME_TARGET {
         operation.to_string()
     } else {
         format!("{operation} {target}")
@@ -840,6 +860,25 @@ fn attr_string(key: &str, value: &str) -> Value {
         "key": key,
         "value": { "stringValue": value },
     })
+}
+
+/// Longest caller-supplied attribute value carried on a span.
+///
+/// The gateway-protocol attributes below are copied from the caller's own
+/// JSON-RPC envelope (the method it invoked, the ids it named), and the
+/// request body limit defaults to unlimited, so their length is the caller's
+/// choice. Every span rides in a batched export, so an unbounded value is a
+/// delivery problem as much as a storage one.
+const MAX_PROTOCOL_ATTR_BYTES: usize = 256;
+
+/// [`attr_string`] for a value a caller controls, cut to
+/// [`MAX_PROTOCOL_ATTR_BYTES`] on a UTF-8 boundary.
+fn attr_string_capped(key: &str, value: &str) -> Value {
+    let mut end = MAX_PROTOCOL_ATTR_BYTES.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    attr_string(key, &value[..end])
 }
 
 fn attr_int(key: &str, value: i64) -> Value {
@@ -1446,6 +1485,53 @@ mod tests {
             find("aisix.mcp.server_name").unwrap()["value"]["stringValue"],
             "github"
         );
+    }
+
+    #[test]
+    fn a_caller_chosen_target_cannot_grow_the_span_name() {
+        // An MCP tool name is the caller's own `tools/call` `params.name`,
+        // recorded before the tool is known to exist, and the request body
+        // limit defaults to unlimited. A trace backend indexes span names, so
+        // an oversized one falls back to the bare operation and travels as an
+        // attribute instead — itself cut to a fixed cap.
+        let mut ev = sample_event();
+        ev.inbound_protocol = "mcp".into();
+        ev.mcp_tool_name = "t".repeat(4096);
+
+        let body = build_otlp_traces_payload(&ev, "test-exp");
+        let span = &body["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+        assert_eq!(span["name"], "execute_tool");
+        let attrs = span["attributes"].as_array().unwrap();
+        let tool = attrs
+            .iter()
+            .find(|a| a["key"] == "gen_ai.tool.name")
+            .unwrap()["value"]["stringValue"]
+            .as_str()
+            .unwrap();
+        assert_eq!(tool.len(), MAX_PROTOCOL_ATTR_BYTES);
+    }
+
+    #[test]
+    fn a_capped_attribute_is_cut_on_a_char_boundary() {
+        // A multi-byte character straddling the cap must not produce invalid
+        // UTF-8 in the export body.
+        let mut ev = sample_event();
+        ev.inbound_protocol = "a2a".into();
+        ev.a2a_method = "情".repeat(200);
+
+        let body = build_otlp_traces_payload(&ev, "test-exp");
+        let attrs = body["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let method = attrs
+            .iter()
+            .find(|a| a["key"] == "aisix.a2a.method")
+            .unwrap()["value"]["stringValue"]
+            .as_str()
+            .unwrap();
+        assert!(method.len() <= MAX_PROTOCOL_ATTR_BYTES);
+        assert!(method.chars().all(|c| c == '情'));
     }
 
     #[test]

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -455,10 +455,59 @@ pub struct UsageEvent {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub a2a_agent_name: String,
 
-    /// The JSON-RPC method invoked on the A2A agent (such as `message/send`).
+    /// The JSON-RPC method invoked on the A2A agent, exactly as the caller
+    /// wrote it (such as `message/send`, or its 1.0 spelling `SendMessage`).
     /// Empty for non-A2A events; cp-api stores empty as NULL.
+    ///
+    /// Unbounded by nature — a caller picks the string — so this is the
+    /// forensic value only. Aggregate on `a2a_operation`.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub a2a_method: String,
+
+    /// The canonical operation `a2a_method` names, collapsing the two wire
+    /// vocabularies onto one bounded set (`message/send`, `message/stream`,
+    /// `tasks/get`, …) and everything unrecognised onto `unknown`.
+    ///
+    /// A gateway may front a 0.3 agent and a 1.0 agent at once, and those call
+    /// the same operation `message/stream` and `SendStreamingMessage`. This is
+    /// the field to group or label by; `a2a_method` keeps the raw value.
+    /// Empty for non-A2A events.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub a2a_operation: String,
+
+    /// The A2A wire version this agent is pinned to (`0.3` / `1.0`) — what the
+    /// gateway announced to it in the `A2A-Version` header. Empty for non-A2A
+    /// events.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub a2a_protocol_version: String,
+
+    /// The A2A task this call created or acted on. Empty when the call names
+    /// no task — a first `message/send` whose agent answers with a bare
+    /// message never has one.
+    ///
+    /// High-cardinality by design: it joins a request to a task across the
+    /// `message/send` → `tasks/get` → `tasks/resubscribe` sequence, so it
+    /// belongs in logs and traces and never in a metric label.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub a2a_task_id: String,
+
+    /// The A2A context (conversation) the call belongs to — the id that ties
+    /// a multi-turn interaction's tasks together. Empty when the exchange
+    /// carried none. High-cardinality, same as `a2a_task_id`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub a2a_context_id: String,
+
+    /// The last task state the upstream reported on this call, normalized to
+    /// the specification's set (`submitted`, `working`, `input-required`,
+    /// `completed`, `canceled`, `failed`, `rejected`, `auth-required`) or
+    /// `unknown` for anything else.
+    ///
+    /// For a streamed call this is the state the task was in when the stream
+    /// ended — including when the caller walked away mid-task, where no
+    /// terminal state is invented. Empty when no response carried a state at
+    /// all (the call failed before the upstream answered).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub a2a_task_state: String,
 }
 
 #[inline]

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -776,20 +776,22 @@ mod tests {
         let app = axum::Router::new().route(
             "/a2a",
             axum::routing::post(|| async {
-                let chunks: Vec<Result<String, std::convert::Infallible>> = [
-                    "submitted",
-                    "working",
-                    "input-required",
-                ]
-                .iter()
-                .map(|state| {
-                    Ok(format!(
-                        "data: {{\"jsonrpc\":\"2.0\",\"result\":{{\"kind\":\"status-update\",\
-                                 \"taskId\":\"task-77\",\"contextId\":\"ctx-77\",\
-                                 \"status\":{{\"state\":\"{state}\"}}}}}}\n\n"
-                    ))
-                })
-                .collect();
+                let chunks: Vec<Result<String, std::convert::Infallible>> =
+                    ["submitted", "working", "input-required"]
+                        .iter()
+                        .map(|state| {
+                            let event = serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "result": {
+                                    "kind": "status-update",
+                                    "taskId": "task-77",
+                                    "contextId": "ctx-77",
+                                    "status": {"state": state},
+                                },
+                            });
+                            Ok(format!("data: {event}\n\n"))
+                        })
+                        .collect();
                 (
                     [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
                     axum::body::Body::from_stream(futures::stream::iter(chunks)),

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -30,14 +30,16 @@
 
 use std::time::{Duration, Instant};
 
-use aisix_a2a::{upstream_from_a2a_agent, A2aBridge, A2aError, HttpBridge};
+use aisix_a2a::{
+    canonical_operation, is_streaming_operation, upstream_from_a2a_agent, A2aBridge, A2aCallFacts,
+    A2aError, HttpBridge,
+};
 use aisix_obs::{AccessLog, UsageEvent};
 use axum::body::to_bytes;
 use axum::extract::{Request, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use futures::StreamExt;
-use serde::Deserialize;
 
 use crate::auth::AuthenticatedKey;
 use crate::reject::AisixPath;
@@ -49,12 +51,21 @@ use crate::state::ProxyState;
 /// kept as a fixed label to match the /mcp convention and #451).
 const A2A_MODEL_LABEL: &str = "a2a";
 
-/// Just enough of a JSON-RPC request to record the method for usage and echo
-/// the id back in a synthesized error. Unknown fields are ignored.
-#[derive(Deserialize)]
-struct JsonRpcPeek {
-    method: Option<String>,
-    id: Option<serde_json::Value>,
+/// One A2A call's protocol-level identity, read off its JSON-RPC envelopes and
+/// carried to the usage emit.
+///
+/// [`A2aCallFacts`] keeps accumulating as responses (or stream events) arrive,
+/// so the emit records the task the call ended on rather than the one it
+/// started with.
+struct A2aCall {
+    /// The wire method exactly as the caller wrote it — unbounded, kept for
+    /// forensics.
+    method: String,
+    /// The bounded operation that method names, for aggregation.
+    operation: &'static str,
+    /// The wire version the agent is pinned to (`0.3` / `1.0`).
+    protocol_version: &'static str,
+    facts: A2aCallFacts,
 }
 
 /// Serve a JSON-RPC request to `/a2a/:agent`. Authentication (`401`), per-agent
@@ -168,12 +179,21 @@ async fn dispatch(
         Ok(value) => value,
         Err(_) => return (StatusCode::BAD_REQUEST, "invalid JSON-RPC body").into_response(),
     };
-    let peek = serde_json::from_slice::<JsonRpcPeek>(&bytes).ok();
-    let method = peek
-        .as_ref()
-        .and_then(|p| p.method.clone())
-        .unwrap_or_default();
-    let rpc_id = peek.and_then(|p| p.id);
+    let method = value
+        .get("method")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let rpc_id = value.get("id").cloned();
+    let mut call = A2aCall {
+        operation: canonical_operation(&method),
+        method,
+        protocol_version: upstream.protocol_version.as_wire_str(),
+        facts: A2aCallFacts::default(),
+    };
+    // Read before the upstream is contacted, so a call that never lands still
+    // records which task the caller was asking about.
+    call.facts.observe_request(&value);
 
     // Reuse the LLM path's rate-limit + budget gate. The reservation is held
     // for the call (an A2A call carries no token cost yet). On 429 /
@@ -187,7 +207,7 @@ async fn dispatch(
                 &auth,
                 request_id,
                 agent,
-                &method,
+                &call,
                 response.status().as_u16(),
                 Duration::ZERO,
             );
@@ -195,7 +215,7 @@ async fn dispatch(
         }
     };
 
-    if is_streaming_method(&method) {
+    if is_streaming_operation(call.operation) {
         return dispatch_stream(
             auth,
             agent,
@@ -203,7 +223,7 @@ async fn dispatch(
             request_id,
             upstream,
             value,
-            &method,
+            call,
             rpc_id,
             reservation,
         )
@@ -218,12 +238,13 @@ async fn dispatch(
 
     match result {
         Ok(response_value) => {
+            call.facts.observe_result(&response_value);
             emit_a2a_usage(
                 state,
                 &auth,
                 request_id,
                 agent,
-                &method,
+                &call,
                 StatusCode::OK.as_u16(),
                 latency,
             );
@@ -237,24 +258,13 @@ async fn dispatch(
                 &auth,
                 request_id,
                 agent,
-                &method,
+                &call,
                 status.as_u16(),
                 latency,
             );
             a2a_error_response(rpc_id, status, &err.to_string())
         }
     }
-}
-
-/// JSON-RPC methods whose response is an SSE event stream rather than one
-/// envelope. Both spellings are listed because the body is forwarded verbatim:
-/// the caller speaks whichever wire version its agent is pinned to, and 1.0
-/// names the same two methods in PascalCase.
-fn is_streaming_method(method: &str) -> bool {
-    matches!(
-        method,
-        "message/stream" | "SendStreamingMessage" | "tasks/resubscribe" | "SubscribeToTask"
-    )
 }
 
 /// Fires the A2A usage event once a streamed call is over, and owns the
@@ -275,7 +285,11 @@ struct StreamUsageOnDrop {
     auth: AuthenticatedKey,
     request_id: String,
     agent: String,
-    method: String,
+    /// The call's protocol identity. Its [`A2aCallFacts`] keep accumulating as
+    /// events arrive, so a caller that walks away mid-task is recorded against
+    /// the last state the upstream actually reported rather than an invented
+    /// terminal one.
+    call: A2aCall,
     started: Instant,
     /// What to record for the call. Starts at the status already sent to the
     /// caller and is downgraded if the stream later faults — once the headers
@@ -296,7 +310,7 @@ impl Drop for StreamUsageOnDrop {
             &self.auth,
             &self.request_id,
             &self.agent,
-            &self.method,
+            &self.call,
             self.status,
             self.started.elapsed(),
         );
@@ -316,7 +330,7 @@ async fn dispatch_stream(
     request_id: &str,
     upstream: aisix_a2a::A2aUpstream,
     request: serde_json::Value,
-    method: &str,
+    call: A2aCall,
     rpc_id: Option<serde_json::Value>,
     reservation: aisix_ratelimit::MultiReservation,
 ) -> Response {
@@ -335,7 +349,7 @@ async fn dispatch_stream(
                 &auth,
                 request_id,
                 agent,
-                method,
+                &call,
                 status.as_u16(),
                 started.elapsed(),
             );
@@ -348,7 +362,7 @@ async fn dispatch_stream(
         auth,
         request_id: request_id.to_string(),
         agent: agent.to_string(),
-        method: method.to_string(),
+        call,
         started,
         status: StatusCode::OK.as_u16(),
         _concurrency: reservation.into_stream_hold(),
@@ -359,9 +373,14 @@ async fn dispatch_stream(
         let mut events = events;
         while let Some(event) = events.next().await {
             match event {
-                Ok(value) => yield Ok::<_, std::convert::Infallible>(
-                    axum::response::sse::Event::default().data(value.to_string()),
-                ),
+                Ok(value) => {
+                    // Read the task's progress off the event on its way past —
+                    // the relay itself stays verbatim.
+                    guard.call.facts.observe_result(&value);
+                    yield Ok::<_, std::convert::Infallible>(
+                        axum::response::sse::Event::default().data(value.to_string()),
+                    );
+                }
                 Err(err) => {
                     // Mid-stream the status line is long gone, so the failure
                     // can only be told to the caller in-band. Relay it as a
@@ -528,7 +547,7 @@ fn emit_a2a_usage(
     auth: &AuthenticatedKey,
     request_id: &str,
     agent: &str,
-    method: &str,
+    call: &A2aCall,
     status_code: u16,
     latency: Duration,
 ) {
@@ -543,7 +562,12 @@ fn emit_a2a_usage(
         downstream_latency_ms: latency.as_millis().min(u32::MAX as u128) as u32,
         inbound_protocol: "a2a".to_string(),
         a2a_agent_name: agent.to_string(),
-        a2a_method: method.to_string(),
+        a2a_method: call.method.clone(),
+        a2a_operation: call.operation.to_string(),
+        a2a_protocol_version: call.protocol_version.to_string(),
+        a2a_task_id: call.facts.task_id.clone(),
+        a2a_context_id: call.facts.context_id.clone(),
+        a2a_task_state: call.facts.task_state.clone(),
         ..Default::default()
     };
     state.usage_sink.try_emit("a2a", event.clone());
@@ -687,6 +711,178 @@ mod tests {
         assert_eq!(event.a2a_method, "message/stream");
     }
 
+    /// An agent that answers `message/send` with a Task in the state the
+    /// caller asked for, echoing the task and context ids it was given.
+    async fn spawn_task_agent() -> String {
+        let app = axum::Router::new().route(
+            "/a2a",
+            axum::routing::post(|body: axum::Json<serde_json::Value>| async move {
+                let message = &body.0["params"]["message"];
+                axum::Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": body.0["id"],
+                    "result": {
+                        "kind": "task",
+                        "id": "task-42",
+                        "contextId": message["contextId"],
+                        "status": {"state": "completed"},
+                    }
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app.into_make_service())
+                .await
+                .unwrap();
+        });
+        format!("http://{addr}/a2a")
+    }
+
+    /// Drive one A2A request through the real router and return the usage
+    /// event it emitted.
+    async fn usage_event_for(agent_url: &str, body: serde_json::Value) -> aisix_obs::UsageEvent {
+        use aisix_obs::UsageSink;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let handle = SnapshotHandle::new(snapshot_with(agent_url, true, serde_json::json!(["*"])));
+        let hub = Arc::new(aisix_gateway::Hub::new());
+        let state = ProxyState::new(handle, hub, &proxy_cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let response = build_router(state)
+            .oneshot(
+                HttpRequest::post("/a2a/invoice")
+                    .header("host", "gw.example.com")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {TOKEN}"))
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .expect("router responds");
+        // Drain the body so a streamed response reaches its end and its
+        // drop guard fires.
+        let _ = axum::body::to_bytes(response.into_body(), 1_048_576).await;
+        tokio::task::yield_now().await;
+        rx.try_recv().expect("a usage event is emitted")
+    }
+
+    /// An agent whose stream walks a task through several states and then
+    /// ends, the way a real long-running task reports progress.
+    async fn spawn_progressing_stream_agent() -> String {
+        use axum::response::IntoResponse;
+        let app = axum::Router::new().route(
+            "/a2a",
+            axum::routing::post(|| async {
+                let chunks: Vec<Result<String, std::convert::Infallible>> = [
+                    "submitted",
+                    "working",
+                    "input-required",
+                ]
+                .iter()
+                .map(|state| {
+                    Ok(format!(
+                        "data: {{\"jsonrpc\":\"2.0\",\"result\":{{\"kind\":\"status-update\",\
+                                 \"taskId\":\"task-77\",\"contextId\":\"ctx-77\",\
+                                 \"status\":{{\"state\":\"{state}\"}}}}}}\n\n"
+                    ))
+                })
+                .collect();
+                (
+                    [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                    axum::body::Body::from_stream(futures::stream::iter(chunks)),
+                )
+                    .into_response()
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app.into_make_service())
+                .await
+                .unwrap();
+        });
+        format!("http://{addr}/a2a")
+    }
+
+    #[tokio::test]
+    async fn a_stream_records_the_state_its_task_ended_in() {
+        // A streamed task's outcome is only ever stated in-band, so a call
+        // whose task stalled on `input-required` is indistinguishable from one
+        // that completed unless the events are read on their way past.
+        let event = usage_event_for(
+            &spawn_progressing_stream_agent().await,
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "SendStreamingMessage",
+                "params": {"message": {"role": "user"}}
+            }),
+        )
+        .await;
+
+        assert_eq!(event.a2a_operation, "message/stream");
+        assert_eq!(event.a2a_task_id, "task-77");
+        assert_eq!(event.a2a_context_id, "ctx-77");
+        assert_eq!(event.a2a_task_state, "input-required");
+    }
+
+    #[tokio::test]
+    async fn a_call_records_the_task_and_context_it_touched() {
+        // Without these the log answers "someone called the invoice agent" and
+        // nothing else — not which task it produced, nor how that task ended
+        // (AISIX-Cloud#1215).
+        let event = usage_event_for(
+            &spawn_task_agent().await,
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "message/send",
+                "params": {"message": {"role": "user", "contextId": "ctx-7"}}
+            }),
+        )
+        .await;
+
+        assert_eq!(event.a2a_method, "message/send");
+        assert_eq!(event.a2a_operation, "message/send");
+        assert_eq!(event.a2a_task_id, "task-42");
+        assert_eq!(event.a2a_context_id, "ctx-7");
+        assert_eq!(event.a2a_task_state, "completed");
+        // The agent fixture pins no version, so the resource default applies —
+        // and it is the version the gateway announced upstream.
+        assert_eq!(event.a2a_protocol_version, "1.0");
+    }
+
+    #[tokio::test]
+    async fn a_1_0_caller_aggregates_with_its_0_3_twin() {
+        // `SendMessage` and `message/send` are one operation. A gateway may
+        // front agents on both versions at once, so without canonicalisation
+        // every per-operation figure is silently split in two.
+        let event = usage_event_for(
+            &spawn_task_agent().await,
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "SendMessage",
+                "params": {"message": {"role": "user", "contextId": "ctx-8"}}
+            }),
+        )
+        .await;
+
+        assert_eq!(event.a2a_method, "SendMessage", "the raw value is kept");
+        assert_eq!(event.a2a_operation, "message/send");
+    }
+
+    #[tokio::test]
+    async fn an_unrecognised_method_is_bounded_in_the_event() {
+        // The method is caller-chosen, so it must never reach an aggregated
+        // position unbounded.
+        let event = usage_event_for(
+            &spawn_task_agent().await,
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "vendor/doWhatever"}),
+        )
+        .await;
+
+        assert_eq!(event.a2a_method, "vendor/doWhatever");
+        assert_eq!(event.a2a_operation, "unknown");
+    }
+
     #[test]
     fn streaming_methods_are_recognised_in_both_spellings() {
         // The body is forwarded verbatim, so the caller uses whichever spelling
@@ -698,7 +894,10 @@ mod tests {
             "tasks/resubscribe",
             "SubscribeToTask",
         ] {
-            assert!(is_streaming_method(method), "{method} must stream");
+            assert!(
+                is_streaming_operation(canonical_operation(method)),
+                "{method} must stream"
+            );
         }
         for method in [
             "message/send",
@@ -709,7 +908,10 @@ mod tests {
             "agent/getAuthenticatedExtendedCard",
             "",
         ] {
-            assert!(!is_streaming_method(method), "{method} must not stream");
+            assert!(
+                !is_streaming_operation(canonical_operation(method)),
+                "{method} must not stream"
+            );
         }
     }
 

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -769,6 +769,124 @@ mod tests {
         rx.try_recv().expect("a usage event is emitted")
     }
 
+    /// An agent that reports a task's progress and then keeps the stream open
+    /// without ever finishing it — a long-running task the caller may leave
+    /// before it settles. It emits exactly the two states below and nothing
+    /// more, so what a partial reader saw is not a matter of timing.
+    async fn spawn_unfinished_stream_agent() -> String {
+        use axum::response::IntoResponse;
+        let app = axum::Router::new().route(
+            "/a2a",
+            axum::routing::post(|| async {
+                let chunks: Vec<Result<String, std::convert::Infallible>> =
+                    ["submitted", "working"]
+                        .iter()
+                        .map(|state| {
+                            let event = serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "result": {
+                                    "kind": "status-update",
+                                    "taskId": "task-88",
+                                    "status": {"state": state},
+                                    "final": false,
+                                },
+                            });
+                            Ok(format!("data: {event}\n\n"))
+                        })
+                        .collect();
+                let body = async_stream::stream! {
+                    for chunk in chunks {
+                        yield chunk;
+                    }
+                    // Never completes: the task is still running when the
+                    // caller gives up on it.
+                    std::future::pending::<()>().await;
+                };
+                (
+                    [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                    axum::body::Body::from_stream(body),
+                )
+                    .into_response()
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app.into_make_service())
+                .await
+                .unwrap();
+        });
+        format!("http://{addr}/a2a")
+    }
+
+    #[tokio::test]
+    async fn a_stream_abandoned_mid_task_records_the_last_state_seen() {
+        use aisix_obs::UsageSink;
+        use futures::StreamExt;
+
+        // The claim is that no terminal state is invented for a task the
+        // caller stopped watching. The agent reports `submitted` then
+        // `working` and never finishes, so `working` is the only honest
+        // answer — and the one an operator hunting stuck tasks needs.
+        let agent_url = spawn_unfinished_stream_agent().await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let handle = SnapshotHandle::new(snapshot_with(&agent_url, true, serde_json::json!(["*"])));
+        let hub = Arc::new(aisix_gateway::Hub::new());
+        let state = ProxyState::new(handle, hub, &proxy_cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+        let response = build_router(state)
+            .oneshot(
+                HttpRequest::post("/a2a/invoice")
+                    .header("host", "gw.example.com")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {TOKEN}"))
+                    .body(Body::from(
+                        r#"{"jsonrpc":"2.0","id":1,"method":"message/stream"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .expect("router responds");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Read what the agent has sent so far, then walk away mid-task.
+        let mut body = response.into_body().into_data_stream();
+        let mut seen = String::new();
+        while !seen.contains("working") {
+            let chunk = body.next().await.expect("the relayed events arrive");
+            seen.push_str(std::str::from_utf8(&chunk.expect("a readable chunk")).unwrap());
+        }
+        drop(body);
+        tokio::task::yield_now().await;
+
+        let event = rx
+            .try_recv()
+            .expect("an abandoned stream still emits usage");
+        assert_eq!(event.a2a_task_id, "task-88");
+        assert_eq!(event.a2a_task_state, "working");
+    }
+
+    #[tokio::test]
+    async fn a_failed_call_still_records_the_task_it_asked_about() {
+        // The upstream is unreachable, so no response ever names the task.
+        // Reading the request up front is what keeps a failed `tasks/get`
+        // attributable — the whole point of observing before dispatch.
+        let event = usage_event_for(
+            "http://127.0.0.1:1/a2a",
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tasks/get",
+                "params": {"id": "task-99"}
+            }),
+        )
+        .await;
+
+        assert_eq!(event.status_code, StatusCode::BAD_GATEWAY.as_u16());
+        assert_eq!(event.a2a_operation, "tasks/get");
+        assert_eq!(event.a2a_task_id, "task-99");
+        assert_eq!(event.a2a_task_state, "", "no state may be invented");
+    }
+
     /// An agent whose stream walks a task through several states and then
     /// ends, the way a real long-running task reports progress.
     async fn spawn_progressing_stream_agent() -> String {

--- a/tests/e2e/src/cases/a2a-protocol-telemetry-e2e.test.ts
+++ b/tests/e2e/src/cases/a2a-protocol-telemetry-e2e.test.ts
@@ -62,7 +62,7 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
     throw new Error(
       `no matching span exported within ${EXPORT_TIMEOUT_MS}ms; saw: ${JSON.stringify(
         otlp!.spans.map((s) => s.name),
-      )}`,
+      )}; unparseable export bodies: ${JSON.stringify(otlp!.parseFailures)}`,
     );
   };
 
@@ -103,14 +103,15 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
       allowed_agents: ["*"],
     });
 
+    // The caller key is seeded last, so its arrival means every resource
+    // above it has landed in the snapshot too. Gated on an endpoint this
+    // suite asserts nothing about, so a defect in A2A dispatch fails its own
+    // test by name instead of surfacing as a 60s propagation timeout here.
     await waitConfigPropagation(async () => {
-      const status = await call("invoices", {
-        jsonrpc: "2.0",
-        id: "gate",
-        method: "message/send",
-        params: { message: { role: "user", parts: [] } },
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${KEY}` },
       });
-      return status !== 404 && status !== 401;
+      return res.status === 200;
     });
   }, 60_000);
 
@@ -121,7 +122,7 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
   });
 
   test("a completed call records the task, the context and how it ended", async (ctx) => {
-    if (!etcdReachable) return ctx.skip();
+    if (!etcdReachable || !app || !upstream || !otlp) return ctx.skip();
 
     const contextId = `ctx-${randomUUID()}`;
     expect(
@@ -147,7 +148,7 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
   });
 
   test("both wire vocabularies aggregate under one operation", async (ctx) => {
-    if (!etcdReachable) return ctx.skip();
+    if (!etcdReachable || !app || !upstream || !otlp) return ctx.skip();
 
     // The same operation, spelled the way each agent's version spells it.
     const v10Context = `ctx-${randomUUID()}`;
@@ -185,7 +186,7 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
   });
 
   test("a streamed task is recorded with the state its stream ended on", async (ctx) => {
-    if (!etcdReachable) return ctx.skip();
+    if (!etcdReachable || !app || !upstream || !otlp) return ctx.skip();
 
     const contextId = `ctx-${randomUUID()}`;
     expect(
@@ -207,7 +208,7 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
   });
 
   test("an unrecognised method cannot become an unbounded label", async (ctx) => {
-    if (!etcdReachable) return ctx.skip();
+    if (!etcdReachable || !app || !upstream || !otlp) return ctx.skip();
 
     // The method is caller-chosen. The raw value stays available for
     // forensics, but the aggregating field must collapse to `unknown`.

--- a/tests/e2e/src/cases/a2a-protocol-telemetry-e2e.test.ts
+++ b/tests/e2e/src/cases/a2a-protocol-telemetry-e2e.test.ts
@@ -31,7 +31,12 @@ const EXPORT_TIMEOUT_MS = 20_000;
 
 describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
   let app: SpawnedApp | undefined;
-  let upstream: A2aUpstream | undefined;
+  // Two stubs, each answering in the shape its version actually defines: 1.0
+  // wraps the Task in the response's payload oneof, 0.3 puts it flat under
+  // `result`. One stub for both would leave the default version's real
+  // response shape untested.
+  let upstream10: A2aUpstream | undefined;
+  let upstream03: A2aUpstream | undefined;
   let otlp: MockOtlp | undefined;
   let etcdReachable = false;
 
@@ -72,7 +77,8 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
     if (!etcdReachable) return;
 
     otlp = await startMockOtlp();
-    upstream = await startA2aUpstream({ cardMount: "origin" });
+    upstream10 = await startA2aUpstream({ cardMount: "origin", wireShape: "1.0" });
+    upstream03 = await startA2aUpstream({ cardMount: "origin", wireShape: "0.3" });
     app = await spawnApp();
     const seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -82,16 +88,17 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
       kind: "otlp_http",
       endpoint: otlp.url,
     });
-    // Two agents on the SAME upstream, pinned to different wire versions:
-    // the only difference between them is the vocabulary their callers use,
-    // which is exactly what canonicalisation has to erase.
-    for (const [name, version] of [
-      ["invoices", "1.0"],
-      ["legacy", "0.3"],
+    // One agent per wire version, each against the stub that speaks it. Both
+    // run the same operations, so what has to come out the same (the canonical
+    // operation) and what has to differ (the announced version) are both
+    // visible.
+    for (const [name, version, agent] of [
+      ["invoices", "1.0", upstream10],
+      ["legacy", "0.3", upstream03],
     ] as const) {
       await seed.update("a2a_agents", randomUUID(), {
         name,
-        url: upstream.url,
+        url: agent.url,
         protocol_version: version,
         auth_type: "none",
         enabled: true,
@@ -117,12 +124,13 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
 
   afterAll(async () => {
     await app?.exit();
-    await upstream?.close();
+    await upstream10?.close();
+    await upstream03?.close();
     await otlp?.close();
   });
 
   test("a completed call records the task, the context and how it ended", async (ctx) => {
-    if (!etcdReachable || !app || !upstream || !otlp) return ctx.skip();
+    if (!etcdReachable || !app || !upstream10 || !upstream03 || !otlp) return ctx.skip();
 
     const contextId = `ctx-${randomUUID()}`;
     expect(
@@ -148,7 +156,7 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
   });
 
   test("both wire vocabularies aggregate under one operation", async (ctx) => {
-    if (!etcdReachable || !app || !upstream || !otlp) return ctx.skip();
+    if (!etcdReachable || !app || !upstream10 || !upstream03 || !otlp) return ctx.skip();
 
     // The same operation, spelled the way each agent's version spells it.
     const v10Context = `ctx-${randomUUID()}`;
@@ -177,6 +185,12 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
     // mixed-version deployment is silently split in two.
     expect(v10.attributes["aisix.a2a.operation"]).toBe("message/send");
     expect(v03.attributes["aisix.a2a.operation"]).toBe("message/send");
+    // The two agents return the same task in DIFFERENT envelopes (1.0 wraps
+    // it in the response's payload oneof), and both must be read.
+    expect(v10.attributes["aisix.a2a.task_id"]).toBe("task-e2e-1");
+    expect(v03.attributes["aisix.a2a.task_id"]).toBe("task-e2e-1");
+    expect(v10.attributes["aisix.a2a.task_state"]).toBe("completed");
+    expect(v03.attributes["aisix.a2a.task_state"]).toBe("completed");
     // ...while the raw method each caller actually sent is still recoverable.
     expect(v10.attributes["aisix.a2a.method"]).toBe("SendMessage");
     expect(v03.attributes["aisix.a2a.method"]).toBe("message/send");
@@ -186,7 +200,7 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
   });
 
   test("a streamed task is recorded with the state its stream ended on", async (ctx) => {
-    if (!etcdReachable || !app || !upstream || !otlp) return ctx.skip();
+    if (!etcdReachable || !app || !upstream10 || !upstream03 || !otlp) return ctx.skip();
 
     const contextId = `ctx-${randomUUID()}`;
     expect(
@@ -208,7 +222,7 @@ describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
   });
 
   test("an unrecognised method cannot become an unbounded label", async (ctx) => {
-    if (!etcdReachable || !app || !upstream || !otlp) return ctx.skip();
+    if (!etcdReachable || !app || !upstream10 || !upstream03 || !otlp) return ctx.skip();
 
     // The method is caller-chosen. The raw value stays available for
     // forensics, but the aggregating field must collapse to `unknown`.

--- a/tests/e2e/src/cases/a2a-protocol-telemetry-e2e.test.ts
+++ b/tests/e2e/src/cases/a2a-protocol-telemetry-e2e.test.ts
@@ -1,0 +1,226 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startA2aUpstream,
+  waitConfigPropagation,
+  type A2aUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { startMockOtlp, type MockOtlp } from "../harness/otlp-mock.js";
+
+// E2E for AISIX-Cloud#1215: protocol-level observability for the A2A gateway.
+//
+// The contract pinned here is what an operator can answer AFTER a call is
+// over. Before this, an A2A call left "someone reached agent X with method Y"
+// and nothing else: no task, no context, no outcome — and it was exported to
+// a trace backend encoded as a chat completion, indistinguishable from a model
+// inference.
+//
+// Observed through a real `otlp_http` exporter rather than through the
+// gateway's internals, because the span a trace backend receives IS the
+// user-visible surface: if the attributes are not on the wire, the feature
+// does not exist however well the internals are populated.
+const KEY = "sk-a2a-telemetry-e2e";
+const sha256 = (value: string) => createHash("sha256").update(value).digest("hex");
+
+/** How long to allow for the exporter's batch to reach the receiver. */
+const EXPORT_TIMEOUT_MS = 20_000;
+
+describe("a2a protocol telemetry e2e (AISIX-Cloud#1215)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: A2aUpstream | undefined;
+  let otlp: MockOtlp | undefined;
+  let etcdReachable = false;
+
+  const call = async (agent: string, body: unknown) => {
+    const res = await fetch(`${app!.proxyUrl}/a2a/${agent}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${KEY}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    // Drain so a streamed call reaches its end before the assertions run.
+    await res.text();
+    return res.status;
+  };
+
+  /** Wait for a span the predicate accepts, and return it. */
+  const awaitSpan = async (
+    matches: (span: { name: string; attributes: Record<string, unknown> }) => boolean,
+  ) => {
+    const deadline = Date.now() + EXPORT_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const found = otlp!.spans.find(matches);
+      if (found) return found;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    throw new Error(
+      `no matching span exported within ${EXPORT_TIMEOUT_MS}ms; saw: ${JSON.stringify(
+        otlp!.spans.map((s) => s.name),
+      )}`,
+    );
+  };
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    otlp = await startMockOtlp();
+    upstream = await startA2aUpstream({ cardMount: "origin" });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    await seed.createObservabilityExporter({
+      name: "a2a-telemetry-otlp",
+      enabled: true,
+      kind: "otlp_http",
+      endpoint: otlp.url,
+    });
+    // Two agents on the SAME upstream, pinned to different wire versions:
+    // the only difference between them is the vocabulary their callers use,
+    // which is exactly what canonicalisation has to erase.
+    for (const [name, version] of [
+      ["invoices", "1.0"],
+      ["legacy", "0.3"],
+    ] as const) {
+      await seed.update("a2a_agents", randomUUID(), {
+        name,
+        url: upstream.url,
+        protocol_version: version,
+        auth_type: "none",
+        enabled: true,
+      });
+    }
+    await seed.createApiKey({
+      key_hash: sha256(KEY),
+      allowed_models: [],
+      allowed_agents: ["*"],
+    });
+
+    await waitConfigPropagation(async () => {
+      const status = await call("invoices", {
+        jsonrpc: "2.0",
+        id: "gate",
+        method: "message/send",
+        params: { message: { role: "user", parts: [] } },
+      });
+      return status !== 404 && status !== 401;
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await otlp?.close();
+  });
+
+  test("a completed call records the task, the context and how it ended", async (ctx) => {
+    if (!etcdReachable) return ctx.skip();
+
+    const contextId = `ctx-${randomUUID()}`;
+    expect(
+      await call("invoices", {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "message/send",
+        params: { message: { role: "user", contextId, parts: [] } },
+      }),
+    ).toBe(200);
+
+    const span = await awaitSpan((s) => s.attributes["gen_ai.conversation.id"] === contextId);
+
+    // Not a chat completion: an agent invocation, named after the agent.
+    expect(span.name).toBe("invoke_agent invoices");
+    expect(span.attributes["gen_ai.operation.name"]).toBe("invoke_agent");
+    expect(span.attributes["gen_ai.agent.name"]).toBe("invoices");
+    // The task the call produced, and the state it ended in.
+    expect(span.attributes["aisix.a2a.task_id"]).toBe("task-e2e-1");
+    expect(span.attributes["aisix.a2a.task_state"]).toBe("completed");
+    expect(span.attributes["aisix.a2a.operation"]).toBe("message/send");
+    expect(span.attributes["aisix.a2a.protocol_version"]).toBe("1.0");
+  });
+
+  test("both wire vocabularies aggregate under one operation", async (ctx) => {
+    if (!etcdReachable) return ctx.skip();
+
+    // The same operation, spelled the way each agent's version spells it.
+    const v10Context = `ctx-${randomUUID()}`;
+    const v03Context = `ctx-${randomUUID()}`;
+    expect(
+      await call("invoices", {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "SendMessage",
+        params: { message: { role: "user", contextId: v10Context, parts: [] } },
+      }),
+    ).toBe(200);
+    expect(
+      await call("legacy", {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "message/send",
+        params: { message: { role: "user", contextId: v03Context, parts: [] } },
+      }),
+    ).toBe(200);
+
+    const v10 = await awaitSpan((s) => s.attributes["gen_ai.conversation.id"] === v10Context);
+    const v03 = await awaitSpan((s) => s.attributes["gen_ai.conversation.id"] === v03Context);
+
+    // One operation for both — without this every per-operation figure in a
+    // mixed-version deployment is silently split in two.
+    expect(v10.attributes["aisix.a2a.operation"]).toBe("message/send");
+    expect(v03.attributes["aisix.a2a.operation"]).toBe("message/send");
+    // ...while the raw method each caller actually sent is still recoverable.
+    expect(v10.attributes["aisix.a2a.method"]).toBe("SendMessage");
+    expect(v03.attributes["aisix.a2a.method"]).toBe("message/send");
+    // And each is attributed to the version its agent was announced as.
+    expect(v10.attributes["aisix.a2a.protocol_version"]).toBe("1.0");
+    expect(v03.attributes["aisix.a2a.protocol_version"]).toBe("0.3");
+  });
+
+  test("a streamed task is recorded with the state its stream ended on", async (ctx) => {
+    if (!etcdReachable) return ctx.skip();
+
+    const contextId = `ctx-${randomUUID()}`;
+    expect(
+      await call("invoices", {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "SendStreamingMessage",
+        params: { message: { role: "user", contextId, parts: [] } },
+      }),
+    ).toBe(200);
+
+    const span = await awaitSpan((s) => s.attributes["gen_ai.conversation.id"] === contextId);
+
+    expect(span.attributes["aisix.a2a.operation"]).toBe("message/stream");
+    expect(span.attributes["aisix.a2a.task_id"]).toBe("task-e2e-stream");
+    // The stream walks the task working → completed; a call recorded from the
+    // request alone would have stopped at whatever the first event said.
+    expect(span.attributes["aisix.a2a.task_state"]).toBe("completed");
+  });
+
+  test("an unrecognised method cannot become an unbounded label", async (ctx) => {
+    if (!etcdReachable) return ctx.skip();
+
+    // The method is caller-chosen. The raw value stays available for
+    // forensics, but the aggregating field must collapse to `unknown`.
+    const contextId = `ctx-${randomUUID()}`;
+    await call("invoices", {
+      jsonrpc: "2.0",
+      id: 5,
+      method: "vendor/somethingNobodyDefined",
+      params: { message: { role: "user", contextId, parts: [] } },
+    });
+
+    const span = await awaitSpan((s) => s.attributes["gen_ai.conversation.id"] === contextId);
+    expect(span.attributes["aisix.a2a.operation"]).toBe("unknown");
+    expect(span.attributes["aisix.a2a.method"]).toBe("vendor/somethingNobodyDefined");
+  });
+});

--- a/tests/e2e/src/harness/otlp-mock.ts
+++ b/tests/e2e/src/harness/otlp-mock.ts
@@ -16,6 +16,12 @@ export interface CapturedSpan {
 export interface MockOtlp {
   url: string;
   spans: CapturedSpan[];
+  /**
+   * Bodies this receiver could not parse, empty on a healthy run. Without it a
+   * malformed export and a never-sent one look identical: both end as "no
+   * matching span arrived".
+   */
+  parseFailures: string[];
   close(): Promise<void>;
 }
 
@@ -36,6 +42,7 @@ function anyValue(value: Record<string, unknown>): string | number | boolean {
 
 export async function startMockOtlp(): Promise<MockOtlp> {
   const spans: CapturedSpan[] = [];
+  const parseFailures: string[] = [];
   const server: Server = createServer((req, res) => {
     const chunks: Buffer[] = [];
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
@@ -62,9 +69,11 @@ export async function startMockOtlp(): Promise<MockOtlp> {
             }
           }
         }
-      } catch {
+      } catch (err) {
         // A body this receiver cannot parse is a failure of the thing under
-        // test; the assertion that no matching span arrived reports it.
+        // test, so it is kept rather than swallowed — otherwise it reaches the
+        // test as an indistinguishable "no span arrived".
+        parseFailures.push(String(err));
       }
       res.writeHead(200, { "content-type": "application/json" });
       res.end("{}");
@@ -78,6 +87,7 @@ export async function startMockOtlp(): Promise<MockOtlp> {
   return {
     url: `http://127.0.0.1:${address.port}/v1/traces`,
     spans,
+    parseFailures,
     close: () => new Promise((resolve) => server.close(() => resolve())),
   };
 }

--- a/tests/e2e/src/harness/otlp-mock.ts
+++ b/tests/e2e/src/harness/otlp-mock.ts
@@ -1,0 +1,83 @@
+import { createServer, type Server } from "node:http";
+
+/**
+ * Mock OTLP/HTTP trace receiver: accepts the `ExportTraceServiceRequest`
+ * bodies the `otlp_http` observability exporter POSTs (JSON, uncompressed) and
+ * keeps every span it was sent, flattened, so a test can assert what a real
+ * trace backend would have seen.
+ */
+
+/** One exported span, with its attributes flattened to a plain object. */
+export interface CapturedSpan {
+  name: string;
+  attributes: Record<string, string | number | boolean>;
+}
+
+export interface MockOtlp {
+  url: string;
+  spans: CapturedSpan[];
+  close(): Promise<void>;
+}
+
+/** Read an OTLP `AnyValue` back to the scalar it wraps. */
+function anyValue(value: Record<string, unknown>): string | number | boolean {
+  if (typeof value.stringValue === "string") return value.stringValue;
+  if (typeof value.intValue === "string") return Number(value.intValue);
+  if (typeof value.intValue === "number") return value.intValue;
+  if (typeof value.doubleValue === "number") return value.doubleValue;
+  if (typeof value.boolValue === "boolean") return value.boolValue;
+  if (value.arrayValue !== undefined) {
+    const values = (value.arrayValue as { values?: Record<string, unknown>[] })
+      .values;
+    return (values ?? []).map((v) => String(anyValue(v))).join(",");
+  }
+  return "";
+}
+
+export async function startMockOtlp(): Promise<MockOtlp> {
+  const spans: CapturedSpan[] = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+          resourceSpans?: {
+            scopeSpans?: {
+              spans?: {
+                name: string;
+                attributes?: { key: string; value: Record<string, unknown> }[];
+              }[];
+            }[];
+          }[];
+        };
+        for (const resource of body.resourceSpans ?? []) {
+          for (const scope of resource.scopeSpans ?? []) {
+            for (const span of scope.spans ?? []) {
+              const attributes: Record<string, string | number | boolean> = {};
+              for (const attr of span.attributes ?? []) {
+                attributes[attr.key] = anyValue(attr.value);
+              }
+              spans.push({ name: span.name, attributes });
+            }
+          }
+        }
+      } catch {
+        // A body this receiver cannot parse is a failure of the thing under
+        // test; the assertion that no matching span arrived reports it.
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("otlp mock: no listen address");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}/v1/traces`,
+    spans,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}

--- a/tests/e2e/src/harness/upstream-a2a.ts
+++ b/tests/e2e/src/harness/upstream-a2a.ts
@@ -151,6 +151,14 @@ async function handle(
     body,
   });
 
+  // The context the caller asked to continue, echoed back on every result the
+  // way a real agent does — so a test can prove the gateway correlated the
+  // call to that conversation rather than to one it invented.
+  const params = body?.params as Record<string, unknown> | undefined;
+  const message = params?.message as Record<string, unknown> | undefined;
+  const contextId =
+    typeof message?.contextId === "string" ? message.contextId : undefined;
+
   if (ctx.token !== undefined && header("authorization") !== `Bearer ${ctx.token}`) {
     send(401, { error: "unauthorized" });
     return;
@@ -196,6 +204,7 @@ async function handle(
       envelope({
         kind: "status-update",
         taskId: "task-e2e-stream",
+        contextId,
         status: { state: "working" },
         seq: 1,
         sawVersion: header("a2a-version"),
@@ -204,12 +213,15 @@ async function handle(
     );
     await new Promise((resolve) => setTimeout(resolve, STREAM_GAP_MS));
     res.write("event: status-update\n");
-    res.write(envelope({ kind: "status-update", taskId: "task-e2e-stream", seq: 2 }));
+    res.write(
+      envelope({ kind: "status-update", taskId: "task-e2e-stream", contextId, seq: 2 }),
+    );
     await new Promise((resolve) => setTimeout(resolve, STREAM_GAP_MS));
     res.write(
       envelope({
         kind: "task",
         id: "task-e2e-stream",
+        contextId,
         status: { state: "completed" },
         seq: 3,
       }),
@@ -225,6 +237,7 @@ async function handle(
       result: {
         kind: "task",
         id: "task-e2e-1",
+        contextId,
         status: { state: "completed" },
         // Echoed so the gateway's forwarding can be asserted from the caller
         // side as well as from `requests`.

--- a/tests/e2e/src/harness/upstream-a2a.ts
+++ b/tests/e2e/src/harness/upstream-a2a.ts
@@ -28,6 +28,18 @@ export interface A2aReceivedRequest {
  */
 export type A2aCardMount = "origin" | "path";
 
+/**
+ * Which wire shape the agent answers in.
+ *
+ * - `0.3` — the Task / update event sits directly at `result`, tagged with a
+ *   `kind` discriminator.
+ * - `1.0` — the same object is wrapped in the response's `oneof payload`,
+ *   which protobuf JSON renders as the set field's own name (`task`,
+ *   `statusUpdate`). This is the shape a 1.0 agent actually returns, so a test
+ *   that never uses it cannot see a reader that only understands 0.3.
+ */
+export type A2aWireShape = "0.3" | "1.0";
+
 export interface A2aUpstream {
   /** Register this as the agent's `url`: the A2A service endpoint. */
   url: string;
@@ -40,6 +52,8 @@ export interface A2aUpstreamOptions {
   cardMount?: A2aCardMount;
   /** When set, the agent is registered with `auth_type: bearer` and this token. */
   token?: string;
+  /** Wire shape of the results this agent returns. Defaults to `0.3`. */
+  wireShape?: A2aWireShape;
 }
 
 const PATH_PREFIX = "/v3/agents/serve/tenant-42";
@@ -88,6 +102,7 @@ export async function startA2aUpstream(
       servicePath,
       cardPath,
       token: options.token,
+      wireShape: options.wireShape ?? "0.3",
     }).catch((err: unknown) => {
       // `handle` rejects on a malformed body, and on a write to an already
       // closed socket. Unhandled, that terminates the test process; worse, the
@@ -122,6 +137,7 @@ async function handle(
     servicePath: string;
     cardPath: string;
     token?: string;
+    wireShape: A2aWireShape;
   },
 ): Promise<void> {
   const path = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
@@ -158,6 +174,19 @@ async function handle(
   const message = params?.message as Record<string, unknown> | undefined;
   const contextId =
     typeof message?.contextId === "string" ? message.contextId : undefined;
+
+  /**
+   * Put a Task or an update event where this agent's wire version puts it:
+   * flat under `result` with a `kind` tag on 0.3, inside the response's
+   * payload wrapper on 1.0.
+   */
+  const payload = (
+    kind: "task" | "status-update",
+    obj: Record<string, unknown>,
+  ): Record<string, unknown> =>
+    ctx.wireShape === "1.0"
+      ? { [kind === "task" ? "task" : "statusUpdate"]: obj }
+      : { kind, ...obj };
 
   if (ctx.token !== undefined && header("authorization") !== `Bearer ${ctx.token}`) {
     send(401, { error: "unauthorized" });
@@ -201,30 +230,32 @@ async function handle(
       `data: ${JSON.stringify({ jsonrpc: "2.0", id: body?.id ?? null, result })}\n\n`;
     res.write(": open\n\n");
     res.write(
-      envelope({
-        kind: "status-update",
-        taskId: "task-e2e-stream",
-        contextId,
-        status: { state: "working" },
-        seq: 1,
-        sawVersion: header("a2a-version"),
-        sawAccept: header("accept"),
-      }),
+      envelope(
+        payload("status-update", {
+          taskId: "task-e2e-stream",
+          contextId,
+          status: { state: "working" },
+          seq: 1,
+          sawVersion: header("a2a-version"),
+          sawAccept: header("accept"),
+        }),
+      ),
     );
     await new Promise((resolve) => setTimeout(resolve, STREAM_GAP_MS));
     res.write("event: status-update\n");
     res.write(
-      envelope({ kind: "status-update", taskId: "task-e2e-stream", contextId, seq: 2 }),
+      envelope(payload("status-update", { taskId: "task-e2e-stream", contextId, seq: 2 })),
     );
     await new Promise((resolve) => setTimeout(resolve, STREAM_GAP_MS));
     res.write(
-      envelope({
-        kind: "task",
-        id: "task-e2e-stream",
-        contextId,
-        status: { state: "completed" },
-        seq: 3,
-      }),
+      envelope(
+        payload("task", {
+          id: "task-e2e-stream",
+          contextId,
+          status: { state: "completed" },
+          seq: 3,
+        }),
+      ),
     );
     res.end();
     return;
@@ -234,8 +265,7 @@ async function handle(
     send(200, {
       jsonrpc: "2.0",
       id: body?.id ?? null,
-      result: {
-        kind: "task",
+      result: payload("task", {
         id: "task-e2e-1",
         contextId,
         status: { state: "completed" },
@@ -243,7 +273,7 @@ async function handle(
         // side as well as from `requests`.
         sawVersion: header("a2a-version"),
         sawMethod: body?.method ?? null,
-      },
+      }),
     });
     return;
   }


### PR DESCRIPTION
## Problem

An A2A call left exactly one fact behind: *someone reached agent X with method Y*. Not which task it created, not which conversation it belonged to, not how it ended. For a protocol whose whole model is long-running tasks, that is the part an operator actually needs — and a streamed task's outcome is only ever stated in-band, so a call that stalled on `input-required` was indistinguishable from one that completed.

Two more gaps fell out while wiring this:

- The wire method is recorded raw, and the two A2A wire vocabularies spell the same operation differently (`message/stream` vs `SendStreamingMessage`). A gateway fronting agents on both versions — which the per-agent `protocol_version` field explicitly allows — silently splits every per-operation figure in two. The method is also caller-chosen, so the raw value can never be used as a label.
- The OTLP span encoder hardcoded `gen_ai.operation.name = "chat"` and the span name `chat.completions` for **every** event. An A2A or MCP call arrived at a trace backend looking exactly like a model inference, with the agent, the tool, the method and the task recorded nowhere at all.

## What changed

Protocol facts are read off the JSON-RPC envelopes as they pass; the relay itself stays verbatim.

| field | source |
|---|---|
| `a2a_operation` | canonical operation, both vocabularies onto one bounded set, unrecognised → `unknown` |
| `a2a_method` | the caller's raw string, unchanged (forensics only) |
| `a2a_task_id` | request params first, then every response / stream event |
| `a2a_context_id` | same |
| `a2a_task_state` | normalized to the spec's set; for a stream, the last state the upstream reported |
| `a2a_protocol_version` | the version the gateway announced upstream |

Reading the request *before* the upstream is contacted means a call that never lands still records which task it asked about. For a stream the facts keep accumulating, so a caller that walks away mid-task is recorded against the last state the upstream actually reported — no terminal state is invented.

The two wire versions disagree in three places that all had to be handled explicitly, and each is pinned by a test:

- **Result envelope.** 1.0 wraps the Task or update event in the response's `oneof payload`, rendered by protobuf JSON as the set field's name (`{"result":{"task":{…}}}`); 0.3 puts the object flat under `result` with a `kind` tag. `GetTask` / `CancelTask` define no wrapper in either version. Since 1.0 is the resource's default, reading only the 0.3 shape would have left every field above empty for the common case.
- **Push-notification configs.** 1.0 carries `taskId` (the task) *and* `id` (the config) in the same params; 0.3 puts the task itself in `id`. So `id` is a fallback that only fires when nothing more specific was found — reading it last recorded a config id as a task id.
- **Task state.** 1.0's `TASK_STATE_INPUT_REQUIRED` and 0.3's `input-required` normalize to one value, and anything else lands on `unknown`.

Streaming dispatch now decides on the canonical operation instead of its own method list, so a 1.0 caller's `SendStreamingMessage` cannot be routed down the buffering path because one list was updated and the other was not.

### OTLP span encoding

`invoke_agent {agent}` for A2A and `execute_tool {tool}` for MCP, with `gen_ai.agent.name` / `gen_ai.tool.name` and the A2A context as `gen_ai.conversation.id` — those are the semantic conventions' own well-known values, so the spans land in buckets a trace backend already understands. LLM spans keep the exact name and operation they have always had; a test pins that.

The span-name target and the caller-supplied attributes are length-bounded. An MCP tool name is the caller's own `tools/call` `params.name`, recorded before the tool is known to exist and before the quota gate, and `request_body_limit_bytes` defaults to unlimited — so promoting it into a span name, which trace backends index and derive RED metrics from, would otherwise hand the caller an unbounded index key. Over the cap the span falls back to the bare operation, which the conventions name as the fallback for exactly this case; the raw value still travels as an attribute.

## Ecosystem comparison

Other AI gateways in this space split three ways. One records the agent identity and folds A2A into its existing per-request spend log, but keeps no task, context or task state. Another (a general-purpose API gateway with an A2A plugin) records the fullest protocol field set — canonical operation, task id, context id, normalized task state, plus streaming counters — and is the closest match to what this PR lands. A third has the product narrative for centralized agent observability but publishes no protocol-level field schema. This PR takes the second one's field set as the baseline; the streaming counters and the metric families are a follow-up, tracked under the umbrella issue.

The operation table, the `TASK_STATE_<NAME>` → `input-required` normalization and the response envelope shapes are taken from the A2A specification's protobuf definitions (`SendMessageRequest.message`, `GetTaskRequest.id`, `GetTaskPushNotificationConfigRequest.{task_id,id}`, `SendMessageResponse`/`StreamResponse` payload oneofs, `TaskStatusUpdateEvent.task_id`, the `TaskState` enum) rather than inferred: <https://a2a-protocol.org/latest/specification/>. Span naming and attribute keys follow the OpenTelemetry GenAI semantic conventions for agent and tool spans.

## Behavior changes

None for callers — request and response bodies are still forwarded verbatim, and the streaming path's timing is unchanged. The added fields are omitted from the wire when empty, and cp-api binds `/dp/telemetry` leniently, so an older control plane ignores them.

One change is visible to **trace backends**: A2A and MCP spans stop being named `chat.completions` and stop reporting `gen_ai.operation.name = chat`. A saved query written against those values will no longer match agent or tool traffic. That is the point of the change — the old values were wrong — but it needs a release-note line.

## Still outstanding for the umbrella issue

Deliberately not in this PR, and not implied by it:

- **The control plane ingests none of the five new fields**, so outside a user's own OTLP collector nothing is visible yet. `/dp/telemetry` binds leniently so nothing breaks, but the paired AISIX-Cloud PR (columns, ingestion, list filters, dashboard) is required before this reaches a user through the product.
- **Docs.** `docs/ai-gateway/observability/exporters.md` enumerates the OTLP trace fields and is now incomplete, and the span rename above needs stating. That ships as paired `api7/docs` + `api7/docs.apiseven.com` PRs.
- Streaming counters (TTFB, event count, client disconnect) and the A2A metric families.

## Tests

- `crates/aisix-a2a/src/telemetry.rs` — both vocabularies canonicalise to one operation; a 1.0-only operation is not accepted as a 0.3 method; unrecognised methods are bounded; task states normalise across versions; the 1.0 payload wrapper is read in all four variants and a bare Task still is; a Message is not mistaken for a task; a push-config's own id never displaces its task; a stream records its last state; an error envelope leaves the request's facts standing.
- `crates/aisix-proxy/src/a2a.rs` — the real router, asserting the emitted usage event for a completed call, a 1.0-spelled call, an unrecognised method, a stream whose task advances, a stream abandoned mid-task, and a call whose upstream is unreachable.
- `crates/aisix-obs/src/otlp_http_sink.rs` — agent and tool span shapes, the no-target fallback, the caller-controlled length caps (including a multi-byte cut), and a guard that LLM spans are unmoved.
- `tests/e2e/src/cases/a2a-protocol-telemetry-e2e.test.ts` — the real binary + etcd + two stub agents (one answering in each version's wire shape) + a real `otlp_http` exporter against a mock OTLP receiver. Asserted on the span a trace backend actually receives, because that is the user-visible surface. Verified to fail before this change: all four cases time out with `saw: ["chat.completions", ...]`.

Fixes api7/AISIX-Cloud#1215