### PR TITLE
perf(server): jemalloc global allocator + fat LTO release profile

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -219,6 +219,11 @@ jobs:
           ls -l /tmp/aisix-shipped
           test "$(nm /tmp/aisix-shipped | grep -c ' [tT] ')" -gt 1000
           readelf -S /tmp/aisix-shipped | grep -E '\.symtab|\.eh_frame'
+          # jemalloc must actually be linked (prefixed _rjem_ symbols):
+          # if the cfg gates in aisix-server drift, the binary silently
+          # falls back to glibc malloc with no other signal.
+          nm /tmp/aisix-shipped | grep -q ' [tT] _rjem_' \
+            || { echo "::error::jemalloc symbols missing from shipped binary"; exit 1; }
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.10",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "uuid",
@@ -4858,6 +4859,26 @@ dependencies = [
  "lazy_static",
  "regex",
  "rustc-hash",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,10 @@ tempfile = "3.13"
 #   CARGO_PROFILE_RELEASE_STRIP=none cargo build --release
 # See issue #847.
 [profile.release]
-lto = "thin"
+# Fat LTO over thin: cross-crate inlining across the whole graph is a
+# measured per-request win on the saturation grid, paid for once per
+# release build in link time. Numbers in the PR that flipped it.
+lto = "fat"
 codegen-units = 1
 strip = "debuginfo"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,11 @@ COPY schemas ./schemas
 # `--locked` forces the build to use the exact versions in Cargo.lock —
 # fails fast if the lockfile is stale rather than silently resolving
 # fresh deps in CI.
+#
+# If this ever builds for linux/arm64: jemalloc bakes the build host's
+# page size into the binary, and QEMU reports 4K — set
+# JEMALLOC_SYS_WITH_LG_PAGE=16 here or the image aborts at startup on
+# 64K-page kernels (see crates/aisix-server/src/main.rs).
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
     cargo build --locked --release --bin aisix \

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -56,6 +56,13 @@ socket2 = { version = "0.5", features = ["all"] }
 # axum-server itself depends on, so the builder types unify.
 hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
 
+# jemalloc as the global allocator, only on the targets we ship and
+# bench (Linux glibc — the Docker image and both supported production
+# arches). Other targets (macOS dev builds, musl) keep the system
+# allocator rather than carry an allocator we never run in production.
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 [dev-dependencies]
 tempfile = "3"
 wiremock = "0.6"

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -16,6 +16,18 @@ use std::error::Error as StdError;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+// jemalloc as the global allocator on the shipped/benched targets
+// (Linux glibc): under the thread-per-core saturation load, allocator
+// time drops from ~15% of request CPU (glibc malloc) to ~6%. Other
+// targets keep the system allocator. One deploy caveat: jemalloc bakes
+// the build host's page size into the binary, so an aarch64 binary
+// built on a 4K-page host aborts at startup on a 64K-page kernel —
+// cross-building for such kernels needs JEMALLOC_SYS_WITH_LG_PAGE=16,
+// which runs on both page sizes.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod cert_bundle;
 mod export;
 mod heartbeat;


### PR DESCRIPTION
## What

Two compile-time changes to the shipped binary, no code-path or default-behavior changes:

- **jemalloc as the global allocator** (`tikv-jemallocator` 0.6, the maintained binding, default features) for the aisix binary, gated to the targets we ship and bench: `cfg(all(target_os = "linux", target_env = "gnu"))` — the Docker image (bookworm, glibc) and both supported production arches (x86_64, aarch64). Every other target (macOS dev builds, musl, msvc) keeps the system allocator.
- **Release profile `lto = "thin"` → `"fat"`.** `codegen-units` was already 1; `opt-level` stays at the release default of 3; `strip` stays `"debuginfo"` so shipped binaries remain profileable in the field (#847); `panic` stays `unwind` for per-request isolation.

## Why

The performance program's earlier flamegraphs at the c=128 saturation point put glibc `malloc`/`free` at **15.5 % of request CPU** (prior rig, where glibc internals symbolized fully); the composite spike leg for AISIX-Cloud#1259 item 4 then measured the allocator swap alone at **−11.2 µs/req (+9.2 % rps)** on an anchored same-scene basis — the largest single verified item in the program, at one dependency + one attribute of code.

This is the standard posture across mainstream Rust network infrastructure: maintained jemalloc bindings as the global allocator (gated off non-shipped targets) are shipped by mainstream Rust data stores, proxies, and AI gateways alike, because glibc malloc's arena locking and cache behavior under many-threads/many-small-allocations workloads is a known tax that jemalloc's per-thread caching removes. Fat LTO + `codegen-units = 1` is likewise the common release-profile shape for latency-sensitive Rust servers; we deliberately do **not** adopt the full `strip = true` some projects pair with it, because field profileability of the exact shipped binary is a supported workflow here (#847).

## Measured result (same rig, anchored before/after)

All legs c=128 saturation + c=768 @ 10 ms TTFT, 4 valid windows each, **zero failed requests and zero invalid windows in the whole scene**, gateway pinned to 4 cores at 399.3–399.4 % CPU, front/back anchor drift **+0.07 %** (far inside the ±5 % noise band):

| c=128 | rps (spread) | CPU µs/req | p50 / p99 ms |
|---|---|---|---|
| base, front anchor (2cbf39c) | 31,377 (0.5 %) | 127.3 | 3.90 / 5.94 |
| **this branch** (cea29be) | **36,110** (0.8 %) | **110.6** | **3.46 / 4.87** |
| base, back anchor (2cbf39c) | 31,400 (0.7 %) | 127.2 | 3.92 / 5.85 |
| **delta vs anchor pool** | **+15.0 %** | **−16.7 µs** | −11 % / −18 % |

Shape sanity at c=768 @ 10 ms TTFT (deep queue): 27,548 → 31,396 rps (**+14.0 %**), 144.8 → 127.0 µs/req, anchor drift on the point +0.01 % — the win holds under queue depth, no shape anomaly.

Memory (an allocator swap must answer this): idle RSS 117.2 → 112.7 MB (**−4.5 MB**); peak RSS (VmHWM, includes the 768-connection point) 203.1 → 219.2 MB (**+16.1 MB / +7.9 %**). The peak growth is jemalloc’s documented decay-based purging — dirty pages are returned on a decay schedule instead of immediately — and is the deliberate trade for the allocation-path speed.

Flamegraph (same scene, self-time accounting over allocator symbols): glibc allocator frames 4.10 % / 3.78 % on the two base legs → **0.13 %** on this branch (the residue is C-dependency allocations, which deliberately stay on glibc); jemalloc frames appear at 2.70 % self. Accounting caveat, stated for honesty: on this rig’s kernel the DWARF unwind through glibc breaks into `[unknown]` towers, so SVG-visible glibc shares undercount the true allocator cost — the quantitative claim rests on the anchored CPU counters above, the flamegraph is corroborating shape evidence (glibc allocator symbols vanish, jemalloc symbols appear at the mature share the composite-spike leg also showed).

The composite-spike leg (measured on the #925-head base) predicted −11.2 µs for jemalloc alone, fat LTO worth ~2 µs more. The landing measures −16.7 µs on a base nine feature commits newer — the same direction with the allocator win growing as the request path gains per-request work, which is exactly how an allocator-side win should scale.

## Compile-time cost (the trade this buys)

| build (12-thread x86 dev box) | thin LTO (before) | fat LTO + jemalloc (after) |
|---|---|---|
| cold release | 200.7 s | 392.1 s (~2.0×) |
| touch aisix-server + rebuild | 74.9 s | 263.4 s (~3.5×) |
| peak build RSS | 2.43 GB | 3.73 GB |

The release binary **shrinks** from 57.3 MiB to 52.5 MiB (−8.3 %): whole-graph LTO prunes more than the embedded jemalloc adds. Dev builds are untouched (profile.release only). The cost lands on release builds: CI docker builds and bench-rig builds take the ~2× cold hit; the touch-rebuild ~3.5× is felt only when iterating on release binaries locally.

## Compatibility checklist

- **aarch64 page size**: jemalloc bakes the build host's page size into the binary at configure time (tikv-jemalloc-sys README, `JEMALLOC_SYS_WITH_LG_PAGE`; verified in the crate's build.rs — no per-arch override on linux). Our release matrix is unaffected: the published Docker image is x86_64 (4 K everywhere), and aarch64 deployments build from source on the deploy host, so configure autodetects the right value. The one hazard is cross-building an aarch64 binary on a 4 K-page host and running it on a 64 K-page kernel (RHEL-family aarch64): jemalloc aborts at startup with an explicit page-size error. Documented in the code comment; escape hatch is `JEMALLOC_SYS_WITH_LG_PAGE=16` at build time, which yields a binary that runs on both page sizes.
- **musl / static**: no musl or static artifacts exist in the release matrix (Dockerfile is glibc bookworm; CI is ubuntu-latest gnu). The dependency is target-gated to `linux-gnu`, so a hypothetical musl build simply has no jemalloc in its graph and links exactly as before with the system allocator.
- **Background threads**: default crate features compile in runtime *support* but leave jemalloc's background threads **off** (crate default `background_threads_runtime_support`; `background_thread:true` is only injected by the non-default `background_threads` feature — verified in the crate build.rs). No extra threads appear in the process; this matches the spike leg byte-for-byte.
- **Operator-facing docs**: tracked in api7/docs#2076 (peak-RSS profile, `_RJEM_MALLOC_CONF` vs glibc tunables, aarch64 source-build note). CI now positively asserts the jemalloc symbols are present in the shipped image (the #847 verify step).
- **Allocator scope**: without the `unprefixed_malloc_on_supported_platforms` feature, jemalloc serves Rust's `#[global_allocator]` only; C-library allocations inside dependencies keep glibc. Identical to the measured spike leg.

## Tests

Full workspace suite: 3,017 tests pass, clippy/fmt clean. One environmental failure documented for honesty: `aisix-mcp::bridge::tests::connect_timeout_bounds_an_unreachable_upstream` fails **on the author's dev box only** because a local transparent-proxy TUN answers SYNs for the reserved TEST-NET-3 black-hole address in 4 ms, defeating the test's environmental assumption; it passes in CI and is untouched by this diff (the crate is byte-identical; the diff touches only the server bin crate and the release profile).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved release build optimization for better runtime performance.
  * Added a production memory allocator for Linux GNU builds, while retaining the system allocator on other platforms.

* **Compatibility**
  * Added guidance for Linux ARM64 deployments using systems with 64K memory pages.

* **Reliability**
  * Added automated validation to confirm production Linux builds include the expected memory allocator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
