### PR TITLE
feat(proxy): reuse a caller-supplied request id as the gateway's own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "config",
  "dashmap",
  "hex",
+ "http 1.4.0",
  "ipnet",
  "jsonschema",
  "once_cell",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,6 +53,24 @@ proxy:
   #   trusted_proxies: ["10.0.0.0/8", "127.0.0.1/32"]
   #   recursive: true
   #   header: x-forwarded-for
+  # Which inbound headers a caller may hand the gateway its own request
+  # id in. The id it sends becomes THE id for the request: the
+  # x-aisix-request-id response header, every retry/failover attempt's
+  # usage event, the access log, and the x-aisix-request-id the upstream
+  # sees — so a caller can find a gateway request by an id its own logs
+  # already carry. Headers are consulted in order, first acceptable value
+  # wins; an absent or unusable value (empty, longer than 256 bytes, or
+  # containing anything outside visible ASCII) falls back to a generated
+  # UUID rather than failing the request.
+  # Defaults to ["x-aisix-request-id"]. Add x-request-id to honour the
+  # de-facto standard header — off by default because every reverse proxy
+  # and ingress in front of the gateway stamps it automatically, which
+  # would make the correlation id come from the infrastructure rather
+  # than from the caller. Set to [] to always mint a UUID.
+  # Env-only deployments set the list comma-separated:
+  # AISIX_PROXY__REQUEST_ID__ACCEPT_HEADERS=x-aisix-request-id,x-request-id
+  # request_id:
+  #   accept_headers: ["x-aisix-request-id", "x-request-id"]
   # Serve from independent worker threads, each with its own runtime,
   # its own SO_REUSEPORT listener on addr, and its own upstream
   # connection pool, so a request is handled end to end on the thread

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -50,6 +50,14 @@ proxy:
   # file: AISIX_PROXY__THREAD_PER_CORE, AISIX_PROXY__WORKERS.
   # thread_per_core: true
   # workers: 4
+  # Headers a caller may hand the gateway its own request id in; that id
+  # then becomes the x-aisix-request-id response header, the request_id on
+  # every attempt's usage event, and what the upstream sees. Defaults to
+  # ["x-aisix-request-id"]. Add x-request-id only if the gateway is NOT
+  # behind a proxy that stamps it. Comma-separated from the environment:
+  # AISIX_PROXY__REQUEST_ID__ACCEPT_HEADERS=x-aisix-request-id,x-request-id
+  # request_id:
+  #   accept_headers: ["x-aisix-request-id"]
   # Entry-level URL rewriting (first matching rule wins; `match` runs on
   # the raw, percent-encoded path; `rewrite` replaces the matched portion,
   # $1 = capture group; the query string is preserved). Lets clients keep

--- a/crates/aisix-admin/src/playground_handler.rs
+++ b/crates/aisix-admin/src/playground_handler.rs
@@ -79,6 +79,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-core/Cargo.toml
+++ b/crates/aisix-core/Cargo.toml
@@ -31,6 +31,9 @@ sha2.workspace = true
 hex.workspace = true
 # Trusted-proxy CIDR parsing/validation for proxy.real_ip (#492)
 ipnet.workspace = true
+# Header-name parsing/validation for proxy.request_id.accept_headers
+# (AISIX-Cloud#1288) — same role ipnet plays for real_ip.
+http.workspace = true
 # filesource: resources.yaml parsing + deterministic UUIDv5 resource ids
 yaml-rust2.workspace = true
 uuid.workspace = true

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -412,6 +412,10 @@ pub struct ProxyConfig {
     /// an L7 LB / ingress that sets `x-forwarded-for`.
     #[serde(default)]
     pub real_ip: RealIpConfig,
+    /// Which inbound headers a caller may hand the gateway its own
+    /// request id in (AISIX-Cloud#1288).
+    #[serde(default)]
+    pub request_id: RequestIdConfig,
     /// Serve the proxy from independent worker threads — each with its
     /// own runtime, its own `SO_REUSEPORT` listener on `addr`, and its
     /// own upstream connection pool — instead of one shared runtime
@@ -664,6 +668,51 @@ impl RealIpConfig {
                     .or_else(|_| s.parse::<std::net::IpAddr>().map(ipnet::IpNet::from))
                     .map_err(|_| s.clone())
             })
+            .collect()
+    }
+}
+
+/// Where the gateway will accept a caller-supplied request id
+/// (AISIX-Cloud#1288).
+///
+/// The id a caller sends becomes THE id for the request: the
+/// `x-aisix-request-id` response header, every attempt's usage event, the
+/// access log, and the `x-aisix-request-id` the upstream sees. That is what
+/// lets a caller find a gateway request by an id its own business logs
+/// already carry, instead of maintaining a second mapping.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct RequestIdConfig {
+    /// Inbound headers consulted, in order; the first one carrying an
+    /// acceptable value wins. An unacceptable or absent value falls back
+    /// to a freshly minted UUID, which is the pre-#1288 behaviour.
+    ///
+    /// Defaults to the gateway's own `x-aisix-request-id` alone. Add
+    /// `x-request-id` to honour the de-facto standard header — deliberately
+    /// NOT a default, because every reverse proxy and ingress in front of
+    /// the gateway stamps that header automatically, so enabling it makes
+    /// the correlation id come from the infrastructure rather than from the
+    /// caller unless the operator meant it to. Set to `[]` to refuse
+    /// caller-supplied ids entirely and always mint a UUID.
+    pub accept_headers: Vec<String>,
+}
+
+impl Default for RequestIdConfig {
+    fn default() -> Self {
+        Self {
+            accept_headers: vec!["x-aisix-request-id".into()],
+        }
+    }
+}
+
+impl RequestIdConfig {
+    /// Parse `accept_headers` into header names, rejecting malformed
+    /// entries. Header names are case-insensitive on the wire, so the
+    /// parse also lowercases and gives the proxy ready-to-use keys.
+    pub fn parse_accept_headers(&self) -> Result<Vec<http::HeaderName>, String> {
+        self.accept_headers
+            .iter()
+            .map(|s| s.trim().parse::<http::HeaderName>().map_err(|_| s.clone()))
             .collect()
     }
 }
@@ -1304,6 +1353,7 @@ impl Config {
                 .with_list_parse_key("etcd.endpoints")
                 .with_list_parse_key("admin.admin_keys")
                 .with_list_parse_key("proxy.real_ip.trusted_proxies")
+                .with_list_parse_key("proxy.request_id.accept_headers")
                 .with_list_parse_key("observability.metrics.buckets.request_e2e_latency")
                 .with_list_parse_key("observability.metrics.buckets.request_ttft")
                 .with_list_parse_key("observability.metrics.buckets.guardrail_latency")
@@ -1432,6 +1482,14 @@ impl Config {
                 "proxy.real_ip.trusted_proxies invalid CIDR/IP: {bad}"
             )));
         }
+        // A malformed name here would otherwise just never match any
+        // inbound header, so the operator would see caller-supplied
+        // request ids silently ignored with nothing to point at.
+        if let Err(bad) = self.proxy.request_id.parse_accept_headers() {
+            return Err(BootstrapError::Config(format!(
+                "proxy.request_id.accept_headers invalid HTTP header name: {bad}"
+            )));
+        }
         // Zero workers would bind no listener at all: the proxy would
         // boot, report healthy, and refuse every connection.
         if self.proxy.workers == Some(0) {
@@ -1538,6 +1596,91 @@ admin:
         assert!(!cfg.proxy.real_ip.recursive);
         assert_eq!(cfg.proxy.real_ip.header, "x-forwarded-for");
         assert!(cfg.proxy.real_ip.parse_trusted().unwrap().is_empty());
+    }
+
+    #[test]
+    fn request_id_accept_headers_default_to_the_gateway_header_only() {
+        // The default is the contract from AISIX-Cloud#1288: a caller can
+        // reuse an id through OUR header, and `x-request-id` — which every
+        // ingress in front of the gateway stamps — stays opt-in.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(
+            cfg.proxy.request_id.accept_headers,
+            vec!["x-aisix-request-id"]
+        );
+        assert_eq!(
+            cfg.proxy
+                .request_id
+                .parse_accept_headers()
+                .unwrap()
+                .iter()
+                .map(|h| h.as_str().to_string())
+                .collect::<Vec<_>>(),
+            vec!["x-aisix-request-id"],
+        );
+    }
+
+    #[test]
+    fn request_id_accept_headers_are_configurable_and_validated() {
+        let with = |block: &str| {
+            write_yaml(&format!(
+                r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+proxy:
+  addr: "0.0.0.0:3000"
+{block}
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#
+            ))
+        };
+
+        // Opting `x-request-id` in, and header names normalised to lower
+        // case so the lookup matches however the caller cased it.
+        let f =
+            with("  request_id:\n    accept_headers: [\"X-Aisix-Request-Id\", \"x-request-id\"]\n");
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(
+            cfg.proxy
+                .request_id
+                .parse_accept_headers()
+                .unwrap()
+                .iter()
+                .map(|h| h.as_str().to_string())
+                .collect::<Vec<_>>(),
+            vec!["x-aisix-request-id", "x-request-id"],
+        );
+
+        // An empty list refuses caller-supplied ids entirely.
+        let f = with("  request_id:\n    accept_headers: []\n");
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert!(cfg.proxy.request_id.accept_headers.is_empty());
+
+        // A malformed name fails the boot instead of silently never
+        // matching an inbound header.
+        let f = with("  request_id:\n    accept_headers: [\"not a header\"]\n");
+        let err = Config::load_from_path(Some(f.path()))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("proxy.request_id.accept_headers"),
+            "expected the offending key in the error, got: {err}"
+        );
     }
 
     #[test]
