### PR TITLE
feat(obs): record provider_request_id in the access log and the plain log

### DIFF
--- a/crates/aisix-obs/src/access_log.rs
+++ b/crates/aisix-obs/src/access_log.rs
@@ -20,6 +20,22 @@ pub struct AccessLog<'a> {
     pub completion_tokens: Option<u64>,
     pub total_tokens: Option<u64>,
     pub request_id: &'a str,
+    /// Provider response object `id` of the attempt that served the request
+    /// — OpenAI's `chat.completion.id`, Anthropic's message `id`,
+    /// `/v1/responses`' `resp_…`. Distinct from `request_id` (this
+    /// gateway's own id) and from the provider's HTTP transport header id;
+    /// none of the three may overwrite another (AISIX-Cloud#1289).
+    ///
+    /// `None` whenever no id exists by the time this line is written:
+    /// the request never reached an upstream (guardrail block,
+    /// pre-dispatch error), it was served from cache, the endpoint's
+    /// provider response carries no id at all (embeddings / audio /
+    /// images / count_tokens), or the response is **streamed** — there the
+    /// id arrives in the first frame, after this line. Streamed and
+    /// mid-stream-failed-over calls are covered instead by the per-attempt
+    /// `provider call completed` line (see `UsageSink::try_emit`), which
+    /// shares this `request_id`.
+    pub provider_request_id: Option<&'a str>,
     /// Routing target that ultimately served the request (the winning
     /// attempt's display name). `None` for direct models / cache hits.
     pub served_by_model: Option<&'a str>,
@@ -58,6 +74,7 @@ impl AccessLog<'_> {
             completion_tokens = self.completion_tokens,
             total_tokens = self.total_tokens,
             request_id = self.request_id,
+            provider_request_id = self.provider_request_id,
             served_by_model = self.served_by_model,
             routing_attempt_count = self.routing_attempt_count,
             routing_fallback_count = self.routing_fallback_count,
@@ -124,6 +141,7 @@ mod tests {
                 completion_tokens: Some(1),
                 total_tokens: Some(3),
                 request_id: "req-abc",
+                provider_request_id: Some("chatcmpl-abc"),
                 served_by_model: Some("fallback-target"),
                 routing_attempt_count: Some(2),
                 routing_fallback_count: Some(1),
@@ -141,6 +159,13 @@ mod tests {
         assert!(out.contains("provider=\"openai\"") || out.contains("provider=openai"));
         assert!(out.contains("total_tokens=3"));
         assert!(out.contains("request_id=\"req-abc\"") || out.contains("request_id=req-abc"));
+        // AISIX-Cloud#1289: the provider's own response id, next to — never
+        // instead of — the gateway's `request_id`.
+        assert!(
+            out.contains("provider_request_id=\"chatcmpl-abc\"")
+                || out.contains("provider_request_id=chatcmpl-abc"),
+            "{out}"
+        );
         assert!(
             out.contains("served_by_model=\"fallback-target\"")
                 || out.contains("served_by_model=fallback-target")
@@ -178,6 +203,7 @@ mod tests {
                 completion_tokens: None,
                 total_tokens: None,
                 request_id: "req-fail",
+                provider_request_id: None,
                 served_by_model: None,
                 routing_attempt_count: Some(1),
                 routing_fallback_count: None,
@@ -189,6 +215,10 @@ mod tests {
 
         let out = writer.contents();
         assert!(out.contains("status=504"));
+        // A call that never got a provider response must not carry an empty
+        // `provider_request_id=""` — an always-present field defeats
+        // filtering on it, same rule as `error_kind` above.
+        assert!(!out.contains("provider_request_id"), "{out}");
         assert!(
             out.contains("error_kind=\"timeout\"") || out.contains("error_kind=timeout"),
             "{out}"
@@ -222,6 +252,7 @@ mod tests {
                 completion_tokens: None,
                 total_tokens: None,
                 request_id: "req-xyz",
+                provider_request_id: None,
                 served_by_model: None,
                 routing_attempt_count: None,
                 routing_fallback_count: None,

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -504,6 +504,48 @@ pub struct UsageSink {
     metrics: Option<crate::metrics::Metrics>,
 }
 
+/// Log one line per provider call that came back with a response id
+/// (AISIX-Cloud#1289), so `provider_request_id` is greppable in the plain
+/// application log and not only in telemetry.
+///
+/// This lives on the usage-sink path on purpose: per #655 **every** upstream
+/// attempt — the winner, an abandoned mid-stream fallover, a retried target —
+/// becomes its own `UsageEvent`, and every handler funnels those through
+/// [`UsageSink::try_emit`]. That makes this the single point that sees each
+/// attempt's id, so no handler can be added later that records an id in
+/// telemetry while staying silent in the log. It also covers the two cases the
+/// one-line-per-request access log structurally cannot: a **streamed**
+/// response (the id arrives in the first frame, after the access-log line is
+/// written) and a **mid-stream failover** (two provider calls, two ids, one
+/// access-log line).
+///
+/// `request_id` + `attempt_index` identify the individual call; the line is
+/// skipped entirely when there is no id (guardrail block, pre-dispatch error,
+/// cache hit, a failed attempt that never got a response body, and the
+/// endpoints whose provider response carries no id).
+fn log_provider_call(handler: &'static str, event: &UsageEvent) {
+    if event.provider_request_id.is_empty() {
+        return;
+    }
+    // Field rendering matches `AccessLog::emit` (plain `&str`, so the fmt
+    // layer quotes it) — an operator greps the two lines the same way.
+    tracing::info!(
+        request_id = event.request_id.as_str(),
+        provider_request_id = event.provider_request_id.as_str(),
+        attempt_index = event.attempt_index,
+        attempt_kind = if event.attempt_kind.is_empty() {
+            "initial"
+        } else {
+            event.attempt_kind.as_str()
+        },
+        handler,
+        status = event.status_code,
+        requested_model = event.requested_model.as_str(),
+        provider_model_version = event.provider_model_version.as_str(),
+        "provider call completed",
+    );
+}
+
 impl UsageSink {
     /// Build a real sink backed by an mpsc::Sender. The receiving end
     /// is owned by the worker spawned in aisix-server. No prometheus
@@ -548,6 +590,7 @@ impl UsageSink {
     /// `"embeddings"`, `"messages"`, `"responses"`, etc. Keep it
     /// `&'static str` so cardinality stays bounded.
     pub fn try_emit(&self, handler: &'static str, event: UsageEvent) {
+        log_provider_call(handler, &event);
         // Normalise inbound_protocol to a fixed `&'static str` set at
         // the boundary (audit MEDIUM-3). This both kills the heap
         // alloc per call AND pins prometheus cardinality at the type
@@ -606,6 +649,116 @@ mod tests {
         // row also fine.
         sink.try_emit("test", sample_event("req-1"));
         sink.try_emit("test", sample_event("req-2"));
+    }
+
+    /// Keep every callsite emittable for the whole test binary.
+    ///
+    /// A callsite's `Interest` is cached process-wide the first time it is
+    /// hit, from whichever dispatcher the hitting thread has; with no global
+    /// default that is `NoSubscriber`, and a sibling test reaching
+    /// `log_provider_call` on another thread would cache `Interest::never()`,
+    /// leaving the capture below empty. A permissive global default removes
+    /// the outcome (api7/aisix#909).
+    fn keep_callsites_enabled() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+        });
+    }
+
+    /// Run `emit` with a capturing subscriber installed; return what it wrote.
+    fn capture_logs(emit: impl FnOnce()) -> String {
+        #[derive(Clone)]
+        struct BufWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+        impl std::io::Write for BufWriter {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl tracing_subscriber::fmt::MakeWriter<'_> for BufWriter {
+            type Writer = BufWriter;
+            fn make_writer(&self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        keep_callsites_enabled();
+        let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(BufWriter(buf.clone()))
+            .finish();
+        {
+            let _guard = tracing::subscriber::set_default(subscriber);
+            emit();
+        }
+        let bytes = buf.lock().unwrap().clone();
+        String::from_utf8(bytes).unwrap()
+    }
+
+    /// AISIX-Cloud#1289: a provider call that came back with a response id
+    /// must be greppable in the plain application log, keyed by the gateway
+    /// `request_id` + `attempt_index` so a retried/failed-over request can be
+    /// walked call by call. Emitting from `try_emit` is what makes this hold
+    /// for a *streamed* response too — its id only exists long after the
+    /// one-line-per-request access log was written.
+    #[test]
+    fn try_emit_logs_the_provider_call_with_its_ids() {
+        let mut ev = sample_event("req-1289");
+        ev.provider_request_id = "chatcmpl-abc".into();
+        ev.provider_model_version = "gpt-4o-2024-08-06".into();
+        ev.attempt_index = 2;
+        ev.attempt_kind = "fallback".into();
+        ev.status_code = 200;
+
+        let out = capture_logs(|| UsageSink::disabled().try_emit("chat", ev));
+
+        assert!(out.contains("provider call completed"), "{out}");
+        assert!(
+            out.contains("provider_request_id=\"chatcmpl-abc\"")
+                || out.contains("provider_request_id=chatcmpl-abc"),
+            "{out}"
+        );
+        // The two ids coexist — neither may overwrite the other.
+        assert!(
+            out.contains("request_id=\"req-1289\"") || out.contains("request_id=req-1289"),
+            "{out}"
+        );
+        assert!(out.contains("attempt_index=2"), "{out}");
+        assert!(
+            out.contains("attempt_kind=\"fallback\"") || out.contains("attempt_kind=fallback"),
+            "{out}"
+        );
+    }
+
+    /// The line is skipped entirely when the call produced no provider id
+    /// (guardrail block, pre-dispatch error, cache hit, an attempt that never
+    /// got a response body) — a `provider_request_id=""` on every request
+    /// would defeat filtering on the field, and inventing a value would be
+    /// worse still.
+    #[test]
+    fn try_emit_is_silent_when_there_is_no_provider_id() {
+        let out = capture_logs(|| UsageSink::disabled().try_emit("chat", sample_event("req-none")));
+        assert!(!out.contains("provider call completed"), "{out}");
+    }
+
+    /// An event that predates `attempt_kind` (or a single-shot endpoint that
+    /// never sets it) must still read as a real attempt rather than an empty
+    /// string — the wire default is `initial`.
+    #[test]
+    fn provider_call_log_defaults_a_blank_attempt_kind() {
+        let mut ev = sample_event("req-blank");
+        ev.provider_request_id = "cmpl-1".into();
+        let out = capture_logs(|| UsageSink::disabled().try_emit("completions", ev));
+        assert!(
+            out.contains("attempt_kind=\"initial\"") || out.contains("attempt_kind=initial"),
+            "{out}"
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -99,6 +99,7 @@ pub async fn a2a_endpoint(
         // so no typed error reaches this point.
         error_kind: None,
         error: None,
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -1528,6 +1528,10 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        // No provider response id: transcription/translation return
+        // `{text, usage}` and speech returns audio bytes — neither carries
+        // one (AISIX-Cloud#1289).
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2845,7 +2845,7 @@ async fn dispatch(
     let reasoning_tokens = upstream.usage.reasoning_tokens;
     let cache_creation_tokens = upstream.usage.cache_creation_tokens;
     let cache_read_tokens = upstream.usage.cache_read_tokens;
-    let provider_request_id = upstream.id.clone();
+    let provider_request_id = crate::usage_attr::sanitize_provider_response_id(&upstream.id);
     let provider_model_version = upstream.model.clone();
     let finish_reason = finish_reason_label(&upstream.finish_reason);
     // Fold the winning target's model-layer reservation in so one commit
@@ -3821,7 +3821,9 @@ async fn dispatch_ensemble(
                 cache_creation_tokens: judge_usage.cache_creation_tokens,
                 cache_read_tokens: judge_usage.cache_read_tokens,
                 usage_estimated: judge_estimated,
-                provider_request_id: outcome.response.id.clone(),
+                provider_request_id: crate::usage_attr::sanitize_provider_response_id(
+                    &outcome.response.id,
+                ),
                 provider_model_version: outcome.response.model.clone(),
                 finish_reason: finish_reason_label(&outcome.response.finish_reason),
                 bypass_reason: bypass.to_string(),
@@ -4840,7 +4842,8 @@ where
                     }
                     let comp = guard.comp();
                     if !chunk.id.is_empty() {
-                        comp.provider_request_id = chunk.id.clone();
+                        comp.provider_request_id =
+                            crate::usage_attr::sanitize_provider_response_id(&chunk.id);
                     }
                     if !chunk.model.is_empty() {
                         comp.provider_model_version = chunk.model.clone();

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -178,6 +178,11 @@ pub async fn chat_completions(
                 success.completion_tokens,
                 success.total_tokens,
                 &request_id,
+                // Empty on the streaming path — the id rides the first
+                // upstream frame, which has not arrived yet. That case is
+                // covered by the per-attempt `provider call completed` line
+                // the usage sink emits (AISIX-Cloud#1289).
+                Some(success.provider_request_id.as_str()),
                 &success.routing,
                 None,
             );
@@ -418,6 +423,7 @@ pub async fn chat_completions(
                 al_completion,
                 al_total,
                 &request_id,
+                None,
                 &routing,
                 Some(&err),
             );
@@ -4386,6 +4392,9 @@ fn emit_access_log(
     completion_tokens: Option<u64>,
     total_tokens: Option<u64>,
     request_id: &str,
+    // Winning attempt's provider response id; empty when unknown at this
+    // point (streaming, cache hit, guardrail block, pre-dispatch error).
+    provider_request_id: Option<&str>,
     routing: &RoutingTelemetry,
     error: Option<&ProxyError>,
 ) {
@@ -4412,6 +4421,7 @@ fn emit_access_log(
         completion_tokens,
         total_tokens,
         request_id,
+        provider_request_id: provider_request_id.filter(|s| !s.is_empty()),
         served_by_model: served_by.filter(|s| !s.is_empty()),
         routing_attempt_count: match routing.attempt_count() {
             0 => None,

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -47,6 +47,10 @@ struct CompletionDispatchSuccess {
     /// Provider-side model name, for the `upstream_model` metric label
     /// (AISIX-Cloud#1234 parity with chat / messages / responses).
     upstream_model: String,
+    /// Legacy-completions response object `id` (`cmpl-…`). Empty on the 501
+    /// NotImplemented path (no upstream call) and when the upstream omitted
+    /// it (AISIX-Cloud#1289).
+    provider_request_id: String,
     /// Upstream-reported token counts. `None` on the 501
     /// NotImplemented path (provider doesn't support completions)
     /// or on a 200 with no `usage` block (rare edge). Handler
@@ -140,6 +144,7 @@ pub async fn completions(
                 status,
                 elapsed,
                 &request_id,
+                Some(success.provider_request_id.as_str()),
                 None,
             );
             crate::request_metrics::record(
@@ -175,6 +180,7 @@ pub async fn completions(
                     status,
                     elapsed,
                     &usage,
+                    &success.provider_request_id,
                     &client,
                     success.guardrail_blocked,
                     success.redactions.clone(),
@@ -194,6 +200,7 @@ pub async fn completions(
                 status,
                 elapsed,
                 &request_id,
+                None,
                 Some(&err),
             );
             let snap = state.snapshot.load();
@@ -399,6 +406,9 @@ async fn dispatch(
             // to each. The 200-without-usage edge previously skipped the
             // event entirely; it now emits an estimated record instead.
             // Telemetry only — the response body forwards untouched.
+            // AISIX-Cloud#1289: read the response object id BEFORE the
+            // redaction pass below rewrites the body.
+            let provider_request_id = crate::usage_attr::provider_response_id(&resp_json);
             let usage = {
                 let mut u = extract_completion_usage(&resp_json).unwrap_or(CompletionUsage {
                     prompt_tokens: 0,
@@ -500,6 +510,7 @@ async fn dispatch(
                         provider_key_id: pk_entry.id.to_string(),
                         upstream_model: model.upstream_model().unwrap_or("unknown").to_string(),
                         usage,
+                        provider_request_id,
                         redactions,
                         monitor_hits,
                         guardrail_blocked: true,
@@ -536,6 +547,7 @@ async fn dispatch(
                 provider_key_id: pk_entry.id.to_string(),
                 upstream_model: model.upstream_model().unwrap_or("unknown").to_string(),
                 usage,
+                provider_request_id,
                 redactions,
                 monitor_hits,
                 guardrail_blocked: false,
@@ -556,6 +568,7 @@ async fn dispatch(
                 // gates emission on `usage.is_some()` so 501 stays
                 // out of /logs noise (same convention as #402).
                 usage: None,
+                provider_request_id: String::new(),
                 redactions,
                 monitor_hits,
                 guardrail_blocked: false,
@@ -665,6 +678,7 @@ fn emit_usage_event(
     status_code: u16,
     elapsed: Duration,
     usage: &CompletionUsage,
+    provider_request_id: &str,
     client: &ClientContext,
     guardrail_blocked: bool,
     // Per-detector PII mask counts (#932). Empty = no redaction.
@@ -690,6 +704,7 @@ fn emit_usage_event(
         upstream_latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         downstream_latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
+        provider_request_id: provider_request_id.to_string(),
         inbound_protocol: "openai".to_string(),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
@@ -727,6 +742,7 @@ fn emit_usage_event(
         },
     );
 }
+#[allow(clippy::too_many_arguments)]
 fn emit_access_log(
     model: &str,
     provider: &str,
@@ -734,6 +750,8 @@ fn emit_access_log(
     status: u16,
     latency: Duration,
     request_id: &str,
+    // Provider response id; `None`/empty when the call produced none.
+    provider_request_id: Option<&str>,
     error: Option<&ProxyError>,
 ) {
     let (error_kind, error) = match error {
@@ -759,6 +777,7 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        provider_request_id: provider_request_id.filter(|s| !s.is_empty()),
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
@@ -1105,6 +1124,55 @@ mod tests {
         assert_eq!(event.inbound_protocol, "openai");
         assert!(!event.request_id.is_empty());
         assert!(!event.occurred_at.is_empty());
+    }
+
+    /// AISIX-Cloud#1289: the legacy completions response object carries a
+    /// `cmpl-…` id, and it must reach the UsageEvent — the handler recorded
+    /// none before, so this endpoint's calls had nothing an operator could
+    /// look up in the provider's console. Fails before the fix (empty),
+    /// passes after.
+    #[tokio::test]
+    async fn records_the_provider_response_id_1289() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl_1289",
+                "object": "text_completion",
+                "model": "gpt-3.5-turbo-instruct",
+                "choices": [{"index": 0, "text": "hi", "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("instruct"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        let resp = tower::ServiceExt::oneshot(
+            crate::build_router(state),
+            make_req(serde_json::json!({"model": "instruct", "prompt": "hello"})),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.provider_request_id, "cmpl_1289");
+        assert_ne!(event.request_id, event.provider_request_id);
     }
 
     /// Companion: an upstream 200 with `usage: {}` (malformed —

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -555,6 +555,9 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        // No provider response id: count_tokens returns only the token
+        // estimate, and no upstream response object (AISIX-Cloud#1289).
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -562,6 +562,9 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        // No provider response id: the OpenAI embeddings response shape
+        // carries none (AISIX-Cloud#1289).
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -560,6 +560,9 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        // No provider response id: the images response is
+        // `{created, data, usage}` — no id on the wire (AISIX-Cloud#1289).
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -633,6 +633,10 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        // Files / batches / fine-tuning return resource ids the caller keeps
+        // using, not a per-call response-object id — same reasoning as the
+        // video-job id (AISIX-Cloud#1289).
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -456,6 +456,7 @@ impl Drop for ClientCancelGuard {
             completion_tokens: None,
             total_tokens: None,
             request_id: &self.request_id,
+            provider_request_id: None,
             served_by_model: None,
             routing_attempt_count: None,
             routing_fallback_count: None,

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -135,6 +135,7 @@ async fn serve(
         // code is all this endpoint can attribute a failure to.
         error_kind: None,
         error: None,
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1687,11 +1687,7 @@ fn anthropic_metrics_from_response_json(body: &Value) -> AnthropicUsageMetrics {
             .and_then(|u| u.get("cache_read_input_tokens"))
             .and_then(Value::as_u64)
             .unwrap_or(0) as u32,
-        provider_request_id: body
-            .get("id")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string(),
+        provider_request_id: crate::usage_attr::provider_response_id(body),
         provider_model_version: body
             .get("model")
             .and_then(Value::as_str)
@@ -2127,7 +2123,7 @@ async fn cross_provider_dispatch(
         cache_creation_tokens: resp.usage.cache_creation_tokens,
         cache_read_tokens: resp.usage.cache_read_tokens,
         usage_estimated: false,
-        provider_request_id: resp.id.clone(),
+        provider_request_id: crate::usage_attr::sanitize_provider_response_id(&resp.id),
         provider_model_version: resp.model.clone(),
         finish_reason: finish_reason_label(&resp.finish_reason),
         upstream_ttft_ms: 0,
@@ -2265,7 +2261,8 @@ fn build_anthropic_sse_stream(
                     }
                     let comp = guard.comp();
                     if !chunk.id.is_empty() {
-                        comp.provider_request_id = chunk.id.clone();
+                        comp.provider_request_id =
+                        crate::usage_attr::sanitize_provider_response_id(&chunk.id);
                     }
                     if !chunk.model.is_empty() {
                         comp.provider_model_version = chunk.model.clone();
@@ -2965,7 +2962,7 @@ fn update_anthropic_usage(
                 }
             }
             if let Some(id) = msg.and_then(|m| m.get("id")).and_then(Value::as_str) {
-                acc.provider_request_id = id.to_string();
+                acc.provider_request_id = crate::usage_attr::sanitize_provider_response_id(id);
             }
             if let Some(m) = msg.and_then(|m| m.get("model")).and_then(Value::as_str) {
                 acc.provider_model_version = m.to_string();

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -175,6 +175,11 @@ pub async fn messages(
                 status,
                 elapsed,
                 &request_id,
+                // Empty on the streaming path — the id rides the
+                // `message_start` frame, which has not arrived yet. That case
+                // is covered by the per-attempt `provider call completed`
+                // line the usage sink emits (AISIX-Cloud#1289).
+                Some(metrics.provider_request_id.as_str()),
                 &routing,
                 None,
             );
@@ -286,6 +291,7 @@ pub async fn messages(
                 status,
                 elapsed,
                 &request_id,
+                None,
                 &routing,
                 Some(&err),
             );
@@ -3487,6 +3493,9 @@ fn emit_access_log(
     status: u16,
     latency: Duration,
     request_id: &str,
+    // Winning attempt's provider response id; empty when unknown at this
+    // point (streaming, guardrail block, pre-dispatch error).
+    provider_request_id: Option<&str>,
     routing: &RoutingTelemetry,
     error: Option<&ProxyError>,
 ) {
@@ -3516,6 +3525,7 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        provider_request_id: provider_request_id.filter(|s| !s.is_empty()),
         served_by_model: served_by,
         routing_attempt_count: match routing.attempt_count() {
             0 => None,

--- a/crates/aisix-proxy/src/passthrough.rs
+++ b/crates/aisix-proxy/src/passthrough.rs
@@ -817,6 +817,9 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        // The tunnel forwards the body verbatim and never parses it, so
+        // there is no response object to read an id from (AISIX-Cloud#1289).
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -845,6 +845,7 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/reject.rs
+++ b/crates/aisix-proxy/src/reject.rs
@@ -78,6 +78,7 @@ pub(crate) fn reject_before_dispatch(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        provider_request_id: None,
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -38,6 +38,9 @@ struct RerankDispatchSuccess {
     /// Provider-side model name, for the `upstream_model` metric label
     /// (AISIX-Cloud#1234 parity with chat / messages / responses).
     upstream_model: String,
+    /// Rerank response object `id` (Cohere sends one; Jina-style upstreams
+    /// do not). Empty when the upstream omitted it (AISIX-Cloud#1289).
+    provider_request_id: String,
     /// The `{kind, hook}` set of guardrails that governed this request (#379
     /// parity) — surfaced on the emitted UsageEvent.
     applied_guardrails: Vec<AppliedGuardrail>,
@@ -116,6 +119,7 @@ pub async fn rerank(
                 status,
                 elapsed,
                 &request_id,
+                Some(success.provider_request_id.as_str()),
                 None,
             );
             crate::request_metrics::record(
@@ -152,6 +156,7 @@ pub async fn rerank(
                     status,
                     elapsed,
                     &usage,
+                    &success.provider_request_id,
                     &client,
                     success.redactions.clone(),
                     success.monitor_hits.clone(),
@@ -170,6 +175,7 @@ pub async fn rerank(
                 status,
                 elapsed,
                 &request_id,
+                None,
                 Some(&err),
             );
             let snap = state.snapshot.load();
@@ -505,8 +511,11 @@ async fn dispatch(
     // upstream returned 200 + claimed JSON but the body was
     // unparseable — this is upstream-malformed, not gateway-bug,
     // but operators need to see it).
-    let usage = match serde_json::from_slice::<Value>(&body_bytes) {
-        Ok(v) => extract_rerank_usage(&v),
+    let (usage, provider_request_id) = match serde_json::from_slice::<Value>(&body_bytes) {
+        Ok(v) => (
+            extract_rerank_usage(&v),
+            crate::usage_attr::provider_response_id(&v),
+        ),
         Err(e) => {
             tracing::warn!(
                 request_id = %request_id,
@@ -514,7 +523,7 @@ async fn dispatch(
                 error = %e,
                 "rerank: upstream body parse failed; skipping UsageEvent emission"
             );
-            None
+            (None, String::new())
         }
     };
 
@@ -560,6 +569,7 @@ async fn dispatch(
         upstream_model,
         applied_guardrails: applied_guardrails.clone(),
         usage,
+        provider_request_id,
         redactions,
         monitor_hits,
         captured_content,
@@ -627,6 +637,7 @@ fn emit_usage_event(
     status_code: u16,
     elapsed: Duration,
     usage: &RerankUsage,
+    provider_request_id: &str,
     client: &ClientContext,
     // Per-detector PII mask counts (#932/#696). Empty = no redaction.
     redacted_entity_counts: crate::redact::RedactionCounts,
@@ -649,6 +660,7 @@ fn emit_usage_event(
         upstream_latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         downstream_latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         status_code,
+        provider_request_id: provider_request_id.to_string(),
         inbound_protocol: "openai".to_string(),
         applied_guardrails: applied_guardrails.to_vec(),
         client_source_ip: client.source_ip.clone(),
@@ -715,6 +727,7 @@ fn default_base_for_provider(provider: &str) -> Option<String> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_access_log(
     model: &str,
     provider: &str,
@@ -722,6 +735,8 @@ fn emit_access_log(
     status: u16,
     elapsed: Duration,
     request_id: &str,
+    // Provider response id; `None`/empty when the call produced none.
+    provider_request_id: Option<&str>,
     error: Option<&ProxyError>,
 ) {
     let (error_kind, error) = match error {
@@ -743,6 +758,7 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        provider_request_id: provider_request_id.filter(|s| !s.is_empty()),
         served_by_model: None,
         routing_attempt_count: None,
         routing_fallback_count: None,
@@ -1303,6 +1319,56 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
         upstream.verify().await;
+    }
+
+    /// AISIX-Cloud#1289: a rerank response object carries an `id` (Cohere
+    /// sends one) and it must reach the UsageEvent — the handler recorded
+    /// none before. Fails before the fix (empty), passes after.
+    #[tokio::test]
+    async fn records_the_provider_response_id_1289() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/rerank"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "rerank_1289",
+                "results": [{"index": 0, "relevance_score": 0.9}],
+                "model": "rerank-multilingual-v3.0",
+                "usage": {"prompt_tokens": 12, "total_tokens": 12}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(openai_model("rerank-openai"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        let resp = tower::ServiceExt::oneshot(
+            crate::build_router(state),
+            make_req(serde_json::json!({
+                "model": "rerank-openai",
+                "query": "q",
+                "documents": ["a", "b"]
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.provider_request_id, "rerank_1289");
+        assert_ne!(event.request_id, event.provider_request_id);
     }
 
     /// Issue #405: a successful /v1/rerank call must emit a

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -158,6 +158,10 @@ struct ResponseUsage {
     /// 0 until the stream forwards something (or the handler stamps it on
     /// the non-streaming paths).
     downstream_latency_ms: u32,
+    /// Responses-API response object `id` (`resp_…`), or the bridged
+    /// upstream's own id on the #825 cross-provider path. Empty when the
+    /// upstream returned no id (AISIX-Cloud#1289).
+    provider_request_id: String,
 }
 
 pub async fn responses(
@@ -233,6 +237,14 @@ pub async fn responses(
                 status,
                 elapsed,
                 &request_id,
+                // `None` on the streaming path — `usage` is filled by the
+                // stream's completion callback, long after this line. That
+                // case is covered by the per-attempt `provider call
+                // completed` line the usage sink emits (AISIX-Cloud#1289).
+                success
+                    .usage
+                    .as_ref()
+                    .map(|u| u.provider_request_id.as_str()),
                 &success.routing,
                 None,
             );
@@ -341,6 +353,7 @@ pub async fn responses(
                 status,
                 elapsed,
                 &request_id,
+                None,
                 &routing,
                 Some(&err),
             );
@@ -1958,6 +1971,7 @@ async fn responses_cross_provider_to_target(
                     usage_estimated: comp.usage_estimated,
                     upstream_ttft_ms: comp.upstream_ttft_ms,
                     downstream_latency_ms: comp.downstream_latency_ms,
+                    provider_request_id: comp.provider_request_id,
                 };
                 // A clean stream is a committed 200; an output-guardrail block
                 // (or fail-closed overflow) bills the upstream tokens but is
@@ -2075,6 +2089,10 @@ async fn responses_cross_provider_to_target(
             usage_estimated: false,
             upstream_ttft_ms: 0,
             downstream_latency_ms: 0,
+            // The bridged upstream's own id, not the `resp_…` re-encoded
+            // below — that one is minted here and means nothing to the
+            // provider (AISIX-Cloud#1289).
+            provider_request_id: resp.id.clone(),
         };
         // Token-estimation fallback (AISIX-Cloud#1074): fill counters the
         // bridged upstream never reported. Telemetry only — the re-encoded
@@ -2254,6 +2272,15 @@ fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
         // measured these before this terminal frame arrived.
         upstream_ttft_ms: 0,
         downstream_latency_ms: 0,
+        // `resp_…` straight off the upstream's own response object
+        // (AISIX-Cloud#1289). On the streaming path the caller carries the
+        // id it saw on an earlier frame across this replacement, so an
+        // upstream that only stamps it on `response.created` still records.
+        provider_request_id: body
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
     })
 }
 
@@ -2330,16 +2357,42 @@ fn drain_responses_sse_frames(
                     acc.get_or_insert_with(Default::default).upstream_ttft_ms =
                         attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
                 }
+                // `resp_…` off any frame that carries the response object —
+                // `response.created` is the first, so a stream that dies
+                // before its terminal frame still records which upstream call
+                // it was (AISIX-Cloud#1289).
+                if let Some(id) = json
+                    .get("response")
+                    .and_then(|r| r.get("id"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                {
+                    acc.get_or_insert_with(Default::default).provider_request_id = id.to_string();
+                }
                 if let Some(u) = parse_responses_terminal_usage(&json) {
                     // The terminal frame replaces the token counters; carry
-                    // the two latency figures measured before it across.
-                    let (ttft, down) = acc
+                    // the latency figures and the id observed before it
+                    // across — an upstream that stamps the id only on
+                    // `response.created` would otherwise lose it here.
+                    let (ttft, down, prev_id) = acc
                         .as_ref()
-                        .map(|a| (a.upstream_ttft_ms, a.downstream_latency_ms))
+                        .map(|a| {
+                            (
+                                a.upstream_ttft_ms,
+                                a.downstream_latency_ms,
+                                a.provider_request_id.clone(),
+                            )
+                        })
                         .unwrap_or_default();
+                    let provider_request_id = if u.provider_request_id.is_empty() {
+                        prev_id
+                    } else {
+                        u.provider_request_id.clone()
+                    };
                     *acc = Some(ResponseUsage {
                         upstream_ttft_ms: ttft,
                         downstream_latency_ms: down,
+                        provider_request_id,
                         ..u
                     });
                 }
@@ -2801,8 +2854,8 @@ fn apply_passthrough_headers(
 /// Other fields left at `UsageEvent::default()`:
 ///   - cache_creation_tokens / cache_read_tokens — populated only on the
 ///     #825 cross-provider bridge path (Anthropic backends); 0 otherwise
-///   - provider_request_id / provider_model_version / finish_reason
-///     — not yet plumbed for non-chat handlers (follow-up)
+///   - provider_model_version / finish_reason — not yet plumbed for
+///     non-chat handlers (follow-up)
 ///   - cost_usd — cp-api computes server-side from pricing catalog
 ///   - cache_status / cache_hit_* / ttft_ms — no caching/streaming
 ///     surface on Responses API non-streaming
@@ -2864,6 +2917,7 @@ fn emit_usage_event(
         upstream_ttft_ms: usage.upstream_ttft_ms,
         downstream_latency_ms: usage.downstream_latency_ms,
         status_code,
+        provider_request_id: usage.provider_request_id.clone(),
         inbound_protocol: "openai".to_string(),
         attempt_index: attempt.index,
         attempt_kind: attempt.kind,
@@ -3041,6 +3095,9 @@ fn emit_access_log(
     status: u16,
     elapsed: Duration,
     request_id: &str,
+    // Winning attempt's provider response id; `None` when unknown at this
+    // point (streaming, guardrail block, pre-dispatch error).
+    provider_request_id: Option<&str>,
     routing: &RoutingTelemetry,
     error: Option<&ProxyError>,
 ) {
@@ -3069,6 +3126,7 @@ fn emit_access_log(
         completion_tokens: None,
         total_tokens: None,
         request_id,
+        provider_request_id: provider_request_id.filter(|s| !s.is_empty()),
         served_by_model: served_by,
         routing_attempt_count: match routing.attempt_count() {
             0 => None,
@@ -4709,6 +4767,117 @@ mod tests {
         assert_eq!(event.inbound_protocol, "openai");
         assert!(!event.request_id.is_empty());
         assert!(!event.occurred_at.is_empty());
+    }
+
+    /// AISIX-Cloud#1289: `/v1/responses` must record the upstream's own
+    /// response object id. Before this it was one of the fields the handler
+    /// left at `UsageEvent::default()` ("not yet plumbed for non-chat
+    /// handlers"), so a Codex-class call had no id an operator could take to
+    /// the provider's console. Fails before the fix (empty), passes after.
+    #[tokio::test]
+    async fn records_the_provider_response_id_non_streaming_1289() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp_1289_nonstream",
+                "object": "response",
+                "model": "gpt-4o-2024-08-06",
+                "output": [],
+                "usage": {"input_tokens": 4, "output_tokens": 2}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        let resp = crate::build_router(state)
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": "hello"
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!(ev.provider_request_id, "resp_1289_nonstream");
+        // The gateway's own id must survive alongside it, not be replaced.
+        assert!(!ev.request_id.is_empty());
+        assert_ne!(ev.request_id, ev.provider_request_id);
+    }
+
+    /// AISIX-Cloud#1289, streaming: the id arrives on `response.created` and
+    /// the terminal `response.completed` need not repeat it — this upstream
+    /// deliberately omits it there. A reader that only looked at the terminal
+    /// frame, or one that let the terminal frame overwrite what earlier
+    /// frames established, records nothing; both are the failure this pins.
+    #[tokio::test]
+    async fn streaming_records_the_provider_response_id_from_response_created_1289() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        let sse_body = "\
+data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1289_stream\"}}\n\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n\
+data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":9,\"output_tokens\":3}}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        let resp = crate::build_router(state)
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": "hi",
+                "stream": true
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        // Draining runs the stream to completion → the end-of-stream emit.
+        let _ = to_bytes(resp.into_body(), 65536).await.unwrap();
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted for a streaming 200")
+            .expect("usage event sender dropped");
+        assert_eq!(ev.prompt_tokens, 9, "terminal-frame usage must still win");
+        assert_eq!(
+            ev.provider_request_id, "resp_1289_stream",
+            "the id seen on response.created must survive the terminal frame",
+        );
     }
 
     /// AISIX-Cloud#867: the verbatim-OpenAI /v1/responses path must apply the

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1307,6 +1307,12 @@ async fn responses_to_target(
             // telemetry only, the buffered bytes forward untouched.
             let usage = {
                 let mut u = responses_sse_usage(&buf).unwrap_or_default();
+                // The usage gate is independent of the id: a stream whose
+                // terminal frame reported no usage still names the upstream
+                // call it was (AISIX-Cloud#1289).
+                if u.provider_request_id.is_empty() {
+                    u.provider_request_id = responses_sse_provider_request_id(&buf);
+                }
                 if u.prompt_tokens == 0 || u.completion_tokens == 0 {
                     let est = crate::token_estimate::Estimator::new(
                         &upstream_model,
@@ -1602,6 +1608,13 @@ async fn responses_to_target(
         // object at all becomes a wholly-estimated record instead of None.
         let usage = {
             let mut u = extract_response_usage(&json_body).unwrap_or_default();
+            // `extract_response_usage` returns None on a body with no usable
+            // `usage` block, and the estimation fallback below then works off
+            // a default — which would drop a perfectly good top-level `id`
+            // (AISIX-Cloud#1289).
+            if u.provider_request_id.is_empty() {
+                u.provider_request_id = crate::usage_attr::provider_response_id(&json_body);
+            }
             if u.prompt_tokens == 0 || u.completion_tokens == 0 {
                 let est = crate::token_estimate::Estimator::new(
                     &upstream_model,
@@ -2092,7 +2105,7 @@ async fn responses_cross_provider_to_target(
             // The bridged upstream's own id, not the `resp_…` re-encoded
             // below — that one is minted here and means nothing to the
             // provider (AISIX-Cloud#1289).
-            provider_request_id: resp.id.clone(),
+            provider_request_id: crate::usage_attr::sanitize_provider_response_id(&resp.id),
         };
         // Token-estimation fallback (AISIX-Cloud#1074): fill counters the
         // bridged upstream never reported. Telemetry only — the re-encoded
@@ -2276,11 +2289,7 @@ fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
         // (AISIX-Cloud#1289). On the streaming path the caller carries the
         // id it saw on an earlier frame across this replacement, so an
         // upstream that only stamps it on `response.created` still records.
-        provider_request_id: body
-            .get("id")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string(),
+        provider_request_id: crate::usage_attr::provider_response_id(body),
     })
 }
 
@@ -2326,6 +2335,31 @@ fn responses_sse_usage(bytes: &[u8]) -> Option<ResponseUsage> {
     usage
 }
 
+/// The `resp_…` carried by any frame of a fully-buffered Responses-API SSE
+/// body — `response.created` is the first, so this survives a stream whose
+/// terminal frame reported no usage and therefore produced no
+/// [`ResponseUsage`] (AISIX-Cloud#1289).
+fn responses_sse_provider_request_id(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    for line in text.lines() {
+        let Some(data) = line.strip_prefix("data:").map(str::trim) else {
+            continue;
+        };
+        if data.is_empty() || data == "[DONE]" {
+            continue;
+        }
+        if let Ok(json) = serde_json::from_str::<Value>(data) {
+            if let Some(r) = json.get("response") {
+                let id = crate::usage_attr::provider_response_id(r);
+                if !id.is_empty() {
+                    return id;
+                }
+            }
+        }
+    }
+    String::new()
+}
+
 /// Drain every complete SSE frame from `buf`, updating `acc` with the latest
 /// terminal-event usage (#808) and feeding each parsed event to the optional
 /// content capture (AISIX-Cloud#947). A frame ends at the first blank line;
@@ -2367,7 +2401,8 @@ fn drain_responses_sse_frames(
                     .and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty())
                 {
-                    acc.get_or_insert_with(Default::default).provider_request_id = id.to_string();
+                    acc.get_or_insert_with(Default::default).provider_request_id =
+                        crate::usage_attr::sanitize_provider_response_id(id);
                 }
                 if let Some(u) = parse_responses_terminal_usage(&json) {
                     // The terminal frame replaces the token counters; carry
@@ -4819,6 +4854,85 @@ mod tests {
         // The gateway's own id must survive alongside it, not be replaced.
         assert!(!ev.request_id.is_empty());
         assert_ne!(ev.request_id, ev.provider_request_id);
+    }
+
+    /// AISIX-Cloud#1289 follow-up: `extract_response_usage` gates on a usable
+    /// `usage.input_tokens` and returns `None` without one, so the estimation
+    /// fallback (AISIX-Cloud#1074) works off a defaulted `ResponseUsage` — and
+    /// used to drop a perfectly good top-level `id` with it. The estimated
+    /// record must still name the upstream call it came from. Fails before the
+    /// follow-up (empty), passes after.
+    #[tokio::test]
+    async fn records_the_provider_response_id_when_usage_is_estimated_1289() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp_1289_estimated",
+                "object": "response",
+                "model": "gpt-4o-2024-08-06",
+                "output": [{
+                    "type": "message",
+                    "id": "msg_e",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "hello there"}]
+                }]
+                // No `usage` block at all — the estimator fills the counters.
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        let resp = crate::build_router(state)
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": "hello"
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert!(
+            ev.usage_estimated,
+            "fixture has no usage block, so this must be the estimated path",
+        );
+        assert_eq!(ev.provider_request_id, "resp_1289_estimated");
+    }
+
+    /// The buffered-SSE reader (the output-guardrail path holds the whole
+    /// response) must find the id on `response.created` even when no terminal
+    /// frame carried usage — that combination produces no `ResponseUsage` at
+    /// all, which is exactly where the id used to vanish.
+    #[test]
+    fn buffered_sse_id_survives_a_stream_with_no_terminal_usage_1289() {
+        let body = b"\
+data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1289_buffered\"}}\n\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n\
+data: [DONE]\n\n";
+        assert!(
+            super::responses_sse_usage(body).is_none(),
+            "no terminal usage frame — the precondition for the lost-id case",
+        );
+        assert_eq!(
+            super::responses_sse_provider_request_id(body),
+            "resp_1289_buffered"
+        );
     }
 
     /// AISIX-Cloud#1289, streaming: the id arrives on `response.created` and

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1054,7 +1054,8 @@ pub fn build_responses_bridge_stream(
                     {
                         let comp = guard.comp();
                         if !chunk.id.is_empty() {
-                            comp.provider_request_id = chunk.id.clone();
+                            comp.provider_request_id =
+                                crate::usage_attr::sanitize_provider_response_id(&chunk.id);
                         }
                         if let Some(fr) = chunk.finish_reason.as_ref() {
                             comp.finish_reason = finish_reason_label(fr);

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -896,6 +896,11 @@ pub struct ResponsesStreamCompletion {
     pub cache_creation_tokens: u32,
     pub cache_read_tokens: u32,
     pub finish_reason: String,
+    /// Response object `id` reported by the **bridged upstream** — i.e. the
+    /// chat-completion id the provider sent, not the `resp_…` this encoder
+    /// mints for the client. The minted one is a gateway value and would be
+    /// useless in the provider's console (AISIX-Cloud#1289).
+    pub provider_request_id: String,
     /// Attempt-scoped time to the upstream's first generated chunk.
     pub upstream_ttft_ms: u32,
     /// Request-scoped time until the caller got its first response bytes.
@@ -1048,6 +1053,9 @@ pub fn build_responses_bridge_stream(
                     }
                     {
                         let comp = guard.comp();
+                        if !chunk.id.is_empty() {
+                            comp.provider_request_id = chunk.id.clone();
+                        }
                         if let Some(fr) = chunk.finish_reason.as_ref() {
                             comp.finish_reason = finish_reason_label(fr);
                         }

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -16,6 +16,32 @@ use crate::chat::sanitize_tag;
 use crate::client_ip::ClientContext;
 use crate::state::ProxyState;
 
+/// The provider's own response object `id`, read off a JSON response body —
+/// OpenAI's `chat.completion.id`, a Responses-API `resp_…`, a legacy
+/// completions `cmpl-…`, a Cohere rerank `id`.
+///
+/// AISIX-Cloud#1289 keeps three ids strictly separate: this one, the
+/// gateway's own `request_id`, and the provider's HTTP transport header id.
+/// None of them may stand in for another, and an absent id stays absent — a
+/// synthesised value would send an operator hunting in the provider's console
+/// for a call that never happened there. Empty is a normal outcome:
+/// embeddings / audio / images carry no id in their response shape at all, an
+/// errored call has no response object, and a cache hit never reached a
+/// provider.
+///
+/// The value is upstream-controlled and reaches both a log line and cp-api's
+/// `dpmgr_usage_events`, so it goes through [`sanitize_tag`] (control chars
+/// stripped, 256-char cap) — an unescaped newline in an id would otherwise
+/// let an upstream forge whole log records.
+pub(crate) fn provider_response_id(body: &serde_json::Value) -> String {
+    sanitize_tag(
+        body.get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+    )
+}
+
 /// Resolve a ProviderKey's telemetry attribution tags from the live snapshot.
 /// An empty `provider_key_id` (pre-dispatch error paths) or an id with no
 /// matching row yields the default (all-empty) tags, which serialise to wire

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -34,12 +34,18 @@ use crate::state::ProxyState;
 /// stripped, 256-char cap) — an unescaped newline in an id would otherwise
 /// let an upstream forge whole log records.
 pub(crate) fn provider_response_id(body: &serde_json::Value) -> String {
-    sanitize_tag(
-        body.get("id")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string(),
-    )
+    sanitize_provider_response_id(body.get("id").and_then(|v| v.as_str()).unwrap_or_default())
+}
+
+/// [`provider_response_id`] for a value already decoded into a typed struct
+/// (a bridge `Response.id`, a stream chunk `id`). Every producer must route
+/// through one of the two, or the cap and control-char stripping the field's
+/// consumers assume are not actually applied to that path.
+pub(crate) fn sanitize_provider_response_id(id: &str) -> String {
+    if id.is_empty() {
+        return String::new();
+    }
+    sanitize_tag(id.to_string())
 }
 
 /// Resolve a ProviderKey's telemetry attribution tags from the live snapshot.
@@ -188,4 +194,48 @@ pub(crate) fn emit_error_usage_event(
     state
         .otlp_fan_out
         .fan_out(&event, None, exporters.iter().map(|e| &e.value));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AISIX-Cloud#1289: the id is upstream-controlled and reaches a log line
+    /// and cp-api's `dpmgr_usage_events`. A newline in it would break the
+    /// one-record-per-line shape every log consumer relies on, and an
+    /// unbounded id would ride every line for the request. Both entry points
+    /// must normalise, because producers use whichever fits their decode:
+    /// JSON bodies take the `Value` form, bridge/stream structs the `&str`.
+    #[test]
+    fn both_entry_points_strip_control_chars_and_cap_length() {
+        let injected = "chatcmpl-1\nfake-log-line status=200";
+        assert_eq!(
+            sanitize_provider_response_id(injected),
+            "chatcmpl-1fake-log-line status=200",
+        );
+        assert_eq!(
+            provider_response_id(&serde_json::json!({ "id": injected })),
+            "chatcmpl-1fake-log-line status=200",
+        );
+
+        let long = "x".repeat(1000);
+        assert_eq!(sanitize_provider_response_id(&long).chars().count(), 256);
+        assert_eq!(
+            provider_response_id(&serde_json::json!({ "id": long }))
+                .chars()
+                .count(),
+            256,
+        );
+    }
+
+    /// A response with no id — the normal case on several endpoints — must
+    /// stay empty rather than becoming a placeholder, and a non-string `id`
+    /// must not be coerced into one.
+    #[test]
+    fn absent_or_non_string_id_stays_empty() {
+        assert_eq!(sanitize_provider_response_id(""), "");
+        assert_eq!(provider_response_id(&serde_json::json!({})), "");
+        assert_eq!(provider_response_id(&serde_json::json!({ "id": 42 })), "");
+        assert_eq!(provider_response_id(&serde_json::json!({ "id": null })), "");
+    }
 }

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1459,6 +1459,12 @@ impl Telemetry<'_> {
             completion_tokens: None,
             total_tokens: None,
             request_id: &self.request_id,
+            // The provider's video-job id is a handle to a resource the
+            // caller keeps polling, not this call's response-object id;
+            // recording it here would repeat one id across every poll of the
+            // same job (AISIX-Cloud#1289). It already reaches the caller as
+            // the job's own `id`.
+            provider_request_id: None,
             served_by_model: None,
             routing_attempt_count: None,
             routing_fallback_count: None,

--- a/tests/e2e/src/cases/provider-request-id-logging-e2e.test.ts
+++ b/tests/e2e/src/cases/provider-request-id-logging-e2e.test.ts
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the provider's own response id must be reachable from the plain
+// application log, joined to the gateway request id the caller holds
+// (AISIX-Cloud#1289).
+//
+// The contract is a triage journey, not a field: a caller reports a bad
+// answer and quotes their `x-aisix-request-id`; the operator must be able to
+// turn that into the id the provider's own console indexes by. That only
+// works if ONE line carries both, so every assertion here is co-location on a
+// single line rather than the mere presence of each id somewhere in the
+// output.
+//
+// Kept as an E2E rather than a unit test because the two ids are produced in
+// different places — the gateway id by the request-scoped tracing span in
+// aisix-proxy, the provider id by the response/stream readers — and only a
+// real binary serving a real request exercises the seam. The streamed case
+// additionally covers the SSE generator, which hyper polls long after the
+// access-log line for that request was already written: that is precisely the
+// case the one-line-per-request access log structurally cannot carry, and the
+// reason the per-attempt `provider call completed` line exists.
+
+const CALLER_PLAINTEXT = "sk-provider-request-id-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// Fixed per upstream, so a matching log line proves WHICH provider call it
+// came from rather than merely that some id was printed.
+const NONSTREAM_ID = "chatcmpl-e2e-nonstream-1289";
+const STREAM_ID = "chatcmpl-e2e-stream-1289";
+const RESPONSES_ID = "resp_e2e_1289";
+
+/**
+ * Poll the DP's captured output for a line satisfying `pred`. Log delivery to
+ * the harness lags the HTTP response (the child's stderr is piped), so a bare
+ * read right after the request is racy.
+ */
+async function waitForLogLine(
+  app: SpawnedApp,
+  pred: (line: string) => boolean,
+  what: string,
+): Promise<string> {
+  const deadline = Date.now() + 5_000;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = app.output();
+    const hit = last.split("\n").find(pred);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`timed out waiting for ${what}; DP output was:\n${last}`);
+}
+
+async function call(
+  app: SpawnedApp,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; requestId: string; text: string }> {
+  const res = await fetch(`${app.proxyUrl}${path}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const requestId = res.headers.get("x-aisix-request-id") ?? "";
+  // Drain: a streamed body must run to completion before the end-of-stream
+  // telemetry (and its log line) exists at all.
+  const text = await res.text();
+  return { status: res.status, requestId, text };
+}
+
+describe("provider_request_id reaches the access log and the plain log", () => {
+  let app: SpawnedApp | undefined;
+  let nonStreamUpstream: OpenAiUpstream | undefined;
+  let streamUpstream: OpenAiUpstream | undefined;
+  let responsesUpstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    nonStreamUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: NONSTREAM_ID,
+        object: "chat.completion",
+        created: 1_700_000_000,
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "hi" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+      },
+    });
+
+    streamUpstream = await startOpenAiUpstream({
+      streamEvents: [
+        `{"id":"${STREAM_ID}","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+        `{"id":"${STREAM_ID}","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`,
+        `{"id":"${STREAM_ID}","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}`,
+        "[DONE]",
+      ],
+      eventDelayMs: 2,
+    });
+
+    // `/v1/responses` is one of the endpoints that recorded no id before
+    // #1289 — it must now behave like chat does.
+    responsesUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: RESPONSES_ID,
+        object: "response",
+        model: "gpt-4o-mini",
+        output: [
+          {
+            type: "message",
+            id: "msg_e2e",
+            role: "assistant",
+            content: [{ type: "output_text", text: "hi" }],
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+      },
+    });
+
+    // The access log and the provider-call line are INFO; the shared harness
+    // default is warn.
+    app = await spawnApp({ extraEnv: { RUST_LOG: "info" } });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    for (const [name, upstream] of [
+      ["pri-nonstream", nonStreamUpstream],
+      ["pri-stream", streamUpstream],
+      ["pri-responses", responsesUpstream],
+    ] as const) {
+      const pk = await seed.createProviderKey({
+        display_name: `${name}-pk`,
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      await seed.createModel({
+        display_name: `${name}-e2e`,
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+    }
+
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["pri-nonstream-e2e", "pri-stream-e2e", "pri-responses-e2e"],
+    });
+
+    // The caller key is seeded last, so it authenticating implies every
+    // resource above is in the snapshot. Gating on a chat call instead would
+    // exercise the behavior under test and turn an assertion failure into a
+    // timeout.
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      return res.status === 200;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await nonStreamUpstream?.close();
+    await streamUpstream?.close();
+    await responsesUpstream?.close();
+  });
+
+  test("non-streaming: the access-log line joins both ids", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await call(app, "/v1/chat/completions", {
+      model: "pri-nonstream-e2e",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(res.status).toBe(200);
+    expect(res.requestId, "the 200 must carry x-aisix-request-id").toBeTruthy();
+
+    const line = await waitForLogLine(
+      app,
+      (l) =>
+        l.includes("proxy request completed") &&
+        l.includes(`request_id="${res.requestId}"`),
+      "the access-log line for this request",
+    );
+    // The gap #1289 set out to close: before it this line had `request_id`
+    // and nothing that could be taken to the provider.
+    expect(line).toContain(`provider_request_id="${NONSTREAM_ID}"`);
+    // Two distinct ids, neither standing in for the other.
+    expect(res.requestId).not.toBe(NONSTREAM_ID);
+  });
+
+  test("streaming: the provider-call line carries the id the access log cannot", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await call(app, "/v1/chat/completions", {
+      model: "pri-stream-e2e",
+      stream: true,
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("[DONE]");
+
+    // The whole point of the per-attempt line: the id only exists once the
+    // first upstream frame lands, by which time the access-log line for this
+    // request has already been written.
+    const line = await waitForLogLine(
+      app,
+      (l) =>
+        l.includes("provider call completed") &&
+        l.includes(`request_id="${res.requestId}"`),
+      "the provider-call line for this streamed request",
+    );
+    expect(line).toContain(`provider_request_id="${STREAM_ID}"`);
+    // `request_id` + `attempt_index` is what identifies an individual
+    // provider call across a retried / failed-over request.
+    expect(line).toContain("attempt_index=");
+  });
+
+  test("/v1/responses records the provider id too", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const res = await call(app, "/v1/responses", {
+      model: "pri-responses-e2e",
+      input: "hello",
+    });
+    expect(res.status).toBe(200);
+
+    const line = await waitForLogLine(
+      app,
+      (l) =>
+        l.includes("provider call completed") &&
+        l.includes(`request_id="${res.requestId}"`),
+      "the provider-call line for /v1/responses",
+    );
+    expect(line).toContain(`provider_request_id="${RESPONSES_ID}"`);
+  });
+});


### PR DESCRIPTION
## Problem

The provider's own response id (`chat.completion.id`, Anthropic's message `id`, a Responses-API `resp_…`) was stored in telemetry but existed nowhere an operator could grep, and only `/v1/chat/completions` and `/v1/messages` produced it at all. Triaging a provider-side problem meant joining records by hand across systems, and a streamed or failed-over call could not be traced back to the upstream call that served it.

Fixes api7/AISIX-Cloud#1289

## What changed

**1. The access log carries it.** `AccessLog` gains `provider_request_id`, populated on every path where the id is known by the time the line is written — all non-streaming paths. It is absent rather than empty otherwise, so the field stays filterable.

**2. A `provider call completed` line, once per provider call that returned an id.** Emitted from `UsageSink::try_emit`. Every upstream attempt already funnels through there as its own event, which makes it the single point that sees each attempt's id — no handler can be added later that records an id in telemetry while staying silent in the log. It also covers the two cases the one-line-per-request access log structurally cannot:

- a **streamed** response — the id arrives in the first upstream frame, long after the access-log line for that request was written;
- a **mid-stream failover** — two provider calls, two ids, one access-log line.

`request_id` + `attempt_index` identify the individual call, so a retried or failed-over request can be walked call by call.

**3. The endpoints that recorded nothing now do.** `/v1/responses`, `/v1/completions` and `/v1/rerank` record the id they always had on the wire. On the cross-provider bridge path the **bridged upstream's own** id is recorded, never the `resp_…` the encoder mints locally — that one is a gateway value and means nothing in a provider's console.

## Field semantics

Three ids stay distinct and none may overwrite another: the caller's gateway `request_id`, this response-object id, and the provider's HTTP transport header id (not introduced here). Where a response shape carries no id at all — embeddings, audio, images, `count_tokens` — or where the id is a **resource handle** the caller keeps using rather than a per-call response id — video jobs, files/batches/fine-tuning, the opaque passthrough tunnel — the field stays absent instead of being filled with something misleading. Each such site states the reason in place.

The value is upstream-controlled and now reaches a log line, so it goes through the existing tag sanitiser (control chars stripped, 256-char cap): an unescaped newline in an id would otherwise let an upstream forge whole log records.

## Behaviour changes

- Access-log lines for non-streaming calls gain one field.
- One additional INFO line per provider call that returned an id. Nothing is emitted for guardrail blocks, pre-dispatch errors, cache hits, failed attempts with no response body, or the endpoints listed above.
- `/v1/responses`, `/v1/completions`, `/v1/rerank` usage events now populate `provider_request_id`, which the control plane already stores, returns from its usage API and exports.

## Tests

- E2E (`tests/e2e/src/cases/provider-request-id-logging-e2e.test.ts`): real binary + mock upstreams, asserting **co-location on a single line** rather than the mere presence of each id — non-streaming (access-log line joins both ids), streaming (the provider-call line carries what the access log cannot), and `/v1/responses`.
- Unit: access-log emission with and without the field; the provider-call line's contents; that it is silent when there is no id; `attempt_kind` defaulting.
- Per-endpoint tests for `/v1/responses` (non-streaming and streaming), `/v1/completions` and `/v1/rerank`. The streaming case deliberately puts the id **only** on `response.created` and omits it from the terminal frame, so a reader that consults only the terminal frame — or lets it overwrite what earlier frames established — fails.

All four endpoint tests were confirmed to fail before the change and pass after.