@@ -1691,7 +1834,7 @@ admin:
         // registration. `proxy.real_ip.trusted_proxies` was registered
         // nowhere and shipped unreachable behind exactly that gap.
         const CHILD_MARKER: &str = "TEST_ENV_SEQUENCE_FIELDS_CHILD";
-        const ENV: [(&str, &str); 8] = [
+        const ENV: [(&str, &str); 9] = [
             ("AISIX_ETCD__ENDPOINTS", "http://127.0.0.1:2379"),
             ("AISIX_ADMIN__ADMIN_KEYS", "k1,k2"),
             ("AISIX_PROXY__ADDR", "0.0.0.0:3000"),
@@ -1699,6 +1842,10 @@ admin:
             (
                 "AISIX_PROXY__REAL_IP__TRUSTED_PROXIES",
                 "10.0.0.0/8,127.0.0.1/32",
+            ),
+            (
+                "AISIX_PROXY__REQUEST_ID__ACCEPT_HEADERS",
+                "x-aisix-request-id,x-request-id",
             ),
             (
                 "AISIX_PROXY__URL_REWRITES",
@@ -1743,6 +1890,10 @@ admin:
         assert_eq!(
             cfg.proxy.real_ip.trusted_proxies,
             vec!["10.0.0.0/8".to_string(), "127.0.0.1/32".to_string()],
+        );
+        assert_eq!(
+            cfg.proxy.request_id.accept_headers,
+            vec!["x-aisix-request-id".to_string(), "x-request-id".to_string()],
         );
         assert_eq!(cfg.proxy.url_rewrites.len(), 1);
         assert_eq!(cfg.observability.metrics.client_type_rules.len(), 1);

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -672,6 +672,40 @@ impl RealIpConfig {
     }
 }
 
+/// Headers an operator's `default_headers` block may never set, that are
+/// never forwarded from a client, and that a caller-supplied request id may
+/// never be read out of.
+///
+/// The auth entries are the credentials each bridge mints for itself: letting
+/// config override them would swap the gateway's upstream identity for an
+/// attacker-supplied one. The last three are host-routing / session /
+/// proxy-auth headers that no provider auth scheme uses but that are still
+/// dangerous to hand to config.
+///
+/// cp-api rejects these at write time
+/// (`internal/cpapi/resources/provider_key_overrides.go`); this list is the
+/// runtime half of that pair, and the two must stay in sync.
+///
+/// Lives here rather than in `aisix-gateway` (which re-exports it as
+/// `upstream_headers::RESERVED_UPSTREAM_HEADERS`) so that [`Config::validate`]
+/// can enforce it too: naming one of these in
+/// `proxy.request_id.accept_headers` would turn the caller's credential into
+/// the request id, which the gateway then writes to its logs and telemetry,
+/// returns in `x-aisix-request-id`, and sends upstream — routing around this
+/// very guard by a different door.
+pub const RESERVED_UPSTREAM_HEADERS: &[&str] = &[
+    "authorization",        // OpenAI / Anthropic / Vertex Bearer
+    "x-api-key",            // Anthropic raw, also OpenAI legacy proxies
+    "x-goog-api-key",       // Gemini API key
+    "api-key",              // Azure OpenAI key
+    "x-amz-security-token", // AWS SigV4 session header (Bedrock)
+    "x-amz-date",           // AWS SigV4 timestamp (Bedrock)
+    "x-amz-content-sha256", // AWS SigV4 body hash (Bedrock)
+    "proxy-authorization",  // proxy auth — never operator-controllable
+    "cookie",               // session bleed between caller and upstream
+    "host",                 // URL hijack via Host header
+];
+
 /// Where the gateway will accept a caller-supplied request id
 /// (AISIX-Cloud#1288).
 ///
@@ -706,13 +740,28 @@ impl Default for RequestIdConfig {
 }
 
 impl RequestIdConfig {
-    /// Parse `accept_headers` into header names, rejecting malformed
-    /// entries. Header names are case-insensitive on the wire, so the
-    /// parse also lowercases and gives the proxy ready-to-use keys.
+    /// Parse `accept_headers` into header names, rejecting malformed entries
+    /// and any name in [`RESERVED_UPSTREAM_HEADERS`]. Header names are
+    /// case-insensitive on the wire, so the parse also lowercases and gives
+    /// the proxy ready-to-use keys.
+    ///
+    /// The reserved check is what stops a request id being read out of a
+    /// credential header: the resolved id is echoed to the caller, written to
+    /// the logs and telemetry, and sent upstream, so accepting one from
+    /// `authorization` would disclose the caller's secret through all three.
     pub fn parse_accept_headers(&self) -> Result<Vec<http::HeaderName>, String> {
         self.accept_headers
             .iter()
-            .map(|s| s.trim().parse::<http::HeaderName>().map_err(|_| s.clone()))
+            .map(|s| {
+                let name = s
+                    .trim()
+                    .parse::<http::HeaderName>()
+                    .map_err(|_| s.clone())?;
+                if RESERVED_UPSTREAM_HEADERS.contains(&name.as_str()) {
+                    return Err(s.clone());
+                }
+                Ok(name)
+            })
             .collect()
     }
 }
@@ -1484,10 +1533,15 @@ impl Config {
         }
         // A malformed name here would otherwise just never match any
         // inbound header, so the operator would see caller-supplied
-        // request ids silently ignored with nothing to point at.
+        // request ids silently ignored with nothing to point at. A reserved
+        // name is worse than useless: it would copy a caller credential into
+        // the response header, the logs and the upstream request.
         if let Err(bad) = self.proxy.request_id.parse_accept_headers() {
             return Err(BootstrapError::Config(format!(
-                "proxy.request_id.accept_headers invalid HTTP header name: {bad}"
+                "proxy.request_id.accept_headers rejects {bad:?}: not a valid HTTP \
+                 header name, or a reserved header a request id must never be read \
+                 from ({})",
+                RESERVED_UPSTREAM_HEADERS.join(", ")
             )));
         }
         // Zero workers would bind no listener at all: the proxy would
@@ -1681,6 +1735,42 @@ admin:
             err.contains("proxy.request_id.accept_headers"),
             "expected the offending key in the error, got: {err}"
         );
+    }
+
+    // A request id read out of a credential header would be echoed to the
+    // caller, written to the logs and telemetry, and sent upstream as
+    // `x-aisix-request-id` — disclosing the caller's secret through all
+    // three, and walking around the RESERVED_UPSTREAM_HEADERS guard by a
+    // different door. Every reserved name must fail the boot.
+    #[test]
+    fn request_id_accept_headers_rejects_credential_headers() {
+        for reserved in RESERVED_UPSTREAM_HEADERS {
+            for spelling in [reserved.to_string(), reserved.to_uppercase()] {
+                let f = write_yaml(&format!(
+                    r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+proxy:
+  addr: "0.0.0.0:3000"
+  request_id:
+    accept_headers: ["{spelling}"]
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#
+                ));
+                let err = Config::load_from_path(Some(f.path()))
+                    .expect_err(&format!(
+                        "{spelling} must be refused as a request-id source"
+                    ))
+                    .to_string();
+                assert!(
+                    err.contains("proxy.request_id.accept_headers"),
+                    "expected the offending key in the error for {spelling}, got: {err}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -30,7 +30,8 @@ pub mod wildcard;
 pub use config::{
     AdminConfig, CacheBackend, CacheConfig, ClientTypeRule, Config, EtcdConfig, EtcdTlsConfig,
     HistogramBucketsConfig, ManagedConfig, ObservabilityConfig, ProxyConfig, RateLimitBackend,
-    RateLimitConfig, RealIpConfig, RedisConnConfig, RedisMode, TlsConfig, UrlRewriteRule,
+    RateLimitConfig, RealIpConfig, RedisConnConfig, RedisMode, RequestIdConfig, TlsConfig,
+    UrlRewriteRule,
 };
 pub use config_status::{
     hash_bytes, hash_entries, AppliedSnapshot, ConfigMetricsView, ConfigState, ConfigStatus,

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -31,7 +31,7 @@ pub use config::{
     AdminConfig, CacheBackend, CacheConfig, ClientTypeRule, Config, EtcdConfig, EtcdTlsConfig,
     HistogramBucketsConfig, ManagedConfig, ObservabilityConfig, ProxyConfig, RateLimitBackend,
     RateLimitConfig, RealIpConfig, RedisConnConfig, RedisMode, RequestIdConfig, TlsConfig,
-    UrlRewriteRule,
+    UrlRewriteRule, RESERVED_UPSTREAM_HEADERS,
 };
 pub use config_status::{
     hash_bytes, hash_entries, AppliedSnapshot, ConfigMetricsView, ConfigState, ConfigStatus,

--- a/crates/aisix-gateway/src/upstream_headers.rs
+++ b/crates/aisix-gateway/src/upstream_headers.rs
@@ -36,27 +36,12 @@ use http::{
 /// Headers an operator's `default_headers` block may never set, and that are
 /// never forwarded from a client.
 ///
-/// The auth entries are the credentials each bridge mints for itself: letting
-/// config override them would swap the gateway's upstream identity for an
-/// attacker-supplied one. The last three are host-routing / session /
-/// proxy-auth headers that no provider auth scheme uses but that are still
-/// dangerous to hand to config.
-///
-/// cp-api rejects these at write time
-/// (`internal/cpapi/resources/provider_key_overrides.go`); this list is the
-/// runtime half of that pair, and the two must stay in sync.
-pub const RESERVED_UPSTREAM_HEADERS: &[&str] = &[
-    "authorization",        // OpenAI / Anthropic / Vertex Bearer
-    "x-api-key",            // Anthropic raw, also OpenAI legacy proxies
-    "x-goog-api-key",       // Gemini API key
-    "api-key",              // Azure OpenAI key
-    "x-amz-security-token", // AWS SigV4 session header (Bedrock)
-    "x-amz-date",           // AWS SigV4 timestamp (Bedrock)
-    "x-amz-content-sha256", // AWS SigV4 body hash (Bedrock)
-    "proxy-authorization",  // proxy auth — never operator-controllable
-    "cookie",               // session bleed between caller and upstream
-    "host",                 // URL hijack via Host header
-];
+/// Re-exported from `aisix-core`, which owns the list so that
+/// `Config::validate` can reject the same names in
+/// `proxy.request_id.accept_headers` — reading a request id out of
+/// `authorization` would copy the caller's credential into a response header,
+/// the logs, and the upstream request, walking straight around this guard.
+pub use aisix_core::RESERVED_UPSTREAM_HEADERS;
 
 /// Client headers never forwarded, on top of [`RESERVED_UPSTREAM_HEADERS`].
 ///

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -306,15 +306,39 @@ fn fingerprint_otlp(cfg: &OtlpHttpConfig) -> u64 {
 /// (0.01%) resolution, plenty for an operator-facing percentage knob.
 const SAMPLE_PRECISION: u64 = 10_000;
 
+/// Salt mixed into the sampling hash, drawn once per process.
+///
+/// Without it the bucket is a pure function of `request_id` — and since
+/// AISIX-Cloud#1288 the caller may choose that id. A caller could then grind
+/// FNV-1a (which is trivially cheap) for ids that land outside the configured
+/// bucket and make its own traffic invisible to a sampled exporter, or inside
+/// it to force itself into every trace. The salt is not caller-observable, so
+/// the bucket is no longer predictable off the wire.
+static SAMPLE_SALT: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+
+fn sample_salt() -> u64 {
+    *SAMPLE_SALT.get_or_init(|| uuid::Uuid::new_v4().as_u128() as u64)
+}
+
 /// Per-request sampling decision for an `otlp_http` exporter. `rate` is the
 /// exporter's `sample_rate` (`None` = 1.0, the pre-knob default).
 ///
-/// Deterministic — no clock, no RNG: the request's `request_id` is hashed
-/// (FNV-1a 64, stable across processes and versions) into a bucket in
-/// `0..SAMPLE_PRECISION`, and the request is sampled when the bucket falls
-/// below `rate × SAMPLE_PRECISION`. Same id → same decision, so the
-/// per-attempt events of one request (#655, which share `request_id`) are
-/// exported all-or-nothing, and every DP replica samples the same set.
+/// No clock: the request's `request_id` is hashed (FNV-1a 64) together with a
+/// per-process salt into a bucket in `0..SAMPLE_PRECISION`, and the request is
+/// sampled when the bucket falls below `rate × SAMPLE_PRECISION`. Within a
+/// process the same id always gets the same decision, so the per-attempt
+/// events of one request (#655, which share `request_id`) are exported
+/// all-or-nothing — they are emitted by the process that served the request,
+/// which is the only place that guarantee is needed.
+///
+/// Replicas therefore sample different subsets, and a restart reshuffles.
+/// That is the deliberate cost of the salt (see [`SAMPLE_SALT`]); the property
+/// it replaces — every replica choosing the identical set — only had meaning
+/// when ids were gateway-minted UUIDs that could not repeat across replicas.
+///
+/// Note this samples per REQUEST, not per caller: a caller that reuses one id
+/// across many requests still gets one decision for all of them, so a heavily
+/// id-reusing client can skew what fraction of total traffic an exporter sees.
 fn otlp_should_sample(rate: Option<f64>, request_id: &str) -> bool {
     let rate = rate.unwrap_or(1.0);
     if rate >= 1.0 {
@@ -324,7 +348,10 @@ fn otlp_should_sample(rate: Option<f64>, request_id: &str) -> bool {
         return false;
     }
     let threshold = (rate * SAMPLE_PRECISION as f64).round() as u64;
-    fnv1a_64(request_id.as_bytes()) % SAMPLE_PRECISION < threshold
+    let mut salted = [0u8; 8].to_vec();
+    salted.copy_from_slice(&sample_salt().to_le_bytes());
+    salted.extend_from_slice(request_id.as_bytes());
+    fnv1a_64(&salted) % SAMPLE_PRECISION < threshold
 }
 
 /// FNV-1a 64-bit — implemented inline (a fold over two constants) so the
@@ -1173,14 +1200,40 @@ mod tests {
             }
         }
 
-        // Across many distinct ids the kept fraction tracks the rate. The id
-        // set is fixed, so the count is exact and the test cannot flake.
+        // Across many distinct ids the kept fraction tracks the rate. The
+        // per-process salt makes the exact count vary between runs, so the
+        // band is wide: at n=1000, p=0.5 the standard deviation is ~16, and
+        // ±150 is over nine of them.
         let kept = (0..1000)
             .filter(|i| otlp_should_sample(Some(0.5), &format!("req-{i}")))
             .count();
         assert!(
             (350..=650).contains(&kept),
             "rate 0.5 kept {kept}/1000 — hash badly skewed"
+        );
+    }
+
+    // AISIX-Cloud#1288: the request id is caller-supplied, so the sampling
+    // bucket must not be a pure function of it. Without the salt a caller can
+    // grind ids offline until one falls outside a sampled exporter's bucket
+    // and never appear in a trace again.
+    #[test]
+    fn sampling_bucket_is_not_predictable_from_the_request_id_alone() {
+        // The unsalted hash is what an attacker can compute off the wire.
+        // Over many ids it must disagree with the real decision often enough
+        // that precomputing an evasive id is not possible.
+        let disagreements = (0..1000)
+            .filter(|i| {
+                let id = format!("req-{i}");
+                let unsalted = fnv1a_64(id.as_bytes()) % SAMPLE_PRECISION
+                    < (0.5 * SAMPLE_PRECISION as f64) as u64;
+                unsalted != otlp_should_sample(Some(0.5), &id)
+            })
+            .count();
+        assert!(
+            disagreements > 100,
+            "only {disagreements}/1000 ids differ from the unsalted bucket — \
+             the salt is not reaching the hash"
         );
     }
 

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -115,3 +115,25 @@ Whichever shape, the group's own gate stays enforced pre-dispatch — the two ti
 are additive, not either/or — and a caller-visible rejection must keep the
 direct-model envelope (`ModelIpRestricted` names no model and no CIDR), so a group
 never becomes a probe for which members exist.
+
+## `request_id` is caller-controlled input, not a gateway-minted UUID
+
+Since AISIX-Cloud#1288 a caller can supply the request id via a configured inbound
+header and `request_id::ensure_request_id` adopts it verbatim, so every
+`ClientContext.request_id` / `RequestId` value downstream may be a string the
+caller chose. It is only guaranteed to be 1..=256 bytes of visible ASCII
+(`request_id::is_acceptable`) — **not** a UUID, and not unique: nothing stops two
+requests carrying the same id, so an id is a grouping key, never an identity.
+
+New code that consumes it must therefore treat it as untrusted: escape it for the
+sink rather than interpolating it raw (a URL, a file path, a shell argument, a log
+format that isn't structured). Never make it a Prometheus label — unbounded
+cardinality straight from the caller. The existing sinks are already safe and show
+the shape: an OTLP span attribute, an HTTP header value, a `tracing` field, a
+parameterised SQL bind.
+
+`is_acceptable` is half of a cross-repo contract with cp-api's `validRequestID`
+(AISIX-Cloud `internal/dpmgr/api/telemetry.go`): tightening this side alone
+silently strands ids, and tightening THAT side alone silently drops the request
+from billing and /logs while the caller still gets a 200 carrying the id. Change
+both or neither.

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -771,6 +771,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -1558,6 +1558,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 10_485_760, // 10 MB for audio
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/auth.rs
+++ b/crates/aisix-proxy/src/auth.rs
@@ -379,6 +379,7 @@ mod tests {
             request_body_limit_bytes: 1 << 20,
             tls: None,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
         };
         crate::build_router(

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -787,6 +787,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -582,6 +582,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -716,6 +716,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -589,6 +589,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -1834,6 +1834,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,
@@ -2234,9 +2235,11 @@ mod tests {
         }
         assert_eq!(mgmt, 1);
         let agg = agg.expect("aggregated batch event must be emitted");
-        // The telemetry contract requires a UUID request_id (a non-UUID
-        // event 400s the whole flush on cp-api, dropping co-flushed
-        // events), and the id must stay deterministic for re-emission.
+        // cp-api accepts any visible-ASCII request_id since
+        // AISIX-Cloud#1288, so this is no longer a wire constraint — but a
+        // synthesised batch id has no caller behind it to correlate with,
+        // and minting a UUID keeps it distinguishable from a caller's own
+        // id in /logs. It must also stay deterministic for re-emission.
         uuid::Uuid::parse_str(&agg.request_id)
             .expect("batch attribution request_id must be a UUID");
         assert_eq!(

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -238,7 +238,7 @@ pub fn build_router(state: ProxyState) -> Router {
         Router::new()
             .fallback_service(router)
             .layer(middleware::from_fn_with_state(
-                state,
+                state.clone(),
                 rewrite::rewrite_request_uri,
             ))
     };
@@ -250,7 +250,10 @@ pub fn build_router(state: ProxyState) -> Router {
     // from the layers above) so the whole proxy family carries
     // `x-aisix-request-id` and it equals the telemetry request_id. See
     // request_id.rs.
-    router.layer(middleware::from_fn(request_id::ensure_request_id))
+    router.layer(middleware::from_fn_with_state(
+        state,
+        request_id::ensure_request_id,
+    ))
 }
 
 async fn record_in_flight_request(
@@ -842,6 +845,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,
@@ -1818,6 +1822,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: limit,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -555,6 +555,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3556,6 +3556,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/models.rs
+++ b/crates/aisix-proxy/src/models.rs
@@ -124,6 +124,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -932,6 +932,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -871,6 +871,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/reject.rs
+++ b/crates/aisix-proxy/src/reject.rs
@@ -205,6 +205,7 @@ mod tests {
             request_body_limit_bytes: 0,
             tls: None,
             real_ip: Default::default(),
+            request_id: Default::default(),
             thread_per_core: None,
             workers: None,
             url_rewrites: Vec::new(),

--- a/crates/aisix-proxy/src/request_id.rs
+++ b/crates/aisix-proxy/src/request_id.rs
@@ -1,18 +1,73 @@
-use axum::extract::Request;
+use axum::extract::{Request, State};
 use axum::http::{HeaderName, HeaderValue};
 use axum::middleware::Next;
 use axum::response::Response;
 use tracing::Instrument as _;
 use uuid::Uuid;
 
+use crate::state::ProxyState;
+
 /// Response header carrying the gateway request id so a client can
 /// correlate a response to its usage event (both key on this id).
 pub(crate) const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-aisix-request-id");
 
-/// Gateway correlation IDs may be written to telemetry fields backed by UUID
-/// columns, so keep handler request IDs as plain UUID strings.
+/// The id minted when the caller supplies none. A UUID rather than
+/// something shorter so an id the gateway generated is recognisable as
+/// such next to one a caller chose.
 pub(crate) fn new_request_id() -> String {
     Uuid::new_v4().to_string()
+}
+
+/// Longest caller-supplied request id accepted. Matches cp-api's
+/// `maxRequestIDLen`.
+const MAX_REQUEST_ID_LEN: usize = 256;
+
+/// Whether a caller-supplied request id may be used as-is.
+///
+/// MUST stay byte-identical to cp-api's `validRequestID`
+/// (AISIX-Cloud internal/dpmgr/api/telemetry.go). This side decides what
+/// to hand back to the caller and stamp on every usage event; that side
+/// decides what to persist. If cp-api were stricter, a request the caller
+/// was told succeeded — with this id in its `x-aisix-request-id` — would be
+/// dropped at telemetry ingest and vanish from billing and /logs, which is
+/// the failure AISIX-Cloud#1288 exists to remove.
+///
+/// Visible ASCII only (0x21..=0x7E): no control characters, no spaces, no
+/// non-ASCII. Covers every id shape in the wild (UUID, ULID, `req_abc123`,
+/// nginx `$request_id`) while keeping the value safe to echo back onto the
+/// wire verbatim — in a response header, in the upstream request, and in a
+/// telemetry field.
+fn is_acceptable(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_REQUEST_ID_LEN
+        && id.bytes().all(|b| (0x21..=0x7E).contains(&b))
+}
+
+/// The caller's request id, if they sent an acceptable one in a header the
+/// operator allows it from. Headers are consulted in configured order and
+/// the first acceptable value wins.
+///
+/// An unacceptable value is ignored rather than rejected: it arrives from
+/// callers whose tracing predates the gateway, and failing their requests
+/// over a correlation id would be a worse outcome than correlating them by
+/// a minted one. The fallback is logged at debug so an operator chasing a
+/// missing id has something to find.
+fn client_request_id(headers: &axum::http::HeaderMap, accept: &[HeaderName]) -> Option<String> {
+    for name in accept {
+        let Some(raw) = headers.get(name) else {
+            continue;
+        };
+        match raw.to_str() {
+            Ok(id) if is_acceptable(id) => return Some(id.to_owned()),
+            _ => {
+                tracing::debug!(
+                    header = %name,
+                    "ignoring unusable client request id; minting one instead"
+                );
+            }
+        }
+    }
+    None
 }
 
 /// The per-request correlation id, stashed in the request extensions by
@@ -23,9 +78,22 @@ pub(crate) fn new_request_id() -> String {
 #[derive(Debug, Clone)]
 pub(crate) struct RequestId(pub String);
 
-/// Ingress+egress middleware that gives every proxied response an
-/// `x-aisix-request-id` header derived from the same id the handler
-/// attributes its usage event to.
+/// Ingress+egress middleware that resolves the request id — the caller's
+/// own when they supplied one, a fresh UUID otherwise — and gives every
+/// proxied response an `x-aisix-request-id` header derived from the same id
+/// the handler attributes its usage event to.
+///
+/// Reusing the caller's id (AISIX-Cloud#1288) happens HERE, at the single
+/// mint point, which is what makes it hold everywhere at once: the response
+/// header, every retry/failover attempt's usage event, the access log, the
+/// tracing span, and the `x-aisix-request-id` each bridge sends upstream all
+/// read this one value. A caller can therefore find a gateway request by an
+/// id its own logs already carry, instead of keeping a second mapping.
+///
+/// The caller's copy of the header is still never forwarded upstream by the
+/// `forward_client_headers` allowlist (`x-aisix-` is in
+/// `NEVER_FORWARD_PREFIXES`); the bridges insert this resolved id
+/// themselves, so the upstream sees exactly one value.
 ///
 /// One shared mechanism instead of a per-handler header insert: the
 /// family had drifted (some handlers set it, some didn't — chat /
@@ -48,11 +116,16 @@ pub(crate) struct RequestId(pub String);
 /// Response-body streams (SSE) are polled after this middleware returns,
 /// so they fall outside the span. Generators that moderate streamed
 /// output re-attach it explicitly — see `chat::build_sse_stream`.
-pub(crate) async fn ensure_request_id(mut request: Request, next: Next) -> Response {
+pub(crate) async fn ensure_request_id(
+    State(state): State<ProxyState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
     let id = request
         .extensions()
         .get::<RequestId>()
         .map(|r| r.0.clone())
+        .or_else(|| client_request_id(request.headers(), &state.request_id_accept))
         .unwrap_or_else(new_request_id);
     request.extensions_mut().insert(RequestId(id.clone()));
 
@@ -118,10 +191,72 @@ pub(crate) fn in_request_span<T: 'static>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aisix_core::snapshot::SnapshotHandle;
+    use aisix_core::{AisixSnapshot, ProxyConfig, RequestIdConfig};
+    use aisix_gateway::Hub;
     use axum::response::IntoResponse;
     use axum::routing::get;
     use axum::Router;
+    use std::sync::Arc;
     use tower::ServiceExt;
+
+    fn state_accepting(accept_headers: &[&str]) -> ProxyState {
+        ProxyState::new(
+            SnapshotHandle::new(AisixSnapshot::new()),
+            Arc::new(Hub::new()),
+            &ProxyConfig {
+                addr: "127.0.0.1:0".into(),
+                request_body_limit_bytes: 1_048_576,
+                tls: None,
+                real_ip: Default::default(),
+                request_id: RequestIdConfig {
+                    accept_headers: accept_headers.iter().map(|s| (*s).to_owned()).collect(),
+                },
+                thread_per_core: None,
+                workers: None,
+                url_rewrites: Vec::new(),
+            },
+        )
+    }
+
+    /// The shipped default: the gateway's own header, nothing else.
+    fn default_state() -> ProxyState {
+        state_accepting(
+            &RequestIdConfig::default()
+                .accept_headers
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn app_with(state: ProxyState) -> Router {
+        Router::new().route("/", get(echo_extension_id)).layer(
+            axum::middleware::from_fn_with_state(state, ensure_request_id),
+        )
+    }
+
+    /// Drive one request and return (response header, id the handler saw).
+    async fn run(app: Router, headers: &[(&str, &str)]) -> (String, String) {
+        let mut builder = Request::builder().uri("/");
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        let resp = app
+            .oneshot(builder.body(axum::body::Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let header = resp
+            .headers()
+            .get(&REQUEST_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned)
+            .expect("response must carry x-aisix-request-id");
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (header, String::from_utf8(body.to_vec()).unwrap())
+    }
 
     // A handler that echoes the RequestId it sees in the extensions, so
     // the test can prove the middleware exposes the SAME id it stamps on
@@ -144,46 +279,119 @@ mod tests {
 
     #[tokio::test]
     async fn stamps_header_and_matches_the_extension_id() {
-        let app = Router::new()
-            .route("/", get(echo_extension_id))
-            .layer(axum::middleware::from_fn(ensure_request_id));
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .uri("/")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let header = resp
-            .headers()
-            .get(&REQUEST_ID_HEADER)
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_owned)
-            .expect("response must carry x-aisix-request-id");
+        let (header, seen_by_handler) = run(app_with(default_state()), &[]).await;
         assert!(
             uuid::Uuid::parse_str(&header).is_ok(),
             "stamped id must be a UUID, got {header:?}"
         );
-
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let seen_by_handler = String::from_utf8(body.to_vec()).unwrap();
         assert_eq!(
             header, seen_by_handler,
             "response header must equal the id the handler saw (correlation contract)"
         );
     }
 
+    // AISIX-Cloud#1288. The caller's id must become THE id — what the
+    // handler attributes its usage event to AND what comes back on the
+    // response — not merely be echoed back while telemetry uses another.
+    #[tokio::test]
+    async fn reuses_an_acceptable_client_request_id() {
+        for id in [
+            "req_abc123",
+            "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            "9f8c2b1e4d7a6f3c0b5e8d1a2c4f7b9e",
+            "4d1f0f4e-9b6a-4a1e-9a0b-1c2d3e4f5a6b",
+        ] {
+            let (header, seen_by_handler) =
+                run(app_with(default_state()), &[("x-aisix-request-id", id)]).await;
+            assert_eq!(header, id, "response header must be the caller's id");
+            assert_eq!(
+                seen_by_handler, id,
+                "the handler (and so the usage event) must see the caller's id"
+            );
+        }
+    }
+
+    // An id the gateway cannot use must NOT fail the request — it degrades
+    // to a minted UUID, which is the pre-#1288 behaviour.
+    #[tokio::test]
+    async fn unusable_client_request_ids_fall_back_to_a_minted_uuid() {
+        let too_long = "a".repeat(MAX_REQUEST_ID_LEN + 1);
+        for id in ["", "req abc", "req\tabc", "请求-1", too_long.as_str()] {
+            let (header, seen_by_handler) =
+                run(app_with(default_state()), &[("x-aisix-request-id", id)]).await;
+            assert!(
+                uuid::Uuid::parse_str(&header).is_ok(),
+                "unusable id {id:?} must degrade to a minted UUID, got {header:?}"
+            );
+            assert_eq!(header, seen_by_handler);
+        }
+    }
+
+    // `x-request-id` is stamped by every ingress in front of the gateway,
+    // so honouring it is opt-in: on the default config it must be ignored.
+    #[tokio::test]
+    async fn x_request_id_is_ignored_unless_configured() {
+        let (header, _) = run(
+            app_with(default_state()),
+            &[("x-request-id", "from-the-ingress")],
+        )
+        .await;
+        assert_ne!(header, "from-the-ingress");
+        assert!(uuid::Uuid::parse_str(&header).is_ok());
+
+        let (header, seen_by_handler) = run(
+            app_with(state_accepting(&["x-aisix-request-id", "x-request-id"])),
+            &[("x-request-id", "from-the-ingress")],
+        )
+        .await;
+        assert_eq!(header, "from-the-ingress");
+        assert_eq!(seen_by_handler, "from-the-ingress");
+    }
+
+    // Configured order is priority order: the gateway's own header wins
+    // over the standard one when a caller sends both.
+    #[tokio::test]
+    async fn first_configured_header_wins() {
+        let (header, _) = run(
+            app_with(state_accepting(&["x-aisix-request-id", "x-request-id"])),
+            &[
+                ("x-request-id", "from-the-ingress"),
+                ("x-aisix-request-id", "from-the-caller"),
+            ],
+        )
+        .await;
+        assert_eq!(header, "from-the-caller");
+
+        // ...and an unusable value in the first header does not shadow a
+        // good value in the next one.
+        let (header, _) = run(
+            app_with(state_accepting(&["x-aisix-request-id", "x-request-id"])),
+            &[
+                ("x-request-id", "from-the-ingress"),
+                ("x-aisix-request-id", "bad value"),
+            ],
+        )
+        .await;
+        assert_eq!(header, "from-the-ingress");
+    }
+
+    // An operator can refuse caller-supplied ids outright.
+    #[tokio::test]
+    async fn empty_accept_headers_always_mints() {
+        let (header, _) = run(
+            app_with(state_accepting(&[])),
+            &[("x-aisix-request-id", "req_abc123")],
+        )
+        .await;
+        assert_ne!(header, "req_abc123");
+        assert!(uuid::Uuid::parse_str(&header).is_ok());
+    }
+
     #[tokio::test]
     async fn preserves_a_handler_set_header() {
-        let app = Router::new()
-            .route("/", get(sets_own_header))
-            .layer(axum::middleware::from_fn(ensure_request_id));
+        let app = Router::new().route("/", get(sets_own_header)).layer(
+            axum::middleware::from_fn_with_state(default_state(), ensure_request_id),
+        );
 
         let resp = app
             .oneshot(

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -771,6 +771,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -3105,6 +3105,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/crates/aisix-proxy/src/rewrite.rs
+++ b/crates/aisix-proxy/src/rewrite.rs
@@ -184,6 +184,7 @@ mod tests {
             request_body_limit_bytes: 0,
             tls: None,
             real_ip: Default::default(),
+            request_id: Default::default(),
             thread_per_core: None,
             workers: None,
             url_rewrites: rules,

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -210,6 +210,10 @@ pub struct ProxyStateInner {
     /// client IP on each request (#492). Default = trust nothing → the
     /// logged source IP is the immediate TCP peer.
     pub real_ip: Arc<ResolvedRealIp>,
+    /// Pre-parsed `proxy.request_id.accept_headers`: the inbound headers a
+    /// caller may supply its own request id in, in priority order
+    /// (AISIX-Cloud#1288). Default = `[x-aisix-request-id]`.
+    pub request_id_accept: Arc<[axum::http::HeaderName]>,
     /// Boot-compiled `proxy.url_rewrites` rules, applied in order to every
     /// request before routing (first match wins). Empty = layer no-ops.
     pub url_rewrites: Arc<[crate::rewrite::CompiledRewrite]>,
@@ -296,6 +300,11 @@ impl ProxyState {
             otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
+            request_id_accept: cfg
+                .request_id
+                .parse_accept_headers()
+                .unwrap_or_default()
+                .into(),
             url_rewrites: crate::rewrite::compile(&cfg.url_rewrites),
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
@@ -333,6 +342,11 @@ impl ProxyState {
             otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
+            request_id_accept: cfg
+                .request_id
+                .parse_accept_headers()
+                .unwrap_or_default()
+                .into(),
             url_rewrites: crate::rewrite::compile(&cfg.url_rewrites),
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
@@ -380,6 +394,11 @@ impl ProxyState {
             otlp_fan_out: OtlpHttpFanOut::new(),
             request_body_limit_bytes: cfg.request_body_limit_bytes,
             real_ip: Arc::new(ResolvedRealIp::from_config(&cfg.real_ip)),
+            request_id_accept: cfg
+                .request_id
+                .parse_accept_headers()
+                .unwrap_or_default()
+                .into(),
             url_rewrites: crate::rewrite::compile(&cfg.url_rewrites),
             billed_batches: Arc::new(dashmap::DashSet::new()),
             client_classifier: Arc::new(ClientTypeClassifier::builtin()),
@@ -479,6 +498,7 @@ mod tests {
                 request_body_limit_bytes: 1_048_576,
                 tls: None,
                 real_ip: Default::default(),
+                request_id: Default::default(),
                 thread_per_core: None,
                 workers: None,
                 url_rewrites: Vec::new(),

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -2346,6 +2346,7 @@ mod tests {
             addr: "127.0.0.1:0".into(),
             request_body_limit_bytes: 1_048_576,
             real_ip: Default::default(),
+            request_id: Default::default(),
             url_rewrites: Vec::new(),
             tls: None,
             thread_per_core: None,

--- a/tests/e2e/src/cases/client-request-id-e2e.test.ts
+++ b/tests/e2e/src/cases/client-request-id-e2e.test.ts
@@ -1,0 +1,567 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a caller may hand the gateway its own request id and the gateway
+// uses THAT id everywhere (AISIX-Cloud#1288).
+//
+// The point of the feature is that one id spans systems: the caller's
+// business logs already carry it, so the response header, the telemetry
+// the operator searches /logs by, and the id the provider sees must all be
+// the same value. Before this, the gateway minted a fresh UUID per request
+// and the caller had to maintain a second mapping to find anything.
+//
+// The industry baseline is the same shape: LiteLLM reads its own
+// `x-litellm-call-id` off the request and only generates one when absent;
+// Portkey and Kong's correlation-id plugin behave the same way for their
+// own headers. Like LiteLLM we honour only OUR namespaced header by
+// default — `x-request-id` is opt-in precisely because everything in front
+// of a gateway stamps it.
+//
+// Asserted at every place the id surfaces, since they are populated by
+// different code: the response headers, the upstream request, the usage
+// telemetry (via a mock OTLP receiver, where the per-attempt spans also
+// prove retry/failover share one id), and the pre-dispatch rejection path
+// that never reaches a handler at all.
+
+const CALLER_PLAINTEXT = "sk-client-reqid-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface OtlpReceiver {
+  url: string;
+  spans: Array<Record<string, string>>;
+  close(): Promise<void>;
+}
+
+async function startOtlpReceiver(): Promise<OtlpReceiver> {
+  const spans: Array<Record<string, string>> = [];
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(raw);
+        for (const rs of body.resourceSpans ?? []) {
+          for (const ss of rs.scopeSpans ?? []) {
+            for (const span of ss.spans ?? []) {
+              const attrs: Record<string, string> = {};
+              for (const a of span.attributes ?? []) {
+                const v = a.value ?? {};
+                attrs[a.key] =
+                  v.stringValue ?? String(v.intValue ?? v.boolValue ?? "");
+              }
+              spans.push(attrs);
+            }
+          }
+        }
+      } catch {
+        // ignore malformed bodies — assertions fail on missing spans
+      }
+      res.statusCode = 200;
+      res.end("{}");
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) =>
+    server.listen(port, "127.0.0.1", resolve),
+  );
+  return {
+    url: `http://127.0.0.1:${port}/v1/traces`,
+    spans,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+async function waitForSpans(
+  recv: OtlpReceiver,
+  requestId: string,
+  count: number,
+  timeoutMs = 15_000,
+): Promise<Array<Record<string, string>>> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const hits = recv.spans.filter(
+      (a) => a["aisix.request_id"] === requestId,
+    );
+    if (hits.length >= count) return hits;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `expected ${count} usage span(s) for request_id=${requestId}, saw ${hits.length}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+const OK_BODY = {
+  id: "cmpl-client-reqid",
+  object: "chat.completion",
+  created: 1,
+  model: "gpt-4o-mini",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "ok" },
+      finish_reason: "stop",
+    },
+  ],
+  usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+};
+
+describe("client-supplied request id (AISIX-Cloud#1288)", () => {
+  let etcdReachable = false;
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let otlp: OtlpReceiver | undefined;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+    otlp = await startOtlpReceiver();
+    await seed.createObservabilityExporter({
+      name: "client-reqid-otlp",
+      enabled: true,
+      kind: "otlp_http",
+      endpoint: otlp.url,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+    await otlp?.close();
+  });
+
+  async function createModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+  ): Promise<void> {
+    if (!seed) throw new Error("seed client not initialized");
+    const pk = await seed.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+  }
+
+  /** Seed a throwaway key AFTER the config under test, then poll until it authenticates. */
+  async function awaitPropagation(tag: string): Promise<void> {
+    const canary = `sk-canary-reqid-${tag}-${Date.now()}`;
+    await seed!.createApiKey({
+      key_hash: createHash("sha256").update(canary).digest("hex"),
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${canary}` },
+      });
+      return res.status === 200;
+    });
+  }
+
+  function chat(
+    model: string,
+    headers: Record<string, string>,
+    body: Record<string, unknown> = {},
+  ): Promise<Response> {
+    return fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "hello" }],
+        ...body,
+      }),
+    });
+  }
+
+  test(
+    "the caller's id is what the response, the upstream and the telemetry all carry",
+    async (ctx) => {
+      if (!etcdReachable || !app || !seed || !otlp) {
+        ctx.skip();
+        return;
+      }
+      const upstream = await startOpenAiUpstream({ nonStreamBody: OK_BODY });
+      upstreams.push(upstream);
+      await createModel("reqid-basic", upstream);
+      await awaitPropagation("basic");
+
+      // Deliberately NOT a UUID: the whole point is that a caller keeps
+      // its own id shape. This one used to be rejected by cp-api's
+      // telemetry ingest and the request vanished from billing and /logs.
+      const callerId = "req_abc123-orders-svc";
+      const res = await chat("reqid-basic", {
+        "x-aisix-request-id": callerId,
+      });
+      expect(res.status).toBe(200);
+      await res.text();
+
+      expect(res.headers.get("x-aisix-request-id")).toBe(callerId);
+      // The chat success path sets a second, older alias header off the
+      // same id; it must not drift into a different value.
+      expect(res.headers.get("x-aisix-call-id")).toBe(callerId);
+
+      const sent = upstream.receivedRequests.at(-1)!;
+      expect(sent.headers["x-aisix-request-id"]).toBe(callerId);
+
+      const [span] = await waitForSpans(otlp, callerId, 1);
+      expect(span["aisix.request_id"]).toBe(callerId);
+    },
+    30_000,
+  );
+
+  test(
+    "no client id keeps the old behaviour: a freshly minted UUID",
+    async (ctx) => {
+      if (!etcdReachable || !app || !seed) {
+        ctx.skip();
+        return;
+      }
+      const upstream = await startOpenAiUpstream({ nonStreamBody: OK_BODY });
+      upstreams.push(upstream);
+      await createModel("reqid-minted", upstream);
+      await awaitPropagation("minted");
+
+      const res = await chat("reqid-minted", {});
+      expect(res.status).toBe(200);
+      await res.text();
+
+      const id = res.headers.get("x-aisix-request-id");
+      expect(id).toMatch(UUID_RE);
+      expect(upstream.receivedRequests.at(-1)!.headers["x-aisix-request-id"]).toBe(
+        id,
+      );
+    },
+    30_000,
+  );
+
+  test(
+    "a streamed response carries the caller's id too",
+    async (ctx) => {
+      if (!etcdReachable || !app || !seed) {
+        ctx.skip();
+        return;
+      }
+      const upstream = await startOpenAiUpstream({
+        streamEvents: [
+          JSON.stringify({
+            id: "chatcmpl-reqid",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "gpt-4o-mini",
+            choices: [
+              { index: 0, delta: { content: "hi" }, finish_reason: null },
+            ],
+          }),
+          JSON.stringify({
+            id: "chatcmpl-reqid",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "gpt-4o-mini",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+          }),
+          "[DONE]",
+        ],
+      });
+      upstreams.push(upstream);
+      await createModel("reqid-stream", upstream);
+      await awaitPropagation("stream");
+
+      const callerId = "req_stream_01HZY";
+      const res = await chat(
+        "reqid-stream",
+        { "x-aisix-request-id": callerId },
+        { stream: true },
+      );
+      expect(res.status).toBe(200);
+      // Headers are sent before the body: the id must be on them, not
+      // deferred to end-of-stream.
+      expect(res.headers.get("x-aisix-request-id")).toBe(callerId);
+      await res.text();
+
+      expect(
+        upstream.receivedRequests.at(-1)!.headers["x-aisix-request-id"],
+      ).toBe(callerId);
+    },
+    30_000,
+  );
+
+  test(
+    "every failover attempt shares the caller's id",
+    async (ctx) => {
+      if (!etcdReachable || !app || !seed || !otlp) {
+        ctx.skip();
+        return;
+      }
+      const primary = await startOpenAiUpstream({
+        status: 502,
+        errorBody: { error: { message: "primary down", type: "server_error" } },
+      });
+      const secondary = await startOpenAiUpstream({ nonStreamBody: OK_BODY });
+      upstreams.push(primary, secondary);
+
+      await createModel("reqid-primary", primary);
+      await createModel("reqid-secondary", secondary);
+      await seed.createModel({
+        display_name: "reqid-virtual",
+        routing: {
+          strategy: "failover",
+          targets: [{ model: "reqid-primary" }, { model: "reqid-secondary" }],
+          retries: 0,
+          max_fallbacks: 1,
+        },
+      });
+      await awaitPropagation("failover");
+
+      const callerId = "req_failover_7f3a";
+      const res = await chat("reqid-virtual", {
+        "x-aisix-request-id": callerId,
+      });
+      expect(res.status).toBe(200);
+      await res.text();
+      expect(res.headers.get("x-aisix-request-id")).toBe(callerId);
+
+      // Both upstreams were reached, and both saw the caller's id — an
+      // operator correlating provider-side logs finds the same value on
+      // the failed attempt and the winning one.
+      expect(primary.receivedRequests.length).toBe(1);
+      expect(secondary.receivedRequests.length).toBe(1);
+      expect(primary.receivedRequests[0]!.headers["x-aisix-request-id"]).toBe(
+        callerId,
+      );
+      expect(secondary.receivedRequests[0]!.headers["x-aisix-request-id"]).toBe(
+        callerId,
+      );
+
+      // #655 emits one usage event per attempt, all keyed on request_id:
+      // querying /logs by the caller's id must return the whole chain.
+      const attempts = await waitForSpans(otlp, callerId, 2);
+      const kinds = attempts
+        .map((a) => a["aisix.attempt_kind"])
+        .sort();
+      expect(kinds).toEqual(["fallback", "initial"]);
+    },
+    45_000,
+  );
+
+  test(
+    "an unusable id degrades to a minted UUID rather than failing the request",
+    async (ctx) => {
+      if (!etcdReachable || !app || !seed) {
+        ctx.skip();
+        return;
+      }
+      const upstream = await startOpenAiUpstream({ nonStreamBody: OK_BODY });
+      upstreams.push(upstream);
+      await createModel("reqid-degrade", upstream);
+      await awaitPropagation("degrade");
+
+      // A space is legal in an HTTP header value but outside the id
+      // charset; 300 bytes is past the 256-byte ceiling. Neither may cost
+      // the caller their request — nor be persisted, which is why the
+      // charset and the ceiling match cp-api's ingest rule exactly.
+      for (const bad of ["req abc 123", "x".repeat(300)]) {
+        const res = await chat("reqid-degrade", {
+          "x-aisix-request-id": bad,
+        });
+        expect(res.status).toBe(200);
+        await res.text();
+
+        const id = res.headers.get("x-aisix-request-id");
+        expect(id).not.toBe(bad);
+        expect(id).toMatch(UUID_RE);
+        expect(
+          upstream.receivedRequests.at(-1)!.headers["x-aisix-request-id"],
+        ).toBe(id);
+      }
+    },
+    30_000,
+  );
+
+  test(
+    "a request rejected before dispatch still comes back with the caller's id",
+    async (ctx) => {
+      if (!etcdReachable || !app) {
+        ctx.skip();
+        return;
+      }
+      // Bad credential: refused by the auth extractor, so no handler and
+      // no upstream is involved — the id has to come from the middleware.
+      const callerId = "req_rejected_9c2";
+      const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer sk-not-a-real-key",
+          "content-type": "application/json",
+          "x-aisix-request-id": callerId,
+        },
+        body: JSON.stringify({
+          model: "reqid-basic",
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+      expect(res.status).toBe(401);
+      await res.text();
+      expect(res.headers.get("x-aisix-request-id")).toBe(callerId);
+    },
+    30_000,
+  );
+
+  test(
+    "x-request-id is ignored on the default config",
+    async (ctx) => {
+      if (!etcdReachable || !app || !seed) {
+        ctx.skip();
+        return;
+      }
+      const upstream = await startOpenAiUpstream({ nonStreamBody: OK_BODY });
+      upstreams.push(upstream);
+      await createModel("reqid-default", upstream);
+      await awaitPropagation("default");
+
+      const res = await chat("reqid-default", {
+        "x-request-id": "stamped-by-the-ingress",
+      });
+      expect(res.status).toBe(200);
+      await res.text();
+      expect(res.headers.get("x-aisix-request-id")).not.toBe(
+        "stamped-by-the-ingress",
+      );
+      expect(res.headers.get("x-aisix-request-id")).toMatch(UUID_RE);
+    },
+    30_000,
+  );
+});
+
+// A second gateway, configured to also accept the de-facto standard
+// header. Separate describe because `accept_headers` is boot config.
+describe("client-supplied request id: x-request-id opted in", () => {
+  let etcdReachable = false;
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+    app = await spawnApp({
+      requestId: { accept_headers: ["x-aisix-request-id", "x-request-id"] },
+    });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test(
+    "x-request-id is honoured, and the gateway's own header still outranks it",
+    async (ctx) => {
+      if (!etcdReachable || !app || !seed) {
+        ctx.skip();
+        return;
+      }
+      const upstream = await startOpenAiUpstream({ nonStreamBody: OK_BODY });
+      upstreams.push(upstream);
+      const pk = await seed.createProviderKey({
+        display_name: "reqid-optin-pk",
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      await seed.createModel({
+        display_name: "reqid-optin",
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+      const canary = `sk-canary-optin-${Date.now()}`;
+      await seed.createApiKey({
+        key_hash: createHash("sha256").update(canary).digest("hex"),
+        allowed_models: ["*"],
+      });
+      await waitConfigPropagation(async () => {
+        const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+          headers: { authorization: `Bearer ${canary}` },
+        });
+        return res.status === 200;
+      });
+
+      const send = (headers: Record<string, string>) =>
+        fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${CALLER_PLAINTEXT}`,
+            "content-type": "application/json",
+            ...headers,
+          },
+          body: JSON.stringify({
+            model: "reqid-optin",
+            messages: [{ role: "user", content: "hello" }],
+          }),
+        });
+
+      let res = await send({ "x-request-id": "from-the-ingress" });
+      expect(res.status).toBe(200);
+      await res.text();
+      expect(res.headers.get("x-aisix-request-id")).toBe("from-the-ingress");
+      expect(
+        upstream.receivedRequests.at(-1)!.headers["x-aisix-request-id"],
+      ).toBe("from-the-ingress");
+
+      // Configured order is priority order.
+      res = await send({
+        "x-request-id": "from-the-ingress",
+        "x-aisix-request-id": "from-the-caller",
+      });
+      expect(res.status).toBe(200);
+      await res.text();
+      expect(res.headers.get("x-aisix-request-id")).toBe("from-the-caller");
+    },
+    45_000,
+  );
+});

--- a/tests/e2e/src/cases/upstream-header-context-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-header-context-e2e.test.ts
@@ -278,7 +278,7 @@ describe("upstream header context e2e: ${...} variables + client-header allowlis
       const { status, sent } = await chat(CALLER_PLAINTEXT, {
         "x-api-key": CALLER_PLAINTEXT,
         cookie: "session=secret",
-        "x-aisix-request-id": "spoofed-by-caller",
+        "x-aisix-routing-tags": "spoofed-by-caller",
         "x-stainless-lang": "js",
       });
       expect(status).toBe(200);
@@ -295,9 +295,12 @@ describe("upstream header context e2e: ${...} variables + client-header allowlis
       expect(req.body).not.toContain(CALLER_PLAINTEXT);
       expect(req.headers.cookie).toBeUndefined();
       expect(req.headers["x-stainless-lang"]).toBeUndefined();
-      // The gateway stamps its own correlation id; the caller's forged
-      // value must not be what the upstream sees.
-      expect(req.headers["x-aisix-request-id"]).not.toBe("spoofed-by-caller");
+      // `x-aisix-*` is the gateway's own namespace: a caller's copy is
+      // never relayed as-is, so gateway-asserted context cannot be forged
+      // upstream. (`x-aisix-request-id` is the deliberate exception — the
+      // gateway ADOPTS the caller's id at the mint point and sends that
+      // one value itself; see client-request-id-e2e.test.ts.)
+      expect(req.headers["x-aisix-routing-tags"]).toBeUndefined();
     },
     30_000,
   );

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -42,6 +42,13 @@ export interface AppOverrides {
     header?: string;
   };
   /**
+   * `proxy.request_id` block (AISIX-Cloud#1288). Merged into the base
+   * proxy config like `realIp`. Names the inbound headers a caller may
+   * supply its own request id in; omitted, the binary's default
+   * (`["x-aisix-request-id"]`) applies.
+   */
+  requestId?: { accept_headers?: string[] };
+  /**
    * `proxy.url_rewrites` block. Merged into the base proxy config (like
    * `realIp`) so the listener addr is preserved. Entry-level path
    * rewriting: first matching rule wins, `rewrite` replaces the matched
@@ -271,6 +278,7 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
       addr: `127.0.0.1:${proxyPort}`,
       request_body_limit_bytes: overrides.requestBodyLimitBytes ?? 10485760,
       ...(overrides.realIp ? { real_ip: overrides.realIp } : {}),
+      ...(overrides.requestId ? { request_id: overrides.requestId } : {}),
       ...((overrides.threadPerCore ?? suiteThreadPerCore) !== undefined
         ? { thread_per_core: overrides.threadPerCore ?? suiteThreadPerCore }
         : {}),


### PR DESCRIPTION
## Problem

A caller whose upstream service already generated a request id has no way to make the gateway use it. `ensure_request_id` only ever mints a fresh UUID, so the `x-aisix-request-id` in the response, the `request_id` on every usage event, and the id the provider sees are all a *different* value from the one the caller's own logs carry. Finding a gateway request from a business log means maintaining a second mapping.

The industry baseline is the opposite: LiteLLM reads `x-litellm-call-id` off the request and only generates one when it is absent; Portkey and Kong's correlation-id plugin behave the same way for their own headers.

## Implementation

Read the id off the request at the single mint point. Because every consumer already derives from `RequestId` / `ClientContext.request_id`, one change covers the whole surface at once — the response headers, each retry/failover attempt's usage event, the access log, the tracing span, and the `x-aisix-request-id` each bridge sends upstream. No per-endpoint work, and no way for the endpoint family to drift.

**Which headers** is `proxy.request_id.accept_headers`, consulted in order, first acceptable value wins:

```yaml
proxy:
  request_id:
    accept_headers: ["x-aisix-request-id"]   # the default
```

- The default is our own header alone — the same scope LiteLLM gives `x-litellm-call-id`.
- `x-request-id` is **opt-in**. Every reverse proxy and ingress in front of a gateway stamps that header automatically, so honouring it by default would silently make the correlation id come from the infrastructure rather than from the caller. An operator who wants it adds it to the list.
- `[]` refuses caller-supplied ids entirely and always mints.

**Which values.** An id is used verbatim when it is 1..=256 bytes of visible ASCII (`0x21..=0x7E`) — covering a UUID, a ULID, `req_abc123` and an nginx `$request_id` alike. Anything else is ignored in favour of a minted UUID rather than failing the request: the caller's tracing predates the gateway, and losing their request over a correlation id is the worse outcome. The fallback logs at debug.

That rule is byte-identical to cp-api's `validRequestID`, and the comment on each side names the other. A mismatch would not error — it would drop the request from billing and `/logs` while the caller holds a 200 carrying that id.

A malformed header name in `accept_headers` fails the boot rather than silently never matching.

## Security

Two hardening points came out of review and are in the branch:

- **`accept_headers` cannot name a credential header.** Reading the request id out of `authorization` / `x-api-key` / `cookie` would have turned the caller's secret into an id that is logged, persisted, returned in `x-aisix-request-id` and sent upstream — routing around `RESERVED_UPSTREAM_HEADERS` by a different door. That list now lives in `aisix-core` (re-exported unchanged from `aisix-gateway`) so `Config::validate` enforces the same names, and a config naming one fails the boot.
- **The OTLP sampling bucket is salted.** It was a pure FNV-1a of `request_id`, which the caller now chooses; grinding that hash is trivial, so a caller could pick ids that always land outside a sampled exporter's bucket and vanish from tracing. A per-process salt is mixed in: the decision stays stable within a process (so a request's per-attempt spans remain all-or-nothing) but is no longer predictable off the wire.

The caller's copy of the header is still never relayed by the `forward_client_headers` allowlist — `x-aisix-` stays in `NEVER_FORWARD_PREFIXES`, and the bridges insert the resolved id themselves, so the upstream sees exactly one value, not a caller-injected second one. What changes is only *which* value that is.

The id is now caller-controlled input everywhere downstream, which is written up in `crates/aisix-proxy/AGENTS.md`: it is not a UUID, not unique, and must be escaped for its sink rather than interpolated raw (and never used as a Prometheus label). The existing sinks — an OTLP span attribute, an HTTP header value, a `tracing` field — are already safe.

## Behaviour changes

- With the default config, a caller sending `x-aisix-request-id` now gets that id back and sees it in `/logs`, where before it was ignored. A caller sending nothing is unaffected.
- `upstream-header-context-e2e` swapped its spoofing probe from `x-aisix-request-id` to `x-aisix-routing-tags`: the prefix rule it guards is unchanged, but the request-id header is now adopted by design rather than being a forgery vector.

## Compatibility

Requires api7/AISIX-Cloud#1291, which widens `dpmgr_usage_events.request_id` from `uuid` to `text`. Until that ships, a caller-supplied non-UUID id is skipped at telemetry ingest and the request is missing from billing and `/logs`. Merge order is CP first.

## Tests

Unit (`request_id.rs`): reuse of the four common id shapes; the degrade-to-UUID path for empty / spaced / tabbed / non-ASCII / over-length values; `x-request-id` ignored by default and honoured when configured; configured order as priority order, including an unusable value in the first header not shadowing a good one in the next; and the `[]` opt-out.

Config (`config.rs`): the shipped default, lower-casing of configured names, the empty-list case, boot rejection of a malformed name, and the new key added to `env_only_deployments_can_set_every_sequence_field` so it stays reachable in an env-var-only deployment.

E2E (`client-request-id-e2e.test.ts`, 8 cases against a real gateway + real upstream + a mock OTLP receiver): the caller's id on the response headers, on the upstream request and on the usage span; a minted UUID when none is sent; streaming, where the id must be on the headers rather than deferred to end-of-stream; both attempts of a failover sharing one id, with `initial` + `fallback` spans; the degrade path; a pre-dispatch 401 that reaches no handler at all; and a second gateway booted with `x-request-id` opted in.

Verified the e2e discriminates: with the reuse line reverted, 5 of the 8 fail and the 3 baseline-preservation cases still pass.

Fixes api7/AISIX-Cloud#1288